### PR TITLE
Revert "Circumvent attempt to connect logger if reusing an old deployment (#1132)"

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -742,12 +742,6 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         }
         await exit(0)
       } else {
-        if(!now.syncFileCount && !forceNew) {
-          if (!quiet) {
-            log(chalk`{cyan Deployment ready!}`)
-          }
-          exit(0)
-        }
         if (!quiet) {
           log('Initializing…')
         }


### PR DESCRIPTION
Such change breaks `now && now alias` for any new deployment – `now.syncFileCount` is subtracted every time a file is successfully uploaded. cc @pranaygp 