### PR TITLE
Decide the deployment type after checking the config files

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -288,6 +288,19 @@ async function sync(token) {
   let hasDockerfile
   let isStatic
 
+  let metaData
+  try {
+    metaData = await readMetaData(path, {
+      deploymentType,
+      deploymentName,
+      isStatic,
+      quiet: true
+    })
+  } catch (err) {
+    error(err.message)
+    process.exit(1)
+  }
+
   if (argv.docker) {
     if (debug) {
       console.log(`> [debug] Forcing \`deploymentType\` = \`docker\``)
@@ -329,7 +342,7 @@ async function sync(token) {
       })()
     ])
 
-    if (hasPackage && hasDockerfile) {
+    if (hasPackage && hasDockerfile && !metaData.deploymentType) {
       if (debug) {
         console.log('[debug] multiple manifests found, disambiguating')
       }
@@ -370,13 +383,6 @@ async function sync(token) {
     }
   }
 
-  const {nowConfig} = await readMetaData(path, {
-    deploymentType,
-    deploymentName,
-    isStatic,
-    quiet: true
-  })
-
   const now = new Now(apiUrl, token, {debug})
 
   let dotenvConfig
@@ -384,8 +390,8 @@ async function sync(token) {
 
   if (argv.dotenv) {
     dotenvOption = argv.dotenv
-  } else if (nowConfig && nowConfig.dotenv) {
-    dotenvOption = nowConfig.dotenv
+  } else if (metaData.nowConfig && metaData.nowConfig.dotenv) {
+    dotenvOption = metaData.nowConfig.dotenv
   }
 
   if (dotenvOption) {
@@ -401,7 +407,7 @@ async function sync(token) {
   }
 
   // Merge `now.env` from package.json with `-e` arguments.
-  const pkgEnv = nowConfig && nowConfig.env
+  const pkgEnv = metaData.nowConfig && metaData.nowConfig.env
   const envs = [
     ...Object.keys(dotenvConfig || {}).map(k => `${k}=${dotenvConfig[k]}`),
     ...Object.keys(pkgEnv || {}).map(k => `${k}=${pkgEnv[k]}`),

--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -15,21 +15,24 @@ const listPackage = {
 module.exports = readMetaData
 
 async function readMetaData(path, {
-  deploymentType = 'npm',
+  deploymentType = null,
   deploymentName,
   quiet = false,
   strict = true,
   isStatic = false
 }) {
   let pkg = {}
-  let nowConfig = null
+  let nowConfigJson = {}
+  let nowConfigPkg = {}
+  let nowConfig = {}
   let hasNowJson = false
+  let hasNowPkgJson = false
 
   let name
   let description
 
   try {
-    nowConfig = JSON.parse(await readFile(resolvePath(path, 'now.json')))
+    nowConfigJson = JSON.parse(await readFile(resolvePath(path, 'now.json')))
     hasNowJson = true
   } catch (err) {
     // if the file doesn't exist then that's fine; any other error bubbles up
@@ -40,16 +43,33 @@ async function readMetaData(path, {
     }
   }
 
-  if (hasNowJson) {
+  try {
+    pkg = JSON.parse(await readFile(resolvePath(path, 'package.json')))
+    nowConfigPkg = pkg.now || {}
+    hasNowPkgJson = nowConfigPkg !== null
+  } catch (err) {
+    // if the file doesn't exist then that's fine; any other error bubbles up
+    if (err.code !== 'ENOENT') {
+      const e = Error(`Failed to read JSON in "${path}/package.json"`)
+      e.userError = true
+      throw e
+    }
+  }
+
+  if (hasNowJson || hasNowPkgJson) {
     // user can specify the type of deployment explicitly in the `now.json` file
     // when both a package.json and Dockerfile exist
-    if (nowConfig.type) {
-      deploymentType = nowConfig.type
-    } else if (nowConfig.type === undefined && !await exists(resolvePath(path, 'package.json'))) {
+    if (nowConfigJson.type && !nowConfigPkg.type) {
+      deploymentType = nowConfigJson.type
+    } else if (nowConfigPkg.type && !hasNowJson) {
+      deploymentType = nowConfigPkg.type
+    } else if (nowConfigJson.type === undefined && !await exists(resolvePath(path, 'package.json'))) {
       deploymentType = 'static'
     }
-    if (nowConfig.name) {
-      deploymentName = nowConfig.name
+    if (nowConfigJson && nowConfigJson.name) {
+      deploymentName = nowConfigJson.name
+    } else if (nowConfigPkg && nowConfigPkg.name) {
+      deploymentName = nowConfigPkg.name
     }
   }
 
@@ -145,7 +165,7 @@ async function readMetaData(path, {
     }
 
     description = labels.description
-  } else {
+  } else if (deploymentType) {
     throw new TypeError(`Unsupported "deploymentType": ${deploymentType}`)
   }
 
@@ -158,14 +178,16 @@ async function readMetaData(path, {
     // file, then fail hard and let the user know that they need to pick one or the
     // other
     if (hasNowJson) {
-      const e = new Error('You have a `now` configuration field' +
-      'inside `package.json`, but configuration is also present' +
+      const e = new Error('You have a `now` configuration field ' +
+      'inside `package.json`, but configuration is also present ' +
       'in `now.json`! Please ensure there\'s a single source of configuration by removing one')
       e.userError = true
       throw e
     } else {
       nowConfig = pkg.now
     }
+  } else {
+    nowConfig = nowConfigJson
   }
 
   return {


### PR DESCRIPTION
… the deployment type. (#266)

If `--npm` and `--docker` was not present the cli checked for the presence of a Dockerfile and package.json file. If both exist it would ask the user which one to use.
We should check for the presence of the `type` field in now.json as well as package.json before doing this.