### PR TITLE
Downgrade socket.io client

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "progress": "1.1.8",
     "resumer": "0.0.0",
     "semver-compare": "1.0.0",
-    "socket.io-client": "1.5.1",
+    "socket.io-client": "1.4.8",
     "spdy": "3.4.4",
     "split-array": "1.0.1",
     "text-table": "0.2.0"


### PR DESCRIPTION
There was a regression on engine.io-client whre establishing connection over https failed, see: https://github.com/socketio/engine.io-client/pull/514 and https://github.com/socketio/engine.io-client/pull/513

Let's downgrade socket.io-client until there is a new release
