### PR TITLE
Ability to set team scope using `--team` flag

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -382,13 +382,13 @@ const main = async (argv_) => {
       ctx.argv = ctx.argv.splice(0, 3)
     } else {
       console.error(error('No existing credentials found. Please ' +
-      '`now login` to log in or pass `--token`'))
+      `${param('now login')} to log in or pass ${param('--token')}`))
       await exit(1)
     }
   }
 
   if (argv.token && subcommand === 'switch') {
-    console.error(error('This command doesn\'t work with `--token`. Please use `--team`.'))
+    console.error(error(`This command doesn't work with ${param('--token')}. Please use ${param('--team')}.`))
     await exit(1)
   }
 
@@ -396,7 +396,7 @@ const main = async (argv_) => {
     const {token} = argv
 
     if (token.length === 0) {
-      console.error(error(`You defined ${`--token`}, but it's missing a value`))
+      console.error(error(`You defined ${param('--token')}, but it's missing a value`))
       await exit(1)
     }
 
@@ -431,7 +431,7 @@ const main = async (argv_) => {
     const {team} = argv
 
     if (team.length === 0) {
-      console.log(error(`You defined ${`--team`}, but it's missing a value`))
+      console.log(error(`You defined ${param('--team')}, but it's missing a value`))
       await exit(1)
     }
 

--- a/src/now.js
+++ b/src/now.js
@@ -416,7 +416,7 @@ const main = async (argv_) => {
     }
 
     if (isTTY) {
-      console.log(info('Caching account information...'))
+      console.log(info('Caching account information'))
     }
 
     const user = await getUser({
@@ -436,7 +436,7 @@ const main = async (argv_) => {
     }
 
     if (isTTY) {
-      console.log(info('Caching team information...'))
+      console.log(info('Caching team information'))
     }
 
     const {token} = ctx.authConfig.credentials.find(item => item.provider === 'sh')
@@ -450,6 +450,12 @@ const main = async (argv_) => {
 
     try {
       const res = await fetch(url, { headers })
+
+      if (res.status === 403) {
+        console.error(error('Not authorized to load teams'))
+        await exit(1)
+      }
+
       body = await res.json()
     } catch (err) {
       console.error(error('Not able to load teams'))

--- a/src/now.js
+++ b/src/now.js
@@ -35,9 +35,11 @@ const main = async (argv_) => {
 
   const argv = mri(argv_, {
     boolean: ['help', 'version'],
+    string: ['token'],
     alias: {
       help: 'h',
-      version: 'v'
+      version: 'v',
+      token: 't'
     }
   })
 
@@ -356,16 +358,6 @@ const main = async (argv_) => {
     ctx.argv.push('-h')
   }
 
-  let hasToken = false
-
-  if (ctx.argv.includes('-t')) {
-    hasToken = '-t'
-  }
-
-  if (ctx.argv.includes('--token')) {
-    hasToken = '--token'
-  }
-
   // $FlowFixMe
   const { isTTY } = process.stdout
 
@@ -374,7 +366,7 @@ const main = async (argv_) => {
   if (
     !authConfig.credentials.length &&
     !ctx.argv.includes('-h') && !ctx.argv.includes('--help') &&
-    !hasToken &&
+    !argv.token &&
     subcommand !== 'login'
   ) {
     if (isTTY) {
@@ -393,18 +385,16 @@ const main = async (argv_) => {
     }
   }
 
-  if (hasToken && subcommand === 'switch') {
+  if (argv.token && subcommand === 'switch') {
     console.error(error('This command doesn\'t work with `--token`. Please use `--team`.'))
     await exit(1)
   }
 
-  if (hasToken) {
-    const {argv} = ctx
-    const tokenIndex = argv.indexOf(hasToken) + 1
-    const token = argv[tokenIndex]
+  if (typeof argv.token === 'string') {
+    const {token} = argv
 
-    if (!token) {
-      console.log(error(`You defined ${param(hasToken)}, but it's missing a value`))
+    if (token.length === 0) {
+      console.log(error(`You defined ${`--token`}, but it's missing a value`))
       await exit(1)
     }
 

--- a/src/now.js
+++ b/src/now.js
@@ -462,12 +462,15 @@ const main = async (argv_) => {
       await exit(1)
     }
 
-    if (body.error) {
+    if (!body || body.error) {
       console.error(error('The specified team doesn\'t exist'))
       await exit(1)
     }
 
+    // $FlowFixMe
     delete body.creator_id
+
+    // $FlowFixMe
     delete body.created
 
     ctx.config.sh.currentTeam = body

--- a/src/now.js
+++ b/src/now.js
@@ -452,7 +452,7 @@ const main = async (argv_) => {
       const res = await fetch(url, { headers })
 
       if (res.status === 403) {
-        console.error(error('Not authorized to load teams'))
+        console.error(error(`You don't have access to the specified team`))
         await exit(1)
       }
 

--- a/src/now.js
+++ b/src/now.js
@@ -2,7 +2,7 @@
 //@flow
 
 // Native
-const { join, basename } = require('path')
+const { join } = require('path')
 
 // Packages
 const debug = require('debug')('now:main')
@@ -404,7 +404,7 @@ const main = async (argv_) => {
     const token = argv[tokenIndex]
 
     if (!token) {
-      console.log(error(`You defined ${param(hasToken)}, but it\'s missing a value`))
+      console.log(error(`You defined ${param(hasToken)}, but it's missing a value`))
       await exit(1)
     }
 

--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -50,6 +50,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}             Login token
+    -T, --team                          Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/billing.js
+++ b/src/providers/sh/commands/billing.js
@@ -41,6 +41,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/certs.js
+++ b/src/providers/sh/commands/certs.js
@@ -49,6 +49,7 @@ const help = () => {
     --crt ${chalk.bold.underline('FILE')}                     Certificate file
     --key ${chalk.bold.underline('FILE')}                     Certificate key file
     --ca ${chalk.bold.underline('FILE')}                      CA certificate chain file
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -124,7 +124,8 @@ const help = () => {
   )}         Include env vars from .env file. Defaults to '.env'
     -C, --no-clipboard             Do not attempt to copy URL to clipboard
     -N, --forward-npm              Forward login information to install private npm modules
-    --session-affinity             Session affinity, \`ip\` (default) or \`random\` to control session affinity.
+    --session-affinity             Session affinity, \`ip\` (default) or \`random\` to control session affinity
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim(
     'Enforceable Types (when both package.json and Dockerfile exist):'

--- a/src/providers/sh/commands/dns.js
+++ b/src/providers/sh/commands/dns.js
@@ -39,6 +39,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -43,6 +43,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -32,6 +32,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/logs.js
+++ b/src/providers/sh/commands/logs.js
@@ -46,6 +46,7 @@ const help = () => {
     --until=${chalk.bold.underline(
       'UNTIL'
     )}                  Only return logs before date (ISO 8601), ignored for ${'`-f`'}
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -34,6 +34,7 @@ const help = () => {
   )}        Login token
     -y, --yes                      Skip confirmation
     -s, --safe                     Skip deployments with an active alias
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -39,6 +39,7 @@ const help = () => {
     'TOKEN'
   )}        Login token
     -d, --debug                    Debug mode [off]
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/secrets.js
+++ b/src/providers/sh/commands/secrets.js
@@ -38,6 +38,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -36,9 +36,6 @@ const help = () => {
     'DIR'
   )}    Path to the global ${'`.now`'} directory
     -d, --debug                    Debug mode [off]
-    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
-    'TOKEN'
-  )}        Login token
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/upgrade.js
+++ b/src/providers/sh/commands/upgrade.js
@@ -35,6 +35,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -T, --team                     Set a custom team scope
 
   ${chalk.dim('Examples:')}
 


### PR DESCRIPTION
This allows the user to select the current scope for deploying. For example:

```
now --team zeit
```

It will only work using the "sh" provider.