### PR TITLE
Test installation over `npm` after deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,6 @@
         "tags": true
       }
     }
-  ]
+  ],
+  "after_deploy": "npm install -g now"
 }


### PR DESCRIPTION
This PR will ensure that - after Travis CI has deployed a new version of Now CLI to npm - it will automatically try to download that version. This will result in **two advantages** for us:

- Since the npm package download is connected to the CDN, the CDN will pull the latest version of the CLI from the platform and cache it. This means that all following installations by users don't have the delay that the CDN takes to download and cache a binary.

- Travis CI will automatically let us know if the `npm install -g now` command failed and we can immediately act to fix it, so that no users experience any problems.