### PR TITLE
Add `--all` to `now ls --help`

### DIFF
--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -33,6 +33,7 @@ const help = () => {
     'TOKEN'
   )}        Login token
     -T, --team                     Set a custom team scope
+    --all                          See all instances for an app
 
   ${chalk.dim('Examples:')}
 
@@ -43,6 +44,10 @@ const help = () => {
   ${chalk.gray('–')} List all deployments for the app ${chalk.dim('`my-app`')}
 
     ${chalk.cyan('$ now ls my-app')}
+
+  ${chalk.gray('–')} List all deployments and all instances for the app ${chalk.dim('`my-app`')}
+
+    ${chalk.cyan('$ now ls my-app --all')}
 `)
 }
 


### PR DESCRIPTION
Updated --help flag for list to include information about the --all flag.

This fixes https://github.com/zeit/now-cli/issues/887