### PR TITLE
Introduced a much cleaner token name

### DIFF
--- a/src/providers/sh/commands/login.js
+++ b/src/providers/sh/commands/login.js
@@ -66,7 +66,10 @@ const help = () => {
 // token: should be used to verify the status of the login process
 // securityCode: will be sent to the user in the email body
 const getVerificationData = async ({ apiUrl, email }) => {
-  const tokenName = `Now CLI ${version} – ${platform()}-${arch()} (${hostname()})`
+  const hyphens = new RegExp('-', 'g')
+  const host = hostname().replace(hyphens, ' ').replace('.local', '')
+  const tokenName = `Now CLI on ${host}`
+
   const data = JSON.stringify({ email, tokenName })
 
   debug('POST /now/registration')


### PR DESCRIPTION
This makes the CLI align with Now Desktop as per https://github.com/zeit/now-desktop/pull/365.

**BEFORE**

<img width="503" alt="screen shot 2017-09-12 at 12 25 14" src="https://user-images.githubusercontent.com/6170607/30321191-7b1ea3c8-97b5-11e7-9ee8-b43376bfc360.png">

**AFTER**

<img width="476" alt="screen shot 2017-09-12 at 12 21 21" src="https://user-images.githubusercontent.com/6170607/30321196-804a905a-97b5-11e7-8947-8125cc792932.png">