### PR TITLE
Fixed duplicate deployment type prompt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
             >-
               for file in ./packed/*.gz;
               do
-               github-release upload -t `git describe --tags` -n ${file##*/} -f $file
+               github-release upload -R -t `git describe --tags` -n ${file##*/} -f $file
               done
       - save_cache:
           key: v1-pkg-cache

--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -178,6 +178,7 @@ let apiUrl
 let isTTY
 let quiet
 let alwaysForwardNpm
+let meta
 
 // If the current deployment is a repo
 const gitRepo = {}
@@ -424,8 +425,6 @@ async function sync({ token, config: { currentTeam, user }, showMessage }) {
           )}`)
       }
     }
-
-    let meta
 
     if (!isFile && deploymentType !== 'static') {
       if (argv.docker) {


### PR DESCRIPTION
A duplicate deployment type prompt was displayed if the project had multiple deployment options.

This fixes #1163.