### PR TITLE
Validate whether port is exposed in a Dockerfile

### DIFF
--- a/errors/missing-port-dockerfile.md
+++ b/errors/missing-port-dockerfile.md
@@ -1,0 +1,11 @@
+# Missing port dockerfile
+
+#### Why This Error Occurred
+
+You tried to deploy with a Dockerfile that doesn't expose a port.
+
+#### Possible Ways to Fix It
+
+Expose a port in the Dockerfile.
+
+Documentation for Port Selection can be found [here](https://zeit.co/docs/deployment-types/docker#port-selection).

--- a/src/providers/sh/util/read-metadata.js
+++ b/src/providers/sh/util/read-metadata.js
@@ -11,6 +11,7 @@ const determineType = require('deployment-type')
 
 // Utilities
 const getLocalConfigPath = require('../../../config/local-path')
+const { error } = require('../util/error')
 
 module.exports = readMetaData
 
@@ -109,6 +110,12 @@ async function readMetaData(
     }
 
     const labels = {}
+    const expose = dockerfile.find(cmd => cmd.name === 'EXPOSE')
+
+    if (expose === undefined || expose.args.length === 0 || expose.args[0] <= 0) {
+      console.error(error(`A port needs to be exposed in the dockerfile. https://err.sh/now-cli/missing-port-dockerfile`))
+      return process.exit(1)
+    }
 
     dockerfile.filter(cmd => cmd.name === 'LABEL').forEach(({ args }) => {
       for (const key in args) {

--- a/test/fixtures/unit/dockerfile/Dockerfile
+++ b/test/fixtures/unit/dockerfile/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80

--- a/test/fixtures/unit/multiple-manifests-throws/Dockerfile
+++ b/test/fixtures/unit/multiple-manifests-throws/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80

--- a/test/fixtures/unit/now-json-docker-dockerignore-override/Dockerfile
+++ b/test/fixtures/unit/now-json-docker-dockerignore-override/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80

--- a/test/fixtures/unit/now-json-docker-gitignore-override/Dockerfile
+++ b/test/fixtures/unit/now-json-docker-gitignore-override/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80

--- a/test/fixtures/unit/now-json-docker/Dockerfile
+++ b/test/fixtures/unit/now-json-docker/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80

--- a/test/fixtures/unit/type-in-package-now-with-dockerfile/Dockerfile
+++ b/test/fixtures/unit/type-in-package-now-with-dockerfile/Dockerfile
@@ -1,1 +1,2 @@
 CMD echo 'world'
+EXPOSE 80


### PR DESCRIPTION
Validates if a port is exposed in the Dockerfile. This was a suggestion in https://github.com/zeit/now-cli/issues/1019#issuecomment-354550268