### PR TITLE
Don't print the alias `uid` upon removal

### DIFF
--- a/src/providers/sh/commands/alias.js
+++ b/src/providers/sh/commands/alias.js
@@ -337,7 +337,7 @@ async function run({ token, sh: { currentTeam, user } }) {
         const elapsed = ms(new Date() - start)
         console.log(
           `${chalk.cyan('> Success!')} Alias ${chalk.bold(
-            _alias.uid
+            _alias.alias
           )} removed [${elapsed}]`
         )
       } catch (err) {
@@ -438,7 +438,6 @@ async function confirmDeploymentRemoval(alias, _alias) {
   const tbl = table(
     [
       [
-        _alias.uid,
         ...(_sourceUrl ? [_sourceUrl] : []),
         chalk.underline(_alias.alias),
         time


### PR DESCRIPTION
It's irrelevant information and now the uids are very long,
so let's not bother printing that information.