### PR TITLE
pass flags to subcommands

### DIFF
--- a/bin/now.js
+++ b/bin/now.js
@@ -29,6 +29,7 @@ const defaultCommand = 'deploy'
 
 const commands = new Set([
   defaultCommand,
+  'help',
   'list',
   'ls',
   'rm',
@@ -54,25 +55,26 @@ const aliases = new Map([
   ['secret', 'secrets']
 ])
 
-let cmd = argv._[0]
-let args = []
+let cmd = defaultCommand
+const args = process.argv.slice(2)
+const index = args.findIndex(a => commands.has(a))
 
-if (cmd === 'help') {
-  cmd = argv._[1]
+if (index > -1) {
+  cmd = args[index]
+  args.splice(index, 1)
 
-  if (!commands.has(cmd)) {
-    cmd = defaultCommand
+  if (cmd === 'help') {
+    if (index < args.length && commands.has(args[index])) {
+      cmd = args[index]
+      args.splice(index, 1)
+    } else {
+      cmd = defaultCommand
+    }
+
+    args.unshift('--help')
   }
 
-  args.push('--help')
-}
-
-if (commands.has(cmd)) {
   cmd = aliases.get(cmd) || cmd
-  args = args.concat(process.argv.slice(3))
-} else {
-  cmd = defaultCommand
-  args = args.concat(process.argv.slice(2))
 }
 
 let bin = resolve(__dirname, 'now-' + cmd)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "gulp",
     "test": "xo && ava",
+    "pretest": "gulp compile",
     "prepublish": "gulp compile",
     "pkg": "pkg . --out-dir out"
   },

--- a/test/args-parsing.js
+++ b/test/args-parsing.js
@@ -1,0 +1,88 @@
+import path from 'path'
+import test from 'ava'
+import {spawn} from 'cross-spawn'
+
+const deployHelpMessage = '𝚫 now [options] <command | path>'
+const aliasHelpMessage = '𝚫 now alias <ls | set | rm> <deployment> <alias>'
+
+test('"now help" prints deploy help message', async t => {
+  const result = await now('help')
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(deployHelpMessage))
+})
+
+test('"now --help" prints deploy help message', async t => {
+  const result = await now('--help')
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(deployHelpMessage))
+})
+
+test('"now deploy --help" prints deploy help message', async t => {
+  const result = await now('deploy', '--help')
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(deployHelpMessage))
+})
+
+test('"now --help deploy" prints deploy help message', async t => {
+  const result = await now('--help', 'deploy')
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(deployHelpMessage))
+})
+
+test('"now help alias" prints alias help message', async t => {
+  const result = await now('help', 'alias')
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(aliasHelpMessage))
+})
+
+test('"now alias --help" is the same as "now --help alias"', async t => {
+  const [result1, result2] = await Promise.all([now('alias', '--help'), now('--help', 'alias')])
+
+  t.is(result1.code, 0)
+  t.is(result1.code, result2.code)
+  t.is(result1.stdout, result2.stdout)
+})
+
+/**
+ * Run the built now binary with given arguments
+ *
+ * @param  {String} args  string arguements
+ * @return {Promise}      promise that resolves to an object {code, stdout}
+ */
+function now(...args) {
+  return new Promise((resolve, reject) => {
+    const command = path.resolve(__dirname, '../build/bin/now')
+    const now = spawn(command, args)
+
+    let stdout = ''
+    now.stdout.on('data', data => {
+      stdout += data
+    })
+
+    now.on('error', err => {
+      reject(err)
+    })
+
+    now.on('close', code => {
+      resolve({
+        code,
+        stdout
+      })
+    })
+  })
+}


### PR DESCRIPTION
Instead of assuming the subcommand is the first argument, this enhancement searches for the first valid subcommand in all of the process arguments. The result being the arguments are more or less "re-ordered" to push all the flags after the subcommand. Processing of the the help command was then refactored to work with the new parsing.

@leo @rauchg this fixes #3. Let me know if there is something I can improve. cheers!
