### PR TITLE
Use config for GCP settings, allow function update

### DIFF
--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -86,7 +86,7 @@ const deploy = async (ctx: {
   // {
   //   functionName: String,
   //   timeout: String,
-  //   availableMemoryMb: Number,
+  //   memory: Number,
   //   region: String
   // }
   const { nowJSON: { gcp: gcpConfig } } = desc
@@ -216,7 +216,7 @@ const deploy = async (ctx: {
       body: JSON.stringify({
         name: `projects/${project.id}/locations/${region}/functions/${deploymentId}`,
         timeout: gcpConfig.timeout || '15s',
-        availableMemoryMb: gcpConfig.availableMemoryMb || 512,
+        availableMemoryMb: gcpConfig.memory || 512,
         sourceArchiveUrl: `gs://${encodeURIComponent(
           bucketName
         )}/${zipFileName}`,

--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -82,11 +82,20 @@ const deploy = async (ctx: {
     }
   }
 
+  // Example now.json for gcpConfig
+  // {
+  //   functionName: String,
+  //   timeout: String,
+  //   availableMemoryMb: Number,
+  //   region: String
+  // }
+  const { nowJSON: { gcp: gcpConfig } } = desc
+
   const overrides = {
     'function.js': getFunctionHandler(desc)
   }
 
-  const region = 'us-central1'
+  const region = gcpConfig.region || 'us-central1'
 
   console.log(
     info(
@@ -114,13 +123,26 @@ const deploy = async (ctx: {
     )
   )
 
-  const deploymentId = 'now-' + desc.name + '-' + (await uid(10))
+  const deploymentId = gcpConfig.functionName || 'now-' + desc.name + '-' + (await uid(10))
   const zipFileName = `${deploymentId}.zip`
 
   const { project } = ctx.authConfig.credentials.find(p => p.provider === 'gcp')
 
   const resourcesStart = Date.now()
-  const stopResourcesSpinner = wait('Creating API resources')
+
+  debug('checking gcp function check')
+  const fnCheckExistsRes = await fetch(
+    `https://cloudfunctions.googleapis.com/v1beta2/projects/${project.id}/locations/${region}/functions/${deploymentId}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      }
+    }
+  )
+  const fnExists = fnCheckExistsRes.status !== 404
+
+  const stopResourcesSpinner = wait(`${fnExists ? 'Updating' : 'Creating'} API resources`)
 
   if (!ctx.config.gcp) ctx.config.gcp = {}
   if (!ctx.config.gcp.bucketName) {
@@ -184,17 +206,17 @@ const deploy = async (ctx: {
 
   debug('creating gcp function create')
   const fnCreateRes = await fetch(
-    `https://cloudfunctions.googleapis.com/v1beta2/projects/${project.id}/locations/${region}/functions`,
+    `https://cloudfunctions.googleapis.com/v1beta2/projects/${project.id}/locations/${region}/functions${fnExists ? `/${deploymentId}` : ''}`,
     {
-      method: 'POST',
+      method: fnExists ? 'PUT' : 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`
       },
       body: JSON.stringify({
         name: `projects/${project.id}/locations/${region}/functions/${deploymentId}`,
-        timeout: '15s',
-        availableMemoryMb: 512,
+        timeout: gcpConfig.timeout || '15s',
+        availableMemoryMb: gcpConfig.availableMemoryMb || 512,
         sourceArchiveUrl: `gs://${encodeURIComponent(
           bucketName
         )}/${zipFileName}`,
@@ -240,30 +262,20 @@ const deploy = async (ctx: {
       await sleep(5000)
     }
 
-    const fnRes = await fetch(
-      `https://cloudfunctions.googleapis.com/v1beta2/projects/${project.id}/locations/${region}/functions/${deploymentId}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      }
-    )
-
     try {
-      await assertSuccessfulResponse(fnRes)
+      await assertSuccessfulResponse(fnCheckExistsRes)
     } catch (err) {
       console.error(error(err.message))
       return 1
     }
 
-    ;({ status, httpsTrigger: { url } } = await fnRes.json())
+    ;({ status, httpsTrigger: { url } } = await fnCheckExistsRes.json())
   } while (status !== 'READY')
 
   stopResourcesSpinner()
   console.log(
     ok(
-      `API resources created (id: ${param(deploymentId)}) ${gray(
+      `API resources ${fnExists ? 'updated' : 'created'} (id: ${param(deploymentId)}) ${gray(
         `[${ms(Date.now() - resourcesStart)}]`
       )}`
     )


### PR DESCRIPTION
Initial work to use the `now.json` to customize each single function (name, timeout, memory, etc...).

The most important part is the the name. If you are using a reverse proxy to call the function (like when you want to run Next.JS on a function as it needs to run in the root) you might want to use a custom name for the function without prefix and `uid` suffix. 

This change brings also the second part: **update** the existing function instead of creating a new one every time there is a new deploy.

Example `now.json`:
```json
{
  "gcp": {
    "functionName": "my-function-name",
    "memory": 256,
    "timeout: "30s"
  }
}
```

This change suits my deployment strategy as I need to update the same function.

Thanks