### PR TITLE
Ensure that update message shows up

### DIFF
--- a/src/util/updates.js
+++ b/src/util/updates.js
@@ -6,29 +6,11 @@ const chalk = require('chalk')
 const pkg = require('./pkg')
 
 module.exports = () => {
-  if (!process.pkg) {
-    return
-  }
-
-  const notifier = updateNotifier({ pkg })
-  const update = notifier.update
+  const { update } = updateNotifier({ pkg })
 
   if (!update) {
     return
   }
 
-  let message = `Update available! ${chalk.red(
-    update.current
-  )} → ${chalk.green(update.latest)} \n`
-  message += `${chalk.magenta(
-    'Changelog:'
-  )} https://github.com/zeit/now-cli/releases/tag/${update.latest}\n`
-
-  if (pkg._npmPkg) {
-    message += `Run ${chalk.magenta('npm i -g now')} to update!`
-  } else {
-    message += `Please download binaries from https://zeit.co/download`
-  }
-
-  notifier.notify({ message })
+  console.log(`${chalk.white.bold.bgRed('UPDATE AVAILABLE')} The latest version of Now CLI is ${chalk.bold(update.latest)}`)
 }


### PR DESCRIPTION
This makes the update notification much prettier and ensures that it always shows up if there's a new update for the binary available:

<img width="449" alt="screen shot 2017-11-07 at 21 54 52" src="https://user-images.githubusercontent.com/6170607/32517322-51930b7a-c406-11e7-95ac-2b52b6a22565.png">

We decided to not make it include any details about the provider from where the binary came, because the calculations for this are very expensive for our runtime in terms of size and performance.

As mentioned in https://github.com/zeit/zeit/issues/326.