### PR TITLE
insert newline into alias-success msg

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -244,7 +244,7 @@ export default class Alias extends Now {
     const {created, uid} = newAlias
     if (created) {
       const pretty = `https://${alias}`
-      const output = `${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}: ${chalk.bold(chalk.underline(pretty))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`
+      const output = `${chalk.cyan('> Success!')} Alias created ${chalk.dim(`(${uid})`)}:\n${chalk.bold(chalk.underline(pretty))} now points to ${chalk.bold(`https://${depl.url}`)} ${chalk.dim(`(${depl.uid})`)}`
       if (isTTY && clipboard) {
         let append
         try {


### PR DESCRIPTION
Success message after creating an alias got a bit long.

New example:

```
> Success! Alias created (vHtl3AcStIRuwvBVc6FgrKeB):
https://inferno-starter.now.sh now points to https://inferno-starter-firbedifww.now.sh (sm6u8PxiD0C2khzyBOXK1RC4) [copied to clipboard]
```