### PR TITLE
Disable update-notifier

### DIFF
--- a/bin/now.js
+++ b/bin/now.js
@@ -26,15 +26,17 @@ try {
 // Utilities
 const pkg = require('../lib/pkg')
 
-const notifier = updateNotifier({ pkg })
-const update = notifier.update
+if (!process.pkg) {
+  const notifier = updateNotifier({ pkg })
+  const update = notifier.update
 
-if (update) {
-  let message = `Update available! ${chalk.red(update.current)} → ${chalk.green(update.latest)} \n`
-  message += `Run ${chalk.magenta('npm i -g now')} to update!\n`
-  message += `${chalk.magenta('Changelog:')} https://github.com/zeit/now-cli/releases/tag/${update.latest}`
+  if (update) {
+    let message = `Update available! ${chalk.red(update.current)} → ${chalk.green(update.latest)} \n`
+    message += `Run ${chalk.magenta('npm i -g now')} to update!\n`
+    message += `${chalk.magenta('Changelog:')} https://github.com/zeit/now-cli/releases/tag/${update.latest}`
 
-  notifier.notify({ message })
+    notifier.notify({ message })
+  }
 }
 
 // This command will be run if no other sub command is specified

--- a/bin/now.js
+++ b/bin/now.js
@@ -26,17 +26,15 @@ try {
 // Utilities
 const pkg = require('../lib/pkg')
 
-if (pkg._npmPkg) {
-  const notifier = updateNotifier({ pkg })
-  const update = notifier.update
+const notifier = updateNotifier({ pkg })
+const update = notifier.update
 
-  if (update) {
-    let message = `Update available! ${chalk.red(update.current)} → ${chalk.green(update.latest)} \n`
-    message += `Run ${chalk.magenta('npm i -g now')} to update!\n`
-    message += `${chalk.magenta('Changelog:')} https://github.com/zeit/now-cli/releases/tag/${update.latest}`
+if (update) {
+  let message = `Update available! ${chalk.red(update.current)} → ${chalk.green(update.latest)} \n`
+  message += `Run ${chalk.magenta('npm i -g now')} to update!\n`
+  message += `${chalk.magenta('Changelog:')} https://github.com/zeit/now-cli/releases/tag/${update.latest}`
 
-    notifier.notify({ message })
-  }
+  notifier.notify({ message })
 }
 
 // This command will be run if no other sub command is specified

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -1,13 +1,10 @@
 /* eslint-disable import/no-unresolved */
 
-const path = require('path')
-const pkg = require('../package.json')
-
+let pkg
 try {
-  const distDir = path.dirname(process.execPath)
-  pkg._npmPkg = require(path.join(distDir, '../../package.json'))
+  pkg = require('../package.json')
 } catch (err) {
-  pkg._npmPkg = null
+  pkg = require('../../package.json')
 }
 
 module.exports = pkg


### PR DESCRIPTION
Somehow `update-notifier` + `pkg` (not very sure if `pkg` is involved, but I think so) were causing `now` to duplicate itself (to the point of freezing the computer) and deploy hundreds of [`check.js`](https://github.com/yeoman/update-notifier/blob/master/check.js) to Now.