### PR TITLE
Fix file count with 1 file

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -582,7 +582,7 @@ async function sync({ token, config: { currentTeam, user } }) {
       )
     }
     const size = bytes(now.syncAmount)
-    const syncCount = `${now.syncFileCount} file${now.syncFileCount > 1 && 's'}`
+    const syncCount = `${now.syncFileCount} file${now.syncFileCount > 1 ? 's' : ''}`
     const bar = new Progress(
       `> Upload [:bar] :percent :etas (${size}) [${syncCount}]`,
       {


### PR DESCRIPTION
Missed this, causing it to say "filefalse" 😄 
I think it's easier to read with a terany than to do `&& 's' || ''`