### PR TITLE
Do not reference `newTeam` when switching to user scope

### DIFF
--- a/src/providers/sh/commands/teams/switch.js
+++ b/src/providers/sh/commands/teams/switch.js
@@ -53,7 +53,7 @@ module.exports = async function({ teams, args, config }) {
       updateCurrentTeam(config)
 
       stopSpinner()
-      console.log(success(`Your account (${chalk.bold(desiredSlug)}) (${newTeam.slug}) is now active!`))
+      console.log(success(`Your account (${chalk.bold(desiredSlug)}) is now active!`))
       return 0
     }
 


### PR DESCRIPTION
Fixes error:

    $ now switch tootallnate
    > Error! An unexpected error occurred in switch: TypeError: Cannot read property 'slug' of undefined
        at module.exports (/snapshot/now-cli/dist/now.js:2995:81)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:188:7)