### PR TITLE
Ensure that `now logout` revokes the token

### DIFF
--- a/src/providers/sh/commands/logout.js
+++ b/src/providers/sh/commands/logout.js
@@ -53,7 +53,7 @@ const main = async ctx => {
   })
 
   apiUrl = argv.url || 'https://api.zeit.co'
-  endpoint = apiUrl + '/www/user/tokens/'
+  endpoint = apiUrl + '/user/tokens/'
 
   argv._ = argv._.slice(1)
 


### PR DESCRIPTION
It was broken before.