### PR TITLE
Fix zeit.world nameservers check

### DIFF
--- a/src/providers/sh/util/is-zeit-world.js
+++ b/src/providers/sh/util/is-zeit-world.js
@@ -1,32 +1,13 @@
 /**
- * List of `zeit.world` nameservers
- */
-
-const nameservers = new Set([
-  'california.zeit.world',
-  'london.zeit.world',
-  'newark.zeit.world',
-  'sydney.zeit.world',
-  'iowa.zeit.world',
-  'dallas.zeit.world',
-  'amsterdam.zeit.world',
-  'paris.zeit.world',
-  'frankfurt.zeit.world',
-  'singapore.zeit.world'
-])
-
-/**
  * Given an array of nameservers (ie: as returned
  * by `resolveNs` from Node, assert that they're
  * zeit.world's.
  */
 function isZeitWorld(ns) {
-  return (
-    ns.length > 1 &&
-    ns.every(host => {
-      return nameservers.has(host)
-    })
-  )
+  if (!ns.length) {
+    return false
+  }
+  return ns.every(host => host.endsWith('.zeit.world'))
 }
 
 module.exports = isZeitWorld


### PR DESCRIPTION
Instead of checking if the nameservers are from a known list we
can just check that every nameserver set for the domain ends with
.zeit.world.