### PR TITLE
Improve domain removal UX

### DIFF
--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -220,9 +220,7 @@ async function run({ token, sh: { currentTeam, user } }) {
         await domain.rm(_domain)
         const elapsed = ms(new Date() - start)
         console.log(
-          `${chalk.cyan('> Success!')} Domain ${chalk.bold(
-            _domain.uid
-          )} removed [${elapsed}]`
+          `${chalk.cyan('> Success!')} Domain ${chalk.bold(_domain.name)} removed [${elapsed}]`
         )
       } catch (err) {
         console.error(error(err))
@@ -308,7 +306,7 @@ async function run({ token, sh: { currentTeam, user } }) {
 async function readConfirmation(domain, _domain) {
   return new Promise(resolve => {
     const time = chalk.gray(ms(new Date() - new Date(_domain.created)) + ' ago')
-    const tbl = table([[chalk.underline(`https://${_domain.name}`), time]], {
+    const tbl = table([[chalk.bold(_domain.name), time]], {
       align: ['r', 'l'],
       hsep: ' '.repeat(6)
     })


### PR DESCRIPTION
- Don't prefix the domain with https as it may not be even using
  https nor have any records
- Don't show domain ID after the domain is removed as it has no
  meaning for cli users