### PR TITLE
Authentication error offers the incorrect login command

### DIFF
--- a/src/providers/sh/util/error.js
+++ b/src/providers/sh/util/error.js
@@ -18,7 +18,7 @@ function handleError(err, { debug = false } = {}) {
 
   if (err.status === 403) {
     console.error(error(
-      'Authentication error. Run `now -L` or `now --login` to log-in again.'
+      'Authentication error. Run `now login` to log-in again.'
     ))
   } else if (err.status === 429) {
     if (err.retryAfter === 'never') {


### PR DESCRIPTION
If you make a now command without being logged in you are met with this error message:
```
> Error! Authentication error. Run `now -L` or `now --login` to log-in again.
```
I tried using each of the recommended commands but each time was met with:
```
> Deploying ...
>Error! Not authorized
```


If you check the commands offered by the error message against the commands listed under `now --help` neither of these two commands - `now -L` nor `now --login` - are listed. So now thought I was trying to deploy the current directory.