### PR TITLE
Allow `--token` to act without a config file

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -424,7 +424,7 @@ const main = async (argv_) => {
       token
     })
 
-    ctx.config.sh = Object.assign(ctx.config.sh, { user })
+    ctx.config.sh = Object.assign(ctx.config.sh || {}, { user })
   }
 
   if (typeof argv.team === 'string') {


### PR DESCRIPTION
This closes #854.