### PR TITLE
Made `now whoami` return the correct team context

### DIFF
--- a/src/providers/sh/commands/whoami.js
+++ b/src/providers/sh/commands/whoami.js
@@ -62,11 +62,16 @@ module.exports = async ctx => {
   }
 }
 
-async function whoami({user}) {
+async function whoami({user, currentTeam}) {
   if (process.stdout.isTTY) {
     process.stdout.write('> ')
   }
 
-  const name = user.username || user.email
+  let name = user.username || user.email
+
+  if (currentTeam) {
+    name = currentTeam.slug
+  }
+
   console.log(name)
 }


### PR DESCRIPTION
Previously, the command only respected the currently logged in user. Now it's also respecting the real scope (the team that you're on).

This fixes #585. (cc @chabou)