### PR TITLE
Replace standard with XO

### DIFF
--- a/bin/now
+++ b/bin/now
@@ -1,50 +1,68 @@
 #!/usr/bin/env node
-import minimist from 'minimist';
-import { resolve } from 'path';
-import { spawn } from 'cross-spawn';
-import checkUpdate from '../lib/check-update';
 
-const argv = minimist(process.argv.slice(2));
+// Native
+import {resolve} from 'path'
+
+// Packages
+import minimist from 'minimist'
+import {spawn} from 'cross-spawn'
+
+// Ours
+import checkUpdate from '../lib/check-update'
+
+const argv = minimist(process.argv.slice(2))
 
 // options
-const debug = argv.debug || argv.d;
+const debug = argv.debug || argv.d
 
 // auto-update checking
-const update = checkUpdate({ debug });
-const exit = (code) => {
-  update.then(() => process.exit(code));
+const update = checkUpdate({
+  debug
+})
+
+const exit = code => {
+  update.then(() => process.exit(code))
   // don't wait for updates more than a second
   // when the process really wants to exit
-  setTimeout(() => process.exit(code), 1000);
-};
+  setTimeout(() => process.exit(code), 1000)
+}
 
-const defaultCommand = 'deploy';
-const commands = new Set([defaultCommand, 'list', 'ls', 'rm', 'remove', 'alias', 'aliases', 'ln', 'domain', 'domains', 'secret', 'secrets']);
-const aliases = new Map([['ls', 'list'], ['rm', 'remove'], ['ln', 'alias'], ['aliases', 'alias'], ['domain', 'domains'], ['secret', 'secrets']]);
+const defaultCommand = 'deploy'
+const commands = new Set([defaultCommand, 'list', 'ls', 'rm', 'remove', 'alias', 'aliases', 'ln', 'domain', 'domains', 'secret', 'secrets'])
+const aliases = new Map([['ls', 'list'], ['rm', 'remove'], ['ln', 'alias'], ['aliases', 'alias'], ['domain', 'domains'], ['secret', 'secrets']])
 
-let cmd = argv._[0];
-let args = [];
+let cmd = argv._[0]
+let args = []
 
-if ('help' === cmd) {
-  cmd = argv._[1];
-  if (!commands.has(cmd)) cmd = defaultCommand;
-  args.push('--help');
+if (cmd === 'help') {
+  cmd = argv._[1]
+
+  if (!commands.has(cmd)) {
+    cmd = defaultCommand
+  }
+
+  args.push('--help')
 }
 
 if (commands.has(cmd)) {
-  cmd = aliases.get(cmd) || cmd;
-  args = args.concat(process.argv.slice(3));
+  cmd = aliases.get(cmd) || cmd
+  args = args.concat(process.argv.slice(3))
 } else {
-  cmd = defaultCommand;
-  args = args.concat(process.argv.slice(2));
+  cmd = defaultCommand
+  args = args.concat(process.argv.slice(2))
 }
 
-let bin = resolve(__dirname, 'now-' + cmd);
+let bin = resolve(__dirname, 'now-' + cmd)
+
 if (process.pkg) {
-  args.unshift('--entrypoint', bin);
-  bin = process.execPath;
+  args.unshift('--entrypoint', bin)
+  bin = process.execPath
 }
 
-const proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] });
-proc.on('close', (code) => exit(code));
-proc.on('error', () => exit(1));
+const proc = spawn(bin, args, {
+  stdio: 'inherit',
+  customFds: [0, 1, 2]
+})
+
+proc.on('close', code => exit(code))
+proc.on('error', () => exit(1))

--- a/bin/now-alias
+++ b/bin/now-alias
@@ -109,141 +109,139 @@ if (argv.help || !subcommand) {
   })
 }
 
-async function run (token) {
-  const alias = new NowAlias(apiUrl, token, { debug });
-  const args = argv._.slice(1);
+async function run(token) {
+  const alias = new NowAlias(apiUrl, token, {debug})
+  const args = argv._.slice(1)
 
   switch (subcommand) {
     case 'list':
-    case 'ls':
-      if (0 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+    case 'ls': {
+      if (args.length !== 0) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
 
-      const start_ = new Date();
-      const list = await alias.list();
-      const urls = new Map(list.map(l => [l.uid, l.url]));
-      const aliases = await alias.ls();
-      aliases.sort((a, b) => new Date(b.created) - new Date(a.created));
-      const current = new Date();
+      const start_ = new Date()
+      const list = await alias.list()
+      const urls = new Map(list.map(l => [l.uid, l.url]))
+      const aliases = await alias.ls()
+      aliases.sort((a, b) => new Date(b.created) - new Date(a.created))
+      const current = new Date()
 
-      const text = table(aliases.map((_alias) => {
-        const _url = chalk.underline(`https://${_alias.alias}`);
-        const target = _alias.deploymentId;
-        const _sourceUrl = urls.get(target)
-          ? chalk.underline(`https://${urls.get(target)}`)
-          : chalk.gray('<null>');
+      const text = table(aliases.map(_alias => {
+        const _url = chalk.underline(`https://${_alias.alias}`)
+        const target = _alias.deploymentId
+        const _sourceUrl = urls.get(target) ?
+          chalk.underline(`https://${urls.get(target)}`) :
+          chalk.gray('<null>')
 
-        const time = chalk.gray(ms(current - new Date(_alias.created)) + ' ago');
+        const time = chalk.gray(ms(current - new Date(_alias.created)) + ' ago')
         return [
           '',
           // we default to `''` because some early aliases didn't
           // have an uid associated
-          null == _alias.uid ? '' : _alias.uid,
+          (_alias.uid === null || _alias.uid === undefined) ? '' : _alias.uid,
           _sourceUrl,
           _url,
           time
-        ];
-      }), { align: ['l', 'r', 'l'], hsep: ' '.repeat(2) });
+        ]
+      }), {align: ['l', 'r', 'l'], hsep: ' '.repeat(2)})
 
-      const elapsed_ = ms(new Date() - start_);
-      console.log(`> ${aliases.length} alias${aliases.length > 1 ? 'es' : ''} found ${chalk.gray(`[${elapsed_}]`)}`);
-      if (text) console.log('\n' + text + '\n');
-      break;
-
+      const elapsed_ = ms(new Date() - start_)
+      console.log(`> ${aliases.length} alias${aliases.length > 1 ? 'es' : ''} found ${chalk.gray(`[${elapsed_}]`)}`)
+      if (text) {
+        console.log('\n' + text + '\n')
+      }
+      break
+    }
     case 'remove':
-    case 'rm':
-      const _target = String(args[0]);
+    case 'rm': {
+      const _target = String(args[0])
       if (!_target) {
-        const err = new Error('No alias id specified');
-        err.userError = true;
-        throw err;
+        const err = new Error('No alias id specified')
+        err.userError = true
+        throw err
       }
 
-      if (1 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+      if (args.length !== 1) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
 
-      const _aliases = await alias.ls();
-      const _alias = findAlias(_target, _aliases);
+      const _aliases = await alias.ls()
+      const _alias = findAlias(_target, _aliases)
 
       if (!_alias) {
-        const err = new Error(`Alias not found by "${_target}". Run ${chalk.dim('`now alias ls`')} to see your aliases.`);
-        err.userError = true;
-        throw err;
+        const err = new Error(`Alias not found by "${_target}". Run ${chalk.dim('`now alias ls`')} to see your aliases.`)
+        err.userError = true
+        throw err
       }
 
       try {
-        const confirmation = (await readConfirmation(alias, _alias, _aliases)).toLowerCase();
-        if ('y' !== confirmation && 'yes' !== confirmation) {
-          console.log('\n> Aborted');
-          process.exit(0);
+        const confirmation = (await readConfirmation(alias, _alias)).toLowerCase()
+        if (confirmation !== 'y' && confirmation !== 'yes') {
+          console.log('\n> Aborted')
+          process.exit(0)
         }
 
-        const start = new Date();
-        await alias.rm(_alias);
-        const elapsed = ms(new Date() - start);
-        console.log(`${chalk.cyan('> Success!')} Alias ${chalk.bold(_alias.uid)} removed [${elapsed}]`);
+        const start = new Date()
+        await alias.rm(_alias)
+        const elapsed = ms(new Date() - start)
+        console.log(`${chalk.cyan('> Success!')} Alias ${chalk.bold(_alias.uid)} removed [${elapsed}]`)
       } catch (err) {
-        error(err);
-        exit(1);
+        error(err)
+        exit(1)
       }
 
-      break;
-
+      break
+    }
     case 'add':
     case 'set':
-      if (2 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+      if (args.length !== 2) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
-      await alias.set(String(args[0]), String(args[1]));
-      break;
+      await alias.set(String(args[0]), String(args[1]))
+      break
 
     default:
-      if (2 === argv._.length) {
-        await alias.set(String(argv._[0]), String(argv._[1]));
+      if (argv._.length === 2) {
+        await alias.set(String(argv._[0]), String(argv._[1]))
       } else if (argv._.length >= 3) {
-        error('Invalid number of arguments');
-        help();
-        exit(1);
+        error('Invalid number of arguments')
+        help()
+        exit(1)
       } else {
-        error('Please specify a valid subcommand: ls | set | rm');
-        help();
-        exit(1);
+        error('Please specify a valid subcommand: ls | set | rm')
+        help()
+        exit(1)
       }
   }
 
-  alias.close();
+  alias.close()
 }
 
-function indent (text, n) {
-  return text.split('\n').map((l) => ' '.repeat(n) + l).join('\n');
-}
+async function readConfirmation(alias, _alias) {
+  const deploymentsList = await alias.list()
+  const urls = new Map(deploymentsList.map(l => [l.uid, l.url]))
 
-async function readConfirmation (alias, _alias, list) {
-  const deploymentsList = await alias.list();
-  const urls = new Map(deploymentsList.map(l => [l.uid, l.url]));
-
-  return new Promise((resolve, reject) => {
-    const time = chalk.gray(ms(new Date() - new Date(_alias.created)) + ' ago');
-    const _sourceUrl = chalk.underline(`https://${urls.get(_alias.deploymentId)}`);
+  return new Promise(resolve => {
+    const time = chalk.gray(ms(new Date() - new Date(_alias.created)) + ' ago')
+    const _sourceUrl = chalk.underline(`https://${urls.get(_alias.deploymentId)}`)
     const tbl = table(
       [[_alias.uid, _sourceUrl, chalk.underline(`https://${_alias.alias}`), time]],
-      { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) }
-    );
+      {align: ['l', 'r', 'l'], hsep: ' '.repeat(6)}
+    )
 
-    process.stdout.write('> The following alias will be removed permanently\n');
-    process.stdout.write('  ' + tbl + '\n');
-    process.stdout.write(`  ${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`);
+    process.stdout.write('> The following alias will be removed permanently\n')
+    process.stdout.write('  ' + tbl + '\n')
+    process.stdout.write(`  ${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`)
 
-    process.stdin.on('data', (d) => {
-      process.stdin.pause();
-      resolve(d.toString().trim());
-    }).resume();
-  });
+    process.stdin.on('data', d => {
+      process.stdin.pause()
+      resolve(d.toString().trim())
+    }).resume()
+  })
 }
 
 function findAlias(alias, list) {

--- a/bin/now-alias
+++ b/bin/now-alias
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
-import minimist from 'minimist';
-import table from 'text-table';
-import ms from 'ms';
-import NowAlias from '../lib/alias';
-import login from '../lib/login';
-import * as cfg from '../lib/cfg';
-import { error } from '../lib/error';
-import toHost from '../lib/to-host';
+import chalk from 'chalk'
+import minimist from 'minimist'
+import table from 'text-table'
+import ms from 'ms'
+import NowAlias from '../lib/alias'
+import login from '../lib/login'
+import * as cfg from '../lib/cfg'
+import {error} from '../lib/error'
+import toHost from '../lib/to-host'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -18,8 +18,8 @@ const argv = minimist(process.argv.slice(2), {
     debug: 'd',
     token: 't'
   }
-});
-const subcommand = argv._[0];
+})
+const subcommand = argv._[0]
 
 // options
 const help = () => {
@@ -65,45 +65,48 @@ const help = () => {
       To get the list of alias ids, use ${chalk.dim('`now alias ls`')}.
 
   ${chalk.dim('Alias:')} ln
-`);
-};
+`)
+}
 
 // options
-const debug = argv.debug;
-const apiUrl = argv.url || 'https://api.zeit.co';
-if (argv.config) cfg.setConfigFile(argv.config);
+const debug = argv.debug
+const apiUrl = argv.url || 'https://api.zeit.co'
 
-const exit = (code) => {
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
+
+const exit = code => {
   // we give stdout some time to flush out
   // because there's a node bug where
   // stdout writes are asynchronous
   // https://github.com/nodejs/node/issues/6456
-  setTimeout(() => process.exit(code || 0), 100);
-};
+  setTimeout(() => process.exit(code || 0), 100)
+}
 
 if (argv.help || !subcommand) {
-  help();
-  exit(0);
+  help()
+  exit(0)
 } else {
-  const config = cfg.read();
+  const config = cfg.read()
 
   Promise.resolve(argv.token || config.token || login(apiUrl))
-  .then(async (token) => {
+  .then(async token => {
     try {
-      await run(token);
+      await run(token)
     } catch (err) {
       if (err.userError) {
-        error(err.message);
+        error(err.message)
       } else {
-        error(`Unknown error: ${err.stack}`);
+        error(`Unknown error: ${err.stack}`)
       }
-      exit(1);
+      exit(1)
     }
   })
-  .catch((e) => {
-    error(`Authentication error – ${e.message}`);
-    exit(1);
-  });
+  .catch(e => {
+    error(`Authentication error – ${e.message}`)
+    exit(1)
+  })
 }
 
 async function run (token) {
@@ -243,32 +246,37 @@ async function readConfirmation (alias, _alias, list) {
   });
 }
 
-function findAlias (alias, list) {
-  let key, val;
+function findAlias(alias, list) {
+  let key
+  let val
+
   if (/\./.test(alias)) {
-    val = toHost(alias);
-    key = 'alias';
+    val = toHost(alias)
+    key = 'alias'
   } else {
-    val = alias;
-    key = 'uid';
+    val = alias
+    key = 'uid'
   }
 
-  const _alias = list.find((d) => {
+  const _alias = list.find(d => {
     if (d[key] === val) {
-      if (debug) console.log(`> [debug] matched alias ${d.uid} by ${key} ${val}`);
-      return true;
+      if (debug) {
+        console.log(`> [debug] matched alias ${d.uid} by ${key} ${val}`)
+      }
+      return true
     }
 
     // match prefix
     if (`${val}.now.sh` === d.alias) {
-      if (debug) console.log(`> [debug] matched alias ${d.uid} by url ${d.host}`);
-      return true;
+      if (debug) {
+        console.log(`> [debug] matched alias ${d.uid} by url ${d.host}`)
+      }
+
+      return true
     }
 
-    return false;
-  });
+    return false
+  })
 
-  return _alias;
+  return _alias
 }
-
-

--- a/bin/now-deploy
+++ b/bin/now-deploy
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
-import Progress from 'progress';
-import copy from '../lib/copy';
-import { resolve } from 'path';
-import login from '../lib/login';
-import { stat } from 'fs-promise';
-import * as cfg from '../lib/cfg';
-import { version } from '../../package';
-import Logger from '../lib/build-logger';
-import bytes from 'bytes';
-import chalk from 'chalk';
-import minimist from 'minimist';
-import Now from '../lib';
-import toHumanPath from '../lib/utils/to-human-path';
-import promptOptions from '../lib/utils/prompt-options';
-import ms from 'ms';
-import { handleError, error } from '../lib/error';
+import {resolve} from 'path'
+import Progress from 'progress'
+import {stat} from 'fs-promise'
+import bytes from 'bytes'
+import chalk from 'chalk'
+import minimist from 'minimist'
+import ms from 'ms'
+import Now from '../lib'
+import copy from '../lib/copy'
+import login from '../lib/login'
+import * as cfg from '../lib/cfg'
+import {version} from '../../package' // eslint-disable-line import/no-unresolved
+import Logger from '../lib/build-logger'
+import toHumanPath from '../lib/utils/to-human-path'
+import promptOptions from '../lib/utils/prompt-options'
+import {handleError, error} from '../lib/error'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -33,7 +33,7 @@ const argv = minimist(process.argv.slice(2), {
     'no-clipboard': 'C',
     'forward-npm': 'N'
   }
-});
+})
 
 const help = () => {
   console.log(`
@@ -91,230 +91,240 @@ const help = () => {
   ${chalk.gray('–')} Displays comprehensive help for the subcommand ${chalk.dim('`list`')}
 
     ${chalk.cyan('$ now help list')}
-`);
-};
-
-let path = argv._[0];
-
-if (null != path) {
-  // if path is relative: resolve
-  // if path is absolute: clear up strange `/` etc
-  path = resolve(process.cwd(), path);
-} else {
-  path = process.cwd();
+`)
 }
 
-const exit = (code) => {
+let path = argv._[0]
+
+if (path == null) {
+  path = process.cwd()
+} else {
+  // if path is relative: resolve
+  // if path is absolute: clear up strange `/` etc
+  path = resolve(process.cwd(), path)
+}
+
+const exit = code => {
   // we give stdout some time to flush out
   // because there's a node bug where
   // stdout writes are asynchronous
   // https://github.com/nodejs/node/issues/6456
-  setTimeout(() => process.exit(code || 0), 100);
-};
-
-// options
-const debug = argv.debug;
-const clipboard = !argv['no-clipboard'];
-const forwardNpm = argv['forward-npm'];
-const forceNew = argv.force;
-const forceSync = argv.forceSync;
-const shouldLogin = argv.login;
-const wantsPublic = argv.public;
-const apiUrl = argv.url || 'https://api.zeit.co';
-const isTTY = process.stdout.isTTY;
-const quiet = !isTTY;
-if (argv.config) cfg.setConfigFile(argv.config);
-const config = cfg.read();
-const alwaysForwardNpm = config.forwardNpm;
-
-if (argv.h || argv.help) {
-  help();
-  exit(0);
-} else if (argv.v || argv.version) {
-  console.log(chalk.bold('𝚫 now'), version);
-  process.exit(0);
-} else if (!(argv.token || config.token) || shouldLogin) {
-  login(apiUrl)
-  .then((token) => {
-    if (shouldLogin) {
-      console.log('> Logged in successfully. Token saved in ~/.now.json');
-      process.exit(0);
-    } else {
-      sync(token).catch((err) => {
-        error(`Unknown error: ${err.stack}`);
-        process.exit(1);
-      });
-    }
-  })
-  .catch((e) => {
-    error(`Authentication error – ${e.message}`);
-    process.exit(1);
-  });
-} else {
-  sync(argv.token || config.token).catch((err) => {
-    error(`Unknown error: ${err.stack}`);
-    process.exit(1);
-  });
+  setTimeout(() => process.exit(code || 0), 100)
 }
 
-async function sync (token) {
-  const start = Date.now();
+// options
+const debug = argv.debug
+const clipboard = !argv['no-clipboard']
+const forwardNpm = argv['forward-npm']
+const forceNew = argv.force
+const forceSync = argv.forceSync
+const shouldLogin = argv.login
+const wantsPublic = argv.public
+const apiUrl = argv.url || 'https://api.zeit.co'
+const isTTY = process.stdout.isTTY
+const quiet = !isTTY
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
+const config = cfg.read()
+const alwaysForwardNpm = config.forwardNpm
+
+if (argv.h || argv.help) {
+  help()
+  exit(0)
+} else if (argv.v || argv.version) {
+  console.log(chalk.bold('𝚫 now'), version)
+  process.exit(0)
+} else if (!(argv.token || config.token) || shouldLogin) {
+  login(apiUrl)
+  .then(token => {
+    if (shouldLogin) {
+      console.log('> Logged in successfully. Token saved in ~/.now.json')
+      process.exit(0)
+    } else {
+      sync(token).catch(err => {
+        error(`Unknown error: ${err.stack}`)
+        process.exit(1)
+      })
+    }
+  })
+  .catch(e => {
+    error(`Authentication error – ${e.message}`)
+    process.exit(1)
+  })
+} else {
+  sync(argv.token || config.token).catch(err => {
+    error(`Unknown error: ${err.stack}`)
+    process.exit(1)
+  })
+}
+
+async function sync(token) {
+  const start = Date.now()
 
   if (!quiet) {
-    console.log(`> Deploying ${chalk.bold(toHumanPath(path))}`);
+    console.log(`> Deploying ${chalk.bold(toHumanPath(path))}`)
   }
 
   try {
-    await stat(path);
+    await stat(path)
   } catch (err) {
-    error(`Could not read directory ${chalk.bold(path)}`);
-    process.exit(1);
+    error(`Could not read directory ${chalk.bold(path)}`)
+    process.exit(1)
   }
 
-  let deploymentType, hasPackage, hasDockerfile;
+  let deploymentType
+  let hasPackage
+  let hasDockerfile
 
   if (argv.docker) {
     if (debug) {
-      console.log(`> [debug] Forcing \`deploymentType\` = \`docker\``);
+      console.log(`> [debug] Forcing \`deploymentType\` = \`docker\``)
     }
