### PR TITLE
Cleaned up the usage information

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -374,7 +374,8 @@ const main = async (argv_) => {
   if (
     !authConfig.credentials.length &&
     !ctx.argv.includes('-h') && !ctx.argv.includes('--help') &&
-    !hasToken
+    !hasToken &&
+    subcommand !== 'login'
   ) {
     if (isTTY) {
       console.log(info(`No existing credentials found. Please log in:`))

--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -26,7 +26,13 @@ const underlineWidth = 11
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now alias`)} <ls | set | rm> <deployment> <alias>
+  ${chalk.bold(`${logo} now alias`)} [options] <command>
+
+  ${chalk.dim('Commands:')}
+
+    ls    [app]                  Show all aliases (or per app name)
+    set   [deployment] [alias]   Create a new alias
+    rm    [id]                   Remove an alias using its ID
 
   ${chalk.dim('Options:')}
 
@@ -39,7 +45,7 @@ const help = () => {
   )}        Path to the global ${'`.now`'} directory
     -r ${chalk.bold.underline('RULES_FILE')}, --rules=${chalk.bold.underline(
     'RULES_FILE'
-  )}  Rules file
+  )}   Rules file
     -d, --debug                        Debug mode [off]
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
@@ -47,11 +53,7 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Lists all your aliases:
-
-      ${chalk.cyan('$ now alias ls')}
-
-  ${chalk.gray('–')} Adds a new alias to ${chalk.underline('my-api.now.sh')}:
+  ${chalk.gray('–')} Add a new alias to ${chalk.underline('my-api.now.sh')}
 
       ${chalk.cyan(
         `$ now alias set ${chalk.underline(
@@ -59,15 +61,7 @@ const help = () => {
         )} ${chalk.underline('my-api.now.sh')}`
       )}
 
-      The ${chalk.dim('`.now.sh`')} suffix can be ommited:
-
-      ${chalk.cyan('$ now alias set api-ownv3nc9f8 my-api')}
-
-      The deployment id can be used as the source:
-
-      ${chalk.cyan('$ now alias set deploymentId my-alias')}
-
-      Custom domains work as alias targets:
+      Custom domains work as alias targets
 
       ${chalk.cyan(
         `$ now alias set ${chalk.underline(
@@ -79,12 +73,12 @@ const help = () => {
     '`set`'
   )} is the default and can be skipped.
       ${chalk.dim('–')} ${chalk.dim(
-    '`http(s)://`'
-  )} in the URLs is unneeded / ignored.
+    'Protocols'
+  )} in the URLs are unneeded and ignored.
 
   ${chalk.gray('–')} Add and modify path based aliases for ${chalk.underline(
     'zeit.ninja'
-  )}:
+  )}
 
       ${chalk.cyan(
         `$ now alias ${chalk.underline('zeit.ninja')} -r ${chalk.underline(
@@ -92,21 +86,11 @@ const help = () => {
         )}`
       )}
 
-      Export effective routing rules:
+      Export effective routing rules
 
       ${chalk.cyan(
         `$ now alias ls aliasId --json > ${chalk.underline('rules.json')}`
       )}
-
-      ${chalk.cyan(`$ now alias ls zeit.ninja`)}
-
-  ${chalk.gray('–')} Removing an alias:
-
-      ${chalk.cyan('$ now alias rm aliasId')}
-
-      To get the list of alias ids, use ${chalk.dim('`now alias ls`')}.
-
-  ${chalk.dim('Alias:')} ln
 `)
 }
 

--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -36,20 +36,20 @@ const help = () => {
 
   ${chalk.dim('Options:')}
 
-    -h, --help                         Output usage information
+    -h, --help                          Output usage information
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'
-  )}       Path to the local ${'`now.json`'} file
+  )}        Path to the local ${'`now.json`'} file
     -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
     'DIR'
-  )}        Path to the global ${'`.now`'} directory
+  )}         Path to the global ${'`.now`'} directory
     -r ${chalk.bold.underline('RULES_FILE')}, --rules=${chalk.bold.underline(
     'RULES_FILE'
   )}   Rules file
-    -d, --debug                        Debug mode [off]
+    -d, --debug                         Debug mode [off]
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
-  )}            Login token
+  )}             Login token
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/billing.js
+++ b/src/providers/sh/commands/billing.js
@@ -19,7 +19,14 @@ const exit = require('../../../util/exit')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now billing`)} <ls | add | rm | set-default>
+  ${chalk.bold(`${logo} now billing`)} [options] <command>
+
+  ${chalk.dim('Options:')}
+
+    ls                   Show all of your credit cards
+    add                  Add a new credit card
+    rm            [id]   Remove a credit card
+    set-default   [id]   Make a credit card your default one
 
   ${chalk.dim('Options:')}
 
