### PR TITLE
Perfected OSS confirmation prompt

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -656,9 +656,15 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
             return
           }
-
-          console.log(note(`You can use ${cmd('now --public')} to skip this prompt`))
         }
+
+        let url = 'https://zeit.co/account/plan'
+
+        if (currentTeam) {
+          url = `https://zeit.co/teams/${currentTeam.slug}/settings/plan`
+        }
+
+        console.log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
 
         wantsPublic = true
 

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -650,7 +650,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
               await exit(1)
             } else {
-              console.log(info('Aborted the deployment'))
+              console.log(info('Aborted'))
               await exit(0)
             }
 

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -665,7 +665,6 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         }
 
         console.log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
-
         wantsPublic = true
 
         sync({

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -301,13 +301,13 @@ async function main(ctx) {
   alwaysForwardNpm = config.forwardNpm
 
   try {
-    return sync({ token, config })
+    return sync({ token, config, showMessage: true })
   } catch (err) {
     await stopDeployment(err)
   }
 }
 
-async function sync({ token, config: { currentTeam, user } }) {
+async function sync({ token, config: { currentTeam, user }, showMessage }) {
   return new Promise(async (_resolve, reject) => {
     const start = Date.now()
     const rawPath = argv._[0]
@@ -374,10 +374,11 @@ async function sync({ token, config: { currentTeam, user } }) {
         message: err.message,
         slug: 'path-not-deployable'
       }))
+
       await exit(1)
     }
 
-    if (!quiet) {
+    if (!quiet && showMessage) {
       if (gitRepo.main) {
         const gitRef = gitRepo.ref ? ` at "${chalk.bold(gitRepo.ref)}" ` : ''
         console.log(
@@ -666,7 +667,8 @@ async function sync({ token, config: { currentTeam, user } }) {
           config: {
             currentTeam,
             user
-          }
+          },
+          showMessage: false
         })
 
         return

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -643,6 +643,14 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
             )
           }
 
+          let url = 'https://zeit.co/account/plan'
+
+          if (currentTeam) {
+            url = `https://zeit.co/teams/${currentTeam.slug}/settings/plan`
+          }
+
+          console.log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
+
           if (!proceed) {
             if (typeof proceed === 'undefined') {
               const message = `${story} If you agree with that, please run again with ${cmd('--public')}.`
@@ -658,13 +666,6 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           }
         }
 
-        let url = 'https://zeit.co/account/plan'
-
-        if (currentTeam) {
-          url = `https://zeit.co/teams/${currentTeam.slug}/settings/plan`
-        }
-
-        console.log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
         wantsPublic = true
 
         sync({

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -633,20 +633,25 @@ async function sync({ token, config: { currentTeam, user } }) {
           const who = currentTeam ? 'your team is' : 'you are'
           const story = `Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`
 
-          let proceed = false
+          let proceed
 
           if (isTTY) {
             proceed = await promptBool(
               `${story} Are you sure you want to proceed?`,
               { trailing: eraseLines(2) }
             )
-          } else {
-            console.log(info(`${story} If you agree with that, please run again with ${cmd('--public')}.`))
           }
 
           if (!proceed) {
-            console.log(info('Aborted the deployment'))
-            await exit(0)
+            if (typeof proceed === 'undefined') {
+              const message = `${story} If you agree with that, please run again with ${cmd('--public')}.`
+              console.error(error(message))
+
+              await exit(1)
+            } else {
+              console.log(info('Aborted the deployment'))
+              await exit(0)
+            }
 
             return
           }

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -312,14 +312,6 @@ async function sync({ token, config: { currentTeam, user } }) {
     const start = Date.now()
     const rawPath = argv._[0]
 
-    const nowPlans = new NowPlans({
-      apiUrl,
-      token,
-      debug,
-      currentTeam
-    })
-    const planPromise = nowPlans.getCurrent()
-
     try {
       await fs.stat(rawPath || path)
     } catch (err) {
@@ -590,6 +582,7 @@ async function sync({ token, config: { currentTeam, user } }) {
         )
 
       await now.create(path, createArgs)
+
       if (now.syncFileCount > 0) {
         await new Promise((resolve) => {
           if (debug && now.syncFileCount !== now.fileCount) {
@@ -635,7 +628,44 @@ async function sync({ token, config: { currentTeam, user } }) {
         await now.create(path, createArgs)
       }
     } catch (err) {
-      if (debug) {
+      if (err.code === 'plan_requires_public') {
+        if (!wantsPublic) {
+          const who = currentTeam ? 'your team is' : 'you are'
+          const story = `Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`
+
+          let proceed = false
+
+          if (isTTY) {
+            proceed = await promptBool(
+              `${story} Are you sure you want to proceed?`,
+              { trailing: eraseLines(2) }
+            )
+          } else {
+            console.log(info(`${story} If you agree with that, please run again with ${cmd('--public')}.`))
+          }
+
+          if (!proceed) {
+            console.log(info('Aborted the deployment'))
+            await exit(0)
+
+            return
+          }
+
+          console.log(note(`You can use ${cmd('now --public')} to skip this prompt`))
+        }
+
+        wantsPublic = true
+
+        sync({
+          token,
+          config: {
+            currentTeam,
+            user
+          }
+        })
+
+        return
+      } else if (debug) {
         console.log(`> [debug] error: ${err}\n${err.stack}`)
       }
 
@@ -667,48 +697,6 @@ async function sync({ token, config: { currentTeam, user } }) {
     }
 
     const startU = new Date()
-    const plan = await planPromise
-    if (plan.id === 'oss' && !wantsPublic) {
-      if (isTTY) {
-        console.log(
-          info(
-            `${chalk.bold(
-              (currentTeam && `${currentTeam.slug} is`) ||
-                `You (${user.username || user.email}) are`
-            )} on the OSS plan. Your code and logs will be made ${chalk.bold(
-              'public'
-            )}.`
-          )
-        )
-
-        const proceed = await promptBool(
-          'Are you sure you want to proceed with the deployment?',
-          { trailing: eraseLines(1) }
-        )
-
-        if (proceed) {
-          console.log(
-            note(`You can use ${cmd('now --public')} to skip this prompt`)
-          )
-        } else {
-          const stopSpinner = wait('Canceling deployment')
-          await now.remove(now.id, { hard: true })
-          stopSpinner()
-          console.log(
-            info(
-              'Deployment aborted. No files were synced.',
-              `  You can upgrade by running ${cmd('now upgrade')}.`
-            )
-          )
-          return 0
-        }
-      } else if (!wantsPublic) {
-        const msg =
-          '\nYou are on the OSS plan. Your code and logs will be made public.' +
-          ' If you agree with that, please run again with --public.'
-        await stopDeployment(msg)
-      }
-    }
 
     if (!quiet) {
       if (syncCount) {

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -127,6 +127,7 @@ module.exports = class Now extends EventEmitter {
       if (this._debug) {
         console.time('> [debug] get files ready for deployment')
       }
+
       const files = await Promise.all(
         Array.prototype.concat.apply(
           [],
@@ -158,9 +159,10 @@ module.exports = class Now extends EventEmitter {
       }
 
       if (this._debug) {
-        console.time('> [debug] v2/now/deployments')
+        console.time('> [debug] v3/now/deployments')
       }
-      const res = await this._fetch('/v2/now/deployments', {
+
+      const res = await this._fetch('/v3/now/deployments', {
         method: 'POST',
         body: {
           env,
@@ -178,11 +180,12 @@ module.exports = class Now extends EventEmitter {
       })
 
       if (this._debug) {
-        console.timeEnd('> [debug] v2/now/deployments')
+        console.timeEnd('> [debug] v3/now/deployments')
       }
 
       // No retry on 4xx
       let body
+
       try {
         body = await res.json()
       } catch (err) {
@@ -191,12 +194,16 @@ module.exports = class Now extends EventEmitter {
 
       if (res.status === 429) {
         let msg = `You reached your 20 deployments limit in the OSS plan.\n`
+
         msg += `${chalk.gray('>')} Please run ${chalk.gray('`')}${chalk.cyan(
           'now upgrade'
         )}${chalk.gray('`')} to proceed`
+
         const err = new Error(msg)
+
         err.status = res.status
         err.retryAfter = 'never'
+
         return bail(err)
       } else if (res.status === 400 && body.error && body.error.code === 'missing_files') {
         return body


### PR DESCRIPTION
Here's the new OSS confirmation prompt, which now directly uses the response from our deployment creation API – effectively avoiding another HTTP request.

Furthermore, it actually blocks the deployment process for teams or users on the OSS plan instead of deploying and then removing it if the user decides not to agree with the prompt (which is a huge security risk, because the deployment code is publicly accessible).

I also tested it on non-TTY. 🌷 