### PR TITLE
Removed not working `--login` flag from usage information

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -41,7 +41,6 @@ const mriOpts = {
     'debug',
     'force',
     'links',
-    'login',
     'no-clipboard',
     'forward-npm',
     'docker',
@@ -57,7 +56,6 @@ const mriOpts = {
     force: 'f',
     forceSync: 'F',
     links: 'l',
-    login: 'L',
     public: 'p',
     'no-clipboard': 'C',
     'forward-npm': 'N',
@@ -114,7 +112,6 @@ const help = () => {
     -t ${chalk.underline('TOKEN')}, --token=${chalk.underline(
     'TOKEN'
   )}        Login token
-    -L, --login                    Configure login
     -l, --links                    Copy symlinks without resolving their target
     -p, --public                   Deployment is public (${chalk.dim(
       '`/_src`'


### PR DESCRIPTION
In Now CLI 8.0.0 (which was a major/breaking release), we removed support for the `--login` flag in favor of the new `now login` and `now logout` commands (actions should be commands and modifiers/options should be flags).

However, we didn't remove it from the usage information - this PR fixes that.