### PR TITLE
Fix DNS verification on 'now alias'

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -366,7 +366,7 @@ export default class Alias extends Now {
       }
 
       for (const ip of ips) {
-        if (targets.indexOf(ip) !== -1) {
+        if (targets.indexOf(ip) === -1) {
           const err = new Error(`The domain ${domain} has an A record ${chalk.bold(ip)} that doesn't resolve to ${chalk.bold(chalk.underline('alias.zeit.co'))}.\n> ` + DOMAIN_VERIFICATION_ERROR)
           err.ip = ip
           err.userError = true


### PR DESCRIPTION
`> Error! > We configured the DNS settings for your alias, but we were unable to verify that they've propagated. Please try the alias again later.`
