### PR TITLE
Handle tag checkouts properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,14 +174,14 @@ workflows:
             - upload
           filters:
             branches:
-              only: canary
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /canary/
       - publish-stable:
           requires:
             - upload
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
-              only: /.*/
+              ignore: /canary/


### PR DESCRIPTION
This adjusts our tag usage when publishing releases according to [this document](https://circleci.com/docs/2.0/workflows/).