### PR TITLE
Migrate to arg@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ansi-escapes": "3.0.0",
     "ansi-regex": "3.0.0",
     "archiver": "2.0.3",
-    "arg": "1.0.1",
+    "arg": "2.0.0",
     "arr-flatten": "1.1.0",
     "async-retry": "1.1.3",
     "async-sema": "1.2.0",

--- a/src/providers/sh/commands/alias/alias.js
+++ b/src/providers/sh/commands/alias/alias.js
@@ -1,7 +1,6 @@
 // @flow
 
 // Packages
-const arg = require('arg')
 const chalk = require('chalk')
 const ms = require('ms')
 const plural = require('pluralize')
@@ -9,7 +8,6 @@ const table = require('text-table')
 
 // Utilities
 const { handleError } = require('../../util/error')
-const argCommon = require('../../util/arg-common')()
 const cmd = require('../../../../util/output/cmd')
 const createOutput = require('../../../../util/output')
 const getContextName = require('../../util/get-context-name')
@@ -25,6 +23,7 @@ const wait = require('../../../../util/output/wait')
 import { Output } from '../../util/types'
 import * as Errors from '../../util/errors'
 import assignAlias from './assign-alias'
+import getArgs from '../../util/get-args'
 import getDeploymentForAlias from './get-deployment-for-alias'
 import getRulesFromFile from './get-rules-from-file'
 import getSubcommand from './get-subcommand'
@@ -114,8 +113,7 @@ const COMMAND_CONFIG = {
 module.exports = async function main(ctx: any): Promise<number> {
   let argv
   try {
-    argv = arg(ctx.argv.slice(2), {
-      ...argCommon,
+    argv = getArgs(ctx.argv.slice(2), {
       '--yes': Boolean,
       '-y': '--yes',
 

--- a/src/providers/sh/commands/inspect.js
+++ b/src/providers/sh/commands/inspect.js
@@ -2,7 +2,6 @@
 
 // Packages
 const chalk = require('chalk')
-const arg = require('arg')
 const table = require('text-table')
 
 // Utilities
@@ -11,11 +10,12 @@ const createOutput = require('../../../util/output')
 const Now = require('../util/')
 const logo = require('../../../util/output/logo')
 const elapsed = require('../../../util/output/elapsed')
-const argCommon = require('../util/arg-common')()
 const wait = require('../../../util/output/wait')
 const { handleError } = require('../util/error')
 const strlen = require('../util/strlen')
 const getContextName = require('../util/get-context-name')
+
+import getArgs from '../util/get-args'
 
 const STATIC = 'STATIC'
 
@@ -50,9 +50,7 @@ module.exports = async function main (ctx: any): Promise<number> {
   let argv;
 
   try {
-    argv = arg(ctx.argv.slice(3), {
-      ...argCommon
-    })
+    argv = getArgs(ctx.argv.slice(2))
   } catch (err) {
     handleError(err)
     return 1;
@@ -69,9 +67,9 @@ module.exports = async function main (ctx: any): Promise<number> {
   const { print, log, error } = output;
 
   // extract the first parameter
-  id = argv._[0]
+  id = argv._[1]
 
-  if (argv._.length !== 1) {
+  if (argv._.length !== 2) {
     error(`${cmd('now inspect <url>')} expects exactly one argument`)
     help();
     return 1;

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -2,7 +2,6 @@
 //@flow
 
 // Packages
-const arg = require('arg')
 const chalk = require('chalk')
 const ms = require('ms')
 const plural = require('pluralize')
@@ -19,7 +18,8 @@ const wait = require('../../../util/output/wait')
 const strlen = require('../util/strlen')
 const getContextName = require('../util/get-context-name')
 const toHost = require('../util/to-host')
-const argCommon = require('../util/arg-common')()
+
+import getArgs from '../util/get-args'
 import getDeploymentInstances from '../util/deploy/get-deployment-instances'
 
 const help = () => {
@@ -64,8 +64,7 @@ module.exports = async function main(ctx) {
   let argv
 
   try {
-    argv = arg(ctx.argv.slice(3), {
-      ...argCommon,
+    argv = getArgs(ctx.argv.slice(2), {
       '--all': Boolean,
       '-a': '--all',
     })
@@ -77,12 +76,12 @@ module.exports = async function main(ctx) {
   const debugEnabled = argv['--debug']
   const { print, log, error, note, debug } = createOutput({ debug: debugEnabled })
 
-  if (argv._.length > 1) {
+  if (argv._.length > 2) {
     error(`${cmd('now ls [app]')} accepts at most one argument`);
     return 1;
   }
 
-  let app = argv._[0]
+  let app = argv._[1]
   let host = null
 
   const apiUrl = ctx.apiUrl

--- a/src/providers/sh/util/get-args.js
+++ b/src/providers/sh/util/get-args.js
@@ -2,11 +2,15 @@
 import arg from 'arg'
 const getCommonArgs = require('./arg-common')
 
-function getArgs(cliArgs: string[], options: Object) {
-  return arg(cliArgs, {
-    ...options,
-    ...getCommonArgs()
-  })
+type ArgOptions = {
+  permissive?: boolean
+}
+
+function getArgs(argv: string[], argsOptions?: Object = {}, argOptions?: ArgOptions = {}) {
+  return arg({
+    ...getCommonArgs(),
+    ...argsOptions
+  }, { ...argOptions, argv })
 }
 
 export default getArgs

--- a/test/integration.js
+++ b/test/integration.js
@@ -173,6 +173,31 @@ test('find deployment in list', async t => {
   }
 })
 
+test('find deployment in list with mixed args', async t => {
+  const { stdout, code } = await execa(binaryPath, [
+    '--debug',
+    'ls',
+    ...defaultArgs
+  ], {
+    reject: false
+  })
+
+  const deployments = parseList(stdout)
+
+  t.true(deployments.length > 0)
+  t.is(code, 0)
+
+  const target = deployments.find(deployment => {
+    return deployment.includes(`${session}-`)
+  })
+
+  t.truthy(target)
+
+  if (target) {
+    context.deployment = target
+  }
+})
+
 test('create alias for deployment', async t => {
   const hosts = {
     deployment: context.deployment,

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,9 +781,9 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arg@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-1.0.1.tgz#892a26d841bd5a64880bbc8f73dd64a705910ca3"
+arg@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-2.0.0.tgz#c06e7ff69ab05b3a4a03ebe0407fac4cba657545"
 
 argparse@^1.0.7:
   version "1.0.10"


### PR DESCRIPTION
This PR adapts all places where we were using `arg` to invoke a wrapper function where we are using the new signature for `2.0.0`. Also, it fixes a bug we had parsing arguments so that now when we pass something like `now --debug ls` it's going to work 👌 

Please, test carefully!