### PR TITLE
Added scheduled CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,24 @@ jobs:
 
 workflows:
   version: 2
-  compile:
+  scheduled:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - canary
+    jobs:
+      - install
+      - build:
+          requires:
+            - install
+      - test-integration:
+          requires:
+            - build
+  unscheduled:
     jobs:
       - install:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ workflows:
   scheduled:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "30 * * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
Once this is merged, our integration tests will run automatically every hour – apart from us pushing to any of the branches.

For now, this is the tightest interval possible (except for every minute, which is too tight), because Circle CI [doesn't support crontab steps](https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow).