### PR TITLE
Return an empty object early when nothing to prompt

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -213,11 +213,7 @@ const envFields = async list => {
   )
   const answers = await inquirer.prompt(questions)
 
-  for (const answer in answers) {
-    if (!{}.hasOwnProperty.call(answers, answer)) {
-      continue
-    }
-
+  for (const answer of Object.keys(answers)) {
     const content = answers[answer]
 
     if (content === '') {

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -192,6 +192,10 @@ const stopDeployment = async msg => {
 }
 
 const envFields = async list => {
+  if (list.length === 0) {
+    return {}
+  }
+
   const questions = []
 
   for (const field of list) {


### PR DESCRIPTION
So that the `console.log()` a few lines down does not get invoked.

Also use `Object.keys()` to iterate over the answers.