@@ -37,25 +44,9 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Lists all your credit cards:
-
-      ${chalk.cyan('$ now billing ls')}
-
-  ${chalk.gray('–')} Adds a credit card (interactively):
+  ${chalk.gray('–')} Add a new credit card (interactively)
 
       ${chalk.cyan(`$ now billing add`)}
-
-  ${chalk.gray('–')} Removes a credit card:
-
-      ${chalk.cyan(`$ now billing rm <id>`)}
-
-      ${chalk.gray('–')} If the id is omitted, you can choose interactively
-
-  ${chalk.gray('–')} Selects your default credit card:
-
-      ${chalk.cyan(`$ now billing set-default <id>`)}
-
-      ${chalk.gray('–')} If the id is omitted, you can choose interactively
   `)
 }
 

--- a/src/providers/sh/commands/certs.js
+++ b/src/providers/sh/commands/certs.js
@@ -21,13 +21,17 @@ const logo = require('../../../util/output/logo')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now certs`)} <ls | create | renew | replace | rm> <cn>
+  ${chalk.bold(`${logo} now certs`)} [options] <command>
 
-  ${chalk.dim('Note:')}
+  ${chalk.yellow('NOTE:')} This command is intended for advanced use only. By default,
+  Now manages your certificates automatically.
 
-  This command is intended for advanced use only, normally ${chalk.bold(
-    'now'
-  )} manages your certificates automatically.
+  ${chalk.dim('Commands:')}
+
+    ls                    Show all available certificates
+    create    [domain]    Create a certificate for a domain
+    renew     [domain]    Renew the certificate of a existing domain
+    replace   [domain]    Switch out a domain's certificate
 
   ${chalk.dim('Options:')}
 
