### PR TITLE
Fix: encode accented chars in filenames

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -296,7 +296,7 @@ export default class Now extends EventEmitter {
             'Content-Length': data.length,
             'x-now-deployment-id': this._id,
             'x-now-sha': sha,
-            'x-now-file': names.map((name) => toRelative(name, this._path)).join(','),
+            'x-now-file': names.map((name) => toRelative(encodeURIComponent(name), this._path)).join(','),
             'x-now-size': data.length
           },
           body: stream


### PR DESCRIPTION
Before:

![screen shot 2016-10-02 at 6 37 15 pm](https://cloud.githubusercontent.com/assets/4721750/19024040/2e441918-88d2-11e6-847f-e81bab13cded.png)

After:

![screen shot 2016-10-02 at 6 57 56 pm](https://cloud.githubusercontent.com/assets/4721750/19024042/33112b0c-88d2-11e6-91e4-b57f92260f1b.png)
