### PR TITLE
Properly error on wrong token and handle team

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -437,10 +437,22 @@ const main = async (argv_) => {
       ctx.authConfig.credentials[credentialsIndex] = obj
     }
 
-    const user = await getUser({
-      apiUrl: ctx.apiUrl,
-      token
-    })
+    let user
+
+    try {
+      user = await getUser({
+        apiUrl: ctx.apiUrl,
+        token
+      })
+    } catch (err) {
+      console.error(error(err))
+      await exit(1)
+    }
+
+    // Don't use team from config if `--token` was set
+    if (ctx.config.sh && ctx.config.sh.currentTeam) {
+      delete ctx.config.sh.currentTeam
+    }
 
     ctx.config.sh = Object.assign(ctx.config.sh || {}, { user })
   }

--- a/src/util/get-user.js
+++ b/src/util/get-user.js
@@ -19,7 +19,7 @@ const getUser = async ({ apiUrl, token }) => {
     res = await fetch(url, { headers })
   } catch (err) {
     debug(`error fetching /www/user: $O`, err.stack)
-    throw new Error(`An unexpected error occurred while trying to fetch your personal details: ${err.message}`)
+    throw new Error(`An unexpected error occurred while trying to fetch your user information: ${err.message}`)
   }
 
   debug('parsing response from GET /www/user')

--- a/src/util/get-user.js
+++ b/src/util/get-user.js
@@ -19,11 +19,7 @@ const getUser = async ({ apiUrl, token }) => {
     res = await fetch(url, { headers })
   } catch (err) {
     debug(`error fetching /www/user: $O`, err.stack)
-    throw new Error(
-      error(
-        `An unexpected error occurred while trying to fetch your personal details: ${err.message}`
-      )
-    )
+    throw new Error(`An unexpected error occurred while trying to fetch your personal details: ${err.message}`)
   }
 
   debug('parsing response from GET /www/user')
@@ -36,11 +32,11 @@ const getUser = async ({ apiUrl, token }) => {
       `error parsing the response from /www/user as JSON – got %O`,
       err.stack
     )
-    throw new Error(
-      error(
-        `An unexpected error occurred while trying to fetch your personal details: ${err.message}`
-      )
-    )
+    throw new Error(`An unexpected error occurred while trying to fetch your personal details: ${err.message}`)
+  }
+
+  if (body.error && body.error.code === 'forbidden') {
+    throw new Error('The specified token is not valid')
   }
 
   const { user } = body


### PR DESCRIPTION
This PR ensures we're not using the team from the config if `--token` was passed. In addition, a invalid token now leads to a proper error.

This closes #1072.