### PR TITLE
Fix path detection when a path is specified

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -232,6 +232,13 @@ async function main(ctx) {
   if (argv._[0] === 'deploy') {
     argv._.shift()
   }
+  if (argv._.length > 0) {
+    path = argv._.shift()
+  }
+  if (argv._.length > 0) {
+    console.error(error(`At most one directory can be specified for deploying (${path})`))
+    process.exit(1)
+  }
 
   if (path) {
     // If path is relative: resolve


### PR DESCRIPTION
```console
$ now --static some-path
```

currently ignores the path and deploys the CWD in almost all cases. This fixes that and re-introduces the ability to deploy a specific path.