### PR TITLE
fix(token): token argument problems for two subcommands

### DIFF
--- a/src/providers/sh/commands/logs.js
+++ b/src/providers/sh/commands/logs.js
@@ -125,7 +125,7 @@ const main = async ctx => {
   types = argv.all ? [] : ['command', 'stdout', 'stderr', 'exit']
 
   const {authConfig: { credentials }, config: { sh }} = ctx
-  const {token} = argv.token || credentials.find(item => item.provider === 'sh')
+  const {token} = credentials.find(item => item.provider === 'sh')
 
   await printLogs({ token, sh })
 }

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -94,7 +94,7 @@ const main = async ctx => {
   }
 
   const {authConfig: { credentials }, config} = ctx
-  const {token} = argv.token || credentials.find(item => item.provider === 'sh')
+  const {token} = credentials.find(item => item.provider === 'sh')
 
   try {
     await run({ token, config })


### PR DESCRIPTION
There is `token` alias problem for two subcommands.

## Reproduce

```cmd
# work
$ now switch -t <TOKEN>

# fail
$ now switch --token <TOKEN>

> Caching account information...
⠦ Fetching teams> Error! Unknown error: Error: Unauthorized
    at module.exports.Now.ls.retry (/snapshot/now-cli/dist/now.js:11661:21)
    at process._tickCallback (internal/process/next_tick.js:109:7)
```

## Version

`v8.2.5`