### PR TITLE
fix(currentTeam): deploy to specific team with token

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -426,7 +426,8 @@ const main = async (argv_) => {
       token
     })
 
-    ctx.config.sh = {user}
+    // Remind: Keep the currentTeam information 
+    ctx.config.sh = Object.assign(ctx.config.sh, { user })
   }
 
   try {


### PR DESCRIPTION
I want to deploy to specific team with token argument:

## Reproduce

```cmd
$ now switch <TEAM_NAME> -t <TOKEN>

# Fail, missing team info
$ now deploy -t <TOKEN>
```

## Version

`v8.2.5`