### PR TITLE
Better error message for missing `gcp` property

### DIFF
--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -89,6 +89,7 @@ const deploy = async (ctx: {
   //   memory: Number,
   //   region: String
   // }
+  let gcpConfig = {};
   try {
     const { nowJSON: { gcp: gcpConfig } } = desc
   } catch (err) {

--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -89,7 +89,11 @@ const deploy = async (ctx: {
   //   memory: Number,
   //   region: String
   // }
-  const { nowJSON: { gcp: gcpConfig } } = desc
+  try {
+    const { nowJSON: { gcp: gcpConfig } } = desc
+  } catch (err) {
+    console.error(error(`Couldn't find "gcp" property in now.json`))
+  }
 
   const overrides = {
     'function.js': getFunctionHandler(desc)

--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -91,7 +91,7 @@ const deploy = async (ctx: {
   // }
   let gcpConfig = {};
   try {
-    const { nowJSON: { gcp: gcpConfig } } = desc
+    gcpConfig = desc.nowJSON.gcp;
   } catch (err) {
     console.error(error(`Couldn't find "gcp" property in now.json`))
   }


### PR DESCRIPTION
Better error message when "gcp" property is missing in now.json