### PR TITLE
1153:Fixed sync timer

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -751,12 +751,9 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
       process.stdout.write(url)
     }
 
-    const startU = new Date()
-
     if (!quiet) {
       if (syncCount) {
-        const elapsedU = ms(new Date() - startU)
-        log(`Synced ${syncCount} (${bytes(now.syncAmount)}) [${elapsedU}]`)
+        log(`Synced ${syncCount} (${bytes(now.syncAmount)}) [${elapsed}]`)
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/zeit/now-cli/issues/1153. The elapsed deployment time was previously displaying 0s.