### PR TITLE
Remove associated aliases and certificates before removing a domain

### DIFF
--- a/bin/now-domains.js
+++ b/bin/now-domains.js
@@ -361,10 +361,10 @@ async function run({ token, config: { currentTeam, user } }) {
 async function readConfirmation(domain, _domain) {
   return new Promise(resolve => {
     const time = chalk.gray(ms(new Date() - new Date(_domain.created)) + ' ago')
-    const tbl = table(
-      [[_domain.uid, chalk.underline(`https://${_domain.name}`), time]],
-      { align: ['l', 'r', 'l'], hsep: ' '.repeat(6) }
-    )
+    const tbl = table([[chalk.underline(`https://${_domain.name}`), time]], {
+      align: ['r', 'l'],
+      hsep: ' '.repeat(6)
+    })
 
     process.stdout.write('> The following domain will be removed permanently\n')
     process.stdout.write('  ' + tbl + '\n')

--- a/bin/now-domains.js
+++ b/bin/now-domains.js
@@ -263,8 +263,7 @@ async function run({ token, config: { currentTeam, user } }) {
       try {
         const confirmation = (await readConfirmation(
           domain,
-          _domain,
-          _domains
+          _domain
         )).toLowerCase()
         if (confirmation !== 'y' && confirmation !== 'yes') {
           console.log('\n> Aborted')
@@ -272,7 +271,7 @@ async function run({ token, config: { currentTeam, user } }) {
         }
 
         const start = new Date()
-        await domain.rm(_domain.name)
+        await domain.rm(_domain)
         const elapsed = ms(new Date() - start)
         console.log(
           `${chalk.cyan('> Success!')} Domain ${chalk.bold(
@@ -379,6 +378,17 @@ async function readConfirmation(domain, _domain) {
               (_domain.aliases.length === 1 ? '' : 'es')
           )} ` +
           `will be removed. Run ${chalk.dim('`now alias ls`')} to list.\n`
+      )
+    }
+    if (_domain.certs.length > 0) {
+      process.stdout.write(
+        `> ${chalk.yellow('Warning!')} This domain's ` +
+          `${chalk.bold(
+            _domain.certs.length +
+              ' certificate' +
+              (_domain.certs.length === 1 ? '' : 's')
+          )} ` +
+          `will be removed. Run ${chalk.dim('`now cert ls`')} to list.\n`
       )
     }
 

--- a/bin/now-domains.js
+++ b/bin/now-domains.js
@@ -393,7 +393,7 @@ async function readConfirmation(domain, _domain) {
     }
 
     process.stdout.write(
-      `  ${chalk.bold.red('> Are you sure?')} ${chalk.gray('[y/N] ')}`
+      `${chalk.bold.red('> Are you sure?')} ${chalk.gray('[y/N] ')}`
     )
 
     process.stdin

--- a/bin/now-domains.js
+++ b/bin/now-domains.js
@@ -377,7 +377,7 @@ async function readConfirmation(domain, _domain) {
               ' alias' +
               (_domain.aliases.length === 1 ? '' : 'es')
           )} ` +
-          `will be removed. Run ${chalk.dim('`now alias ls`')} to list.\n`
+          `will be removed. Run ${chalk.dim('`now alias ls`')} to list them.\n`
       )
     }
     if (_domain.certs.length > 0) {
@@ -388,7 +388,7 @@ async function readConfirmation(domain, _domain) {
               ' certificate' +
               (_domain.certs.length === 1 ? '' : 's')
           )} ` +
-          `will be removed. Run ${chalk.dim('`now cert ls`')} to list.\n`
+          `will be removed. Run ${chalk.dim('`now cert ls`')} to list them.\n`
       )
     }
 

--- a/lib/domains.js
+++ b/lib/domains.js
@@ -17,20 +17,80 @@ module.exports = class Domains extends Now {
     return this.listDomains()
   }
 
-  async rm(name) {
+  async rm(domain) {
+    // Remove aliases
+    for (const aliasId of domain.aliases) {
+      this.retry(async (bail, attempt) => {
+        const label = `> [debug] #${attempt} DELETE now/aliases/${aliasId}`
+        if (this._debug) {
+          console.time(label)
+        }
+
+        const res = await this._fetch(`/now/aliases/${aliasId}`, {
+          method: 'DELETE'
+        })
+
+        if (this._debug) {
+          console.timeEnd(label)
+        }
+
+        if (res.status === 403) {
+          return bail(new Error('Unauthorized'))
+        }
+
+        if (res.status !== 200) {
+          const body = await res.json()
+          throw new Error(body.error.message)
+        }
+      })
+    }
+
+    // Remove certs
+    for (const cn of domain.certs) {
+      this.retry(async (bail, attempt) => {
+        const label = `> [debug] #${attempt} DELETE now/certs/${cn}`
+        if (this._debug) {
+          console.time(label)
+        }
+
+        const res = await this._fetch(`/now/certs/${cn}`, { method: 'DELETE' })
+
+        if (this._debug) {
+          console.timeEnd(label)
+        }
+
+        if (res.status === 403) {
+          return bail(new Error('Unauthorized'))
+        }
+
+        if (res.status !== 200) {
+          const body = await res.json()
+          throw new Error(body.error.message)
+        }
+      })
+    }
+
+    // Remove the domain
+    const name = domain.name
     return this.retry(async (bail, attempt) => {
+      const label = `> [debug] #${attempt} DELETE /domains/${name}`
       if (this._debug) {
-        console.time(`> [debug] #${attempt} DELETE /domains/${name}`)
+        console.time(label)
       }
 
       const res = await this._fetch(`/domains/${name}`, { method: 'DELETE' })
 
       if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} DELETE /domains/${name}`)
+        console.timeEnd(label)
       }
 
       if (res.status === 403) {
         return bail(new Error('Unauthorized'))
+      }
+
+      if (res.status === 409) {
+        const body = await res.json()
+        return bail(new Error(body.error.message))
       }
 
       if (res.status !== 200) {


### PR DESCRIPTION
Previously this has been partially done on the server side but
it's better to do it client side to avoid accidentally removing
something that shouldn't be removed in team environments.