### PR TITLE
Added Spectrum badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 ![now](https://github.com/zeit/art/blob/a7867d60f54a41127023a8740a221921df309d24/now-cli/repo-banner.png?raw=true)
 
 [![Build Status](https://circleci.com/gh/zeit/now-cli.svg?&style=shield)](https://circleci.com/gh/zeit/workflows/now-cli)
-[![Slack Channel](http://zeit-slackin.now.sh/badge.svg)](https://zeit.chat/)
+[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/now)
 
 ## Usage
 


### PR DESCRIPTION
This introduces a badge for our new [Spectrum community](https://spectrum.chat/now)! 🎉 

<img width="392" alt="screen shot 2018-03-10 at 20 47 14" src="https://user-images.githubusercontent.com/6170607/37249847-542b83fe-24a4-11e8-8ebb-e58326d6f70f.png">
