### PR TITLE
Add `--team` flag to show current team

### DIFF
--- a/bin/now-whoami.js
+++ b/bin/now-whoami.js
@@ -12,7 +12,7 @@ const logo = require('../lib/utils/output/logo')
 
 const argv = minimist(process.argv.slice(2), {
   string: ['config', 'token'],
-  boolean: ['help', 'debug', 'all'],
+  boolean: ['help', 'debug', 'team'],
   alias: {
     help: 'h',
     config: 'c',
@@ -35,12 +35,17 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )} Login token
+    --team                  Show the team name [off]
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Show the current team context
+  ${chalk.gray('–')} Show the current user
 
     ${chalk.cyan('$ now whoami')}
+
+  ${chalk.gray('–')} Show the current team context
+
+    ${chalk.cyan('$ now whoami --team')}
 `)
 }
 
@@ -66,7 +71,13 @@ async function whoami() {
     process.stdout.write('> ')
   }
 
-  const { user } = config
+  const { user, currentTeam } = config
+
+  if (argv.team && currentTeam) {
+    console.log(currentTeam.slug)
+    return
+  }
+
   const name = user.username || user.email
   console.log(name)
 }


### PR DESCRIPTION
Would be helpful when running `whoami` to know the team I'll be deploying as. Particularly noticed when I inadvertently deployed a site to the wrong team--whoops! I've since modified my bash profile with the help of this modification to always show me who I'm deploying as :)

<img width="370" alt="screen shot 2017-06-04 at 3 44 47 pm" src="https://cloud.githubusercontent.com/assets/4356436/26765214/d2a2c5c4-493c-11e7-94fb-cb6d6219463b.png">

I noticed an earlier version of the script simply used the team name by default if one existed. Since this was reverted I'm assuming there was a good reason for going to username by default. As such I've maintained existing functionality by adding a `--team` flag to change the output from username to team name. If a team is not selected, the output falls through to the current user.

Also, there was nothing using the `--all` flag on this command so I just replaced it with the new one. I can roll that back if it's better to stick to the scope of this particular change.