### PR TITLE
Allow different environment configs in now.json and package.json

### DIFF
--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -14,6 +14,18 @@ const listPackage = {
 
 module.exports = readMetaData;
 
+function parseEnvironment(config) {
+  const env = process.env.NODE_ENV;
+
+  // Check if the user has a specific environment config in either now.json
+  // or in their package.json config
+  if (env && config[env]) {
+    return config[env];
+  }
+
+  return config;
+}
+
 async function readMetaData(
   path,
   {
@@ -32,7 +44,9 @@ async function readMetaData(
   let description;
 
   try {
-    nowConfig = JSON.parse(await readFile(resolvePath(path, 'now.json')));
+    nowConfig = parseEnvironment(
+      JSON.parse(await readFile(resolvePath(path, 'now.json')))
+    );
     hasNowJson = true;
   } catch (err) {
     // If the file doesn't exist then that's fine; any other error bubbles up
@@ -186,7 +200,7 @@ async function readMetaData(
       e.userError = true;
       throw e;
     } else {
-      nowConfig = pkg.now;
+      nowConfig = parseEnvironment(pkg.now);
     }
   }
 

--- a/test/_fixtures/now-json-env/now.json
+++ b/test/_fixtures/now-json-env/now.json
@@ -1,0 +1,8 @@
+{
+  "staging": {
+    "alias": "bar.dev.com"
+  },
+  "production": {
+    "alias": "bar.com"
+  }
+}

--- a/test/_fixtures/package-json-env/package.json
+++ b/test/_fixtures/package-json-env/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "woot",
+  "version": "0.0.1",
+  "description": "",
+  "dependencies": {},
+  "now": {
+    "staging": {
+      "alias": "foo.dev.com"
+    },
+    "production": {
+      "alias": "foo.com"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,45 @@ test('support `now.json` files with Dockerfile', async t => {
   t.is(base(files[2]), 'now-json-docker/now.json');
 });
 
+test('support configurations', async t => {
+  const f = fixture('now-json');
+  const { nowConfig } = await readMetadata(f, { quiet: true, strict: false });
+
+  t.is(nowConfig.files.length, 1);
+});
+
+test.serial(
+  'support environment specific configurations in now.json',
+  async t => {
+    const oldEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'staging';
+
+    const f = fixture('now-json-env');
+    const { nowConfig } = await readMetadata(f, { quiet: true, strict: false });
+
+    t.is(nowConfig.alias, 'bar.dev.com');
+
+    process.env.NODE_ENV = oldEnv;
+  }
+);
+
+test.serial(
+  'support environment specific configurations in package.json',
+  async t => {
+    const oldEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'staging';
+
+    const f = fixture('package-json-env');
+    const { nowConfig } = await readMetadata(f, { quiet: true, strict: false });
+
+    t.is(nowConfig.alias, 'foo.dev.com');
+
+    process.env.NODE_ENV = oldEnv;
+  }
+);
+
 test('throws when both `now.json` and `package.json:now` exist', async t => {
   let e;
   try {


### PR DESCRIPTION
**tl;dr: Users can now, optionally, customize now.json & package.json per environment**

This should provide a nice, backwards compatible solution to #275. This refers to the value of `NODE_ENV` when set to dynamically use a set of now config options per environment. If `NODE_ENV` is set, but no environments are established, it does the existing behavior which is to assume the keys in the root of the json object are the config.

### Examples
The backwards compatible way
```json
{
  "alias": "foo.com"
}
```

The optional new way
```json
{
  "staging": {
    "alias": "dev.foo.com"
  },
  "production": {
    "alias": "foo.com"
  }
}
```

### Changes
- adds support for environment specific now configs
- adds `prettier` to the dev dependencies since it runs when committing and wasn't being installed
- adds a test for existing functionality, which is when no environment is configured

### Caveats
- If they have environments configured in `now.json` or `package.json` and don't specify `NODE_ENV, then it won't deploy correctly

### Doc updates
If this change is accepted, the docs will need to be updated. Obviously I can't write them, but here is a rough draft:

<details>
<summary><strong>rough draft</strong></summary>
All of the properties mentioned below can be used both in the package.json and inside the now.json file. Additionally, if you need support for multiple environments, each property can be specified in separate environment objects and used by setting the `NODE_ENV` environment variable:

```
{
  "staging": {
    "name": "app-staging",
    "alias": "dev.app.com"
  },
  "production": {
    "name": "app",
    "alias": "app.com"
  }
}
```
</details>

### Other considerations
I did consider using different files per environment (i.e. `now.staging.json`, `now.production.json`, etc. I decided against that, however, as there could be tons of files which isn't so great. Additionally, having everything in a single file reduces the cognitive load and keeps everything in one place.