### PR TITLE
Add new `output` helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.6.0",
     "bytes": "3.0.0",
-    "chalk": "2.1.0",
+    "chalk": "2.3.1",
     "child-process-promise": "2.2.1",
     "clipboardy": "1.1.4",
     "convert-stream": "1.0.2",

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -20,6 +20,7 @@ const jsonlines = require('jsonlines');
 // Utilities
 const Logger = require('../util/build-logger')
 const Now = require('../util')
+const createOutput = require('../../../util/output')
 const toHumanPath = require('../../../util/humanize-path')
 const { handleError, error } = require('../util/error')
 const { fromGit, isRepoPath, gitPathParts } = require('../util/git')

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -14,8 +14,8 @@ const dotenv = require('dotenv')
 const { eraseLines } = require('ansi-escapes')
 const { write: copy } = require('clipboardy')
 const inquirer = require('inquirer')
-const retry = require('async-retry');
-const jsonlines = require('jsonlines');
+const retry = require('async-retry')
+const jsonlines = require('jsonlines')
 
 // Utilities
 const Logger = require('../util/build-logger')
@@ -174,7 +174,9 @@ let path
 let forceNew
 let deploymentName
 let sessionAffinity
+let log
 let debug
+let debugEnabled
 let clipboard
 let forwardNpm
 let followSymlinks
@@ -240,9 +242,7 @@ const promptForEnvFields = async list => {
   // eslint-disable-next-line import/no-unassigned-import
   require('../../../util/input/patch-inquirer')
 
-  console.log(
-    info('Please enter values for the following environment variables:')
-  )
+  log('Please enter values for the following environment variables:')
   const answers = await inquirer.prompt(questions)
 
   for (const answer of Object.keys(answers)) {
@@ -281,7 +281,7 @@ async function main(ctx) {
   forceNew = argv.force
   deploymentName = argv.name
   sessionAffinity = argv['session-affinity']
-  debug = argv.debug
+  debugEnabled = argv.debug
   clipboard = !argv['no-clipboard']
   forwardNpm = argv['forward-npm']
   followSymlinks = !argv.links
@@ -289,6 +289,7 @@ async function main(ctx) {
   apiUrl = ctx.apiUrl
   isTTY = process.stdout.isTTY
   quiet = !isTTY
+  ;({ log, debug } = createOutput({ debug: debugEnabled }))
 
   if (argv.h || argv.help) {
     help()
@@ -334,13 +335,11 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         Object.assign(gitRepo, gitParts)
 
         const searchMessage = setTimeout(() => {
-          console.log(
-            `> Didn't find directory. Searching on ${gitRepo.type}...`
-          )
+          log(`Didn't find directory. Searching on ${gitRepo.type}...`)
         }, 500)
 
         try {
-          repo = await fromGit(rawPath, debug)
+          repo = await fromGit(rawPath, debugEnabled)
         } catch (err) {}
 
         clearTimeout(searchMessage)
@@ -362,7 +361,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           )}" ${gitRef}on ${gitRepo.type}`
         )
       } else {
-        console.error(error(`The specified directory "${basename(path)}" doesn't exist.`))
+        log(error(`The specified directory "${basename(path)}" doesn't exist.`))
         await exit(1)
       }
     }
@@ -380,7 +379,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
       try {
         await checkPath(path)
       } catch (err) {
-        console.error(error({
+        log(error({
           message: err.message,
           slug: 'path-not-deployable'
         }))
@@ -392,40 +391,29 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
     if (!quiet && showMessage) {
       if (gitRepo.main) {
         const gitRef = gitRepo.ref ? ` at "${chalk.bold(gitRepo.ref)}" ` : ''
-        console.log(
-          info(`Deploying ${gitRepo.type} repository "${chalk.bold(
+        log(`Deploying ${gitRepo.type} repository "${chalk.bold(
             gitRepo.main
           )}"${gitRef} under ${chalk.bold(
             (currentTeam && currentTeam.slug) || user.username || user.email
-          )}`)
+          )}`
         )
       } else {
-        console.log(
-          info(`Deploying ${chalk.bold(toHumanPath(path))} under ${chalk.bold(
+        log(`Deploying ${chalk.bold(toHumanPath(path))} under ${chalk.bold(
             (currentTeam && currentTeam.slug) || user.username || user.email
-          )}`)
+          )}`
         )
       }
     }
 
     // CLI deployment type explicit overrides
     if (argv.docker) {
-      if (debug) {
-        console.log(`> [debug] Forcing \`deploymentType\` = \`docker\``)
-      }
-
+      debug(`Forcing \`deploymentType\` = \`docker\``)
       deploymentType = 'docker'
     } else if (argv.npm) {
-      if (debug) {
-        console.log(`> [debug] Forcing \`deploymentType\` = \`npm\``)
-      }
-
+      debug(`Forcing \`deploymentType\` = \`npm\``)
       deploymentType = 'npm'
     } else if (argv.static) {
-      if (debug) {
-        console.log(`> [debug] Forcing \`deploymentType\` = \`static\``)
-      }
-
+      debug(`Forcing \`deploymentType\` = \`static\``)
       deploymentType = 'static'
     }
 
@@ -453,7 +441,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
     }
 
     const nowConfig = meta.nowConfig
-    const now = new Now({ apiUrl, token, debug, currentTeam })
+    const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam })
 
     let dotenvConfig
     let dotenvOption
