### PR TITLE
Allow overwriting custom certificates with auto-renewable certs

### DIFF
--- a/src/providers/sh/util/certs.js
+++ b/src/providers/sh/util/certs.js
@@ -19,8 +19,8 @@ module.exports = class Certs extends Now {
     })
   }
 
-  create(cn) {
-    return this.createCert(cn)
+  create(cn, { overwrite }) {
+    return this.createCert(cn, { renew: true, overwriteCustom: overwrite })
   }
 
   renew(cn) {

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -755,7 +755,7 @@ module.exports = class Now extends EventEmitter {
     })
   }
 
-  createCert(domain, { renew } = {}) {
+  createCert(domain, { renew, overwriteCustom } = {}) {
     return this.retry(
       async (bail, attempt) => {
         if (this._debug) {
@@ -766,7 +766,8 @@ module.exports = class Now extends EventEmitter {
           method: 'POST',
           body: {
             domains: [domain],
-            renew
+            renew,
+            overwriteCustom
           }
         })
 


### PR DESCRIPTION
Currently it's not possible to create a new auto-renewable
certificate if a custom certificate already exist for a domain,
as we only allow the other direction from the cli.

Add a command flag that allows overwriting a custom certificate
with an auto-renewable certificate.

`now cert create --overwrite zeit.rocks`