### PR TITLE
Fixes to Dockerfile metadata parsing

### DIFF
--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -44,7 +44,7 @@ export default async function (path, {
       throw e
     }
 
-    if (pkg.name === null || typeof pkg.name !== 'string') {
+    if (typeof pkg.name !== 'string') {
       name = basename(path)
 
       if (!quiet && !isStatic) {
@@ -106,7 +106,7 @@ export default async function (path, {
       }
     })
 
-    if (labels.name === null) {
+    if (!labels.name) {
       name = basename(path)
 
       if (!quiet) {


### PR DESCRIPTION
- No need to check if pkg.name is null
- Properly default to basename if labels.name isn't set
