### PR TITLE
Fix deployments with no `now.json` file

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -707,7 +707,7 @@ async function sync({ token, config: { currentTeam, user } }) {
       }
       await exit(0);
     } else {
-      if (nowConfig.atlas) {
+      if (nowConfig && nowConfig.atlas) {
         const cancelWait = wait('Initializing…');
         try {
           await printEvents(now, currentTeam, {


### PR DESCRIPTION
This makes deployments with no `now.json` work again on the canary channel.