### PR TITLE
Made deploying static directories without `--static` work again

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -334,6 +334,9 @@ async function sync({ output, token, config: { currentTeam, user }, showMessage 
           isFile = true
           deploymentType = 'static'
           atlas = await isELF(paths[0]) && executable.checkMode(fsData.mode, fsData.gid, fsData.uid)
+        } else {
+          isFile = false
+          deploymentType = 'static'
         }
       } catch (err) {
         let repo


### PR DESCRIPTION
In version [11.0.0](https://github.com/zeit/now-cli/releases/tag/11.0.0), we accidentally introduced a regression that prevented deploying static directories without the `--static` flag. After this PR is merged, this will work again.