### PR TITLE
Remove Microsoft Azure deployment section from README.md until it's implemented

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,14 +104,6 @@ $ now gcp login
 
 and follow the instructions!
 
-### Microsoft Azure (`az`)
-
-```
-$ now az login
-```
-
-and follow the instructions!
-
 ## <span id="configuration">Project Configuration</span>
 
 <table>


### PR DESCRIPTION
It seems azure deployment was listed as a feature in the docs before it was actually supported by now-cli.

I'm also new to now-cli and just become confused by the same error message and found the related issue:
https://github.com/zeit/now-cli/issues/787

It looks like it was intended to be removed a couple months ago, but never was.  It should be say to revert this commit and add this section back to docs when the feature is added.