### PR TITLE
Only write URL to stdout

### DIFF
--- a/src/util/output/wait.js
+++ b/src/util/output/wait.js
@@ -1,6 +1,5 @@
 const ora2 = require('ora')
 const { gray } = require('chalk')
-const eraseLines = require('./erase-lines')
 
 const wait = (msg, timeOut = 300, ora = ora2) => {
   let running = false
@@ -21,7 +20,6 @@ const wait = (msg, timeOut = 300, ora = ora2) => {
     stopped = true
     if (running) {
       spinner.stop()
-      process.stdout.write(eraseLines(1))
       running = false
     }
     process.removeListener('nowExit', cancel)

--- a/src/util/output/wait.js
+++ b/src/util/output/wait.js
@@ -1,5 +1,6 @@
 const ora2 = require('ora')
 const { gray } = require('chalk')
+const eraseLines = require('./erase-lines')
 
 const wait = (msg, timeOut = 300, ora = ora2) => {
   let running = false
@@ -20,6 +21,7 @@ const wait = (msg, timeOut = 300, ora = ora2) => {
     stopped = true
     if (running) {
       spinner.stop()
+      process.stderr.write(eraseLines(1))
       running = false
     }
     process.removeListener('nowExit', cancel)


### PR DESCRIPTION
I'm not sure about the purpose of the line removed in this PR but it was writing to `stdout` and thus it was polluting the output when `URL=$(now deploy)`.

It was working for static deployments because we are not verifying that the instances are running at the end of the process in such case so we don't get to call the spinner.