### PR TITLE
Run integration tests on Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ jobs:
           command: yarn test-unit
 
   test-integration:
-    macos:
-      xcode: '9.2.0'
+    docker:
+      - image: circleci/node:9.7.1
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Running scheduled integration tests on macOS inside Circle CI is pretty expensive. As a result, I've decided to run them on Linux instead, which is free forever.