### PR TITLE
When on non-TTY mode, wait for the deployment to complete before exiting

### DIFF
--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -724,7 +724,7 @@ async function sync({ token, config: { currentTeam, user } }) {
     now.close()
 
     // Show build logs
-    if (deploymentType === 'static' && !queit) {
+    if (deploymentType === 'static' && !quiet) {
       console.log(`${chalk.cyan('> Deployment complete!')}`)
     } else {
       printLogs(now.host, token, currentTeam, user)

--- a/bin/now-deploy.js
+++ b/bin/now-deploy.js
@@ -724,12 +724,10 @@ async function sync({ token, config: { currentTeam, user } }) {
     now.close()
 
     // Show build logs
-    if (!quiet) {
-      if (deploymentType === 'static') {
-        console.log(`${chalk.cyan('> Deployment complete!')}`)
-      } else {
-        printLogs(now.host, token, currentTeam, user)
-      }
+    if (deploymentType === 'static' && !queit) {
+      console.log(`${chalk.cyan('> Deployment complete!')}`)
+    } else {
+      printLogs(now.host, token, currentTeam, user)
     }
   }
 }


### PR DESCRIPTION
Before: `now` was returning before the deployment had a chance to be completed
```
▲ gifs at master ✖ https='https://'
▲ gifs at master ✖ url=`now --force`; api /now/deployments | jq . | grep -3 "${url#$https}"
    {
      "uid": "5dsgGjrZrQAjJkezR1L3Rjgy",
      "name": "gifs",
      "url": "gifs-afnxqsprzr.now.sh",
      "created": "1503438980049",
      "state": "BOOTED",
      "type": "NPM",
```

After: `now` only returns after the deployment is completed:
```
▲ gifs at master ✖ url=`now --force`; api /now/deployments | jq . | grep -3 "${url#$https}"
    {
      "uid": "ibwoWGa8tRo2WSSjTg8vzzbR",
      "name": "gifs",
      "url": "gifs-acxwryyboo.now.sh",
      "created": "1503439022144",
      "state": "READY",
      "type": "NPM",
```

No side effects for deployments on TTY mode:
```
▲ gifs at master ✖ now --force
> Deploying ~/dev/gifs under matheus
> Using Node.js 8.2.1 (default)
> Ready! https://gifs-mqyxnajvlz.now.sh (copied to clipboard) [4s]
> Initializing…
> Building
> ▲ npm install
> ⧗ Installing 1 main dependency…
> ✓ Installed 13 modules [2s]
> ▲ npm start
> > gifs@0.1.0 start /home/nowuser/src
> > micro index.js
> > Ready! Listening on http://0.0.0.0:3000
> Deployment complete!
▲ gifs at master ✖ now --static --force
> Deploying ~/dev/gifs under matheus
> Ready! https://gifs-rydwwytqec.now.sh (copied to clipboard) [4s]
> Initializing…
> Deployment complete!
```