### PR TITLE
Pluralize words automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
       "dist/*"
     ],
     "targets": [
-      "node9-alpine-x64",
-      "node9-linux-x64",
-      "node9-macos-x64",
-      "node9-win-x64"
+      "node8-alpine-x64",
+      "node8-linux-x64",
+      "node8-macos-x64",
+      "node8-win-x64"
     ]
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "ora": "1.3.0",
     "pipe-streams-to-promise": "0.2.0",
     "pkg": "4.3.0-beta.1",
+    "pluralize": "7.0.0",
     "pre-commit": "1.2.2",
     "prettier": "1.7.2",
     "printf": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "opn": "5.1.0",
     "ora": "1.3.0",
     "pipe-streams-to-promise": "0.2.0",
-    "pkg": "4.3.0-beta.1",
+    "pkg": "4.3.0-beta.4",
     "pluralize": "7.0.0",
     "pre-commit": "1.2.2",
     "prettier": "1.7.2",

--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -6,6 +6,7 @@ const mri = require('mri')
 const table = require('text-table')
 const ms = require('ms')
 const printf = require('printf')
+const plural = require('pluralize')
 require('epipebomb')()
 const supportsColor = require('supports-color')
 
@@ -218,9 +219,9 @@ async function run({ token, sh: { currentTeam, user } }) {
         }, 0) + 8
       const elapsed_ = ms(new Date() - start_)
       console.log(
-        `> ${aliases.length} alias${aliases.length === 1
-          ? ''
-          : 'es'} found ${chalk.gray(`[${elapsed_}]`)} under ${chalk.bold(
+        `> ${
+          plural('alias', aliases.length, true)
+        } found ${chalk.gray(`[${elapsed_}]`)} under ${chalk.bold(
           (currentTeam && currentTeam.slug) || user.username || user.email
         )}`
       )
@@ -268,9 +269,7 @@ async function run({ token, sh: { currentTeam, user } }) {
           }
         } else if (_alias.rules) {
           _sourceUrl = chalk.gray(
-            `[${_alias.rules.length} custom rule${_alias.rules.length > 1
-              ? 's'
-              : ''}]`
+            `[${plural('custom rule', _alias.rules.length, true)}]`
           )
           if (supportsColor) {
             urlSpec += underlineWidth

--- a/src/providers/sh/commands/billing.js
+++ b/src/providers/sh/commands/billing.js
@@ -4,6 +4,7 @@
 const chalk = require('chalk')
 const mri = require('mri')
 const ms = require('ms')
+const plural = require('pluralize')
 
 // Utilities
 const { handleError, error } = require('../util/error')
@@ -174,9 +175,9 @@ async function run({ token, sh: { currentTeam, user } }) {
 
       const elapsed = ms(new Date() - start)
       console.log(
-        `> ${cards.cards.length} card${cards.cards.length === 1
-          ? ''
-          : 's'} found under ${chalk.bold(
+        `> ${
+          plural('card', cards.cards.length, true)
+        } found under ${chalk.bold(
           (currentTeam && currentTeam.slug) || user.username || user.email
         )} ${chalk.gray(`[${elapsed}]`)}`
       )

--- a/src/providers/sh/commands/certs.js
+++ b/src/providers/sh/commands/certs.js
@@ -10,6 +10,7 @@ const mri = require('mri')
 const fs = require('fs-extra')
 const ms = require('ms')
 const printf = require('printf')
+const plural = require('pluralize')
 require('epipebomb')()
 const supportsColor = require('supports-color')
 
@@ -134,9 +135,9 @@ async function run({ token, sh: { currentTeam, user } }) {
     const elapsed = ms(new Date() - start)
 
     console.log(
-      `> ${list.length} certificate${list.length === 1
-        ? ''
-        : 's'} found ${chalk.gray(`[${elapsed}]`)} under ${chalk.bold(
+      `> ${
+        plural('certificate', list.length, true)
+      } found ${chalk.gray(`[${elapsed}]`)} under ${chalk.bold(
         (currentTeam && currentTeam.slug) || user.username || user.email
       )}`
     )

--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -6,6 +6,7 @@ const mri = require('mri')
 const ms = require('ms')
 const psl = require('psl')
 const table = require('text-table')
+const plural = require('pluralize')
 
 // Utilities
 const NowDomains = require('../util/domains')
@@ -166,9 +167,7 @@ async function run({ token, sh: { currentTeam, user } }) {
 
       const elapsed_ = ms(new Date() - start_)
       console.log(
-        `> ${domains.length} domain${domains.length === 1
-          ? ''
-          : 's'} found under ${chalk.bold(
+        `> ${plural('domain', domains.length, true)} found under ${chalk.bold(
           (currentTeam && currentTeam.slug) || user.username || user.email
         )} ${chalk.gray(`[${elapsed_}]`)}`
       )
@@ -320,9 +319,7 @@ async function readConfirmation(domain, _domain) {
       process.stdout.write(
         `> ${chalk.yellow('Warning!')} This domain's ` +
           `${chalk.bold(
-            _domain.aliases.length +
-              ' alias' +
-              (_domain.aliases.length === 1 ? '' : 'es')
+            plural('alias', _domain.aliases.length, true)
           )} ` +
           `will be removed. Run ${chalk.dim('`now alias ls`')} to list them.\n`
       )
@@ -331,9 +328,7 @@ async function readConfirmation(domain, _domain) {
       process.stdout.write(
         `> ${chalk.yellow('Warning!')} This domain's ` +
           `${chalk.bold(
-            _domain.certs.length +
-              ' certificate' +
-              (_domain.certs.length === 1 ? '' : 's')
+            plural('certificate', _domain.certs.length, true)
           )} ` +
           `will be removed. Run ${chalk.dim('`now cert ls`')} to list them.\n`
       )

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -5,6 +5,7 @@ const mri = require('mri')
 const chalk = require('chalk')
 const ms = require('ms')
 const printf = require('printf')
+const plural = require('pluralize')
 require('epipebomb')()
 const supportsColor = require('supports-color')
 
@@ -161,9 +162,9 @@ async function list({ token, sh: { currentTeam, user }, includeScheme }) {
     }, 0) + 5
   const timeNow = new Date()
   console.log(
-    `> ${deployments.length} deployment${deployments.length === 1
-      ? ''
-      : 's'} found under ${chalk.bold(
+    `> ${
+      plural('deployment', deployments.length, true)
+    } found under ${chalk.bold(
       (currentTeam && currentTeam.slug) || user.username || user.email
     )} ${chalk.grey('[' + ms(timeNow - start) + ']')}`
   )

--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -4,6 +4,7 @@
 const mri = require('mri')
 const chalk = require('chalk')
 const ms = require('ms')
+const plural = require('pluralize')
 const table = require('text-table')
 
 // Utilities
@@ -111,11 +112,11 @@ module.exports = async ctx => {
 
 function readConfirmation(matches) {
   return new Promise(resolve => {
-    process.stdout.write(
-      info(`The following deployment${matches.length === 1
-        ? ''
-        : 's'} will be removed permanently:\n`)
-    )
+    console.log(info(
+      `> The following ${
+        plural('deployment', matches.length, true)
+      } will be removed permanently:`
+    ))
 
     const tbl = table(
       matches.map(depl => {

--- a/src/providers/sh/commands/secrets.js
+++ b/src/providers/sh/commands/secrets.js
@@ -5,6 +5,7 @@ const chalk = require('chalk')
 const table = require('text-table')
 const mri = require('mri')
 const ms = require('ms')
+const plural = require('pluralize')
 
 // Utilities
 const strlen = require('../util/strlen')
@@ -126,9 +127,9 @@ async function run({ token, sh: { currentTeam, user } }) {
     const elapsed = ms(new Date() - start)
 
     console.log(
-      `> ${list.length} secret${list.length === 1
-        ? ''
-        : 's'} found under ${chalk.bold(
+      `> ${
+        plural('secret', list.length, true)
+      } found under ${chalk.bold(
         (currentTeam && currentTeam.slug) || user.username || user.email
       )} ${chalk.gray(`[${elapsed}]`)}`
     )

--- a/src/providers/sh/util/alias.js
+++ b/src/providers/sh/util/alias.js
@@ -5,6 +5,7 @@ const publicSuffixList = require('psl')
 const mri = require('mri')
 const ms = require('ms')
 const chalk = require('chalk')
+const plural = require('pluralize')
 const { write: copy } = require('clipboardy')
 
 // Ours
@@ -319,12 +320,14 @@ module.exports = class Alias extends Now {
         console.log(
           `> Alias ${alias} points to ${chalk.bold(
             aliasedDeployment.url
-          )} (${chalk.bold(aliasedDeployment.scale.current + ' instances')})`
+          )} (${chalk.bold(
+            plural('instance', aliasedDeployment.scale.current, true)
+          )})`
         )
         // Test if we need to change the scale or just update the rules
         console.log(
           `> Scaling ${depl.url} to ${chalk.bold(
-            aliasedDeployment.scale.current + ' instances'
+            plural('instance', aliasedDeployment.scale.current, true)
           )} atomically` // Not a typo
         )
         if (depl.scale.current !== aliasedDeployment.scale.current) {

--- a/src/providers/sh/util/scale-info.js
+++ b/src/providers/sh/util/scale-info.js
@@ -2,6 +2,7 @@ const linelog = require('single-line-log').stdout
 const range = require('lodash.range')
 const ms = require('ms')
 const chalk = require('chalk')
+const plural = require('pluralize')
 const retry = require('async-retry')
 
 function barify(cur, tot) {
@@ -35,10 +36,9 @@ module.exports = async function(now, url) {
   let barcurr = current
   const end = Math.max(current, max)
   linelog(
-    `${chalk.gray('>')} Scaling to ${chalk.bold(
-      String(targetReplicaCount) +
-        (targetReplicaCount === 1 ? ' instance' : ' instances')
-    )}: ` + barify(barcurr, end)
+    `${chalk.gray('>')} Scaling to ${
+      chalk.bold(plural('instance', targetReplicaCount, true))
+    }: ` + barify(barcurr, end)
   )
 
   const instances = await retry(
@@ -47,19 +47,17 @@ module.exports = async function(now, url) {
       if (barcurr !== res.length) {
         barcurr = res.length
         linelog(
-          `${chalk.gray('>')} Scaling to ${chalk.bold(
-            String(targetReplicaCount) +
-              (targetReplicaCount === 1 ? ' instance' : ' instances')
-          )}: ` + barify(barcurr, end)
+          `${chalk.gray('>')} Scaling to ${
+            chalk.bold(plural('instance', targetReplicaCount, true))
+          }: ` + barify(barcurr, end)
         )
 
         if (barcurr === targetReplicaCount) {
           linelog.clear()
           linelog(
-            `> Scaled to ${chalk.bold(
-              String(targetReplicaCount) +
-                (targetReplicaCount === 1 ? ' instance' : ' instances')
-            )}: ${chalk.gray('[' + ms(Date.now() - startTime) + ']')}\n`
+            `> Scaled to ${
+              chalk.bold(plural('instance', targetReplicaCount, true))
+            }: ${chalk.gray('[' + ms(Date.now() - startTime) + ']')}\n`
           )
           return res
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,8 +96,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.1.5, ajv@^5.2.0, ajv@^5.2.3:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -117,8 +117,8 @@ alpha-sort@2.0.1:
   resolved "https://registry.yarnpkg.com/alpha-sort/-/alpha-sort-2.0.1.tgz#50d3538947cf70ebcc15a6b461fb04fff3bf1ed9"
 
 already@0.x:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/already/-/already-0.7.0.tgz#68e52005060a2da1c6dffcfce7efe44143896509"
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/already/-/already-0.7.1.tgz#a999eaf3e0b9268888c3b0d55e046e1dc53a3e70"
   dependencies:
     throat "4.x"
 
@@ -1051,8 +1051,8 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
 binary-extensions@^1.0.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
 bl@^1.0.0:
   version "1.2.1"
@@ -1093,8 +1093,8 @@ boom@2.x.x:
     hoek "2.x.x"
 
 boxen@^1.0.0, boxen@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.2.2.tgz#3f1d4032c30ffea9d4b02c322eaf2ea741dcbce5"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
   dependencies:
     ansi-align "^2.0.0"
     camelcase "^4.0.0"
@@ -1102,7 +1102,7 @@ boxen@^1.0.0, boxen@^1.2.1:
     cli-boxes "^1.0.0"
     string-width "^2.0.0"
     term-size "^1.2.0"
-    widest-line "^1.0.0"
+    widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1169,18 +1169,18 @@ browserify-sign@^4.0.0:
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
-browserify-zlib@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+browserify-zlib@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
   dependencies:
-    pako "~0.2.0"
+    pako "~1.0.5"
 
 browserslist@^2.1.2:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.9.0.tgz#706aca15c53be15610f466e348cbfa0c00a6a379"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
   dependencies:
-    caniuse-lite "^1.0.30000760"
-    electron-to-chromium "^1.3.27"
+    caniuse-lite "^1.0.30000780"
+    electron-to-chromium "^1.3.28"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -1254,8 +1254,8 @@ caller-path@^0.1.0:
     callsites "^0.2.0"
 
 callguard@1.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/callguard/-/callguard-1.0.2.tgz#471ec6dadc473f27acc549e9e09ac161ddd00f9d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/callguard/-/callguard-1.1.0.tgz#e4be36cbd96788689094c76bace3b20dc155119f"
 
 callsite@1.0.0:
   version "1.0.0"
@@ -1284,9 +1284,9 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@^1.0.30000760:
-  version "1.0.30000760"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz#ec720395742f1c7ec8947fd6dd2604e77a8f98ff"
+caniuse-lite@^1.0.30000780:
+  version "1.0.30000780"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz#1f9095f2efd4940e0ba6c5992ab7a9b64cc35ba4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1346,6 +1346,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
 child-process-promise@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
@@ -1374,8 +1378,8 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
 ci-info@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -1497,8 +1501,8 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -1604,8 +1608,8 @@ content-disposition@^0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 convert-source-map@^1.2.0, convert-source-map@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 convert-stream@1.0.2:
   version "1.0.2"
@@ -1938,8 +1942,8 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
 
 detect-libc@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.2.tgz#71ad5d204bf17a6a6ca8f450c61454066ef461e1"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1954,11 +1958,10 @@ docker-file-parser@1.0.2:
   resolved "https://registry.yarnpkg.com/docker-file-parser/-/docker-file-parser-1.0.2.tgz#b0c63d18ceee2ac5d5385968d077feab88c37e26"
 
 doctrine@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
     esutils "^2.0.2"
-    isarray "^1.0.0"
 
 domain-browser@^1.1.1:
   version "1.1.7"
@@ -2004,9 +2007,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-to-chromium@^1.3.27:
-  version "1.3.27"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
+electron-to-chromium@^1.3.28:
+  version "1.3.28"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -2116,8 +2119,8 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.35"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.35.tgz#18ee858ce6a3c45c7d79e91c15fcca9ec568494f"
+  version "0.10.37"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.37.tgz#0ee741d148b80069ba27d020393756af257defc3"
   dependencies:
     es6-iterator "~2.0.1"
     es6-symbol "~3.1.1"
@@ -2397,11 +2400,11 @@ extend@~3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.5.tgz#52c249a3981b9ba187c7cacf5beb50bf1d91a6bc"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
   dependencies:
+    chardet "^0.4.0"
     iconv-lite "^0.4.17"
-    jschardet "^1.4.2"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -2410,9 +2413,13 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
+extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -2545,8 +2552,8 @@ flow-babel-webpack-plugin@1.1.0:
     lodash.merge "^4.6.0"
 
 "flow-bin@>=0.44.2 <1":
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+  version "0.60.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.60.1.tgz#0f4fa7b49be2a916f18cd946fc4a51e32ffe4b48"
 
 fn-name@^2.0.0:
   version "2.0.1"
@@ -2600,7 +2607,7 @@ fs-extra@4.0.2:
 
 fs-extra@^0.26.4:
   version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
+  resolved "http://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
@@ -2731,14 +2738,14 @@ glob@^6.0.4:
     path-is-absolute "^1.0.0"
 
 global-dirs@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.0.tgz#10d34039e0df04272e262cf24224f7209434df4f"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
   dependencies:
     ini "^1.3.4"
 
 globals@^10.0.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-10.3.0.tgz#716aba93657b56630b5a0e77de5ea8ac6215afaa"
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
 
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
@@ -2921,9 +2928,9 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-browserify@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
 hullabaloo-config-manager@^1.1.0:
   version "1.1.1"
@@ -3012,9 +3019,13 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@1.3.4, ini@^1.3.4, ini@~1.3.0:
+ini@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+ini@^1.3.4, ini@~1.3.0:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 inquirer@3.3.0, inquirer@^3.0.6:
   version "3.3.0"
@@ -3036,8 +3047,8 @@ inquirer@3.3.0, inquirer@^3.0.6:
     through "^2.3.6"
 
 interpret@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
@@ -3195,8 +3206,8 @@ is-path-in-cwd@^1.0.0:
     is-path-inside "^1.0.0"
 
 is-path-inside@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   dependencies:
     path-is-inside "^1.0.1"
 
@@ -3318,10 +3329,6 @@ js-yaml@^3.4.3, js-yaml@^3.8.2, js-yaml@^3.9.1:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
-jschardet@^1.4.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -3759,8 +3766,8 @@ miller-rabin@^4.0.0:
     brorand "^1.0.1"
 
 mime-db@^1.28.0:
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.31.0.tgz#a49cd8f3ebf3ed1a482b60561d9105ad40ca74cb"
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.32.0.tgz#485b3848b01a3cda5f968b4882c0771e58e09414"
 
 mime-db@~1.30.0:
   version "1.30.0"
@@ -3826,9 +3833,13 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@2.0.0, ms@^2.0.0:
+ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -3851,8 +3862,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 native-or-bluebird@^1.2.0:
   version "1.2.0"
@@ -3876,28 +3887,28 @@ node-fetch@1.7.3:
     is-stream "^1.0.1"
 
 node-libs-browser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.0.0.tgz#a3a59ec97024985b46e958379646f96c4b616646"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
   dependencies:
     assert "^1.1.1"
-    browserify-zlib "^0.1.4"
+    browserify-zlib "^0.2.0"
     buffer "^4.3.0"
     console-browserify "^1.1.0"
     constants-browserify "^1.0.0"
     crypto-browserify "^3.11.0"
     domain-browser "^1.1.1"
     events "^1.0.0"
-    https-browserify "0.0.1"
-    os-browserify "^0.2.0"
+    https-browserify "^1.0.0"
+    os-browserify "^0.3.0"
     path-browserify "0.0.0"
-    process "^0.11.0"
+    process "^0.11.10"
     punycode "^1.2.4"
     querystring-es3 "^0.2.0"
-    readable-stream "^2.0.5"
+    readable-stream "^2.3.3"
     stream-browserify "^2.0.1"
-    stream-http "^2.3.1"
-    string_decoder "^0.10.25"
-    timers-browserify "^2.0.2"
+    stream-http "^2.7.2"
+    string_decoder "^1.0.0"
+    timers-browserify "^2.0.4"
     tty-browserify "0.0.0"
     url "^0.11.0"
     util "^0.10.3"
@@ -4070,9 +4081,9 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-os-browserify@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
+os-browserify@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -4130,8 +4141,8 @@ p-map@^1.1.1:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 p-timeout@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.0.tgz#9820f99434c5817868b4f34809ee5291660d5b6c"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
   dependencies:
     p-finally "^1.0.0"
 
@@ -4159,9 +4170,9 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@~0.2.0:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+pako@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -4330,9 +4341,9 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-fetch@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.5.0.tgz#d1dadbb5cf0aff865c0ca4686202cf6827a8787b"
+pkg-fetch@2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-2.5.3.tgz#fe9f13795a0aa99e66d227db98da3936229bc1ca"
   dependencies:
     babel-runtime "6.25.0"
     byline "5.0.0"
@@ -4347,9 +4358,9 @@ pkg-fetch@2.5.0:
     semver "5.4.1"
     unique-temp-dir "1.0.0"
 
-pkg@4.3.0-beta.1:
-  version "4.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.0-beta.1.tgz#1e73a73975eb4cdfddbc9ecff8afb586056c0cac"
+pkg@4.3.0-beta.4:
+  version "4.3.0-beta.4"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.0-beta.4.tgz#61c48c27a4970cab269a79f4a0f0dc5a2fae62b2"
   dependencies:
     acorn "5.1.1"
     babel-runtime "6.25.0"
@@ -4359,7 +4370,7 @@ pkg@4.3.0-beta.1:
     globby "6.1.0"
     minimist "1.2.0"
     multistream "2.1.0"
-    pkg-fetch "2.5.0"
+    pkg-fetch "2.5.3"
     progress "2.0.0"
     resolve "1.4.0"
     simple-bufferstream "1.0.0"
@@ -4375,7 +4386,7 @@ plur@^2.0.0:
   dependencies:
     irregular-plurals "^1.0.0"
 
-pluralize@^7.0.0:
+pluralize@7.0.0, pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
@@ -4436,7 +4447,7 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process@^0.11.0:
+process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
@@ -4445,8 +4456,8 @@ progress@2.0.0, progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promise-polyfill@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.0.2.tgz#d9c86d3dc4dc2df9016e88946defd69b49b41162"
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -4475,8 +4486,8 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
 
 pump@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -4568,7 +4579,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -4807,10 +4818,10 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rxjs@^5.0.0-beta.11:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.5.tgz#e164f11d38eaf29f56f08c3447f74ff02dd84e97"
   dependencies:
-    symbol-observable "^1.0.1"
+    symbol-observable "1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -5036,7 +5047,7 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-http@^2.3.1:
+stream-http@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
   dependencies:
@@ -5084,11 +5095,7 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@^0.10.25:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@~1.0.3:
+string_decoder@^1.0.0, string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -5183,13 +5190,17 @@ supports-color@^4.0.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+symbol-observable@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
 
 table@^4.0.1:
   version "4.0.2"
@@ -5297,7 +5308,7 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
-timers-browserify@^2.0.2:
+timers-browserify@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
@@ -5563,8 +5574,8 @@ webpack-node-externals@1.6.0:
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz#232c62ec6092b100635a3d29d83c1747128df9bd"
 
 webpack-sources@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.2.tgz#d0148ec083b3b5ccef1035a6b3ec16442983b27a"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
@@ -5630,11 +5641,11 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widest-line@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
   dependencies:
-    string-width "^1.0.1"
+    string-width "^2.1.1"
 
 window-size@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Instead of manually formatting these singular vs. plural cases.

Note that `util/alias.js` was previously incorrectly always printing as
plural, which is what led me down this rabbit hole in the first place.