### PR TITLE
Split OSS confirmation into multiple lines

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -632,14 +632,14 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
       if (err.code === 'plan_requires_public') {
         if (!wantsPublic) {
           const who = currentTeam ? 'your team is' : 'you are'
-          const story = `Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`
-
           let proceed
+
+          console.log(info(`Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`))
 
           if (isTTY) {
             proceed = await promptBool(
-              `${story} Are you sure you want to proceed?`,
-              { trailing: eraseLines(2) }
+              'Are you sure you want to proceed?',
+              { trailing: eraseLines(1) }
             )
           }
 


### PR DESCRIPTION
To make it look like this:

<img width="788" alt="screen shot 2018-02-16 at 18 13 09" src="https://user-images.githubusercontent.com/6170607/36337172-3f6db894-1345-11e8-83d2-d35aaa56c5dc.png">

This ensures the message indicating that the logs and code will be public stays around all the time. Only the prompt gets erased after it was answered.