### PR TITLE
Test for packed `now` binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "npm run build && npm run lint && ava",
     "prepublish": "npm run build",
     "build": "./build.sh",
-    "pack": "npm run build && pkg . --out-dir packed -t node7-alpine-x64,node7-linux-x64,node7-macos-x64,node7-win-x64"
+    "pack": "npm run build && npm run pkg",
+    "pkg": "pkg . --out-dir packed -t node7-alpine-x64,node7-linux-x64,node7-macos-x64,node7-win-x64"
   },
   "pkg": {
     "scripts": [

--- a/test/pack-now.js
+++ b/test/pack-now.js
@@ -1,0 +1,50 @@
+const path = require('path')
+const crossSpawn = require('cross-spawn')
+const test = require('ava')
+
+test.serial('make binary', async t => {
+  if (!process.env.CI) return // eslint-disable-line curly
+  const result = await spawn('npm', ['run', 'pkg'])
+  t.is(result.code, 0)
+})
+
+const binary = {
+  darwin: 'now-macos',
+  linux: 'now-linux',
+  win32: 'now-win.exe'
+}[process.platform]
+
+const binaryPath = path.resolve(__dirname, '../packed/' + binary)
+const deployHelpMessage = '𝚫 now [options] <command | path>'
+
+test.serial('packed "now help" prints deploy help message', async t => {
+  if (!process.env.CI) return // eslint-disable-line curly
+  const result = await spawn(binaryPath, ['help'])
+
+  t.is(result.code, 0)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout.length > 1)
+  t.true(stdout[1].includes(deployHelpMessage))
+})
+
+function spawn(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = crossSpawn.spawn(command, args)
+
+    let stdout = ''
+    child.stdout.on('data', data => {
+      stdout += data
+    })
+
+    child.on('error', err => {
+      reject(err)
+    })
+
+    child.on('close', code => {
+      resolve({
+        code,
+        stdout
+      })
+    })
+  })
+}


### PR DESCRIPTION
Packed executable may fail if not all the files are taken into the executable. It concerns all the dependencies as well as `now` itself. Such a failure is revealed by simply running the executable - one gets `Can not require some-package`.