-    deploymentType = 'docker';
+    deploymentType = 'docker'
+  } else if (argv.npm) {
+    deploymentType = 'npm'
   } else {
-    if (argv.npm) {
-      deploymentType = 'npm';
-    } else {
-      try {
-        await stat(resolve(path, 'package.json'));
-      } catch (err) {
-        hasPackage = true;
-      }
+    try {
+      await stat(resolve(path, 'package.json'))
+    } catch (err) {
+      hasPackage = true
+    }
 
-      [hasPackage, hasDockerfile] = await Promise.all([
-        await (async () => {
-          try {
-            await stat(resolve(path, 'package.json'));
-          } catch (err) {
-            return false;
-          }
-          return true;
-        })(),
-        await (async () => {
-          try {
-            await stat(resolve(path, 'Dockerfile'));
-          } catch (err) {
-            return false;
-          }
-          return true;
-        })()
-      ]);
-
-      if (hasPackage && hasDockerfile) {
-        if (debug) console.log('[debug] multiple manifests found, disambiguating');
-        if (isTTY) {
-          try {
-            console.log(`> Two manifests found. Press [${chalk.bold('n')}] to deploy or re-run with --flag`);
-            deploymentType = await promptOptions([
-              ['npm', `${chalk.bold('package.json')}\t${chalk.gray('   --npm')} `],
-              ['docker', `${chalk.bold('Dockerfile')}\t${chalk.gray('--docker')} `]
-            ]);
-          } catch (err) {
-            error(err.message);
-            process.exit(1);
-          }
-        } else {
-          error('Ambiguous deployment (`package.json` and `Dockerfile` found). ' +
-            'Please supply `--npm` or `--docker` to disambiguate.');
+    [hasPackage, hasDockerfile] = await Promise.all([
+      await (async () => {
+        try {
+          await stat(resolve(path, 'package.json'))
+        } catch (err) {
+          return false
         }
-      } else if (hasPackage) {
-        if (debug) console.log('[debug] `package.json` found, assuming `deploymentType` = `npm`');
-        deploymentType = 'npm';
-      } else if (hasDockerfile) {
-        if (debug) console.log('[debug] `Dockerfile` found, assuming `deploymentType` = `docker`');
-        deploymentType = 'docker';
-      } else {
-        error(`Could not access a ${chalk.dim('`package.json`')} or ${chalk.dim('`Dockerfile`')} in ${chalk.bold(path)}`);
-        console.log(`> To deploy statically, try: ${chalk.dim(chalk.underline('https://zeit.co/blog/serve-it-now'))}.`);
-        process.exit(1);
+        return true
+      })(),
+      await (async () => {
+        try {
+          await stat(resolve(path, 'Dockerfile'))
+        } catch (err) {
+          return false
+        }
+        return true
+      })()
+    ])
+
+    if (hasPackage && hasDockerfile) {
+      if (debug) {
+        console.log('[debug] multiple manifests found, disambiguating')
       }
+      if (isTTY) {
+        try {
+          console.log(`> Two manifests found. Press [${chalk.bold('n')}] to deploy or re-run with --flag`)
+          deploymentType = await promptOptions([
+            ['npm', `${chalk.bold('package.json')}\t${chalk.gray('   --npm')} `],
+            ['docker', `${chalk.bold('Dockerfile')}\t${chalk.gray('--docker')} `]
+          ])
+        } catch (err) {
+          error(err.message)
+          process.exit(1)
+        }
+      } else {
+        error('Ambiguous deployment (`package.json` and `Dockerfile` found). ' +
+          'Please supply `--npm` or `--docker` to disambiguate.')
+      }
+    } else if (hasPackage) {
+      if (debug) {
+        console.log('[debug] `package.json` found, assuming `deploymentType` = `npm`')
+      }
+      deploymentType = 'npm'
+    } else if (hasDockerfile) {
+      if (debug) {
+        console.log('[debug] `Dockerfile` found, assuming `deploymentType` = `docker`')
+      }
+      deploymentType = 'docker'
+    } else {
+      error(`Could not access a ${chalk.dim('`package.json`')} or ${chalk.dim('`Dockerfile`')} in ${chalk.bold(path)}`)
+      console.log(`> To deploy statically, try: ${chalk.dim(chalk.underline('https://zeit.co/blog/serve-it-now'))}.`)
+      process.exit(1)
     }
   }
 
-  const now = new Now(apiUrl, token, { debug });
-  const envs = [].concat(argv.env || []);
+  const now = new Now(apiUrl, token, {debug})
+  const envs = [].concat(argv.env || [])
 
-  let secrets;
-  const findSecret = async (uidOrName) => {
-    if (!secrets) secrets = await now.listSecrets();
-    return secrets.filter((secret) => {
-      return secret.name === uidOrName || secret.uid === uidOrName;
-    });
-  };
+  let secrets
+  const findSecret = async uidOrName => {
+    if (!secrets) {
+      secrets = await now.listSecrets()
+    }
+    return secrets.filter(secret => {
+      return secret.name === uidOrName || secret.uid === uidOrName
+    })
+  }
 
-  const env_ = await Promise.all(envs.map(async (kv) => {
-    const [key, val_, ...rest] = kv.split('=');
-    let val;
+  const env_ = await Promise.all(envs.map(async kv => {
+    const [key, val_, ...rest] = kv.split('=')
+    let val
 
-    if (rest.length) {
-      error(`Invalid env ${chalk.bold(`"${kv}"`)}. It cannot contain more than one ${chalk.dim(`=`)} symbol`);
-      return process.exit(1);
+    if (rest.length > 0) {
+      error(`Invalid env ${chalk.bold(`"${kv}"`)}. It cannot contain more than one ${chalk.dim(`=`)} symbol`)
+      return process.exit(1)
     }
 
     if (/[^A-z0-9_]/i.test(key)) {
-      error(`Invalid ${chalk.dim('-e')} key ${chalk.bold(`"${chalk.bold(key)}"`)}. Only letters, digits and underscores are allowed.`);
-      return process.exit(1);
+      error(`Invalid ${chalk.dim('-e')} key ${chalk.bold(`"${chalk.bold(key)}"`)}. Only letters, digits and underscores are allowed.`)
+      return process.exit(1)
     }
 
-    if ('' === key || null == key) {
-      error(`Invalid env option ${chalk.bold(`"${kv}"`)}`);
-      return process.exit(1);
+    if (key === '' || key == null) {
+      error(`Invalid env option ${chalk.bold(`"${kv}"`)}`)
+      return process.exit(1)
     }
 
     if (val_ == null) {
       if (!(key in process.env)) {
-        error(`No value specified for env ${chalk.bold(`"${chalk.bold(key)}"`)} and it was not found in your env.`);
-        return process.exit(1);
-      } else {
-        console.log(`> Reading ${chalk.bold(`"${chalk.bold(key)}"`)} from your env (as no value was specified)`);
-        // escape value if it begins with @
-        val = process.env[key].replace(/^\@/, '\\@');
+        error(`No value specified for env ${chalk.bold(`"${chalk.bold(key)}"`)} and it was not found in your env.`)
+        return process.exit(1)
       }
+      console.log(`> Reading ${chalk.bold(`"${chalk.bold(key)}"`)} from your env (as no value was specified)`)
+      // escape value if it begins with @
+      val = process.env[key].replace(/^@/, '\\@')
     } else {
-      val = val_;
+      val = val_
     }
 
-    if ('@' === val[0]) {
-      const uidOrName = val.substr(1);
-      const secrets = await findSecret(uidOrName);
+    if (val[0] === '@') {
+      const uidOrName = val.substr(1)
+      const secrets = await findSecret(uidOrName)
       if (secrets.length === 0) {
-        if ('' === uidOrName) {
-          error(`Empty reference provided for env key ${chalk.bold(`"${chalk.bold(key)}"`)}`);
+        if (uidOrName === '') {
+          error(`Empty reference provided for env key ${chalk.bold(`"${chalk.bold(key)}"`)}`)
         } else {
-          error(`No secret found by uid or name ${chalk.bold(`"${uidOrName}"`)}`);
+          error(`No secret found by uid or name ${chalk.bold(`"${uidOrName}"`)}`)
         }
-        return process.exit(1);
+        return process.exit(1)
       } else if (secrets.length > 1) {
-        error(`Ambiguous secret ${chalk.bold(`"${uidOrName}"`)} (matches ${chalk.bold(secrets.length)} secrets)`);
-        return process.exit(1);
-      } else {
-        val = { uid: secrets[0].uid };
+        error(`Ambiguous secret ${chalk.bold(`"${uidOrName}"`)} (matches ${chalk.bold(secrets.length)} secrets)`)
+        return process.exit(1)
       }
+      val = {uid: secrets[0].uid}
     }
 
     return [
       key,
-      typeof val === 'string'
+      typeof val === 'string' ?
         // add support for escaping the @ as \@
-        ? val.replace(/^\\@/, '@')
-        : val
-    ];
-  }));
+        val.replace(/^\\@/, '@') :
+        val
+    ]
+  }))
 
-  let env = {};
+  const env = {}
   env_
-  .filter(v => !!v)
+  .filter(v => Boolean(v))
   .forEach(([key, val]) => {
-    if (key in env) console.log(`> ${chalk.yellow('NOTE:')} Overriding duplicate env key ${chalk.bold(`"${key}"`)}`);
+    if (key in env) {
+      console.log(`> ${chalk.yellow('NOTE:')} Overriding duplicate env key ${chalk.bold(`"${key}"`)}`)
+    }
     env[key] = val
-  });
+  })
 
   try {
     await now.create(path, {
@@ -325,45 +335,47 @@ async function sync (token) {
       forwardNpm: alwaysForwardNpm || forwardNpm,
       quiet,
       wantsPublic
-    });
+    })
   } catch (err) {
-    if (debug) console.log(`> [debug] error: ${err.stack}`);
-    handleError(err);
-    process.exit(1);
+    if (debug) {
+      console.log(`> [debug] error: ${err.stack}`)
+    }
+    handleError(err)
+    process.exit(1)
   }
 
-  const { url } = now;
-  const elapsed = ms(new Date() - start);
+  const {url} = now
+  const elapsed = ms(new Date() - start)
 
   if (isTTY) {
     if (clipboard) {
       try {
-        await copy(url);
-        console.log(`${chalk.cyan('> Ready!')} ${chalk.bold(url)} (copied to clipboard) [${elapsed}]`);
+        await copy(url)
+        console.log(`${chalk.cyan('> Ready!')} ${chalk.bold(url)} (copied to clipboard) [${elapsed}]`)
       } catch (err) {
-        console.log(`${chalk.cyan('> Ready!')} ${chalk.bold(url)} [${elapsed}]`);
+        console.log(`${chalk.cyan('> Ready!')} ${chalk.bold(url)} [${elapsed}]`)
       }
     } else {
-      console.log(`> ${url} [${elapsed}]`);
+      console.log(`> ${url} [${elapsed}]`)
     }
   } else {
-    process.stdout.write(url);
+    process.stdout.write(url)
   }
 
-  const start_u = new Date();
+  const startDate = new Date()
   const complete = () => {
     if (!quiet) {
-      const elapsed_u = ms(new Date() - start_u);
-      console.log(`> Sync complete (${bytes(now.syncAmount)}) [${elapsed_u}] `);
-      console.log('> Initializing…');
+      const elapsedTime = ms(new Date() - startDate)
+      console.log(`> Sync complete (${bytes(now.syncAmount)}) [${elapsedTime}] `)
+      console.log('> Initializing…')
     }
 
     // close http2 agent
-    now.close();
+    now.close()
 
     // show build logs
-    printLogs(now.host);
-  };
+    printLogs(now.host)
+  }
 
   if (now.syncAmount) {
     const bar = new Progress('> Upload [:bar] :percent :etas', {
@@ -371,45 +383,45 @@ async function sync (token) {
       complete: '=',
       incomplete: '',
       total: now.syncAmount
-    });
+    })
 
-    now.upload();
+    now.upload()
 
-    now.on('upload', ({ names, data }) => {
-      const amount = data.length;
+    now.on('upload', ({names, data}) => {
+      const amount = data.length
       if (debug) {
-        console.log(`> [debug] Uploaded: ${names.join(' ')} (${bytes(data.length)})`);
+        console.log(`> [debug] Uploaded: ${names.join(' ')} (${bytes(data.length)})`)
       }
-      bar.tick(amount);
-    });
+      bar.tick(amount)
+    })
 
-    now.on('complete', complete);
+    now.on('complete', complete)
 
-    now.on('error', (err) => {
-      error('Upload failed');
-      handleError(err);
-      process.exit(1);
-    });
+    now.on('error', err => {
+      error('Upload failed')
+      handleError(err)
+      process.exit(1)
+    })
   } else {
     if (!quiet) {
-      console.log(`> Initializing…`);
+      console.log(`> Initializing…`)
     }
 
     // close http2 agent
-    now.close();
+    now.close()
 
     // show build logs
-    printLogs(now.host);
+    printLogs(now.host)
   }
 }
 
-function printLogs (host) {
+function printLogs(host) {
   // log build
-  const logger = new Logger(host, { debug, quiet });
+  const logger = new Logger(host, {debug, quiet})
   logger.on('close', () => {
     if (!quiet) {
-      console.log(`${chalk.cyan('> Deployment complete!')}`);
+      console.log(`${chalk.cyan('> Deployment complete!')}`)
     }
-    process.exit(0);
-  });
+    process.exit(0)
+  })
 }

--- a/bin/now-domains
+++ b/bin/now-domains
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
-import minimist from 'minimist';
-import table from 'text-table';
-import ms from 'ms';
-import login from '../lib/login';
-import * as cfg from '../lib/cfg';
-import { error } from '../lib/error';
-import toHost from '../lib/to-host';
-import NowDomains from '../lib/domains';
+import chalk from 'chalk'
+import minimist from 'minimist'
+import table from 'text-table'
+import ms from 'ms'
+import login from '../lib/login'
+import * as cfg from '../lib/cfg'
+import {error} from '../lib/error'
+import toHost from '../lib/to-host'
+import NowDomains from '../lib/domains'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -18,8 +18,8 @@ const argv = minimist(process.argv.slice(2), {
     debug: 'd',
     token: 't'
   }
-});
-const subcommand = argv._[0];
+})
+const subcommand = argv._[0]
 
 // options
 const help = () => {
@@ -70,189 +70,191 @@ const help = () => {
       ${chalk.cyan('$ now domain rm domainId')}
 
       To get the list of domain ids, use ${chalk.dim('`now domains ls`')}.
-`);
-};
+`)
+}
 
 // options
-const debug = argv.debug;
-const apiUrl = argv.url || 'https://api.zeit.co';
-if (argv.config) cfg.setConfigFile(argv.config);
+const debug = argv.debug
+const apiUrl = argv.url || 'https://api.zeit.co'
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
 
-const exit = (code) => {
+const exit = code => {
   // we give stdout some time to flush out
   // because there's a node bug where
   // stdout writes are asynchronous
   // https://github.com/nodejs/node/issues/6456
-  setTimeout(() => process.exit(code || 0), 100);
-};
-
-if (argv.help || !subcommand) {
-  help();
-  exit(0);
-} else {
-  const config = cfg.read();
-
-  Promise.resolve(argv.token || config.token || login(apiUrl))
-  .then(async (token) => {
-    try {
-      await run(token);
-    } catch (err) {
-      if (err.userError) {
-        error(err.message);
-      } else {
-        error(`Unknown error: ${err.stack}`);
-      }
-      exit(1);
-    }
-  })
-  .catch((e) => {
-    error(`Authentication error – ${e.message}`);
-    exit(1);
-  });
+  setTimeout(() => process.exit(code || 0), 100)
 }
 
-async function run (token) {
-  const domain = new NowDomains(apiUrl, token, { debug });
-  const args = argv._.slice(1);
+if (argv.help || !subcommand) {
+  help()
+  exit(0)
+} else {
+  const config = cfg.read()
+
+  Promise.resolve(argv.token || config.token || login(apiUrl))
+  .then(async token => {
+    try {
+      await run(token)
+    } catch (err) {
+      if (err.userError) {
+        error(err.message)
+      } else {
+        error(`Unknown error: ${err.stack}`)
+      }
+      exit(1)
+    }
+  })
+  .catch(e => {
+    error(`Authentication error – ${e.message}`)
+    exit(1)
+  })
+}
+
+async function run(token) {
+  const domain = new NowDomains(apiUrl, token, {debug})
+  const args = argv._.slice(1)
 
   switch (subcommand) {
     case 'ls':
-    case 'list':
-      if (0 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+    case 'list': {
+      if (args.length !== 0) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
 
-      const start_ = new Date();
-      const domains = await domain.ls();
-      domains.sort((a, b) => new Date(b.created) - new Date(a.created));
-      const current = new Date();
-      const out = table(domains.map((domain) => {
-        const url = chalk.underline(`https://${domain.name}`);
-        const time = chalk.gray(ms(current - new Date(domain.created)) + ' ago');
+      const start_ = new Date()
+      const domains = await domain.ls()
+      domains.sort((a, b) => new Date(b.created) - new Date(a.created))
+      const current = new Date()
+      const out = table(domains.map(domain => {
+        const url = chalk.underline(`https://${domain.name}`)
+        const time = chalk.gray(ms(current - new Date(domain.created)) + ' ago')
         return [
           '',
           domain.uid,
           url,
           time
-        ];
-      }), { align: ['l', 'r', 'l'], hsep: ' '.repeat(2) });
+        ]
+      }), {align: ['l', 'r', 'l'], hsep: ' '.repeat(2)})
 
-      const elapsed_ = ms(new Date() - start_);
-      console.log(`> ${domains.length} domain${domains.length > 1 ? 's' : ''} found ${chalk.gray(`[${elapsed_}]`)}`);
-      if (out) console.log('\n' + out + '\n');
-      break;
-
+      const elapsed_ = ms(new Date() - start_)
+      console.log(`> ${domains.length} domain${domains.length > 1 ? 's' : ''} found ${chalk.gray(`[${elapsed_}]`)}`)
+      if (out) {
+        console.log('\n' + out + '\n')
+      }
+      break
+    }
     case 'rm':
-    case 'remove':
-      if (1 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+    case 'remove': {
+      if (args.length !== 1) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
 
-      const _target = String(args[0]);
+      const _target = String(args[0])
       if (!_target) {
-        const err = new Error('No domain specified');
-        err.userError = true;
-        throw err;
+        const err = new Error('No domain specified')
+        err.userError = true
+        throw err
       }
 
-      const _domains = await domain.ls();
-      const _domain = findDomain(_target, _domains);
+      const _domains = await domain.ls()
+      const _domain = findDomain(_target, _domains)
 
       if (!_domain) {
-        const err = new Error(`Domain not found by "${_target}". Run ${chalk.dim('`now domains ls`')} to see your domains.`);
-        err.userError = true;
-        throw err;
+        const err = new Error(`Domain not found by "${_target}". Run ${chalk.dim('`now domains ls`')} to see your domains.`)
+        err.userError = true
+        throw err
       }
 
       try {
-        const confirmation = (await readConfirmation(domain, _domain, _domains)).toLowerCase();
-        if ('y' !== confirmation && 'yes' !== confirmation) {
-          console.log('\n> Aborted');
-          process.exit(0);
+        const confirmation = (await readConfirmation(domain, _domain)).toLowerCase()
+        if (confirmation !== 'y' && confirmation !== 'yes') {
+          console.log('\n> Aborted')
+          process.exit(0)
         }
 
-        const start = new Date();
-        await domain.rm(_domain.name);
-        const elapsed = ms(new Date() - start);
-        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(_domain.uid)} removed [${elapsed}]`);
+        const start = new Date()
+        await domain.rm(_domain.name)
+        const elapsed = ms(new Date() - start)
+        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(_domain.uid)} removed [${elapsed}]`)
       } catch (err) {
-        error(err);
-        exit(1);
+        error(err)
+        exit(1)
       }
-      break;
-
+      break
+    }
     case 'add':
-    case 'set':
-      if (1 !== args.length) {
-        error('Invalid number of arguments');
-        return exit(1);
+    case 'set': {
+      if (args.length !== 1) {
+        error('Invalid number of arguments')
+        return exit(1)
       }
 
-      const start = new Date();
-      const name = String(args[0]);
-      const { uid, created } = await domain.add(name);
-      const elapsed = ms(new Date() - start);
+      const start = new Date()
+      const name = String(args[0])
+      const {uid, created} = await domain.add(name)
+      const elapsed = ms(new Date() - start)
       if (created) {
-        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(chalk.underline(name))} ${chalk.dim(`(${uid})`)} added [${elapsed}]`);
+        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(chalk.underline(name))} ${chalk.dim(`(${uid})`)} added [${elapsed}]`)
       } else {
-        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(chalk.underline(name))} ${chalk.dim(`(${uid})`)} already exists [${elapsed}]`);
+        console.log(`${chalk.cyan('> Success!')} Domain ${chalk.bold(chalk.underline(name))} ${chalk.dim(`(${uid})`)} already exists [${elapsed}]`)
       }
-      break;
-
+      break
+    }
     default:
-      error('Please specify a valid subcommand: ls | add | rm');
-      help();
-      exit(1);
+      error('Please specify a valid subcommand: ls | add | rm')
+      help()
+      exit(1)
   }
 
-  domain.close();
+  domain.close()
 }
 
-function indent (text, n) {
-  return text.split('\n').map((l) => ' '.repeat(n) + l).join('\n');
-}
-
-async function readConfirmation (domain, _domain, list) {
-  const urls = new Map(list.map(l => [l.uid, l.url]));
-
-  return new Promise((resolve, reject) => {
-    const time = chalk.gray(ms(new Date() - new Date(_domain.created)) + ' ago');
+async function readConfirmation(domain, _domain) {
+  return new Promise(resolve => {
+    const time = chalk.gray(ms(new Date() - new Date(_domain.created)) + ' ago')
     const tbl = table(
       [[_domain.uid, chalk.underline(`https://${_domain.name}`), time]],
-      { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) }
-    );
+      {align: ['l', 'r', 'l'], hsep: ' '.repeat(6)}
+    )
 
-    process.stdout.write('> The following domain will be removed permanently\n');
-    process.stdout.write('  ' + tbl + '\n');
-    if (_domain.aliases.length) {
-      process.stdout.write(`> ${chalk.yellow('Warning!')} This domain's `
-      + `${chalk.bold(_domain.aliases.length + ' alias' + (_domain.aliases.length > 1 ? 'es': ''))} `
-      + `will be removed. Run ${chalk.dim('`now alias ls`')} to list.\n`);
+    process.stdout.write('> The following domain will be removed permanently\n')
+    process.stdout.write('  ' + tbl + '\n')
+    if (_domain.aliases.length > 0) {
+      process.stdout.write(`> ${chalk.yellow('Warning!')} This domain's ` +
+        `${chalk.bold(_domain.aliases.length + ' alias' + (_domain.aliases.length > 1 ? 'es' : ''))} ` +
+        `will be removed. Run ${chalk.dim('`now alias ls`')} to list.\n`)
     }
-    process.stdout.write(`  ${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`);
+    process.stdout.write(`  ${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`)
 
-    process.stdin.on('data', (d) => {
-      process.stdin.pause();
-      resolve(d.toString().trim());
-    }).resume();
-  });
+    process.stdin.on('data', d => {
+      process.stdin.pause()
+      resolve(d.toString().trim())
+    }).resume()
+  })
 }
 
-function findDomain (val, list) {
-  return list.find((d) => {
+function findDomain(val, list) {
+  return list.find(d => {
     if (d.uid === val) {
-      if (debug) console.log(`> [debug] matched domain ${d.uid} by uid`);
-      return true;
+      if (debug) {
+        console.log(`> [debug] matched domain ${d.uid} by uid`)
+      }
+      return true
     }
 
     // match prefix
     if (d.name === toHost(val)) {
-      if (debug) console.log(`> [debug] matched domain ${d.uid} by name ${d.name}`);
-      return true;
+      if (debug) {
+        console.log(`> [debug] matched domain ${d.uid} by name ${d.name}`)
+      }
+      return true
     }
 
-    return false;
-  });
+    return false
+  })
 }

--- a/bin/now-list
+++ b/bin/now-list
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-import fs from 'fs-promise';
-import minimist from 'minimist';
-import chalk from 'chalk';
-import table from 'text-table';
-import ms from 'ms';
-import Now from '../lib';
-import login from '../lib/login';
-import * as cfg from '../lib/cfg';
-import { handleError, error } from '../lib/error';
+import fs from 'fs-promise'
+import minimist from 'minimist'
+import chalk from 'chalk'
+import table from 'text-table'
+import ms from 'ms'
+import Now from '../lib'
+import login from '../lib/login'
+import * as cfg from '../lib/cfg'
+import {handleError, error} from '../lib/error'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -19,7 +19,7 @@ const argv = minimist(process.argv.slice(2), {
     debug: 'd',
     token: 't'
   }
-});
+})
 
 const help = () => {
   console.log(`
@@ -43,95 +43,103 @@ const help = () => {
     ${chalk.cyan('$ now ls my-app')}
 
   ${chalk.dim('Alias:')} ls
-`);
-};
+`)
+}
 
 if (argv.help) {
-  help();
-  process.exit(0);
+  help()
+  process.exit(0)
 }
 
-const app = argv._[0];
+const app = argv._[0]
 
 // options
-const debug = argv.debug;
-const apiUrl = argv.url || 'https://api.zeit.co';
-if (argv.config) cfg.setConfigFile(argv.config);
-const config = cfg.read();
+const debug = argv.debug
+const apiUrl = argv.url || 'https://api.zeit.co'
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
+const config = cfg.read()
 
 Promise.resolve(argv.token || config.token || login(apiUrl))
-.then(async (token) => {
+.then(async token => {
   try {
-    await list(token);
+    await list(token)
   } catch (err) {
-    error(`Unknown error: ${err.stack}`);
-    process.exit(1);
+    error(`Unknown error: ${err.stack}`)
+    process.exit(1)
   }
 })
-.catch((e) => {
-  error(`Authentication error – ${e.message}`);
-  process.exit(1);
-});
+.catch(e => {
+  error(`Authentication error – ${e.message}`)
+  process.exit(1)
+})
 
-async function list (token) {
-  const now = new Now(apiUrl, token, { debug });
-  const start = new Date();
+async function list(token) {
+  const now = new Now(apiUrl, token, {debug})
+  const start = new Date()
 
-  let deployments;
+  let deployments
   try {
-    deployments = await now.list(app);
+    deployments = await now.list(app)
   } catch (err) {
-    handleError(err);
-    process.exit(1);
+    handleError(err)
+    process.exit(1)
   }
 
-  now.close();
+  now.close()
 
-  const apps = new Map();
+  const apps = new Map()
   for (const dep of deployments) {
-    const deps = apps.get(dep.name) || [];
-    apps.set(dep.name, deps.concat(dep));
+    const deps = apps.get(dep.name) || []
+    apps.set(dep.name, deps.concat(dep))
   }
 
-  const sorted = await sort([...apps]);
+  const sorted = await sort([...apps])
 
-  const current = Date.now();
+  const current = Date.now()
   const text = sorted.map(([name, deps]) => {
-    const t = table(deps.map(({ uid, url, created }) => {
-      const _url = chalk.underline(`https://${url}`);
-      const time = chalk.gray(ms(current - created) + ' ago');
-      return [uid, _url, time];
-    }), { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) });
-    return chalk.bold(name) + '\n\n' + indent(t, 2);
-  }).join('\n\n');
-  const elapsed = ms(new Date() - start);
-  console.log(`> ${deployments.length} deployment${deployments.length !== 1 ? 's' : ''} found ${chalk.gray(`[${elapsed}]`)}`);
-  if (text) console.log('\n' + text + '\n');
+    const t = table(deps.map(({uid, url, created}) => {
+      const _url = chalk.underline(`https://${url}`)
+      const time = chalk.gray(ms(current - created) + ' ago')
+      return [uid, _url, time]
+    }), {align: ['l', 'r', 'l'], hsep: ' '.repeat(6)})
+    return chalk.bold(name) + '\n\n' + indent(t, 2)
+  }).join('\n\n')
+  const elapsed = ms(new Date() - start)
+  console.log(`> ${deployments.length} deployment${deployments.length === 1 ? '' : 's'} found ${chalk.gray(`[${elapsed}]`)}`)
+  if (text) {
+    console.log('\n' + text + '\n')
+  }
 }
 
-async function sort (apps) {
-  let pkg;
+async function sort(apps) {
+  let pkg
   try {
-    const json = await fs.readFile('package.json');
-    pkg = JSON.parse(json);
+    const json = await fs.readFile('package.json')
+    pkg = JSON.parse(json)
   } catch (err) {
-    pkg = {};
+    pkg = {}
   }
 
   return apps
   .map(([name, deps]) => {
     deps = deps.slice().sort((a, b) => {
-      return b.created - a.created;
-    });
-    return [name, deps];
+      return b.created - a.created
+    })
+    return [name, deps]
   })
   .sort(([nameA, depsA], [nameB, depsB]) => {
-    if (pkg.name === nameA) return -1;
-    if (pkg.name === nameB) return 1;
-    return depsB[0].created - depsA[0].created;
-  });
+    if (pkg.name === nameA) {
+      return -1
+    }
+    if (pkg.name === nameB) {
+      return 1
+    }
+    return depsB[0].created - depsA[0].created
+  })
 }
 
-function indent (text, n) {
-  return text.split('\n').map((l) => ' '.repeat(n) + l).join('\n');
+function indent(text, n) {
+  return text.split('\n').map(l => ' '.repeat(n) + l).join('\n')
 }

--- a/bin/now-remove
+++ b/bin/now-remove
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-import minimist from 'minimist';
-import chalk from 'chalk';
-import ms from 'ms';
-import table from 'text-table';
-import Now from '../lib';
-import login from '../lib/login';
-import * as cfg from '../lib/cfg';
-import { handleError, error } from '../lib/error';
+import minimist from 'minimist'
+import chalk from 'chalk'
+import ms from 'ms'
+import table from 'text-table'
+import Now from '../lib'
+import login from '../lib/login'
+import * as cfg from '../lib/cfg'
+import {handleError, error} from '../lib/error'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -18,9 +18,9 @@ const argv = minimist(process.argv.slice(2), {
     debug: 'd',
     token: 't'
   }
-});
+})
 
-const ids = argv._;
+const ids = argv._
 
 // options
 const help = () => {
@@ -49,107 +49,108 @@ const help = () => {
     ${chalk.cyan('$ now rm eyWt6zuSdeus uWHoA9RQ1d1o')}
 
   ${chalk.dim('Alias:')} rm
-`);
-};
+`)
+}
 
