### PR TITLE
Don't prompt for login if token was defined

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -364,7 +364,7 @@ const main = async (argv_) => {
 
   // If no credentials are set at all, prompt for
   // login to the .sh provider
-  if (!authConfig.credentials.length && !ctx.argv.includes('-h')) {
+  if (!authConfig.credentials.length && !ctx.argv.includes('-h') && !ctx.argv.includes('-t')) {
     console.log(info(`No existing credentials found. Please log in:`))
 
     subcommand = 'login'

--- a/src/now.js
+++ b/src/now.js
@@ -364,7 +364,9 @@ const main = async (argv_) => {
 
   // If no credentials are set at all, prompt for
   // login to the .sh provider
-  if (!authConfig.credentials.length && !ctx.argv.includes('-h') && !ctx.argv.includes('-t')) {
+  console.log(ctx.argv)
+  console.log(ctx)
+  if (!authConfig.credentials.length && !ctx.argv.includes('-h') && !ctx.argv.includes('-t') && !ctx.argv.includes('--token')) {
     console.log(info(`No existing credentials found. Please log in:`))
 
     subcommand = 'login'

--- a/src/now.js
+++ b/src/now.js
@@ -364,9 +364,11 @@ const main = async (argv_) => {
 
   // If no credentials are set at all, prompt for
   // login to the .sh provider
-  console.log(ctx.argv)
-  console.log(ctx)
-  if (!authConfig.credentials.length && !ctx.argv.includes('-h') && !ctx.argv.includes('-t') && !ctx.argv.includes('--token')) {
+  if (
+    !authConfig.credentials.length &&
+    !ctx.argv.includes('-h') && !ctx.argv.includes('--help') &&
+    !ctx.argv.includes('-t') && !ctx.argv.includes('--token')
+  ) {
     console.log(info(`No existing credentials found. Please log in:`))
 
     subcommand = 'login'


### PR DESCRIPTION
Do not prompt if the command is used with `token` argument.

for issue #796 