### PR TITLE
#255 add https proxy agent to support https_proxy and http_proxy

### DIFF
--- a/download/src/index.js
+++ b/download/src/index.js
@@ -9,6 +9,7 @@ import zlib from 'zlib'
 import onDeath from 'death'
 import fetch from 'node-fetch'
 import retry from 'async-retry'
+import ProxyAgent from 'https-proxy-agent'
 
 // Utilities
 import plusxSync from './chmod'
@@ -76,9 +77,15 @@ async function main() {
     showProgress(0)
 
     try {
+      const proxyAddress = process.env.https_proxy 
+        || process.env.HTTPS_PROXY 
+        || process.env.http_proxy 
+        || process.env.HTTP_PROXY
+      const proxyAgent = proxyAddress ? new ProxyAgent(proxyAddress) : undefined
+
       const name = platformToName[process.platform]
       const url = `https://cdn.zeit.co/releases/now-cli/${packageJSON.version}/${name}`
-      const resp = await fetch(url, { compress: false })
+      const resp = await fetch(url, { compress: false, agent: proxyAgent })
 
       if (resp.status !== 200) {
         throw new Error(resp.statusText + ' ' + url)

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-config-prettier": "2.3.0",
     "fs-extra": "4.0.0",
     "glob": "7.1.2",
+    "https-proxy-agent": "2.1.0",
     "ignore": "3.3.3",
     "in-publish": "2.0.0",
     "ini": "1.3.4",


### PR DESCRIPTION
tested locally behind a corporate proxy.

can someone verify this?

And please cane someone update package-lock.json? if i try to let npm install update the package-lock.json it removes all requires notes and replaces it with "dev: true"

**here an example image of the diff**

![unbenannt](https://user-images.githubusercontent.com/5736450/29412796-74c8c13a-835a-11e7-8679-c85f5b8bea91.PNG)


**Tasks**:
- [ ] verify proxy agent works
- [ ] update package-lock.json