### PR TITLE
don't include the "main" file by default

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -98,11 +98,6 @@ async function npm(
     )
   );
 
-  // Always include the "main" file
-  if (pkg.main) {
-    search.push(require.resolve(resolve(path, pkg.main), 'may-exclude')); // Pkg: may-exclude suppresses warnings
-  }
-
   // Compile list of ignored patterns and files
   const npmIgnore = await maybeRead(resolve(path, '.npmignore'), null);
   const gitIgnore = npmIgnore === null
@@ -277,7 +272,7 @@ async function explode(paths, { accepts, debug }) {
     try {
       s = await stat(path);
     } catch (e) {
-      // In case the file comes from `files` or `main`
+      // In case the file comes from `files`
       // and it wasn't specified with `.js` by the user
       path = file + '.js';
 


### PR DESCRIPTION
It's not correct to forcefully include the file specified in "main"
at upload-time. Consider an `npm run build` script that ends up
creating the file that "main" specifies. It would not exist until
inside the deployment, after the build script is ran for that
deployment.

Fixes https://github.com/zeit/now-cli/issues/281.