### PR TITLE
Allow shorthand aliases with `now --alias`

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -569,8 +569,14 @@ const assignAlias = async (autoAlias, token, deployment) => {
     }
   }
 
-  // Throw an error if it doesn't
+  // If alias doesn't exist
   if (!related) {
+    // Check if the uid was actually an alias
+    if (type === 'uid') {
+      return assignAlias(`${autoAlias}.now.sh`, token, deployment)
+    }
+
+    // If not, throw an error
     const withID = type === 'uid' ? 'with ID ' : ''
     error(`Alias ${withID}"${autoAlias}" doesn't exist`)
     return


### PR DESCRIPTION
Resolves https://github.com/zeit/now-cli/issues/198

If you run `now --alias foo` it will interpret foo as an alias uid instead of the subdomain so you get an error saying `Error! Alias with ID "foo" doesn't exist`. This threw me off as it's inconsistent with `now alias` where just using the subdomain is allowed.

With this PR if a uid isn't found, `now.sh` is appended to the uid and it's checked again as an alias.