### PR TITLE
Handle ENOENT error when deploying unexistent path

### DIFF
--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -405,20 +405,13 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       checkers.push(checkPath(paths[0]))
     } else {
       for (const path of paths) {
-        try {
-          const fsData = await fs.lstat(path)
-          if (fsData.isFile()) {
-            continue
-          }
-          checkers.push(checkPath(path))
-        } catch (error) {
-          if (error.code === 'ENOENT') {
-            output.error(error.message, 'path-not-deployable')
-            await exit(1)
-          } else {
-            throw error
-          }
+        const fsData = await fs.lstat(path)
+
+        if (fsData.isFile()) {
+          continue
         }
+
+        checkers.push(checkPath(path))
       }
     }
 
@@ -924,10 +917,10 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
             }
           }
         }
-
-        output.success(`Deployment ready`)
-        await exit(0)
       }
+
+      output.success(`Deployment ready`)
+      await exit(0)
     }
   })
 }

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -405,13 +405,20 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       checkers.push(checkPath(paths[0]))
     } else {
       for (const path of paths) {
-        const fsData = await fs.lstat(path)
-
-        if (fsData.isFile()) {
-          continue
+        try {
+          const fsData = await fs.lstat(path)
+          if (fsData.isFile()) {
+            continue
+          }
+          checkers.push(checkPath(path))
+        } catch (error) {
+          if (error.code === 'ENOENT') {
+            output.error(error.message, 'path-not-deployable')
+            await exit(1)
+          } else {
+            throw error
+          }
         }
-
-        checkers.push(checkPath(path))
       }
     }
 


### PR DESCRIPTION
In the current version when you try to run `now` over some unexistent paths it fails with an unexpected error. With this PR the `deploy` command handles such case showing a proper error and a link to show more information about deployable paths.

This PR also shows the `Deployment ready` message when the deployment was dedupped.