### PR TITLE
exclude test/_fixtures from eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "eslintIgnore": [
     "download",
-    "dist"
+    "dist",
+    "test/_fixtures"
   ],
   "eslintConfig": {
     "parserOptions": {


### PR DESCRIPTION
After cloning and running "yarn run eslint", I received the following output

![image](https://user-images.githubusercontent.com/1797812/31519592-7044f5ea-af68-11e7-962e-aa6bddfe8dfb.png)

Upon further inspection, it seems as if those test file fixtures are files that just represent javascript code, whereas it isn't valid JS code.

Seems like something that should be ignored from linting