### PR TITLE
Wait at least 1 instance when scale min preset is 0

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -32,10 +32,12 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
     if (deploymentShouldCopyScale(prevDeployment, deployment)) {
       const scaleStamp = stamp()
       await setDeploymentScale(output, now, deployment.uid, prevDeployment.scale)
+      output.log(`Scale rules copied from previous alias ${prevDeployment.url} ${scaleStamp()}`);
       if (!noVerify) {
         const result = await waitForScale(output, now, deployment.uid, prevDeployment.scale)
-        if (result instanceof Errors.VerifyScaleTimeout) { return result }
-        output.log(`Scale rules copied from previous alias ${prevDeployment.url} ${scaleStamp()}`);
+        if (result instanceof Errors.VerifyScaleTimeout) {
+          return result
+        }
       }
     } else {
       output.debug(`Both deployments have the same scaling rules.`)

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -900,7 +900,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           const verifyStamp = stamp()
           const verifyDCsGenerator: AsyncGenerator<DeploymentEvent | [string, number], VerifyScaleTimeout, void> = raceAsyncGenerators(
             eventListenerToGenerator('data', eventsStream),
-            verifyDeploymentScale(now, deployment.deploymentId, deployment.scale)
+            verifyDeploymentScale(output, now, deployment.deploymentId, deployment.scale)
           )
 
           for await (const dcOrEvent of verifyDCsGenerator) {

--- a/src/providers/sh/util/scale/wait-verify-deployment-scale.js
+++ b/src/providers/sh/util/scale/wait-verify-deployment-scale.js
@@ -15,7 +15,7 @@ async function waitForScale(output: Output, now: Now, deploymentId: string, scal
   const scaleStamp = stamp()
   let cancelWait = renderWaitDcs(Array.from(remainingDCs.keys()))
 
-  for await (const dcReady of verifyDeploymentScale(now, deploymentId, scale)) {
+  for await (const dcReady of verifyDeploymentScale(output, now, deploymentId, scale)) {
     cancelWait()
     if (Array.isArray(dcReady)) {
       const [dc, instances] = dcReady


### PR DESCRIPTION
We have changed the verification behaviour to use the minimum value instead of the max but the default preset for scaling is `{ min: 0, max: 1 }` which means that on a fresh deployment we are verifying 0 while you want to make sure that at least one instance is running.

This PR changes it to use `Math.min(Math.max(scale[dc].min, 1), scale[dc].max)` so it will not wait only for those cases where `max` is set to 0. Also, it brings back the `Scale presets updated` message right after setting the presets instead of after verifying them for `alias`.