### PR TITLE
Added missing `--token` flag to `now scale` sub command

### DIFF
--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -26,14 +26,17 @@ const help = () => {
 
   ${chalk.dim('Options:')}
 
-    -h, --help              Output usage information
+    -h, --help                     Output usage information
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'
   )}   Path to the local ${'`now.json`'} file
     -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
     'DIR'
   )}    Path to the global ${'`.now`'} directory
-    -d, --debug             Debug mode [off]
+    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
+    'TOKEN'
+  )}        Login token
+    -d, --debug                    Debug mode [off]
 
   ${chalk.dim('Examples:')}
 


### PR DESCRIPTION
This command is the only one that is still missing the flag in the usage information. In addition, I adjusted the indentation.