@@ -48,23 +52,9 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Listing all your certificates:
-
-      ${chalk.cyan('$ now certs ls')}
-
-  ${chalk.gray('–')} Creating a new certificate:
-
-      ${chalk.cyan('$ now certs create domain.com')}
-
-  ${chalk.gray('–')} Renewing an existing certificate issued with ${chalk.bold(
-    'now'
-  )}:
-
-      ${chalk.cyan('$ now certs renew domain.com')}
-
   ${chalk.gray(
     '–'
-  )} Replacing an existing certificate with a user-supplied certificate:
+  )} Replace an existing certificate with a custom one
 
       ${chalk.cyan(
         '$ now certs replace --crt domain.crt --key domain.key --ca ca_chain.crt domain.com'

--- a/src/providers/sh/commands/certs.js
+++ b/src/providers/sh/commands/certs.js
@@ -23,8 +23,8 @@ const help = () => {
   console.log(`
   ${chalk.bold(`${logo} now certs`)} [options] <command>
 
-  ${chalk.yellow('NOTE:')} This command is intended for advanced use only. By default,
-  Now manages your certificates automatically.
+  ${chalk.yellow('NOTE:')} This command is intended for advanced use only.
+  By default, Now manages your certificates automatically.
 
   ${chalk.dim('Commands:')}
 

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -136,29 +136,25 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Deploys the current directory
+  ${chalk.gray('–')} Deploy the current directory
 
     ${chalk.cyan('$ now')}
 
-  ${chalk.gray('–')} Deploys a custom path ${chalk.dim('`/usr/src/project`')}
+  ${chalk.gray('–')} Deploy a custom path ${chalk.dim('`/usr/src/project`')}
 
     ${chalk.cyan('$ now /usr/src/project')}
 
-  ${chalk.gray('–')} Deploys a GitHub repository
+  ${chalk.gray('–')} Deploy a GitHub repository
 
     ${chalk.cyan('$ now user/repo#ref')}
 
-  ${chalk.gray('–')} Deploys a GitHub, GitLab or Bitbucket repo using its URL
-
-    ${chalk.cyan('$ now https://gitlab.com/user/repo')}
-
-  ${chalk.gray('–')} Deploys with ENV vars
+  ${chalk.gray('–')} Deploy with environment variables
 
     ${chalk.cyan(
       '$ now -e NODE_ENV=production -e MYSQL_PASSWORD=@mysql-password'
     )}
 
-  ${chalk.gray('–')} Displays comprehensive help for the subcommand ${chalk.dim(
+  ${chalk.gray('–')} Show the usage information for the sub command ${chalk.dim(
     '`list`'
   )}
 

--- a/src/providers/sh/commands/dns.js
+++ b/src/providers/sh/commands/dns.js
@@ -45,7 +45,7 @@ const help = () => {
   ${chalk.gray('–')} Add an A record for a subdomain
 
       ${chalk.cyan(
-        '$ now dns add <DOMAIN> <SUBDOMAIN> A | AAAA | ALIAS | CNAME | TXT>  <VALUE>'
+        '$ now dns add <DOMAIN> <SUBDOMAIN> <A | AAAA | ALIAS | CNAME | TXT>  <VALUE>'
       )}
       ${chalk.cyan('$ now dns add zeit.rocks api A 198.51.100.100')}
 

--- a/src/providers/sh/commands/dns.js
+++ b/src/providers/sh/commands/dns.js
@@ -16,15 +16,15 @@ const logo = require('../../../util/output/logo')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now dns ls`)} [domain]
   ${chalk.bold(
-    `${logo} now dns add`
-  )} <domain> <name> <A | AAAA | ALIAS | CNAME | TXT> <value>
-  ${chalk.bold(`${logo} now dns add`)} <domain> <name> MX <value> <mx_priority>
-  ${chalk.bold(
-    `${logo} now dns add`
-  )} <domain> <name> SRV <priority> <weight> <port> <target>
-  ${chalk.bold(`${logo} now dns rm`)} <id>
+    `${logo} now dns`
+  )} [options] <command>
+
+  ${chalk.dim('Commands:')}
+
+    add   [details]    Add a new DNS entry (see below for examples)
+    rm    [id]         Remove a DNS entry using its ID
+    ls    [domain]     List all DNS entries for a domain
 
   ${chalk.dim('Options:')}
 
@@ -42,23 +42,26 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} List all your DNS records
-
-      ${chalk.cyan('$ now dns ls')}
-
   ${chalk.gray('–')} Add an A record for a subdomain
 
       ${chalk.cyan(
-        '$ now dns add <YOUR DOMAIN> <SUBDOMAIN NAME> A <RECORD VALUE>'
+        '$ now dns add <DOMAIN> <SUBDOMAIN> A | AAAA | ALIAS | CNAME | TXT>  <VALUE>'
       )}
       ${chalk.cyan('$ now dns add zeit.rocks api A 198.51.100.100')}
 
   ${chalk.gray('–')} Add an MX record (@ as a name refers to the domain)
 
       ${chalk.cyan(
-        '$ now dns add <YOUR DOMAIN> @ MX <RECORD VALUE> <PRIORITY>'
+        '$ now dns add <DOMAIN> @ MX <RECORD VALUE> <PRIORITY>'
       )}
       ${chalk.cyan('$ now dns add zeit.rocks @ MX mail.zeit.rocks 10')}
+
+  ${chalk.gray('–')} Add an SVR record
+
+      ${chalk.cyan(
+        '$ now dns add <DOMAIN> <NAME> SRV <PRIORITY> <WEIGHT> <PORT> <TARGET>'
+      )}
+      ${chalk.cyan('$ now dns add zeit.rocks SRV 10 0 389 zeit.party')}
 `)
 }
 

--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -19,7 +19,14 @@ const buy = require('./domains/buy')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now domains`)} <ls | add | rm | buy> <domain>
+  ${chalk.bold(`${logo} now domains`)} [options] <command>
+
+  ${chalk.dim('Commands:')}
+
+    ls             Show all domains in a list
+    add   [name]   Add a new domain that you already own
+    rm    [name]   Remove a domain
+    buy   [name]   Buy a domain that you don't yet own
 
   ${chalk.dim('Options:')}
 
