### PR TITLE
Circumvent attempt to connect logger if reusing an old deployment

### DIFF
--- a/src/providers/sh/commands/billing.js
+++ b/src/providers/sh/commands/billing.js
@@ -234,7 +234,7 @@ async function run({ token, sh: { currentTeam, user } }) {
           trailing: '\n'
         })
         if (!confirmation) {
-          consoel.log(info('Aborted'))
+          console.log(info('Aborted'))
           break
         }
         const start = new Date()

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -740,6 +740,12 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         }
         await exit(0);
       } else {
+        if(!now.syncFileCount && !forceNew) {
+          if (!quiet) {
+            console.log(success('Deployment ready!'));
+          }
+          exit(0);
+        }
         if (!quiet) {
           console.log(info('Initializing…'));
         }


### PR DESCRIPTION
This fixes the issue described in #1106 

Idk if this is the best way to do it, or if there's a better way to recognise that there's already an existing deployment 

(also, the change in billing.js is an unrelated typo I decided to fix since it seems rather important)