### PR TITLE
Ensure `chalk` is being used properly

### DIFF
--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -253,7 +253,7 @@ module.exports = class Now extends EventEmitter {
     if (!quiet && type === 'npm' && deployment.nodeVersion) {
       if (engines && engines.node && !missingVersion) {
         log(chalk`Using Node.js {bold ${
-          deployment.nodeVersion}} (requested: {dim \`${engines.node}\`)`)
+          deployment.nodeVersion}} (requested: {dim \`${engines.node}\`})`)
       } else {
         log(chalk`Using Node.js {bold ${deployment.nodeVersion}} (default)`)
       }


### PR DESCRIPTION
Prevents the following error:

```
> [debug] Computing hashes: 27.100ms
> [debug] Get files ready for deployment: 1.303ms
> [debug] POST /v3/now/deployments: 4636.582ms
> [debug] Error: Error: Chalk template literal is missing 1 closing bracket (`}`)
Error: Chalk template literal is missing 1 closing bracket (`}`)
    at module.exports (/snapshot/now-cli/node_modules/chalk/templates.js:124:9)
    at chalkTag (/snapshot/now-cli/node_modules/chalk/index.js:221:9)
    at __dirname.Chalk.chalk.template (/snapshot/now-cli/node_modules/chalk/index.js:36:20)
    at Now.create (/snapshot/now-cli/dist/now.js:482:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
> Error! Unexpected error. Please try again later. (Chalk template literal is missing 1 closing bracket (`}`))
```