### PR TITLE
Use correct file count

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -524,11 +524,11 @@ async function sync({ token, config: { currentTeam, user } }) {
 
   const startU = new Date()
 
-  const complete = ({ fileCount }) => {
+  const complete = ({ syncCount }) => {
     if (!quiet) {
       const elapsedU = ms(new Date() - startU)
       console.log(
-        `> Synced ${fileCount} (${bytes(now.syncAmount)}) [${elapsedU}] `
+        `> Synced ${syncCount} (${bytes(now.syncAmount)}) [${elapsedU}] `
       )
       console.log('> Initializing…')
     }
@@ -576,10 +576,15 @@ async function sync({ token, config: { currentTeam, user } }) {
   }
 
   if (now.syncAmount) {
+    if (debug && now.syncFileCount !== now.fileCount) {
+      console.log(
+        `> [debug] total files ${now.fileCount}, ${now.syncFileCount} changed. `
+      )
+    }
     const size = bytes(now.syncAmount)
-    const fileCount = `${now.fileCount} file${now.fileCount > 1 && 's'}`
+    const syncCount = `${now.syncFileCount} file${now.syncFileCount > 1 && 's'}`
     const bar = new Progress(
-      `> Upload [:bar] :percent :etas (${size}) [${fileCount}]`,
+      `> Upload [:bar] :percent :etas (${size}) [${syncCount}]`,
       {
         width: 20,
         complete: '=',
@@ -601,7 +606,7 @@ async function sync({ token, config: { currentTeam, user } }) {
       bar.tick(amount)
     })
 
-    now.on('complete', () => complete({ fileCount }))
+    now.on('complete', () => complete({ syncCount }))
 
     now.on('error', err => {
       error('Upload failed')

--- a/lib/index.js
+++ b/lib/index.js
@@ -843,6 +843,10 @@ module.exports = class Now extends EventEmitter {
     return this._syncAmount
   }
 
+  get syncFileCount() {
+    return this._missing.length
+  }
+
   _fetch(_url, opts = {}) {
     if (!opts.useCurrentTeam && this.currentTeam) {
       const parsedUrl = parseUrl(_url, true)


### PR DESCRIPTION
Since `syncAmount` is based on the files that are synced (only changed/added files are uploaded), I think the file count being displayed should be counted on the same files? (e.g the ones actually being uploaded)