### PR TITLE
Fixes inconsistency with flag for API URL

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -489,10 +489,12 @@ const main = async (argv_) => {
     }
   }
 
-  const { api } = argv
+  const { sh } = ctx.config
 
-  if (api && typeof api === 'string') {
-    ctx.apiUrl = api
+  if (argv.api && typeof argv.api === 'string') {
+    ctx.apiUrl = argv.api
+  } else if (sh && sh.api) {
+    ctx.apiUrl = sh.api
   }
 
   try {

--- a/src/now.js
+++ b/src/now.js
@@ -232,7 +232,7 @@ const main = async (argv_) => {
   }
 
   // the context object to supply to the providers or the commands
-  const ctx = {
+  const ctx: Object = {
     config,
     authConfig,
     argv: argv_
@@ -343,6 +343,15 @@ const main = async (argv_) => {
     ctx.argv.push('-h')
   }
 
+  const { sh } = ctx.config
+  ctx.apiUrl = 'https://api.zeit.co'
+
+  if (argv.api && typeof argv.api === 'string') {
+    ctx.apiUrl = argv.api
+  } else if (sh && sh.api) {
+    ctx.apiUrl = sh.api
+  }
+
   // $FlowFixMe
   const { isTTY } = process.stdout
 
@@ -412,7 +421,7 @@ const main = async (argv_) => {
     }
 
     const user = await getUser({
-      apiUrl: 'https://api.zeit.co',
+      apiUrl: ctx.apiUrl,
       token
     })
 
@@ -487,14 +496,6 @@ const main = async (argv_) => {
 
       ctx.config.sh.currentTeam = body
     }
-  }
-
-  const { sh } = ctx.config
-
-  if (argv.api && typeof argv.api === 'string') {
-    ctx.apiUrl = argv.api
-  } else if (sh && sh.api) {
-    ctx.apiUrl = sh.api
   }
 
   try {

--- a/src/now.js
+++ b/src/now.js
@@ -35,8 +35,15 @@ const main = async (argv_) => {
   await checkForUpdates()
 
   const argv = mri(argv_, {
-    boolean: ['help', 'version'],
-    string: ['token', 'team'],
+    boolean: [
+      'help',
+      'version'
+    ],
+    string: [
+      'token',
+      'team',
+      'api'
+    ],
     alias: {
       help: 'h',
       version: 'v',
@@ -480,6 +487,12 @@ const main = async (argv_) => {
 
       ctx.config.sh.currentTeam = body
     }
+  }
+
+  const { api } = argv
+
+  if (api && typeof api === 'string') {
+    ctx.apiUrl = api
   }
 
   try {

--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -117,7 +117,7 @@ const main = async ctx => {
   subcommand = argv._[0]
 
   debug = argv.debug
-  apiUrl = argv.apiUrl || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
 
   if (argv.help) {
     help()

--- a/src/providers/sh/commands/billing.js
+++ b/src/providers/sh/commands/billing.js
@@ -68,7 +68,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   subcommand = argv._[0]
 
   if (argv.help || !subcommand) {

--- a/src/providers/sh/commands/certs.js
+++ b/src/providers/sh/commands/certs.js
@@ -81,7 +81,7 @@ const main = async ctx => {
 
   argv._ = argv._.slice(1)
 
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   debug = argv.debug
   subcommand = argv._[0]
 

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -251,7 +251,7 @@ async function main(ctx) {
   forwardNpm = argv['forward-npm']
   followSymlinks = !argv.links
   wantsPublic = argv.public
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   isTTY = process.stdout.isTTY
   quiet = !isTTY
 

--- a/src/providers/sh/commands/dns.js
+++ b/src/providers/sh/commands/dns.js
@@ -84,7 +84,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   subcommand = argv._[0]
 
   if (argv.help || !subcommand) {

--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -91,7 +91,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   subcommand = argv._[0]
 
   if (argv.help || !subcommand) {

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -70,7 +70,7 @@ const main = async ctx => {
 
   app = argv._[0]
   debug = argv.debug
-  apiUrl = argv.apiUrl || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
 
   if (argv.help || app === 'help') {
     help()

--- a/src/providers/sh/commands/login.js
+++ b/src/providers/sh/commands/login.js
@@ -202,8 +202,7 @@ const login = async ctx => {
 
   argv._ = argv._.slice(1)
 
-  const apiUrl =
-    (ctx.config.sh && ctx.config.sh.apiUrl) || 'https://api.zeit.co'
+  const apiUrl = ctx.apiUrl
   let email
   let emailIsValid = false
   let stopSpinner

--- a/src/providers/sh/commands/logout.js
+++ b/src/providers/sh/commands/logout.js
@@ -52,7 +52,7 @@ const main = async ctx => {
     }
   })
 
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   endpoint = apiUrl + '/user/tokens/'
 
   argv._ = argv._.slice(1)

--- a/src/providers/sh/commands/logs.js
+++ b/src/providers/sh/commands/logs.js
@@ -118,7 +118,7 @@ const main = async ctx => {
   }
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
 
   limit = typeof argv.n === 'number' ? argv.n : 1000
   query = argv.query || ''

--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -78,7 +78,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   hard = argv.hard || false
   skipConfirmation = argv.yes || false
   ids = argv._

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -90,7 +90,7 @@ const main = async ctx => {
   id = argv._[0]
   scaleArg = argv._[1]
   optionalScaleArg = argv._[2]
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   debug = argv.debug
 
   if (argv.help) {

--- a/src/providers/sh/commands/secrets.js
+++ b/src/providers/sh/commands/secrets.js
@@ -81,7 +81,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
   subcommand = argv._[0]
 
   if (argv.help || !subcommand) {

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -74,7 +74,7 @@ const main = async ctx => {
   })
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
 
   const isSwitch = argv._[0] && argv._[0] === 'switch'
 

--- a/src/providers/sh/commands/upgrade.js
+++ b/src/providers/sh/commands/upgrade.js
@@ -79,7 +79,7 @@ const main = async ctx => {
   argv._ = argv._.slice(1)
 
   debug = argv.debug
-  apiUrl = argv.url || 'https://api.zeit.co'
+  apiUrl = ctx.apiUrl
 
   if (argv.help || argv._[0] === 'help') {
     help()


### PR DESCRIPTION
Previously, some command accepted `--apiUrl` and some `--url`, etc. - it was all very confusing for users because there was 0 consistency.

This PR ensures that ALL Now commands let you pass `--api` for setting the API URL.