### PR TITLE
Fix unhandled promise rejection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -404,7 +404,7 @@ export default class Now extends EventEmitter {
   }
 
   getNameservers(domain) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       let fallback = false
 
       this.retry(async (bail, attempt) => {
@@ -445,6 +445,8 @@ export default class Now extends EventEmitter {
           return ns.length
         })
         resolve(body)
+      }).catch(err => {
+        reject(err)
       })
     })
   }


### PR DESCRIPTION
Before:
```
now domain add isotalo.tk
> Verifying nameservers…
(node:28814) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Whois error (500): An unexpected internal error occurred
(node:28814) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After:
```
now domain add isotalo.tk
> Verifying nameservers…
> Error! Unable to fetch nameservers for isotalo.tk.
```