@@ -39,85 +46,25 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Lists all your domains:
-
-      ${chalk.cyan('$ now domains ls')}
-
-  ${chalk.gray('–')} Buy a new domain:
-
-      ${chalk.cyan(`$ now domains buy ${chalk.underline('domain-name.com')}`)}
-
-  ${chalk.gray('–')} Adds a domain name:
+  ${chalk.gray('–')} Add a domain that you already own
 
       ${chalk.cyan(`$ now domains add ${chalk.underline('domain-name.com')}`)}
 
-      Make sure the domain's DNS nameservers are at least 2 of these:
+      Make sure the domain's DNS nameservers are at least 2 of the
+      ones listed on ${chalk.underline('https://zeit.world')}.
 
-      ${chalk.gray('–')} ${chalk.underline(
-    'california.zeit.world'
-  )}    ${chalk.dim('173.255.215.107')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'london.zeit.world'
-  )}        ${chalk.dim('178.62.47.76')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'newark.zeit.world'
-  )}        ${chalk.dim('173.255.231.87')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'amsterdam.zeit.world'
-  )}     ${chalk.dim('188.226.197.55')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'dallas.zeit.world'
-  )}        ${chalk.dim('173.192.101.194')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'paris.zeit.world'
-  )}         ${chalk.dim('37.123.115.172')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'singapore.zeit.world'
-  )}     ${chalk.dim('119.81.97.170')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'sydney.zeit.world'
-  )}        ${chalk.dim('52.64.171.200')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'frankfurt.zeit.world'
-  )}     ${chalk.dim('91.109.245.139')}
-      ${chalk.gray('–')} ${chalk.underline(
-    'iowa.zeit.world'
-  )}          ${chalk.dim('23.236.59.22')}
-
-      ${chalk.yellow('NOTE:')} running ${chalk.dim(
+      ${chalk.yellow('NOTE:')} Running ${chalk.dim(
     '`now alias`'
   )} will automatically register your domain
       if it's configured with these nameservers (no need to ${chalk.dim(
         '`domain add`'
       )}).
 
-      For more details head to ${chalk.underline('https://zeit.world')}.
-
-  ${chalk.gray('–')} Removing a domain:
-
-      ${chalk.cyan('$ now domain rm my-app.com')}
-
-      or
-
-      ${chalk.cyan('$ now domain rm domainId')}
-
-      To get the list of domain ids, use ${chalk.dim('`now domains ls`')}.
-
   ${chalk.gray(
     '–'
-  )} Adding and verifying a domain name using zeit.world nameservers:
-
-      ${chalk.cyan('$ now domain add my-app.com')}
-
-      The command will tell you if the domain was verified succesfully. In case the domain was not verified succesfully you should retry adding the domain after some time.
-
-  ${chalk.gray(
-    '–'
-  )} Adding and verifying a domain name using an external nameserver:
+  )} Add a domain using an external nameserver
 
       ${chalk.cyan('$ now domain add -e my-app.com')}
-
-      and follow the verification instructions if requested. Finally, rerun the same command after completing the verification step.
 `)
 }
 

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -42,8 +42,6 @@ const help = () => {
   ${chalk.gray('–')} List all deployments for the app ${chalk.dim('`my-app`')}
 
     ${chalk.cyan('$ now ls my-app')}
-
-  ${chalk.dim('Alias:')} ls
 `)
 }
 

