### PR TITLE
Add TXT record type to `now dns --help`

### DIFF
--- a/bin/now-dns.js
+++ b/bin/now-dns.js
@@ -30,7 +30,7 @@ const subcommand = argv._[0]
 const help = () => {
   console.log(`
   ${chalk.bold('𝚫 now dns ls')} [domain]
-  ${chalk.bold('𝚫 now dns add')} <domain> <name> <A | AAAA | ALIAS | CNAME | MX> <value> [mx_priority]
+  ${chalk.bold('𝚫 now dns add')} <domain> <name> <A | AAAA | ALIAS | CNAME | MX | TXT> <value> [mx_priority]
   ${chalk.bold('𝚫 now dns rm')} <id>
 
   ${chalk.dim('Options:')}


### PR DESCRIPTION
TXT record support was recently added to now.