@@ -473,7 +461,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         dotenvConfig = dotenv.parse(dotenvFile)
       } catch (err) {
         if (err.code === 'ENOENT') {
-          console.error(error({
+          log(error({
             message: `--dotenv flag is set but ${dotenvFileName} file is missing`,
             slug: 'missing-dotenv-target'
           }))
@@ -510,7 +498,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
     const env_ = await Promise.all(
       Object.keys(deploymentEnv).map(async key => {
         if (!key) {
-          console.error(error({
+          log(error({
             message: 'Environment variable name is missing',
             slug: 'missing-env-key-value'
           }))
@@ -518,7 +506,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         }
 
         if (/[^A-z0-9_]/i.test(key)) {
-          console.error(error(
+          log(error(
             `Invalid ${chalk.dim('-e')} key ${chalk.bold(
               `"${chalk.bold(key)}"`
             )}. Only letters, digits and underscores are allowed.`
@@ -530,15 +518,15 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
         if (val === undefined) {
           if (key in process.env) {
-            console.log(
-              `> Reading ${chalk.bold(
+            log(
+              `Reading ${chalk.bold(
                 `"${chalk.bold(key)}"`
               )} from your env (as no value was specified)`
             )
             // Escape value if it begins with @
             val = process.env[key].replace(/^@/, '\\@')
           } else {
-            console.error(error(
+            log(error(
               `No value specified for env ${chalk.bold(
                 `"${chalk.bold(key)}"`
               )} and it was not found in your env.`
@@ -552,20 +540,20 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           const _secrets = await findSecret(uidOrName)
           if (_secrets.length === 0) {
             if (uidOrName === '') {
-              console.error(error(
+              log(error(
                 `Empty reference provided for env key ${chalk.bold(
                   `"${chalk.bold(key)}"`
                 )}`
               ))
             } else {
-              console.error(error({
+              log(error({
                 message: `No secret found by uid or name ${chalk.bold(`"${uidOrName}"`)}`,
                 slug: 'env-no-secret'
               }))
             }
             await exit(1)
           } else if (_secrets.length > 1) {
-            console.error(error(
+            log(error(
               `Ambiguous secret ${chalk.bold(
                 `"${uidOrName}"`
               )} (matches ${chalk.bold(_secrets.length)} secrets)`
@@ -583,7 +571,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
     const env = {}
     env_.filter(v => Boolean(v)).forEach(([key, val]) => {
       if (key in env) {
-        console.log(
+        log(
           note(`Overriding duplicate env key ${chalk.bold(`"${key}"`)}`)
         )
       }
@@ -611,10 +599,8 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
       if (now.syncFileCount > 0) {
         await new Promise((resolve) => {
-          if (debug && now.syncFileCount !== now.fileCount) {
-            console.log(
-              `> [debug] total files ${now.fileCount}, ${now.syncFileCount} changed. `
-            )
+          if (now.syncFileCount !== now.fileCount) {
+            debug(`Total files ${now.fileCount}, ${now.syncFileCount} changed`)
           }
           const size = bytes(now.syncAmount)
           syncCount = `${now.syncFileCount} file${now.syncFileCount > 1
@@ -635,18 +621,14 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
 
           now.on('upload', ({ names, data }) => {
             const amount = data.length
-            if (debug) {
-              console.log(
-                `> [debug] Uploaded: ${names.join(' ')} (${bytes(data.length)})`
-              )
-            }
+            debug(`Uploaded: ${names.join(' ')} (${bytes(data.length)})`)
             bar.tick(amount)
           })
 
           now.on('complete', () => resolve())
 
           now.on('error', err => {
-            console.error(error('Upload failed'))
+            log(error('Upload failed'))
             reject(err)
           })
         })
@@ -659,7 +641,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           const who = currentTeam ? 'your team is' : 'you are'
           let proceed
 
-          console.log(info(`Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`))
+          log(`Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`)
 
           if (isTTY) {
             proceed = await promptBool(
@@ -674,16 +656,16 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
             url = `https://zeit.co/teams/${currentTeam.slug}/settings/plan`
           }
 
-          console.log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
+          log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
 
           if (!proceed) {
             if (typeof proceed === 'undefined') {
               const message = `If you agree with that, please run again with ${cmd('--public')}.`
-              console.error(error(message))
+              log(error(message))
 
               await exit(1)
             } else {
-              console.log(info('Aborted'))
+              log('Aborted')
               await exit(0)
             }
 
@@ -703,8 +685,8 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         })
 
         return
-      } else if (debug) {
-        console.log(`> [debug] error: ${err}\n${err.stack}`)
+      } else {
+        debug(`Error: ${err}\n${err.stack}`)
       }
 
       await stopDeployment(err)
@@ -717,18 +699,15 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
       if (clipboard) {
         try {
           await copy(url)
-          console.log(
-            `${chalk.cyan('> Ready!')} ${chalk.bold(
-              url
-            )} (copied to clipboard) [${elapsed}]`
+          log(
+            chalk`{cyan Ready!} {bold ${url}} (copied to clipboard) [${elapsed}]`
           )
         } catch (err) {
-          console.log(
-            `${chalk.cyan('> Ready!')} ${chalk.bold(url)} [${elapsed}]`
-          )
+          debug(`Error copying to clipboard: ${err}`)
+          log(chalk`{cyan Ready!} {bold ${url}} [${elapsed}]`)
         }
       } else {
-        console.log(`> ${url} [${elapsed}]`)
+        log(`${url} [${elapsed}]`)
       }
     } else {
       process.stdout.write(url)
@@ -739,40 +718,38 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
     if (!quiet) {
       if (syncCount) {
         const elapsedU = ms(new Date() - startU)
-        console.log(
-          `> Synced ${syncCount} (${bytes(now.syncAmount)}) [${elapsedU}] `
-        )
+        log(`Synced ${syncCount} (${bytes(now.syncAmount)}) [${elapsedU}]`)
       }
     }
 
     // Show build logs
     if (deploymentType === 'static') {
       if (!quiet) {
-        console.log(success('Deployment complete!'));
+        log(chalk`{cyan Deployment complete!}`)
       }
-      await exit(0);
+      await exit(0)
     } else {
       if (nowConfig && nowConfig.atlas) {
-        const cancelWait = wait('Initializing…');
+        const cancelWait = wait('Initializing…')
         try {
           await printEvents(now, currentTeam, {
             onOpen: cancelWait,
-            debug
-          });
+            debug: debugEnabled
+          })
         } catch (err) {
-          cancelWait();
-          throw err;
+          cancelWait()
+          throw err
         }
-        await exit(0);
+        await exit(0)
       } else {
         if(!now.syncFileCount && !forceNew) {
           if (!quiet) {
-            console.log(success('Deployment ready!'));
+            log(chalk`{cyan Deployment ready!}`)
           }
-          exit(0);
+          exit(0)
         }
         if (!quiet) {
-          console.log(info('Initializing…'));
+          log('Initializing…')
         }
         printLogs(now.host, token, currentTeam, user)
       }
@@ -796,22 +773,12 @@ async function readMeta(
 
     if (!deploymentType) {
       deploymentType = meta.type
-
-      if (debug) {
-        console.log(
-          `> [debug] Detected \`deploymentType\` = \`${deploymentType}\``
-        )
-      }
+      debug(`Detected \`deploymentType\` = \`${deploymentType}\``)
     }
 
     if (!_deploymentName) {
       _deploymentName = meta.name
-
-      if (debug) {
-        console.log(
-          `> [debug] Detected \`deploymentName\` = "${_deploymentName}"`
-        )
-      }
+      debug(`Detected \`deploymentName\` = "${_deploymentName}"`)
     }
 
     return {
@@ -822,12 +789,9 @@ async function readMeta(
     }
   } catch (err) {
     if (isTTY && err.code === 'MULTIPLE_MANIFESTS') {
-      if (debug) {
-        console.log('> [debug] Multiple manifests found, disambiguating')
-      }
-
-      console.log(
-        `> Two manifests found. Press [${chalk.bold(
+      debug('Multiple manifests found, disambiguating')
+      log(
+        `Two manifests found. Press [${chalk.bold(
           'n'
         )}] to deploy or re-run with --flag`
       )
@@ -837,12 +801,7 @@ async function readMeta(
         ['docker', `${chalk.bold('Dockerfile')}\t${chalk.gray('--docker')} `]
       ])
 
-      if (debug) {
-        console.log(
-          `> [debug] Selected \`deploymentType\` = "${deploymentType}"`
-        )
-      }
-
+      debug(`Selected \`deploymentType\` = "${deploymentType}"`)
       return readMeta(_path, _deploymentName, deploymentType)
     }
     throw err
@@ -853,109 +812,107 @@ async function printEvents(now, currentTeam = null, {
   onOpen = ()=>{},
   debug = false
 } = {}) {
-  let url = `${apiUrl}/v1/now/deployments/${now.id}/events?follow=1`;
+  let url = `${apiUrl}/v1/now/deployments/${now.id}/events?follow=1`
   if (currentTeam) {
-    url += `&teamId=${currentTeam.id}`;
+    url += `&teamId=${currentTeam.id}`
   }
 
-  if (debug) {
-    console.log(info(`[debug] events ${url}`));
-  }
+  debug(`Events ${url}`)
 
   // we keep track of how much we log in case we
   // drop the connection and have to start over
-  let o = 0;
+  let o = 0
 
   await retry(async (bail, attemptNumber) => {
-    if (debug && attemptNumber > 1) {
-      console.log(info('[debug] retrying events'));
+    if (attemptNumber > 1) {
+      debug('Retrying events')
     }
 
     // if we are retrying, we clear past logs
-    if (!quiet && o) process.stdout.write(eraseLines(0));
+    if (!quiet && o) process.stdout.write(eraseLines(0))
 
-    const res = await now._fetch(url);
+    const res = await now._fetch(url)
     if (res.ok) {
       // fire the open callback and ensure it's only fired once
-      onOpen();
-      onOpen = ()=>{};
+      onOpen()
+      onOpen = ()=>{}
 
       // handle the event stream and make the promise get rejected
       // if errors occur so we can retry
       return new Promise((resolve, reject) => {
-        const stream = res.body.pipe(jsonlines.parse());
+        const stream = res.body.pipe(jsonlines.parse())
         const onData = ({ type, payload }) => {
           // if we are 'quiet' because we are piping, simply
           // wait for the first instance to be started
           // and ignore everything else
           if (quiet) {
             if (type === 'instance-start') {
-              resolve();
+              resolve()
             }
-            return;
+            return
           }
 
           switch (type) {
             case 'build-start':
-              o++;
-              console.log(info('Building…'));
-              break;
+              o++
+              log('Building…')
+              break
 
             case 'stdout':
             case 'stderr':
-              console.log(payload);
-              break;
+              log(payload)
+              break
 
             case 'build-complete':
-              o++;
-              console.log(success('Build complete'));
-              break;
+              o++
+              log(chalk`{cyan Success!} Build complete`)
+              break
 
             case 'instance-start':
-              o++;
-              console.log(success('Deployment started!'));
+              o++
+              log(chalk`{cyan Success!} Build complete`)
 
               // avoid lingering events
-              stream.off('data', onData);
+              stream.off('data', onData)
 
               // close the stream and resolve
-              stream.end();
-              resolve();
-              break;
+              stream.end()
+              resolve()
+              break
           }
-        };
+        }
         stream.on('data', onData)
         stream.on('error', err => {
-          reject(new Error(`Deployment event stream error: ${err.stack}`));
-        });
-      });
+          reject(new Error(`Deployment event stream error: ${err.stack}`))
+        })
+      })
     } else {
-      const err = new Error(`Deployment events status ${res.status}`);
+      const err = new Error(`Deployment events status ${res.status}`)
       if (res.status < 500) {
-        bail(err);
+        bail(err)
       } else {
-        throw err;
+        throw err
       }
     }
   }, {
     retries: 4
-  });
+  })
 }
 
 function printLogs(host, token) {
   // Log build
-  const logger = new Logger(host, token, { debug, quiet })
+  const logger = new Logger(host, token, { debug: debugEnabled, quiet })
 
   logger.on('error', async err => {
     if (!quiet) {
       if (err && err.type === 'BUILD_ERROR') {
-        console.error(error(
+        log(error(
           `The build step of your project failed. To retry, run ${cmd(
             'now --force'
           )}.`
         ))
       } else {
-        console.error(error('Deployment failed'))
+        log(error('Deployment failed'))
       }
     }
 
@@ -963,9 +920,7 @@ function printLogs(host, token) {
       // Delete temporary directory that contains repository
       gitRepo.cleanup()
 
-      if (debug) {
-        console.log(`> [debug] Removed temporary repo directory`)
-      }
+      debug(`Removed temporary repo directory`)
     }
 
     await exit(1)
@@ -973,16 +928,14 @@ function printLogs(host, token) {
 
   logger.on('close', async () => {
     if (!quiet) {
-      console.log(`${chalk.cyan('> Deployment complete!')}`)
+      log(chalk`{cyan Deployment complete!}`)
     }
 
     if (gitRepo && gitRepo.cleanup) {
       // Delete temporary directory that contains repository
       gitRepo.cleanup()
 
-      if (debug) {
-        console.log(`> [debug] Removed temporary repo directory`)
-      }
+      debug(`Removed temporary repo directory`)
     }
 
     await exit()

--- a/src/providers/sh/util/build-logger.js
+++ b/src/providers/sh/util/build-logger.js
@@ -123,16 +123,12 @@ module.exports = class Logger extends EventEmitter {
 
     if (log.type === 'command') {
       this.output.log(`▲ ${data}`)
-    } else if (log.type === 'stderr') {
+    } else if (log.type === 'stdout' || log.type === 'stderr') {
       data.split('\n').forEach(v => {
         if (v.length > 0) {
-          this.output.log(v)
-        }
-      })
-    } else if (log.type === 'stdout') {
-      data.split('\n').forEach(v => {
-        if (v.length > 0) {
-          this.output.log(v)
+          // strip out the beginning `>` if there is one because
+          // `log()` prepends its own and we don't want `> >`
+          this.output.log(v.replace(/^> /, ''))
         }
       })
     }

--- a/src/providers/sh/util/build-logger.js
+++ b/src/providers/sh/util/build-logger.js
@@ -2,8 +2,9 @@
 const EventEmitter = require('events')
 
 // Packages
-const io = require('socket.io-client')
 const chalk = require('chalk')
+const io = require('socket.io-client')
+const createOutput = require('../../../util/output')
 
 const { compare, deserialize } = require('./logs')
 
@@ -14,6 +15,7 @@ module.exports = class Logger extends EventEmitter {
     this.token = token
     this.debug = debug
     this.quiet = quiet
+    this.output = createOutput({ debug })
 
     // ReadyState
     this.building = false
@@ -31,16 +33,16 @@ module.exports = class Logger extends EventEmitter {
   }
 
   onAuth(callback) {
-    if (this.debug) {
-      console.log('> [debug] authenticate')
-    }
+    const { debug } = this.output
+    debug('Authenticate')
     callback(this.token)
   }
 
   onState(state) {
-    // Console.log(state)
+    const { log } = this.output
+
     if (!state.id) {
-      console.error('> Deployment not found')
+      log('Deployment not found')
       this.emit('error')
       return
     }
@@ -63,7 +65,7 @@ module.exports = class Logger extends EventEmitter {
   onLog(log) {
     if (!this.building) {
       if (!this.quiet) {
-        console.log('> Building')
+        this.output.log('Building')
       }
       this.building = true
     }
@@ -108,7 +110,7 @@ module.exports = class Logger extends EventEmitter {
 
   onSocketError(err) {
     if (this.debug) {
-      console.log(`> [debug] Socket error ${err}\n${err.stack}`)
+      this.output.debug(`Socket error ${err}\n${err.stack}`)
     }
   }
 
@@ -120,17 +122,17 @@ module.exports = class Logger extends EventEmitter {
     const data = log.object ? JSON.stringify(log.object) : log.text
 
     if (log.type === 'command') {
-      console.log(`${chalk.gray('>')} ▲ ${data}`)
+      this.output.log(`▲ ${data}`)
     } else if (log.type === 'stderr') {
       data.split('\n').forEach(v => {
         if (v.length > 0) {
-          console.error(chalk.gray(`> ${v}`))
+          this.output.log(v)
         }
       })
     } else if (log.type === 'stdout') {
       data.split('\n').forEach(v => {
         if (v.length > 0) {
-          console.log(`${chalk.gray('>')} ${v}`)
+          this.output.log(v)
         }
       })
     }

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -25,6 +25,7 @@ const ua = require('./ua')
 const hash = require('./hash')
 const Agent = require('./agent')
 const toHost = require('./to-host')
+const createOutput = require('./output')
 const { responseError } = require('./error')
 
 // How many concurrent HTTP/2 stream uploads
@@ -40,6 +41,7 @@ module.exports = class Now extends EventEmitter {
     this._token = token
     this._debug = debug
     this._forceNew = forceNew
+    this._output = createOutput({ debug })
     this._agent = new Agent(apiUrl, { debug })
     this._onRetry = this._onRetry.bind(this)
     this.currentTeam = currentTeam
@@ -66,46 +68,41 @@ module.exports = class Now extends EventEmitter {
       isStaticFile = false
     }
   ) {
+    const { log, warn, time } = this._output
     this._path = isStaticFile ? path.split('/').slice(0, -1).join('/') : path
 
     let files
     let engines
 
-    if (this._debug) {
-      console.time('> [debug] Getting files')
-    }
+    await time('Getting files', async () => {
+      const opts = { debug: this._debug, hasNowJson }
 
-    const opts = { debug: this._debug, hasNowJson }
+      if (type === 'npm') {
+        files = await getNpmFiles(path, pkg, nowConfig, opts)
 
-    if (type === 'npm') {
-      files = await getNpmFiles(path, pkg, nowConfig, opts)
+        // A `start` or `now-start` npm script, or a `server.js` file
+        // in the root directory of the deployment are required
+        if (!hasNpmStart(pkg) && !hasFile(path, files, 'server.js')) {
+          const err = new Error(
+            'Missing `start` (or `now-start`) script in `package.json`. ' +
+              'See: https://docs.npmjs.com/cli/start'
+          )
+          err.userError = true
+          throw err
+        }
 
-      // A `start` or `now-start` npm script, or a `server.js` file
-      // in the root directory of the deployment are required
-      if (!hasNpmStart(pkg) && !hasFile(path, files, 'server.js')) {
-        const err = new Error(
-          'Missing `start` (or `now-start`) script in `package.json`. ' +
-            'See: https://docs.npmjs.com/cli/start'
-        )
-        err.userError = true
-        throw err
+        engines = nowConfig.engines || pkg.engines
+        forwardNpm = forwardNpm || nowConfig.forwardNpm
+      } else if (type === 'static') {
+        if (isStaticFile) {
+          files = [resolvePath(path)]
+        } else {
+          files = await getFiles(path, nowConfig, opts)
+        }
+      } else if (type === 'docker') {
+        files = await getDockerFiles(path, nowConfig, opts)
       }
-
-      engines = nowConfig.engines || pkg.engines
-      forwardNpm = forwardNpm || nowConfig.forwardNpm
-    } else if (type === 'static') {
-      if (isStaticFile) {
-        files = [resolvePath(path)]
-      } else {
-        files = await getFiles(path, nowConfig, opts)
-      }
-    } else if (type === 'docker') {
-      files = await getDockerFiles(path, nowConfig, opts)
-    }
-
-    if (this._debug) {
-      console.timeEnd('> [debug] Getting files')
-    }
+    })
 
     // Read `registry.npmjs.org` authToken from .npmrc
     let authToken
@@ -114,27 +111,17 @@ module.exports = class Now extends EventEmitter {
         (await readAuthToken(path)) || (await readAuthToken(homedir()))
     }
 
-    if (this._debug) {
-      console.time('> [debug] Computing hashes')
-    }
-
-    const pkgDetails = Object.assign({ name }, pkg)
-    const hashes = await hash(files, pkgDetails)
-
-    if (this._debug) {
-      console.timeEnd('> [debug] Computing hashes')
-    }
+    const hashes = await time('Computing hashes', async () => {
+      const pkgDetails = Object.assign({ name }, pkg)
+      return hash(files, pkgDetails)
+    })
 
     this._files = hashes
 
     const deployment = await this.retry(async bail => {
       // Flatten the array to contain files to sync where each nested input
       // array has a group of files with the same sha but different path
-      if (this._debug) {
-        console.time('> [debug] get files ready for deployment')
-      }
-
-      const files = await Promise.all(
+      const files = await time('Get files ready for deployment', Promise.all(
         Array.prototype.concat.apply(
           [],
           await Promise.all(
@@ -159,35 +146,27 @@ module.exports = class Now extends EventEmitter {
             })
           )
         )
+      ))
+
+      const res = await time(
+        'GET /v3/now/deployments',
+        this._fetch('/v3/now/deployments', {
+          method: 'POST',
+          body: {
+            env,
+            public: wantsPublic || nowConfig.public,
+            forceNew,
+            name,
+            description,
+            deploymentType: type,
+            registryAuthToken: authToken,
+            files,
+            engines,
+            sessionAffinity,
+            atlas: hasNowJson && Boolean(nowConfig.atlas)
+          }
+        })
       )
-      if (this._debug) {
-        console.timeEnd('> [debug] get files ready for deployment')
-      }
-
-      if (this._debug) {
-        console.time('> [debug] v3/now/deployments')
-      }
-
-      const res = await this._fetch('/v3/now/deployments', {
-        method: 'POST',
-        body: {
-          env,
-          public: wantsPublic || nowConfig.public,
-          forceNew,
-          name,
-          description,
-          deploymentType: type,
-          registryAuthToken: authToken,
-          files,
-          engines,
-          sessionAffinity,
-          atlas: hasNowJson && Boolean(nowConfig.atlas)
-        }
-      })
-
-      if (this._debug) {
-        console.timeEnd('> [debug] v3/now/deployments')
-      }
 
       // No retry on 4xx
       let body
@@ -253,32 +232,18 @@ module.exports = class Now extends EventEmitter {
         if (warning.reason === 'size_limit_exceeded') {
           const { sha, limit } = warning
           const n = hashes.get(sha).names.pop()
-          console.error(
-            '> \u001B[31mWarning!\u001B[39m Skipping file %s (size exceeded %s)',
-            n,
-            bytes(limit)
-          )
+          warn(`Skipping file ${n} (size exceeded ${bytes(limit)})
           hashes.get(sha).names.unshift(n) // Move name (hack, if duplicate matches we report them in order)
           sizeExceeded++
         } else if (warning.reason === 'node_version_not_found') {
-          const { wanted, used } = warning
-          console.error(
-            '> \u001B[31mWarning!\u001B[39m Requested node version %s is not available',
-            wanted,
-            used
-          )
+          warn(`Requested node version ${warning.wanted} is not available`);
           missingVersion = true
         }
       })
 
-      if (sizeExceeded) {
-        console.error(
-          `> \u001B[31mWarning!\u001B[39m ${sizeExceeded} of the files ` +
-            'exceeded the limit for your plan.\n' +
-            `> Please run ${chalk.gray('`')}${chalk.cyan(
-              'now upgrade'
-            )}${chalk.gray('`')} to upgrade.`
-        )
+      if (sizeExceeded > 0) {
+        warn(`${sizeExceeded} of the files exceeded the limit for your plan.`);
+        log(chalk`Please run {gray `}{cyan now upgrade}{gray `} to upgrade.`);
       }
     }
 
@@ -289,22 +254,11 @@ module.exports = class Now extends EventEmitter {
     }
 
     if (!quiet && type === 'npm' && deployment.nodeVersion) {
-      if (engines && engines.node) {
-        if (missingVersion) {
-          console.log(
-            `> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`
-          )
-        } else {
-          console.log(
-            `> Using Node.js ${chalk.bold(
-              deployment.nodeVersion
-            )} (requested: ${chalk.dim(`\`${engines.node}\``)})`
-          )
-        }
+      if (engines && engines.node && !missingVersion) {
+        log(chalk`Using Node.js {bold ${
+          deployment.nodeVersion}} (requested: {dim \`${engines.node}\`)`)
       } else {
-        console.log(
-          `> Using Node.js ${chalk.bold(deployment.nodeVersion)} (default)`
-        )
+        log(chalk`Using Node.js {bold ${deployment.nodeVersion}} (default)`)
       }
     }
 
@@ -317,65 +271,43 @@ module.exports = class Now extends EventEmitter {
   }
 
   upload() {
-    if (this._debug) {
-      console.log(
-        '> [debug] Will upload ' +
-          `${this._missing.length} files`
-      )
-    }
+    const { debug, time } = this._output;
+    debug(`Will upload ${this._missing.length} files`)
 
     this._agent.setConcurrency({
       maxStreams: MAX_CONCURRENT,
       capacity: this._missing.length
     })
 
-    if (this._debug) {
-      console.time('> [debug] Uploading files')
-    }
-
-    Promise.all(
+    time('Uploading files', Promise.all(
       this._missing.map(sha =>
         retry(
           async (bail, attempt) => {
             const file = this._files.get(sha)
             const { data, names } = file
-
-            if (this._debug) {
-              console.time(`> [debug] v2/now/files #${attempt} ${names.join(' ')}`)
-            }
-
             const stream = through2()
             stream.write(data)
             stream.end()
-            const res = await this._fetch('/v2/now/files', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'Content-Length': data.length,
-                'x-now-digest': sha,
-                'x-now-size': data.length
-              },
-              body: stream
-            })
-
-            if (this._debug) {
-              console.timeEnd(
-                `> [debug] v2/now/files #${attempt} ${names.join(' ')}`
-              )
-            }
+            const res = await time(
+              `v2/now/files #${attempt} ${names.join(' ')}`
+              this._fetch('/v2/now/files', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/octet-stream',
+                  'Content-Length': data.length,
+                  'x-now-digest': sha,
+                  'x-now-size': data.length
+                },
+                body: stream
+              })
+            )
 
             // No retry on 4xx
             if (
               res.status !== 200 &&
               (res.status >= 400 || res.status < 500)
             ) {
-              if (this._debug) {
-                console.log(
-                  '> [debug] bailing on creating due to %s',
-                  res.status
-                )
-              }
-
+              debug(`Bailing on creating due to ${res.status}`);
               return bail(await responseError(res))
             }
 
@@ -384,54 +316,41 @@ module.exports = class Now extends EventEmitter {
           { retries: 3, randomize: true, onRetry: this._onRetry }
         )
       )
-    )
+    ))
       .then(() => {
-        if (this._debug) {
-          console.timeEnd('> [debug] Uploading files')
-        }
-
         this.emit('complete')
       })
       .catch(err => this.emit('error', err))
   }
 
   async listSecrets() {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} GET /secrets`)
-      }
+    const { time } = this._output
 
-      const res = await this._fetch('/now/secrets')
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} GET /secrets`)
-      }
-
-      const body = await res.json()
-      return body.secrets
+    const { secrets } = await this.retry(async (bail, attempt) => {
+      const res = await time(
+        `#${attempt} GET /secrets`,
+        this._fetch('/now/secrets')
+      )
+      return res.json()
     })
+
+    return secrets
   }
 
   async list(app) {
+    const { debug, time } = this._output
     const query = app ? `?app=${encodeURIComponent(app)}` : ''
 
     const { deployments } = await this.retry(
       async bail => {
-        if (this._debug) {
-          console.time('> [debug] GET /v2/now/deployments')
-        }
-
-        const res = await this._fetch('/v2/now/deployments' + query)
-
-        if (this._debug) {
-          console.timeEnd('> [debug] GET /v2/now/deployments')
-        }
+        const res = await time(
+          'GET /v2/now/deployments',
+          this._fetch('/v2/now/deployments' + query)
+        );
 
         // No retry on 4xx
         if (res.status >= 400 && res.status < 500) {
-          if (this._debug) {
-            console.log('> [debug] bailing on listing due to %s', res.status)
-          }
+          debug(`Bailing on listing deployments due to ${res.status}`)
           return bail(await responseError(res))
         }
 
@@ -448,25 +367,18 @@ module.exports = class Now extends EventEmitter {
   }
 
   async listInstances(deploymentId) {
+    const { debug, time } = this._output
+
     const { instances } = await this.retry(
       async bail => {
-        if (this._debug) {
-          console.time(`> [debug] /deployments/${deploymentId}/instances`)
-        }
-
-        const res = await this._fetch(
-          `/now/deployments/${deploymentId}/instances`
+        const res = await time(
+          `/deployments/${deploymentId}/instances`,
+          this._fetch(`/now/deployments/${deploymentId}/instances`)
         )
-
-        if (this._debug) {
-          console.timeEnd(`> [debug] /deployments/${deploymentId}/instances`)
-        }
 
         // No retry on 4xx
         if (res.status >= 400 && res.status < 500) {
-          if (this._debug) {
-            console.log('> [debug] bailing on listing due to %s', res.status)
-          }
+          debug(`Bailing on listing instances due to ${res.status}`)
           return bail(await responseError(res))
         }
 
@@ -483,6 +395,7 @@ module.exports = class Now extends EventEmitter {
   }
 
   async findDeployment(deployment) {
+    const { debug } = this._output
     const list = await this.list()
 
     let key
@@ -498,19 +411,13 @@ module.exports = class Now extends EventEmitter {
 
     const depl = list.find(d => {
       if (d[key] === val) {
-        if (this._debug) {
-          console.log(`> [debug] matched deployment ${d.uid} by ${key} ${val}`)
-        }
-
+        debug(`Matched deployment ${d.uid} by ${key} ${val}`)
         return true
       }
 
       // Match prefix
       if (`${val}.now.sh` === d.url) {
-        if (this._debug) {
-          console.log(`> [debug] matched deployment ${d.uid} by url ${d.url}`)
-        }
-
+        debug(`Matched deployment ${d.uid} by url ${d.url}`)
         return true
       }
 
@@ -524,6 +431,7 @@ module.exports = class Now extends EventEmitter {
     deploymentIdOrURL,
     { instanceId, types, limit, query, since, until } = {}
   ) {
+    const { debug, time } = this._outut
     const q = qs.stringify({
       instanceId,
       types: types.join(','),
@@ -535,28 +443,14 @@ module.exports = class Now extends EventEmitter {
 
     const { logs } = await this.retry(
       async bail => {
-        if (this._debug) {
-          console.time('> [debug] /logs')
-        }
-
         const url = `/now/deployments/${encodeURIComponent(
           deploymentIdOrURL
         )}/logs?${q}`
-        const res = await this._fetch(url)
-
-        if (this._debug) {
-          console.timeEnd('> [debug] /logs')
-        }
+        const res = await time('GET /logs', this._fetch(url))
 
         // No retry on 4xx
         if (res.status >= 400 && res.status < 500) {
-          if (this._debug) {
-            console.log(
-              '> [debug] bailing on printing logs due to %s',
-              res.status
-            )
-          }
-
+          debug(`Bailing on printing logs due to ${res.status}`)
           return bail(await responseError(res))
         }
 
@@ -577,7 +471,9 @@ module.exports = class Now extends EventEmitter {
   }
 
   async listAliases(deploymentId) {
-    return this.retry(async bail => {
+    const { debug } = this._output
+
+    const { aliases } = await this.retry(async bail => {
       const res = await this._fetch(
         deploymentId
           ? `/now/deployments/${deploymentId}/aliases`
@@ -585,9 +481,7 @@ module.exports = class Now extends EventEmitter {
       )
 
       if (res.status >= 400 && res.status < 500) {
-        if (this._debug) {
-          console.log('> [debug] bailing on get domain due to %s', res.status)
-        }
+        debug(`Bailing on get domain due to ${res.status}`)
         return bail(await responseError(res))
       }
 
@@ -595,9 +489,10 @@ module.exports = class Now extends EventEmitter {
         throw new Error('API error getting aliases')
       }
 
-      const body = await res.json()
-      return body.aliases
+      return res.json()
     })
+
+    return aliases
   }
 
   async last(app) {
@@ -619,21 +514,16 @@ module.exports = class Now extends EventEmitter {
   }
 
   async listDomains() {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} GET /domains`)
-      }
+    const { debug, time } = this._output
 
-      const res = await this._fetch('/domains')
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} GET /domains`)
-      }
+    const { domains } = await this.retry(async (bail, attempt) => {
+      const res = await time(
+        `#${attempt} GET /domains`,
+        this._fetch('/domains')
+      )
 
       if (res.status >= 400 && res.status < 500) {
-        if (this._debug) {
-          console.log('> [debug] bailing on get domain due to %s', res.status)
-        }
+        debug(`Bailing on get domain due to ${res.status}`)
         return bail(await responseError(res))
       }
 
@@ -641,23 +531,21 @@ module.exports = class Now extends EventEmitter {
         throw new Error('API error getting domains')
       }
 
-      const body = await res.json()
-      return body.domains
+      return res.json()
     })
+
+    return domains
   }
 
   async getDomain(domain) {
     return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} GET /domains/${domain}`)
-      }
-
-      const res = await this._fetch(`/domains/${domain}`)
+      const res = await time(
+        `#${attempt} GET /domains/${domain}`,
+        this._fetch(`/domains/${domain}`)
+      )
 
       if (res.status >= 400 && res.status < 500) {
-        if (this._debug) {
-          console.log('> [debug] bailing on get domain due to %s', res.status)
-        }
+        debug(`Bailing on get domain due to ${res.status}`)
         return bail(await responseError(res))
       }
 
@@ -665,97 +553,70 @@ module.exports = class Now extends EventEmitter {
         throw new Error('API error getting domain name')
       }
 
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} GET /domains/${domain}`)
-      }
-
       return res.json()
     })
   }
 
-  getNameservers(domain) {
-    return new Promise((resolve, reject) => {
-      this.retry(async (bail, attempt) => {
-        if (this._debug) {
-          console.time(
-            `> [debug] #${attempt} GET /whois-ns`
-          )
-        }
+  async getNameservers(domain) {
+    const { time } = this._output
 
-        const res = await this._fetch(
-          `/whois-ns?domain=${encodeURIComponent(domain)}`
-        )
+    const body = await this.retry(async (bail, attempt) => {
+      const res = await time(
+        `#${attempt} GET /whois-ns`,
+        this._fetch(`/whois-ns?domain=${encodeURIComponent(domain)}`)
+      )
 
-        if (this._debug) {
-          console.timeEnd(
-            `> [debug] #${attempt} GET /whois-ns`
-          )
-        }
+      const body = await res.json()
 
-        const body = await res.json()
+      if (res.status === 200) {
+        return body
+      }
 
-        if (res.status === 200) {
-          return body
-        }
-
-        throw new Error(`Whois error (${res.status}): ${body.error.message}`)
-      })
-        .then(body => {
-          body.nameservers = body.nameservers.filter(ns => {
-            // Temporary hack:
-            // sometimes we get a response that looks like:
-            // ['ns', 'ns', '', '']
-            // so we filter the empty ones
-            return ns.length
-          })
-          resolve(body)
-        })
-        .catch(err => {
-          reject(err)
-        })
+      throw new Error(`Whois error (${res.status}): ${body.error.message}`)
     })
+
+    body.nameservers = body.nameservers.filter(ns => {
+      // Temporary hack:
+      // sometimes we get a response that looks like:
+      // ['ns', 'ns', '', '']
+      // so we filter the empty ones
+      return ns.length > 0
+    })
+
+    return body
   }
 
   // _ensures_ the domain is setup (idempotent)
   setupDomain(name, { isExternal } = {}) {
+    const { debug, time } = this._output
+
     return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} POST /domains`)
-      }
-
-      const res = await this._fetch('/domains', {
-        method: 'POST',
-        body: { name, isExternal: Boolean(isExternal) }
-      })
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} POST /domains`)
-      }
+      const res = await time(
+        `#${attempt} POST /domains`,
+        this._fetch('/domains', {
+          method: 'POST',
+          body: { name, isExternal: Boolean(isExternal) }
+        })
+      )
 
       const body = await res.json()
 
       if (res.status === 403) {
         const code = body.error.code
         let err
-
         if (code === 'custom_domain_needs_upgrade') {
           err = new Error(
-            `Custom domains are only enabled for premium accounts. Please upgrade at ${chalk.underline(
-              'https://zeit.co/account'
-            )}.`
+            `Custom domains are only enabled for premium accounts. ` +
+              chalk`Please upgrade at {underline https://zeit.co/account}`
           )
         } else {
           err = new Error(`Not authorized to access domain ${name} http://err.sh/now-cli/unauthorized-domain`)
         }
-
         err.userError = true
         return bail(err)
       } else if (res.status === 409) {
         // Domain already exists
-        if (this._debug) {
-          console.log('> [debug] Domain already exists (noop)')
-        }
-
+        debug('Domain already exists (noop)')
         return { uid: body.error.uid, code: body.error.code }
       } else if (
         res.status === 401 &&
@@ -772,31 +633,27 @@ module.exports = class Now extends EventEmitter {
   }
 
   createCert(domain, { renew, overwriteCustom } = {}) {
+    const { log, time } = this._output
     return this.retry(
       async (bail, attempt) => {
-        if (this._debug) {
-          console.time(`> [debug] /now/certs #${attempt}`)
-        }
-
-        const res = await this._fetch('/now/certs', {
-          method: 'POST',
-          body: {
-            domains: [domain],
-            renew,
-            overwriteCustom
-          }
-        })
+        const res = await time(
+          `/now/certs #${attempt}`,
+          this._fetch('/now/certs', {
+            method: 'POST',
+            body: {
+              domains: [domain],
+              renew,
+              overwriteCustom
+            }
+          })
+        )
 
         if (res.status === 304) {
-          console.log('> Certificate already issued.')
+          log('Certificate already issued.')
           return
         }
 
         const body = await res.json()
-
-        if (this._debug) {
-          console.timeEnd(`> [debug] /now/certs #${attempt}`)
-        }
 
         if (body.error) {
           const { code } = body.error
@@ -829,15 +686,15 @@ module.exports = class Now extends EventEmitter {
   }
 
   deleteCert(domain) {
+    const { time } = this._output
     return this.retry(
       async (bail, attempt) => {
-        if (this._debug) {
-          console.time(`> [debug] /now/certs #${attempt}`)
-        }
-
-        const res = await this._fetch(`/now/certs/${domain}`, {
-          method: 'DELETE'
-        })
+        const res = await time(
+          `/now/certs #${attempt}`,
+          this._fetch(`/now/certs/${domain}`, {
+            method: 'DELETE'
+          })
+        )
 
         if (res.status !== 200) {
           const err = new Error(res.body.error.message)
@@ -855,26 +712,20 @@ module.exports = class Now extends EventEmitter {
   }
 
   async remove(deploymentId, { hard }) {
-    const url =`/now/deployments/${deploymentId}?hard=${hard ? '1' : '0' }`
+    const { debug, time } = this._output
+    const url =`/now/deployments/${deploymentId}?hard=${hard ? 1 : 0 }`
 
     await this.retry(async bail => {
-      if (this._debug) {
-        console.time(`> [debug] DELETE ${url}`)
-      }
-
-      const res = await this._fetch(url, {
-        method: 'DELETE'
-      })
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] DELETE ${url}`)
-      }
+      const res = await time(
+        `DELETE ${url}`,
+        this._fetch(url, {
+          method: 'DELETE'
+        })
+      )
 
       // No retry on 4xx
       if (res.status >= 400 && res.status < 500) {
-        if (this._debug) {
-          console.log('> [debug] bailing on removal due to %s', res.status)
-        }
+        debug(`Bailing on removal due to ${res.status}`)
         return bail(await responseError(res))
       }
 
@@ -895,9 +746,7 @@ module.exports = class Now extends EventEmitter {
   }
 
   _onRetry(err) {
-    if (this._debug) {
-      console.log(`> [debug] Retrying: ${err}\n${err.stack}`)
-    }
+    this._output.debug(`Retrying: ${err}\n${err.stack}`)
   }
 
   close() {
@@ -950,27 +799,20 @@ module.exports = class Now extends EventEmitter {
   }
 
   setScale(nameOrId, scale) {
+    const { time } = this._output
+
     return this.retry(
       async (bail, attempt) => {
-        if (this._debug) {
-          console.time(
-            `> [debug] #${attempt} POST /deployments/${nameOrId}/instances`
+        const res = await time(
+          `#${attempt} POST /deployments/${nameOrId}/instances`,
+          this._fetch(
+            `/now/deployments/${nameOrId}/instances`,
+            {
+              method: 'POST',
+              body: scale
+            }
           )
-        }
-
-        const res = await this._fetch(
-          `/now/deployments/${nameOrId}/instances`,
-          {
-            method: 'POST',
-            body: scale
-          }
         )
-
-        if (this._debug) {
-          console.timeEnd(
-            `> [debug] #${attempt} POST /deployments/${nameOrId}/instances`
-          )
-        }
 
         if (res.status === 403) {
           return bail(new Error('Unauthorized'))

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -76,7 +76,7 @@ module.exports = class Now extends EventEmitter {
     let engines
 
     await time('Getting files', async () => {
-      const opts = { debug: this._debug, hasNowJson }
+      const opts = { output: this._output, hasNowJson }
 
       if (type === 'npm') {
         files = await getNpmFiles(path, pkg, nowConfig, opts)

--- a/src/providers/sh/util/output.js
+++ b/src/providers/sh/util/output.js
@@ -1,26 +1,26 @@
-const chalk = require('chalk');
-const { format } = require('util');
-const { Console } = require('console');
+const chalk = require('chalk')
+const { format } = require('util')
+const { Console } = require('console')
 
 function createOutput({ debug: debugEnabled = false } = {}) {
   function print(v) {
-    process.stderr.write(v);
+    process.stderr.write(v)
   }
 
   function log(v, color = chalk.grey) {
-    print(`${color('>')} ${v}\n`);
+    print(`${color('>')} ${v}\n`)
   }
 
   function warn(v) {
-    log(chalk`{yellow.bold Warning!} ${v}`);
+    log(chalk`{yellow.bold Warning!} ${v}`)
   }
 
   function error(v) {
-    log(chalk`{red.bold Error!} ${v}`);
+    log(chalk`{red.bold Error!} ${v}`)
   }
 
   function debug(v) {
-    if (debugEnabled) log(chalk`{bold [debug]} ${v}`);
+    if (debugEnabled) log(chalk`{bold [debug]} ${v}`)
   }
 
   // This is pretty hacky, but since we control the version of Node.js
@@ -30,12 +30,14 @@ function createOutput({ debug: debugEnabled = false } = {}) {
     log(...args) { debug(format(...args)) }
   }
 
-  function time(v) {
+  async function time(label, promise) {
     if (debugEnabled) {
-      Console.prototype.time.call(c, v);
-      return () => Console.prototype.timeEnd.call(c, v);
+      Console.prototype.time.call(c, label)
+      const r = await promise
+      Console.prototype.timeEnd.call(c, label)
+      return r
     } else {
-      return () => {};
+      return promise
     }
   }
 
@@ -46,7 +48,7 @@ function createOutput({ debug: debugEnabled = false } = {}) {
     error,
     debug,
     time
-  };
+  }
 }
 
-module.exports = createOutput;
+module.exports = createOutput

--- a/src/providers/sh/util/output.js
+++ b/src/providers/sh/util/output.js
@@ -1,0 +1,52 @@
+const chalk = require('chalk');
+const { format } = require('util');
+const { Console } = require('console');
+
+function createOutput({ debug: debugEnabled = false } = {}) {
+  function print(v) {
+    process.stderr.write(v);
+  }
+
+  function log(v, color = chalk.grey) {
+    print(`${color('>')} ${v}\n`);
+  }
+
+  function warn(v) {
+    log(chalk`{yellow.bold Warning!} ${v}`);
+  }
+
+  function error(v) {
+    log(chalk`{red.bold Error!} ${v}`);
+  }
+
+  function debug(v) {
+    if (debugEnabled) log(chalk`{bold [debug]} ${v}`);
+  }
+
+  // This is pretty hacky, but since we control the version of Node.js
+  // being used because of `pkg` it's safe to do in this case.
+  const c = {
+    _times: new Map(),
+    log(...args) { debug(format(...args)) }
+  }
+
+  function time(v) {
+    if (debugEnabled) {
+      Console.prototype.time.call(c, v);
+      return () => Console.prototype.timeEnd.call(c, v);
+    } else {
+      return () => {};
+    }
+  }
+
+  return {
+    print,
+    log,
+    warn,
+    error,
+    debug,
+    time
+  };
+}
+
+module.exports = createOutput;

--- a/src/util/output/index.js
+++ b/src/util/output/index.js
@@ -30,7 +30,8 @@ function createOutput({ debug: debugEnabled = false } = {}) {
     log(...args) { debug(format(...args)) }
   }
 
-  async function time(label, promise) {
+  async function time(label, fn) {
+    const promise = !fn.then && typeof fn === 'function' ? fn() : fn
     if (debugEnabled) {
       Console.prototype.time.call(c, label)
       const r = await promise

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ const getStaticFiles = async dir => {
   return getStaticFiles_(dir, nowConfig, { hasNowJson, output })
 }
 
-test.only('`files`', async t => {
+test('`files`', async t => {
   let files = await getNpmFiles(fixture('files-in-package'))
   t.is(files.length, 3)
   files = files.sort(alpha)

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ const {
   staticFiles: getStaticFiles_
 } = require('../src/providers/sh/util/get-files')
 
-const output = createOutput({ debug: true })
+const output = createOutput({ debug: false })
 const prefix = join(__dirname, '_fixtures') + '/'
 const base = path => path.replace(prefix, '')
 const fixture = name => resolve(`./test/_fixtures/${name}`)

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const test = require('ava')
 const { asc: alpha } = require('alpha-sort')
 
 // Utilities
+const createOutput = require('../src/util/output')
 const hash = require('../src/providers/sh/util/hash')
 const readMetadata = require('../src/providers/sh/util/read-metadata')
 const getLocalConfigPath = require('../src/config/local-path')
@@ -16,6 +17,7 @@ const {
   staticFiles: getStaticFiles_
 } = require('../src/providers/sh/util/get-files')
 
+const output = createOutput({ debug: true })
 const prefix = join(__dirname, '_fixtures') + '/'
 const base = path => path.replace(prefix, '')
 const fixture = name => resolve(`./test/_fixtures/${name}`)
@@ -27,7 +29,7 @@ const getNpmFiles = async dir => {
     strict: false
   })
 
-  return getNpmFiles_(dir, pkg, nowConfig, { hasNowJson })
+  return getNpmFiles_(dir, pkg, nowConfig, { hasNowJson, output })
 }
 
 const getDockerFiles = async dir => {
@@ -36,7 +38,7 @@ const getDockerFiles = async dir => {
     strict: false
   })
 
-  return getDockerFiles_(dir, nowConfig, { hasNowJson })
+  return getDockerFiles_(dir, nowConfig, { hasNowJson, output })
 }
 
 const getStaticFiles = async dir => {
@@ -45,10 +47,10 @@ const getStaticFiles = async dir => {
     strict: false
   })
 
-  return getStaticFiles_(dir, nowConfig, { hasNowJson })
+  return getStaticFiles_(dir, nowConfig, { hasNowJson, output })
 }
 
-test('`files`', async t => {
+test.only('`files`', async t => {
   let files = await getNpmFiles(fixture('files-in-package'))
   t.is(files.length, 3)
   files = files.sort(alpha)


### PR DESCRIPTION
* Consistently style the opening `>` as grey
 * All logging goes to stderr (any line that beings with `>`).
   No more cases of accidentally forgetting to check `if (!quiet)` since
   its going to stderr anyways. In fact I'd like to remove `quiet` soon.
 * You instantiate the output helper with "debug mode", so that `if (debug)`
   is not constantly being copy+pasted
 * The `time()` function accepts a Promise or async function and wraps it
   with `console.time()` and `timeEnd()`, and passes through the return value.
   There is no way to typo the label since it is only specified once,
   and no way to forget to call `timeEnd()`, which was happening in a few
   cases which are now fixed.

I've only refactored enough for `now deploy` at the moment, but I'll continue refactor other commands once we land this one.

**Before:**

<img width="610" alt="screen shot 2018-02-27 at 12 41 49 pm" src="https://user-images.githubusercontent.com/71256/36753792-21624a5c-1bbc-11e8-8c15-c5be388973e7.png">

**After:**

<img width="616" alt="screen shot 2018-02-27 at 12 42 11 pm" src="https://user-images.githubusercontent.com/71256/36753797-275e390c-1bbc-11e8-8108-87f581f075c5.png">
