### PR TITLE
Now asking for value of missing environment variables

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -232,6 +232,9 @@ const envFields = async list => {
     })
   }
 
+  // eslint-disable-next-line import/no-unassigned-import
+  require('../lib/utils/input/patch-inquirer')
+
   info('Please enter the values for the following environment variables:')
   const answers = await inquirer.prompt(questions)
 

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -232,9 +232,7 @@ const envFields = async list => {
     })
   }
 
-  console.log(
-    '> Please enter the values for the following environment variables:'
-  )
+  info('Please enter the values for the following environment variables:')
   const answers = await inquirer.prompt(questions)
 
   for (const answer in answers) {

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -232,7 +232,9 @@ const envFields = async list => {
     })
   }
 
-  console.log('> Please enter the values for the following environment variables:')
+  console.log(
+    '> Please enter the values for the following environment variables:'
+  )
   const answers = await inquirer.prompt(questions)
 
   for (const answer in answers) {

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -447,17 +447,21 @@ async function sync({ token, config: { currentTeam, user } }) {
     dotenvConfig = dotenv.parse(dotenvFile)
   }
 
-  // Merge `now.env` from package.json with `-e` arguments.
   const pkgEnv = nowConfig && nowConfig.env
+  const argEnv = [].concat(argv.env || [])
 
   if (pkgEnv && Array.isArray(nowConfig.env)) {
-    nowConfig.env = await envFields(nowConfig.env)
+    const defined = argEnv.join()
+    const askFor = nowConfig.env.filter(item => !defined.includes(`${item}=`))
+
+    nowConfig.env = await envFields(askFor)
   }
 
+  // Merge `now.env` from package.json with `-e` arguments
   const envs = [
     ...Object.keys(dotenvConfig || {}).map(k => `${k}=${dotenvConfig[k]}`),
     ...Object.keys(pkgEnv || {}).map(k => `${k}=${pkgEnv[k]}`),
-    ...[].concat(argv.env || [])
+    ...argEnv
   ]
 
   let secrets

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -451,8 +451,6 @@ async function sync({ token, config: { currentTeam, user } }) {
     nowConfig.env = await envFields(nowConfig.env)
   }
 
-  console.log(nowConfig.env)
-
   const envs = [
     ...Object.keys(dotenvConfig || {}).map(k => `${k}=${dotenvConfig[k]}`),
     ...Object.keys(pkgEnv || {}).map(k => `${k}=${pkgEnv[k]}`),

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -447,7 +447,7 @@ async function sync({ token, config: { currentTeam, user } }) {
   // Merge `now.env` from package.json with `-e` arguments.
   const pkgEnv = nowConfig && nowConfig.env
 
-  if (Array.isArray(nowConfig.env)) {
+  if (pkgEnv && Array.isArray(nowConfig.env)) {
     nowConfig.env = await envFields(nowConfig.env)
   }
 

--- a/lib/utils/input/list.js
+++ b/lib/utils/input/list.js
@@ -1,19 +1,8 @@
-const chalk = require('chalk')
 const inquirer = require('inquirer')
 const stripAnsi = require('strip-ansi')
 
-/* eslint-disable no-multiple-empty-lines, no-var, no-undef, no-eq-null, eqeqeq, semi */
-inquirer.prompt.prompts.list.prototype.getQuestion = function() {
-  var message = chalk.bold('> ' + this.opt.message) + ' '
-
-  // Append the default if available, and if question isn't answered
-  if (this.opt.default != null && this.status !== 'answered') {
-    message += chalk.dim('(' + this.opt.default + ') ')
-  }
-
-  return message
-}
-/* eslint-enable */
+// eslint-disable-next-line import/no-unassigned-import
+require('./patch-inquirer')
 
 function getLength(string) {
   let biggestLength = 0

--- a/lib/utils/input/patch-inquirer.js
+++ b/lib/utils/input/patch-inquirer.js
@@ -1,0 +1,20 @@
+const inquirer = require('inquirer')
+const chalk = require('chalk')
+
+// Here we patch inquirer to use a `>` instead of the ugly green `?`
+
+/* eslint-disable no-multiple-empty-lines, no-var, no-undef, no-eq-null, eqeqeq, semi */
+const getQuestion = function() {
+  var message = chalk.bold('> ' + this.opt.message) + ' '
+
+  // Append the default if available, and if question isn't answered
+  if (this.opt.default != null && this.status !== 'answered') {
+    message += chalk.dim('(' + this.opt.default + ') ')
+  }
+
+  return message
+}
+/* eslint-enable */
+
+inquirer.prompt.prompts.input.prototype.getQuestion = getQuestion
+inquirer.prompt.prompts.list.prototype.getQuestion = getQuestion


### PR DESCRIPTION
If your `env` config property contains an array instead of an object, `now` will ask you for the value of these environment variables. This makes the initial command much shorter (no `-e` needed)!

**BEFORE**

```bash
now -e SLACK_API_TOKEN="<token>" \
    -e SLACK_SUBDOMAIN="<team-name>" \
    -e GOOGLE_CAPTCHA_SECRET="<secret>" \
    -e GOOGLE_CAPTCHA_SITEKEY="<sitekey>" \
    now-examples/slackin
```

**AFTER**

```bash
now now-examples/slackin
```

```json
"env": [
  "SLACK_API_TOKEN",
  "SLACK_SUBDOMAIN",
  "GOOGLE_CAPTCHA_SECRET",
  "GOOGLE_CAPTCHA_SITEKEY"
]
```

Leads to (similar):

![screen shot 2017-06-07 at 16 13 54](https://user-images.githubusercontent.com/6170607/26883032-557ce00e-4b9c-11e7-9edf-a49067f70c90.png)


[This](https://github.com/rauchg/slackin/pull/312) is how we do it.