### PR TITLE
Now respecting the `files` property inside `now.json`

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -161,7 +161,7 @@ async function npm(
   nowConfig = {},
   { limit = null, hasNowJson = false, debug = false } = {}
 ) {
-  const whitelist = nowConfig.files || pkg.files
+  const whitelist = nowConfig.files || pkg.files || (pkg.now && pkg.now.files)
 
   // The package.json `files` whitelist still
   // honors ignores: https://docs.npmjs.com/files/package.json#files
@@ -193,7 +193,7 @@ async function npm(
   // but we don't ignore if the user is explicitly listing files
   // under the now namespace, or using files in combination with gitignore
   const overrideIgnores =
-    (pkg.now && pkg.now.files) || (gitIgnore !== null && pkg.files)
+    (pkg.now && pkg.now.files) || nowConfig.files || (gitIgnore !== null && pkg.files)
   const accepts = overrideIgnores
     ? () => true
     : file => {

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -193,7 +193,9 @@ async function npm(
   // but we don't ignore if the user is explicitly listing files
   // under the now namespace, or using files in combination with gitignore
   const overrideIgnores =
-    (pkg.now && pkg.now.files) || nowConfig.files || (gitIgnore !== null && pkg.files)
+    (pkg.now && pkg.now.files) ||
+    nowConfig.files ||
+    (gitIgnore !== null && pkg.files)
   const accepts = overrideIgnores
     ? () => true
     : file => {


### PR DESCRIPTION
This is a fix for #596.

If `"files"` exists in `now.json`, use that as the whitelist. This piggybacks off the whitelisting functionality for `package.json`'s apparent support for `{"now": {"files": [...]}}`.

Was only slightly tested with various configurations; I'll be using this patch for a while to see if I broke anything, but any other feedback would be great.