### PR TITLE
alias set --debug: Only print nameservers if we fetched them

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -133,7 +133,11 @@ export default class Alias extends Now {
       let skipDNSVerification = false
 
       if (this._debug) {
-        console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`)
+        if (domainInfo) {
+          console.log(`> [debug] Found domain ${domain} with verified:${domainInfo.verified}`)
+        } else {
+          console.log(`> [debug] Found domain ${domain} and nameservers ${nameservers}`)
+        }
       }
 
       if (!usingZeitWorld && domainInfo) {


### PR DESCRIPTION
Fixes the minor issue seen in #163 that causes `--debug` to print

```
> [debug] Found domain mydomain.com and nameservers undefined
```

for verified domains.