### PR TITLE
Replace combine-async-generators

### DIFF
--- a/src/providers/sh/util/deploy/get-deployment-events.js
+++ b/src/providers/sh/util/deploy/get-deployment-events.js
@@ -23,9 +23,14 @@ type Options = {
   until?: number,
 }
 
-export default async function getDeploymentEvents(now: Now, contextName: string, idOrHost: string, options: Options) {
+export default async function getDeploymentEvents(
+  now: Now, 
+  contextName: string,
+  idOrHost: string,
+  options: Options
+): Promise<AsyncGenerator<DeploymentEvent, void, void>> {
   const eventsStream = await getEventsStream(now, idOrHost, options)
-  const eventsStreamGenerator: AsyncGenerator<DeploymentEvent, void, void> = eventListenerToGenerator('data', eventsStream)
+  const eventsStreamGenerator = eventListenerToGenerator('data', eventsStream)
   const eventsFromPollingGenerator = getStatusChangeFromPolling(now, contextName, idOrHost)
   return combineAsyncGenerators(eventsStreamGenerator, eventsFromPollingGenerator)
 }
@@ -56,7 +61,6 @@ async function* getStatusChangeFromPolling(now: Now, contextName: string, idOrHo
         created: Date.now(),
         payload: { value: deployment.state }
       }
-      break
     } else {
       lastResult = deployment
     }

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -202,7 +202,7 @@ export type InstanceStopEvent = GenericEvent<'instance-stop', {
   billingId: string
 }>
 
-export type AliasSetEvent = GenericEvent<'alias-set', {
+export type AliasSetEvent = GenericEvent<'alias-add', {
   dc: 'sfo1' | 'bru1',
   billingId: string,
   aliasId: string,

--- a/src/util/combine-async-generators.js
+++ b/src/util/combine-async-generators.js
@@ -1,27 +1,21 @@
-// @flow
-
-async function* combineImplementation(...args) {
-  // $FlowFixMe
-  const threads = args.map(i => i[Symbol.asyncIterator]())
-  const sparks = new Set(threads.map(i => ({thread:i,step:i.next()})))
-  try {
-    while(sparks.size) {
-      const promises = [...sparks].map(i => i.step.then(({done,value}) => ({done,value,spark:i})))
-      const v = await Promise.race(promises)
-      sparks.delete(v.spark)
-      if (!v.done) {
-        sparks.add({...v.spark,step:v.spark.thread.next()})
-        yield v.value
-      }
-    }
-  } finally {
-    await Promise.all([...threads].map((i) => i.return()))
+export default async function* combineAsyncIterators(...args) {
+  const nextPromises = args.map(i => i.next())
+  while (true) {
+    yield new Promise(resolve => {
+      let resolved = false
+      nextPromises.forEach((nextPromise, idx) => {
+        nextPromise.then(({ value, done }) => {
+          if (!resolved) {
+            resolved = true
+            resolve(value)
+            if (!done) {
+              nextPromises[idx] = args[idx].next()
+            } else {
+              delete nextPromises[idx]
+            }
+          }
+        })
+      })
+    })
   }
 }
-
-type CombineAsyncGenerators = 
-  <A, B>(AsyncGenerator<A, void, void>, AsyncGenerator<B, void, void>) => AsyncGenerator<A | B, void, void> |
-  <A, B, C>(AsyncGenerator<A, void, void>, AsyncGenerator<B, void, void>, AsyncGenerator<C, void, void>) => AsyncGenerator<A | B | C, void, void>
-
-const combine: CombineAsyncGenerators = combineImplementation
-export default combine

--- a/src/util/event-listener-to-generator.js
+++ b/src/util/event-listener-to-generator.js
@@ -3,7 +3,7 @@ import type { Readable } from 'stream'
 
 async function* eventListenerToGenerator(event: string, emitter: Readable): AsyncGenerator<any, any, any> {
   while (true) {
-    yield await new Promise(resolve => {
+    yield new Promise(resolve => {
       const handler = (...args) => {
         emitter.removeListener(event, handler);
         resolve(...args);


### PR DESCRIPTION
This PR replaces the function that we were using to merge two async generators for a much simpler version that works faster and it serves the same purpose. Also, it ignores potentially empty objects that we could get from the events stream and changes the type of the `alias-set` event to `alias-add`.