### PR TITLE
Fix creating a new default certificate

### DIFF
--- a/src/providers/sh/util/certs.js
+++ b/src/providers/sh/util/certs.js
@@ -20,7 +20,7 @@ module.exports = class Certs extends Now {
   }
 
   create(cn, { overwrite }) {
-    return this.createCert(cn, { renew: true, overwriteCustom: overwrite })
+    return this.createCert(cn, { renew: overwrite, overwriteCustom: overwrite })
   }
 
   renew(cn) {


### PR DESCRIPTION
The commit 6e476ad45466e62a45d5ee1d34fcb0199337c646 broke
creating new certificates with `now certs create`.