### PR TITLE
Don't fall back to a different provider than Now

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -297,15 +297,8 @@ const main = async (argv_) => {
 
   if (null === suppliedProvider) {
     if (null === defaultProvider) {
-      // the first provider the user ever logged in to is
-      // the default provider
-      if (authConfig && authConfig.credentials.length) {
-        debug('using first credential as default provider')
-        defaultProvider = authConfig.credentials[0].provider
-      } else {
-        debug(`fallbacking to default now provider 'sh'`)
-        defaultProvider = 'sh'
-      }
+      debug(`falling back to default now provider 'sh'`)
+      defaultProvider = 'sh'
     } else {
       debug('using provider supplied by user', defaultProvider)
       if (!(defaultProvider in providers)) {


### PR DESCRIPTION
Before, we used the first provider in the config. This caused several problems because people expected `now` to deploy their project on Now even if they're logged into AWS or GCP.

This fixes #817.