### PR TITLE
XO Happiness

### DIFF
--- a/bin/now-alias.js
+++ b/bin/now-alias.js
@@ -120,8 +120,8 @@ async function run(token) {
   const args = argv._.slice(1)
 
   switch (subcommand) {
-    case 'list':
     case 'ls':
+    case 'list': {
       if (args.length !== 0) {
         error(`Invalid number of arguments. Usage: ${chalk.cyan('`now alias ls`')}`)
         return exit(1)
@@ -160,9 +160,9 @@ async function run(token) {
       }
 
       break
-
-    case 'remove':
+    }
     case 'rm':
+    case 'remove': {
       const _target = String(args[0])
       if (!_target) {
         const err = new Error('No alias id specified')
@@ -201,17 +201,17 @@ async function run(token) {
       }
 
       break
-
+    }
     case 'add':
-    case 'set':
+    case 'set': {
       if (args.length !== 2) {
         error(`Invalid number of arguments. Usage: ${chalk.cyan('`now alias set <id> <domain>`')}`)
         return exit(1)
       }
       await alias.set(String(args[0]), String(args[1]))
       break
-
-    default:
+    }
+    default: {
       if (argv._.length === 0) {
         await realias(alias)
         break
@@ -228,6 +228,7 @@ async function run(token) {
         help()
         exit(1)
       }
+    }
   }
 
   alias.close()

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -235,7 +235,7 @@ async function sync(token) {
       Object.assign(gitRepo, gitParts)
 
       const searchMessage = setTimeout(() => {
-        console.log(`> Didn\'t find directory. Searching on ${gitRepo.type}...`)
+        console.log(`> Didn't find directory. Searching on ${gitRepo.type}...`)
       }, 500)
 
       try {
@@ -416,7 +416,7 @@ async function sync(token) {
       if ((key in process.env)) {
         console.log(`> Reading ${chalk.bold(`"${chalk.bold(key)}"`)} from your env (as no value was specified)`)
         // escape value if it begins with @
-        val = process.env[key].replace(/^\@/, '\\@')
+        val = process.env[key].replace(/^@/, '\\@')
       } else {
         error(`No value specified for env ${chalk.bold(`"${chalk.bold(key)}"`)} and it was not found in your env.`)
         return process.exit(1)

--- a/bin/now-domains.js
+++ b/bin/now-domains.js
@@ -141,7 +141,7 @@ async function run(token) {
 
   switch (subcommand) {
     case 'ls':
-    case 'list':
+    case 'list': {
       if (args.length !== 0) {
         error('Invalid number of arguments')
         return exit(1)
@@ -174,9 +174,9 @@ async function run(token) {
       }
 
       break
-
+    }
     case 'rm':
-    case 'remove':
+    case 'remove': {
       if (args.length !== 1) {
         error('Invalid number of arguments')
         return exit(1)
@@ -214,9 +214,9 @@ async function run(token) {
         exit(1)
       }
       break
-
+    }
     case 'add':
-    case 'set':
+    case 'set': {
       if (args.length !== 1) {
         error('Invalid number of arguments')
         return exit(1)
@@ -238,7 +238,7 @@ async function run(token) {
         console.log('> Verification required: Please rerun this command after some time')
       }
       break
-
+    }
     default:
       error('Please specify a valid subcommand: ls | add | rm')
       help()

--- a/bin/now-remove.js
+++ b/bin/now-remove.js
@@ -128,7 +128,7 @@ async function remove(token) {
   const matches = deployments.filter(d => {
     return ids.find(id => {
       // `url` should match the hostname of the deployment
-      let u = id.replace(/^https\:\/\//i, '')
+      let u = id.replace(/^https:\/\//i, '')
 
       if (u.indexOf('.') === -1) {
         // `.now.sh` domain is implied if just the subdomain is given

--- a/lib/git.js
+++ b/lib/git.js
@@ -73,10 +73,11 @@ const downloadRepo = async repoPath => {
   let url
 
   switch (pathParts.type) {
-    case 'GitLab':
+    case 'GitLab': {
       const ref = pathParts.ref ? `?ref=${pathParts.ref}` : ''
       url = `https://gitlab.com/${pathParts.main}/repository/archive.tar` + ref
       break
+    }
     case 'Bitbucket':
       url = `https://bitbucket.org/${pathParts.main}/get/${pathParts.ref || 'default'}.zip`
       break

--- a/lib/to-host.js
+++ b/lib/to-host.js
@@ -14,5 +14,5 @@ export default function toHost(url) {
 
   // remove any path if present
   // `a.b.c/` => `a.b.c`
-  return url.replace(/(\/\/)?([^\/]+)(.*)/, '$2')
+  return url.replace(/(\/\/)?([^/]+)(.*)/, '$2')
 }

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
       "complexity": 0,
       "unicorn/no-process-exit": 0,
       "no-control-regex": 0,
-      "no-case-declarations": 0,
-      "no-useless-escape": 0
+      "no-case-declarations": 0
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
       "no-use-before-define": 0,
       "complexity": 0,
       "unicorn/no-process-exit": 0,
-      "no-control-regex": 0,
-      "no-case-declarations": 0
+      "no-control-regex": 0
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     ],
     "rules": {
       "import/no-unresolved": 0,
-      "ava/no-ignored-test-files": 0,
       "max-depth": 0,
       "no-use-before-define": 0,
       "complexity": 0,


### PR DESCRIPTION
Partially satisfies #92 

**Done:**

- `ava/no-ignored-test-files`
- `no-case-declarations`
- `no-useless-escape`

**Notes re:Remaining**
- `import/no-unresolved`

  Takes issue with `../../package` imports. If changed to `../../package.json`, new errors thrown about an unexpected json extension (`import/extensions`).

- `max-depth`
- `complexity`

  These two, if to be fixed, go hand-in-hand. A handful of functions (mostly `bin/*`) are too deep / have too many blocks according to XO; slicing them will require some refactoring. I'm waiting for a sign-off on this specifically before continuing.

- `no-use-before-define`

  Like the previous two, most of `lib/get-files.js` will have to be shifted around. And, unfortunately in [some cases](https://github.com/zeit/now-cli/blob/master/lib/get-files.js#L226-L237), it may not be able to satisfy this rule without some sub-optimal checks.

- `unicorn/no-process-exit`
  
  Easy one. [This](https://github.com/zeit/now-cli/blob/master/lib/utils/check-path.js#L50) is the only error. Not sure if `throw Error()` would suffice.

- `no-control-regex`
  
  TBH, no idea what this is. XO does not like `\x1b` from [here](https://github.com/zeit/now-cli/blob/master/lib/strlen.js#L2) & there appears to be no workaround...(because it's a hidden character?)
