### PR TITLE
Temporarily hide providers from usage information

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -97,10 +97,6 @@ const help = () => {
       login                            Login into your account or creates a new one
       logout                           Logout from your account
 
-    ${chalk.dim('Providers')}
-
-      sh, aws, gcp         [cmd]       Deploy using a different provider
-
   ${chalk.dim('Options:')}
 
     -h, --help                Output usage information


### PR DESCRIPTION
As discussed with @rauchg, the sub commands for different providers should stay accessible, but we shouldn't make them "visible" anywhere until they're completely finished.