### PR TITLE
Remove certs by cn

### DIFF
--- a/src/providers/sh/commands/certs/index.js
+++ b/src/providers/sh/commands/certs/index.js
@@ -24,7 +24,7 @@ const help = () => {
 
     ls                    Show all available certificates
     add    <cn>[, <cn>]   Create a certificate for a domain
-    rm     <id>           Remove an available certificate
+    rm     <id or cn>     Remove an available certificate
 
   ${chalk.dim('Options:')}
 
@@ -59,7 +59,7 @@ const help = () => {
   )} Remove a certificate
 
       ${chalk.cyan(
-        '$ now certs rm 5n7g8eBEwslBF930FUAx'
+        '$ now certs rm acme.com'
       )}
   `)
 }

--- a/src/providers/sh/commands/certs/ls.js
+++ b/src/providers/sh/commands/certs/ls.js
@@ -8,6 +8,7 @@ import table from 'text-table'
 import Now from '../../util'
 import getContextName from '../../util/get-context-name'
 import stamp from '../../../../util/output/stamp'
+import getCerts from '../../util/certs/get-certs'
 import strlen from '../../util/strlen'
 import { CLIContext, Output } from '../../util/types'
 import type { CLICertsOptions } from '../../util/types'
@@ -29,7 +30,7 @@ async function ls(ctx: CLIContext, opts: CLICertsOptions, args: string[], output
   }
 
   // Get the list of certificates
-  const certs = sortByCn(await getCerts(now))
+  const certs = sortByCn(await getCerts(output, now))
   output.log(`${plural('certificate', certs.length, true)} found under ${chalk.bold(contextName)} ${lsStamp()}`)
 
   if (certs.length > 0) {
@@ -115,11 +116,6 @@ function sortByCn(certsList) {
     if (!domainA || !domainB) return 0;
     return domainA.localeCompare(domainB)
   })
-}
-
-async function getCerts(now) {
-  const { certs } = await now.fetch('/v3/now/certs')
-  return certs
 }
 
 export default ls

--- a/src/providers/sh/util/certs/delete-cert-by-id.js
+++ b/src/providers/sh/util/certs/delete-cert-by-id.js
@@ -1,0 +1,10 @@
+// @flow 
+import { Output, Now } from '../types'
+
+async function deleteCertById(output: Output, now: Now, id: string) {
+  return now.fetch(`/v3/now/certs/${id}`, {
+    method: 'DELETE',
+  })
+}
+
+export default deleteCertById

--- a/src/providers/sh/util/certs/get-cert-by-id.js
+++ b/src/providers/sh/util/certs/get-cert-by-id.js
@@ -1,0 +1,11 @@
+// @flow
+
+import getCerts from './get-certs'
+import { Output, Now } from '../types'
+
+async function getCertById(output: Output, now: Now, id: string) {
+  const certs = await getCerts(output, now)
+  return certs.find(c => c.uid === id)
+}
+
+export default getCertById

--- a/src/providers/sh/util/certs/get-certs.js
+++ b/src/providers/sh/util/certs/get-certs.js
@@ -1,0 +1,13 @@
+// @flow
+import { stringify } from 'querystring'
+import { Output, Now } from '../types'
+import type { Certificate } from '../types'
+
+async function getCerts(output: Output, now: Now, domain?: string[]) {
+  const query = domain ? stringify({ domain }) : ''
+  const payload = await now.fetch(`/v3/now/certs?${query}`)
+  const certs: Certificate[] = payload.certs
+  return certs
+}
+
+export default getCerts

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -1,6 +1,6 @@
 // @flow
 type FetchOptions = {
-  body: any,
+  body?: any,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 }
 


### PR DESCRIPTION
Allows to remove multiple certificates at once querying by `cn` instead of just `id`.
Now both options are allowed.