### PR TITLE
Bring back progress bar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@
         "tags": true
       }
     }
-  ],
-  "after_deploy": "npm install -g now"
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
         "secure": "ff5V20LO5B8nwguQYtmb3Es/WHBP6GYFo0yOaiw7d1GrmeVFyZauQ7CQgI41toEuYnPlDxd+CQACXjARKLGzJbz80bIPuHZ07GevrmhEgYVHq4DuWAiQnuVf0CJKehDUAKUtR+c8giMQK9tE7O+M+yBciiC9UEKYRCmfyQPXOnEU+cRWNaL0PH2hnlz1AIgScdLblAqdJbVUjHQ+eT2yYeKx2qR09pxu9MDwYLCfpWsLa+8PAcS4MHyuU7mqF27Y484Ab/X3kwNDhnzanyG9YhgHcCeNTZULDQUAJh7Pdf5uQvsfrcgNh1IzY+xvxmYPo2YavkGoDraPBqV46L7FP7KZX3pyh+crR1J+915pE96yHcV3+o40OgSuvW1jw7JCnVkkefryrABFlu7Dez7vd2mlUE+YXcnWhOEp12KUC2izfvm+hvQOqlA+I4VmCWHCA4peM93upQ3QCRhfB18L7JjoGo9/UvUF7wtm/1urMRSU3pWfcNRUtAg497gUUEbA9zVpLya+fQ2QdDe13L/03lYOz78NtDrzSIaWDfJTFrYSpgzwqmSwsTuismxP4NUV0aVEnpL9M+iKBxT0aLWeOIylGsnO5Ido7A+6SGqh8qqeNI84VRKZheOLV6GAqM5zvPDPeFdijRFNbP1n+rW+eepv2uCU8Km38FfhV1Qp85k="
       },
       "file_glob": true,
-      "file": "packed/*",
+      "file": "packed/*.gz",
       "skip_cleanup": true,
       "on": {
         "tags": true

--- a/download/src/index.js
+++ b/download/src/index.js
@@ -115,18 +115,12 @@ async function download() {
             }
           })
 
-        const encoding = resp.headers.get('content-encoding')
+        const gunzip = zlib.createGunzip()
 
-        if (encoding && encoding === 'gzip') {
-          const gunzip = zlib.createGunzip()
+        gunzip
+          .on('error', reject)
 
-          gunzip
-            .on('error', reject)
-
-          resp.body.pipe(gunzip).pipe(ws)
-        } else {
-          resp.body.pipe(ws)
-        }
+        resp.body.pipe(gunzip).pipe(ws)
 
         ws
           .on('error', reject)

--- a/download/src/index.js
+++ b/download/src/index.js
@@ -92,7 +92,7 @@ async function download() {
 
     try {
       const name = platformToName[platform]
-      const url = `https://cdn.zeit.co/releases/now-cli/${packageJSON.version}/${name}`
+      const url = `https://assets.zeit.co/raw/upload/now-cli/${packageJSON.version}/${name}.gz`
       const resp = await fetch(url, { compress: false })
 
       if (resp.status !== 200) {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "gzip": "ls packed/now* | xargs gzip -f",
+    "gzip": "ls packed/now* | xargs gzip",
     "bundle": "pkg dist/now.js -c package.json -o packed/now --options no-warnings",
-    "pack": "webpack && npm run bundle && npm run gzip",
+    "pack": "rm -rf packed && webpack && npm run bundle && npm run gzip",
     "build-download": "webpack --context download --config download/webpack.config.js",
     "link": "webpack && cd link && npm link",
     "build": "webpack"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "gzip": "ls packed/now* | xargs gzip",
+    "gzip": "ls packed/now* | xargs gzip -f",
     "bundle": "pkg dist/now.js -c package.json -o packed/now --options no-warnings",
     "pack": "webpack && npm run bundle && npm run gzip",
     "build-download": "webpack --context download --config download/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "pack": "webpack && pkg dist/now.js -c package.json -o packed/now --options no-warnings",
+    "gzip": "ls packed/now* | xargs gzip",
+    "bundle": "pkg dist/now.js -c package.json -o packed/now --options no-warnings",
+    "pack": "webpack && npm run bundle && npm run gzip",
     "build-download": "webpack --context download --config download/webpack.config.js",
     "link": "webpack && cd link && npm link",
     "build": "webpack"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "webpack -w",
     "precommit": "lint-staged",
     "postinstall": "node download/install.js",
-    "gzip": "ls packed/now* | xargs gzip",
+    "gzip": "ls packed/now* | xargs gzip -k",
     "bundle": "pkg dist/now.js -c package.json -o packed/now --options no-warnings",
     "pack": "rm -rf packed && webpack && npm run bundle && npm run gzip",
     "build-download": "webpack --context download --config download/webpack.config.js",


### PR DESCRIPTION
This brings back the progress bar, but with a few improvements:

- Start using Cloudinary
- We don't require the `content-length` header to exist anymore
- Removed `after_deploy` test. If it exits with 1, Travis doesn't care and doesn't fail the test, it just keeps running. So no need to have it (I added it earlier).