### PR TITLE
Reduce the number of retries on cert creation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -756,31 +756,34 @@ module.exports = class Now extends EventEmitter {
         }
         return body
       },
-      { retries: 5, minTimeout: 30000, maxTimeout: 90000 }
+      { retries: 3, minTimeout: 30000, maxTimeout: 90000 }
     )
   }
 
   deleteCert(domain) {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] /now/certs #${attempt}`)
-      }
-
-      const res = await this._fetch(`/now/certs/${domain}`, {
-        method: 'DELETE'
-      })
-
-      if (res.status !== 200) {
-        const err = new Error(res.body.error.message)
-        err.userError = false
-
-        if (res.status === 400 || res.status === 404) {
-          return bail(err)
+    return this.retry(
+      async (bail, attempt) => {
+        if (this._debug) {
+          console.time(`> [debug] /now/certs #${attempt}`)
         }
 
-        throw err
-      }
-    })
+        const res = await this._fetch(`/now/certs/${domain}`, {
+          method: 'DELETE'
+        })
+
+        if (res.status !== 200) {
+          const err = new Error(res.body.error.message)
+          err.userError = false
+
+          if (res.status === 400 || res.status === 404) {
+            return bail(err)
+          }
+
+          throw err
+        }
+      },
+      { retries: 3 }
+    )
   }
 
   async remove(deploymentId, { hard }) {


### PR DESCRIPTION
Retrying multiple times on cert creation doesn't usually help but
makes the user wait for a longer time for nothing. Usually there
is either a configuration error that must be solved or the DNS
change hasn't propagated yet, which will usually take longer than
the retry window.