### PR TITLE
Fix typo in alias.js

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -306,7 +306,7 @@ module.exports = class Alias extends Now {
         console.log(
           `> Scaling ${depl.url} to ${chalk.bold(
             aliasedDeployment.scale.current + ' instances'
-          )} atomically`
+          )} automatically`
         )
         if (depl.scale.current !== aliasedDeployment.scale.current) {
           if (depl.scale.max < 1) {


### PR DESCRIPTION
Every time I see this I *think* it's a typo, but if I'm wrong, my apologies, and please go ahead and disregard this PR.

Changed `atomically` to `automatically` in `lib/alias.js`.