### PR TITLE
check for Dockerfile when now.json is present

### DIFF
--- a/lib/read-metadata.js
+++ b/lib/read-metadata.js
@@ -55,8 +55,8 @@ async function readMetaData(
     if (nowConfig.type) {
       deploymentType = nowConfig.type
     } else if (
-      nowConfig.type === undefined &&
-      !await exists(resolvePath(path, 'package.json'))
+      !await exists(resolvePath(path, 'package.json')) &&
+      !await exists(resolvePath(path, 'Dockerfile'))
     ) {
       deploymentType = 'static'
     }


### PR DESCRIPTION
Consider a tree like:

```
.
├── Dockerfile
└── now.json

0 directories, 2 files
```

Before this patch, this deployment would be considered a "static"
deployment, which is incorrect. Now it is properly detected
as a "docker" deployment type.