### PR TITLE
Don't throw `Domain not found` when trying to `now alias` to a new domain

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -675,7 +675,6 @@ module.exports = class Alias extends Now {
         _domainInfo = await this.getDomain(_domain)
       } catch (err) {
         if (err.status === 404) {
-          console.log('got 404')
           // It's ok if the domain was not found – we'll add it when creating
           // the alias
         } else {

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -681,9 +681,8 @@ module.exports = class Alias extends Now {
           throw err
         }
       }
-      const domainInfo = _domainInfo && !_domainInfo.error
-        ? _domainInfo
-        : undefined
+      const domainInfo =
+        _domainInfo && !_domainInfo.error ? _domainInfo : undefined
       const { domain, nameservers } = domainInfo
         ? { domain: _domain }
         : await this.getNameservers(alias)

--- a/lib/alias.js
+++ b/lib/alias.js
@@ -670,9 +670,21 @@ module.exports = class Alias extends Now {
       )
 
       const _domain = publicSuffixList.parse(alias).domain
-      const _domainInfo = await this.getDomain(_domain)
-      const domainInfo =
-        _domainInfo && !_domainInfo.error ? _domainInfo : undefined
+      let _domainInfo
+      try {
+        _domainInfo = await this.getDomain(_domain)
+      } catch (err) {
+        if (err.status === 404) {
+          console.log('got 404')
+          // It's ok if the domain was not found – we'll add it when creating
+          // the alias
+        } else {
+          throw err
+        }
+      }
+      const domainInfo = _domainInfo && !_domainInfo.error
+        ? _domainInfo
+        : undefined
       const { domain, nameservers } = domainInfo
         ? { domain: _domain }
         : await this.getNameservers(alias)


### PR DESCRIPTION
Before
```
▲ now-cli at master ✔ now alias gifs-xfylwzhmgg.now.sh zeit.com
> zeit.com is a custom domain.
> Verifying the DNS settings for zeit.com (see https://zeit.world for help)
> Error! Domain name not found
```

After
```
▲ now-cli at fix/alias-new-domain ✔ now alias gifs-xfylwzhmgg.now.sh zeit.com           
> zeit.com is a custom domain.
> Verifying the DNS settings for zeit.com (see https://zeit.world for help)
[...]
```