### PR TITLE
Fixed GitHub, Bitbucket and GitLab deployments

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -305,6 +305,7 @@ async function main(ctx) {
 async function sync({ token, config: { currentTeam, user }, showMessage }) {
   return new Promise(async (_resolve, reject) => {
     const start = Date.now()
+    const rawPath = argv._[0]
 
     let deploymentType
     let isFile
@@ -322,7 +323,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         let isValidRepo = false
 
         try {
-          isValidRepo = isRepoPath(paths[0])
+          isValidRepo = isRepoPath(rawPath)
         } catch (_err) {
           if (err.code === 'INVALID_URL') {
             await stopDeployment(_err)
@@ -332,7 +333,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
         }
 
         if (isValidRepo) {
-          const gitParts = gitPathParts(paths[0])
+          const gitParts = gitPathParts(rawPath)
           Object.assign(gitRepo, gitParts)
 
           const searchMessage = setTimeout(() => {
@@ -340,7 +341,7 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           }, 500)
 
           try {
-            repo = await fromGit(paths[0], debugEnabled)
+            repo = await fromGit(rawPath, debugEnabled)
           } catch (err) {}
 
           clearTimeout(searchMessage)


### PR DESCRIPTION
On the canary channel, Git deployments recently stopped working properly. This brings it back to normal and ensures everything is working as it should.