### PR TITLE
Remove whois check when using domains add command

### DIFF
--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -34,7 +34,6 @@ const help = () => {
     -h, --help                     Output usage information
     -d, --debug                    Debug mode [off]
     -e, --external                 Use external DNS server
-    -f, --force                    Skip DNS verification
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'
   )}   Path to the local ${'`now.json`'} file
@@ -79,13 +78,12 @@ let subcommand
 const main = async ctx => {
   argv = mri(ctx.argv.slice(2), {
     string: ['coupon'],
-    boolean: ['help', 'debug', 'external', 'force'],
+    boolean: ['help', 'debug', 'external'],
     alias: {
       help: 'h',
       coupon: 'c',
       debug: 'd',
       external: 'e',
-      force: 'f'
     }
   })
 
@@ -254,7 +252,6 @@ async function run({ token, sh: { currentTeam, user } }) {
       const start = new Date()
       const { uid, code, created, verified } = await domain.add(
         name,
-        argv.force,
         argv.external
       )
       const elapsed = ms(new Date() - start)

--- a/src/providers/sh/util/domains.js
+++ b/src/providers/sh/util/domains.js
@@ -6,9 +6,7 @@ const chalk = require('chalk')
 
 // Ours
 const Now = require('.')
-const isZeitWorld = require('./is-zeit-world')
 const isValidDomain = require('./domains/is-valid-domain')
-const { DNS_VERIFICATION_ERROR } = require('./errors')
 const cmd = require('../../../util/output/param')
 
 module.exports = class Domains extends Now {
@@ -99,7 +97,7 @@ module.exports = class Domains extends Now {
     })
   }
 
-  async add(domain, skipVerification, isExternal) {
+  async add(domain, isExternal) {
     if (!isValidDomain(domain)) {
       const err = new Error(
         `The supplied value ${chalk.bold(`"${domain}"`)} is not a valid domain.`
@@ -116,40 +114,7 @@ module.exports = class Domains extends Now {
       throw err
     }
 
-    if (skipVerification || isExternal) {
-      return this.setupDomain(domain, { isExternal })
-    }
-
-    let ns
-
-    try {
-      console.log('> Verifying nameservers…')
-      const res = await this.getNameservers(domain)
-      ns = res.nameservers
-    } catch (err) {
-      const err2 = new Error(
-        `Unable to fetch nameservers for ${chalk.underline(
-          chalk.bold(domain)
-        )}.`
-      )
-      err2.userError = true
-      throw err2
-    }
-
-    if (isZeitWorld(ns)) {
-      console.log(`> Verification ${chalk.bold('OK')}!`)
-      return this.setupDomain(domain)
-    }
-
-    if (this._debug) {
-      console.log(
-        `> [debug] Supplied domain "${domain}" has non-zeit nameservers`
-      )
-    }
-
-    const err3 = new Error(DNS_VERIFICATION_ERROR)
-    err3.userError = true
-    throw err3
+    return this.setupDomain(domain, { isExternal })
   }
 
   async status(name) {


### PR DESCRIPTION
When a domain is added with `now domains add` command it's often
because the user needs a working Zone file before changing the NS
records at the registrar or due to issues with the whois service.
Therefore the command is almost always run with `-f` flag.

Remove the `--force` option and always add send the domain add
request without client side verification.