### PR TITLE
Fix repeated logs and corrupted characters

### DIFF
--- a/lib/build-logger.js
+++ b/lib/build-logger.js
@@ -27,6 +27,7 @@ module.exports = class Logger extends EventEmitter {
 
     // Log buffer
     this.buf = []
+    this.printed = new Set()
   }
 
   onAuth(callback) {
@@ -81,7 +82,7 @@ module.exports = class Logger extends EventEmitter {
         this.printLog(b.log)
       }
       this.buf = this.buf.slice(idx)
-    }, 300)
+    }, 500)
 
     this.buf.push({ log, timer })
   }
@@ -112,6 +113,10 @@ module.exports = class Logger extends EventEmitter {
   }
 
   printLog(log) {
+    if (this.printed.has(log.id)) return
+
+    this.printed.add(log.id)
+
     const data = log.object ? JSON.stringify(log.object) : log.text
 
     if (log.type === 'command') {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "serve": "5.1.5",
     "single-line-log": "1.1.2",
     "slackup": "2.0.1",
-    "socket.io-client": "2.0.1",
+    "socket.io-client": "1.7.4",
     "split-array": "1.0.1",
     "strip-ansi": "3.0.1",
     "stripe": "4.22.0",


### PR DESCRIPTION
Basically, the problem is because of mismatch of socket.io and socket.io-client versions, so I reverted the client for now.
Additionally, I added duplication check for sure.