### PR TITLE
Add output mode option to logs command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,7 +252,7 @@ All feedback and suggestions are welcome!
 - 📣 Stay up to date on new features and announcments on [@zeithq](https://twitter.com/zeithq).
 - 🔐 Subscribe to our [security](http://zeit.us12.list-manage1.com/subscribe?u=3c9e9e13d7e6dae8faf375bed&id=110e586914) mailing list to stay up-to-date on urgent security disclosures.
 
-Please note: we adhere to the [contributor coventant](http://contributor-covenant.org/) for
+Please note: we adhere to the [contributor covenant](http://contributor-covenant.org/) for
 all interactions in our community.
 
 #### Contributions


### PR DESCRIPTION
Adds the following option to `now logs`:

```bash
-o MODE, --output=MODE         Specify the output format (short|raw) [short]
```

The `short` mode is default and what the logs currently output, and `raw` just logs the stringified object or text. I wasn't sure what to do about req/res logs, so need some help there.

Getting the raw log is useful for people using something like [bunyan](https://github.com/trentm/node-bunyan):

```bash
$ now logs myapp.now.sh -o raw | bunyan
npm start

> myapp@0.0.1 start /home/nowuser/src
> node server.js

07:46:42.707Z  INFO myapp: start
07:46:42.709Z  INFO myapp: creating a wuzzle (widget_type=wuzzle)
07:46:42.709Z  WARN myapp: This wuzzle is woosey. (widget_type=wuzzle)
07:46:42.709Z  INFO myapp: done
```

