### PR TITLE
Added force flag for skipping alias owner verification

### DIFF
--- a/bin/now-alias.js
+++ b/bin/now-alias.js
@@ -17,11 +17,12 @@ import readMetaData from '../lib/read-metadata'
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
-  boolean: ['help', 'debug'],
+  boolean: ['help', 'debug', 'force'],
   alias: {
     help: 'h',
     config: 'c',
     debug: 'd',
+    force: 'f',
     token: 't'
   }
 })
@@ -37,6 +38,7 @@ const help = () => {
     -h, --help              Output usage information
     -c ${chalk.bold.underline('FILE')}, --config=${chalk.bold.underline('FILE')}  Config file
     -d, --debug             Debug mode [off]
+    -f, --force             Skip DNS verification
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline('TOKEN')} Login token
 
   ${chalk.dim('Examples:')}
@@ -76,6 +78,7 @@ const help = () => {
 
 // options
 const debug = argv.debug
+const force = argv.force
 const apiUrl = argv.url || 'https://api.zeit.co'
 
 if (argv.config) {
@@ -116,7 +119,7 @@ if (argv.help) {
 }
 
 async function run(token) {
-  const alias = new NowAlias(apiUrl, token, {debug})
+  const alias = new NowAlias(apiUrl, token, {debug, force})
   const args = argv._.slice(1)
 
   switch (subcommand) {
@@ -218,7 +221,7 @@ async function run(token) {
       }
 
       if (argv._.length === 2) {
-        await alias.set(String(argv._[0]), String(argv._[1]))
+        await alias.set(String(argv._[0]), String(argv._[1]), argv.force)
       } else if (argv._.length >= 3) {
         error('Invalid number of arguments')
         help()

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -80,7 +80,7 @@ export default class Alias extends Now {
     return depl
   }
 
-  async set(deployment, alias) {
+  async set(deployment, alias, skipVerification) {
     // make alias lowercase
     alias = alias.toLowerCase()
 
@@ -125,7 +125,9 @@ export default class Alias extends Now {
       }
 
       try {
-        await this.verifyOwnership(alias)
+        if (!skipVerification) {
+          await this.verifyOwnership(alias)
+        }
       } catch (err) {
         if (err.userError) {
           // a user error would imply that verification failed


### PR DESCRIPTION
### Background

I use Zeit Now with CloudFlare. Yes, I know that Zeit World offers some similar features. But I prefer CloudFlare at the moment (due the features and since I use CloudFlare for all my projects). I use CloudFlare for DNS and I also use the CloudFlare proxy (which provides caching, analytics, and many other things).
### Problem

The problem is that if I enable the CloudFlare proxy for my domains, then Zeit Now is unable to verify my domains when **updating** an alias. Let's consider an example:

`https://browserframe.com` is to `https://browserframe-abababa.now.sh`

```
Browser requests https://browserframe.com
=> browserframe.com resolves to 104.31.65.122 (CloudFlare)
=> CloudFlare maps this request to alias.zeit.co (behind the proxy)
=> alias.zeit.co responds for aliased deployment
```

Now, let's say I want to deploy and update and update the alias:

```
>now alias https://browserframe-nuefnrooab.now.sh browserframe.com
> browserframe.com is a custom domain.
> Verifying the DNS settings for browserframe.com (see https://zeit.world for help)
> Resolved IP: 104.31.64.122 (unknown)
> Nameservers: max.ns.cloudflare.com, barbara.ns.cloudflare.com
> Error! The domain browserframe.com has an A record 104.31.64.122 that doesn't resolve to alias.zeit.co.
> Please make sure that your nameservers point to zeit.world.
> Examples: (full list at https://zeit.world)
> - california.zeit.world    173.255.215.107
> - newark.zeit.world        173.255.231.87
> - london.zeit.world        178.62.47.76
> - singapore.zeit.world     119.81.97.170
> Alternatively, ensure it resolves to alias.zeit.co via CNAME / ALIAS.
```

As expected, this doesn't work since the domain doesn't point directly to alias.zeit.co. It does so only indirectly behind the CloudFlare proxy. However, this doesn't affect the fact that if I tell Zeit Now to update the alias it should still work.
### Solution 1

Hence, I propose that a `--force` flag be added to the alias command. This would allow me to update my aliases anyways.

```
now alias https://browserframe-nuefnrooab.now.sh browserframe.com -f
```

Of course, this wouldn't work when the domain hasn't already been added to a Zeit account, but that's fine. The easiest way of working around that is to just disable the CloudFlare proxy when adding the domain. Then enable the CloudFlare proxy once the domain has been added to your account.
### Solution 2

An alternative solution would be to perform verification of DNS ownership in a different way (this would require more work/changes). A suggestion would be to use TXT records for verification (Google-style). For example:

```
TXT browserframe.com zeit-now-verification=SOME_UNIQUE_VALUE
```
