### PR TITLE
Only output error slug if it's available

### DIFF
--- a/src/util/output/error.js
+++ b/src/util/output/error.js
@@ -6,11 +6,11 @@ module.exports = (...input) => {
 
   if (typeof input[0] === 'object') {
     const {slug, message} = input[0]
+    messages = [ message ]
 
-    messages = [
-      message,
-      `> More details: https://err.sh/now-cli/${slug}`
-    ]
+    if (slug) {
+      messages.push(`> More details: https://err.sh/now-cli/${slug}`)
+    }
   }
 
   return `${red('> Error!')} ${messages.join('\n')}`


### PR DESCRIPTION
This avoids errors like these:

```
> Error! Deletion failed. Try again later.
> More details: https://err.sh/now-cli/undefined
```