### PR TITLE
exit the process immediately upon Ctrl+C

### DIFF
--- a/lib/utils/prompt-options.js
+++ b/lib/utils/prompt-options.js
@@ -1,7 +1,9 @@
 // Packages
 const chalk = require('chalk')
 
-module.exports = function(opts) {
+module.exports = promptOptions
+
+function promptOptions(opts) {
   return new Promise((resolve, reject) => {
     opts.forEach(([, text], i) => {
       console.log(`${chalk.gray('>')} [${chalk.bold(i + 1)}] ${text}`)
@@ -15,10 +17,12 @@ module.exports = function(opts) {
         process.stdin.removeListener('data', ondata)
       }
 
+      // Ctrl + C
       if (s === '\u0003') {
         cleanup()
-        reject(new Error('Aborted'))
-        return
+        const err = new Error('Aborted')
+        err.code = 'USER_ABORT'
+        return reject(err)
       }
 
       const n = Number(s)


### PR DESCRIPTION
During the deployment selection prompt, don't print out a stack
trace of the "Aborted" error to the user, just exit the process
directly.