### PR TITLE
Pinned CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   install:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -42,7 +42,7 @@ jobs:
 
   test-lint:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -54,7 +54,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -78,7 +78,7 @@ jobs:
 
   compress:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -94,7 +94,7 @@ jobs:
 
   upload:
     docker:
-      - image: circleci/golang:latest
+      - image: circleci/golang:1.10
     working_directory: ~/repo
     steps:
       - checkout
@@ -121,7 +121,7 @@ jobs:
 
   publish-stable:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -136,7 +136,7 @@ jobs:
 
   publish-canary:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   install:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -42,7 +42,7 @@ jobs:
 
   test-lint:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -54,7 +54,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -78,7 +78,7 @@ jobs:
 
   compress:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -121,7 +121,7 @@ jobs:
 
   publish-stable:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout
@@ -136,7 +136,7 @@ jobs:
 
   publish-canary:
     docker:
-      - image: circleci/node:9.7.1
+      - image: circleci/node:9.8.0
     working_directory: ~/repo
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/fixtures/integration
 
 # logs
 npm-debug.log
+yarn-error.log


### PR DESCRIPTION
Today, Circle CI released a new Node.js image that was missing `yarn`. This broke our tests, so we pinned the versions of all images to prevent this from happening again! 🔒 