### PR TITLE
copy alias to clipboard & show message

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -243,17 +243,20 @@ export default class Alias extends Now {
     }
     const {created, uid} = newAlias
     if (created) {
-      let append
       const pretty = `https://${alias}`
+      const output = `${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(pretty))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`
       if (isTTY && clipboard) {
+        let append
         try {
           await copy(pretty)
           append = '[copied to clipboard]'
         } catch (err) {
           append = ''
         } finally {
-          console.log(`${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(pretty))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)} ${append}`)
+          console.log(`${output} ${append}`)
         }
+      } else {
+        console.log(output)
       }
     } else {
       console.log(`${chalk.cyan('> Success!')} Alias already exists ${chalk.dim(`(${uid})`)}.`)

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -1,14 +1,23 @@
 // Packages
 import publicSuffixList from 'psl'
+import minimist from 'minimist'
 import chalk from 'chalk'
 
 // Ours
+import copy from './copy'
 import toHost from './to-host'
 import resolve4 from './dns'
 import isZeitWorld from './is-zeit-world'
 import {DOMAIN_VERIFICATION_ERROR} from './errors'
 import Now from './'
 
+const argv = minimist(process.argv.slice(2), {
+  boolean: ['no-clipboard'],
+  alias: {'no-clipboard': 'C'}
+})
+
+const isTTY = process.stdout.isTTY
+const clipboard = !argv['no-clipboard']
 const domainRegex = /^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/
 
 export default class Alias extends Now {
@@ -234,7 +243,18 @@ export default class Alias extends Now {
     }
     const {created, uid} = newAlias
     if (created) {
-      console.log(`${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(`https://${alias}`))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`)
+      let append
+      const pretty = `https://${alias}`
+      if (isTTY && clipboard) {
+        try {
+          await copy(pretty)
+          append = '[copied to clipboard]'
+        } catch (err) {
+          append = ''
+        } finally {
+          console.log(`${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(pretty))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)} ${append}`)
+        }
+      }
     } else {
       console.log(`${chalk.cyan('> Success!')} Alias already exists ${chalk.dim(`(${uid})`)}.`)
     }


### PR DESCRIPTION
Closes #186 

However, I feel now that the success message should be trimmed a bit. This is the final form:

```
> Success! Alias created (vHtl3AcStIRuwvBVc6FgrKeB): https://inferno-starter.now.sh now points to https://inferno-starter-firbedifww.now.sh (sm6u8PxiD0C2khzyBOXK1RC4) [copied to clipboard]
```

Perhaps either (1) a new line after `Alias created ${chalk.dim(`(${uid})`)}:`  or (2) trim the meta data:

```
# 1
> Success! Alias created (vHtl3AcStIRuwvBVc6FgrKeB):
https://inferno-starter.now.sh now points to https://inferno-starter-firbedifww.now.sh (sm6u8PxiD0C2khzyBOXK1RC4) [copied to clipboard]

# 2
> Success! Alias created: https://inferno-starter.now.sh now points to https://inferno-starter-firbedifww.now.sh [copied to clipboard]
```
