### PR TITLE
Show an appropriate message for incomplete deployments

### DIFF
--- a/bin/now-list.js
+++ b/bin/now-list.js
@@ -108,7 +108,7 @@ async function list(token) {
 
   const text = sorted.map(([name, deps]) => {
     const t = table(deps.map(({uid, url, created}) => {
-      const _url = chalk.underline(`https://${url}`)
+      const _url = url ? chalk.underline(`https://${url}`) : 'incomplete';
       const time = chalk.gray(ms(current - created) + ' ago')
       return [uid, _url, time]
     }), {align: ['l', 'r', 'l'], hsep: ' '.repeat(6), stringLength: strlen})


### PR DESCRIPTION
If syncing files fails or the user just happens to run `now ls`
before the deployment is ready `https://null` is shown as an URL
to the deployment. Instead of showing `null` we could show
something nice.