--- a/src/providers/sh/commands/login.js
+++ b/src/providers/sh/commands/login.js
@@ -253,7 +253,7 @@ const login = async ctx => {
   stopSpinner()
 
   // Clear up `Sending email` success message
-  process.stdout.write(eraseLines(2))
+  process.stdout.write(eraseLines(possibleAddress ? 1 : 2))
 
   console.log(info(
     `We sent an email to ${highlight(email)}. Please follow the steps provided`,

--- a/src/providers/sh/commands/login.js
+++ b/src/providers/sh/commands/login.js
@@ -8,6 +8,8 @@ const debug = require('debug')('now:sh:login')
 const promptEmail = require('email-prompt')
 const ms = require('ms')
 const { validate: validateEmail } = require('email-validator')
+const chalk = require('chalk')
+const minimist = require('minimist')
 
 // Utilities
 const { version } = require('../../../util/pkg')
@@ -30,6 +32,34 @@ const {
 } = require('../../../util/config-files')
 const getNowDir = require('../../../config/global-path')
 const hp = require('../../../util/humanize-path')
+const logo = require('../../../util/output/logo')
+const exit = require('../../../util/exit')
+
+const help = () => {
+  console.log(`
+  ${chalk.bold(`${logo} now login`)} <email>
+
+  ${chalk.dim('Options:')}
+
+    -h, --help                     Output usage information
+    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
+    'FILE'
+  )}   Path to the local ${'`now.json`'} file
+    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
+    'DIR'
+  )}    Path to the global ${'`.now`'} directory
+
+  ${chalk.dim('Examples:')}
+
+  ${chalk.gray('–')} Log into the Now platform
+
+    ${chalk.cyan('$ now login')}
+
+  ${chalk.gray('–')} Log in using a specific email address
+
+    ${chalk.cyan('$ now login john@doe.com')}
+`)
+}
 
 // POSTs to /now/registration – either creates an account or performs a login
 // returns {token, securityCode}
@@ -148,37 +178,39 @@ const readEmail = async () => {
   return email
 }
 
-// TODO open issues: .co, error messages
-
 const login = async ctx => {
-  const { argv } = ctx
+  const argv = minimist(ctx.argv.slice(2), {
+    boolean: ['help'],
+    alias: {
+      help: 'h'
+    }
+  })
+
+  if (argv.help) {
+    help()
+    await exit(0)
+  }
+
+  argv._ = argv._.slice(1)
+
   const apiUrl =
     (ctx.config.sh && ctx.config.sh.apiUrl) || 'https://api.zeit.co'
   let email
   let emailIsValid = false
   let stopSpinner
 
-  // node file sh login [email|help]
-  const argvHasSh = argv[2] === 'sh'
-  const allowedNumberOfArgs = argvHasSh ? 5 : 4
-  if (argv.length > allowedNumberOfArgs) {
-    const _cmd = argvHasSh ? 'now sh login' : 'now login'
-    console.log(error(`Invalid number of arguments for ${cmd(_cmd)}`))
-    console.log(info(`See ${cmd(_cmd + ' help')}`))
-    return 1
-  }
-
-  const maybeEmail = argv[argv.length - 1]
+  const possibleAddress = argv._[0]
 
   // if the last arg is not the command itself, then maybe it's an email
-  if (maybeEmail !== 'login') {
-    if (!validateEmail(maybeEmail)) {
+  if (possibleAddress) {
+    if (!validateEmail(possibleAddress)) {
       // if it's not a valid email, let's just error
-      console.log(error(`Invalid email: ${param(maybeEmail)}.`))
+      console.log(error(`Invalid email: ${param(possibleAddress)}.`))
       return 1
     }
+
     // valid email, no need to prompt the user
-    email = maybeEmail
+    email = possibleAddress
   } else {
     do {
       try {

--- a/src/providers/sh/commands/logs.js
+++ b/src/providers/sh/commands/logs.js
@@ -32,7 +32,7 @@ const help = () => {
     'DIR'
   )}    Path to the global ${'`.now`'} directory
     -d, --debug                    Debug mode [off]
-    -f                             Wait for additional data [off]
+    -f, --follow                   Wait for additional data [off]
     -n ${chalk.bold.underline('NUMBER')}                      Number of logs [1000]
     -q ${chalk.bold.underline('QUERY')}, --query=${chalk.bold.underline(
     'QUERY'
@@ -74,12 +74,13 @@ let instanceId
 const main = async ctx => {
   argv = minimist(ctx.argv.slice(2), {
     string: ['query', 'since', 'until'],
-    boolean: ['help', 'all', 'debug', 'f'],
+    boolean: ['help', 'all', 'debug', 'follow'],
     alias: {
       help: 'h',
       all: 'a',
       debug: 'd',
-      query: 'q'
+      query: 'q',
+      follow: 'f'
     }
   })
 

--- a/src/providers/sh/commands/logs.js
+++ b/src/providers/sh/commands/logs.js
@@ -49,7 +49,7 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Print logs for the deployment ${chalk.dim(
+  ${chalk.gray('–')} Print the logs for the deployment ${chalk.dim(
     '`deploymentId`'
   )}
 

--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -33,7 +33,7 @@ const help = () => {
     'TOKEN'
   )}        Login token
     -y, --yes                      Skip confirmation
-    --safe                         Skip deployments with an active alias
+    -s, --safe                     Skip deployments with an active alias
 
   ${chalk.dim('Examples:')}
 
@@ -69,7 +69,8 @@ const main = async ctx => {
     alias: {
       help: 'h',
       debug: 'd',
-      yes: 'y'
+      yes: 'y',
+      safe: 's'
     }
   })
 

--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -17,7 +17,7 @@ const help = () => {
   console.log(`
   ${chalk.bold(
     `${logo} now remove`
-  )} deploymentId|deploymentName [...deploymentId|deploymentName]
+  )} [...deploymentId|deploymentName]
 
   ${chalk.dim('Options:')}
 
@@ -39,21 +39,19 @@ const help = () => {
 
   ${chalk.gray('–')} Remove a deployment identified by ${chalk.dim(
     '`deploymentId`'
-  )}:
+  )}
 
     ${chalk.cyan('$ now rm deploymentId')}
 
-  ${chalk.gray('–')} Remove all deployments with name ${chalk.dim('`my-app`')}:
+  ${chalk.gray('–')} Remove all deployments with name ${chalk.dim('`my-app`')}
 
     ${chalk.cyan('$ now rm my-app')}
 
   ${chalk.gray('–')} Remove two deployments with IDs ${chalk.dim(
     '`eyWt6zuSdeus`'
-  )} and ${chalk.dim('`uWHoA9RQ1d1o`')}:
+  )} and ${chalk.dim('`uWHoA9RQ1d1o`')}
 
     ${chalk.cyan('$ now rm eyWt6zuSdeus uWHoA9RQ1d1o')}
-
-  ${chalk.dim('Alias:')} rm
 `)
 }
 

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -40,31 +40,25 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Create a deployment with 3 instances, never sleeps:
+  ${chalk.gray('–')} Scale a deployment to 3 instances (never sleeps):
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 3')}
 
-  ${chalk.gray('–')} Create an automatically scaling deployment:
+  ${chalk.gray('–')} Set a deployment to scale automatically between 1 and 5 instances:
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 1 5')}
 
   ${chalk.gray(
     '–'
-  )} Create an automatically scaling deployment without specifying max:
+  )} Set a deployment to scale until your plan limit, but at least 1 instance:
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 1 auto')}
 
   ${chalk.gray(
     '–'
-  )} Create an automatically scaling deployment without specifying min or max:
+  )} Set a deployment to scale up and down without limits:
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh auto')}
-
-  ${chalk.gray(
-    '–'
-  )} Create a deployment that is always active and never "sleeps":
-
-    ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 1')}
   `)
 }
 

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -42,23 +42,23 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Scale a deployment to 3 instances (never sleeps):
+  ${chalk.gray('–')} Scale a deployment to 3 instances (never sleeps)
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 3')}
 
-  ${chalk.gray('–')} Set a deployment to scale automatically between 1 and 5 instances:
+  ${chalk.gray('–')} Set a deployment to scale automatically between 1 and 5 instances
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 1 5')}
 
   ${chalk.gray(
     '–'
-  )} Set a deployment to scale until your plan limit, but at least 1 instance:
+  )} Set a deployment to scale until your plan limit, but at least 1 instance
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh 1 auto')}
 
   ${chalk.gray(
     '–'
-  )} Set a deployment to scale up and down without limits:
+  )} Set a deployment to scale up and down without limits
 
     ${chalk.cyan('$ now scale my-deployment-ntahoeato.now.sh auto')}
   `)

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -20,9 +20,11 @@ const success = require('../../../util/output/success')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now scale`)} ls
-  ${chalk.bold(`${logo} now scale`)} <url>
   ${chalk.bold(`${logo} now scale`)} <url> <min> [max]
+
+  ${chalk.dim('Commands:')}
+
+    ls    List the scaling information for all deployments
 
   ${chalk.dim('Options:')}
 

--- a/src/providers/sh/commands/secrets.js
+++ b/src/providers/sh/commands/secrets.js
@@ -15,7 +15,14 @@ const logo = require('../../../util/output/logo')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now secrets`)} <ls | add | rename | rm> <secret>
+  ${chalk.bold(`${logo} now secrets`)} [options] <command>
+
+  ${chalk.dim('Commands:')}
+
+    ls                               Show all secrets in a list
+    add      [name] [value]          Add a new secret
+    rename   [old-name] [new-name]   Change the name of a secret
+    rm       [name]                  Remove a secret
 
   ${chalk.dim('Options:')}
 
@@ -34,37 +41,23 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Lists all your secrets:
-
-    ${chalk.cyan('$ now secrets ls')}
-
-  ${chalk.gray('–')} Adds a new secret:
+  ${chalk.gray('–')} Add a new secret
 
     ${chalk.cyan('$ now secrets add my-secret "my value"')}
 
     ${chalk.gray(
       '–'
-    )} Once added, a secret's value can't be retrieved in plaintext anymore
+    )} Once added, a secret's value can't be retrieved in plain text anymore
     ${chalk.gray(
       '–'
     )} If the secret's value is more than one word, wrap it in quotes
-    ${chalk.gray('–')} Actually, when in doubt, wrap your value in quotes
+    ${chalk.gray('–')} When in doubt, always wrap your value in quotes
 
-  ${chalk.gray('–')} Exposes a secret as an env variable:
+  ${chalk.gray('–')} Expose a secret as an environment variable (notice the ${chalk.cyan.bold(
+    '`@`'
+  )} symbol)
 
     ${chalk.cyan(`$ now -e MY_SECRET=${chalk.bold('@my-secret')}`)}
-
-    Notice the ${chalk.cyan.bold(
-      '`@`'
-    )} symbol which makes the value a secret reference.
-
-  ${chalk.gray('–')} Renames a secret:
-
-    ${chalk.cyan(`$ now secrets rename my-secret my-renamed-secret`)}
-
-  ${chalk.gray('–')} Removes a secret:
-
-    ${chalk.cyan(`$ now secrets rm my-secret`)}
 `)
 }
 

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -17,7 +17,14 @@ const invite = require('./teams/invite')
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now teams`)} <add | ls | switch | invite>
+  ${chalk.bold(`${logo} now teams`)} [options] <command>
+
+  ${chalk.dim('Commands:')}
+
+    add                Create a new team
+    ls                 Show all teams you're a part of
+    switch   [name]    Switch to a different team
+    invite   [email]   Invite a new member to a team
 
   ${chalk.dim('Options:')}
 
