### PR TITLE
fixed display message.

### DIFF
--- a/bin/domains/buy.js
+++ b/bin/domains/buy.js
@@ -71,6 +71,6 @@ module.exports = async function({ domains, args, currentTeam, user }) {
 
   success(`Domain purchased and created ${uid(domain.uid)} ${elapsed()}`)
   info(
-    `You may now use your domain as an alias to your deployments. Run ${cmd('now alias help')}`
+    `You may now use your domain as an alias to your deployments. Run ${cmd('now alias --help')}`
   )
 }


### PR DESCRIPTION
Upon buying my first domain I was prompted on success with the following message:

```sh
Codys-Mac-mini: my-blog codybrunner$ now domains buy rcws-development.com
> The domain "rcws-development.com" is available to buy under rockchalkwushock! [2s]
> Success! Domain purchased and created (some hash) [7s]
> You may now use your domain as an alias to your deployments. Run `now alias help`
```

Upon running that command I received:

```sh
Codys-Mac-mini: my-blog codybrunner$ now alias help
> Assigning alias help to deployment...
> Error! The alias you are trying to configure (help.now.sh) is already in use by a different account.
```

I believe what was meant was `now alias --help` or `now alias -h`. Changes have been made in this PR to that display message. All tests pass locally.