-if (argv.help || 0 === ids.length) {
-  help();
-  process.exit(0);
+if (argv.help || ids.length === 0) {
+  help()
+  process.exit(0)
 }
 
 // options
-const debug = argv.debug;
-const apiUrl = argv.url || 'https://api.zeit.co';
-const hard = argv.hard || false;
-if (argv.config) cfg.setConfigFile(argv.config);
-const config = cfg.read();
+const debug = argv.debug
+const apiUrl = argv.url || 'https://api.zeit.co'
+const hard = argv.hard || false
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
+const config = cfg.read()
 
-function readConfirmation (matches) {
-  return new Promise((resolve, reject) => {
-
-    process.stdout.write(`> The following deployment${matches.length === 1 ? '' : 's'} will be removed permanently:\n`);
+function readConfirmation(matches) {
+  return new Promise(resolve => {
+    process.stdout.write(`> The following deployment${matches.length === 1 ? '' : 's'} will be removed permanently:\n`)
 
     const tbl = table(
-      matches.map((depl) => {
-        const time = chalk.gray(ms(new Date() - depl.created) + ' ago');
-        const url = chalk.underline(`https://${depl.url}`);
-        return [depl.uid, url, time];
+      matches.map(depl => {
+        const time = chalk.gray(ms(new Date() - depl.created) + ' ago')
+        const url = chalk.underline(`https://${depl.url}`)
+        return [depl.uid, url, time]
       }),
-      { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) }
-    );
-    process.stdout.write(tbl + '\n');
+      {align: ['l', 'r', 'l'], hsep: ' '.repeat(6)}
+    )
+    process.stdout.write(tbl + '\n')
 
-    for (let depl of matches) {
-      for (let alias of depl.aliases) {
+    for (const depl of matches) {
+      for (const alias of depl.aliases) {
         process.stdout.write(
           `> ${chalk.yellow('Warning!')} Deployment ${chalk.bold(depl.uid)} ` +
           `is an alias for ${chalk.underline(`https://${alias.alias}`)} and will be removed.\n`
-        );
+        )
       }
     }
 
-    process.stdout.write(`${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`);
+    process.stdout.write(`${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`)
 
-    process.stdin.on('data', (d) => {
-      process.stdin.pause();
-      resolve(d.toString().trim());
-    }).resume();
-  });
+    process.stdin.on('data', d => {
+      process.stdin.pause()
+      resolve(d.toString().trim())
+    }).resume()
+  })
 }
 
 Promise.resolve(argv.token || config.token || login(apiUrl))
-.then(async (token) => {
+.then(async token => {
   try {
-    await remove(token);
+    await remove(token)
   } catch (err) {
-    error(`Unknown error: ${err.stack}`);
-    process.exit(1);
+    error(`Unknown error: ${err.stack}`)
+    process.exit(1)
   }
 })
-.catch((e) => {
-  error(`Authentication error – ${e.message}`);
-  process.exit(1);
-});
+.catch(e => {
+  error(`Authentication error – ${e.message}`)
+  process.exit(1)
+})
 
-async function remove (token) {
-  const now = new Now(apiUrl, token, { debug });
+async function remove(token) {
+  const now = new Now(apiUrl, token, {debug})
 
-  const deployments = await now.list();
+  const deployments = await now.list()
 
-  const matches = deployments.filter((d) => {
-    return ids.find((id) => d.uid === id || d.name === id);
-  });
+  const matches = deployments.filter(d => {
+    return ids.find(id => d.uid === id || d.name === id)
+  })
 
-  if (0 === matches.length) {
-    error(`Could not find any deployments matching ${ids.map((id) => chalk.bold(`"${id}"`)).join(', ')}. Run ${chalk.dim(`\`now ls\``)} to list.`);
-    return process.exit(1);
+  if (matches.length === 0) {
+    error(`Could not find any deployments matching ${ids.map(id => chalk.bold(`"${id}"`)).join(', ')}. Run ${chalk.dim(`\`now ls\``)} to list.`)
+    return process.exit(1)
   }
 
-  const aliases = await Promise.all(matches.map((depl) => now.listAliases(depl.uid)));
+  const aliases = await Promise.all(matches.map(depl => now.listAliases(depl.uid)))
   for (let i = 0; i < matches.length; i++) {
-    matches[i].aliases = aliases[i];
+    matches[i].aliases = aliases[i]
   }
 
   try {
-    const confirmation = (await readConfirmation(matches)).toLowerCase();
-    if ('y' !== confirmation && 'yes' !== confirmation) {
-      console.log('\n> Aborted');
-      process.exit(0);
+    const confirmation = (await readConfirmation(matches)).toLowerCase()
+    if (confirmation !== 'y' && confirmation !== 'yes') {
+      console.log('\n> Aborted')
+      process.exit(0)
     }
 
-    const start = new Date();
+    const start = new Date()
 
-    await Promise.all(matches.map((depl) => now.remove(depl.uid, { hard })));
+    await Promise.all(matches.map(depl => now.remove(depl.uid, {hard})))
 
-    const elapsed = ms(new Date() - start);
-    console.log(`${chalk.cyan('> Success!')} [${elapsed}]`);
-    console.log(table(matches.map((depl) => {
-      return [ `Deployment ${chalk.bold(depl.uid)} removed` ];
-    })));
+    const elapsed = ms(new Date() - start)
+    console.log(`${chalk.cyan('> Success!')} [${elapsed}]`)
+    console.log(table(matches.map(depl => {
+      return [`Deployment ${chalk.bold(depl.uid)} removed`]
+    })))
   } catch (err) {
-    handleError(err);
-    process.exit(1);
+    handleError(err)
+    process.exit(1)
   }
 
-  now.close();
+  now.close()
 }

--- a/bin/now-secrets
+++ b/bin/now-secrets
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
-import table from 'text-table';
-import minimist from 'minimist';
-import * as cfg from '../lib/cfg';
-import { handleError, error } from '../lib/error';
-import NowSecrets from '../lib/secrets';
-import ms from 'ms';
-import login from '../lib/login';
+import ms from 'ms'
+import chalk from 'chalk'
+import table from 'text-table'
+import minimist from 'minimist'
+import * as cfg from '../lib/cfg'
+import {handleError, error} from '../lib/error'
+import NowSecrets from '../lib/secrets'
+import login from '../lib/login'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -18,8 +18,8 @@ const argv = minimist(process.argv.slice(2), {
     base64: 'b',
     token: 't'
   }
-});
-const subcommand = argv._[0];
+})
+const subcommand = argv._[0]
 
 // options
 const help = () => {
@@ -61,157 +61,160 @@ const help = () => {
   ${chalk.gray('–')} Removes a secret:
 
     ${chalk.cyan(`$ now secrets rm my-secret`)}
-`);
-};
+`)
+}
 
 // options
-const debug = argv.debug;
-const apiUrl = argv.url || 'https://api.zeit.co';
-if (argv.config) cfg.setConfigFile(argv.config);
+const debug = argv.debug
+const apiUrl = argv.url || 'https://api.zeit.co'
+if (argv.config) {
+  cfg.setConfigFile(argv.config)
+}
 
-const exit = (code) => {
+const exit = code => {
   // we give stdout some time to flush out
   // because there's a node bug where
   // stdout writes are asynchronous
   // https://github.com/nodejs/node/issues/6456
-  setTimeout(() => process.exit(code || 0), 100);
-};
-
-if (argv.help || !subcommand) {
-  help();
-  exit(0);
-} else {
-  const config = cfg.read();
-
-  Promise.resolve(argv.token || config.token || login(apiUrl))
-  .then(async (token) => {
-    try {
-      await run(token);
-    } catch (err) {
-      handleError(err);
-      exit(1);
-    }
-  })
-  .catch((e) => {
-    error(`Authentication error – ${e.message}`);
-    exit(1);
-  });
+  setTimeout(() => process.exit(code || 0), 100)
 }
 
-async function run (token) {
-  const secrets = new NowSecrets(apiUrl, token, { debug });
-  const args = argv._.slice(1);
-  const start = Date.now();
+if (argv.help || !subcommand) {
+  help()
+  exit(0)
+} else {
+  const config = cfg.read()
 
-  if ('ls' === subcommand || 'list' === subcommand) {
-    if (0 !== args.length) {
-      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret ls`')}`);
-      return exit(1);
+  Promise.resolve(argv.token || config.token || login(apiUrl))
+  .then(async token => {
+    try {
+      await run(token)
+    } catch (err) {
+      handleError(err)
+      exit(1)
     }
-    const list = await secrets.ls();
-    const elapsed = ms(new Date() - start);
-    console.log(`> ${list.length} secret${list.length > 1 ? 's' : ''} found ${chalk.gray(`[${elapsed}]`)}`);
-    const cur = Date.now();
-    const out = table(list.map((secret) => {
+  })
+  .catch(e => {
+    error(`Authentication error – ${e.message}`)
+    exit(1)
+  })
+}
+
+async function run(token) {
+  const secrets = new NowSecrets(apiUrl, token, {debug})
+  const args = argv._.slice(1)
+  const start = Date.now()
+
+  if (subcommand === 'ls' || subcommand === 'list') {
+    if (args.length !== 0) {
+      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret ls`')}`)
+      return exit(1)
+    }
+    const list = await secrets.ls()
+    const elapsed = ms(new Date() - start)
+    console.log(`> ${list.length} secret${list.length > 1 ? 's' : ''} found ${chalk.gray(`[${elapsed}]`)}`)
+    const cur = Date.now()
+    const out = table(list.map(secret => {
       return [
         '',
         secret.uid,
         chalk.bold(secret.name),
         chalk.gray(ms(cur - new Date(secret.created)) + ' ago')
-      ];
-    }), { align: ['l', 'r', 'l'], hsep: ' '.repeat(2) });
-    if (out) console.log('\n' + out + '\n');
-    return secrets.close();
+      ]
+    }), {align: ['l', 'r', 'l'], hsep: ' '.repeat(2)})
+    if (out) {
+      console.log('\n' + out + '\n')
+    }
+    return secrets.close()
   }
 
-  if ('rm' === subcommand || 'remove' === subcommand) {
-    if (1 !== args.length) {
-      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret rm <id | name>`')}`);
-      return exit(1);
+  if (subcommand === 'rm' || subcommand === 'remove') {
+    if (args.length !== 1) {
+      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret rm <id | name>`')}`)
+      return exit(1)
     }
-    const list = await secrets.ls();
-    const theSecret = list.filter((secret) => {
-      return secret.uid === args[0]
-          || secret.name === args[0];
-    })[0];
+    const list = await secrets.ls()
+    const theSecret = list.filter(secret => {
+      return secret.uid === args[0] ||
+        secret.name === args[0]
+    })[0]
 
     if (theSecret) {
-      const yes = await readConfirmation(theSecret);
+      const yes = await readConfirmation(theSecret)
       if (!yes) {
-        error('User abort');
-        return exit(0);
+        error('User abort')
+        return exit(0)
       }
     } else {
-      error(`No secret found by id or name "${args[0]}"`);
-      return exit(1);
+      error(`No secret found by id or name "${args[0]}"`)
+      return exit(1)
     }
 
-    const secret = await secrets.rm(args[0]);
-    const elapsed = ms(new Date() - start);
-    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(secret.name)} ${chalk.gray(`(${secret.uid})`)} removed ${chalk.gray(`[${elapsed}]`)}`);
-    return secrets.close();
+    const secret = await secrets.rm(args[0])
+    const elapsed = ms(new Date() - start)
+    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(secret.name)} ${chalk.gray(`(${secret.uid})`)} removed ${chalk.gray(`[${elapsed}]`)}`)
+    return secrets.close()
   }
 
-  if ('rename' === subcommand) {
-    if (2 !== args.length) {
-      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret rename <old-name> <new-name>`')}`);
-      return exit(1);
+  if (subcommand === 'rename') {
+    if (args.length !== 2) {
+      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret rename <old-name> <new-name>`')}`)
+      return exit(1)
     }
-    const secret = await secrets.rename(args[0], args[1]);
-    const elapsed = ms(new Date() - start);
-    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(secret.oldName)} ${chalk.gray(`(${secret.uid})`)} renamed to ${chalk.bold(args[1])} ${chalk.gray(`[${elapsed}]`)}`);
-    return secrets.close();
+    const secret = await secrets.rename(args[0], args[1])
+    const elapsed = ms(new Date() - start)
+    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(secret.oldName)} ${chalk.gray(`(${secret.uid})`)} renamed to ${chalk.bold(args[1])} ${chalk.gray(`[${elapsed}]`)}`)
+    return secrets.close()
   }
 
