### PR TITLE
Added deployment URL to final message

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -813,7 +813,7 @@ function printLogs(host, token) {
 
   logger.on('close', async () => {
     if (!quiet) {
-      console.log(`${chalk.cyan('> Deployment complete!')}`)
+      console.log(`${chalk.cyan('> Deployment complete!')} access in ${chalk.bold(url)}`)
     }
 
     if (gitRepo && gitRepo.cleanup) {

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -813,7 +813,8 @@ function printLogs(host, token) {
 
   logger.on('close', async () => {
     if (!quiet) {
-      console.log(`${chalk.cyan('> Deployment complete!')} access in ${chalk.bold(url)}`)
+      console.log(chalk.cyan('> Deployment complete!'))
+      console.log(chalk.cyan(`> You can access it here: ${chalk.bold(url)}`))
     }
 
     if (gitRepo && gitRepo.cleanup) {


### PR DESCRIPTION
It would be wonderful if I can access the url when the deployment is complete. 
I don't like to scroll it up just to copy the url. 
I know it copies for me at beginning, but while it is deploying I am still working and in the vast majority of times I have another thing in my clipboard when the deployment end.