### PR TITLE
Removed undefined variable reference

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -653,7 +653,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
           if (!proceed) {
             if (typeof proceed === 'undefined') {
-              const message = `${story} If you agree with that, please run again with ${cmd('--public')}.`
+              const message = `If you agree with that, please run again with ${cmd('--public')}.`
               console.error(error(message))
 
               await exit(1)


### PR DESCRIPTION
This removes `story`, a variable reference that slipped into the code without actually being defined earlier. Prevents an error reported by the community!