### PR TITLE
Allow dotenv option in now.json

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -379,8 +379,9 @@ async function sync(token) {
   const now = new Now(apiUrl, token, {debug})
 
   let dotenvConfig
-  if (argv.dotenv) {
-    const dotenvFileName = typeof argv.dotenv === 'string' ? argv.dotenv : '.env'
+  const dotenvOption = argv.dotenv ? argv.dotenv : nowConfig.dotenv
+  if (dotenvOption) {
+    const dotenvFileName = typeof dotenvOption === 'string' ? dotenvOption : '.env'
 
     if (!fs.existsSync(dotenvFileName)) {
       error(`--dotenv flag is set but ${dotenvFileName} file is missing`)


### PR DESCRIPTION
Fixes #300

Has the exact same behaviour as `--dotenv`. If `--dotenv` is provided it is used instead of `now.json`