### PR TITLE
Fix now alias on new domains

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -413,9 +413,12 @@ export default class Alias extends Now {
           if (this._debug) {
             console.log(`> [debug] No records found for "${domain}"`)
           }
-        } else {
-          throw err
+
+          const err = new Error(DOMAIN_VERIFICATION_ERROR)
+          err.userError = true
+          return bail(err)
         }
+        throw err
       }
 
       if (ips.length <= 0) {


### PR DESCRIPTION
Bail if no records are found for a domain to allow adding the records.

now alias derp domain.com -d
> [debug] Checking for updates.
> [debug] Up to date (1.0.0).
> [debug] /list: 583.880ms
> [debug] matched deployment derp by url derp.now.sh
> domain.com is a custom domain.
> Verifying the DNS settings for domain.com (see https://zeit.world for help)
> [debug] #1 GET /domains/domain.com: 271.741ms
> [debug] Found domain domain.com with verified:true
> [debug] No records found for "domain.com"
> Verification OK!