### PR TITLE
Ignore DNS record conflict on aliasing

### DIFF
--- a/src/providers/sh/util/alias.js
+++ b/src/providers/sh/util/alias.js
@@ -541,11 +541,18 @@ module.exports = class Alias extends Now {
 
       const body = await res.json()
 
+      if (res.status === 409 && body.error.code === 'record_conflict') {
+        if (this._debug) {
+          console.log(`> [debug] ${body.error.oldId} is a conflicting record for "${name}"`)
+        }
+        return
+      }
+
       if (res.status !== 200) {
         throw new Error(body.error.message)
       }
 
-      return body
+      return
     })
   }
 


### PR DESCRIPTION
Conflicting record is just the right record in most of the cases
and in other cases altering the record would break something
explicitly setup by the user.