### PR TITLE
Deploy and publish using Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,15 +166,22 @@ workflows:
       - upload:
           requires:
             - compress
+          filters:
+            tags:
+              only: /.*/
       - publish-canary:
           requires:
             - upload
           filters:
             branches:
               only: canary
+            tags:
+              only: /.*/
       - publish-stable:
           requires:
             - upload
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/


### PR DESCRIPTION
It turns out that all jobs who should be executed for tag checkouts need this rule:

```
filters:
  tags:
    only: /.*/
```

Otherwise (even if the jobs below them catch it) they don't catch the checkout. 🙈 