### PR TITLE
Corrected whitelisting mechanism for `now.json`

### DIFF
--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -24,6 +24,54 @@ const glob = async function(pattern, options) {
   })
 }
 
+const walkSync = async (dir, path, filelist = [], {debug=false}={}) => {
+	// console.log("AHA: ", dir)
+	// console.log(filelist)
+	const dirc = await readdir(asAbsolute(dir, path))
+	// console.log("WOAH: ",dirc)
+	for (let file of dirc) {
+		file = asAbsolute(file, dir)
+	//   console.log("fielname: ",file)
+	try{
+
+		const file_stat = await stat(file)
+		  filelist = file_stat.isDirectory()
+			? await walkSync(file, path, filelist)
+			: filelist.concat(file)
+	} catch(e) {
+		if (debug) {
+			console.log('> [debug] ignoring invalid file "%s"', file)
+		}
+	}
+    }
+    return filelist
+  }
+
+const getFilesInWhitelist = async function(whitelist, path, {debug=false}={}) {
+  let files = []
+
+  await Promise.all(whitelist.map(async file => {
+	file = asAbsolute(file, path)
+	// console.log(file)
+	try {
+		const file_stat = (await stat(file))
+		if (file_stat.isDirectory()){
+			const dir_files = await walkSync(file, path)
+			files.push(...dir_files)
+		} else {
+			files.push(file)
+		}
+	} catch(e) {
+		if (debug) {
+			console.log('> [debug] ignoring invalid file "%s"', file)
+		}
+	}
+
+  }))
+//   console.log(files)
+  return files
+}
+
 /**
  * Remove leading `./` from the beginning of ignores
  * because our parser doesn't like them :|
@@ -80,59 +128,64 @@ async function staticFiles(
   nowConfig = {},
   { limit = null, hasNowJson = false, debug = false } = {}
 ) {
-  const whitelist = nowConfig.files
-
-  // The package.json `files` whitelist still
-  // honors ignores: https://docs.npmjs.com/files/package.json#files
-  const search_ = Array.isArray(whitelist) ? whitelist : ['.']
-  // Convert all filenames into absolute paths
-  const search = Array.prototype.concat.apply(
-    [],
-    await Promise.all(
-      search_.map(file => glob(file, { cwd: path, absolute: true, dot: true }))
+  let files = []
+  if (nowConfig.files && Array.isArray(nowConfig.files)) {
+	files = await getFilesInWhitelist(nowConfig.files, path)
+  } else {
+    // The package.json `files` whitelist still
+    // honors ignores: https://docs.npmjs.com/files/package.json#files
+    const search_ = ['.']
+    // Convert all filenames into absolute paths
+    const search = Array.prototype.concat.apply(
+      [],
+      await Promise.all(
+        search_.map(file =>
+          glob(file, { cwd: path, absolute: true, dot: true })
+        )
+      )
     )
-  )
 
-  // Compile list of ignored patterns and files
-  const gitIgnore = await maybeRead(resolve(path, '.gitignore'))
+    // Compile list of ignored patterns and files
+    const gitIgnore = await maybeRead(resolve(path, '.gitignore'))
 
-  const filter = ignore()
-    .add(IGNORED + '\n' + clearRelative(gitIgnore))
-    .createFilter()
+    const filter = ignore()
+      .add(IGNORED + '\n' + clearRelative(gitIgnore))
+      .createFilter()
 
-  const prefixLength = path.length + 1
+    const prefixLength = path.length + 1
 
-  // The package.json `files` whitelist still
-  // honors npmignores: https://docs.npmjs.com/files/package.json#files
-  // but we don't ignore if the user is explicitly listing files
-  // under the now namespace, or using files in combination with gitignore
-  const accepts = file => {
-    const relativePath = file.substr(prefixLength)
+    // The package.json `files` whitelist still
+    // honors npmignores: https://docs.npmjs.com/files/package.json#files
+    // but we don't ignore if the user is explicitly listing files
+    // under the now namespace, or using files in combination with gitignore
+    const accepts = file => {
+      const relativePath = file.substr(prefixLength)
 
-    if (relativePath === '') {
-      return true
+      if (relativePath === '') {
+        return true
+      }
+
+      const accepted = filter(relativePath)
+      if (!accepted && debug) {
+        console.log('> [debug] ignoring "%s"', file)
+      }
+      return accepted
     }
 
-    const accepted = filter(relativePath)
-    if (!accepted && debug) {
-      console.log('> [debug] ignoring "%s"', file)
+    // Locate files
+    if (debug) {
+      console.time(`> [debug] locating files ${path}`)
     }
-    return accepted
-  }
 
-  // Locate files
-  if (debug) {
-    console.time(`> [debug] locating files ${path}`)
-  }
+    files = await explode(search, {
+      accepts,
+      limit,
+      debug
+    })
 
-  const files = await explode(search, {
-    accepts,
-    limit,
-    debug
-  })
-
-  if (debug) {
-    console.timeEnd(`> [debug] locating files ${path}`)
+    if (debug) {
+      console.timeEnd(`> [debug] locating files ${path}`)
+    }
   }
 
   if (hasNowJson) {
@@ -163,68 +216,77 @@ async function npm(
   { limit = null, hasNowJson = false, debug = false } = {}
 ) {
   const whitelist = nowConfig.files || pkg.files || (pkg.now && pkg.now.files)
+  let files = []
 
-  // The package.json `files` whitelist still
-  // honors ignores: https://docs.npmjs.com/files/package.json#files
-  const search_ = whitelist || ['.']
-  // Convert all filenames into absolute paths
-  const search = Array.prototype.concat.apply(
-    [],
-    await Promise.all(
-      search_.map(file => glob(file, { cwd: path, absolute: true, dot: true }))
+  if (whitelist) {
+	files = await getFilesInWhitelist(whitelist, path)
+  } else {
+    // The package.json `files` whitelist still
+    // honors ignores: https://docs.npmjs.com/files/package.json#files
+    const search_ = ['.']
+    // Convert all filenames into absolute paths
+    const search = Array.prototype.concat.apply(
+      [],
+      await Promise.all(
+        search_.map(file =>
+          glob(file, { cwd: path, absolute: true, dot: true })
+        )
+      )
     )
-  )
 
-  // Compile list of ignored patterns and files
-  const npmIgnore = await maybeRead(resolve(path, '.npmignore'), null)
-  const gitIgnore =
-    npmIgnore === null ? await maybeRead(resolve(path, '.gitignore')) : null
+    // Compile list of ignored patterns and files
+    const npmIgnore = await maybeRead(resolve(path, '.npmignore'), null)
+    const gitIgnore =
+      npmIgnore === null ? await maybeRead(resolve(path, '.gitignore')) : null
 
-  const filter = ignore()
-    .add(
-      IGNORED + '\n' + clearRelative(npmIgnore === null ? gitIgnore : npmIgnore)
-    )
-    .createFilter()
+    const filter = ignore()
+      .add(
+        IGNORED +
+          '\n' +
+          clearRelative(npmIgnore === null ? gitIgnore : npmIgnore)
+      )
+      .createFilter()
 
-  const prefixLength = path.length + 1
+    const prefixLength = path.length + 1
 
-  // The package.json `files` whitelist still
-  // honors npmignores: https://docs.npmjs.com/files/package.json#files
-  // but we don't ignore if the user is explicitly listing files
-  // under the now namespace, or using files in combination with gitignore
-  const overrideIgnores =
-    (pkg.now && pkg.now.files) ||
-    nowConfig.files ||
-    (gitIgnore !== null && pkg.files)
-  const accepts = overrideIgnores
-    ? () => true
-    : file => {
-        const relativePath = file.substr(prefixLength)
+    // The package.json `files` whitelist still
+    // honors npmignores: https://docs.npmjs.com/files/package.json#files
+    // but we don't ignore if the user is explicitly listing files
+    // under the now namespace, or using files in combination with gitignore
+    const overrideIgnores =
+      (pkg.now && pkg.now.files) ||
+      nowConfig.files ||
+      (gitIgnore !== null && pkg.files)
+    const accepts = overrideIgnores
+      ? () => true
+      : file => {
+          const relativePath = file.substr(prefixLength)
 
-        if (relativePath === '') {
-          return true
+          if (relativePath === '') {
+            return true
+          }
+
+          const accepted = filter(relativePath)
+          if (!accepted && debug) {
+            console.log('> [debug] ignoring "%s"', file)
+          }
+          return accepted
         }
 
-        const accepted = filter(relativePath)
-        if (!accepted && debug) {
-          console.log('> [debug] ignoring "%s"', file)
-        }
-        return accepted
-      }
+    // Locate files
+    if (debug) {
+      console.time(`> [debug] locating files ${path}`)
+    }
 
-  // Locate files
-  if (debug) {
-    console.time(`> [debug] locating files ${path}`)
-  }
+    files = await explode(search, {
+      accepts,
+      limit,
+      debug
+    })
 
-  const files = await explode(search, {
-    accepts,
-    limit,
-    debug
-  })
-
-  if (debug) {
-    console.timeEnd(`> [debug] locating files ${path}`)
+    if (debug) {
+      console.timeEnd(`> [debug] locating files ${path}`)
+    }
   }
 
   // Always include manifest as npm does not allow ignoring it
@@ -257,64 +319,66 @@ async function docker(
   nowConfig = {},
   { limit = null, hasNowJson = false, debug = false } = {}
 ) {
-  const whitelist = nowConfig.files
+  let files = []
 
-  // Base search path
-  // the now.json `files` whitelist still
-  // honors ignores: https://docs.npmjs.com/files/package.json#files
-  const search_ = whitelist || ['.']
+  if (nowConfig.files) {
+	files = await getFilesInWhitelist(nowConfig.files, path)
+  } else {
+    // Base search path
+    // the now.json `files` whitelist still
+    // honors ignores: https://docs.npmjs.com/files/package.json#files
+    const search_ = ['.']
 
-  // Convert all filenames into absolute paths
-  const search = search_.map(file => asAbsolute(file, path))
+    // Convert all filenames into absolute paths
+    const search = search_.map(file => asAbsolute(file, path))
 
-  // Compile list of ignored patterns and files
-  const dockerIgnore = await maybeRead(resolve(path, '.dockerignore'), null)
+    // Compile list of ignored patterns and files
+    const dockerIgnore = await maybeRead(resolve(path, '.dockerignore'), null)
 
-  const filter = ignore()
-    .add(
-      IGNORED +
-        '\n' +
-        clearRelative(
-          dockerIgnore === null
-            ? await maybeRead(resolve(path, '.gitignore'))
-            : dockerIgnore
-        )
+    const ignoredFiles = clearRelative(
+      dockerIgnore === null
+        ? await maybeRead(resolve(path, '.gitignore'))
+        : dockerIgnore
     )
-    .createFilter()
 
-  const prefixLength = path.length + 1
-  const accepts = function(file) {
-    const relativePath = file.substr(prefixLength)
+    const filter = ignore()
+      .add(IGNORED + '\n' + ignoredFiles)
+      .createFilter()
 
-    if (relativePath === '') {
-      return true
+    const prefixLength = path.length + 1
+    const accepts = function(file) {
+      const relativePath = file.substr(prefixLength)
+
+      if (relativePath === '') {
+        return true
+      }
+
+      const accepted = filter(relativePath)
+      if (!accepted && debug) {
+        console.log('> [debug] ignoring "%s"', file)
+      }
+      return accepted
     }
 
-    const accepted = filter(relativePath)
-    if (!accepted && debug) {
-      console.log('> [debug] ignoring "%s"', file)
+    // Locate files
+    if (debug) {
+      console.time(`> [debug] locating files ${path}`)
     }
-    return accepted
+
+    files = await explode(search, { accepts, limit, debug })
+
+    if (debug) {
+      console.timeEnd(`> [debug] locating files ${path}`)
+    }
   }
 
-  // Locate files
-  if (debug) {
-    console.time(`> [debug] locating files ${path}`)
-  }
-
-  const files = await explode(search, { accepts, limit, debug })
-
-  if (debug) {
-    console.timeEnd(`> [debug] locating files ${path}`)
+  if (hasNowJson) {
+    files.push(asAbsolute(getLocalConfigPath(path), path))
   }
 
   // Always include manifest as npm does not allow ignoring it
   // source: https://docs.npmjs.com/files/package.json#files
   files.push(asAbsolute('Dockerfile', path))
-
-  if (hasNowJson) {
-    files.push(asAbsolute(getLocalConfigPath(path), path))
-  }
 
   // Get files
   return uniqueStrings(files)

--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -25,17 +25,12 @@ const glob = async function(pattern, options) {
 }
 
 const walkSync = async (dir, path, filelist = [], {debug=false}={}) => {
-	// console.log("AHA: ", dir)
-	// console.log(filelist)
 	const dirc = await readdir(asAbsolute(dir, path))
-	// console.log("WOAH: ",dirc)
 	for (let file of dirc) {
 		file = asAbsolute(file, dir)
-	//   console.log("fielname: ",file)
 	try{
-
 		const file_stat = await stat(file)
-		  filelist = file_stat.isDirectory()
+		filelist = file_stat.isDirectory()
 			? await walkSync(file, path, filelist)
 			: filelist.concat(file)
 	} catch(e) {

--- a/test/_fixtures/files-in-package-ignore/.npmignore
+++ b/test/_fixtures/files-in-package-ignore/.npmignore
@@ -1,2 +1,2 @@
 should-be-excluded.js
-./build/a/should-be-excluded.js
+./build/a/should-be-included.js

--- a/test/_fixtures/files-overrides-gitignore/test.json
+++ b/test/_fixtures/files-overrides-gitignore/test.json
@@ -1,3 +1,3 @@
 {
-	"Teapot": true
+  "Teapot": true
 }

--- a/test/_fixtures/files-overrides-gitignore/test.json
+++ b/test/_fixtures/files-overrides-gitignore/test.json
@@ -1,0 +1,3 @@
+{
+	"Teapot": true
+}

--- a/test/_fixtures/now-json-docker-dockerignore-override/.dockerignore
+++ b/test/_fixtures/now-json-docker-dockerignore-override/.dockerignore
@@ -1,0 +1,4 @@
+a.js
+b.js
+c.js
+build/

--- a/test/_fixtures/now-json-docker-dockerignore-override/.gitignore
+++ b/test/_fixtures/now-json-docker-dockerignore-override/.gitignore
@@ -1,0 +1,2 @@
+a.js
+build/

--- a/test/_fixtures/now-json-docker-dockerignore-override/Dockerfile
+++ b/test/_fixtures/now-json-docker-dockerignore-override/Dockerfile
@@ -1,0 +1,1 @@
+CMD echo 'world'

--- a/test/_fixtures/now-json-docker-dockerignore-override/a.js
+++ b/test/_fixtures/now-json-docker-dockerignore-override/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-dockerignore-override/b.js
+++ b/test/_fixtures/now-json-docker-dockerignore-override/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-dockerignore-override/build/a/c.js
+++ b/test/_fixtures/now-json-docker-dockerignore-override/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-dockerignore-override/now.json
+++ b/test/_fixtures/now-json-docker-dockerignore-override/now.json
@@ -1,0 +1,8 @@
+{
+  "files": [
+	"b.js",
+	"a.js",
+	"c.js",
+	"build"
+  ]
+}

--- a/test/_fixtures/now-json-docker-dockerignore-override/now.json
+++ b/test/_fixtures/now-json-docker-dockerignore-override/now.json
@@ -1,8 +1,8 @@
 {
   "files": [
-	"b.js",
-	"a.js",
-	"c.js",
-	"build"
+    "b.js",
+    "a.js",
+    "c.js",
+    "build"
   ]
 }

--- a/test/_fixtures/now-json-docker-gitignore-override/.gitignore
+++ b/test/_fixtures/now-json-docker-gitignore-override/.gitignore
@@ -1,0 +1,3 @@
+a.js
+b.js
+build/

--- a/test/_fixtures/now-json-docker-gitignore-override/Dockerfile
+++ b/test/_fixtures/now-json-docker-gitignore-override/Dockerfile
@@ -1,0 +1,1 @@
+CMD echo 'world'

--- a/test/_fixtures/now-json-docker-gitignore-override/a.js
+++ b/test/_fixtures/now-json-docker-gitignore-override/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-gitignore-override/b.js
+++ b/test/_fixtures/now-json-docker-gitignore-override/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-gitignore-override/build/a/c.js
+++ b/test/_fixtures/now-json-docker-gitignore-override/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-docker-gitignore-override/now.json
+++ b/test/_fixtures/now-json-docker-gitignore-override/now.json
@@ -1,7 +1,7 @@
 {
   "files": [
-	"b.js",
-	"a.js",
-	"build"
+    "b.js",
+    "a.js",
+    "build"
   ]
 }

--- a/test/_fixtures/now-json-docker-gitignore-override/now.json
+++ b/test/_fixtures/now-json-docker-gitignore-override/now.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+	"b.js",
+	"a.js",
+	"build"
+  ]
+}

--- a/test/_fixtures/now-json-npm-gitignore-override/.gitignore
+++ b/test/_fixtures/now-json-npm-gitignore-override/.gitignore
@@ -1,0 +1,3 @@
+a.js
+b.js
+build/

--- a/test/_fixtures/now-json-npm-gitignore-override/a.js
+++ b/test/_fixtures/now-json-npm-gitignore-override/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-gitignore-override/b.js
+++ b/test/_fixtures/now-json-npm-gitignore-override/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-gitignore-override/build/a/c.js
+++ b/test/_fixtures/now-json-npm-gitignore-override/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-gitignore-override/now.json
+++ b/test/_fixtures/now-json-npm-gitignore-override/now.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+	"b.js",
+	"a.js",
+	"build"
+  ]
+}

--- a/test/_fixtures/now-json-npm-gitignore-override/now.json
+++ b/test/_fixtures/now-json-npm-gitignore-override/now.json
@@ -1,7 +1,7 @@
 {
   "files": [
-	  "b.js",
-	  "a.js",
-	  "build"
+    "b.js",
+    "a.js",
+    "build"
   ]
 }

--- a/test/_fixtures/now-json-npm-gitignore-override/now.json
+++ b/test/_fixtures/now-json-npm-gitignore-override/now.json
@@ -1,7 +1,7 @@
 {
   "files": [
-	"b.js",
-	"a.js",
-	"build"
+	  "b.js",
+	  "a.js",
+	  "build"
   ]
 }

--- a/test/_fixtures/now-json-npm-gitignore-override/package.json
+++ b/test/_fixtures/now-json-npm-gitignore-override/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "now-json-npm-gitignore-override"
+}

--- a/test/_fixtures/now-json-npm-gitignore-override/package.json
+++ b/test/_fixtures/now-json-npm-gitignore-override/package.json
@@ -1,3 +1,3 @@
 {
-	"name": "now-json-npm-gitignore-override"
+  "name": "now-json-npm-gitignore-override"
 }

--- a/test/_fixtures/now-json-npm-npmignore-override/.gitignore
+++ b/test/_fixtures/now-json-npm-npmignore-override/.gitignore
@@ -1,0 +1,3 @@
+a.js
+b.js
+build/

--- a/test/_fixtures/now-json-npm-npmignore-override/.npmignore
+++ b/test/_fixtures/now-json-npm-npmignore-override/.npmignore
@@ -1,0 +1,4 @@
+a.js
+b.js
+c.js
+build/

--- a/test/_fixtures/now-json-npm-npmignore-override/a.js
+++ b/test/_fixtures/now-json-npm-npmignore-override/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-npmignore-override/b.js
+++ b/test/_fixtures/now-json-npm-npmignore-override/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-npmignore-override/build/a/c.js
+++ b/test/_fixtures/now-json-npm-npmignore-override/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-npmignore-override/c.js
+++ b/test/_fixtures/now-json-npm-npmignore-override/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-npm-npmignore-override/now.json
+++ b/test/_fixtures/now-json-npm-npmignore-override/now.json
@@ -1,0 +1,8 @@
+{
+  "files": [
+	"b.js",
+	"a.js",
+	"c.js",
+	"build"
+  ]
+}

--- a/test/_fixtures/now-json-npm-npmignore-override/now.json
+++ b/test/_fixtures/now-json-npm-npmignore-override/now.json
@@ -1,8 +1,8 @@
 {
   "files": [
-	  "b.js",
-  	"a.js",
-	  "c.js",
-  	"build"
+    "b.js",
+    "a.js",
+    "c.js",
+    "build"
   ]
 }

--- a/test/_fixtures/now-json-npm-npmignore-override/now.json
+++ b/test/_fixtures/now-json-npm-npmignore-override/now.json
@@ -1,8 +1,8 @@
 {
   "files": [
-	"b.js",
-	"a.js",
-	"c.js",
-	"build"
+	  "b.js",
+  	"a.js",
+	  "c.js",
+  	"build"
   ]
 }

--- a/test/_fixtures/now-json-npm-npmignore-override/package.json
+++ b/test/_fixtures/now-json-npm-npmignore-override/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "now-json-npm-gitignore-override"
+}

--- a/test/_fixtures/now-json-npm-npmignore-override/package.json
+++ b/test/_fixtures/now-json-npm-npmignore-override/package.json
@@ -1,3 +1,3 @@
 {
-	"name": "now-json-npm-gitignore-override"
+  "name": "now-json-npm-gitignore-override"
 }

--- a/test/_fixtures/now-json-static-gitignore-override/.gitignore
+++ b/test/_fixtures/now-json-static-gitignore-override/.gitignore
@@ -1,0 +1,3 @@
+a.js
+b.js
+build/

--- a/test/_fixtures/now-json-static-gitignore-override/a.js
+++ b/test/_fixtures/now-json-static-gitignore-override/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-static-gitignore-override/b.js
+++ b/test/_fixtures/now-json-static-gitignore-override/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-static-gitignore-override/build/a/c.js
+++ b/test/_fixtures/now-json-static-gitignore-override/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/_fixtures/now-json-static-gitignore-override/now.json
+++ b/test/_fixtures/now-json-static-gitignore-override/now.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+	"b.js",
+	"a.js",
+	"build"
+  ]
+}

--- a/test/_fixtures/now-json-static-gitignore-override/now.json
+++ b/test/_fixtures/now-json-static-gitignore-override/now.json
@@ -1,7 +1,7 @@
 {
   "files": [
-	  "b.js",
-	  "a.js",
-	  "build"
+    "b.js",
+    "a.js",
+    "build"
   ]
 }

--- a/test/_fixtures/now-json-static-gitignore-override/now.json
+++ b/test/_fixtures/now-json-static-gitignore-override/now.json
@@ -1,7 +1,7 @@
 {
   "files": [
-	"b.js",
-	"a.js",
-	"build"
+	  "b.js",
+	  "a.js",
+	  "build"
   ]
 }

--- a/test/_fixtures/now-json-static-gitignore-override/package.json
+++ b/test/_fixtures/now-json-static-gitignore-override/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "now-json-npm-gitignore-override"
+}

--- a/test/_fixtures/now-json-static-gitignore-override/package.json
+++ b/test/_fixtures/now-json-static-gitignore-override/package.json
@@ -1,3 +1,3 @@
 {
-	"name": "now-json-npm-gitignore-override"
+  "name": "now-json-npm-gitignore-override"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,9 +8,12 @@ const { asc: alpha } = require('alpha-sort')
 // Utilities
 const hash = require('../src/providers/sh/util/hash')
 const readMetadata = require('../src/providers/sh/util/read-metadata')
+const getLocalConfigPath = require('../src/config/local-path')	
+const loadJSON = require('load-json-file')
 const {
   npm: getNpmFiles_,
-  docker: getDockerFiles
+  docker: getDockerFiles_,
+  staticFiles: getStaticFiles_
 } = require('../src/providers/sh/util/get-files')
 
 const prefix = join(__dirname, '_fixtures') + '/'
@@ -25,6 +28,24 @@ const getNpmFiles = async dir => {
   })
 
   return getNpmFiles_(dir, pkg, nowConfig, { hasNowJson })
+}
+
+const getDockerFiles = async dir => {
+	const { nowConfig, hasNowJson } = await readMetadata(dir, {
+		quiet: true,
+		strict: false
+	})
+
+	return getDockerFiles_(dir, nowConfig, { hasNowJson })
+}
+
+const getStaticFiles = async dir => {
+	const { nowConfig, hasNowJson } = await readMetadata(dir, {
+		quiet: true,
+		strict: false
+	})
+
+	return getStaticFiles_(dir, nowConfig, { hasNowJson })
 }
 
 test('`files`', async t => {
@@ -51,9 +72,76 @@ test('`files` overrides `.gitignore`', async t => {
   let files = await getNpmFiles(fixture('files-overrides-gitignore'))
   files = files.sort(alpha)
 
-  t.is(files.length, 2)
+  t.is(files.length, 3)
   t.is(base(files[0]), 'files-overrides-gitignore/package.json')
   t.is(base(files[1]), 'files-overrides-gitignore/test.js')
+  t.is(base(files[2]), 'files-overrides-gitignore/test.json')
+})
+
+test('`now.files` overrides `.gitignore` in Docker', async t => {
+	const path = 'now-json-docker-gitignore-override'
+	let files = await getDockerFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
+	files = files.sort(alpha)
+
+	t.is(files.length, 5)
+	t.is(base(files[0]), `${path}/Dockerfile`)
+	t.is(base(files[1]), `${path}/a.js`)
+	t.is(base(files[2]), `${path}/b.js`)
+	t.is(base(files[3]), `${path}/build/a/c.js`)
+	t.is(base(files[4]), `${path}/now.json`)
+})
+
+test('`now.files` overrides `.dockerignore` in Docker', async t => {
+	const path = 'now-json-docker-dockerignore-override'
+	let files = await getDockerFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
+	files = files.sort(alpha)
+
+	t.is(files.length, 6)
+	t.is(base(files[0]), `${path}/Dockerfile`)
+	t.is(base(files[1]), `${path}/a.js`)
+	t.is(base(files[2]), `${path}/b.js`)
+	t.is(base(files[3]), `${path}/build/a/c.js`)
+	t.is(base(files[4]), `${path}/c.js`)
+	t.is(base(files[5]), `${path}/now.json`)
+})
+
+test('`now.files` overrides `.gitignore` in Node', async t => {
+	const path = 'now-json-npm-gitignore-override'
+	let files = await getNpmFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
+	files = files.sort(alpha)
+
+	t.is(files.length, 5)
+	t.is(base(files[0]), `${path}/a.js`)
+	t.is(base(files[1]), `${path}/b.js`)
+	t.is(base(files[2]), `${path}/build/a/c.js`)
+	t.is(base(files[3]), `${path}/now.json`)
+	t.is(base(files[4]), `${path}/package.json`)
+})
+
+test('`now.files` overrides `.npmignore` in Node', async t => {
+	const path = 'now-json-npm-npmignore-override'
+	let files = await getNpmFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
+	files = files.sort(alpha)
+
+	t.is(files.length, 6)
+	t.is(base(files[0]), `${path}/a.js`)
+	t.is(base(files[1]), `${path}/b.js`)
+	t.is(base(files[2]), `${path}/build/a/c.js`)
+	t.is(base(files[3]), `${path}/c.js`)
+	t.is(base(files[4]), `${path}/now.json`)
+	t.is(base(files[5]), `${path}/package.json`)
+})
+
+test('`now.files` overrides `.gitignore` in Static', async t => {
+	const path = 'now-json-static-gitignore-override'
+	let files = await getStaticFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
+	files = files.sort(alpha)
+
+	t.is(files.length, 4)
+	t.is(base(files[0]), `${path}/a.js`)
+	t.is(base(files[1]), `${path}/b.js`)
+	t.is(base(files[2]), `${path}/build/a/c.js`)
+	t.is(base(files[3]), `${path}/now.json`)
 })
 
 test('`now.files` overrides `.npmignore`', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ const { asc: alpha } = require('alpha-sort')
 // Utilities
 const hash = require('../src/providers/sh/util/hash')
 const readMetadata = require('../src/providers/sh/util/read-metadata')
-const getLocalConfigPath = require('../src/config/local-path')	
+const getLocalConfigPath = require('../src/config/local-path')
 const loadJSON = require('load-json-file')
 const {
   npm: getNpmFiles_,
@@ -31,21 +31,21 @@ const getNpmFiles = async dir => {
 }
 
 const getDockerFiles = async dir => {
-	const { nowConfig, hasNowJson } = await readMetadata(dir, {
-		quiet: true,
-		strict: false
-	})
+  const { nowConfig, hasNowJson } = await readMetadata(dir, {
+    quiet: true,
+    strict: false
+  })
 
-	return getDockerFiles_(dir, nowConfig, { hasNowJson })
+  return getDockerFiles_(dir, nowConfig, { hasNowJson })
 }
 
 const getStaticFiles = async dir => {
-	const { nowConfig, hasNowJson } = await readMetadata(dir, {
-		quiet: true,
-		strict: false
-	})
+  const { nowConfig, hasNowJson } = await readMetadata(dir, {
+    quiet: true,
+    strict: false
+  })
 
-	return getStaticFiles_(dir, nowConfig, { hasNowJson })
+  return getStaticFiles_(dir, nowConfig, { hasNowJson })
 }
 
 test('`files`', async t => {
@@ -79,69 +79,84 @@ test('`files` overrides `.gitignore`', async t => {
 })
 
 test('`now.files` overrides `.gitignore` in Docker', async t => {
-	const path = 'now-json-docker-gitignore-override'
-	let files = await getDockerFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
-	files = files.sort(alpha)
+  const path = 'now-json-docker-gitignore-override'
+  let files = await getDockerFiles(
+    fixture(path),
+    await loadJSON(getLocalConfigPath(fixture(path)))
+  )
+  files = files.sort(alpha)
 
-	t.is(files.length, 5)
-	t.is(base(files[0]), `${path}/Dockerfile`)
-	t.is(base(files[1]), `${path}/a.js`)
-	t.is(base(files[2]), `${path}/b.js`)
-	t.is(base(files[3]), `${path}/build/a/c.js`)
-	t.is(base(files[4]), `${path}/now.json`)
+  t.is(files.length, 5)
+  t.is(base(files[0]), `${path}/Dockerfile`)
+  t.is(base(files[1]), `${path}/a.js`)
+  t.is(base(files[2]), `${path}/b.js`)
+  t.is(base(files[3]), `${path}/build/a/c.js`)
+  t.is(base(files[4]), `${path}/now.json`)
 })
 
 test('`now.files` overrides `.dockerignore` in Docker', async t => {
-	const path = 'now-json-docker-dockerignore-override'
-	let files = await getDockerFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
-	files = files.sort(alpha)
+  const path = 'now-json-docker-dockerignore-override'
+  let files = await getDockerFiles(
+    fixture(path),
+    await loadJSON(getLocalConfigPath(fixture(path)))
+  )
+  files = files.sort(alpha)
 
-	t.is(files.length, 6)
-	t.is(base(files[0]), `${path}/Dockerfile`)
-	t.is(base(files[1]), `${path}/a.js`)
-	t.is(base(files[2]), `${path}/b.js`)
-	t.is(base(files[3]), `${path}/build/a/c.js`)
-	t.is(base(files[4]), `${path}/c.js`)
-	t.is(base(files[5]), `${path}/now.json`)
+  t.is(files.length, 6)
+  t.is(base(files[0]), `${path}/Dockerfile`)
+  t.is(base(files[1]), `${path}/a.js`)
+  t.is(base(files[2]), `${path}/b.js`)
+  t.is(base(files[3]), `${path}/build/a/c.js`)
+  t.is(base(files[4]), `${path}/c.js`)
+  t.is(base(files[5]), `${path}/now.json`)
 })
 
 test('`now.files` overrides `.gitignore` in Node', async t => {
-	const path = 'now-json-npm-gitignore-override'
-	let files = await getNpmFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
-	files = files.sort(alpha)
+  const path = 'now-json-npm-gitignore-override'
+  let files = await getNpmFiles(
+    fixture(path),
+    await loadJSON(getLocalConfigPath(fixture(path)))
+  )
+  files = files.sort(alpha)
 
-	t.is(files.length, 5)
-	t.is(base(files[0]), `${path}/a.js`)
-	t.is(base(files[1]), `${path}/b.js`)
-	t.is(base(files[2]), `${path}/build/a/c.js`)
-	t.is(base(files[3]), `${path}/now.json`)
-	t.is(base(files[4]), `${path}/package.json`)
+  t.is(files.length, 5)
+  t.is(base(files[0]), `${path}/a.js`)
+  t.is(base(files[1]), `${path}/b.js`)
+  t.is(base(files[2]), `${path}/build/a/c.js`)
+  t.is(base(files[3]), `${path}/now.json`)
+  t.is(base(files[4]), `${path}/package.json`)
 })
 
 test('`now.files` overrides `.npmignore` in Node', async t => {
-	const path = 'now-json-npm-npmignore-override'
-	let files = await getNpmFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
-	files = files.sort(alpha)
+  const path = 'now-json-npm-npmignore-override'
+  let files = await getNpmFiles(
+    fixture(path),
+    await loadJSON(getLocalConfigPath(fixture(path)))
+  )
+  files = files.sort(alpha)
 
-	t.is(files.length, 6)
-	t.is(base(files[0]), `${path}/a.js`)
-	t.is(base(files[1]), `${path}/b.js`)
-	t.is(base(files[2]), `${path}/build/a/c.js`)
-	t.is(base(files[3]), `${path}/c.js`)
-	t.is(base(files[4]), `${path}/now.json`)
-	t.is(base(files[5]), `${path}/package.json`)
+  t.is(files.length, 6)
+  t.is(base(files[0]), `${path}/a.js`)
+  t.is(base(files[1]), `${path}/b.js`)
+  t.is(base(files[2]), `${path}/build/a/c.js`)
+  t.is(base(files[3]), `${path}/c.js`)
+  t.is(base(files[4]), `${path}/now.json`)
+  t.is(base(files[5]), `${path}/package.json`)
 })
 
 test('`now.files` overrides `.gitignore` in Static', async t => {
-	const path = 'now-json-static-gitignore-override'
-	let files = await getStaticFiles(fixture(path), await loadJSON(getLocalConfigPath(fixture(path))))
-	files = files.sort(alpha)
+  const path = 'now-json-static-gitignore-override'
+  let files = await getStaticFiles(
+    fixture(path),
+    await loadJSON(getLocalConfigPath(fixture(path)))
+  )
+  files = files.sort(alpha)
 
-	t.is(files.length, 4)
-	t.is(base(files[0]), `${path}/a.js`)
-	t.is(base(files[1]), `${path}/b.js`)
-	t.is(base(files[2]), `${path}/build/a/c.js`)
-	t.is(base(files[3]), `${path}/now.json`)
+  t.is(files.length, 4)
+  t.is(base(files[0]), `${path}/a.js`)
+  t.is(base(files[1]), `${path}/b.js`)
+  t.is(base(files[2]), `${path}/build/a/c.js`)
+  t.is(base(files[3]), `${path}/now.json`)
 })
 
 test('`now.files` overrides `.npmignore`', async t => {
@@ -333,10 +348,15 @@ test('support `package.json:now.type` to bypass multiple manifests error', async
 })
 
 test('friendly error for malformed JSON', async t => {
-  const err = await t.throws(readMetadata(fixture('json-syntax-error'), {
-    quiet: true,
-    strict: false
-  }))
+  const err = await t.throws(
+    readMetadata(fixture('json-syntax-error'), {
+      quiet: true,
+      strict: false
+    })
+  )
   t.is(err.name, 'JSONError')
-  t.is(err.message, 'Unexpected token \'o\' at 2:5 in test/_fixtures/json-syntax-error/package.json\n    oops\n    ^')
+  t.is(
+    err.message,
+    "Unexpected token 'o' at 2:5 in test/_fixtures/json-syntax-error/package.json\n    oops\n    ^"
+  )
 })

--- a/test/index.js
+++ b/test/index.js
@@ -40,10 +40,11 @@ test('`files` + `.*.swp` + `.npmignore`', async t => {
   let files = await getNpmFiles(fixture('files-in-package-ignore'))
   files = files.sort(alpha)
 
-  t.is(files.length, 3)
+  t.is(files.length, 4)
   t.is(base(files[0]), 'files-in-package-ignore/build/a/b/c/d.js')
   t.is(base(files[1]), 'files-in-package-ignore/build/a/e.js')
-  t.is(base(files[2]), 'files-in-package-ignore/package.json')
+  t.is(base(files[2]), 'files-in-package-ignore/build/a/should-be-included.js')
+  t.is(base(files[3]), 'files-in-package-ignore/package.json')
 })
 
 test('`files` overrides `.gitignore`', async t => {


### PR DESCRIPTION
I'v written what I believe to a be a solution to several different issues raised with how now handles files specifically added in the `now.json` file. Currently if a file or directory is mentioned in any `.ignore` file it is ignored from the deployment even if it is specifically mentioned as a required file in `now.json`. This PR changes how files are added to a deployment by checking if a file attribute exists in `now.json` and if so it uses the list of files and directories to create a list of files to upload to the specified deployment.

There are several reasons why this can be a good idea. For example if you want to ignore config files in your repo using a `.gitignore`, `.dockerignore`, `.npmignore`, or you want to ignore compiled binaries but have them uploaded to your deployment.

This PR fixes #717, fixes #273, fixes #742 and fixes #157. It even closes #597, because this PR basically provides a workaround.