### PR TITLE
Fix empty user-agent on logs

### DIFF
--- a/bin/now-logs.js
+++ b/bin/now-logs.js
@@ -229,7 +229,7 @@ function printLog(log) {
     data =
       `REQ "${obj.method} ${obj.uri} ${obj.protocol}"` +
       ` ${obj.remoteAddr} - ${obj.remoteUser || ''}` +
-      ` "${obj.referer || ''}" "${obj.userAgent}"`
+      ` "${obj.referer || ''}" "${obj.userAgent || ''}"`
   } else if (log.type === 'response') {
     data =
       `RES "${obj.method} ${obj.uri} ${obj.protocol}"` +


### PR DESCRIPTION
It displays "undefined" when there is no user-agent on request logs now.