### PR TITLE
Retrieve deployment type from cli instead of now.json

### DIFF
--- a/src/providers/sh/commands/dns.js
+++ b/src/providers/sh/commands/dns.js
@@ -57,7 +57,7 @@ const help = () => {
       )}
       ${chalk.cyan('$ now dns add zeit.rocks @ MX mail.zeit.rocks 10')}
 
-  ${chalk.gray('–')} Add an SVR record
+  ${chalk.gray('–')} Add an SRV record
 
       ${chalk.cyan(
         '$ now dns add <DOMAIN> <NAME> SRV <PRIORITY> <WEIGHT> <PORT> <TARGET>'

--- a/src/providers/sh/util/read-metadata.js
+++ b/src/providers/sh/util/read-metadata.js
@@ -55,8 +55,8 @@ async function readMetaData(
     type = nowConfig.type
   }
 
-  // The same goes for this
-  if (nowConfig && nowConfig.type) {
+  // If a deployment type hasn't been specified then retrieve it from now.json
+  if (!type && nowConfig && nowConfig.type) {
     type = nowConfig.type
   }
 


### PR DESCRIPTION
Fixes https://github.com/zeit/now-cli/issues/1064 
Validated locally by specifying different deployment types via CLI and now.json