### PR TITLE
Show qr code when deploying

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -15,6 +15,7 @@ const dotenv = require('dotenv')
 const { eraseLines } = require('ansi-escapes')
 const { write: copy } = require('clipboardy')
 const inquirer = require('inquirer')
+const qrcode = require('qrcode-terminal')
 
 // Ours
 const login = require('../lib/login')
@@ -616,6 +617,7 @@ async function sync({ token, config: { currentTeam, user } }) {
       } catch (err) {
         console.log(`${chalk.cyan('> Ready!')} ${chalk.bold(url)} [${elapsed}]`)
       }
+      qrcode.generate(url, {small: true})
     } else {
       console.log(`> ${url} [${elapsed}]`)
     }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "printf": "0.2.5",
     "progress": "2.0.0",
     "psl": "1.1.19",
+    "qrcode-terminal": "^0.11.0",
     "resumer": "0.0.0",
     "single-line-log": "1.1.2",
     "slackup": "2.0.1",


### PR DESCRIPTION
When wanting to check your deployment on a mobile device, it's a bit of pain having to type the address every time. So I thought it'd be nice to have deployments show a QR code which can just be scanned? ¯\_(ツ)_/¯

This PR introduces that feature by default. Maybe it'd make more sense as an option with a flag like `now --qr`? If this is interesting I don't mind tweaking it a bit...

<img width="601" alt="screen shot 2017-07-27 at 14 07 00" src="https://user-images.githubusercontent.com/1495499/28671763-b94e6e6c-72d5-11e7-90a9-f17e82135ee0.png">
