### PR TITLE
Check pkg.files is an array

### DIFF
--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -84,7 +84,7 @@ async function staticFiles(
 
   // The package.json `files` whitelist still
   // honors ignores: https://docs.npmjs.com/files/package.json#files
-  const search_ = whitelist || ['.']
+  const search_ = Array.isArray(whitelist) ? whitelist : ['.']
   // Convert all filenames into absolute paths
   const search = Array.prototype.concat.apply(
     [],


### PR DESCRIPTION
Resolves https://github.com/zeit/now-cli/issues/857

Although undocumented, in npm pkg.files can be an array or string. If it's a string it kills now-cli as it's expecting an array and doesn't check the type.

This PR just checks we have an array, otherwise it falls back to the default.