### PR TITLE
Add option to append 'https://' to deployment URL in now list

### DIFF
--- a/src/config/set.js
+++ b/src/config/set.js
@@ -10,7 +10,14 @@ const CONFIGS = new Map([
     'defaultProvider',
     value => {
       const providers = require('../providers')
-      return providers.hasOwnProperty(value)
+      return [providers.hasOwnProperty(value), value]
+    }
+  ],
+  [
+    'includeProtocol',
+    value => {
+      const isValid = ["true", "false", true, false].includes(value)
+      return [isValid, value === "true" || value === true]
     }
   ]
 ])
@@ -26,12 +33,13 @@ module.exports = function set(ctx) {
   }
 
   const validate = CONFIGS.get(name)
-  if (!validate(value)) {
+  const [isValid, finalValue] = validate(value);
+  if (!isValid) {
     console.error(error(`Unexpected config value for ${name}: ${value}`))
     return 1
   }
 
-  ctx.config[name] = value
+  ctx.config[name] = finalValue
   writeToConfigFile(ctx.config)
 
   console.log(success(`Config saved in ${param(hp(getConfigFilePath()))}`))

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -14,10 +14,10 @@ const CONFIGS = new Map([
     }
   ],
   [
-    'includeProtocol',
+    'includeScheme',
     value => {
-      const isValid = ["true", "false", true, false].includes(value)
-      return [isValid, value === "true" || value === true]
+      const isValid = ['true', 'false', true, false].includes(value)
+      return [isValid, value === 'true' || value === true]
     }
   ]
 ])

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -77,11 +77,11 @@ const main = async ctx => {
     await exit(0)
   }
 
-  const {authConfig: { credentials }, config: { sh, includeProtocol }} = ctx
+  const {authConfig: { credentials }, config: { sh, includeScheme }} = ctx
   const {token} = credentials.find(item => item.provider === 'sh')
 
   try {
-    await list({ token, sh, includeProtocol })
+    await list({ token, sh, includeScheme })
   } catch (err) {
     console.error(error(`Unknown error: ${err}\n${err.stack}`))
     process.exit(1)
@@ -97,7 +97,7 @@ module.exports = async ctx => {
   }
 }
 
-async function list({ token, sh: { currentTeam, user }, includeProtocol }) {
+async function list({ token, sh: { currentTeam, user }, includeScheme }) {
   const now = new Now({ apiUrl, token, debug, currentTeam })
   const start = new Date()
 
@@ -239,7 +239,7 @@ async function list({ token, sh: { currentTeam, user }, includeProtocol }) {
       console.log(
         printf(
           spec,
-          chalk.underline((includeProtocol ? "https://" : "") + dep.url),
+          chalk.underline((includeScheme ? 'https://' : '') + dep.url),
           dep.scale ? dep.scale.current : '✖',
           state,
           dep.created ? ms(timeNow - dep.created) : 'n/a'

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -77,11 +77,11 @@ const main = async ctx => {
     await exit(0)
   }
 
-  const {authConfig: { credentials }, config: { sh }} = ctx
+  const {authConfig: { credentials }, config: { sh, includeProtocol }} = ctx
   const {token} = credentials.find(item => item.provider === 'sh')
 
   try {
-    await list({ token, sh })
+    await list({ token, sh, includeProtocol })
   } catch (err) {
     console.error(error(`Unknown error: ${err}\n${err.stack}`))
     process.exit(1)
@@ -97,7 +97,7 @@ module.exports = async ctx => {
   }
 }
 
-async function list({ token, sh: { currentTeam, user } }) {
+async function list({ token, sh: { currentTeam, user }, includeProtocol }) {
   const now = new Now({ apiUrl, token, debug, currentTeam })
   const start = new Date()
 
@@ -239,7 +239,7 @@ async function list({ token, sh: { currentTeam, user } }) {
       console.log(
         printf(
           spec,
-          chalk.underline(dep.url),
+          chalk.underline((includeProtocol ? "https://" : "") + dep.url),
           dep.scale ? dep.scale.current : '✖',
           state,
           dep.created ? ms(timeNow - dep.created) : 'n/a'


### PR DESCRIPTION
Fixes #800

The weird thing here is allowing non-string options (aka booleans) using `now config set`. My solution is just to return a tuple from the config's `validate` function, but other ideas might be better.

Also, is "includeProtocol" the right name here? Or should it be something more specific like "includeHttps" or "listIncludeHttps"