### PR TITLE
Made `now switch` and `now logs -f` work properly

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -499,7 +499,7 @@ const main = async (argv_) => {
   }
 
   try {
-    await provider[subcommand](ctx)
+    process.exit(await provider[subcommand](ctx))
   } catch (err) {
     console.error(
       error(

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -14,7 +14,6 @@ const cmd = require('../../../../util/output/cmd')
 const note = require('../../../../util/output/note')
 const uid = require('../../../../util/output/uid')
 const textInput = require('../../../../util/input/text')
-const exit = require('../../../../util/exit')
 const invite = require('./invite')
 const {writeToConfigFile} = require('../../../../util/config-files')
 
@@ -31,7 +30,7 @@ const gracefulExit = () => {
       'now switch'
     )} to change it in the future.`
   )
-  return exit()
+  return 0
 }
 
 const teamUrlPrefix = rightPad('Team URL', 14) + chalk.gray('zeit.co/')
@@ -59,7 +58,7 @@ module.exports = async function({ teams, config }) {
     } catch (err) {
       if (err.message === 'USER_ABORT') {
         info('Aborted')
-        return exit()
+        return 0
       }
       throw err
     }
@@ -107,7 +106,7 @@ module.exports = async function({ teams, config }) {
   if (res.error) {
     console.error(error(res.error.message))
     console.log(`${chalk.red(`✖ ${teamNamePrefix}`)}${name}`)
-    exit(1)
+    return 1
     // TODO: maybe we want to ask the user to retry? not sure if
     // there's a scenario where that would be wanted
   }

--- a/src/providers/sh/commands/teams/list.js
+++ b/src/providers/sh/commands/teams/list.js
@@ -50,7 +50,7 @@ module.exports = async function({ teams, config }) {
   if (!count) {
     // Maybe should not happen
     console.error(error(`No team found`))
-    return
+    return 1
   }
 
   info(`${chalk.bold(count)} team${count > 1 ? 's' : ''} found`)

--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -4,7 +4,6 @@ const chalk = require('chalk')
 // Utilities
 const wait = require('../../../../util/output/wait')
 const listInput = require('../../../../util/input/list')
-const exit = require('../../../../util/exit')
 const success = require('../../../../util/output/success')
 const info = require('../../../../util/output/info')
 const error = require('../../../../util/output/error')
@@ -46,7 +45,7 @@ module.exports = async function({ teams, args, config }) {
     if (newTeam) {
       updateCurrentTeam(config, newTeam)
       console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
-      return exit()
+      return 0
     }
 
     if (desiredSlug === user.username) {
@@ -54,11 +53,12 @@ module.exports = async function({ teams, args, config }) {
       updateCurrentTeam(config)
 
       stopSpinner()
-      return console.log(success(`Your account (${chalk.bold(desiredSlug)}) is now active!`))
+      console.log(success(`Your account (${chalk.bold(desiredSlug)}) is now active!`))
+      return 0
     }
 
     console.error(error(`Could not find membership for team ${param(desiredSlug)}`))
-    return exit(1)
+    return 1
   }
 
   const choices = list.map(({ slug, name }) => {
@@ -108,7 +108,7 @@ module.exports = async function({ teams, args, config }) {
   // Abort
   if (!choice) {
     info('No changes made')
-    return exit()
+    return 0
   }
 
   const newTeam = list.find(item => item.slug === choice)
@@ -117,19 +117,20 @@ module.exports = async function({ teams, args, config }) {
   if (!newTeam) {
     if (currentTeam.slug === user.username || currentTeam.slug === user.email) {
       info('No changes made')
-      return exit()
+      return 0
     }
 
     stopSpinner = wait('Saving')
     updateCurrentTeam(config)
 
     stopSpinner()
-    return console.log(success(`Your account (${chalk.bold(choice)}) is now active!`))
+    console.log(success(`Your account (${chalk.bold(choice)}) is now active!`))
+    return 0
   }
 
   if (newTeam.slug === currentTeam.slug) {
     info('No changes made')
-    return exit()
+    return 0
   }
 
   stopSpinner = wait('Saving')
@@ -137,4 +138,5 @@ module.exports = async function({ teams, args, config }) {
 
   stopSpinner()
   console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
+  return 0
 }

--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -108,7 +108,7 @@ module.exports = async function({ teams, args, config }) {
 
   // Abort
   if (!choice) {
-    info('No changes made')
+    console.log(info('No changes made'))
     return 0
   }
 
@@ -117,7 +117,7 @@ module.exports = async function({ teams, args, config }) {
   // Switch to account
   if (!newTeam) {
     if (currentTeam.slug === user.username || currentTeam.slug === user.email) {
-      info('No changes made')
+      console.log(info('No changes made'))
       return 0
     }
 
@@ -130,7 +130,7 @@ module.exports = async function({ teams, args, config }) {
   }
 
   if (newTeam.slug === currentTeam.slug) {
-    info('No changes made')
+    console.log(info('No changes made'))
     return 0
   }
 

--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -102,7 +102,8 @@ module.exports = async function({ teams, args, config }) {
   const choice = await listInput({
     message,
     choices,
-    separator: false
+    separator: false,
+    eraseFinalAnswer: true
   })
 
   // Abort

--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -44,7 +44,7 @@ module.exports = async function({ teams, args, config }) {
 
     if (newTeam) {
       updateCurrentTeam(config, newTeam)
-      console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
+      console.log(success(`The team ${chalk.bold(newTeam.name)} (${newTeam.slug}) is now active!`))
       return 0
     }
 
@@ -53,7 +53,7 @@ module.exports = async function({ teams, args, config }) {
       updateCurrentTeam(config)
 
       stopSpinner()
-      console.log(success(`Your account (${chalk.bold(desiredSlug)}) is now active!`))
+      console.log(success(`Your account (${chalk.bold(desiredSlug)}) (${newTeam.slug}) is now active!`))
       return 0
     }
 
@@ -138,6 +138,6 @@ module.exports = async function({ teams, args, config }) {
   updateCurrentTeam(config, newTeam)
 
   stopSpinner()
-  console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
+  console.log(success(`The team ${chalk.bold(newTeam.name)} (${newTeam.slug}) is now active!`))
   return 0
 }

--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -45,7 +45,7 @@ module.exports = async function({ teams, args, config }) {
 
     if (newTeam) {
       updateCurrentTeam(config, newTeam)
-      success(`The team ${chalk.bold(newTeam.name)} is now active!`)
+      console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
       return exit()
     }
 
@@ -54,7 +54,7 @@ module.exports = async function({ teams, args, config }) {
       updateCurrentTeam(config)
 
       stopSpinner()
-      return success(`Your account (${chalk.bold(desiredSlug)}) is now active!`)
+      return console.log(success(`Your account (${chalk.bold(desiredSlug)}) is now active!`))
     }
 
     console.error(error(`Could not find membership for team ${param(desiredSlug)}`))
@@ -124,7 +124,7 @@ module.exports = async function({ teams, args, config }) {
     updateCurrentTeam(config)
 
     stopSpinner()
-    return success(`Your account (${chalk.bold(choice)}) is now active!`)
+    return console.log(success(`Your account (${chalk.bold(choice)}) is now active!`))
   }
 
   if (newTeam.slug === currentTeam.slug) {
@@ -136,5 +136,5 @@ module.exports = async function({ teams, args, config }) {
   updateCurrentTeam(config, newTeam)
 
   stopSpinner()
-  success(`The team ${chalk.bold(newTeam.name)} is now active!`)
+  console.log(success(`The team ${chalk.bold(newTeam.name)} is now active!`))
 }

--- a/src/util/input/list.js
+++ b/src/util/input/list.js
@@ -1,6 +1,7 @@
 const inquirer = require('inquirer')
 const stripAnsi = require('strip-ansi')
 
+const eraseLines = require('../output/erase-lines')
 // eslint-disable-next-line import/no-unassigned-import
 require('./patch-inquirer')
 
@@ -28,7 +29,8 @@ module.exports = async function({
   ],
   pageSize = 15, // Show 15 lines without scrolling (~4 credit cards)
   separator = true, // Puts a blank separator between each choice
-  abort = 'end' // Wether the `abort` option will be at the `start` or the `end`
+  abort = 'end', // Wether the `abort` option will be at the `start` or the `end`,
+  eraseFinalAnswer = false // If true, the line with the final answee that inquirer prints will be erased before returning
 }) {
   let biggestLength = 0
 
@@ -74,6 +76,8 @@ module.exports = async function({
     choices,
     pageSize
   })
-
+  if (eraseFinalAnswer === true) {
+    process.stdout.write(eraseLines(2))
+  }
   return answer[nonce]
 }


### PR DESCRIPTION
This PR does 3 things:

1. Add missing `console.log`s to `now switch` – most of the `> Success!` messages weren't being printed
2. Fixes a bug in which `now switch` would never exit because the HTTP agent wasn't being closed
3. Makes the exit code (only from `now switch` – other (sub)commands needs to be adapted to `return` correctly) from subcommands bubble correctly

Before:
```
▲ ~ now switch 
> Switch to: kap
^C
```
_(I had to `ctrl+c` because it was hanging forever)_

After:
```
▲ ~ now switch    
> Switch to: kap
> Success! The team Kap is now active!
▲ ~ echo $?    
0
▲ ~ now switch 3489hrwt42           
> Error! Could not find membership for team "3489hrwt42"
▲ ~ echo $?
1
```