### PR TITLE
Use the latest Node.js version in PKG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@
     "node"
   ],
   "install": [
-    "git clone https://github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG",
-    "cd $TRAVIS_REPO_SLUG",
     "yarn"
   ],
   "before_script": [

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "opn": "5.1.0",
     "ora": "1.3.0",
     "pipe-streams-to-promise": "0.2.0",
-    "pkg": "4.3.0-beta.0",
+    "pkg": "4.3.0-beta.1",
     "pre-commit": "1.2.2",
     "prettier": "1.7.2",
     "printf": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "pack": "webpack && pkg dist/now.js -c package.json -o packed/now",
+    "pack": "webpack && pkg dist/now.js -c package.json -o packed/now --options expose-http2",
     "build-download": "webpack --context download --config download/webpack.config.js",
     "link": "webpack && cd link && npm link"
   },
@@ -34,10 +34,10 @@
       "dist/*"
     ],
     "targets": [
-      "node7-alpine-x64",
-      "node7-linux-x64",
-      "node7-macos-x64",
-      "node7-win-x64"
+      "latest-alpine-x64",
+      "latest-linux-x64",
+      "latest-macos-x64",
+      "latest-win-x64"
     ]
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "opn": "5.1.0",
     "ora": "1.3.0",
     "pipe-streams-to-promise": "0.2.0",
-    "pkg": "4.2.4",
+    "pkg": "4.3.0-beta.0",
     "pre-commit": "1.2.2",
     "prettier": "1.7.2",
     "printf": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
       "dist/*"
     ],
     "targets": [
-      "latest-alpine-x64",
-      "latest-linux-x64",
-      "latest-macos-x64",
-      "latest-win-x64"
+      "node8-alpine-x64",
+      "node8-linux-x64",
+      "node8-macos-x64",
+      "node8-win-x64"
     ]
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "pack": "webpack && pkg dist/now.js -c package.json -o packed/now --options expose-http2",
+    "pack": "webpack && pkg dist/now.js -c package.json -o packed/now",
     "build-download": "webpack --context download --config download/webpack.config.js",
     "link": "webpack && cd link && npm link"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4323,9 +4323,9 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-fetch@2.3.10:
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.3.10.tgz#1e81123c0c3b01731347e71afae3e05b1b4bc998"
+pkg-fetch@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.4.1.tgz#636e1e9a8d38b54030934ca072efffe9a2999500"
   dependencies:
     babel-runtime "6.25.0"
     byline "5.0.0"
@@ -4340,9 +4340,9 @@ pkg-fetch@2.3.10:
     semver "5.4.1"
     unique-temp-dir "1.0.0"
 
-pkg@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.2.4.tgz#7781490f9339a8f5cc8eea737e94c37c4e8ed4c8"
+pkg@4.3.0-beta.0:
+  version "4.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.0-beta.0.tgz#56c033ab95dbff61fce3ea1c6f20ff3483897386"
   dependencies:
     acorn "5.1.1"
     babel-runtime "6.25.0"
@@ -4350,10 +4350,9 @@ pkg@4.2.4:
     escodegen "1.8.1"
     fs-extra "4.0.1"
     globby "6.1.0"
-    in-publish "2.0.0"
     minimist "1.2.0"
     multistream "2.1.0"
-    pkg-fetch "2.3.10"
+    pkg-fetch "2.4.1"
     progress "2.0.0"
     resolve "1.4.0"
     simple-bufferstream "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4323,9 +4323,9 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-fetch@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.4.1.tgz#636e1e9a8d38b54030934ca072efffe9a2999500"
+pkg-fetch@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.5.0.tgz#d1dadbb5cf0aff865c0ca4686202cf6827a8787b"
   dependencies:
     babel-runtime "6.25.0"
     byline "5.0.0"
@@ -4340,9 +4340,9 @@ pkg-fetch@2.4.1:
     semver "5.4.1"
     unique-temp-dir "1.0.0"
 
-pkg@4.3.0-beta.0:
-  version "4.3.0-beta.0"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.0-beta.0.tgz#56c033ab95dbff61fce3ea1c6f20ff3483897386"
+pkg@4.3.0-beta.1:
+  version "4.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.0-beta.1.tgz#1e73a73975eb4cdfddbc9ecff8afb586056c0cac"
   dependencies:
     acorn "5.1.1"
     babel-runtime "6.25.0"
@@ -4352,7 +4352,7 @@ pkg@4.3.0-beta.0:
     globby "6.1.0"
     minimist "1.2.0"
     multistream "2.1.0"
-    pkg-fetch "2.4.1"
+    pkg-fetch "2.5.0"
     progress "2.0.0"
     resolve "1.4.0"
     simple-bufferstream "1.0.0"


### PR DESCRIPTION
@igorklopov is working on compiling the PKG binaries for the latest Node.js version that contains support for HTTP/2 (without a flag). Once that's done, we can merge this PR.

This PR is blocking #953.