### PR TITLE
Ensure listing single deployments work

### DIFF
--- a/src/providers/sh/commands/deploy.js
+++ b/src/providers/sh/commands/deploy.js
@@ -34,7 +34,6 @@ const wait = require('../../../util/output/wait')
 const stamp = require('../../../util/output/stamp')
 const promptBool = require('../../../util/input/prompt-bool')
 const promptOptions = require('../util/prompt-options')
-const note = require('../../../util/output/note')
 const exit = require('../../../util/exit')
 const { normalizeRegionsList, isValidRegionOrDcId } = require('../util/dcs')
 const printEvents = require('../util/events')
@@ -175,6 +174,7 @@ let sessionAffinity
 let log
 let error
 let debug
+let note
 let debugEnabled
 let clipboard
 let forwardNpm
@@ -295,7 +295,7 @@ async function main(ctx: any) {
   isTTY = process.stdout.isTTY
   quiet = !isTTY
   const output = createOutput({ debug: debugEnabled })
-  ;({ log, error, debug } = output)
+  ;({ log, error, note, debug } = output)
 
   if (argv.h || argv.help) {
     help()
@@ -678,9 +678,7 @@ async function sync({ output, token, config: { currentTeam, user }, showMessage 
 
     env_.filter(v => Boolean(v)).forEach(([key, val]) => {
       if (key in env) {
-        log(
           note(`Overriding duplicate env key ${chalk.bold(`"${key}"`)}`)
-        )
       }
 
       env[key] = val
@@ -768,7 +766,7 @@ async function sync({ output, token, config: { currentTeam, user }, showMessage 
             url = `https://zeit.co/teams/${currentTeam.slug}/settings/plan`
           }
 
-          log(note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`))
+          note(`You can use ${cmd('now --public')} or upgrade your plan (${url}) to skip this prompt`)
 
           if (!proceed) {
             if (typeof proceed === 'undefined') {

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -18,6 +18,8 @@ const elapsed = require('../../../util/output/elapsed')
 const wait = require('../../../util/output/wait')
 const strlen = require('../util/strlen')
 const getContextName = require('../util/get-context-name')
+const isValidDomain = require('../util/domains/is-valid-domain')
+const toHost = require('../util/to-host')
 const argCommon = require('../util/arg-common')()
 
 const help = () => {
@@ -73,14 +75,16 @@ module.exports = async function main(ctx) {
   }
 
   const debugEnabled = argv['--debug']
-  const { print, log, error, debug } = createOutput({ debug: debugEnabled })
+  const { print, log, error, note, debug } = createOutput({ debug: debugEnabled })
 
   if (argv._.length > 1) {
     error(`${cmd('now ls [app]')} accepts at most one argument`);
     return 1;
   }
 
-  const app = argv._[0]
+  let app = argv._[0]
+  let host = null
+
   const apiUrl = ctx.apiUrl
 
   if (argv['--help']) {
@@ -102,6 +106,28 @@ module.exports = async function main(ctx) {
     stopSpinner()
     error('You must define an app when using `-a` / `--all`')
     return 1;
+  }
+
+  if (app && isValidDomain(app)) {
+    const asHost = toHost(app)
+
+    if (!asHost.endsWith('.now.sh')) {
+      stopSpinner()
+      error('Only deployment hostnames are allowed')
+      return 1
+    }
+
+    note('We suggest using `now inspect <deployment>` for retrieving details about a single deployment')
+    const hostParts = asHost.split('-')
+
+    if (hostParts < 2) {
+      stopSpinner()
+      error('Only deployment hostnames are allowed, no aliases')
+      return 1
+    }
+
+    app = hostParts[0]
+    host = asHost
   }
 
   let deployments
@@ -160,6 +186,12 @@ module.exports = async function main(ctx) {
           : []
       })
     )
+  }
+
+  if (host) {
+    deployments = deployments.filter(deployment => {
+      return deployment.url === host
+    })
   }
 
   stopSpinner()

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -114,7 +114,7 @@ module.exports = async function main(ctx) {
     throw err;
   }
 
-  if (!deployments.length) {
+  if (app && !deployments.length) {
     debug('No deployments: attempting to find deployment that matches supplied app name')
     let match
 
@@ -135,7 +135,7 @@ module.exports = async function main(ctx) {
     }
   }
 
-  if (!deployments.length) {
+  if (app && !deployments.length) {
     debug('No deployments: attempting to find aliases that matches supplied app name')
     const aliases = await now.listAliases()
     const item = aliases.find(e => e.uid === app || e.alias === app)

--- a/src/util/output/index.js
+++ b/src/util/output/index.js
@@ -18,6 +18,10 @@ function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
+  function note(v) {
+    log(chalk`{yellow.bold NOTE:} ${v}`, chalk.yellow)
+  }
+
   function error(v, slug = null) {
     log(chalk`{red.bold Error!} ${v}`, chalk.red)
     if (slug !== null) {
@@ -62,7 +66,8 @@ function createOutput({ debug: debugEnabled = false } = {}) {
     error,
     success,
     debug,
-    time
+    time,
+    note
   }
 }
 

--- a/src/util/output/note.js
+++ b/src/util/output/note.js
@@ -1,5 +1,5 @@
 const { yellow } = require('chalk')
 
-const note = msg => `${yellow('> NOTE:')} ${msg}`
+const note = msg => `${yellow('NOTE:')} ${msg}`
 
 module.exports = note

--- a/src/util/output/note.js
+++ b/src/util/output/note.js
@@ -1,5 +1,5 @@
 const { yellow } = require('chalk')
 
-const note = msg => `${yellow('NOTE:')} ${msg}`
+const note = msg => `${yellow('> NOTE:')} ${msg}`
 
 module.exports = note


### PR DESCRIPTION
This PR ensures that...

- ...running `now ls <deployment>` works as before and shows a note that users should try the `now inspect <deployment>` command instead.
- ...makes use of `createOutput` for showing the `--public` notice when deploying under OSS.
