### PR TITLE
Display confirmation message before adding a domain

### DIFF
--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -233,6 +233,10 @@ async function run({ token, sh: { currentTeam, user } }) {
       }
       const name = String(args[0])
 
+      if (!await promptBool(`Are you sure you want to add "${name}"?`)) {
+        return exit(1)
+      }
+
       const parsedDomain = psl.parse(name)
       if (parsedDomain.subdomain) {
         const msg =


### PR DESCRIPTION
This closes https://github.com/zeit/now-cli/issues/1122.

Adds a confirmation message before adding a domain.