### PR TITLE
Import login method to now-secrets

### DIFF
--- a/bin/now-secrets
+++ b/bin/now-secrets
@@ -6,6 +6,7 @@ import * as cfg from '../lib/cfg';
 import { handleError, error } from '../lib/error';
 import NowSecrets from '../lib/secrets';
 import ms from 'ms';
+import login from '../lib/login';
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],


### PR DESCRIPTION
Hey,

Bit of an edge case, but the login method wasn't being imported into now-secrets causing the following nasty when trying to add a secret before auth (something I genuinely did):

```
$ now secret add foo bar
/Users/np/code/node/now/build/bin/now-secrets:316
  _promise2.default.resolve(argv.token || config.token || login(apiUrl)).then(function () {
                                                          ^

ReferenceError: login is not defined
    at Object.<anonymous> (/Users/np/code/node/now/build/bin/now-secrets:316:59)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
```

The above one-liner fixes that issue. Had a quick look but no tests covering cli stuff at the moment and looked a bit hairy to start trying to add them. I've run this fix locally with success.
