### PR TITLE
Add an improved table formatter for multi block tables

### DIFF
--- a/src/providers/sh/commands/domains.js
+++ b/src/providers/sh/commands/domains.js
@@ -11,9 +11,9 @@ const plural = require('pluralize')
 // Utilities
 const NowDomains = require('../util/domains')
 const exit = require('../../../util/exit')
+const formatTable = require('../util/format-table');
 const logo = require('../../../util/output/logo')
 const promptBool = require('../../../util/input/prompt-bool')
-const strlen = require('../util/strlen')
 const toHost = require('../util/to-host')
 const { handleError, error } = require('../util/error')
 const buy = require('./domains/buy')
@@ -138,30 +138,17 @@ async function run({ token, sh: { currentTeam, user } }) {
       const start_ = new Date()
       const domains = await domain.ls()
       domains.sort((a, b) => new Date(b.created) - new Date(a.created))
-      const current = new Date()
-      const header = [
-        ['', 'domain', 'dns', 'verified', 'created'].map(s => chalk.dim(s))
-      ]
-      const out =
-        domains.length === 0
-          ? null
-          : table(
-              header.concat(
-                domains.map(domain => {
-                  const ns = domain.isExternal ? 'external' : 'zeit.world'
-                  const url = chalk.bold(domain.name)
-                  const time = chalk.gray(
-                    ms(current - new Date(domain.created)) + ' ago'
-                  )
-                  return ['', url, ns, domain.verified, time]
-                })
-              ),
-              {
-                align: ['l', 'l', 'l', 'l', 'l'],
-                hsep: ' '.repeat(2),
-                stringLength: strlen
-              }
-            )
+      const timeNow = new Date()
+      const header = ['domain', 'dns', 'verified', 'created'].map(s => chalk.dim(s))
+      const align = ['l', 'l', 'l', 'l', 'l']
+      const data = [{
+        rows: domains.map((domain) => {
+          const url = chalk.bold(domain.name)
+          const ns = domain.isExternal ? 'external' : 'zeit.world'
+          const age = chalk.gray(ms(timeNow - new Date(domain.created)) + ' ago')
+          return [url, ns, domain.verified, age]
+        })
+      }]
 
       const elapsed_ = ms(new Date() - start_)
       console.log(
@@ -169,10 +156,7 @@ async function run({ token, sh: { currentTeam, user } }) {
           (currentTeam && currentTeam.slug) || user.username || user.email
         )} ${chalk.gray(`[${elapsed_}]`)}`
       )
-
-      if (out) {
-        console.log('\n' + out + '\n')
-      }
+      console.log(formatTable(header, align, data))
 
       break
     }

--- a/src/providers/sh/util/format-table.js
+++ b/src/providers/sh/util/format-table.js
@@ -1,0 +1,61 @@
+// Packages
+const chalk = require('chalk')
+const table = require('text-table')
+
+// Utilities
+const strlen = require('./strlen')
+
+// header:
+// [ 'a', 'b', 'c', ... ]
+// align:
+// ['l', 'l', 'r', ... ]
+// data:
+// [
+//   {
+//     name: 'name',
+//     rows: [
+//       [ col1, col2, col3, ... ],
+//       [ col1, col2, col3, ... ]
+//     ]
+//   },
+//   ...
+// ]
+module.exports = function formatTable(header, align, blocks) {
+  const nrCols = blocks[0].rows[0].length;
+  const padding = [];
+  let out = '\n';
+
+  for (let i = 0; i < nrCols; i++) {
+    padding[i] = blocks.reduce((acc, block) => {
+      const maxLen = Math.max(...block.rows.map((row) => strlen(`${row[i]}`)))
+      return Math.max(acc, Math.ceil(maxLen / 8))
+    }, 1)
+  }
+
+  for (const block of blocks) {
+    if (block.name) {
+      out += `${block.name}\n`
+    }
+
+    const rows = [ header.map(s => chalk.dim(s)) ].concat(block.rows)
+
+    if (rows.length > 0) {
+      rows[0][0] = ' ' + rows[0][0]
+
+      for (let i = 1; i < rows.length; i++) {
+        const row = rows[i].slice(0)
+        row[0] = ' ' + row[0]
+        for (let j = 0; j < nrCols; j++) {
+          const col = `${row[j]}`
+          const al = align[j] || 'l'
+          const pad = padding[j] > 1 ? ' '.repeat(padding[j] * 8 - strlen(col)) : '';
+          rows[i][j] = al === 'l' ? col + pad : pad + col
+        }
+      }
+      out += table(rows, { align, hsep: '\t', stringLength: strlen })
+    }
+    out += '\n\n'
+  }
+
+  return out.slice(0, -1);
+}

--- a/src/providers/sh/util/format-table.js
+++ b/src/providers/sh/util/format-table.js
@@ -21,7 +21,7 @@ const strlen = require('./strlen')
 //   ...
 // ]
 module.exports = function formatTable(header, align, blocks) {
-  const nrCols = blocks[0].rows[0].length;
+  const nrCols = header.length;
   const padding = [];
   let out = '\n';
 


### PR DESCRIPTION
The current table formatting doesn't consider tab stops and it
breaks formatting between headings in `ls` commands such as
`now dns ls`. Add a new table formatter that generates a proper
tab stop layout and matches column stops between tables in the
same listing.