### PR TITLE
Added `api` option to local config

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -358,6 +358,19 @@ const main = async (argv_) => {
     ctx.apiUrl = sh.api
   }
 
+  let localConfig
+
+  try {
+    localConfig = configFiles.readLocalConfig()
+  } catch (err) {}
+
+  if (localConfig) {
+    ctx.apiUrl = localConfig.api
+    delete localConfig.api
+
+    Object.assign(ctx.config, localConfig)
+  }
+
   // $FlowFixMe
   const { isTTY } = process.stdout
 

--- a/src/now.js
+++ b/src/now.js
@@ -358,11 +358,7 @@ const main = async (argv_) => {
     ctx.apiUrl = sh.api
   }
 
-  let localConfig
-
-  try {
-    localConfig = configFiles.readLocalConfig()
-  } catch (err) {}
+  const localConfig = configFiles.readLocalConfig()
 
   if (localConfig) {
     ctx.apiUrl = localConfig.api

--- a/src/util/config-files.js
+++ b/src/util/config-files.js
@@ -9,6 +9,7 @@ const { existsSync } = require('fs-extra')
 // Utilities
 const getNowDir = require('../config/global-path')
 const getLocalPathConfig = require('../config/local-path')
+const error = require('./output/error')
 
 const NOW_DIR = getNowDir()
 const CONFIG_FILE_PATH = joinPath(NOW_DIR, 'config.json')
@@ -39,15 +40,43 @@ function getAuthConfigFilePath() {
 }
 
 function readLocalConfig() {
-  if (existsSync(LOCAL_CONFIG_FILE_PATH)) {
-    return loadJSON.sync(LOCAL_CONFIG_FILE_PATH)
+  let localConfigExists
+
+  try {
+    localConfigExists = existsSync(LOCAL_CONFIG_FILE_PATH)
+  } catch (err) {
+    console.error(error('Failed to check if `now.json` exists'))
+    process.exit(1)
   }
 
-  if (existsSync(PACKAGE_JSON_PATH)) {
-    const { now } = loadJSON.sync(PACKAGE_JSON_PATH)
+  if (localConfigExists) {
+    try {
+      return loadJSON.sync(LOCAL_CONFIG_FILE_PATH)
+    } catch (err) {
+      console.error(error('Failed to read the `now.json` file'))
+      process.exit(1)
+    }
+  }
 
-    if (now) {
-      return now
+  let packageJsonExists
+
+  try {
+    packageJsonExists = existsSync(PACKAGE_JSON_PATH)
+  } catch (err) {
+    console.error(error('Failed to check if `package.json` exists'))
+    process.exit(1)
+  }
+
+  if (packageJsonExists) {
+    try {
+      const { now } = loadJSON.sync(PACKAGE_JSON_PATH)
+
+      if (now) {
+        return now
+      }
+    } catch (err) {
+      console.error(error('Failed to read the `package.json` file'))
+      process.exit(1)
     }
   }
 

--- a/src/util/config-files.js
+++ b/src/util/config-files.js
@@ -8,11 +8,12 @@ const { existsSync } = require('fs-extra')
 
 // Utilities
 const getNowDir = require('../config/global-path')
+const getLocalPathConfig = require('../config/local-path')
 
 const NOW_DIR = getNowDir()
 const CONFIG_FILE_PATH = joinPath(NOW_DIR, 'config.json')
 const AUTH_CONFIG_FILE_PATH = joinPath(NOW_DIR, 'auth.json')
-const LOCAL_CONFIG_FILE_PATH = joinPath(process.cwd(), 'now.json')
+const LOCAL_CONFIG_FILE_PATH = getLocalPathConfig()
 const PACKAGE_JSON_PATH = joinPath(process.cwd(), 'package.json')
 
 // reads `CONFIG_FILE_PATH` atomically

--- a/src/util/config-files.js
+++ b/src/util/config-files.js
@@ -53,7 +53,13 @@ function readLocalConfig() {
     try {
       return loadJSON.sync(LOCAL_CONFIG_FILE_PATH)
     } catch (err) {
-      console.error(error('Failed to read the `now.json` file'))
+      if (err.name === 'JSONError') {
+        console.log(error(err.message))
+      } else {
+        const code = err.code ? `(${err.code})` : ''
+        console.error(error(`Failed to read the \`now.json\` file ${code}`))
+      }
+
       process.exit(1)
     }
   }
@@ -75,7 +81,13 @@ function readLocalConfig() {
         return now
       }
     } catch (err) {
-      console.error(error('Failed to read the `package.json` file'))
+      if (err.name === 'JSONError') {
+        console.log(error(err.message))
+      } else {
+        const code = err.code ? `(${err.code})` : ''
+        console.error(error(`Failed to read the \`package.json\` file ${code}`))
+      }
+
       process.exit(1)
     }
   }

--- a/src/util/config-files.js
+++ b/src/util/config-files.js
@@ -13,7 +13,7 @@ const getLocalPathConfig = require('../config/local-path')
 const NOW_DIR = getNowDir()
 const CONFIG_FILE_PATH = joinPath(NOW_DIR, 'config.json')
 const AUTH_CONFIG_FILE_PATH = joinPath(NOW_DIR, 'auth.json')
-const LOCAL_CONFIG_FILE_PATH = getLocalPathConfig()
+const LOCAL_CONFIG_FILE_PATH = getLocalPathConfig(process.cwd())
 const PACKAGE_JSON_PATH = joinPath(process.cwd(), 'package.json')
 
 // reads `CONFIG_FILE_PATH` atomically

--- a/src/util/config-files.js
+++ b/src/util/config-files.js
@@ -4,6 +4,7 @@ const { join: joinPath } = require('path')
 // Packages
 const loadJSON = require('load-json-file')
 const writeJSON = require('write-json-file')
+const { existsSync } = require('fs-extra')
 
 // Utilities
 const getNowDir = require('../config/global-path')
@@ -11,6 +12,8 @@ const getNowDir = require('../config/global-path')
 const NOW_DIR = getNowDir()
 const CONFIG_FILE_PATH = joinPath(NOW_DIR, 'config.json')
 const AUTH_CONFIG_FILE_PATH = joinPath(NOW_DIR, 'auth.json')
+const LOCAL_CONFIG_FILE_PATH = joinPath(process.cwd(), 'now.json')
+const PACKAGE_JSON_PATH = joinPath(process.cwd(), 'package.json')
 
 // reads `CONFIG_FILE_PATH` atomically
 const readConfigFile = () => loadJSON.sync(CONFIG_FILE_PATH)
@@ -34,11 +37,28 @@ function getAuthConfigFilePath() {
   return AUTH_CONFIG_FILE_PATH
 }
 
+function readLocalConfig() {
+  if (existsSync(LOCAL_CONFIG_FILE_PATH)) {
+    return loadJSON.sync(LOCAL_CONFIG_FILE_PATH)
+  }
+
+  if (existsSync(PACKAGE_JSON_PATH)) {
+    const { now } = loadJSON.sync(PACKAGE_JSON_PATH)
+
+    if (now) {
+      return now
+    }
+  }
+
+  return null
+}
+
 module.exports = {
   readConfigFile,
   writeToConfigFile,
   readAuthConfigFile,
   writeToAuthConfigFile,
+  readLocalConfig,
   getConfigFilePath,
   getAuthConfigFilePath
 }


### PR DESCRIPTION
Both `now` inside `package.json` and `now.json` now support the `api` config property that the global configuration file already has (like mentioned here: #1068).

This is made possible by loading the config file globally for each command.

This closes #1068.