### PR TITLE
Only load the `http2` module if HTTP/2 is enabled

### DIFF
--- a/src/providers/sh/util/agent.js
+++ b/src/providers/sh/util/agent.js
@@ -6,13 +6,14 @@ const https = require('https')
 // Packages
 const fetch = require('node-fetch')
 const {version} = require('../../../util/pkg')
-const Sema = require('async-sema');
+const Sema = require('async-sema')
 
 // TODO: Don't limit to canary
 const USE_HTTP2 = version.indexOf('canary') > -1
 const MAX_REQUESTS_PER_CONNECTION = 1000
 
-let JsonBody, StreamBody, context;
+let JsonBody, StreamBody, context
+
 if (USE_HTTP2) {
   ({ JsonBody, StreamBody, context } = require('fetch-h2'))
 }
@@ -42,7 +43,7 @@ module.exports = class Agent {
       this._currContext.fetchesMade = 0
       this._currContext.ongoingFetches = 0
     }
-    
+
     this._url = url
     const parsed = parse(url)
     this._protocol = parsed.protocol

--- a/src/providers/sh/util/agent.js
+++ b/src/providers/sh/util/agent.js
@@ -5,13 +5,17 @@ const https = require('https')
 
 // Packages
 const fetch = require('node-fetch')
-const { JsonBody, StreamBody, context } = require('fetch-h2')
-const Sema = require('async-sema');
 const {version} = require('../../../util/pkg')
+const Sema = require('async-sema');
 
 // TODO: Don't limit to canary
 const USE_HTTP2 = version.indexOf('canary') > -1
 const MAX_REQUESTS_PER_CONNECTION = 1000
+
+let JsonBody, StreamBody, context;
+if (USE_HTTP2) {
+  ({ JsonBody, StreamBody, context } = require('fetch-h2'))
+}
 
 /**
  * Returns a `fetch` version with a similar
@@ -26,16 +30,18 @@ const MAX_REQUESTS_PER_CONNECTION = 1000
 
 module.exports = class Agent {
   constructor(url, { tls = true, debug } = {}) {
-    // We use multiple contexts because each context represent one connection
-    // With nginx, we're limited to 1000 requests before a connection is closed
-    // http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests
-    // To get arround this, we keep track of requests made on a connection. when we're about to hit 1000
-    // we start up a new connection, and re-route all future traffic through the new connection
-    // and when the final request from the old connection resolves, we auto-close the old connection
-    this._contexts = [context()]
-    this._currContext = this._contexts[0]
-    this._currContext.fetchesMade = 0
-    this._currContext.ongoingFetches = 0
+    if (USE_HTTP2) {
+      // We use multiple contexts because each context represent one connection
+      // With nginx, we're limited to 1000 requests before a connection is closed
+      // http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests
+      // To get arround this, we keep track of requests made on a connection. when we're about to hit 1000
+      // we start up a new connection, and re-route all future traffic through the new connection
+      // and when the final request from the old connection resolves, we auto-close the old connection
+      this._contexts = [context()]
+      this._currContext = this._contexts[0]
+      this._currContext.fetchesMade = 0
+      this._currContext.ongoingFetches = 0
+    }
     
     this._url = url
     const parsed = parse(url)
@@ -72,23 +78,27 @@ module.exports = class Agent {
   async fetch(path, opts = {}) {
     await this._sema.v()
 
-    this._currContext.fetchesMade++;
-    if(this._currContext.fetchesMade >= MAX_REQUESTS_PER_CONNECTION) {
-      const ctx = context()
-      ctx.fetchesMade = 1
-      ctx.ongoingFetches = 0
-      this._contexts.push(ctx)
-      this._currContext = ctx
-    }
+    let currentContext;
 
-    // If we're changing contexts, we don't want to record the ongoingFetch on the old context
-    // That'll cause an off-by-one error when trying to close the old socket later
-    this._currContext.ongoingFetches++;
-    const currentContext = this._currContext
+    if (USE_HTTP2) {
+      this._currContext.fetchesMade++;
+      if(this._currContext.fetchesMade >= MAX_REQUESTS_PER_CONNECTION) {
+        const ctx = context()
+        ctx.fetchesMade = 1
+        ctx.ongoingFetches = 0
+        this._contexts.push(ctx)
+        this._currContext = ctx
+      }
 
-    if (this._debug) {
-      console.log('> [debug] Total requests made on socket #%d: %d', this._contexts.length, this._currContext.fetchesMade)
-      console.log('> [debug] Concurrent requests on socket #%d: %d', this._contexts.length, this._currContext.ongoingFetches)
+      // If we're changing contexts, we don't want to record the ongoingFetch on the old context
+      // That'll cause an off-by-one error when trying to close the old socket later
+      this._currContext.ongoingFetches++;
+      currentContext = this._currContext
+
+      if (this._debug) {
+        console.log('> [debug] Total requests made on socket #%d: %d', this._contexts.length, this._currContext.fetchesMade)
+        console.log('> [debug] Concurrent requests on socket #%d: %d', this._contexts.length, this._currContext.ongoingFetches)
+      }
     }
 
     if (!this._agent) {
@@ -121,19 +131,21 @@ module.exports = class Agent {
     }
 
     const handleCompleted = async (res) => {
-      currentContext.ongoingFetches--;
-      if(currentContext !== this._currContext && currentContext.ongoingFetches <= 0) {
-        // We've completely moved on to a new socket
-        // close the old one
+      if (USE_HTTP2) {
+        currentContext.ongoingFetches--;
+        if(currentContext !== this._currContext && currentContext.ongoingFetches <= 0) {
+          // We've completely moved on to a new socket
+          // close the old one
 
-        // TODO: Fix race condition:
-        // If the response is a stream, and the server is still streaming data
-        // we should check if the stream has closed before disconnecting
-        // hasCompleted CAN technically be called before the res body stream is closed
-        if (this._debug) {
-          console.log('> [debug] Closing old socket');
+          // TODO: Fix race condition:
+          // If the response is a stream, and the server is still streaming data
+          // we should check if the stream has closed before disconnecting
+          // hasCompleted CAN technically be called before the res body stream is closed
+          if (this._debug) {
+            console.log('> [debug] Closing old socket');
+          }
+          currentContext.disconnect(this._url)
         }
-        currentContext.disconnect(this._url)
       }
       this._sema.p()
       return res


### PR DESCRIPTION
gets rid of the experimental http2 warning when http2 is not being used

cc @leo 