### PR TITLE
Add auto-renew column to `now certs ls`

### DIFF
--- a/bin/now-certs.js
+++ b/bin/now-certs.js
@@ -132,7 +132,7 @@ async function run(token) {
       list.sort((a, b) => {
         return a.cn.localeCompare(b.cn)
       })
-      const header = [['', 'id', 'cn', 'created', 'expiration'].map(s => chalk.dim(s))]
+      const header = [['', 'id', 'cn', 'created', 'expiration', 'auto-renew'].map(s => chalk.dim(s))]
       const out = table(header.concat(list.map(cert => {
         const cn = chalk.bold(cert.cn)
         const time = chalk.gray(ms(cur - new Date(cert.created)) + ' ago')
@@ -142,7 +142,8 @@ async function run(token) {
           cert.uid ? cert.uid : 'unknown',
           cn,
           time,
-          expiration
+          expiration,
+          cert.autoRenew ? 'yes' : 'no'
         ]
       })), {align: ['l', 'r', 'l', 'l', 'l'], hsep: ' '.repeat(2), stringLength: strlen})
 


### PR DESCRIPTION
Generally a certificate is renewed automatically if it was created with `now certs create`, while custom certificates added with `now certs add` or `now certs replace` are not renewed automatically.