### PR TITLE
Don't upload meta files for static deployments

### DIFF
--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -165,7 +165,7 @@ async function staticFiles(
 
     const filter = ignore()
       .add(IGNORED + '\n' + clearRelative(gitIgnore))
-      .add([ 'now.json', 'package.json' ])
+      .add([ 'now.json', 'package.json', 'Dockerfile' ])
       .createFilter()
 
     const prefixLength = path.length + 1

--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -29,9 +29,9 @@ const glob = async function(pattern, options) {
  * @param {string} dir the directory to walk
  * @param {string} path the path to this directory
  * @param {Array[string]} filelist a list of files so far identified
- * @param {Object} options 
+ * @param {Object} options
  * 	- `debug` {Boolean} warn upon ignore
- * @returns {Array}  
+ * @returns {Array}
  */
 const walkSync = async (dir, path, filelist = [], { debug = false } = {}) => {
   const dirc = await readdir(asAbsolute(dir, path))
@@ -54,7 +54,7 @@ const walkSync = async (dir, path, filelist = [], { debug = false } = {}) => {
 /**
  * Will return an array containing the expaneded list of all files included in the whitelist.
  * @param {Array[string]} whitelist array of files and directories to include.
- * @param {string} path the path of the deployment. 
+ * @param {string} path the path of the deployment.
  * @param {Object} options
  * 	- `debug` {Boolean} warn upon ignore
  * @returns {Array} the expanded list of whitelisted files.
@@ -165,6 +165,7 @@ async function staticFiles(
 
     const filter = ignore()
       .add(IGNORED + '\n' + clearRelative(gitIgnore))
+      .add([ 'now.json', 'package.json' ])
       .createFilter()
 
     const prefixLength = path.length + 1
@@ -181,9 +182,11 @@ async function staticFiles(
       }
 
       const accepted = filter(relativePath)
+
       if (!accepted && debug) {
         console.log('> [debug] ignoring "%s"', file)
       }
+
       return accepted
     }
 
@@ -201,10 +204,6 @@ async function staticFiles(
     if (debug) {
       console.timeEnd(`> [debug] locating files ${path}`)
     }
-  }
-
-  if (hasNowJson) {
-    files.push(asAbsolute(getLocalConfigPath(path), path))
   }
 
   // Get files

--- a/test/index.js
+++ b/test/index.js
@@ -152,11 +152,10 @@ test('`now.files` overrides `.gitignore` in Static', async t => {
   )
   files = files.sort(alpha)
 
-  t.is(files.length, 4)
+  t.is(files.length, 3)
   t.is(base(files[0]), `${path}/a.js`)
   t.is(base(files[1]), `${path}/b.js`)
   t.is(base(files[2]), `${path}/build/a/c.js`)
-  t.is(base(files[3]), `${path}/now.json`)
 })
 
 test('`now.files` overrides `.npmignore`', async t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5251,12 +5251,6 @@ supports-color@^4.0.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
-  dependencies:
-    has-flag "^3.0.0"
-
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,19 +5051,38 @@ spawn-sync@^1.0.15:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-2.0.4.tgz#d1652ad2ebc516f656f66ea93398558065f1b4a4"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^2.0.1"
+    spdx-license-ids "^2.0.1"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.0.0, spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz#e2e0f229c057eac704c5a6d1c687eed66aca034b"
+  dependencies:
+    spdx-exceptions "^2.0.0"
+    spdx-license-ids "^2.0.1"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz#02017bcc3534ee4ffef6d58d20e7d3e9a1c3c8ec"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 split-array@1.0.1:
   version "1.0.1"
@@ -5581,11 +5600,11 @@ uuid@^3.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.2.tgz#ec39d030e27d1ee714515162c547f66356e49f41"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^2.0.4"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
As per https://github.com/zeit/zeit/issues/409, this prevents `now.json`, `package.json` and `Dockerfile` from being uploaded when a static deployment is created.

This is a security feature for ensuring nobody is accidentally uploading information that shouldn't be made public.