### PR TITLE
secrets: treat any 4xx error code as "user error"

### DIFF
--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,6 +1,8 @@
 // Ours
 const Now = require('../lib')
 
+const isUserError = res => ((res.status / 100) | 0) === 4
+
 module.exports = class Secrets extends Now {
   ls() {
     return this.listSecrets()
@@ -27,7 +29,7 @@ module.exports = class Secrets extends Now {
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (res.status === 404 || res.status === 400) {
+        if (isUserError(res)) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)
@@ -65,7 +67,7 @@ module.exports = class Secrets extends Now {
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (res.status === 404 || res.status === 400) {
+        if (isUserError(res)) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)
@@ -102,7 +104,7 @@ module.exports = class Secrets extends Now {
       const body = await res.json()
 
       if (res.status !== 200) {
-        if (res.status === 404 || res.status === 400) {
+        if (isUserError(res)) {
           const err = new Error(body.error.message)
           err.userError = true
           return bail(err)


### PR DESCRIPTION
The Secrets endpoints used to inappropriately return a 400
error code when a secret name collision occurred (i.e. when
creating a secret with a name that already exists, or when
trying to rename a secret to a name that is already in use).
Now they return 409 Conflict which is more correct for those
scenarios.

So while we're at it, just treat all 4xx error codes as user errors.