### PR TITLE
Let the CI deploy releases to npm automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,28 @@
     'yarn global add slackup',
     './scripts/slack.js'
   ],
-  "deploy": {
-    "provider": "releases",
-    "api_key": {
-      "secure": "ff5V20LO5B8nwguQYtmb3Es/WHBP6GYFo0yOaiw7d1GrmeVFyZauQ7CQgI41toEuYnPlDxd+CQACXjARKLGzJbz80bIPuHZ07GevrmhEgYVHq4DuWAiQnuVf0CJKehDUAKUtR+c8giMQK9tE7O+M+yBciiC9UEKYRCmfyQPXOnEU+cRWNaL0PH2hnlz1AIgScdLblAqdJbVUjHQ+eT2yYeKx2qR09pxu9MDwYLCfpWsLa+8PAcS4MHyuU7mqF27Y484Ab/X3kwNDhnzanyG9YhgHcCeNTZULDQUAJh7Pdf5uQvsfrcgNh1IzY+xvxmYPo2YavkGoDraPBqV46L7FP7KZX3pyh+crR1J+915pE96yHcV3+o40OgSuvW1jw7JCnVkkefryrABFlu7Dez7vd2mlUE+YXcnWhOEp12KUC2izfvm+hvQOqlA+I4VmCWHCA4peM93upQ3QCRhfB18L7JjoGo9/UvUF7wtm/1urMRSU3pWfcNRUtAg497gUUEbA9zVpLya+fQ2QdDe13L/03lYOz78NtDrzSIaWDfJTFrYSpgzwqmSwsTuismxP4NUV0aVEnpL9M+iKBxT0aLWeOIylGsnO5Ido7A+6SGqh8qqeNI84VRKZheOLV6GAqM5zvPDPeFdijRFNbP1n+rW+eepv2uCU8Km38FfhV1Qp85k="
+  "deploy": [
+    {
+      "provider": "releases",
+      "api_key": {
+        "secure": "ff5V20LO5B8nwguQYtmb3Es/WHBP6GYFo0yOaiw7d1GrmeVFyZauQ7CQgI41toEuYnPlDxd+CQACXjARKLGzJbz80bIPuHZ07GevrmhEgYVHq4DuWAiQnuVf0CJKehDUAKUtR+c8giMQK9tE7O+M+yBciiC9UEKYRCmfyQPXOnEU+cRWNaL0PH2hnlz1AIgScdLblAqdJbVUjHQ+eT2yYeKx2qR09pxu9MDwYLCfpWsLa+8PAcS4MHyuU7mqF27Y484Ab/X3kwNDhnzanyG9YhgHcCeNTZULDQUAJh7Pdf5uQvsfrcgNh1IzY+xvxmYPo2YavkGoDraPBqV46L7FP7KZX3pyh+crR1J+915pE96yHcV3+o40OgSuvW1jw7JCnVkkefryrABFlu7Dez7vd2mlUE+YXcnWhOEp12KUC2izfvm+hvQOqlA+I4VmCWHCA4peM93upQ3QCRhfB18L7JjoGo9/UvUF7wtm/1urMRSU3pWfcNRUtAg497gUUEbA9zVpLya+fQ2QdDe13L/03lYOz78NtDrzSIaWDfJTFrYSpgzwqmSwsTuismxP4NUV0aVEnpL9M+iKBxT0aLWeOIylGsnO5Ido7A+6SGqh8qqeNI84VRKZheOLV6GAqM5zvPDPeFdijRFNbP1n+rW+eepv2uCU8Km38FfhV1Qp85k="
+      },
+      "file_glob": true,
+      "file": "packed/*",
+      "skip_cleanup": true,
+      "on": {
+        "tags": true
+      }
     },
-    "file_glob": true,
-    "file": "packed/*",
-    "skip_cleanup": true,
-    "on": {
-      "tags": true
+    {
+      "provider": "npm",
+      "email": "leo@zeit.co",
+      "api_key": {
+        "secure": "HGFqez0XKG3vWJUmDjC1veVJmdASUYviaAbJCqQi4JbgNs49AelhYk3w4vl7K6wOnS2OUPD7tICKNDpxBhunKmVlEkLQtqSnQZjmi4x2tGufGTka0c9O7qNSFsiQXAzta/97MnhmGnJocFsppNNsS21H2aswNQJo+P2QXvmHvFbwzda6k3NwtOc43K+0rW1NM164UwRjtD38LWF+jvhYyysTrWTFXbYUp2o1Q8kI31pn4pMhhOP3qOnuS1jpOzjk6uZ4g5u4cMeK2eSZ/j8B1PNUBXjBfu75IU0yzvlr3ypN7hYcutDTBn4ISDfFM874FdrFhcGiMy7gMO/iwC5LTUqkBGYJT6sYdWEkKU7HQygKeFkinrkmypFdJf9ufw2EDjVCUDYnC5JbnOwu4d3vFHcg3GU6Oa7g1nrScPnZ+jkoM4ugia/3vhFO7serq4qXEj7Mv5p78mW41gxHUTgf8uqwhiOnqo9Or7UsR7vU/hB3uU0DY/nq5BI3Wt4XANrlTDeMDExjDACIQ1GU089va88NbWyU1XDD2zs+o1Y6OigAkn/yZ8V/z52eYcA5znTxcb4s8P36pKCSEkxyRtpHNf138hDx9qC2Hze1alBDfUC4iRhiZCQN4CXhSxVdb6HjZHNwCyWCO16LZLbnBvCbIMR+0WjnL0KzqsUTOboZHkQ="
+      },
+      "on": {
+        "tags": true
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
Just like we had it with Circle CI before, this makes running `npm publish` locally unnecessary.

Read more [here](https://docs.travis-ci.com/user/deployment/npm/).