### PR TITLE
Improved error for environment variable type

### DIFF
--- a/errors/env-value-invalid-type.md
+++ b/errors/env-value-invalid-type.md
@@ -1,0 +1,21 @@
+# Bad Type in Env Value
+
+#### Why This Error Occurred
+
+You supplied a value in the `env` of your deployment whose type is not allowed.
+
+This occurs for example if you use a `Boolean` as a type:
+
+```json
+{
+  "env": {
+    "VALID": 1,
+    "INVALID": true
+  }
+}
+```
+
+#### Possible Ways to Fix It
+
+The only accepted types are `String` or `Number`. If you're using a
+`Boolean`, consider using `1` (`Number`) or `"true"` (`String`).

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -215,7 +215,13 @@ module.exports = class Now extends EventEmitter {
         const err = new Error()
 
         if (body.error) {
-          Object.assign(err, body.error)
+          if (body.error.code === 'env_value_invalid_type') {
+            const {key} = body.error;
+            err.message = `The env key ${key} has an invalid type: ${typeof env[key]}. ` +
+              'Please supply a String or a Number (https://err.sh/now-cli/env-value-invalid-type)'
+          } else {
+            Object.assign(err, body.error)
+          }
         } else {
           err.message = 'Not able to create deployment'
         }


### PR DESCRIPTION
If the user passes a `Boolean` as a value in `env`, we now haver a nicer error and an `err.sh` link.

This fixes #1102.