### PR TITLE
Remove `--base64` argument from `now secret add`

### DIFF
--- a/src/providers/sh/commands/secrets.js
+++ b/src/providers/sh/commands/secrets.js
@@ -28,7 +28,6 @@ const help = () => {
   ${chalk.dim('Options:')}
 
     -h, --help                     Output usage information
-    -b, --base64                   Treat value as base64-encoded
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'
   )}   Path to the local ${'`now.json`'} file
@@ -71,11 +70,10 @@ let subcommand
 
 const main = async ctx => {
   argv = mri(ctx.argv.slice(2), {
-    boolean: ['help', 'debug', 'base64'],
+    boolean: ['help', 'debug'],
     alias: {
       help: 'h',
-      debug: 'd',
-      base64: 'b'
+      debug: 'd'
     }
   })
 
@@ -231,15 +229,7 @@ async function run({ token, sh: { currentTeam, user } }) {
       return exit(1)
     }
 
-    const [name, value_] = args
-    let value
-
-    if (argv.base64) {
-      value = { base64: value_ }
-    } else {
-      value = value_
-    }
-
+    const [name, value] = args
     await secrets.add(name, value)
     const elapsed = ms(new Date() - start)
 


### PR DESCRIPTION
It's been broken on the server-side for quite a while now,
and on top of that it's never been clear as to *how* you
get the binary value back out from within the deployment.

For these reasons, let's get rid of the option altogether.

Users who need to encode binary data as the secret value
should encode to base64 manually. For example:

```
$ now secret add my-secret $(echo 'foo' | base64)
```