### PR TITLE
Support `now alias` shortcut

### DIFF
--- a/bin/now-alias
+++ b/bin/now-alias
@@ -9,6 +9,7 @@ import login from '../lib/login';
 import * as cfg from '../lib/cfg';
 import { error } from '../lib/error';
 import toHost from '../lib/to-host';
+import readMetaData from '../lib/read-metadata';
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
@@ -82,7 +83,7 @@ const exit = (code) => {
   setTimeout(() => process.exit(code || 0), 100);
 };
 
-if (argv.help || !subcommand) {
+if (argv.help) {
   help();
   exit(0);
 } else {
@@ -202,16 +203,20 @@ async function run (token) {
       break;
 
     default:
-      if (2 === argv._.length) {
-        await alias.set(String(argv._[0]), String(argv._[1]));
-      } else if (argv._.length >= 3) {
-        error('Invalid number of arguments');
-        help();
-        exit(1);
+      if (0 === argv._.length) {
+        await realias(alias);
       } else {
-        error('Please specify a valid subcommand: ls | set | rm');
-        help();
-        exit(1);
+        if (2 === argv._.length) {
+          await alias.set(String(argv._[0]), String(argv._[1]));
+        } else if (argv._.length >= 3) {
+          error('Invalid number of arguments');
+          help();
+          exit(1);
+        } else {
+          error('Please specify a valid subcommand: ls | set | rm');
+          help();
+          exit(1);
+        }
       }
   }
 
@@ -273,4 +278,23 @@ function findAlias (alias, list) {
   return _alias;
 }
 
+async function realias (alias) {
+  const path = process.cwd();
+  const { pkg, name, description } = await readMetaData(path, {
+    deploymentType: 'npm', // FIXME: hard coding settings…
+    quiet: true, // `quiet`
+  });
 
+  const pkgConfig = pkg ? pkg.config || {} : {};
+  const target = pkgConfig.alias;
+
+  if (!target) {
+    help();
+    return exit(0);
+  }
+
+  // now try to find the last deployment
+  const source = await alias.last(name);
+
+  await alias.set(source.url, target);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // Native
 import {homedir} from 'os'
-import {basename, resolve as resolvePath} from 'path'
+import {resolve as resolvePath} from 'path'
 import EventEmitter from 'events'
 
 // Packages
@@ -11,11 +11,10 @@ import {parse as parseIni} from 'ini'
 import {readFile} from 'fs-promise'
 import resumer from 'resumer'
 import splitArray from 'split-array'
-import {parse as parseDockerfile} from 'docker-file-parser'
 
 // Ours
 import {npm as getNpmFiles, docker as getDockerFiles} from './get-files'
-import readMetaData from './read-metadata';
+import readMetaData from './read-metadata'
 import ua from './ua'
 import hash from './hash'
 import Agent from './agent'
@@ -48,22 +47,26 @@ export default class Now extends EventEmitter {
   }) {
     this._path = path
 
-    let files;
+    let files
 
-    const { pkg, name, description } = await readMetaData(path, {
+    const {pkg, name, description} = await readMetaData(path, {
       deploymentType,
-      quiet,
-    });
+      quiet
+    })
 
-    if (this._debug) console.time('> [debug] Getting files');
-
-    if ('npm' === deploymentType) {
-      files = await getNpmFiles(path, { debug: this._debug });
-    } else {
-      files = await getDockerFiles(path, { debug: this._debug });
+    if (this._debug) {
+      console.time('> [debug] Getting files')
     }
 
-    if (this._debug) console.timeEnd('> [debug] Getting files');
+    if (deploymentType === 'npm') {
+      files = await getNpmFiles(path, {debug: this._debug})
+    } else {
+      files = await getDockerFiles(path, {debug: this._debug})
+    }
+
+    if (this._debug) {
+      console.timeEnd('> [debug] Getting files')
+    }
 
     const nowProperties = pkg ? pkg.now || {} : {}
 
@@ -315,21 +318,20 @@ export default class Now extends EventEmitter {
     return deployments
   }
 
-  async last (app) {
-    // TODO app is required
-    const deployments = await this.list(app);
+  async last(app) {
+    const deployments = await this.list(app)
 
     const last = deployments.sort((a, b) => {
-      return b.created - a.created;
-    }).shift();
+      return b.created - a.created
+    }).shift()
 
     if (!last) {
-      const e = Error(`No deployments found for "${app}"`);
-      e.userError = true;
-      throw e;
+      const e = Error(`No deployments found for "${app}"`)
+      e.userError = true
+      throw e
     }
 
-    return last;
+    return last
   }
 
   async listAliases(deploymentId) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import {
   npm as getNpmFiles,
   docker as getDockerFiles
 } from './get-files';
+import readMetaData from './read-metadata';
 import ua from './ua';
 import hash from './hash';
 import retry from 'async-retry';
@@ -45,98 +46,20 @@ export default class Now extends EventEmitter {
   }) {
     this._path = path;
 
-    let pkg = {};
-    let name, description, files;
+    let files;
 
+    const { pkg, name, description } = await readMetaData(path, {
+      deploymentType,
+      quiet,
+    });
+
+    if (this._debug) console.time('> [debug] Getting files');
     if ('npm' === deploymentType) {
-      try {
-        pkg = await readFile(resolvePath(path, 'package.json'));
-        pkg = JSON.parse(pkg);
-      } catch (err) {
-        const e = Error(`Failed to read JSON in "${path}/package.json"`);
-        e.userError = true;
-        throw e;
-      }
-
-      if (!pkg.scripts || (!pkg.scripts.start && !pkg.scripts['now-start'])) {
-        const e = Error('Missing `start` (or `now-start`) script in `package.json`. ' +
-          'See: https://docs.npmjs.com/cli/start.');
-        e.userError = true;
-        throw e;
-      }
-
-      if (null == pkg.name || 'string' !== typeof pkg.name) {
-        name = basename(path);
-        if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`);
-      } else {
-        name = pkg.name;
-      }
-
-      description = pkg.description;
-
-      if (this._debug) console.time('> [debug] Getting files');
-      files = await getNpmFiles(path, pkg, { debug: this._debug });
-      if (this._debug) console.timeEnd('> [debug] Getting files');
-    } else if ('docker' === deploymentType) {
-      let docker;
-      try {
-        const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8');
-        docker = parseDockerfile(dockerfile, { includeComments: true });
-      } catch (err) {
-        const e = Error(`Failed to parse "${path}/Dockerfile"`);
-        e.userError = true;
-        throw e;
-      }
-
-      if (!docker.length) {
-        const e = Error('No commands found in `Dockerfile`');
-        e.userError = true;
-        throw e;
-      }
-
-      if (!docker.some((cmd) => 'CMD' === cmd.name)) {
-        const e = Error('No `CMD` found in `Dockerfile`. ' +
-          'See: https://docs.docker.com/engine/reference/builder/#/cmd');
-        e.userError = true;
-        throw e;
-      }
-
-      if (!docker.some((cmd) => 'EXPOSE' === cmd.name)) {
-        const e = Error('No `EXPOSE` found in `Dockerfile`. A port must be supplied. ' +
-          'See: https://docs.docker.com/engine/reference/builder/#/expose');
-        e.userError = true;
-        throw e;
-      }
-
-      const labels = {};
-      docker
-      .filter(cmd => 'LABEL' === cmd.name)
-      .forEach(({ args }) => {
-        for (let key in args) {
-          // unescape and convert into string
-          try {
-            labels[key] = JSON.parse(args[key]);
-          } catch (err) {
-            const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``);
-            e.userError = true;
-            throw e;
-          }
-        }
-      });
-
-      if (null == labels.name) {
-        name = basename(path);
-        if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`);
-      } else {
-        name = labels.name;
-      }
-
-      description = labels.description;
-
-      if (this._debug) console.time('> [debug] Getting files');
+      files = await getNpmFiles(path, { debug: this._debug });
+    } else {
       files = await getDockerFiles(path, { debug: this._debug });
-      if (this._debug) console.timeEnd('> [debug] Getting files');
     }
+    if (this._debug) console.timeEnd('> [debug] Getting files');
 
     const nowProperties = pkg ? pkg.now || {} : {};
 
@@ -352,6 +275,23 @@ export default class Now extends EventEmitter {
     }, { retries: 3, minTimeout: 2500, onRetry: this._onRetry });
 
     return deployments;
+  }
+
+  async last (app) {
+    // TODO app is required
+    const deployments = await this.list(app);
+
+    const last = deployments.sort((a, b) => {
+      return b.created - a.created;
+    }).shift();
+
+    if (!last) {
+      const e = Error(`No deployments found for "${app}"`);
+      e.userError = true;
+      throw e;
+    }
+
+    return last;
   }
 
   async listAliases (deploymentId) {

--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -1,14 +1,15 @@
-import chalk from 'chalk';
-import { readFile } from 'fs-promise';
-import { basename, resolve as resolvePath } from 'path';
-import { parse as parseDockerfile } from 'docker-file-parser';
+import {basename, resolve as resolvePath} from 'path'
+import chalk from 'chalk'
+import {readFile} from 'fs-promise'
+import {parse as parseDockerfile} from 'docker-file-parser'
 
 export default async function (path, {
   deploymentType = 'npm',
-  quiet = false,
+  quiet = false
 }) {
-  let pkg = {};
-  let name, description;
+  let pkg = {}
+  let name
+  let description
 
   if (deploymentType === 'npm') {
     try {
@@ -105,6 +106,6 @@ export default async function (path, {
   return {
     name,
     description,
-    pkg,
-  };
+    pkg
+  }
 }

--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -9,86 +9,97 @@ export default async function (path, {
 }) {
   let pkg = {};
   let name, description;
-  if ('npm' === deploymentType) {
+
+  if (deploymentType === 'npm') {
     try {
-      pkg = await readFile(resolvePath(path, 'package.json'));
-      pkg = JSON.parse(pkg);
+      pkg = await readFile(resolvePath(path, 'package.json'))
+      pkg = JSON.parse(pkg)
     } catch (err) {
-      const e = Error(`Failed to read JSON in "${path}/package.json"`);
-      e.userError = true;
-      throw e;
+      const e = Error(`Failed to read JSON in "${path}/package.json"`)
+      e.userError = true
+      throw e
     }
 
     if (!pkg.scripts || (!pkg.scripts.start && !pkg.scripts['now-start'])) {
       const e = Error('Missing `start` (or `now-start`) script in `package.json`. ' +
-        'See: https://docs.npmjs.com/cli/start.');
-      e.userError = true;
-      throw e;
+        'See: https://docs.npmjs.com/cli/start.')
+      e.userError = true
+      throw e
     }
 
-    if (null == pkg.name || 'string' !== typeof pkg.name) {
-      name = basename(path);
-      if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`);
+    if (pkg.name === null || typeof pkg.name !== 'string') {
+      name = basename(path)
+
+      if (!quiet) {
+        console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`)
+      }
     } else {
-      name = pkg.name;
+      name = pkg.name
     }
 
-    description = pkg.description;
-  } else if ('docker' === deploymentType) {
-    let docker;
+    description = pkg.description
+  } else if (deploymentType === 'docker') {
+    let docker
     try {
-      const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8');
-      docker = parseDockerfile(dockerfile, { includeComments: true });
+      const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8')
+      docker = parseDockerfile(dockerfile, {includeComments: true})
     } catch (err) {
-      const e = Error(`Failed to parse "${path}/Dockerfile"`);
-      e.userError = true;
-      throw e;
+      const e = Error(`Failed to parse "${path}/Dockerfile"`)
+      e.userError = true
+      throw e
     }
 
-    if (!docker.length) {
-      const e = Error('No commands found in `Dockerfile`');
-      e.userError = true;
-      throw e;
+    if (docker.length <= 0) {
+      const e = Error('No commands found in `Dockerfile`')
+      e.userError = true
+      throw e
     }
 
-    if (!docker.some((cmd) => 'CMD' === cmd.name)) {
+    if (!docker.some(cmd => cmd.name === 'CMD')) {
       const e = Error('No `CMD` found in `Dockerfile`. ' +
-        'See: https://docs.docker.com/engine/reference/builder/#/cmd');
-      e.userError = true;
-      throw e;
+        'See: https://docs.docker.com/engine/reference/builder/#/cmd')
+      e.userError = true
+      throw e
     }
 
-    if (!docker.some((cmd) => 'EXPOSE' === cmd.name)) {
+    if (!docker.some(cmd => cmd.name === 'EXPOSE')) {
       const e = Error('No `EXPOSE` found in `Dockerfile`. A port must be supplied. ' +
-        'See: https://docs.docker.com/engine/reference/builder/#/expose');
-      e.userError = true;
-      throw e;
+        'See: https://docs.docker.com/engine/reference/builder/#/expose')
+      e.userError = true
+      throw e
     }
 
-    const labels = {};
+    const labels = {}
     docker
-    .filter(cmd => 'LABEL' === cmd.name)
-    .forEach(({ args }) => {
-      for (let key in args) {
+    .filter(cmd => cmd.name === 'LABEL')
+    .forEach(({args}) => {
+      for (const key in args) {
+        if (!{}.hasOwnProperty.call(args, key)) {
+          continue
+        }
+
         // unescape and convert into string
         try {
-          labels[key] = JSON.parse(args[key]);
+          labels[key] = JSON.parse(args[key])
         } catch (err) {
-          const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``);
-          e.userError = true;
-          throw e;
+          const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``)
+          e.userError = true
+          throw e
         }
       }
-    });
+    })
 
-    if (null == labels.name) {
-      name = basename(path);
-      if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`);
+    if (labels.name === null) {
+      name = basename(path)
+
+      if (!quiet) {
+        console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`)
+      }
     } else {
-      name = labels.name;
+      name = labels.name
     }
 
-    description = labels.description;
+    description = labels.description
   }
 
   return {

--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -1,0 +1,99 @@
+import chalk from 'chalk';
+import { readFile } from 'fs-promise';
+import { basename, resolve as resolvePath } from 'path';
+import { parse as parseDockerfile } from 'docker-file-parser';
+
+export default async function (path, {
+  deploymentType = 'npm',
+  quiet = false,
+}) {
+  let pkg = {};
+  let name, description;
+  if ('npm' === deploymentType) {
+    try {
+      pkg = await readFile(resolvePath(path, 'package.json'));
+      pkg = JSON.parse(pkg);
+    } catch (err) {
+      const e = Error(`Failed to read JSON in "${path}/package.json"`);
+      e.userError = true;
+      throw e;
+    }
+
+    if (!pkg.scripts || (!pkg.scripts.start && !pkg.scripts['now-start'])) {
+      const e = Error('Missing `start` (or `now-start`) script in `package.json`. ' +
+        'See: https://docs.npmjs.com/cli/start.');
+      e.userError = true;
+      throw e;
+    }
+
+    if (null == pkg.name || 'string' !== typeof pkg.name) {
+      name = basename(path);
+      if (!quiet) console.log(`> No \`name\` in \`package.json\`, using ${chalk.bold(name)}`);
+    } else {
+      name = pkg.name;
+    }
+
+    description = pkg.description;
+  } else if ('docker' === deploymentType) {
+    let docker;
+    try {
+      const dockerfile = await readFile(resolvePath(path, 'Dockerfile'), 'utf8');
+      docker = parseDockerfile(dockerfile, { includeComments: true });
+    } catch (err) {
+      const e = Error(`Failed to parse "${path}/Dockerfile"`);
+      e.userError = true;
+      throw e;
+    }
+
+    if (!docker.length) {
+      const e = Error('No commands found in `Dockerfile`');
+      e.userError = true;
+      throw e;
+    }
+
+    if (!docker.some((cmd) => 'CMD' === cmd.name)) {
+      const e = Error('No `CMD` found in `Dockerfile`. ' +
+        'See: https://docs.docker.com/engine/reference/builder/#/cmd');
+      e.userError = true;
+      throw e;
+    }
+
+    if (!docker.some((cmd) => 'EXPOSE' === cmd.name)) {
+      const e = Error('No `EXPOSE` found in `Dockerfile`. A port must be supplied. ' +
+        'See: https://docs.docker.com/engine/reference/builder/#/expose');
+      e.userError = true;
+      throw e;
+    }
+
+    const labels = {};
+    docker
+    .filter(cmd => 'LABEL' === cmd.name)
+    .forEach(({ args }) => {
+      for (let key in args) {
+        // unescape and convert into string
+        try {
+          labels[key] = JSON.parse(args[key]);
+        } catch (err) {
+          const e = Error(`Error parsing value for LABEL ${key} in \`Dockerfile\``);
+          e.userError = true;
+          throw e;
+        }
+      }
+    });
+
+    if (null == labels.name) {
+      name = basename(path);
+      if (!quiet) console.log(`> No \`name\` LABEL in \`Dockerfile\`, using ${chalk.bold(name)}`);
+    } else {
+      name = labels.name;
+    }
+
+    description = labels.description;
+  }
+
+  return {
+    name,
+    description,
+    pkg,
+  };
+}


### PR DESCRIPTION
- [ ] PR ready?
#### What's this PR do?

Add support for reading the default alias target from a `package.json`'s `config.alias` property.

Running `now alias` will look for the latest deployment (and throw if there isn't one) and then look for the `config.alias` to allow the user to shortcut the current `now alias <deployment> <target>`.

Related ticket: https://github.com/zeit/now/issues/68

Note: I'll likely rebase this PR into a single commit for this feature…unless I hear otherwise.