-  if ('add' === subcommand || 'set' === subcommand) {
-    if (2 !== args.length) {
-      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret add <name> <value>`')}`);
+  if (subcommand === 'add' || subcommand === 'set') {
+    if (args.length !== 2) {
+      error(`Invalid number of arguments. Usage: ${chalk.cyan('`now secret add <name> <value>`')}`)
       if (args.length > 2) {
-        const [, ...rest] = args;
-        console.log('> If your secret has spaces, make sure to wrap it in quotes. Example: \n'
-        + `  ${chalk.cyan('$ now secret add ${args[0]} "${escaped}"')} `);
+        console.log('> If your secret has spaces, make sure to wrap it in quotes. Example: \n' +
+          `  ${chalk.cyan('$ now secret add ${args[0]} "${escaped}"')} `) // eslint-disable-line no-template-curly-in-string
       }
-      return exit(1);
+      return exit(1)
     }
-    const [name, value_] = args;
-    let value;
+    const [name, value_] = args
+    let value
     if (argv.base64) {
-      value = { base64: value_ };
+      value = {base64: value_}
     } else {
-      value = value_;
+      value = value_
     }
-    const secret = await secrets.add(name, value);
-    const elapsed = ms(new Date() - start);
-    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(name.toLowerCase())} ${chalk.gray(`(${secret.uid})`)} added ${chalk.gray(`[${elapsed}]`)}`);
-    return secrets.close();
+    const secret = await secrets.add(name, value)
+    const elapsed = ms(new Date() - start)
+    console.log(`${chalk.cyan('> Success!')} Secret ${chalk.bold(name.toLowerCase())} ${chalk.gray(`(${secret.uid})`)} added ${chalk.gray(`[${elapsed}]`)}`)
+    return secrets.close()
   }
 
-  error('Please specify a valid subcommand: ls | add | rename | rm');
-  help();
-  exit(1);
+  error('Please specify a valid subcommand: ls | add | rename | rm')
+  help()
+  exit(1)
 }
 
-process.on('uncaughtException', (err) => {
-  handleError(err);
-  exit(1);
-});
+process.on('uncaughtException', err => {
+  handleError(err)
+  exit(1)
+})
 
-function readConfirmation (secret) {
-  return new Promise((resolve, reject) => {
-    const time = chalk.gray(ms(new Date() - new Date(secret.created)) + ' ago');
+function readConfirmation(secret) {
+  return new Promise(resolve => {
+    const time = chalk.gray(ms(new Date() - new Date(secret.created)) + ' ago')
     const tbl = table(
       [[secret.uid, chalk.bold(secret.name), time]],
-      { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) }
-    );
+      {align: ['l', 'r', 'l'], hsep: ' '.repeat(6)}
+    )
 
-    process.stdout.write('> The following secret will be removed permanently\n');
-    process.stdout.write('  ' + tbl + '\n');
+    process.stdout.write('> The following secret will be removed permanently\n')
+    process.stdout.write('  ' + tbl + '\n')
 
-    process.stdout.write(`${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`);
+    process.stdout.write(`${chalk.bold.red('> Are you sure?')} ${chalk.gray('[yN] ')}`)
 
-    process.stdin.on('data', (d) => {
-      process.stdin.pause();
-      resolve('y' === d.toString().trim().toLowerCase());
-    }).resume();
-  });
+    process.stdin.on('data', d => {
+      process.stdin.pause()
+      resolve(d.toString().trim().toLowerCase() === 'y')
+    }).resume()
+  })
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,28 +1,28 @@
-import gulp from 'gulp';
-import del from 'del';
-import babel from 'gulp-babel';
-import help from 'gulp-task-listing';
+import gulp from 'gulp'
+import del from 'del'
+import babel from 'gulp-babel'
+import help from 'gulp-task-listing'
 
-gulp.task('help', help);
+gulp.task('help', help)
 
 gulp.task('compile', [
   'compile-lib',
   'compile-bin'
-]);
+])
 
 gulp.task('compile-lib', () =>
   gulp.src('lib/**/*.js')
   .pipe(babel())
-  .pipe(gulp.dest('build/lib')));
+  .pipe(gulp.dest('build/lib')))
 
 gulp.task('compile-bin', () =>
   gulp.src('bin/*')
   .pipe(babel())
-  .pipe(gulp.dest('build/bin')));
+  .pipe(gulp.dest('build/bin')))
 
-gulp.task('watch-lib', () => gulp.watch('lib/**/*.js', ['compile-lib']));
-gulp.task('watch-bin', () => gulp.watch('bin/*', ['compile-bin']));
-gulp.task('clean', () => del(['build']));
+gulp.task('watch-lib', () => gulp.watch('lib/**/*.js', ['compile-lib']))
+gulp.task('watch-bin', () => gulp.watch('bin/*', ['compile-bin']))
+gulp.task('clean', () => del(['build']))
 
-gulp.task('watch', ['watch-lib', 'watch-bin']);
-gulp.task('default', ['compile', 'watch']);
+gulp.task('watch', ['watch-lib', 'watch-bin'])
+gulp.task('default', ['compile', 'watch'])

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,6 +1,6 @@
+import {parse} from 'url'
 import http2 from 'spdy'
 import fetch from 'node-fetch'
-import {parse} from 'url'
 
 /**
  * Returns a `fetch` version with a similar
@@ -21,11 +21,15 @@ export default class Agent {
     this._port = parsed.port
     this._protocol = parsed.protocol
     this._debug = debug
-    if (tls) this._initAgent()
+    if (tls) {
+      this._initAgent()
+    }
   }
 
   _initAgent() {
-    if ('https:' !== this._protocol) return
+    if (this._protocol !== 'https:') {
+      return
+    }
 
     this._agent = http2.createAgent({
       host: this._host,
@@ -43,7 +47,9 @@ export default class Agent {
 
   fetch(path, opts = {}) {
     if (this._error) {
-      if (this._debug) console.log('> [debug] re-initializing agent after error')
+      if (this._debug) {
+        console.log('> [debug] re-initializing agent after error')
+      }
       this._error = null
       this._initAgent()
     }
@@ -53,12 +59,12 @@ export default class Agent {
       opts.agent = this._agent
     }
 
-    if (body && 'object' === typeof body && 'function' !== typeof body.pipe) {
+    if (body && typeof body === 'object' && typeof body.pipe !== 'function') {
       opts.headers['Content-Type'] = 'application/json'
       opts.body = JSON.stringify(body)
     }
 
-    if (null != opts.body && 'function' !== typeof body.pipe) {
+    if (opts.body != null && typeof body.pipe !== 'function') {
       opts.headers['Content-Length'] = Buffer.byteLength(opts.body)
     }
 
@@ -66,7 +72,9 @@ export default class Agent {
   }
 
   close() {
-    if (this._debug) console.log('> [debug] closing agent')
+    if (this._debug) {
+      console.log('> [debug] closing agent')
+    }
     if (this._agent) {
       this._agent.close()
     }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,6 +1,6 @@
-import http2 from 'spdy';
-import fetch from 'node-fetch';
-import { parse } from 'url';
+import http2 from 'spdy'
+import fetch from 'node-fetch'
+import {parse} from 'url'
 
 /**
  * Returns a `fetch` version with a similar
@@ -14,61 +14,61 @@ import { parse } from 'url';
  */
 
 export default class Agent {
-  constructor (url, { tls = true, debug } = {}) {
-    this._url = url;
-    const parsed = parse(url);
-    this._host = parsed.hostname;
-    this._port = parsed.port;
-    this._protocol = parsed.protocol;
-    this._debug = debug;
-    if (tls) this._initAgent();
+  constructor(url, {tls = true, debug} = {}) {
+    this._url = url
+    const parsed = parse(url)
+    this._host = parsed.hostname
+    this._port = parsed.port
+    this._protocol = parsed.protocol
+    this._debug = debug
+    if (tls) this._initAgent()
   }
 
-  _initAgent () {
-    if ('https:' !== this._protocol) return;
+  _initAgent() {
+    if ('https:' !== this._protocol) return
 
     this._agent = http2.createAgent({
       host: this._host,
       port: this._port || 443
-    }).once('error', (err) => this._onError(err));
+    }).once('error', err => this._onError(err))
   }
 
-  _onError (err) {
+  _onError(err) {
     // XXX: should we `this.emit()`?
     if (this._debug) {
-      console.log('> [debug] agent connection error', err.stack);
+      console.log('> [debug] agent connection error', err.stack)
     }
-    this._error = err;
+    this._error = err
   }
 
-  fetch (path, opts = {}) {
+  fetch(path, opts = {}) {
     if (this._error) {
-      if (this._debug) console.log('> [debug] re-initializing agent after error');
-      this._error = null;
-      this._initAgent();
+      if (this._debug) console.log('> [debug] re-initializing agent after error')
+      this._error = null
+      this._initAgent()
     }
 
-    const { body } = opts;
+    const {body} = opts
     if (this._agent) {
-      opts.agent = this._agent;
+      opts.agent = this._agent
     }
 
     if (body && 'object' === typeof body && 'function' !== typeof body.pipe) {
-      opts.headers['Content-Type'] = 'application/json';
-      opts.body = JSON.stringify(body);
+      opts.headers['Content-Type'] = 'application/json'
+      opts.body = JSON.stringify(body)
     }
 
     if (null != opts.body && 'function' !== typeof body.pipe) {
-      opts.headers['Content-Length'] = Buffer.byteLength(opts.body);
+      opts.headers['Content-Length'] = Buffer.byteLength(opts.body)
     }
 
-    return fetch(this._url + path, opts);
+    return fetch(this._url + path, opts)
   }
 
-  close () {
-    if (this._debug) console.log('> [debug] closing agent');
+  close() {
+    if (this._debug) console.log('> [debug] closing agent')
     if (this._agent) {
-      this._agent.close();
+      this._agent.close()
     }
   }
 }

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -1,9 +1,9 @@
-import Now from './'
-import toHost from './to-host'
 import chalk from 'chalk'
+import toHost from './to-host'
 import isZeitWorld from './is-zeit-world'
 import {DOMAIN_VERIFICATION_ERROR} from './errors'
 import {resolve4} from './dns'
+import Now from './'
 
 const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
 
@@ -19,18 +19,17 @@ export default class Alias extends Now {
       }
 
       return this.listAliases(target.uid)
-    } else {
-      return this.listAliases()
     }
+    return this.listAliases()
   }
 
   async rm(_alias) {
-    return this.retry(async (bail, attempt) => {
+    return this.retry(async bail => {
       const res = await this._fetch(`/now/aliases/${_alias.uid}`, {
         method: 'DELETE'
       })
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
@@ -43,7 +42,8 @@ export default class Alias extends Now {
 
   async findDeployment(deployment) {
     const list = await this.list()
-    let key, val
+    let key
+    let val
     if (/\./.test(deployment)) {
       val = toHost(deployment)
       key = 'url'
@@ -54,13 +54,17 @@ export default class Alias extends Now {
 
     const depl = list.find(d => {
       if (d[key] === val) {
-        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by ${key} ${val}`)
+        if (this._debug) {
+          console.log(`> [debug] matched deployment ${d.uid} by ${key} ${val}`)
+        }
         return true
       }
 
       // match prefix
       if (`${val}.now.sh` === d.url) {
-        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by url ${d.url}`)
+        if (this._debug) {
+          console.log(`> [debug] matched deployment ${d.uid} by url ${d.url}`)
+        }
         return true
       }
 
@@ -88,11 +92,13 @@ export default class Alias extends Now {
     }
 
     // evaluate the alias
-    if (!/\./.test(alias)) {
-      if (this._debug) console.log(`> [debug] suffixing \`.now.sh\` to alias ${alias}`)
-      alias = `${alias}.now.sh`
-    } else {
+    if (/\./.test(alias)) {
       alias = toHost(alias)
+    } else {
+      if (this._debug) {
+        console.log(`> [debug] suffixing \`.now.sh\` to alias ${alias}`)
+      }
+      alias = `${alias}.now.sh`
     }
 
     if (!domainRegex.test(alias)) {
@@ -106,7 +112,9 @@ export default class Alias extends Now {
       console.log(`> Verifying the DNS settings for ${chalk.bold(chalk.underline(alias))} (see ${chalk.underline('https://zeit.world')} for help)`)
 
       const {domain, nameservers} = await this.getNameservers(alias)
-      if (this._debug) console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`)
+      if (this._debug) {
+        console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`)
+      }
 
       try {
         await this.verifyOwnership(alias)
@@ -151,7 +159,9 @@ export default class Alias extends Now {
               throw err
             }
           } catch (e) {
-            if (e.userError) throw e
+            if (e.userError) {
+              throw e
+            }
             throw err
           }
         } else {
@@ -160,7 +170,9 @@ export default class Alias extends Now {
       }
 
       if (!isZeitWorld(nameservers)) {
-        if (this._debug) console.log(`> [debug] Trying to register a non-ZeitWorld domain ${domain} for the current user`)
+        if (this._debug) {
+          console.log(`> [debug] Trying to register a non-ZeitWorld domain ${domain} for the current user`)
+        }
         await this.setupDomain(domain, {isExternal: true})
       }
 
@@ -184,35 +196,41 @@ export default class Alias extends Now {
 
   createAlias(depl, alias) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
+      if (this._debug) {
+        console.time(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
+      }
       const res = await this._fetch(`/now/deployments/${depl.uid}/aliases`, {
         method: 'POST',
         body: {alias}
       })
 
       const body = await res.json()
-      if (this._debug) console.timeEnd(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
+      }
 
       // 409 conflict is returned if it already exists
-      if (409 === res.status) return {uid: body.error.uid}
+      if (res.status === 409) {
+        return {uid: body.error.uid}
+      }
 
       // no retry on authorization problems
-      if (403 === res.status) {
+      if (res.status === 403) {
         const code = body.error.code
 
-        if ('custom_domain_needs_upgrade' === code) {
+        if (code === 'custom_domain_needs_upgrade') {
           const err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`)
           err.userError = true
           return bail(err)
         }
 
-        if ('alias_in_use' === code) {
+        if (code === 'alias_in_use') {
           const err = new Error(`The alias you are trying to configure (${chalk.underline(chalk.bold(alias))}) is already in use by a different account.`)
           err.userError = true
           return bail(err)
         }
 
-        if ('forbidden' === code) {
+        if (code === 'forbidden') {
           const err = new Error('The domain you are trying to use as an alias is already in use by a different account.')
           err.userError = true
           return bail(err)
@@ -225,11 +243,11 @@ export default class Alias extends Now {
       if (body.error) {
         const code = body.error.code
 
-        if ('deployment_not_found' === code) {
+        if (code === 'deployment_not_found') {
           return bail(new Error('Deployment not found'))
         }
 
-        if ('cert_missing' === code) {
+        if (code === 'cert_missing') {
           console.log(`> Provisioning certificate for ${chalk.underline(chalk.bold(alias))}`)
 
           try {
@@ -249,7 +267,7 @@ export default class Alias extends Now {
       }
 
       // the two expected succesful cods are 200 and 304
-      if (200 !== res.status && 304 !== res.status) {
+      if (res.status !== 200 && res.status !== 304) {
         throw new Error('Unhandled error')
       }
 
@@ -260,27 +278,33 @@ export default class Alias extends Now {
   async setupRecord(domain, name) {
     await this.setupDomain(domain)
 
-    if (this._debug) console.log(`> [debug] Setting up record "${name}" for "${domain}"`)
-    const type = '' === name ? 'ALIAS' : 'CNAME'
+    if (this._debug) {
+      console.log(`> [debug] Setting up record "${name}" for "${domain}"`)
+    }
+    const type = name === '' ? 'ALIAS' : 'CNAME'
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /domains/${domain}/records #${attempt}`)
+      if (this._debug) {
+        console.time(`> [debug] /domains/${domain}/records #${attempt}`)
+      }
       const res = await this._fetch(`/domains/${domain}/records`, {
         method: 'POST',
         body: {
           type,
-          name: '' === name ? name : '*',
+          name: name === '' ? name : '*',
           value: 'alias.zeit.co'
         }
       })
-      if (this._debug) console.timeEnd(`> [debug] /domains/${domain}/records #${attempt}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] /domains/${domain}/records #${attempt}`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
       const body = await res.json()
 
-      if (200 !== res.status) {
+      if (res.status !== 200) {
         throw new Error(body.error.message)
       }
 
@@ -289,10 +313,10 @@ export default class Alias extends Now {
   }
 
   verifyOwnership(domain) {
-    return this.retry(async (bail, attempt) => {
+    return this.retry(async bail => {
       const targets = await resolve4('alias.zeit.co')
 
-      if (!targets.length) {
+      if (targets.length === 0) {
         return bail(new Error('Unable to resolve alias.zeit.co'))
       }
 
@@ -300,22 +324,24 @@ export default class Alias extends Now {
       try {
         ips = await resolve4(domain)
       } catch (err) {
-        if ('ENODATA' === err.code || 'ESERVFAIL' === err.code || 'ENOTFOUND' === err.code) {
+        if (err.code === 'ENODATA' || err.code === 'ESERVFAIL' || err.code === 'ENOTFOUND') {
           // not errors per se, just absence of records
-          if (this._debug) console.log(`> [debug] No records found for "${domain}"`)
+          if (this._debug) {
+            console.log(`> [debug] No records found for "${domain}"`)
+          }
         } else {
           throw err
         }
       }
 
-      if (!ips.length) {
+      if (ips.length === 0) {
         const err = new Error(DOMAIN_VERIFICATION_ERROR)
         err.userError = true
         return bail(err)
       }
 
       for (const ip of ips) {
-        if (!~targets.indexOf(ip)) {
+        if (targets.indexOf(ip) === -1) {
           const err = new Error(`The domain ${domain} has an A record ${chalk.bold(ip)} that doesn\'t resolve to ${chalk.bold(chalk.underline('alias.zeit.co'))}.\n> ` + DOMAIN_VERIFICATION_ERROR)
           err.ip = ip
           err.userError = true
@@ -327,7 +353,9 @@ export default class Alias extends Now {
 
   createCert(domain) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /now/certs #${attempt}`)
+      if (this._debug) {
+        console.time(`> [debug] /now/certs #${attempt}`)
+      }
       const res = await this._fetch('/now/certs', {
         method: 'POST',
         body: {
@@ -335,24 +363,26 @@ export default class Alias extends Now {
         }
       })
 
-      if (304 === res.status) {
+      if (res.status === 304) {
         console.log('> Certificate already issued.')
         return
       }
 
       const body = await res.json()
-      if (this._debug) console.timeEnd(`> [debug] /now/certs #${attempt}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] /now/certs #${attempt}`)
+      }
 
       if (body.error) {
         const {code} = body.error
 
-        if ('verification_failed' === code) {
+        if (code === 'verification_failed') {
           const err = new Error('The certificate issuer failed to verify ownership of the domain. ' +
             'This likely has to do with DNS propagation and caching issues. Please retry later!')
           err.userError = true
           // retry
           throw err
-        } else if ('rate_limited' === code) {
+        } else if (code === 'rate_limited') {
           const err = new Error(body.error.message)
           err.userError = true
           // dont retry
@@ -362,7 +392,7 @@ export default class Alias extends Now {
         throw new Error(body.error.message)
       }
 
-      if (200 !== res.status && 304 !== res.status) {
+      if (res.status !== 200 && res.status !== 304) {
         throw new Error('Unhandled error')
       }
     }, {retries: 5, minTimeout: 30000, maxTimeout: 90000})

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -1,115 +1,115 @@
-import Now from './';
-import toHost from './to-host';
-import chalk from 'chalk';
-import isZeitWorld from './is-zeit-world';
-import { DOMAIN_VERIFICATION_ERROR } from './errors';
-import { resolve4 } from './dns';
+import Now from './'
+import toHost from './to-host'
+import chalk from 'chalk'
+import isZeitWorld from './is-zeit-world'
+import {DOMAIN_VERIFICATION_ERROR} from './errors'
+import {resolve4} from './dns'
 
-const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/;
+const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
 
 export default class Alias extends Now {
 
-  async ls (deployment) {
+  async ls(deployment) {
     if (deployment) {
-      const target = await this.findDeployment(deployment);
+      const target = await this.findDeployment(deployment)
       if (!target) {
-        const err = new Error(`Aliases not found by "${deployment}". Run ${chalk.dim('`now alias ls`')} to see your aliases.`);
-        err.userError = true;
-        throw err;
+        const err = new Error(`Aliases not found by "${deployment}". Run ${chalk.dim('`now alias ls`')} to see your aliases.`)
+        err.userError = true
+        throw err
       }
 
-      return this.listAliases(target.uid);
+      return this.listAliases(target.uid)
     } else {
-      return this.listAliases();
+      return this.listAliases()
     }
   }
 
-  async rm (_alias) {
+  async rm(_alias) {
     return this.retry(async (bail, attempt) => {
       const res = await this._fetch(`/now/aliases/${_alias.uid}`, {
         method: 'DELETE'
-      });
+      })
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
       if (res.status !== 200) {
-        const err = new Error('Deletion failed. Try again later.');
-        throw err;
+        const err = new Error('Deletion failed. Try again later.')
+        throw err
       }
-    });
+    })
   }
 
-  async findDeployment (deployment) {
-    const list = await this.list();
-    let key, val;
+  async findDeployment(deployment) {
+    const list = await this.list()
+    let key, val
     if (/\./.test(deployment)) {
-      val = toHost(deployment);
-      key = 'url';
+      val = toHost(deployment)
+      key = 'url'
     } else {
-      val = deployment;
-      key = 'uid';
+      val = deployment
+      key = 'uid'
     }
 
-    const depl = list.find((d) => {
+    const depl = list.find(d => {
       if (d[key] === val) {
-        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by ${key} ${val}`);
-        return true;
+        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by ${key} ${val}`)
+        return true
       }
 
       // match prefix
       if (`${val}.now.sh` === d.url) {
-        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by url ${d.url}`);
-        return true;
+        if (this._debug) console.log(`> [debug] matched deployment ${d.uid} by url ${d.url}`)
+        return true
       }
 
-      return false;
-    });
+      return false
+    })
 
-    return depl;
+    return depl
   }
 
-  async set (deployment, alias) {
+  async set(deployment, alias) {
     // make alias lowercase
-    alias = alias.toLowerCase();
+    alias = alias.toLowerCase()
 
     // trim leading and trailing dots
     // for example: `google.com.` => `google.com`
     alias = alias
       .replace(/^\.+/, '')
-      .replace(/\.+$/, '');
+      .replace(/\.+$/, '')
 
-    const depl = await this.findDeployment(deployment);
+    const depl = await this.findDeployment(deployment)
     if (!depl) {
-      const err = new Error(`Deployment not found by "${deployment}". Run ${chalk.dim('`now ls`')} to see your deployments.`);
-      err.userError = true;
-      throw err;
+      const err = new Error(`Deployment not found by "${deployment}". Run ${chalk.dim('`now ls`')} to see your deployments.`)
+      err.userError = true
+      throw err
     }
 
     // evaluate the alias
     if (!/\./.test(alias)) {
-      if (this._debug) console.log(`> [debug] suffixing \`.now.sh\` to alias ${alias}`);
-      alias = `${alias}.now.sh`;
+      if (this._debug) console.log(`> [debug] suffixing \`.now.sh\` to alias ${alias}`)
+      alias = `${alias}.now.sh`
     } else {
-      alias = toHost(alias);
+      alias = toHost(alias)
     }
 
     if (!domainRegex.test(alias)) {
-      const err = new Error(`Invalid alias "${alias}"`);
-      err.userError = true;
-      throw err;
+      const err = new Error(`Invalid alias "${alias}"`)
+      err.userError = true
+      throw err
     }
 
     if (!/\.now\.sh$/.test(alias)) {
-      console.log(`> ${chalk.bold(chalk.underline(alias))} is a custom domain.`);
-      console.log(`> Verifying the DNS settings for ${chalk.bold(chalk.underline(alias))} (see ${chalk.underline('https://zeit.world')} for help)`);
+      console.log(`> ${chalk.bold(chalk.underline(alias))} is a custom domain.`)
+      console.log(`> Verifying the DNS settings for ${chalk.bold(chalk.underline(alias))} (see ${chalk.underline('https://zeit.world')} for help)`)
 
-      const { domain, nameservers } = await this.getNameservers(alias);
-      if (this._debug) console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`);
+      const {domain, nameservers} = await this.getNameservers(alias)
+      if (this._debug) console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`)
 
       try {
-        await this.verifyOwnership(alias);
+        await this.verifyOwnership(alias)
       } catch (err) {
         if (err.userError) {
           // a user error would imply that verification failed
@@ -117,153 +117,153 @@ export default class Alias extends Now {
           // configuration (if we can!)
           try {
             if (isZeitWorld(nameservers)) {
-              console.log(`> Detected ${chalk.bold(chalk.underline('zeit.world'))} nameservers! Configuring records.`);
-              const record = alias.substr(0, alias.length - domain.length);
+              console.log(`> Detected ${chalk.bold(chalk.underline('zeit.world'))} nameservers! Configuring records.`)
+              const record = alias.substr(0, alias.length - domain.length)
 
               // lean up trailing and leading dots
               const _record = record
                 .replace(/^\./, '')
-                .replace(/\.$/, '');
+                .replace(/\.$/, '')
               const _domain = domain
                 .replace(/^\./, '')
-                .replace(/\.$/, '');
+                .replace(/\.$/, '')
 
               if (_record === '') {
-                await this.setupRecord(_domain, '*');
+                await this.setupRecord(_domain, '*')
               }
 
-              await this.setupRecord(_domain, _record);
+              await this.setupRecord(_domain, _record)
 
-              this.recordSetup = true;
-              console.log('> DNS Configured! Verifying propagation…');
+              this.recordSetup = true
+              console.log('> DNS Configured! Verifying propagation…')
 
               try {
-                await this.retry(() => this.verifyOwnership(alias), { retries: 10, maxTimeout: 8000 });
+                await this.retry(() => this.verifyOwnership(alias), {retries: 10, maxTimeout: 8000})
               } catch (err2) {
                 const e = new Error('> We configured the DNS settings for your alias, but we were unable to ' +
-                            'verify that they\'ve propagated. Please try the alias again later.');
-                e.userError = true;
-                throw e;
+                            'verify that they\'ve propagated. Please try the alias again later.')
+                e.userError = true
+                throw e
               }
             } else {
-              console.log(`> Resolved IP: ${err.ip ? `${chalk.underline(err.ip)} (unknown)` : chalk.dim('none')}`);
-              console.log(`> Nameservers: ${nameservers && nameservers.length ? nameservers.map(ns => chalk.underline(ns)).join(', ') : chalk.dim('none')}`);
-              throw err;
+              console.log(`> Resolved IP: ${err.ip ? `${chalk.underline(err.ip)} (unknown)` : chalk.dim('none')}`)
+              console.log(`> Nameservers: ${nameservers && nameservers.length ? nameservers.map(ns => chalk.underline(ns)).join(', ') : chalk.dim('none')}`)
+              throw err
             }
           } catch (e) {
-            if (e.userError) throw e;
-            throw err;
+            if (e.userError) throw e
+            throw err
           }
         } else {
-          throw err;
+          throw err
         }
       }
 
       if (!isZeitWorld(nameservers)) {
-        if (this._debug) console.log(`> [debug] Trying to register a non-ZeitWorld domain ${domain} for the current user`);
-        await this.setupDomain(domain, { isExternal: true });
+        if (this._debug) console.log(`> [debug] Trying to register a non-ZeitWorld domain ${domain} for the current user`)
+        await this.setupDomain(domain, {isExternal: true})
       }
 
-      console.log(`> Verification ${chalk.bold('OK')}!`);
+      console.log(`> Verification ${chalk.bold('OK')}!`)
     }
 
     // unfortunately there's a situation where the verification
     // ownership code path in the `catch` above makes the
     // agent unexpectedly close. this is a workaround until
     // we figure out what's going on with `node-spdy`
-    this._agent.close();
-    this._agent._initAgent();
+    this._agent.close()
+    this._agent._initAgent()
 
-    const { created, uid } = await this.createAlias(depl, alias);
+    const {created, uid} = await this.createAlias(depl, alias)
     if (created) {
-      console.log(`${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(`https://${alias}`))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`);
+      console.log(`${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(`https://${alias}`))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`)
     } else {
-      console.log(`${chalk.cyan('> Success!')} Alias already exists ${chalk.dim(`(${uid})`)}.`);
+      console.log(`${chalk.cyan('> Success!')} Alias already exists ${chalk.dim(`(${uid})`)}.`)
     }
   }
 
-  createAlias (depl, alias) {
+  createAlias(depl, alias) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`);
+      if (this._debug) console.time(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
       const res = await this._fetch(`/now/deployments/${depl.uid}/aliases`, {
         method: 'POST',
-        body: { alias }
-      });
+        body: {alias}
+      })
 
-      const body = await res.json();
-      if (this._debug) console.timeEnd(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`);
+      const body = await res.json()
+      if (this._debug) console.timeEnd(`> [debug] /now/deployments/${depl.uid}/aliases #${attempt}`)
 
       // 409 conflict is returned if it already exists
-      if (409 === res.status) return { uid: body.error.uid };
+      if (409 === res.status) return {uid: body.error.uid}
 
       // no retry on authorization problems
       if (403 === res.status) {
-        const code = body.error.code;
+        const code = body.error.code
 
         if ('custom_domain_needs_upgrade' === code) {
-          const err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`);
-          err.userError = true;
-          return bail(err);
+          const err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`)
+          err.userError = true
+          return bail(err)
         }
 
         if ('alias_in_use' === code) {
-          const err = new Error(`The alias you are trying to configure (${chalk.underline(chalk.bold(alias))}) is already in use by a different account.`);
-          err.userError = true;
-          return bail(err);
+          const err = new Error(`The alias you are trying to configure (${chalk.underline(chalk.bold(alias))}) is already in use by a different account.`)
+          err.userError = true
+          return bail(err)
         }
 
         if ('forbidden' === code) {
-          const err = new Error('The domain you are trying to use as an alias is already in use by a different account.');
-          err.userError = true;
-          return bail(err);
+          const err = new Error('The domain you are trying to use as an alias is already in use by a different account.')
+          err.userError = true
+          return bail(err)
         }
 
-        return bail(new Error('Authorization error'));
+        return bail(new Error('Authorization error'))
       }
 
       // all other errors
       if (body.error) {
-        const code = body.error.code;
+        const code = body.error.code
 
         if ('deployment_not_found' === code) {
-          return bail(new Error('Deployment not found'));
+          return bail(new Error('Deployment not found'))
         }
 
         if ('cert_missing' === code) {
-          console.log(`> Provisioning certificate for ${chalk.underline(chalk.bold(alias))}`);
+          console.log(`> Provisioning certificate for ${chalk.underline(chalk.bold(alias))}`)
 
           try {
-            await this.createCert(alias);
+            await this.createCert(alias)
           } catch (err) {
             // we bail to avoid retrying the whole process
             // of aliasing which would involve too many
             // retries on certificate provisioning
-            return bail(err);
+            return bail(err)
           }
 
           // try again, but now having provisioned the certificate
-          return this.createAlias(depl, alias);
+          return this.createAlias(depl, alias)
         }
 
-        return bail(new Error(body.error.message));
+        return bail(new Error(body.error.message))
       }
 
       // the two expected succesful cods are 200 and 304
       if (200 !== res.status && 304 !== res.status) {
-        throw new Error('Unhandled error');
+        throw new Error('Unhandled error')
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
-  async setupRecord (domain, name) {
-    await this.setupDomain(domain);
+  async setupRecord(domain, name) {
+    await this.setupDomain(domain)
 
-    if (this._debug) console.log(`> [debug] Setting up record "${name}" for "${domain}"`);
-    const type = '' === name ? 'ALIAS' : 'CNAME';
+    if (this._debug) console.log(`> [debug] Setting up record "${name}" for "${domain}"`)
+    const type = '' === name ? 'ALIAS' : 'CNAME'
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /domains/${domain}/records #${attempt}`);
+      if (this._debug) console.time(`> [debug] /domains/${domain}/records #${attempt}`)
       const res = await this._fetch(`/domains/${domain}/records`, {
         method: 'POST',
         body: {
@@ -271,101 +271,101 @@ export default class Alias extends Now {
           name: '' === name ? name : '*',
           value: 'alias.zeit.co'
         }
-      });
-      if (this._debug) console.timeEnd(`> [debug] /domains/${domain}/records #${attempt}`);
+      })
+      if (this._debug) console.timeEnd(`> [debug] /domains/${domain}/records #${attempt}`)
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
-      const body = await res.json();
+      const body = await res.json()
 
       if (200 !== res.status) {
-        throw new Error(body.error.message);
+        throw new Error(body.error.message)
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
-  verifyOwnership (domain) {
+  verifyOwnership(domain) {
     return this.retry(async (bail, attempt) => {
-      const targets = await resolve4('alias.zeit.co');
+      const targets = await resolve4('alias.zeit.co')
 
       if (!targets.length) {
-        return bail(new Error('Unable to resolve alias.zeit.co'));
+        return bail(new Error('Unable to resolve alias.zeit.co'))
       }
 
-      let ips = [];
+      let ips = []
       try {
-        ips = await resolve4(domain);
+        ips = await resolve4(domain)
       } catch (err) {
         if ('ENODATA' === err.code || 'ESERVFAIL' === err.code || 'ENOTFOUND' === err.code) {
           // not errors per se, just absence of records
-          if (this._debug) console.log(`> [debug] No records found for "${domain}"`);
+          if (this._debug) console.log(`> [debug] No records found for "${domain}"`)
         } else {
-          throw err;
+          throw err
         }
       }
 
       if (!ips.length) {
-        const err = new Error(DOMAIN_VERIFICATION_ERROR);
-        err.userError = true;
-        return bail(err);
+        const err = new Error(DOMAIN_VERIFICATION_ERROR)
+        err.userError = true
+        return bail(err)
       }
 
       for (const ip of ips) {
         if (!~targets.indexOf(ip)) {
-          const err = new Error(`The domain ${domain} has an A record ${chalk.bold(ip)} that doesn\'t resolve to ${chalk.bold(chalk.underline('alias.zeit.co'))}.\n> ` + DOMAIN_VERIFICATION_ERROR);
-          err.ip = ip;
-          err.userError = true;
-          return bail(err);
+          const err = new Error(`The domain ${domain} has an A record ${chalk.bold(ip)} that doesn\'t resolve to ${chalk.bold(chalk.underline('alias.zeit.co'))}.\n> ` + DOMAIN_VERIFICATION_ERROR)
+          err.ip = ip
+          err.userError = true
+          return bail(err)
         }
       }
-    });
+    })
   }
 
-  createCert (domain) {
+  createCert(domain) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] /now/certs #${attempt}`);
+      if (this._debug) console.time(`> [debug] /now/certs #${attempt}`)
       const res = await this._fetch('/now/certs', {
         method: 'POST',
         body: {
           domains: [domain]
         }
-      });
+      })
 
       if (304 === res.status) {
-        console.log('> Certificate already issued.');
-        return;
+        console.log('> Certificate already issued.')
+        return
       }
 
-      const body = await res.json();
-      if (this._debug) console.timeEnd(`> [debug] /now/certs #${attempt}`);
+      const body = await res.json()
+      if (this._debug) console.timeEnd(`> [debug] /now/certs #${attempt}`)
 
       if (body.error) {
-        const { code } = body.error;
+        const {code} = body.error
 
         if ('verification_failed' === code) {
           const err = new Error('The certificate issuer failed to verify ownership of the domain. ' +
-            'This likely has to do with DNS propagation and caching issues. Please retry later!');
-          err.userError = true;
+            'This likely has to do with DNS propagation and caching issues. Please retry later!')
+          err.userError = true
           // retry
-          throw err;
+          throw err
         } else if ('rate_limited' === code) {
-          const err = new Error(body.error.message);
-          err.userError = true;
+          const err = new Error(body.error.message)
+          err.userError = true
           // dont retry
-          return bail(err);
+          return bail(err)
         }
 
-        throw new Error(body.error.message);
+        throw new Error(body.error.message)
       }
 
       if (200 !== res.status && 304 !== res.status) {
-        throw new Error('Unhandled error');
+        throw new Error('Unhandled error')
       }
-    }, { retries: 5, minTimeout: 30000, maxTimeout: 90000 });
+    }, {retries: 5, minTimeout: 30000, maxTimeout: 90000})
   }
 
 }

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import toHost from './to-host'
 import isZeitWorld from './is-zeit-world'
 import {DOMAIN_VERIFICATION_ERROR} from './errors'
-import {resolve4} from './dns'
+import resolve4 from './dns'
 import Now from './'
 
 const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/

--- a/lib/build-logger.js
+++ b/lib/build-logger.js
@@ -1,93 +1,93 @@
-import ansi from 'ansi-escapes';
-import io from 'socket.io-client';
-import chalk from 'chalk';
-import EventEmitter from 'events';
+import ansi from 'ansi-escapes'
+import io from 'socket.io-client'
+import chalk from 'chalk'
+import EventEmitter from 'events'
 
 export default class Logger extends EventEmitter {
 
-  constructor (host, { debug = false, quiet = false } = {}) {
-    super();
-    this.host = host;
-    this.debug = debug;
-    this.quiet = quiet;
+  constructor(host, {debug = false, quiet = false} = {}) {
+    super()
+    this.host = host
+    this.debug = debug
+    this.quiet = quiet
 
     // readyState
-    this.building = false;
+    this.building = false
 
-    this.socket = io(`https://io.now.sh?host=${host}`);
-    this.socket.once('error', this.onSocketError.bind(this));
-    this.socket.on('state', this.onState.bind(this));
-    this.socket.on('logs', this.onLog.bind(this));
-    this.socket.on('backend', this.onComplete.bind(this));
+    this.socket = io(`https://io.now.sh?host=${host}`)
+    this.socket.once('error', this.onSocketError.bind(this))
+    this.socket.on('state', this.onState.bind(this))
+    this.socket.on('logs', this.onLog.bind(this))
+    this.socket.on('backend', this.onComplete.bind(this))
 
-    this.lines = new Lines(10);
+    this.lines = new Lines(10)
   }
 
-  onState (state) {
+  onState(state) {
     if (!state.id) {
-      console.error('> Deployment not found');
-      this.emit('error');
-      return;
+      console.error('> Deployment not found')
+      this.emit('error')
+      return
     }
 
     if (state.error) {
-      console.error('> Deployment error');
-      this.emit('error');
-      return;
+      console.error('> Deployment error')
+      this.emit('error')
+      return
     }
 
     if (state.backend) {
-      this.onComplete();
-      return;
+      this.onComplete()
+      return
     }
 
     if (state.logs) {
-      state.logs.forEach(this.onLog, this);
+      state.logs.forEach(this.onLog, this)
     }
   }
 
-  onLog (log) {
+  onLog(log) {
     if (!this.building) {
       if (!this.quiet) {
-        console.log('> Building');
+        console.log('> Building')
       }
-      this.building = true;
+      this.building = true
     }
 
-    if (this.quiet) return;
+    if (this.quiet) return
 
     if ('command' === log.type) {
-      console.log(`${chalk.gray('>')} ▲ ${log.data}`);
-      this.lines.reset();
+      console.log(`${chalk.gray('>')} ▲ ${log.data}`)
+      this.lines.reset()
     } else if ('stderr' === log.type) {
-      log.data.split('\n').forEach((v) => {
+      log.data.split('\n').forEach(v => {
         if (v.length) {
-          console.error(chalk.red(`> ${v}`));
+          console.error(chalk.red(`> ${v}`))
         }
-      });
-      this.lines.reset();
+      })
+      this.lines.reset()
     } else if ('stdout' === log.type) {
-      log.data.split('\n').forEach((v) => {
+      log.data.split('\n').forEach(v => {
         if (v.length) {
-          this.lines.write(`${chalk.gray('>')} ${v}`);
+          this.lines.write(`${chalk.gray('>')} ${v}`)
         }
-      });
+      })
     }
   }
 
-  onComplete () {
-    this.socket.disconnect();
+  onComplete() {
+    this.socket.disconnect()
 
     if (this.building) {
-      this.building = false;
+      this.building = false
     }
 
-    this.emit('close');
+    this.emit('close')
   }
 
-  onSocketError (err) {
+  onSocketError(err) {
     if (this.debug) {
-      console.log('> [debug] Socket error', err.stack);
+      console.log('> [debug] Socket error', err.stack)
     }
   }
 
@@ -95,26 +95,26 @@ export default class Logger extends EventEmitter {
 
 class Lines {
 
-  constructor (maxLines = 100) {
-    this.max = maxLines;
-    this.buf = [];
+  constructor(maxLines = 100) {
+    this.max = maxLines
+    this.buf = []
   }
 
-  write (str) {
-    const { max, buf } = this;
+  write(str) {
+    const {max, buf} = this
 
     if (buf.length === max) {
-      process.stdout.write(ansi.eraseLines(max + 1));
-      buf.shift();
-      buf.forEach((line) => console.log(line));
+      process.stdout.write(ansi.eraseLines(max + 1))
+      buf.shift()
+      buf.forEach(line => console.log(line))
     }
 
-    buf.push(str);
-    console.log(str);
+    buf.push(str)
+    console.log(str)
   }
 
-  reset () {
-    this.buf = [];
+  reset() {
+    this.buf = []
   }
 
 }

--- a/lib/build-logger.js
+++ b/lib/build-logger.js
@@ -1,7 +1,33 @@
+import EventEmitter from 'events'
 import ansi from 'ansi-escapes'
 import io from 'socket.io-client'
 import chalk from 'chalk'
-import EventEmitter from 'events'
+
+class Lines {
+
+  constructor(maxLines = 100) {
+    this.max = maxLines
+    this.buf = []
+  }
+
+  write(str) {
+    const {max, buf} = this
+
+    if (buf.length === max) {
+      process.stdout.write(ansi.eraseLines(max + 1))
+      buf.shift()
+      buf.forEach(line => console.log(line))
+    }
+
+    buf.push(str)
+    console.log(str)
+  }
+
+  reset() {
+    this.buf = []
+  }
+
+}
 
 export default class Logger extends EventEmitter {
 
@@ -54,21 +80,23 @@ export default class Logger extends EventEmitter {
       this.building = true
     }
 
-    if (this.quiet) return
+    if (this.quiet) {
+      return
+    }
 
-    if ('command' === log.type) {
+    if (log.type === 'command') {
       console.log(`${chalk.gray('>')} ▲ ${log.data}`)
       this.lines.reset()
-    } else if ('stderr' === log.type) {
+    } else if (log.type === 'stderr') {
       log.data.split('\n').forEach(v => {
-        if (v.length) {
+        if (v.length > 0) {
           console.error(chalk.red(`> ${v}`))
         }
       })
       this.lines.reset()
-    } else if ('stdout' === log.type) {
+    } else if (log.type === 'stdout') {
       log.data.split('\n').forEach(v => {
-        if (v.length) {
+        if (v.length > 0) {
           this.lines.write(`${chalk.gray('>')} ${v}`)
         }
       })
@@ -89,32 +117,6 @@ export default class Logger extends EventEmitter {
     if (this.debug) {
       console.log('> [debug] Socket error', err.stack)
     }
-  }
-
-}
-
-class Lines {
-
-  constructor(maxLines = 100) {
-    this.max = maxLines
-    this.buf = []
-  }
-
-  write(str) {
-    const {max, buf} = this
-
-    if (buf.length === max) {
-      process.stdout.write(ansi.eraseLines(max + 1))
-      buf.shift()
-      buf.forEach(line => console.log(line))
-    }
-
-    buf.push(str)
-    console.log(str)
-  }
-
-  reset() {
-    this.buf = []
   }
 
 }

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -1,6 +1,6 @@
+import {homedir} from 'os'
 import path from 'path'
 import fs from 'fs-promise'
-import {homedir} from 'os'
 
 let file = process.env.NOW_JSON ? path.resolve(process.env.NOW_JSON) : path.resolve(homedir(), '.now.json')
 

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -1,20 +1,20 @@
-import path from 'path';
-import fs from 'fs-promise';
-import { homedir } from 'os';
+import path from 'path'
+import fs from 'fs-promise'
+import {homedir} from 'os'
 
-let file = process.env.NOW_JSON ? path.resolve(process.env.NOW_JSON) : path.resolve(homedir(), '.now.json');
+let file = process.env.NOW_JSON ? path.resolve(process.env.NOW_JSON) : path.resolve(homedir(), '.now.json')
 
-export function setConfigFile (nowjson) {
-  file = path.resolve(nowjson);
+export function setConfigFile(nowjson) {
+  file = path.resolve(nowjson)
 }
 
-export function read () {
-  let existing = null;
+export function read() {
+  let existing = null
   try {
-    existing = fs.readFileSync(file, 'utf8');
-    existing = JSON.parse(existing);
+    existing = fs.readFileSync(file, 'utf8')
+    existing = JSON.parse(existing)
   } catch (err) {}
-  return existing || {};
+  return existing || {}
 }
 
 /**
@@ -25,7 +25,7 @@ export function read () {
  * @param {Object} data
  */
 
-export function merge (data) {
-  const cfg = Object.assign({}, read(), data);
-  fs.writeFileSync(file, JSON.stringify(cfg, null, 2));
+export function merge(data) {
+  const cfg = Object.assign({}, read(), data)
+  fs.writeFileSync(file, JSON.stringify(cfg, null, 2))
 }

--- a/lib/check-update.js
+++ b/lib/check-update.js
@@ -32,7 +32,7 @@ export default function checkUpdate(opts = {}) {
     process.on('SIGINT', () => {
       // clean up output after ^C
       process.stdout.write('\n')
-      process.exit(1)
+      process.exit(1) // eslint-disable-line xo/no-process-exit
     })
   }, err => console.error(err.stack))
 

--- a/lib/check-update.js
+++ b/lib/check-update.js
@@ -1,81 +1,81 @@
-import ms from 'ms';
-import pkg from '../../package'; // relative to `build/` :\
-import fetch from 'node-fetch';
-import chalk from 'chalk';
-import compare from 'semver-compare';
+import ms from 'ms'
+import pkg from '../../package' // relative to `build/` :\
+import fetch from 'node-fetch'
+import chalk from 'chalk'
+import compare from 'semver-compare'
 
-const isTTY = process.stdout.isTTY;
+const isTTY = process.stdout.isTTY
 
 // if we're not in a tty the update checker
 // will always return a resolved promise
-const resolvedPromise = new Promise((resolve, reject) => resolve());
+const resolvedPromise = new Promise((resolve, reject) => resolve())
 
 /**
  * Configures auto updates.
  * Sets up a `exit` listener to report them.
  */
 
-export default function checkUpdate (opts = {}) {
+export default function checkUpdate(opts = {}) {
   if (!isTTY) {
     // don't attempt to check for updates
     // if the user is piping or redirecting
-    return resolvedPromise;
+    return resolvedPromise
   }
 
-  let updateData;
+  let updateData
 
-  const update = check(opts).then((data) => {
-    updateData = data;
+  const update = check(opts).then(data => {
+    updateData = data
 
     // forces the `exit` event upon Ctrl + C
     process.on('SIGINT', () => {
       // clean up output after ^C
-      process.stdout.write('\n');
-      process.exit(1);
-    });
-  }, (err) => console.error(err.stack));
+      process.stdout.write('\n')
+      process.exit(1)
+    })
+  }, err => console.error(err.stack))
 
-  process.on('exit', (code) => {
+  process.on('exit', code => {
     if (updateData) {
-      const { current, latest, at } = updateData;
-      const ago = ms(Date.now() - at);
+      const {current, latest, at} = updateData
+      const ago = ms(Date.now() - at)
       console.log(`> ${chalk.white.bgRed('UPDATE NEEDED')} ` +
         `Current: ${current} – ` +
-        `Latest ${chalk.bold(latest)} (released ${ago} ago)`);
-      console.log('> Run `npm install -g now` to update');
+        `Latest ${chalk.bold(latest)} (released ${ago} ago)`)
+      console.log('> Run `npm install -g now` to update')
     }
-  });
+  })
 
-  return update;
+  return update
 }
 
-function check ({ debug = false }) {
+function check({debug = false}) {
   return new Promise((resolve, reject) => {
-    if (debug) console.log('> [debug] Checking for updates.');
+    if (debug) console.log('> [debug] Checking for updates.')
 
-    fetch('https://registry.npmjs.org/now').then((res) => {
+    fetch('https://registry.npmjs.org/now').then(res => {
       if (200 !== res.status) {
-        if (debug) console.log(`> [debug] Update check error. NPM ${res.status}.`);
-        resolve(false);
-        return;
+        if (debug) console.log(`> [debug] Update check error. NPM ${res.status}.`)
+        resolve(false)
+        return
       }
 
-      res.json().then((data) => {
-        const { latest } = data['dist-tags'];
-        const current = pkg.version;
+      res.json().then(data => {
+        const {latest} = data['dist-tags']
+        const current = pkg.version
 
         if (1 === compare(latest, pkg.version)) {
-          if (debug) console.log(`> [debug] Needs update. Current ${current}, latest ${latest}`);
+          if (debug) console.log(`> [debug] Needs update. Current ${current}, latest ${latest}`)
           resolve({
             latest,
             current,
             at: new Date(data.time[latest])
-          });
+          })
         } else {
-          if (debug) console.log(`> [debug] Up to date (${pkg.version}).`);
-          resolve(false);
+          if (debug) console.log(`> [debug] Up to date (${pkg.version}).`)
+          resolve(false)
         }
-      }, () => resolve(false));
-    }, () => resolve(false));
-  });
+      }, () => resolve(false))
+    }, () => resolve(false))
+  })
 }

--- a/lib/check-update.js
+++ b/lib/check-update.js
@@ -1,14 +1,15 @@
 import ms from 'ms'
-import pkg from '../../package' // relative to `build/` :\
 import fetch from 'node-fetch'
 import chalk from 'chalk'
 import compare from 'semver-compare'
+// eslint-disable-next-line import/no-unresolved
+import pkg from '../../package' // relative to `build/` :\
 
 const isTTY = process.stdout.isTTY
 
 // if we're not in a tty the update checker
 // will always return a resolved promise
-const resolvedPromise = new Promise((resolve, reject) => resolve())
+const resolvedPromise = Promise.resolve()
 
 /**
  * Configures auto updates.
@@ -35,7 +36,7 @@ export default function checkUpdate(opts = {}) {
     })
   }, err => console.error(err.stack))
 
-  process.on('exit', code => {
+  process.on('exit', () => {
     if (updateData) {
       const {current, latest, at} = updateData
       const ago = ms(Date.now() - at)
@@ -50,12 +51,16 @@ export default function checkUpdate(opts = {}) {
 }
 
 function check({debug = false}) {
-  return new Promise((resolve, reject) => {
-    if (debug) console.log('> [debug] Checking for updates.')
+  return new Promise(resolve => {
+    if (debug) {
+      console.log('> [debug] Checking for updates.')
+    }
 
     fetch('https://registry.npmjs.org/now').then(res => {
-      if (200 !== res.status) {
-        if (debug) console.log(`> [debug] Update check error. NPM ${res.status}.`)
+      if (res.status !== 200) {
+        if (debug) {
+          console.log(`> [debug] Update check error. NPM ${res.status}.`)
+        }
         resolve(false)
         return
       }
@@ -64,15 +69,19 @@ function check({debug = false}) {
         const {latest} = data['dist-tags']
         const current = pkg.version
 
-        if (1 === compare(latest, pkg.version)) {
-          if (debug) console.log(`> [debug] Needs update. Current ${current}, latest ${latest}`)
+        if (compare(latest, pkg.version) === 1) {
+          if (debug) {
+            console.log(`> [debug] Needs update. Current ${current}, latest ${latest}`)
+          }
           resolve({
             latest,
             current,
             at: new Date(data.time[latest])
           })
         } else {
-          if (debug) console.log(`> [debug] Up to date (${pkg.version}).`)
+          if (debug) {
+            console.log(`> [debug] Up to date (${pkg.version}).`)
+          }
           resolve(false)
         }
       }, () => resolve(false))

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,10 +1,10 @@
-import { copy as _copy } from 'copy-paste';
+import {copy as _copy} from 'copy-paste'
 
-export default function copy (text) {
+export default function copy(text) {
   return new Promise((resolve, reject) => {
-    _copy(text, (err) => {
-      if (err) return reject(err);
-      resolve();
-    });
-  });
+    _copy(text, err => {
+      if (err) return reject(err)
+      resolve()
+    })
+  })
 }

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -3,7 +3,9 @@ import {copy as _copy} from 'copy-paste'
 export default function copy(text) {
   return new Promise((resolve, reject) => {
     _copy(text, err => {
-      if (err) return reject(err)
+      if (err) {
+        return reject(err)
+      }
       resolve()
     })
   })

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -1,10 +1,10 @@
-import dns from 'dns';
+import dns from 'dns'
 
-export function resolve4 (host) {
+export function resolve4(host) {
   return new Promise((resolve, reject) => {
     return dns.resolve4(host, (err, answer) => {
-      if (err) return reject(err);
-      resolve(answer);
-    });
-  });
+      if (err) return reject(err)
+      resolve(answer)
+    })
+  })
 }

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -1,9 +1,11 @@
 import dns from 'dns'
 
-export function resolve4(host) {
+export default function resolve4(host) {
   return new Promise((resolve, reject) => {
     return dns.resolve4(host, (err, answer) => {
-      if (err) return reject(err)
+      if (err) {
+        return reject(err)
+      }
       resolve(answer)
     })
   })

--- a/lib/domains.js
+++ b/lib/domains.js
@@ -1,66 +1,66 @@
-import Now from '../lib';
-import isZeitWorld from './is-zeit-world';
-import chalk from 'chalk';
-import { DNS_VERIFICATION_ERROR } from './errors';
+import Now from '../lib'
+import isZeitWorld from './is-zeit-world'
+import chalk from 'chalk'
+import {DNS_VERIFICATION_ERROR} from './errors'
 
-const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/;
+const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
 
 export default class Domains extends Now {
 
-  async ls () {
+  async ls() {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} GET /domains`);
-      const res = await this._fetch('/domains');
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /domains`);
-      const body = await res.json();
-      return body.domains;
-    });
+      if (this._debug) console.time(`> [debug] #${attempt} GET /domains`)
+      const res = await this._fetch('/domains')
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /domains`)
+      const body = await res.json()
+      return body.domains
+    })
   }
 
-  async rm (name) {
+  async rm(name) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} DELETE /domains/${name}`);
-      const res = await this._fetch(`/domains/${name}`, { method: 'DELETE' });
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /domains/${name}`);
+      if (this._debug) console.time(`> [debug] #${attempt} DELETE /domains/${name}`)
+      const res = await this._fetch(`/domains/${name}`, {method: 'DELETE'})
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /domains/${name}`)
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
       if (res.status !== 200) {
-        const body = await res.json();
-        throw new Error(body.error.message);
+        const body = await res.json()
+        throw new Error(body.error.message)
       }
-    });
+    })
   }
 
-  async add (domain) {
+  async add(domain) {
     if (!domainRegex.test(domain)) {
-      const err = new Error(`The supplied value ${chalk.bold(`"${domain}"`)} is not a valid domain.`);
-      err.userError = true;
-      throw err;
+      const err = new Error(`The supplied value ${chalk.bold(`"${domain}"`)} is not a valid domain.`)
+      err.userError = true
+      throw err
     }
 
-    let ns;
+    let ns
 
     try {
-      console.log('> Verifying nameservers…');
-      const res = await this.getNameservers(domain);
-      ns = res.nameservers;
+      console.log('> Verifying nameservers…')
+      const res = await this.getNameservers(domain)
+      ns = res.nameservers
     } catch (err) {
-      const err2 = new Error(`Unable to fetch nameservers for ${chalk.underline(chalk.bold(domain))}.`);
-      err2.userError = true;
-      throw err2;
+      const err2 = new Error(`Unable to fetch nameservers for ${chalk.underline(chalk.bold(domain))}.`)
+      err2.userError = true
+      throw err2
     }
 
     if (isZeitWorld(ns)) {
-      console.log(`> Verification ${chalk.bold('OK')}!`);
-      return this.setupDomain(domain);
+      console.log(`> Verification ${chalk.bold('OK')}!`)
+      return this.setupDomain(domain)
     } else {
-      if (this._debug) console.log(`> [debug] Supplied domain "${domain}" has non-zeit nameservers`);
-      const err3 = new Error(DNS_VERIFICATION_ERROR);
-      err3.userError = true;
-      throw err3;
+      if (this._debug) console.log(`> [debug] Supplied domain "${domain}" has non-zeit nameservers`)
+      const err3 = new Error(DNS_VERIFICATION_ERROR)
+      err3.userError = true
+      throw err3
     }
   }
 

--- a/lib/domains.js
+++ b/lib/domains.js
@@ -1,6 +1,6 @@
+import chalk from 'chalk'
 import Now from '../lib'
 import isZeitWorld from './is-zeit-world'
-import chalk from 'chalk'
 import {DNS_VERIFICATION_ERROR} from './errors'
 
 const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
@@ -9,9 +9,13 @@ export default class Domains extends Now {
 
   async ls() {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} GET /domains`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} GET /domains`)
+      }
       const res = await this._fetch('/domains')
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /domains`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} GET /domains`)
+      }
       const body = await res.json()
       return body.domains
     })
@@ -19,11 +23,15 @@ export default class Domains extends Now {
 
   async rm(name) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} DELETE /domains/${name}`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} DELETE /domains/${name}`)
+      }
       const res = await this._fetch(`/domains/${name}`, {method: 'DELETE'})
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /domains/${name}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} DELETE /domains/${name}`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
@@ -56,12 +64,13 @@ export default class Domains extends Now {
     if (isZeitWorld(ns)) {
       console.log(`> Verification ${chalk.bold('OK')}!`)
       return this.setupDomain(domain)
-    } else {
-      if (this._debug) console.log(`> [debug] Supplied domain "${domain}" has non-zeit nameservers`)
-      const err3 = new Error(DNS_VERIFICATION_ERROR)
-      err3.userError = true
-      throw err3
     }
+    if (this._debug) {
+      console.log(`> [debug] Supplied domain "${domain}" has non-zeit nameservers`)
+    }
+    const err3 = new Error(DNS_VERIFICATION_ERROR)
+    err3.userError = true
+    throw err3
   }
 
 }

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,26 +1,26 @@
-import ms from 'ms';
-import chalk from 'chalk';
+import ms from 'ms'
+import chalk from 'chalk'
 
-export function handleError (err) {
+export function handleError(err) {
   if (403 === err.status) {
-    error('Authentication error. Run `now -L` or `now --login` to log-in again.');
+    error('Authentication error. Run `now -L` or `now --login` to log-in again.')
   } else if (429 === err.status) {
     if (null != err.retryAfter) {
       error('Rate limit exceeded error. Try again in ' +
-          ms(err.retryAfter * 1000, { long: true }) +
-          ', or upgrade your account: https://zeit.co/now#pricing');
+          ms(err.retryAfter * 1000, {long: true}) +
+          ', or upgrade your account: https://zeit.co/now#pricing')
     } else {
-      error('Rate limit exceeded error. Please try later.');
+      error('Rate limit exceeded error. Please try later.')
     }
   } else if (err.userError) {
-    error(err.message);
+    error(err.message)
   } else if (500 === err.status) {
-    error('Unexpected server error. Please retry.');
+    error('Unexpected server error. Please retry.')
   } else {
-    error(`Unexpected error. Please try later. (${err.message})`);
+    error(`Unexpected error. Please try later. (${err.message})`)
   }
 }
 
-export function error (err) {
-  console.error(`> ${chalk.red('Error!')} ${err}`);
+export function error(err) {
+  console.error(`> ${chalk.red('Error!')} ${err}`)
 }

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,19 +2,19 @@ import ms from 'ms'
 import chalk from 'chalk'
 
 export function handleError(err) {
-  if (403 === err.status) {
+  if (err.status === 403) {
     error('Authentication error. Run `now -L` or `now --login` to log-in again.')
-  } else if (429 === err.status) {
-    if (null != err.retryAfter) {
-      error('Rate limit exceeded error. Try again in ' +
-          ms(err.retryAfter * 1000, {long: true}) +
-          ', or upgrade your account: https://zeit.co/now#pricing')
-    } else {
+  } else if (err.status === 429) {
+    if (err.retryAfter == null) {
       error('Rate limit exceeded error. Please try later.')
+    } else {
+      error('Rate limit exceeded error. Try again in ' +
+      ms(err.retryAfter * 1000, {long: true}) +
+      ', or upgrade your account: https://zeit.co/now#pricing')
     }
   } else if (err.userError) {
     error(err.message)
-  } else if (500 === err.status) {
+  } else if (err.status === 500) {
     error('Unexpected server error. Please retry.')
   } else {
     error(`Unexpected error. Please try later. (${err.message})`)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,11 +1,11 @@
-import chalk from 'chalk';
+import chalk from 'chalk'
 
 export const DNS_VERIFICATION_ERROR = `Please make sure that your nameservers point to ${chalk.underline('zeit.world')}.
 > Examples: (full list at ${chalk.underline('https://zeit.world')})
 > ${chalk.gray('-')} ${chalk.underline('california.zeit.world')}    ${chalk.dim('173.255.215.107')}
 > ${chalk.gray('-')} ${chalk.underline('newark.zeit.world')}        ${chalk.dim('173.255.231.87')}
 > ${chalk.gray('-')} ${chalk.underline('london.zeit.world')}        ${chalk.dim('178.62.47.76')}
-> ${chalk.gray('-')} ${chalk.underline('singapore.zeit.world')}     ${chalk.dim('119.81.97.170')}`;
+> ${chalk.gray('-')} ${chalk.underline('singapore.zeit.world')}     ${chalk.dim('119.81.97.170')}`
 
 export const DOMAIN_VERIFICATION_ERROR = DNS_VERIFICATION_ERROR +
-`\n> Alternatively, ensure it resolves to ${chalk.underline('alias.zeit.co')} via ${chalk.dim('CNAME')} / ${chalk.dim('ALIAS')}.`;
+`\n> Alternatively, ensure it resolves to ${chalk.underline('alias.zeit.co')} via ${chalk.dim('CNAME')} / ${chalk.dim('ALIAS')}.`

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -1,9 +1,9 @@
-import flatten from 'arr-flatten';
-import unique from 'array-unique';
-import IGNORED from './ignored';
-import { resolve } from 'path';
-import { stat, readdir, readFile } from 'fs-promise';
-import ignore from 'ignore';
+import flatten from 'arr-flatten'
+import unique from 'array-unique'
+import IGNORED from './ignored'
+import {resolve} from 'path'
+import {stat, readdir, readFile} from 'fs-promise'
+import ignore from 'ignore'
 
 /**
  * Returns a list of files in the given
@@ -18,58 +18,58 @@ import ignore from 'ignore';
  * @return {Array} comprehensive list of paths to sync
  */
 
-export async function npm (path, pkg, {
+export async function npm(path, pkg, {
   limit = null,
   debug = false
 } = {}) {
   const whitelist = pkg.now && pkg.now.files
     ? pkg.now.files
-    : pkg.files;
+    : pkg.files
 
   // the package.json `files` whitelist still
   // honors ignores: https://docs.npmjs.com/files/package.json#files
-  const search_ = whitelist || ['.'];
+  const search_ = whitelist || ['.']
 
   // always include the "main" file
   if (pkg.main) {
-    search_.push(pkg.main);
+    search_.push(pkg.main)
   }
 
   // convert all filenames into absolute paths
-  const search = search_.map((file) => asAbsolute(file, path));
+  const search = search_.map(file => asAbsolute(file, path))
 
   // compile list of ignored patterns and files
-  const npmIgnore = await maybeRead(resolve(path, '.npmignore'), null);
+  const npmIgnore = await maybeRead(resolve(path, '.npmignore'), null)
   const filter = ignore().add(
     IGNORED +
     '\n' +
     clearRelative(null != npmIgnore
       ? npmIgnore
       : await maybeRead(resolve(path, '.gitignore')))
-  ).createFilter();
+  ).createFilter()
 
-  const prefixLength = path.length + 1;
+  const prefixLength = path.length + 1
   const accepts = function (file) {
-    const relativePath = file.substr(prefixLength);
-    if ('' === relativePath) return true;
-    const accepted = filter(relativePath);
+    const relativePath = file.substr(prefixLength)
+    if ('' === relativePath) return true
+    const accepted = filter(relativePath)
     if (!accepted && debug) {
-      console.log('> [debug] ignoring "%s"', file);
+      console.log('> [debug] ignoring "%s"', file)
     }
-    return accepted;
-  };
+    return accepted
+  }
 
   // locate files
-  if (debug) console.time(`> [debug] locating files ${path}`);
-  const files = await explode(search, { accepts, limit, debug });
-  if (debug) console.timeEnd(`> [debug] locating files ${path}`);
+  if (debug) console.time(`> [debug] locating files ${path}`)
+  const files = await explode(search, {accepts, limit, debug})
+  if (debug) console.timeEnd(`> [debug] locating files ${path}`)
 
   // always include manifest as npm does not allow ignoring it
   // source: https://docs.npmjs.com/files/package.json#files
-  files.push(asAbsolute('package.json', path));
+  files.push(asAbsolute('package.json', path))
 
   // get files
-  return unique(files);
+  return unique(files)
 }
 
 /**
@@ -85,45 +85,45 @@ export async function npm (path, pkg, {
  * @return {Array} comprehensive list of paths to sync
  */
 
-export async function docker (path, {
+export async function docker(path, {
   limit = null,
   debug = false
 } = {}) {
   // base search path
-  const search_ = ['.'];
+  const search_ = ['.']
 
   // convert all filenames into absolute paths
-  const search = search_.map((file) => asAbsolute(file, path));
+  const search = search_.map(file => asAbsolute(file, path))
 
   // compile list of ignored patterns and files
   const filter = ignore().add(
     IGNORED +
     '\n' +
     await maybeRead(resolve(path, '.dockerignore'))
-  ).createFilter();
+  ).createFilter()
 
-  const prefixLength = path.length + 1;
+  const prefixLength = path.length + 1
   const accepts = function (file) {
-    const relativePath = file.substr(prefixLength);
-    if ('' === relativePath) return true;
-    const accepted = filter(relativePath);
+    const relativePath = file.substr(prefixLength)
+    if ('' === relativePath) return true
+    const accepted = filter(relativePath)
     if (!accepted && debug) {
-      console.log('> [debug] ignoring "%s"', file);
+      console.log('> [debug] ignoring "%s"', file)
     }
-    return accepted;
-  };
+    return accepted
+  }
 
   // locate files
-  if (debug) console.time(`> [debug] locating files ${path}`);
-  const files = await explode(search, { accepts, limit, debug });
-  if (debug) console.timeEnd(`> [debug] locating files ${path}`);
+  if (debug) console.time(`> [debug] locating files ${path}`)
+  const files = await explode(search, {accepts, limit, debug})
+  if (debug) console.timeEnd(`> [debug] locating files ${path}`)
 
   // always include manifest as npm does not allow ignoring it
   // source: https://docs.npmjs.com/files/package.json#files
-  files.push(asAbsolute('Dockerfile', path));
+  files.push(asAbsolute('Dockerfile', path))
 
   // get files
-  return unique(files);
+  return unique(files)
 }
 
 /**
@@ -135,9 +135,9 @@ export async function docker (path, {
  */
 
 const asAbsolute = function (path, parent) {
-  if ('/' === path[0]) return path;
-  return resolve(parent, path);
-};
+  if ('/' === path[0]) return path
+  return resolve(parent, path)
+}
 
 /**
  * Explodes directories into a full list of files.
@@ -153,45 +153,45 @@ const asAbsolute = function (path, parent) {
  * @return {Array} of {String}s of full paths
  */
 
-const explode = async function (paths, { accepts, limit, debug }) {
-  const many = async (all) => {
-    return await Promise.all(all.map(async (file) => {
-      return await list(file);
-    }));
-  };
+const explode = async function (paths, {accepts, limit, debug}) {
+  const many = async all => {
+    return await Promise.all(all.map(async file => {
+      return await list(file)
+    }))
+  }
 
-  const list = async (file) => {
-    let path = file;
-    let s;
+  const list = async file => {
+    let path = file
+    let s
 
     if (!accepts(file)) {
-      return null;
+      return null
     }
 
     try {
-      s = await stat(path);
+      s = await stat(path)
     } catch (e) {
       // in case the file comes from `files` or `main`
       // and it wasn't specified with `.js` by the user
-      path = file + '.js';
+      path = file + '.js'
 
       try {
-        s = await stat(path);
+        s = await stat(path)
       } catch (e2) {
-        return null;
+        return null
       }
     }
 
     if (s.isDirectory()) {
-      const all = await readdir(file);
-      return many(all.map(subdir => asAbsolute(subdir, file)));
+      const all = await readdir(file)
+      return many(all.map(subdir => asAbsolute(subdir, file)))
     } else {
-      return path;
+      return path
     }
-  };
+  }
 
-  return flatten((await many(paths))).filter((v) => null !== v);
-};
+  return flatten((await many(paths))).filter(v => null !== v)
+}
 
 /**
  * Returns the contents of a file if it exists.
@@ -201,11 +201,11 @@ const explode = async function (paths, { accepts, limit, debug }) {
 
 const maybeRead = async function (path, default_ = '') {
   try {
-    return (await readFile(path, 'utf8'));
+    return (await readFile(path, 'utf8'))
   } catch (e) {
-    return default_;
+    return default_
   }
-};
+}
 
 /**
  * Remove leading `./` from the beginning of ignores
@@ -213,5 +213,5 @@ const maybeRead = async function (path, default_ = '') {
  */
 
 const clearRelative = function (str) {
-  return str.replace(/(\n|^)\.\//g, '$1');
-};
+  return str.replace(/(\n|^)\.\//g, '$1')
+}

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -1,9 +1,100 @@
+import {resolve} from 'path'
+import ignore from 'ignore'
 import flatten from 'arr-flatten'
 import unique from 'array-unique'
-import IGNORED from './ignored'
-import {resolve} from 'path'
 import {stat, readdir, readFile} from 'fs-promise'
-import ignore from 'ignore'
+import IGNORED from './ignored'
+
+/**
+ * Transform relative paths into absolutes,
+ * and maintains absolutes as such.
+ *
+ * @param {String} maybe relative path
+ * @param {String} parent full path
+ */
+
+const asAbsolute = function (path, parent) {
+  if (path[0] === '/') {
+    return path
+  }
+  return resolve(parent, path)
+}
+
+/**
+ * Returns the contents of a file if it exists.
+ *
+ * @return {String} results or `''`
+ */
+
+const maybeRead = async function (path, default_ = '') {
+  try {
+    return (await readFile(path, 'utf8'))
+  } catch (err) {
+    return default_
+  }
+}
+
+/**
+ * Remove leading `./` from the beginning of ignores
+ * because our parser doesn't like them :|
+ */
+
+const clearRelative = function (str) {
+  return str.replace(/(\n|^)\.\//g, '$1')
+}
+
+/**
+ * Explodes directories into a full list of files.
+ * Eg:
+ *   in:  ['/a.js', '/b']
+ *   out: ['/a.js', '/b/c.js', '/b/d.js']
+ *
+ * @param {Array} of {String}s representing paths
+ * @param {Array} of ignored {String}s.
+ * @param {Object} options:
+ *  - `limit` {Number|null} byte limit
+ *  - `debug` {Boolean} warn upon ignore
+ * @return {Array} of {String}s of full paths
+ */
+
+const explode = async function (paths, {accepts}) {
+  const many = async all => {
+    return await Promise.all(all.map(async file => {
+      return await list(file)
+    }))
+  }
+
+  async function list(file) {
+    let path = file
+    let s
+
+    if (!accepts(file)) {
+      return null
+    }
+
+    try {
+      s = await stat(path)
+    } catch (e) {
+      // in case the file comes from `files` or `main`
+      // and it wasn't specified with `.js` by the user
+      path = file + '.js'
+
+      try {
+        s = await stat(path)
+      } catch (e2) {
+        return null
+      }
+    }
+
+    if (s.isDirectory()) {
+      const all = await readdir(file)
+      return many(all.map(subdir => asAbsolute(subdir, file)))
+    }
+    return path
+  }
+
+  return flatten((await many(paths))).filter(v => v !== null)
+}
 
 /**
  * Returns a list of files in the given
@@ -22,9 +113,9 @@ export async function npm(path, pkg, {
   limit = null,
   debug = false
 } = {}) {
-  const whitelist = pkg.now && pkg.now.files
-    ? pkg.now.files
-    : pkg.files
+  const whitelist = pkg.now && pkg.now.files ?
+    pkg.now.files :
+    pkg.files
 
   // the package.json `files` whitelist still
   // honors ignores: https://docs.npmjs.com/files/package.json#files
@@ -43,15 +134,17 @@ export async function npm(path, pkg, {
   const filter = ignore().add(
     IGNORED +
     '\n' +
-    clearRelative(null != npmIgnore
-      ? npmIgnore
-      : await maybeRead(resolve(path, '.gitignore')))
+    clearRelative(npmIgnore == null ?
+      await maybeRead(resolve(path, '.gitignore')) :
+      npmIgnore)
   ).createFilter()
 
   const prefixLength = path.length + 1
   const accepts = function (file) {
     const relativePath = file.substr(prefixLength)
-    if ('' === relativePath) return true
+    if (relativePath === '') {
+      return true
+    }
     const accepted = filter(relativePath)
     if (!accepted && debug) {
       console.log('> [debug] ignoring "%s"', file)
@@ -60,9 +153,13 @@ export async function npm(path, pkg, {
   }
 
   // locate files
-  if (debug) console.time(`> [debug] locating files ${path}`)
+  if (debug) {
+    console.time(`> [debug] locating files ${path}`)
+  }
   const files = await explode(search, {accepts, limit, debug})
-  if (debug) console.timeEnd(`> [debug] locating files ${path}`)
+  if (debug) {
+    console.timeEnd(`> [debug] locating files ${path}`)
+  }
 
   // always include manifest as npm does not allow ignoring it
   // source: https://docs.npmjs.com/files/package.json#files
@@ -105,7 +202,9 @@ export async function docker(path, {
   const prefixLength = path.length + 1
   const accepts = function (file) {
     const relativePath = file.substr(prefixLength)
-    if ('' === relativePath) return true
+    if (relativePath === '') {
+      return true
+    }
     const accepted = filter(relativePath)
     if (!accepted && debug) {
       console.log('> [debug] ignoring "%s"', file)
@@ -114,9 +213,13 @@ export async function docker(path, {
   }
 
   // locate files
-  if (debug) console.time(`> [debug] locating files ${path}`)
+  if (debug) {
+    console.time(`> [debug] locating files ${path}`)
+  }
   const files = await explode(search, {accepts, limit, debug})
-  if (debug) console.timeEnd(`> [debug] locating files ${path}`)
+  if (debug) {
+    console.timeEnd(`> [debug] locating files ${path}`)
+  }
 
   // always include manifest as npm does not allow ignoring it
   // source: https://docs.npmjs.com/files/package.json#files
@@ -124,94 +227,4 @@ export async function docker(path, {
 
   // get files
   return unique(files)
-}
-
-/**
- * Transform relative paths into absolutes,
- * and maintains absolutes as such.
- *
- * @param {String} maybe relative path
- * @param {String} parent full path
- */
-
-const asAbsolute = function (path, parent) {
-  if ('/' === path[0]) return path
-  return resolve(parent, path)
-}
-
-/**
- * Explodes directories into a full list of files.
- * Eg:
- *   in:  ['/a.js', '/b']
- *   out: ['/a.js', '/b/c.js', '/b/d.js']
- *
- * @param {Array} of {String}s representing paths
- * @param {Array} of ignored {String}s.
- * @param {Object} options:
- *  - `limit` {Number|null} byte limit
- *  - `debug` {Boolean} warn upon ignore
- * @return {Array} of {String}s of full paths
- */
-
-const explode = async function (paths, {accepts, limit, debug}) {
-  const many = async all => {
-    return await Promise.all(all.map(async file => {
-      return await list(file)
-    }))
-  }
-
-  const list = async file => {
-    let path = file
-    let s
-
-    if (!accepts(file)) {
-      return null
-    }
-
-    try {
-      s = await stat(path)
-    } catch (e) {
-      // in case the file comes from `files` or `main`
-      // and it wasn't specified with `.js` by the user
-      path = file + '.js'
-
-      try {
-        s = await stat(path)
-      } catch (e2) {
-        return null
-      }
-    }
-
-    if (s.isDirectory()) {
-      const all = await readdir(file)
-      return many(all.map(subdir => asAbsolute(subdir, file)))
-    } else {
-      return path
-    }
-  }
-
-  return flatten((await many(paths))).filter(v => null !== v)
-}
-
-/**
- * Returns the contents of a file if it exists.
- *
- * @return {String} results or `''`
- */
-
-const maybeRead = async function (path, default_ = '') {
-  try {
-    return (await readFile(path, 'utf8'))
-  } catch (e) {
-    return default_
-  }
-}
-
-/**
- * Remove leading `./` from the beginning of ignores
- * because our parser doesn't like them :|
- */
-
-const clearRelative = function (str) {
-  return str.replace(/(\n|^)\.\//g, '$1')
 }

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,5 +1,5 @@
-import { createHash } from 'crypto';
-import { readFile } from 'fs-promise';
+import {createHash} from 'crypto'
+import {readFile} from 'fs-promise'
 
 /**
  * Computes hashes for the contents of each file given.
@@ -8,19 +8,19 @@ import { readFile } from 'fs-promise';
  * @return {Map}
  */
 
-export default async function hashes (files) {
-  const map = new Map();
-  await Promise.all(files.map(async (name) => {
-    const data = await readFile(name);
-    const h = hash(data);
-    const entry = map.get(h);
+export default async function hashes(files) {
+  const map = new Map()
+  await Promise.all(files.map(async name => {
+    const data = await readFile(name)
+    const h = hash(data)
+    const entry = map.get(h)
     if (entry) {
-      entry.names.push(name);
+      entry.names.push(name)
     } else {
-      map.set(hash(data), { names: [name], data });
+      map.set(hash(data), {names: [name], data})
     }
-  }));
-  return map;
+  }))
+  return map
 }
 
 /**
@@ -30,8 +30,8 @@ export default async function hashes (files) {
  * @return {String} hex digest
  */
 
-function hash (buf) {
+function hash(buf) {
   return createHash('sha1')
     .update(buf)
-    .digest('hex');
+    .digest('hex')
 }

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -10,6 +10,7 @@ import {readFile} from 'fs-promise'
 
 export default async function hashes(files) {
   const map = new Map()
+  // eslint-disable-next-line array-callback-return
   await Promise.all(files.map(async name => {
     const data = await readFile(name)
     const h = hash(data)

--- a/lib/ignored.js
+++ b/lib/ignored.js
@@ -14,4 +14,4 @@ export default `.hg
 npm-debug.log
 config.gypi
 node_modules
-CVS`;
+CVS`

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,40 +1,40 @@
-import bytes from 'bytes';
-import chalk from 'chalk';
+import bytes from 'bytes'
+import chalk from 'chalk'
 import {
   npm as getNpmFiles,
   docker as getDockerFiles
-} from './get-files';
-import ua from './ua';
-import hash from './hash';
-import retry from 'async-retry';
-import Agent from './agent';
-import EventEmitter from 'events';
-import { basename, resolve as resolvePath } from 'path';
-import { homedir } from 'os';
-import { parse as parseIni } from 'ini';
-import { readFile } from 'fs-promise';
-import resumer from 'resumer';
-import splitArray from 'split-array';
-import { parse as parseDockerfile } from 'docker-file-parser';
+} from './get-files'
+import ua from './ua'
+import hash from './hash'
+import retry from 'async-retry'
+import Agent from './agent'
+import EventEmitter from 'events'
+import {basename, resolve as resolvePath} from 'path'
+import {homedir} from 'os'
+import {parse as parseIni} from 'ini'
+import {readFile} from 'fs-promise'
+import resumer from 'resumer'
+import splitArray from 'split-array'
+import {parse as parseDockerfile} from 'docker-file-parser'
 
 // how many concurrent HTTP/2 stream uploads
-const MAX_CONCURRENT = 10;
+const MAX_CONCURRENT = 10
 
 // check if running windows
-const IS_WIN = /^win/.test(process.platform);
-const SEP = IS_WIN ? '\\' : '/';
+const IS_WIN = /^win/.test(process.platform)
+const SEP = IS_WIN ? '\\' : '/'
 
 export default class Now extends EventEmitter {
-  constructor (url, token, { forceNew = false, debug = false }) {
-    super();
-    this._token = token;
-    this._debug = debug;
-    this._forceNew = forceNew;
-    this._agent = new Agent(url, { debug });
-    this._onRetry = this._onRetry.bind(this);
+  constructor(url, token, {forceNew = false, debug = false}) {
+    super()
+    this._token = token
+    this._debug = debug
+    this._forceNew = forceNew
+    this._agent = new Agent(url, {debug})
+    this._onRetry = this._onRetry.bind(this)
   }
 
-  async create (path, {
+  async create(path, {
     wantsPublic,
     quiet = false,
     env = {},
@@ -43,138 +43,138 @@ export default class Now extends EventEmitter {
     forwardNpm = false,
     deploymentType = 'npm'
   }) {
-    this._path = path;
+    this._path = path
 
-    let pkg = {};
-    let name, description, files;
+    let pkg = {}
+    let name, description, files
 
     if ('npm' === deploymentType) {
       try {
-        pkg = await readFile(resolvePath(path, 'package.json'));
-        pkg = JSON.parse(pkg);
+        pkg = await readFile(resolvePath(path, 'package.json'))
+        pkg = JSON.parse(pkg)
       } catch (err) {
-        const e = Error(`Failed to read JSON in "${path}/package.json"`);
-        e.userError = true;
-        throw e;
+        const e = Error(`Failed to read JSON in "${path}/package.json"`)
+        e.userError = true
+        throw e
       }
 
       if (!pkg.scripts || (!pkg.scripts.start && !pkg.scripts['now-start'])) {
         const e = Error('Missing `start` (or `now-start`) script in `package.json`. ' +
-          'See: https://docs.npmjs.com/cli/start.');
-        e.userError = true;
-        throw e;
+          'See: https://docs.npmjs.com/cli/start.')
+        e.userError = true
+        throw e
       }
 
       if (null == pkg.name || 'string' !== typeof pkg.name) {
-        name = basename(path);
-        if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`);
+        name = basename(path)
+        if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`)
       } else {
-        name = pkg.name;
+        name = pkg.name
       }
 
-      description = pkg.description;
+      description = pkg.description
 
-      if (this._debug) console.time('> [debug] Getting files');
-      files = await getNpmFiles(path, pkg, { debug: this._debug });
-      if (this._debug) console.timeEnd('> [debug] Getting files');
+      if (this._debug) console.time('> [debug] Getting files')
+      files = await getNpmFiles(path, pkg, {debug: this._debug})
+      if (this._debug) console.timeEnd('> [debug] Getting files')
     } else if ('docker' === deploymentType) {
-      let docker;
+      let docker
       try {
-        const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8');
-        docker = parseDockerfile(dockerfile, { includeComments: true });
+        const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8')
+        docker = parseDockerfile(dockerfile, {includeComments: true})
       } catch (err) {
-        const e = Error(`Failed to parse "${path}/Dockerfile"`);
-        e.userError = true;
-        throw e;
+        const e = Error(`Failed to parse "${path}/Dockerfile"`)
+        e.userError = true
+        throw e
       }
 
       if (!docker.length) {
-        const e = Error('No commands found in `Dockerfile`');
-        e.userError = true;
-        throw e;
+        const e = Error('No commands found in `Dockerfile`')
+        e.userError = true
+        throw e
       }
 
-      if (!docker.some((cmd) => 'CMD' === cmd.name)) {
+      if (!docker.some(cmd => 'CMD' === cmd.name)) {
         const e = Error('No `CMD` found in `Dockerfile`. ' +
-          'See: https://docs.docker.com/engine/reference/builder/#/cmd');
-        e.userError = true;
-        throw e;
+          'See: https://docs.docker.com/engine/reference/builder/#/cmd')
+        e.userError = true
+        throw e
       }
 
-      if (!docker.some((cmd) => 'EXPOSE' === cmd.name)) {
+      if (!docker.some(cmd => 'EXPOSE' === cmd.name)) {
         const e = Error('No `EXPOSE` found in `Dockerfile`. A port must be supplied. ' +
-          'See: https://docs.docker.com/engine/reference/builder/#/expose');
-        e.userError = true;
-        throw e;
+          'See: https://docs.docker.com/engine/reference/builder/#/expose')
+        e.userError = true
+        throw e
       }
 
-      const labels = {};
+      const labels = {}
       docker
       .filter(cmd => 'LABEL' === cmd.name)
-      .forEach(({ args }) => {
+      .forEach(({args}) => {
         for (let key in args) {
           // unescape and convert into string
           try {
-            labels[key] = JSON.parse(args[key]);
+            labels[key] = JSON.parse(args[key])
           } catch (err) {
-            const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``);
-            e.userError = true;
-            throw e;
+            const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``)
+            e.userError = true
+            throw e
           }
         }
-      });
+      })
 
       if (null == labels.name) {
-        name = basename(path);
-        if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`);
+        name = basename(path)
+        if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`)
       } else {
-        name = labels.name;
+        name = labels.name
       }
 
-      description = labels.description;
+      description = labels.description
 
-      if (this._debug) console.time('> [debug] Getting files');
-      files = await getDockerFiles(path, { debug: this._debug });
-      if (this._debug) console.timeEnd('> [debug] Getting files');
+      if (this._debug) console.time('> [debug] Getting files')
+      files = await getDockerFiles(path, {debug: this._debug})
+      if (this._debug) console.timeEnd('> [debug] Getting files')
     }
 
-    const nowProperties = pkg ? pkg.now || {} : {};
+    const nowProperties = pkg ? pkg.now || {} : {}
 
-    forwardNpm = forwardNpm || nowProperties['forwardNpm'];
+    forwardNpm = forwardNpm || nowProperties['forwardNpm']
 
     // Read .npmrc
-    let npmrc = {};
-    let authToken;
+    let npmrc = {}
+    let authToken
     if ('npm' === deploymentType && forwardNpm) {
       try {
-        npmrc = await readFile(resolvePath(path, '.npmrc'), 'utf8');
-        npmrc = parseIni(npmrc);
-        authToken = npmrc['//registry.npmjs.org/:_authToken'];
+        npmrc = await readFile(resolvePath(path, '.npmrc'), 'utf8')
+        npmrc = parseIni(npmrc)
+        authToken = npmrc['//registry.npmjs.org/:_authToken']
       } catch (err) {
         // Do nothing
       }
 
       if (!authToken) {
         try {
-          npmrc = await readFile(resolvePath(homedir(), '.npmrc'), 'utf8');
-          npmrc = parseIni(npmrc);
-          authToken = npmrc['//registry.npmjs.org/:_authToken'];
+          npmrc = await readFile(resolvePath(homedir(), '.npmrc'), 'utf8')
+          npmrc = parseIni(npmrc)
+          authToken = npmrc['//registry.npmjs.org/:_authToken']
         } catch (err) {
           // Do nothing
         }
       }
     }
 
-    if (this._debug) console.time('> [debug] Computing hashes');
-    const hashes = await hash(files);
-    if (this._debug) console.timeEnd('> [debug] Computing hashes');
+    if (this._debug) console.time('> [debug] Computing hashes')
+    const hashes = await hash(files)
+    if (this._debug) console.timeEnd('> [debug] Computing hashes')
 
-    this._files = hashes;
+    this._files = hashes
 
-    const engines = nowProperties.engines || pkg.engines;
+    const engines = nowProperties.engines || pkg.engines
 
-    const deployment = await this.retry(async (bail) => {
-      if (this._debug) console.time('> [debug] /now/create');
+    const deployment = await this.retry(async bail => {
+      if (this._debug) console.time('> [debug] /now/create')
       const res = await this._fetch('/now/create', {
         method: 'POST',
         body: {
@@ -188,107 +188,107 @@ export default class Now extends EventEmitter {
           registryAuthToken: authToken,
           // Flatten the array to contain files to sync where each nested input
           // array has a group of files with the same sha but different path
-          files: Array.prototype.concat.apply([], Array.from(this._files).map(([sha, { data, names }]) => {
-            return names.map((n) => {
+          files: Array.prototype.concat.apply([], Array.from(this._files).map(([sha, {data, names}]) => {
+            return names.map(n => {
               return {
                 sha,
                 size: data.length,
                 file: toRelative(n, this._path)
-              };
-            });
+              }
+            })
           })),
           engines
         }
-      });
-      if (this._debug) console.timeEnd('> [debug] /now/create');
+      })
+      if (this._debug) console.timeEnd('> [debug] /now/create')
 
       // no retry on 4xx
-      let body;
+      let body
       try {
-        body = await res.json();
+        body = await res.json()
       } catch (err) {
-        throw new Error('Unexpected response');
+        throw new Error('Unexpected response')
       }
 
       if (429 === res.status) {
-        return bail(responseError(res));
+        return bail(responseError(res))
       } else if (res.status >= 400 && res.status < 500) {
-        const err = new Error(body.error.message);
-        err.userError = true;
-        return bail(err);
+        const err = new Error(body.error.message)
+        err.userError = true
+        return bail(err)
       } else if (200 !== res.status) {
-        throw new Error(body.error.message);
+        throw new Error(body.error.message)
       }
 
-      return body;
-    });
+      return body
+    })
 
     // we report about files whose sizes are too big
-    let missingVersion = false;
+    let missingVersion = false
     if (deployment.warnings) {
-      let sizeExceeded = 0;
-      deployment.warnings.forEach((warning) => {
+      let sizeExceeded = 0
+      deployment.warnings.forEach(warning => {
         if ('size_limit_exceeded' === warning.reason) {
-          const { sha, limit } = warning;
-          const n = hashes.get(sha).names.pop();
+          const {sha, limit} = warning
+          const n = hashes.get(sha).names.pop()
           console.error('> \u001b[31mWarning!\u001b[39m Skipping file %s (size exceeded %s)',
             n,
             bytes(limit)
-          );
-          hashes.get(sha).names.unshift(n); // move name (hack, if duplicate matches we report them in order)
-          sizeExceeded++;
+          )
+          hashes.get(sha).names.unshift(n) // move name (hack, if duplicate matches we report them in order)
+          sizeExceeded++
         } else if ('node_version_not_found' === warning.reason) {
-          const { wanted, used } = warning;
+          const {wanted, used} = warning
           console.error('> \u001b[31mWarning!\u001b[39m Requested node version %s is not available',
             wanted,
             used
-          );
-          missingVersion = true;
+          )
+          missingVersion = true
         }
-      });
+      })
 
       if (sizeExceeded) {
         console.error(`> \u001b[31mWarning!\u001b[39m ${sizeExceeded} of the files ` +
           'exceeded the limit for your plan.\n' +
-          `> See ${chalk.underline('https://zeit.co/account')} to upgrade.`);
+          `> See ${chalk.underline('https://zeit.co/account')} to upgrade.`)
       }
     }
 
     if (!quiet && deployment.nodeVersion) {
       if (engines && engines.node) {
         if (missingVersion) {
-          console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`);
+          console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`)
         } else {
-          console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (requested: ${chalk.dim(`\`${engines.node}\``)})`);
+          console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (requested: ${chalk.dim(`\`${engines.node}\``)})`)
         }
       } else {
-        console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`);
+        console.log(`> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`)
       }
     }
 
-    this._id = deployment.deploymentId;
-    this._host = deployment.url;
-    this._missing = deployment.missing || [];
+    this._id = deployment.deploymentId
+    this._host = deployment.url
+    this._missing = deployment.missing || []
 
-    return this._url;
+    return this._url
   }
 
-  upload () {
-    const parts = splitArray(this._missing, MAX_CONCURRENT);
+  upload() {
+    const parts = splitArray(this._missing, MAX_CONCURRENT)
 
     if (this._debug) {
       console.log('> [debug] Will upload ' +
         `${this._missing.length} files in ${parts.length} ` +
-        `steps of ${MAX_CONCURRENT} uploads.`);
+        `steps of ${MAX_CONCURRENT} uploads.`)
     }
 
     const uploadChunk = () => {
-      Promise.all(parts.shift().map((sha) => retry(async (bail, attempt) => {
-        const file = this._files.get(sha);
-        const { data, names } = file;
+      Promise.all(parts.shift().map(sha => retry(async (bail, attempt) => {
+        const file = this._files.get(sha)
+        const {data, names} = file
 
-        if (this._debug) console.time(`> [debug] /sync #${attempt} ${names.join(' ')}`);
-        const stream = resumer().queue(data).end();
+        if (this._debug) console.time(`> [debug] /sync #${attempt} ${names.join(' ')}`)
+        const stream = resumer().queue(data).end()
         const res = await this._fetch('/now/sync', {
           method: 'POST',
           headers: {
@@ -296,241 +296,241 @@ export default class Now extends EventEmitter {
             'Content-Length': data.length,
             'x-now-deployment-id': this._id,
             'x-now-sha': sha,
-            'x-now-file': names.map((name) => toRelative(encodeURIComponent(name), this._path)).join(','),
+            'x-now-file': names.map(name => toRelative(encodeURIComponent(name), this._path)).join(','),
             'x-now-size': data.length
           },
           body: stream
-        });
-        if (this._debug) console.timeEnd(`> [debug] /sync #${attempt} ${names.join(' ')}`);
+        })
+        if (this._debug) console.timeEnd(`> [debug] /sync #${attempt} ${names.join(' ')}`)
 
         // no retry on 4xx
         if (200 !== res.status && (400 <= res.status || 500 > res.status)) {
-          if (this._debug) console.log('> [debug] bailing on creating due to %s', res.status);
-          return bail(responseError(res));
+          if (this._debug) console.log('> [debug] bailing on creating due to %s', res.status)
+          return bail(responseError(res))
         }
 
-        this.emit('upload', file);
-      }, { retries: 3, randomize: true, onRetry: this._onRetry })))
+        this.emit('upload', file)
+      }, {retries: 3, randomize: true, onRetry: this._onRetry})))
       .then(() => parts.length ? uploadChunk() : this.emit('complete'))
-      .catch((err) => this.emit('error', err));
-    };
+      .catch(err => this.emit('error', err))
+    }
 
-    uploadChunk();
+    uploadChunk()
   }
 
-  async listSecrets () {
+  async listSecrets() {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} GET /secrets`);
-      const res = await this._fetch('/now/secrets');
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /secrets`);
-      const body = await res.json();
-      return body.secrets;
-    });
+      if (this._debug) console.time(`> [debug] #${attempt} GET /secrets`)
+      const res = await this._fetch('/now/secrets')
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /secrets`)
+      const body = await res.json()
+      return body.secrets
+    })
   }
 
-  async list (app) {
-    const query = app ? `?app=${encodeURIComponent(app)}` : '';
+  async list(app) {
+    const query = app ? `?app=${encodeURIComponent(app)}` : ''
 
-    const { deployments } = await this.retry(async (bail) => {
-      if (this._debug) console.time('> [debug] /list');
-      const res = await this._fetch('/now/list' + query);
-      if (this._debug) console.timeEnd('> [debug] /list');
+    const {deployments} = await this.retry(async bail => {
+      if (this._debug) console.time('> [debug] /list')
+      const res = await this._fetch('/now/list' + query)
+      if (this._debug) console.timeEnd('> [debug] /list')
 
       // no retry on 4xx
       if (400 <= res.status && 500 > res.status) {
         if (this._debug) {
-          console.log('> [debug] bailing on listing due to %s', res.status);
+          console.log('> [debug] bailing on listing due to %s', res.status)
         }
-        return bail(responseError(res));
+        return bail(responseError(res))
       }
 
       if (200 !== res.status) {
-        throw new Error('Fetching deployment list failed');
+        throw new Error('Fetching deployment list failed')
       }
 
-      return res.json();
-    }, { retries: 3, minTimeout: 2500, onRetry: this._onRetry });
+      return res.json()
+    }, {retries: 3, minTimeout: 2500, onRetry: this._onRetry})
 
-    return deployments;
+    return deployments
   }
 
-  async listAliases (deploymentId) {
+  async listAliases(deploymentId) {
     return this.retry(async (bail, attempt) => {
       const res = await this._fetch(deploymentId
         ? `/now/deployments/${deploymentId}/aliases`
-        : '/now/aliases');
-      const body = await res.json();
-      return body.aliases;
-    });
+        : '/now/aliases')
+      const body = await res.json()
+      return body.aliases
+    })
   }
 
-  getNameservers (domain) {
+  getNameservers(domain) {
     return new Promise((resolve, reject) => {
-      let fallback = false;
+      let fallback = false
 
       this.retry(async (bail, attempt) => {
-        if (this._debug) console.time(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`);
-        const res = await this._fetch(`/whois-ns${fallback ? '-fallback' : ''}?domain=${encodeURIComponent(domain)}`);
-        if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`);
-        const body = await res.json();
+        if (this._debug) console.time(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        const res = await this._fetch(`/whois-ns${fallback ? '-fallback' : ''}?domain=${encodeURIComponent(domain)}`)
+        if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        const body = await res.json()
         if (200 === res.status) {
           if ((!body.nameservers || body.nameservers.length === 0) && !fallback) {
             // if the nameservers are `null` it's likely
             // that our whois service failed to parse it
-            fallback = true;
-            throw new Error('Invalid whois response');
+            fallback = true
+            throw new Error('Invalid whois response')
           }
 
-          return body;
+          return body
         } else {
-        if (attempt > 1) fallback = true;
-          throw new Error(`Whois error (${res.status}): ${body.error.message}`);
+          if (attempt > 1) fallback = true
+          throw new Error(`Whois error (${res.status}): ${body.error.message}`)
         }
-      }).then((body) => {
-        body.nameservers = body.nameservers.filter((ns) => {
+      }).then(body => {
+        body.nameservers = body.nameservers.filter(ns => {
           // temporary hack:
           // sometimes we get a response that looks like:
           // ['ns', 'ns', '', '']
           // so we filter the empty ones
-          return ns.length;
-        });
-        resolve(body);
-      });
-    });
+          return ns.length
+        })
+        resolve(body)
+      })
+    })
   }
 
   // _ensures_ the domain is setup (idempotent)
-  setupDomain (name, { isExternal } = {}) {
+  setupDomain(name, {isExternal} = {}) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} POST /domains`);
+      if (this._debug) console.time(`> [debug] #${attempt} POST /domains`)
       const res = await this._fetch('/domains', {
         method: 'POST',
-        body: { name, isExternal: !!isExternal }
-      });
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /domains`);
+        body: {name, isExternal: !!isExternal}
+      })
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /domains`)
 
       if (403 === res.status) {
-        const body = await res.json();
-        const code = body.error.code;
-        let err;
+        const body = await res.json()
+        const code = body.error.code
+        let err
 
         if ('custom_domain_needs_upgrade' === code) {
-          err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`);
+          err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`)
         } else {
-          err = new Error(`Not authorized to access domain ${name}`);
+          err = new Error(`Not authorized to access domain ${name}`)
         }
 
-        err.userError = true;
-        return bail(err);
+        err.userError = true
+        return bail(err)
       }
 
-      const body = await res.json();
+      const body = await res.json()
 
       // domain already exists
       if (409 === res.status) {
-        if (this._debug) console.log('> [debug] Domain already exists (noop)');
-        return { uid: body.error.uid };
+        if (this._debug) console.log('> [debug] Domain already exists (noop)')
+        return {uid: body.error.uid}
       }
 
       if (200 !== res.status) {
-        throw new Error(body.error.message);
+        throw new Error(body.error.message)
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
-  async remove (deploymentId, { hard }) {
-    const data = { deploymentId, hard };
+  async remove(deploymentId, {hard}) {
+    const data = {deploymentId, hard}
 
-    await this.retry(async (bail) => {
-      if (this._debug) console.time('> [debug] /remove');
+    await this.retry(async bail => {
+      if (this._debug) console.time('> [debug] /remove')
       const res = await this._fetch('/now/remove', {
         method: 'DELETE',
         body: data
-      });
-      if (this._debug) console.timeEnd('> [debug] /remove');
+      })
+      if (this._debug) console.timeEnd('> [debug] /remove')
 
       // no retry on 4xx
       if (400 <= res.status && 500 > res.status) {
         if (this._debug) {
-          console.log('> [debug] bailing on removal due to %s', res.status);
+          console.log('> [debug] bailing on removal due to %s', res.status)
         }
-        return bail(responseError(res));
+        return bail(responseError(res))
       }
 
       if (200 !== res.status) {
-        throw new Error('Removing deployment failed');
+        throw new Error('Removing deployment failed')
       }
-    });
+    })
 
-    return true;
+    return true
   }
 
-  retry (fn, { retries = 3, maxTimeout = Infinity } = {}) {
+  retry(fn, {retries = 3, maxTimeout = Infinity} = {}) {
     return retry(fn, {
       retries,
       maxTimeout,
       onRetry: this._onRetry
-    });
+    })
   }
 
-  _onRetry (err) {
+  _onRetry(err) {
     if (this._debug) {
-      console.log(`> [debug] Retrying: ${err.stack}`);
+      console.log(`> [debug] Retrying: ${err.stack}`)
     }
   }
 
-  close () {
-    this._agent.close();
+  close() {
+    this._agent.close()
   }
 
-  get id () {
-    return this._id;
+  get id() {
+    return this._id
   }
 
-  get url () {
-    return `https://${this._host}`;
+  get url() {
+    return `https://${this._host}`
   }
 
-  get host () {
-    return this._host;
+  get host() {
+    return this._host
   }
 
-  get syncAmount () {
+  get syncAmount() {
     if (!this._syncAmount) {
       this._syncAmount = this._missing
-      .map((sha) => this._files.get(sha).data.length)
-      .reduce((a, b) => a + b, 0);
+      .map(sha => this._files.get(sha).data.length)
+      .reduce((a, b) => a + b, 0)
     }
-    return this._syncAmount;
+    return this._syncAmount
   }
 
-  _fetch (_url, opts = {}) {
-    opts.headers = opts.headers || {};
-    opts.headers.authorization = `Bearer ${this._token}`;
-    opts.headers['user-agent'] = ua;
-    return this._agent.fetch(_url, opts);
+  _fetch(_url, opts = {}) {
+    opts.headers = opts.headers || {}
+    opts.headers.authorization = `Bearer ${this._token}`
+    opts.headers['user-agent'] = ua
+    return this._agent.fetch(_url, opts)
   }
 }
 
-function toRelative (path, base) {
-  const fullBase = base.endsWith(SEP) ? base : base + SEP;
-  let relative = path.substr(fullBase.length);
-  if (relative.startsWith(SEP)) relative = relative.substr(1);
-  return relative.replace(/\\/g, '/');
+function toRelative(path, base) {
+  const fullBase = base.endsWith(SEP) ? base : base + SEP
+  let relative = path.substr(fullBase.length)
+  if (relative.startsWith(SEP)) relative = relative.substr(1)
+  return relative.replace(/\\/g, '/')
 }
 
-function responseError (res) {
-  const err = new Error('Response error');
-  err.status = res.status;
+function responseError(res) {
+  const err = new Error('Response error')
+  err.status = res.status
 
   if (429 === res.status) {
-    const retryAfter = res.headers.get('Retry-After');
+    const retryAfter = res.headers.get('Retry-After')
     if (retryAfter) {
-      err.retryAfter = parseInt(retryAfter, 10);
+      err.retryAfter = parseInt(retryAfter, 10)
     }
   }
 
-  return err;
+  return err
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,21 @@
+import {homedir} from 'os'
+import EventEmitter from 'events'
+import {basename, resolve as resolvePath} from 'path'
 import bytes from 'bytes'
 import chalk from 'chalk'
+import retry from 'async-retry'
+import {parse as parseIni} from 'ini'
+import {readFile} from 'fs-promise'
+import resumer from 'resumer'
+import splitArray from 'split-array'
+import {parse as parseDockerfile} from 'docker-file-parser'
 import {
   npm as getNpmFiles,
   docker as getDockerFiles
 } from './get-files'
 import ua from './ua'
 import hash from './hash'
-import retry from 'async-retry'
 import Agent from './agent'
-import EventEmitter from 'events'
-import {basename, resolve as resolvePath} from 'path'
-import {homedir} from 'os'
-import {parse as parseIni} from 'ini'
-import {readFile} from 'fs-promise'
-import resumer from 'resumer'
-import splitArray from 'split-array'
-import {parse as parseDockerfile} from 'docker-file-parser'
 
 // how many concurrent HTTP/2 stream uploads
 const MAX_CONCURRENT = 10
@@ -46,9 +46,11 @@ export default class Now extends EventEmitter {
     this._path = path
 
     let pkg = {}
-    let name, description, files
+    let name
+    let description
+    let files
 
-    if ('npm' === deploymentType) {
+    if (deploymentType === 'npm') {
       try {
         pkg = await readFile(resolvePath(path, 'package.json'))
         pkg = JSON.parse(pkg)
@@ -65,19 +67,25 @@ export default class Now extends EventEmitter {
         throw e
       }
 
-      if (null == pkg.name || 'string' !== typeof pkg.name) {
+      if (pkg.name == null || typeof pkg.name !== 'string') {
         name = basename(path)
-        if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`)
+        if (!quiet) {
+          console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`)
+        }
       } else {
         name = pkg.name
       }
 
       description = pkg.description
 
-      if (this._debug) console.time('> [debug] Getting files')
+      if (this._debug) {
+        console.time('> [debug] Getting files')
+      }
       files = await getNpmFiles(path, pkg, {debug: this._debug})
-      if (this._debug) console.timeEnd('> [debug] Getting files')
-    } else if ('docker' === deploymentType) {
+      if (this._debug) {
+        console.timeEnd('> [debug] Getting files')
+      }
+    } else if (deploymentType === 'docker') {
       let docker
       try {
         const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8')
@@ -88,20 +96,20 @@ export default class Now extends EventEmitter {
         throw e
       }
 
-      if (!docker.length) {
+      if (docker.length === 0) {
         const e = Error('No commands found in `Dockerfile`')
         e.userError = true
         throw e
       }
 
-      if (!docker.some(cmd => 'CMD' === cmd.name)) {
+      if (!docker.some(cmd => cmd.name === 'CMD')) {
         const e = Error('No `CMD` found in `Dockerfile`. ' +
           'See: https://docs.docker.com/engine/reference/builder/#/cmd')
         e.userError = true
         throw e
       }
 
-      if (!docker.some(cmd => 'EXPOSE' === cmd.name)) {
+      if (!docker.some(cmd => cmd.name === 'EXPOSE')) {
         const e = Error('No `EXPOSE` found in `Dockerfile`. A port must be supplied. ' +
           'See: https://docs.docker.com/engine/reference/builder/#/expose')
         e.userError = true
@@ -110,42 +118,50 @@ export default class Now extends EventEmitter {
 
       const labels = {}
       docker
-      .filter(cmd => 'LABEL' === cmd.name)
+      .filter(cmd => cmd.name === 'LABEL')
       .forEach(({args}) => {
-        for (let key in args) {
-          // unescape and convert into string
-          try {
-            labels[key] = JSON.parse(args[key])
-          } catch (err) {
-            const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``)
-            e.userError = true
-            throw e
+        for (const key in args) {
+          if ({}.hasOwnProperty.call(args, key)) {
+            // unescape and convert into string
+            try {
+              labels[key] = JSON.parse(args[key])
+            } catch (err) {
+              const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``)
+              e.userError = true
+              throw e
+            }
           }
         }
       })
 
-      if (null == labels.name) {
+      if (labels.name == null) {
         name = basename(path)
-        if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`)
+        if (!quiet) {
+          console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`)
+        }
       } else {
         name = labels.name
       }
 
       description = labels.description
 
-      if (this._debug) console.time('> [debug] Getting files')
+      if (this._debug) {
+        console.time('> [debug] Getting files')
+      }
       files = await getDockerFiles(path, {debug: this._debug})
-      if (this._debug) console.timeEnd('> [debug] Getting files')
+      if (this._debug) {
+        console.timeEnd('> [debug] Getting files')
+      }
     }
 
     const nowProperties = pkg ? pkg.now || {} : {}
 
-    forwardNpm = forwardNpm || nowProperties['forwardNpm']
+    forwardNpm = forwardNpm || nowProperties.forwardNpm
 
     // Read .npmrc
     let npmrc = {}
     let authToken
-    if ('npm' === deploymentType && forwardNpm) {
+    if (deploymentType === 'npm' && forwardNpm) {
       try {
         npmrc = await readFile(resolvePath(path, '.npmrc'), 'utf8')
         npmrc = parseIni(npmrc)
@@ -165,16 +181,22 @@ export default class Now extends EventEmitter {
       }
     }
 
-    if (this._debug) console.time('> [debug] Computing hashes')
+    if (this._debug) {
+      console.time('> [debug] Computing hashes')
+    }
     const hashes = await hash(files)
-    if (this._debug) console.timeEnd('> [debug] Computing hashes')
+    if (this._debug) {
+      console.timeEnd('> [debug] Computing hashes')
+    }
 
     this._files = hashes
 
     const engines = nowProperties.engines || pkg.engines
 
     const deployment = await this.retry(async bail => {
-      if (this._debug) console.time('> [debug] /now/create')
+      if (this._debug) {
+        console.time('> [debug] /now/create')
+      }
       const res = await this._fetch('/now/create', {
         method: 'POST',
         body: {
@@ -182,7 +204,7 @@ export default class Now extends EventEmitter {
           public: wantsPublic,
           forceNew,
           forceSync,
-          name: name,
+          name,
           description,
           deploymentType,
           registryAuthToken: authToken,
@@ -200,7 +222,9 @@ export default class Now extends EventEmitter {
           engines
         }
       })
-      if (this._debug) console.timeEnd('> [debug] /now/create')
+      if (this._debug) {
+        console.timeEnd('> [debug] /now/create')
+      }
 
       // no retry on 4xx
       let body
@@ -210,13 +234,13 @@ export default class Now extends EventEmitter {
         throw new Error('Unexpected response')
       }
 
-      if (429 === res.status) {
+      if (res.status === 429) {
         return bail(responseError(res))
       } else if (res.status >= 400 && res.status < 500) {
         const err = new Error(body.error.message)
         err.userError = true
         return bail(err)
-      } else if (200 !== res.status) {
+      } else if (res.status !== 200) {
         throw new Error(body.error.message)
       }
 
@@ -228,7 +252,7 @@ export default class Now extends EventEmitter {
     if (deployment.warnings) {
       let sizeExceeded = 0
       deployment.warnings.forEach(warning => {
-        if ('size_limit_exceeded' === warning.reason) {
+        if (warning.reason === 'size_limit_exceeded') {
           const {sha, limit} = warning
           const n = hashes.get(sha).names.pop()
           console.error('> \u001b[31mWarning!\u001b[39m Skipping file %s (size exceeded %s)',
@@ -237,7 +261,7 @@ export default class Now extends EventEmitter {
           )
           hashes.get(sha).names.unshift(n) // move name (hack, if duplicate matches we report them in order)
           sizeExceeded++
-        } else if ('node_version_not_found' === warning.reason) {
+        } else if (warning.reason === 'node_version_not_found') {
           const {wanted, used} = warning
           console.error('> \u001b[31mWarning!\u001b[39m Requested node version %s is not available',
             wanted,
@@ -287,7 +311,9 @@ export default class Now extends EventEmitter {
         const file = this._files.get(sha)
         const {data, names} = file
 
-        if (this._debug) console.time(`> [debug] /sync #${attempt} ${names.join(' ')}`)
+        if (this._debug) {
+          console.time(`> [debug] /sync #${attempt} ${names.join(' ')}`)
+        }
         const stream = resumer().queue(data).end()
         const res = await this._fetch('/now/sync', {
           method: 'POST',
@@ -301,11 +327,15 @@ export default class Now extends EventEmitter {
           },
           body: stream
         })
-        if (this._debug) console.timeEnd(`> [debug] /sync #${attempt} ${names.join(' ')}`)
+        if (this._debug) {
+          console.timeEnd(`> [debug] /sync #${attempt} ${names.join(' ')}`)
+        }
 
         // no retry on 4xx
-        if (200 !== res.status && (400 <= res.status || 500 > res.status)) {
-          if (this._debug) console.log('> [debug] bailing on creating due to %s', res.status)
+        if (res.status !== 200 && (res.status >= 400 || res.status < 500)) {
+          if (this._debug) {
+            console.log('> [debug] bailing on creating due to %s', res.status)
+          }
           return bail(responseError(res))
         }
 
@@ -320,9 +350,13 @@ export default class Now extends EventEmitter {
 
   async listSecrets() {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} GET /secrets`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} GET /secrets`)
+      }
       const res = await this._fetch('/now/secrets')
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /secrets`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} GET /secrets`)
+      }
       const body = await res.json()
       return body.secrets
     })
@@ -332,19 +366,23 @@ export default class Now extends EventEmitter {
     const query = app ? `?app=${encodeURIComponent(app)}` : ''
 
     const {deployments} = await this.retry(async bail => {
-      if (this._debug) console.time('> [debug] /list')
+      if (this._debug) {
+        console.time('> [debug] /list')
+      }
       const res = await this._fetch('/now/list' + query)
-      if (this._debug) console.timeEnd('> [debug] /list')
+      if (this._debug) {
+        console.timeEnd('> [debug] /list')
+      }
 
       // no retry on 4xx
-      if (400 <= res.status && 500 > res.status) {
+      if (res.status >= 400 && res.status < 500) {
         if (this._debug) {
           console.log('> [debug] bailing on listing due to %s', res.status)
         }
         return bail(responseError(res))
       }
 
-      if (200 !== res.status) {
+      if (res.status !== 200) {
         throw new Error('Fetching deployment list failed')
       }
 
@@ -355,25 +393,29 @@ export default class Now extends EventEmitter {
   }
 
   async listAliases(deploymentId) {
-    return this.retry(async (bail, attempt) => {
-      const res = await this._fetch(deploymentId
-        ? `/now/deployments/${deploymentId}/aliases`
-        : '/now/aliases')
+    return this.retry(async () => {
+      const res = await this._fetch(deploymentId ?
+        `/now/deployments/${deploymentId}/aliases` :
+        '/now/aliases')
       const body = await res.json()
       return body.aliases
     })
   }
 
   getNameservers(domain) {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       let fallback = false
 
       this.retry(async (bail, attempt) => {
-        if (this._debug) console.time(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        if (this._debug) {
+          console.time(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        }
         const res = await this._fetch(`/whois-ns${fallback ? '-fallback' : ''}?domain=${encodeURIComponent(domain)}`)
-        if (this._debug) console.timeEnd(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        if (this._debug) {
+          console.timeEnd(`> [debug] #${attempt} GET /whois-ns${fallback ? '-fallback' : ''}`)
+        }
         const body = await res.json()
-        if (200 === res.status) {
+        if (res.status === 200) {
           if ((!body.nameservers || body.nameservers.length === 0) && !fallback) {
             // if the nameservers are `null` it's likely
             // that our whois service failed to parse it
@@ -382,10 +424,11 @@ export default class Now extends EventEmitter {
           }
 
           return body
-        } else {
-          if (attempt > 1) fallback = true
-          throw new Error(`Whois error (${res.status}): ${body.error.message}`)
         }
+        if (attempt > 1) {
+          fallback = true
+        }
+        throw new Error(`Whois error (${res.status}): ${body.error.message}`)
       }).then(body => {
         body.nameservers = body.nameservers.filter(ns => {
           // temporary hack:
@@ -402,19 +445,23 @@ export default class Now extends EventEmitter {
   // _ensures_ the domain is setup (idempotent)
   setupDomain(name, {isExternal} = {}) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} POST /domains`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} POST /domains`)
+      }
       const res = await this._fetch('/domains', {
         method: 'POST',
-        body: {name, isExternal: !!isExternal}
+        body: {name, isExternal: Boolean(isExternal)}
       })
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /domains`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} POST /domains`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         const body = await res.json()
         const code = body.error.code
         let err
 
-        if ('custom_domain_needs_upgrade' === code) {
+        if (code === 'custom_domain_needs_upgrade') {
           err = new Error(`Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline('https://zeit.co/account')}.`)
         } else {
           err = new Error(`Not authorized to access domain ${name}`)
@@ -427,12 +474,14 @@ export default class Now extends EventEmitter {
       const body = await res.json()
 
       // domain already exists
-      if (409 === res.status) {
-        if (this._debug) console.log('> [debug] Domain already exists (noop)')
+      if (res.status === 409) {
+        if (this._debug) {
+          console.log('> [debug] Domain already exists (noop)')
+        }
         return {uid: body.error.uid}
       }
 
-      if (200 !== res.status) {
+      if (res.status !== 200) {
         throw new Error(body.error.message)
       }
 
@@ -444,22 +493,26 @@ export default class Now extends EventEmitter {
     const data = {deploymentId, hard}
 
     await this.retry(async bail => {
-      if (this._debug) console.time('> [debug] /remove')
+      if (this._debug) {
+        console.time('> [debug] /remove')
+      }
       const res = await this._fetch('/now/remove', {
         method: 'DELETE',
         body: data
       })
-      if (this._debug) console.timeEnd('> [debug] /remove')
+      if (this._debug) {
+        console.timeEnd('> [debug] /remove')
+      }
 
       // no retry on 4xx
-      if (400 <= res.status && 500 > res.status) {
+      if (res.status <= 400 && res.status < 500) {
         if (this._debug) {
           console.log('> [debug] bailing on removal due to %s', res.status)
         }
         return bail(responseError(res))
       }
 
-      if (200 !== res.status) {
+      if (res.status !== 200) {
         throw new Error('Removing deployment failed')
       }
     })
@@ -517,7 +570,9 @@ export default class Now extends EventEmitter {
 function toRelative(path, base) {
   const fullBase = base.endsWith(SEP) ? base : base + SEP
   let relative = path.substr(fullBase.length)
-  if (relative.startsWith(SEP)) relative = relative.substr(1)
+  if (relative.startsWith(SEP)) {
+    relative = relative.substr(1)
+  }
   return relative.replace(/\\/g, '/')
 }
 
@@ -525,7 +580,7 @@ function responseError(res) {
   const err = new Error('Response error')
   err.status = res.status
 
-  if (429 === res.status) {
+  if (res.status === 429) {
     const retryAfter = res.headers.get('Retry-After')
     if (retryAfter) {
       err.retryAfter = parseInt(retryAfter, 10)

--- a/lib/is-zeit-world.js
+++ b/lib/is-zeit-world.js
@@ -13,15 +13,15 @@ const nameservers = new Set([
   'paris.zeit.world',
   'frankfurt.zeit.world',
   'singapore.zeit.world'
-]);
+])
 
 /**
  * Given an array of nameservers (ie: as returned
  * by `resolveNs` from Node, assert that they're
  * zeit.world's.
  */
-export default function isZeitWorld (ns) {
-  return ns.length > 1 && ns.every((host) => {
-    return nameservers.has(host);
-  });
+export default function isZeitWorld(ns) {
+  return ns.length > 1 && ns.every(host => {
+    return nameservers.has(host)
+  })
 }

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,16 +1,16 @@
-import os from 'os';
-import chalk from 'chalk';
-import fetch from 'node-fetch';
-import * as cfg from './cfg';
-import { stringify as stringifyQuery } from 'querystring';
-import { validate } from 'email-validator';
-import readEmail from 'email-prompt';
-import ua from './ua';
-import pkg from '../../package.json';
+import os from 'os'
+import chalk from 'chalk'
+import fetch from 'node-fetch'
+import * as cfg from './cfg'
+import {stringify as stringifyQuery} from 'querystring'
+import {validate} from 'email-validator'
+import readEmail from 'email-prompt'
+import ua from './ua'
+import pkg from '../../package.json'
 
-async function getVerificationToken (url, email) {
-  const tokenName = `Now CLI ${os.platform()}-${os.arch()} ${pkg.version} (${os.hostname()})`;
-  const data = JSON.stringify({ email, tokenName });
+async function getVerificationToken(url, email) {
+  const tokenName = `Now CLI ${os.platform()}-${os.arch()} ${pkg.version} (${os.hostname()})`
+  const data = JSON.stringify({email, tokenName})
   const res = await fetch(`${url}/now/registration`, {
     method: 'POST',
     headers: {
@@ -19,62 +19,62 @@ async function getVerificationToken (url, email) {
       'User-Agent': ua
     },
     body: data
-  });
+  })
 
   if (200 !== res.status) {
-    throw new Error('Verification error');
+    throw new Error('Verification error')
   }
 
-  const body = await res.json();
-  return body.token;
+  const body = await res.json()
+  return body.token
 }
 
-async function verify (url, email, verificationToken) {
+async function verify(url, email, verificationToken) {
   const query = {
     email,
     token: verificationToken
-  };
+  }
 
   const res = await fetch(`${url}/now/registration/verify?${stringifyQuery(query)}`, {
-    headers: { 'User-Agent': ua }
-  });
-  const body = await res.json();
-  return body.token;
+    headers: {'User-Agent': ua}
+  })
+  const body = await res.json()
+  return body.token
 }
 
-function sleep (ms) {
+function sleep(ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms);
-  });
+    setTimeout(resolve, ms)
+  })
 }
 
-async function register (url, { retryEmail = false } = {}) {
-  const email = await readEmail({ invalid: retryEmail });
-  process.stdout.write('\n');
+async function register(url, {retryEmail = false} = {}) {
+  const email = await readEmail({invalid: retryEmail})
+  process.stdout.write('\n')
 
-  if (!validate(email)) return register(url, { retryEmail: true });
+  if (!validate(email)) return register(url, {retryEmail: true})
 
-  const verificationToken = await getVerificationToken(url, email);
+  const verificationToken = await getVerificationToken(url, email)
 
-  console.log(`> Please follow the link sent to ${chalk.bold(email)} to log in.`);
-  process.stdout.write('> Waiting for confirmation..');
+  console.log(`> Please follow the link sent to ${chalk.bold(email)} to log in.`)
+  process.stdout.write('> Waiting for confirmation..')
 
-  let final;
+  let final
   do {
-    await sleep(2500);
+    await sleep(2500)
     try {
-      final = await verify(url, email, verificationToken);
+      final = await verify(url, email, verificationToken)
     } catch (e) {}
-    process.stdout.write('.');
-  } while (!final);
+    process.stdout.write('.')
+  } while (!final)
 
-  process.stdout.write('\n');
+  process.stdout.write('\n')
 
-  return { email, token: final };
+  return {email, token: final}
 }
 
 export default async function (url) {
-  const loginData = await register(url);
-  cfg.merge(loginData);
-  return loginData.token;
+  const loginData = await register(url)
+  cfg.merge(loginData)
+  return loginData.token
 }

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,12 +1,12 @@
 import os from 'os'
+import {stringify as stringifyQuery} from 'querystring'
 import chalk from 'chalk'
 import fetch from 'node-fetch'
-import * as cfg from './cfg'
-import {stringify as stringifyQuery} from 'querystring'
 import {validate} from 'email-validator'
 import readEmail from 'email-prompt'
+import pkg from '../../package' // eslint-disable-line import/no-unresolved
 import ua from './ua'
-import pkg from '../../package.json'
+import * as cfg from './cfg'
 
 async function getVerificationToken(url, email) {
   const tokenName = `Now CLI ${os.platform()}-${os.arch()} ${pkg.version} (${os.hostname()})`
@@ -21,7 +21,7 @@ async function getVerificationToken(url, email) {
     body: data
   })
 
-  if (200 !== res.status) {
+  if (res.status !== 200) {
     throw new Error('Verification error')
   }
 
@@ -43,7 +43,7 @@ async function verify(url, email, verificationToken) {
 }
 
 function sleep(ms) {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     setTimeout(resolve, ms)
   })
 }
@@ -52,7 +52,9 @@ async function register(url, {retryEmail = false} = {}) {
   const email = await readEmail({invalid: retryEmail})
   process.stdout.write('\n')
 
-  if (!validate(email)) return register(url, {retryEmail: true})
+  if (!validate(email)) {
+    return register(url, {retryEmail: true})
+  }
 
   const verificationToken = await getVerificationToken(url, email)
 
@@ -60,13 +62,15 @@ async function register(url, {retryEmail = false} = {}) {
   process.stdout.write('> Waiting for confirmation..')
 
   let final
+  /* eslint-disable babel/no-await-in-loop */
   do {
     await sleep(2500)
     try {
       final = await verify(url, email, verificationToken)
-    } catch (e) {}
+    } catch (err) {}
     process.stdout.write('.')
   } while (!final)
+  /* eslint-enable babel/no-await-in-loop */
 
   process.stdout.write('\n')
 

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -8,24 +8,27 @@ export default class Secrets extends Now {
 
   rm(nameOrId) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
+      }
       const res = await this._fetch(`/now/secrets/${nameOrId}`, {method: 'DELETE'})
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (404 === res.status || 400 === res.status) {
+        if (res.status === 404 || res.status === 400) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)
-        } else {
-          throw new Error(body.error.message)
         }
+        throw new Error(body.error.message)
       }
 
       return body
@@ -34,7 +37,9 @@ export default class Secrets extends Now {
 
   add(name, value) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} POST /secrets`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} POST /secrets`)
+      }
       const res = await this._fetch('/now/secrets', {
         method: 'POST',
         body: {
@@ -42,22 +47,23 @@ export default class Secrets extends Now {
           value: value.toString()
         }
       })
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /secrets`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} POST /secrets`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (404 === res.status || 400 === res.status) {
+        if (res.status === 404 || res.status === 400) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)
-        } else {
-          throw new Error(body.error.message)
         }
+        throw new Error(body.error.message)
       }
 
       return body
@@ -66,29 +72,32 @@ export default class Secrets extends Now {
 
   rename(nameOrId, newName) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
+      if (this._debug) {
+        console.time(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
+      }
       const res = await this._fetch(`/now/secrets/${nameOrId}`, {
         method: 'PATCH',
         body: {
           name: newName
         }
       })
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
+      if (this._debug) {
+        console.timeEnd(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
+      }
 
-      if (403 === res.status) {
+      if (res.status === 403) {
         return bail(new Error('Unauthorized'))
       }
 
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (404 === res.status || 400 === res.status) {
+        if (res.status === 404 || res.status === 400) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)
-        } else {
-          throw new Error(body.error.message)
         }
+        throw new Error(body.error.message)
       }
 
       return body

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,98 +1,98 @@
-import Now from '../lib';
+import Now from '../lib'
 
 export default class Secrets extends Now {
 
-  ls () {
-    return this.listSecrets();
+  ls() {
+    return this.listSecrets()
   }
 
-  rm (nameOrId) {
+  rm(nameOrId) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`);
-      const res = await this._fetch(`/now/secrets/${nameOrId}`, { method: 'DELETE' });
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`);
+      if (this._debug) console.time(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
+      const res = await this._fetch(`/now/secrets/${nameOrId}`, {method: 'DELETE'})
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} DELETE /secrets/${nameOrId}`)
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
-      const body = await res.json();
+      const body = await res.json()
 
       if (res.status !== 200) {
         if (404 === res.status || 400 === res.status) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
+          const err = new Error(body.error.message)
+          err.userError = true
+          return bail(err)
         } else {
-          throw new Error(body.error.message);
+          throw new Error(body.error.message)
         }
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
-  add (name, value) {
+  add(name, value) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} POST /secrets`);
+      if (this._debug) console.time(`> [debug] #${attempt} POST /secrets`)
       const res = await this._fetch('/now/secrets', {
         method: 'POST',
         body: {
           name,
           value: value.toString()
         }
-      });
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /secrets`);
+      })
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} POST /secrets`)
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
-      const body = await res.json();
+      const body = await res.json()
 
       if (res.status !== 200) {
         if (404 === res.status || 400 === res.status) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
+          const err = new Error(body.error.message)
+          err.userError = true
+          return bail(err)
         } else {
-          throw new Error(body.error.message);
+          throw new Error(body.error.message)
         }
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
-  rename (nameOrId, newName) {
+  rename(nameOrId, newName) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) console.time(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`);
+      if (this._debug) console.time(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
       const res = await this._fetch(`/now/secrets/${nameOrId}`, {
         method: 'PATCH',
         body: {
           name: newName
         }
-      });
-      if (this._debug) console.timeEnd(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`);
+      })
+      if (this._debug) console.timeEnd(`> [debug] #${attempt} PATCH /secrets/${nameOrId}`)
 
       if (403 === res.status) {
-        return bail(new Error('Unauthorized'));
+        return bail(new Error('Unauthorized'))
       }
 
-      const body = await res.json();
+      const body = await res.json()
 
       if (res.status !== 200) {
         if (404 === res.status || 400 === res.status) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
+          const err = new Error(body.error.message)
+          err.userError = true
+          return bail(err)
         } else {
-          throw new Error(body.error.message);
+          throw new Error(body.error.message)
         }
       }
 
-      return body;
-    });
+      return body
+    })
   }
 
 }

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,5 +1,5 @@
-import getFiles from './get-files'
 import {resolve} from 'path'
+import getFiles from './get-files'
 
 getFiles(resolve('../mng-test/files-in-package'))
 .then(files => {
@@ -17,4 +17,3 @@ getFiles(resolve('../mng-test/files-in-package'))
 .catch(err => {
   console.log(err.stack)
 })
-

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,20 +1,20 @@
-import getFiles from './get-files';
-import { resolve } from 'path';
+import getFiles from './get-files'
+import {resolve} from 'path'
 
 getFiles(resolve('../mng-test/files-in-package'))
 .then(files => {
-  console.log(files);
+  console.log(files)
 
   getFiles(resolve('../mng-test/files-in-package-ignore'))
   .then(files2 => {
-    console.log('ignored: ');
-    console.log(files2);
+    console.log('ignored: ')
+    console.log(files2)
   })
   .catch(err => {
-    console.log(err.stack);
-  });
+    console.log(err.stack)
+  })
 })
 .catch(err => {
-  console.log(err.stack);
-});
+  console.log(err.stack)
+})
 

--- a/lib/to-host.js
+++ b/lib/to-host.js
@@ -1,4 +1,4 @@
-import { parse } from 'url';
+import {parse} from 'url'
 
 /**
  * Converts a valid deployment lookup parameter to a hostname.
@@ -6,12 +6,12 @@ import { parse } from 'url';
  * google.com => google.com
  */
 
-export default function toHost (url) {
+export default function toHost(url) {
   if (/^https?:\/\//.test(url)) {
-    return parse(url).host;
+    return parse(url).host
   } else {
     // remove any path if present
     // `a.b.c/` => `a.b.c`
-    return url.replace(/(\/\/)?([^\/]+)(.*)/, '$2');
+    return url.replace(/(\/\/)?([^\/]+)(.*)/, '$2')
   }
 }

--- a/lib/to-host.js
+++ b/lib/to-host.js
@@ -9,9 +9,8 @@ import {parse} from 'url'
 export default function toHost(url) {
   if (/^https?:\/\//.test(url)) {
     return parse(url).host
-  } else {
-    // remove any path if present
-    // `a.b.c/` => `a.b.c`
-    return url.replace(/(\/\/)?([^\/]+)(.*)/, '$2')
   }
+  // remove any path if present
+  // `a.b.c/` => `a.b.c`
+  return url.replace(/(\/\/)?([^\/]+)(.*)/, '$2')
 }

--- a/lib/ua.js
+++ b/lib/ua.js
@@ -1,4 +1,4 @@
-import os from 'os';
-import { version } from '../../package';
+import os from 'os'
+import {version} from '../../package'
 
-export default `now ${version} node-${process.version} ${os.platform()} (${os.arch()})`;
+export default `now ${version} node-${process.version} ${os.platform()} (${os.arch()})`

--- a/lib/ua.js
+++ b/lib/ua.js
@@ -1,4 +1,4 @@
 import os from 'os'
-import {version} from '../../package'
+import {version} from '../../package' // eslint-disable-line import/no-unresolved
 
 export default `now ${version} node-${process.version} ${os.platform()} (${os.arch()})`

--- a/lib/utils/prompt-options.js
+++ b/lib/utils/prompt-options.js
@@ -5,9 +5,10 @@ export default function (opts) {
     opts.forEach(([, text], i) => {
       console.log(`${chalk.gray('>')} [${chalk.bold(i + 1)}] ${text}`)
     })
+
     const ondata = v => {
       const s = v.toString()
-      if ('\u0003' === s) {
+      if (s === '\u0003') {
         cleanup()
         reject(new Error('Aborted'))
         return
@@ -19,10 +20,12 @@ export default function (opts) {
         resolve(opts[n - 1][0])
       }
     }
-    const cleanup = () => {
+
+    function cleanup() {
       process.stdin.setRawMode(false)
       process.stdin.removeListener('data', ondata)
     }
+
     process.stdin.setRawMode(true)
     process.stdin.resume()
     process.stdin.on('data', ondata)

--- a/lib/utils/prompt-options.js
+++ b/lib/utils/prompt-options.js
@@ -1,30 +1,30 @@
-import chalk from 'chalk';
+import chalk from 'chalk'
 
 export default function (opts) {
   return new Promise((resolve, reject) => {
     opts.forEach(([, text], i) => {
-      console.log(`${chalk.gray('>')} [${chalk.bold(i + 1)}] ${text}`);
-    });
-    const ondata = (v) => {
-      const s = v.toString();
+      console.log(`${chalk.gray('>')} [${chalk.bold(i + 1)}] ${text}`)
+    })
+    const ondata = v => {
+      const s = v.toString()
       if ('\u0003' === s) {
-        cleanup();
-        reject(new Error('Aborted'));
-        return;
+        cleanup()
+        reject(new Error('Aborted'))
+        return
       }
 
-      const n = Number(s);
+      const n = Number(s)
       if (opts[n - 1]) {
-        cleanup();
-        resolve(opts[n - 1][0]);
+        cleanup()
+        resolve(opts[n - 1][0])
       }
-    };
+    }
     const cleanup = () => {
-      process.stdin.setRawMode(false);
-      process.stdin.removeListener('data', ondata);
-    };
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.on('data', ondata);
-  });
+      process.stdin.setRawMode(false)
+      process.stdin.removeListener('data', ondata)
+    }
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+    process.stdin.on('data', ondata)
+  })
 }

--- a/lib/utils/to-human-path.js
+++ b/lib/utils/to-human-path.js
@@ -1,8 +1,8 @@
-import { resolve } from 'path';
-import { homedir } from 'os';
+import {resolve} from 'path'
+import {homedir} from 'os'
 
 // cleaned-up `$HOME` (i.e.: no trailing slash)
-const HOME = resolve(homedir());
+const HOME = resolve(homedir())
 
 /**
  * Attempts to show the given path in
@@ -10,6 +10,6 @@ const HOME = resolve(homedir());
  * `/Users/rauchg/test.js` becomes `~/test.js`
  */
 
-export default function toHumanPath (path) {
-  return path.replace(HOME, '~');
+export default function toHumanPath(path) {
+  return path.replace(HOME, '~')
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "rules": {
       "complexity": "off",
       "eqeqeq": "off",
+      "max-depth": "off",
       "no-eq-null": "off"
     }
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,38 @@
   "files": [
     "build"
   ],
+  "scripts": {
+    "start": "gulp",
+    "test": "xo && ava",
+    "prepublish": "gulp compile",
+    "pkg": "pkg . --out-dir out"
+  },
+  "xo": {
+    "esnext": true,
+    "space": true,
+    "semicolon": false,
+    "ignores": [
+      "build/**",
+      "out/**",
+      "test/_fixtures/**"
+    ],
+    "extensions": [
+      "",
+      ".js"
+    ]
+  },
+  "ava": {
+    "failFast": true,
+    "files": [
+      "test/*.js"
+    ],
+    "require": [
+      "babel-register"
+    ]
+  },
+  "pkg": {
+    "scripts": "build/**/*"
+  },
   "greenkeeper": {
     "emails": false,
     "ignore": [
@@ -22,33 +54,6 @@
       "transform-runtime",
       "transform-async-to-generator"
     ]
-  },
-  "eslintConfig": {
-    "extends": "standard",
-    "parser": "babel-eslint",
-    "rules": {
-      "yoda": 0,
-      "arrow-parens": 0,
-      "semi": [
-        2,
-        "always"
-      ],
-      "no-extra-semi": 2,
-      "semi-spacing": [
-        2,
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-shadow": [
-        2,
-        {
-          "builtinGlobals": true,
-          "hoist": "functions"
-        }
-      ]
-    }
   },
   "bin": {
     "now": "./build/bin/now"
@@ -85,39 +90,16 @@
   "devDependencies": {
     "alpha-sort": "1.0.2",
     "ava": "0.16.0",
-    "babel-eslint": "7.0.0",
     "babel-plugin-transform-async-to-generator": "6.16.0",
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-es2015": "6.16.0",
     "babel-register": "6.16.3",
     "del": "2.2.2",
-    "eslint": "3.8.0",
-    "eslint-config-standard": "6.2.0",
-    "eslint-plugin-promise": "3.2.1",
-    "eslint-plugin-standard": "2.0.1",
     "estraverse-fb": "1.3.1",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
-    "gulp-eslint": "3.0.1",
     "gulp-task-listing": "1.0.1",
-    "pkg": "3.0.0-beta.14"
-  },
-  "scripts": {
-    "start": "gulp",
-    "test": "ava",
-    "prepublish": "gulp compile",
-    "pkg": "pkg . --out-dir out"
-  },
-  "pkg": {
-    "scripts": "build/**/*"
-  },
-  "ava": {
-    "failFast": true,
-    "files": [
-      "test/*.js"
-    ],
-    "require": [
-      "babel-register"
-    ]
+    "pkg": "3.0.0-beta.14",
+    "xo": "0.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,12 @@
     "extensions": [
       "",
       ".js"
-    ]
+    ],
+    "rules": {
+      "complexity": "off",
+      "eqeqeq": "off",
+      "no-eq-null": "off"
+    }
   },
   "ava": {
     "failFast": true,

--- a/test/_fixtures/no-node_modules/index.js
+++ b/test/_fixtures/no-node_modules/index.js
@@ -1,1 +1,1 @@
-console.log('index');
+console.log('index')

--- a/test/index.js
+++ b/test/index.js
@@ -1,130 +1,130 @@
-import test from 'ava';
-import { join, resolve } from 'path';
+import test from 'ava'
+import {join, resolve} from 'path'
 import {
   npm as getNpmFiles_,
   docker as getDockerFiles
-} from '../lib/get-files';
-import hash from '../lib/hash';
-import { asc as alpha } from 'alpha-sort';
-import { readFile } from 'fs-promise';
+} from '../lib/get-files'
+import hash from '../lib/hash'
+import {asc as alpha} from 'alpha-sort'
+import {readFile} from 'fs-promise'
 
-const prefix = join(__dirname, '_fixtures') + '/';
-const base = (path) => path.replace(prefix, '');
-const fixture = (name) => resolve(`./_fixtures/${name}`);
+const prefix = join(__dirname, '_fixtures') + '/'
+const base = path => path.replace(prefix, '')
+const fixture = name => resolve(`./_fixtures/${name}`)
 
 // overload to force debugging
-const getNpmFiles = async (dir) => {
-  const pkg = await readJSON(resolve(dir, 'package.json'));
-  return getNpmFiles_(dir, pkg);
-};
+const getNpmFiles = async dir => {
+  const pkg = await readJSON(resolve(dir, 'package.json'))
+  return getNpmFiles_(dir, pkg)
+}
 
-const readJSON = async (file) => {
-  const data = await readFile(file);
-  return JSON.parse(data);
-};
+const readJSON = async file => {
+  const data = await readFile(file)
+  return JSON.parse(data)
+}
 
 test('`files`', async t => {
-  let files = await getNpmFiles(fixture('files-in-package'));
-  t.is(files.length, 3);
-  files = files.sort(alpha);
-  t.is(base(files[0]), 'files-in-package/build/a/b/c/d.js');
-  t.is(base(files[1]), 'files-in-package/build/a/e.js');
-  t.is(base(files[2]), 'files-in-package/package.json');
-});
+  let files = await getNpmFiles(fixture('files-in-package'))
+  t.is(files.length, 3)
+  files = files.sort(alpha)
+  t.is(base(files[0]), 'files-in-package/build/a/b/c/d.js')
+  t.is(base(files[1]), 'files-in-package/build/a/e.js')
+  t.is(base(files[2]), 'files-in-package/package.json')
+})
 
 test('`files` + `.*.swp` + `.npmignore`', async t => {
-  let files = await getNpmFiles(fixture('files-in-package-ignore'));
-  files = files.sort(alpha);
-  t.is(files.length, 3);
-  t.is(base(files[0]), 'files-in-package-ignore/build/a/b/c/d.js');
-  t.is(base(files[1]), 'files-in-package-ignore/build/a/e.js');
-  t.is(base(files[2]), 'files-in-package-ignore/package.json');
-});
+  let files = await getNpmFiles(fixture('files-in-package-ignore'))
+  files = files.sort(alpha)
+  t.is(files.length, 3)
+  t.is(base(files[0]), 'files-in-package-ignore/build/a/b/c/d.js')
+  t.is(base(files[1]), 'files-in-package-ignore/build/a/e.js')
+  t.is(base(files[2]), 'files-in-package-ignore/package.json')
+})
 
 test('simple', async t => {
-  let files = await getNpmFiles(fixture('simple'));
-  files = files.sort(alpha);
-  t.is(files.length, 5);
-  t.is(base(files[0]), 'simple/bin/test');
-  t.is(base(files[1]), 'simple/index.js');
-  t.is(base(files[2]), 'simple/lib/woot');
-  t.is(base(files[3]), 'simple/lib/woot.jsx');
-  t.is(base(files[4]), 'simple/package.json');
-});
+  let files = await getNpmFiles(fixture('simple'))
+  files = files.sort(alpha)
+  t.is(files.length, 5)
+  t.is(base(files[0]), 'simple/bin/test')
+  t.is(base(files[1]), 'simple/index.js')
+  t.is(base(files[2]), 'simple/lib/woot')
+  t.is(base(files[3]), 'simple/lib/woot.jsx')
+  t.is(base(files[4]), 'simple/package.json')
+})
 
 test('simple with main', async t => {
-  let files = await getNpmFiles(fixture('simple-main'));
-  t.is(files.length, 3);
-  files = files.sort(alpha);
-  t.is(files.length, 3);
-  t.is(base(files[0]), 'simple-main/build/a.js');
-  t.is(base(files[1]), 'simple-main/index.js');
-  t.is(base(files[2]), 'simple-main/package.json');
-});
+  let files = await getNpmFiles(fixture('simple-main'))
+  t.is(files.length, 3)
+  files = files.sort(alpha)
+  t.is(files.length, 3)
+  t.is(base(files[0]), 'simple-main/build/a.js')
+  t.is(base(files[1]), 'simple-main/index.js')
+  t.is(base(files[2]), 'simple-main/package.json')
+})
 
 test('hashes', async t => {
-  const files = await getNpmFiles(fixture('hashes'));
-  const hashes = await hash(files);
-  t.is(hashes.size, 3);
-  t.is(hashes.get('277c55a2042910b9fe706ad00859e008c1b7d172').names[0], prefix + 'hashes/dei.png');
-  t.is(hashes.get('277c55a2042910b9fe706ad00859e008c1b7d172').names[1], prefix + 'hashes/duplicate/dei.png');
-  t.is(hashes.get('56c00d0466fc6bdd41b13dac5fc920cc30a63b45').names[0], prefix + 'hashes/index.js');
-  t.is(hashes.get('706214f42ae940a01d2aa60c5e32408f4d2127dd').names[0], prefix + 'hashes/package.json');
-});
+  const files = await getNpmFiles(fixture('hashes'))
+  const hashes = await hash(files)
+  t.is(hashes.size, 3)
+  t.is(hashes.get('277c55a2042910b9fe706ad00859e008c1b7d172').names[0], prefix + 'hashes/dei.png')
+  t.is(hashes.get('277c55a2042910b9fe706ad00859e008c1b7d172').names[1], prefix + 'hashes/duplicate/dei.png')
+  t.is(hashes.get('56c00d0466fc6bdd41b13dac5fc920cc30a63b45').names[0], prefix + 'hashes/index.js')
+  t.is(hashes.get('706214f42ae940a01d2aa60c5e32408f4d2127dd').names[0], prefix + 'hashes/package.json')
+})
 
 test('ignore node_modules', async t => {
-  let files = await getNpmFiles(fixture('no-node_modules'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'no-node_modules/index.js');
-  t.is(base(files[1]), 'no-node_modules/package.json');
-});
+  let files = await getNpmFiles(fixture('no-node_modules'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'no-node_modules/index.js')
+  t.is(base(files[1]), 'no-node_modules/package.json')
+})
 
 test('ignore nested `node_modules` with .npmignore **', async t => {
-  let files = await getNpmFiles(fixture('nested-node_modules'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'nested-node_modules/index.js');
-  t.is(base(files[1]), 'nested-node_modules/package.json');
-});
+  let files = await getNpmFiles(fixture('nested-node_modules'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'nested-node_modules/index.js')
+  t.is(base(files[1]), 'nested-node_modules/package.json')
+})
 
 test('include `main` even if not in files', async t => {
-  let files = await getNpmFiles(fixture('always-include-main'));
-  files = files.sort(alpha);
-  t.is(files.length, 3);
-  t.is(base(files[0]), 'always-include-main/a.js');
-  t.is(base(files[1]), 'always-include-main/package.json');
-  t.is(base(files[2]), 'always-include-main/woot.js');
-});
+  let files = await getNpmFiles(fixture('always-include-main'))
+  files = files.sort(alpha)
+  t.is(files.length, 3)
+  t.is(base(files[0]), 'always-include-main/a.js')
+  t.is(base(files[1]), 'always-include-main/package.json')
+  t.is(base(files[2]), 'always-include-main/woot.js')
+})
 
 test('support whitelisting with .npmignore and !', async t => {
-  let files = await getNpmFiles(fixture('negation'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'negation/a.js');
-  t.is(base(files[1]), 'negation/package.json');
-});
+  let files = await getNpmFiles(fixture('negation'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'negation/a.js')
+  t.is(base(files[1]), 'negation/package.json')
+})
 
 test('support `now.files`', async t => {
-  let files = await getNpmFiles(fixture('now-files'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'now-files/b.js');
-  t.is(base(files[1]), 'now-files/package.json');
-});
+  let files = await getNpmFiles(fixture('now-files'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'now-files/b.js')
+  t.is(base(files[1]), 'now-files/package.json')
+})
 
 test('support docker', async t => {
-  let files = await getDockerFiles(fixture('dockerfile'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'dockerfile/Dockerfile');
-  t.is(base(files[1]), 'dockerfile/a.js');
-});
+  let files = await getDockerFiles(fixture('dockerfile'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'dockerfile/Dockerfile')
+  t.is(base(files[1]), 'dockerfile/a.js')
+})
 
 test('prefix regression', async t => {
-  let files = await getNpmFiles(fixture('prefix-regression'));
-  files = files.sort(alpha);
-  t.is(files.length, 2);
-  t.is(base(files[0]), 'prefix-regression/package.json');
-  t.is(base(files[1]), 'prefix-regression/woot.js');
-});
+  let files = await getNpmFiles(fixture('prefix-regression'))
+  files = files.sort(alpha)
+  t.is(files.length, 2)
+  t.is(base(files[0]), 'prefix-regression/package.json')
+  t.is(base(files[1]), 'prefix-regression/woot.js')
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,28 @@
-import test from 'ava'
+// Native
 import {join, resolve} from 'path'
-import {
-  npm as getNpmFiles_,
-  docker as getDockerFiles
-} from '../lib/get-files'
-import hash from '../lib/hash'
+
+// Packages
+import test from 'ava'
 import {asc as alpha} from 'alpha-sort'
 import {readFile} from 'fs-promise'
+
+// Ours
+import {npm as getNpmFiles_, docker as getDockerFiles} from '../lib/get-files'
+import hash from '../lib/hash'
 
 const prefix = join(__dirname, '_fixtures') + '/'
 const base = path => path.replace(prefix, '')
 const fixture = name => resolve(`./_fixtures/${name}`)
 
+const readJSON = async file => {
+  const data = await readFile(file)
+  return JSON.parse(data)
+}
+
 // overload to force debugging
 const getNpmFiles = async dir => {
   const pkg = await readJSON(resolve(dir, 'package.json'))
   return getNpmFiles_(dir, pkg)
-}
-
-const readJSON = async file => {
-  const data = await readFile(file)
-  return JSON.parse(data)
 }
 
 test('`files`', async t => {

--- a/test/to-host.js
+++ b/test/to-host.js
@@ -1,26 +1,26 @@
-import test from 'ava';
-import toHost from '../lib/to-host';
+import test from 'ava'
+import toHost from '../lib/to-host'
 
 test('simple', async t => {
-  t.is(toHost('zeit.co'), 'zeit.co');
-});
+  t.is(toHost('zeit.co'), 'zeit.co')
+})
 
 test('leading //', async t => {
-  t.is(toHost('//zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh');
-});
+  t.is(toHost('//zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh')
+})
 
 test('leading http://', async t => {
-  t.is(toHost('http://zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh');
-});
+  t.is(toHost('http://zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh')
+})
 
 test('leading https://', async t => {
-  t.is(toHost('https://zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh');
-});
+  t.is(toHost('https://zeit-logos-rnemgaicnc.now.sh'), 'zeit-logos-rnemgaicnc.now.sh')
+})
 
 test('leading https:// and path', async t => {
-  t.is(toHost('https://zeit-logos-rnemgaicnc.now.sh/path'), 'zeit-logos-rnemgaicnc.now.sh');
-});
+  t.is(toHost('https://zeit-logos-rnemgaicnc.now.sh/path'), 'zeit-logos-rnemgaicnc.now.sh')
+})
 
 test('simple and path', async t => {
-  t.is(toHost('zeit.co/test'), 'zeit.co');
-});
+  t.is(toHost('zeit.co/test'), 'zeit.co')
+})


### PR DESCRIPTION
This continues the work started in https://github.com/zeit/now/pull/69.

I disabled certain rules because they were too present at the moment, so this could be done at a later time.

There was a lot of manual fixes, so there are obviously chances for breakage. The test coverage is not that great, so it won't help much.
Let me know if you want me re-do the work in a way that will be easier to read, or on a step by step basis.

I kept the version at 0.16 at the moment, as there is I think a bug in XO ([I filed an issue here](https://github.com/sindresorhus/xo/issues/156) if you want to follow it) when you want to ignore a subdirectory (`test/_fixtures`) while also running on the parent directory (`test/`) and you changed the file extensions to lint to "no-extension". The files in `bin/` are not linted by default because they do not have a `.js` extension.
