### PR TITLE
Fix number of instances verification

### DIFF
--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -309,7 +309,7 @@ module.exports = async function main (ctx) {
   if (updatedDeployment.type === 'NPM') {
     const result = await waitVerifyDeploymentScale(output, now, deployment.uid, updatedDeployment.scale)
     if (result instanceof VerifyScaleTimeout) {
-      output.error(`Instance verification timed out (${ms(error.meta.timeout)})`)
+      output.error(`Instance verification timed out (${ms(result.meta.timeout)})`)
       output.log('Read more: https://err.sh/now-cli/verification-timeout')
       now.close()
       return 1

--- a/src/providers/sh/util/scale/verify-deployment-scale.js
+++ b/src/providers/sh/util/scale/verify-deployment-scale.js
@@ -56,7 +56,7 @@ function allDcsMatched(target: InstancesCount, current: InstancesCount): boolean
 
 function getTargetInstancesCountForScale(scale: DeploymentScale): InstancesCount {
   return Object.keys(scale).reduce((result, dc) =>({ 
-    ...result, [dc]: scale[dc].max 
+    ...result, [dc]: scale[dc].min 
   }), {})
 }
 


### PR DESCRIPTION
This PR fixes two issues:
- A typo accessing the error information in `scale` when the verification times out
- We were taking `max` from scaling presets as the number of instances to verify instead of `min`.