@@ -35,10 +42,6 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Add a new team:
-
-      ${chalk.cyan('$ now teams add')}
-
   ${chalk.gray('–')} Switch to a team:
 
       ${chalk.cyan(`$ now switch <slug>`)}
@@ -55,10 +58,6 @@ const help = () => {
   ${chalk.gray('–')} Invite new members (interactively):
 
       ${chalk.cyan(`$ now teams invite`)}
-
-  ${chalk.gray('–')} Invite a specific email:
-
-      ${chalk.cyan(`$ now teams invite geist@zeit.co`)}
   `)
 }
 

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -42,7 +42,7 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Switch to a team:
+  ${chalk.gray('–')} Switch to a team
 
       ${chalk.cyan(`$ now switch <slug>`)}
 
@@ -55,7 +55,7 @@ const help = () => {
         'NOTE:'
       )} When you switch, everything you add, list or remove will be scoped that team!
 
-  ${chalk.gray('–')} Invite new members (interactively):
+  ${chalk.gray('–')} Invite new members (interactively)
 
       ${chalk.cyan(`$ now teams invite`)}
   `)

--- a/src/providers/sh/commands/upgrade.js
+++ b/src/providers/sh/commands/upgrade.js
@@ -20,7 +20,7 @@ const { bold } = chalk
 
 const help = () => {
   console.log(`
-  ${chalk.bold(`${logo} now upgrade`)} [plan]
+  ${chalk.bold(`${logo} now upgrade`)} [options] <plan>
 
   ${chalk.dim('Options:')}
 
@@ -48,7 +48,7 @@ const help = () => {
 
       ${chalk.cyan(`$ now billing add`)}
 
-  ${chalk.gray('–')} Pick a specific plan (premium):
+  ${chalk.gray('–')} Pick a specific plan (e.g. "premium")
 
       ${chalk.cyan(`$ now upgrade premium`)}
   `)


### PR DESCRIPTION
This PR makes the usage information of all sub commands consistent and removes unnecessary examples to keep it as short as possible (as discussed with @matheuss).

In addition, it makes `now login <email>` work (which didn't before) and adds the usage information for the new `now logout` sub command.