### PR TITLE
Add expectedPrice check

### DIFF
--- a/src/providers/sh/commands/domains/buy.js
+++ b/src/providers/sh/commands/domains/buy.js
@@ -106,7 +106,7 @@ module.exports = async function({ domains, args, currentTeam, user, coupon }) {
   stopSpinner = wait('Purchasing')
   elapsed = stamp()
   try {
-    await domains.buy({ name, coupon })
+    await domains.buy({ name, coupon, expectedPrice: price })
   } catch (err) {
     stopSpinner()
     return treatBuyError(err)

--- a/src/providers/sh/util/domains.js
+++ b/src/providers/sh/util/domains.js
@@ -161,12 +161,12 @@ module.exports = class Domains extends Now {
     })
   }
 
-  async buy({ name, coupon }) {
+  async buy({ name, coupon, expectedPrice }) {
     if (!name) {
       throw new Error('`name` is not defined')
     }
 
-    const body = JSON.stringify({ name, coupon })
+    const body = JSON.stringify({ name, coupon, expectedPrice })
 
     return this.retry(async (bail, attempt) => {
       if (this._debug) {


### PR DESCRIPTION
We have the price in the workflow and the API supports an `expectedPrice` parameter so in case the user gets a different price from the server the purchase will fail.