### PR TITLE
Fix now alias failing when now.json doesn’t define deployment type

### DIFF
--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -1,6 +1,6 @@
 const {basename, resolve: resolvePath} = require('path')
 const chalk = require('chalk')
-const {readFile} = require('fs-promise')
+const {readFile, exists} = require('fs-promise')
 const {parse: parseDockerfile} = require('docker-file-parser')
 
 const listPackage = {
@@ -45,6 +45,8 @@ async function readMetaData(path, {
     // when both a package.json and Dockerfile exist
     if (nowConfig.type) {
       deploymentType = nowConfig.type
+    } else if (nowConfig.type === undefined && !await exists(resolvePath(path, 'package.json'))) {
+      deploymentType = 'static'
     }
     if (nowConfig.name) {
       deploymentName = nowConfig.name


### PR DESCRIPTION
This should fix #320:
<blockquote>
now version: `4.5.6`

Performing `now alias` with a `now.json` of the following:
```JSON
{
  "alias": "this-is-a-test.now.sh"
}
```

Fails with:
```
> Error! Failed to read JSON in "/Users/hugo/Desktop/test/package.json"
```

This error doesn't occur if `now.json` defines a `type`. 

Ideally, `now` should work out the deployment type as it does when running `now` without a `now.json` file.

I believe this could be fixed by modifying [read-metadata.js](https://github.com/zeit/now-cli/blob/b1a2e6feeeb2e0082e97e8cf69e7d8f7bd989e29/lib/read-metadata.js).
</blockquote>

I'm very open to feedback and discussion, so please fire away! 👍 