### PR TITLE
Fix many issues with `now teams` 

### DIFF
--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -79,7 +79,7 @@ const main = async ctx => {
   const isSwitch = argv._[0] && argv._[0] === 'switch'
 
   argv._ = argv._.slice(1)
-  subcommand = argv._[0]
+  subcommand = argv._.shift()
 
   if (isSwitch) {
     subcommand = 'switch'

--- a/src/providers/sh/commands/teams.js
+++ b/src/providers/sh/commands/teams.js
@@ -79,10 +79,11 @@ const main = async ctx => {
   const isSwitch = argv._[0] && argv._[0] === 'switch'
 
   argv._ = argv._.slice(1)
-  subcommand = argv._.shift()
 
   if (isSwitch) {
     subcommand = 'switch'
+  } else {
+    subcommand = argv._.shift()
   }
 
   if (argv.help || !subcommand) {

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -12,7 +12,6 @@ const { tick } = require('../../../../util/output/chars')
 const success = require('../../../../util/output/success')
 const cmd = require('../../../../util/output/cmd')
 const note = require('../../../../util/output/note')
-const uid = require('../../../../util/output/uid')
 const textInput = require('../../../../util/input/text')
 const invite = require('./invite')
 const {writeToConfigFile} = require('../../../../util/config-files')
@@ -85,7 +84,7 @@ module.exports = async function({ teams, config }) {
   } while (!team)
 
   process.stdout.write(eraseLines(2))
-  console.log(success(`Team created ${uid(team.id)} ${elapsed()}`))
+  console.log(success(`Team created ${elapsed()}`))
   console.log(chalk.cyan(`${tick} `) + teamUrlPrefix + slug + '\n')
 
   console.log(info('Pick a display name for your team'))

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -79,12 +79,12 @@ module.exports = async function({ teams, config }) {
       team = res
     } catch (err) {
       stopSpinner()
-      eraseLines(2)
+      process.stdout.write(eraseLines(2))
       console.error(error(err.message))
     }
   } while (!team)
 
-  eraseLines(2)
+  process.stdout.write(eraseLines(2))
   console.log(success(`Team created ${uid(team.id)} ${elapsed()}`))
   console.log(chalk.cyan(`${tick} `) + teamUrlPrefix + slug + '\n')
 
@@ -108,7 +108,7 @@ module.exports = async function({ teams, config }) {
   const res = await teams.edit({ id: team.id, name })
   stopSpinner()
 
-  eraseLines(2)
+  process.stdout.write(eraseLines(2))
   if (res.error) {
     console.error(error(res.error.message))
     console.log(`${chalk.red(`✖ ${teamNamePrefix}`)}${name}`)

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -48,9 +48,9 @@ module.exports = async function({ teams, config }) {
   let elapsed
   let stopSpinner
 
-  info(
+  console.log(info(
     `Pick a team identifier for its url (e.g.: ${chalk.cyan('`zeit.co/acme`')})`
-  )
+  ))
   do {
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -85,10 +85,10 @@ module.exports = async function({ teams, config }) {
   } while (!team)
 
   eraseLines(2)
-  success(`Team created ${uid(team.id)} ${elapsed()}`)
+  console.log(success(`Team created ${uid(team.id)} ${elapsed()}`))
   console.log(chalk.cyan(`${tick} `) + teamUrlPrefix + slug + '\n')
 
-  info('Pick a display name for your team')
+  console.log(info('Pick a display name for your team'))
   let name
   try {
     name = await textInput({
@@ -97,7 +97,7 @@ module.exports = async function({ teams, config }) {
     })
   } catch (err) {
     if (err.message === 'USER_ABORT') {
-      info('No name specified')
+      console.log(info('No name specified'))
       gracefulExit()
     } else {
       throw err
@@ -119,7 +119,7 @@ module.exports = async function({ teams, config }) {
 
   team = Object.assign(team, res)
 
-  success(`Team name saved ${elapsed()}`)
+  console.log(success(`Team name saved ${elapsed()}`))
   console.log(chalk.cyan(`${tick} `) + teamNamePrefix + team.name + '\n')
 
   stopSpinner = wait('Saving')

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -135,8 +135,8 @@ module.exports = async function({ teams, config }) {
     args: [],
     config,
     introMsg:
-      'Invite your team mates! When done, press enter on an empty field',
-    noopMsg: `You can invite team mates later by running ${cmd(
+      'Invite your teammates! When done, press enter on an empty field',
+    noopMsg: `You can invite teammates later by running ${cmd(
       'now teams invite'
     )}`
   })

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -23,6 +23,12 @@ const validateSlugKeypress = (data, value) => {
   return /^[a-zA-Z]+[a-zA-Z0-9_-]*$/.test(value + data)
 }
 
+const validateNameKeypress = (data, value) => (
+  // TODO: the `value` here should contain the current value + the keypress
+  // should be fixed on utils/input/text.js
+  /^[ a-zA-Z0-9_-]+$/.test(value + data)
+)
+
 const gracefulExit = () => {
   console.log() // Blank line
   note(
@@ -87,7 +93,7 @@ module.exports = async function({ teams, config }) {
   try {
     name = await textInput({
       label: `- ${teamNamePrefix}`,
-      validateValue: value => value.trim().length > 0
+      validateKeypress: validateNameKeypress
     })
   } catch (err) {
     if (err.message === 'USER_ABORT') {

--- a/src/providers/sh/commands/teams/add.js
+++ b/src/providers/sh/commands/teams/add.js
@@ -98,7 +98,7 @@ module.exports = async function({ teams, config }) {
   } catch (err) {
     if (err.message === 'USER_ABORT') {
       console.log(info('No name specified'))
-      gracefulExit()
+      return gracefulExit()
     } else {
       throw err
     }

--- a/src/providers/sh/commands/teams/invite.js
+++ b/src/providers/sh/commands/teams/invite.js
@@ -124,7 +124,7 @@ module.exports = async function(
         console.log(`${chalk.cyan(tick)} ${inviteUserPrefix}${email}`)
         if (hasError) {
           hasError = false
-          eraseLines(emails.length + 2)
+          process.stdout.write(eraseLines(emails.length + 2))
           console.log(info(
             introMsg ||
               `Inviting team members to ${chalk.bold(currentTeam.name)}`
@@ -135,7 +135,7 @@ module.exports = async function(
         }
       } catch (err) {
         stopSpinner()
-        eraseLines(emails.length + 2)
+        process.stdout.write(eraseLines(emails.length + 2))
         console.error(error(err.message))
         hasError = true
         for (const email of emails) {
@@ -145,7 +145,7 @@ module.exports = async function(
     }
   } while (email !== '')
 
-  eraseLines(emails.length + 2)
+  process.stdout.write(eraseLines(emails.length + 2))
 
   const n = emails.length
   if (emails.length === 0) {

--- a/src/providers/sh/commands/teams/invite.js
+++ b/src/providers/sh/commands/teams/invite.js
@@ -74,7 +74,7 @@ module.exports = async function(
     return fatalError(err)
   }
 
-  info(introMsg || `Inviting team members to ${chalk.bold(currentTeam.name)}`)
+  console.log(info(introMsg || `Inviting team members to ${chalk.bold(currentTeam.name)}`))
 
   if (args.length > 0) {
     for (const email of args) {
@@ -125,10 +125,10 @@ module.exports = async function(
         if (hasError) {
           hasError = false
           eraseLines(emails.length + 2)
-          info(
+          console.log(info(
             introMsg ||
               `Inviting team members to ${chalk.bold(currentTeam.name)}`
-          )
+          ))
           for (const email of emails) {
             console.log(`${chalk.cyan(tick)} ${inviteUserPrefix}${email}`)
           }
@@ -149,9 +149,9 @@ module.exports = async function(
 
   const n = emails.length
   if (emails.length === 0) {
-    info(noopMsg)
+    console.log(info(noopMsg))
   } else {
-    success(`Invited ${n} team mate${n > 1 ? 's' : ''}`)
+    console.log(success(`Invited ${n} team mate${n > 1 ? 's' : ''}`))
     for (const email of emails) {
       console.log(`${chalk.cyan(tick)} ${inviteUserPrefix}${email}`)
     }


### PR DESCRIPTION
Before:
```
▲ ~ now team invite
✖ invite [invalid]
▲ ~ 
```

After:
```
▲ ~ now team invite
> Inviting team members to ZEIT
- Invite User   <cursor here, interactive mode>
```

---

Before:
```
▲ ~ now team create
✔ Team URL      zeit.co/acme10

⠹ Team Name     !!!> Error! An unexpected error occurred in team: Error: The `name` must be composed only of letters, numbers, spaces, underscore or dash, and not be empty
    at retry (/Users/matheus/dev/zeit/now-cli/src/providers/sh/util/teams.js:71:19)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
⠙ Team Name     !!!^C
▲ ~ 
```

After:
It doesn't let you type non-allowed characters

---

Before:
```
▲ ~ now team create
✔ Team URL      zeit.co/acme-inc

✔ Team Name     Acme Inc

✔ Invite User   geist@zeit.co [1s]
✔ Invite User   geist@zeit.co [1s]

▲ ~ 
```

After:
```
▲ ~ now team create
> Success! Team created [1s]
✔ Team URL      zeit.co/acme-inc-2

> Success! Team name saved [260ms]
✔ Team Name     Acme

> Success! Invited 1 team mate
✔ Invite User   geist@zeit.co [1s]

▲ ~ 
```

---

Before:
```
▲ ~ now team create
✔ Team URL      zeit.co/acme-inc-3


✔ Team Name     Acme Inc 3


▲ ~ 
```
I hit `ctrl+c` when it asked me for the team name – it didn't quit, automatically set the team name and then I had to `ctrl+c` again

After:
```
▲ ~ now team create
> Success! Team created [1s]
✔ Team URL      zeit.co/acme-inc-4

> Pick a display name for your team
> No name specified

▲ ~ 
```