### PR TITLE
Add --dotenv flag to load .env file

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -98,7 +98,7 @@ const help = () => {
     -l, --links               Copy symlinks without resolving their target
     -p, --public              Deployment is public (${chalk.dim('`/_src`')} is exposed) [on for oss, off for premium]
     -e, --env                 Include an env var (e.g.: ${chalk.dim('`-e KEY=value`')}). Can appear many times.
-    -E, --dotenv              Include an env vars from .env file
+    -E ${chalk.underline('FILE')}, --dotenv=${chalk.underline('FILE')}    Include env vars from .env file. Will default to '.env'
     -C, --no-clipboard        Do not attempt to copy URL to clipboard
     -N, --forward-npm         Forward login information to install private npm modules
     -a, --alias               Re-assign existing aliases to the deployment
@@ -377,12 +377,14 @@ async function sync(token) {
 
   let dotenvConfig
   if (argv.dotenv) {
-    if (!fs.existsSync('.env')) {
-      error('--dotenv flag is set but .env file is missing')
+    const dotenvFileName = typeof argv.dotenv === 'string' ? argv.dotenv : '.env'
+
+    if (!fs.existsSync(dotenvFileName)) {
+      error(`--dotenv flag is set but ${dotenvFileName} file is missing`)
       return process.exit(1)
     }
 
-    const dotenvFile = await fs.readFile('.env')
+    const dotenvFile = await fs.readFile(dotenvFileName)
     dotenvConfig = dotenv.parse(dotenvFile)
   }
 

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -98,7 +98,7 @@ const help = () => {
     -l, --links               Copy symlinks without resolving their target
     -p, --public              Deployment is public (${chalk.dim('`/_src`')} is exposed) [on for oss, off for premium]
     -e, --env                 Include an env var (e.g.: ${chalk.dim('`-e KEY=value`')}). Can appear many times.
-    -E ${chalk.underline('FILE')}, --dotenv=${chalk.underline('FILE')}    Include env vars from .env file. Will default to '.env'
+    -E ${chalk.underline('FILE')}, --dotenv=${chalk.underline('FILE')}    Include env vars from .env file. Defaults to '.env'
     -C, --no-clipboard        Do not attempt to copy URL to clipboard
     -N, --forward-npm         Forward login information to install private npm modules
     -a, --alias               Re-assign existing aliases to the deployment

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -51,6 +51,7 @@ const argv = minimist(process.argv.slice(2), {
   ],
   alias: {
     env: 'e',
+    dotenv: 'E',
     help: 'h',
     config: 'c',
     debug: 'd',

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "copy-paste": "^1.3.0",
     "cross-spawn": "^5.0.1",
     "docker-file-parser": "^0.1.0",
+    "dotenv": "^4.0.0",
     "download": "^5.0.2",
     "email-prompt": "^0.2.0",
     "email-validator": "^1.0.7",


### PR DESCRIPTION
Fixes #230. I'm wondering if we should move `require('dotenv')` into the if statement. Since all imports are added to the top of the file in the whole project I kept that standard.