### PR TITLE
Added validation for `.ws` domains

### DIFF
--- a/src/providers/sh/util/alias.js
+++ b/src/providers/sh/util/alias.js
@@ -236,6 +236,15 @@ module.exports = class Alias extends Now {
   async set(deployment, alias, domains, currentTeam, user) {
     alias = alias.replace(/^https:\/\//i, '')
 
+    if (alias.endsWith('.ws')) {
+      const err = new Error(
+        `ZEIT.world currently does't support ${chalk.bold('.ws')} domains`
+      )
+
+      err.userError = true
+      throw err
+    }
+
     if (alias.indexOf('.') === -1) {
       // `.now.sh` domain is implied if just the subdomain is given
       alias += '.now.sh'

--- a/src/providers/sh/util/domains.js
+++ b/src/providers/sh/util/domains.js
@@ -109,6 +109,14 @@ module.exports = class Domains extends Now {
       throw err
     }
 
+    if (domain.endsWith('.ws')) {
+      const err = new Error(
+        `ZEIT.world currently does't support ${chalk.bold('.ws')} domains`
+      )
+      err.userError = true
+      throw err
+    }
+
     if (skipVerification || isExternal) {
       return this.setupDomain(domain, { isExternal })
     }


### PR DESCRIPTION
as in #365, ZEIT.world currently doesn't support .ws domains
and user should receive a notice when adding aliases or adding domains

as it's my first contribution it might probably have something missing, I will be glad to fix/add possible missing stuff.

closes #365 