### PR TITLE
Don't whitelist the resolved IP address

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -338,12 +338,6 @@ export default class Alias extends Now {
 
   verifyOwnership(domain) {
     return this.retry(async bail => {
-      const targets = await resolve4('alias.zeit.co')
-
-      if (targets.length <= 0) {
-        return bail(new Error('Unable to resolve alias.zeit.co'))
-      }
-
       let ips = []
 
       try {
@@ -363,15 +357,6 @@ export default class Alias extends Now {
         const err = new Error(DOMAIN_VERIFICATION_ERROR)
         err.userError = true
         return bail(err)
-      }
-
-      for (const ip of ips) {
-        if (targets.indexOf(ip) === -1) {
-          const err = new Error(`The domain ${domain} has an A record ${chalk.bold(ip)} that doesn't resolve to ${chalk.bold(chalk.underline('alias.zeit.co'))}.\n> ` + DOMAIN_VERIFICATION_ERROR)
-          err.ip = ip
-          err.userError = true
-          return bail(err)
-        }
       }
     })
   }


### PR DESCRIPTION
This is to support websites behind content proxies like Cloudflare that [flatten the CNAME](https://support.cloudflare.com/hc/en-us/articles/200169056-CNAME-Flattening-RFC-compliant-support-for-CNAME-at-the-root), currently the `now alias` command just errors:
```
❯ now alias z0GIyDKdF4gH8LDesAqYlnST rolandwarmerdam.com
> rolandwarmerdam.com is a custom domain.
> Verifying the DNS settings for rolandwarmerdam.com (see https://zeit.world for help)
> Resolved IP: 104.27.178.220 (unknown)
> Nameservers: ara.ns.cloudflare.com, curt.ns.cloudflare.com
> Error! The domain rolandwarmerdam.com has an A record 104.27.178.220 that doesn't resolve to alias.zeit.co.
> Please make sure that your nameservers point to zeit.world.
> Examples: (full list at https://zeit.world)
> - california.zeit.world    173.255.215.107
> - newark.zeit.world        173.255.231.87
> - london.zeit.world        178.62.47.76
> - singapore.zeit.world     119.81.97.170
> Alternatively, ensure it resolves to alias.zeit.co via CNAME / ALIAS.
```