### PR TITLE
Safe deployment polling and other minor fixes

### DIFF
--- a/src/providers/sh/commands/alias/validate-path-alias-rules.js
+++ b/src/providers/sh/commands/alias/validate-path-alias-rules.js
@@ -15,11 +15,6 @@ function validatePathAliasRules(location: string, rules: any) {
       return new RulesFileValidationError(location, 'all rules must have a dest field')
     }
   }
-
-  const fallbackItem = rules.find((rule) => Object.keys(rule).length === 1 && rule.dest)
-  if (!fallbackItem) {
-    return new RulesFileValidationError(location, 'there must be at least one fallback destination url')
-  }
 }
 
 export default validatePathAliasRules

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -865,7 +865,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         const eventsStream = await getEventsStream(now, deployment.deploymentId, { direction: 'forward', follow: true })
         const eventsGenerator: AsyncGenerator<DeploymentEvent, void, void> = combineAsyncGenerators(
           eventListenerToGenerator('data', eventsStream), 
-          getStateChangeFromPolling(now, contextName, deployment.deploymentId)
+          getStateChangeFromPolling(now, contextName, deployment.deploymentId, deployment.readyState)
         )
 
         for await (const event of eventsGenerator) {

--- a/src/providers/sh/util/deploy/get-events-stream.js
+++ b/src/providers/sh/util/deploy/get-events-stream.js
@@ -4,6 +4,7 @@ import jsonlines from 'jsonlines'
 import { stringify } from 'querystring'
 import type { Readable } from 'stream'
 import { Now } from '../../util/types'
+import noop from '../../../../util/noop'
 
 type Options = {
   direction: 'forward' | 'backwards',
@@ -30,7 +31,10 @@ async function getEventsStream(now: Now, idOrHost: string, options: Options): Pr
     until: options.until
   })}`)
   const stream = response.readable ? await response.readable() : response.body
-  return stream.pipe(jsonlines.parse()).pipe(ignoreEmptyObjects)
+  const pipeStream = stream.pipe(jsonlines.parse()).pipe(ignoreEmptyObjects)
+  stream.on('error', noop)
+  pipeStream.on('error', noop)
+  return pipeStream
 }
 
 // Since we will be receiving empty object from the stream, this transform will ignore them

--- a/src/providers/sh/util/deploy/get-state-change-from-polling.js
+++ b/src/providers/sh/util/deploy/get-state-change-from-polling.js
@@ -1,21 +1,29 @@
 // @flow
 import { Now } from '../../util/types'
 import createPollingFn from '../../../../util/create-polling-fn'
-import type { Deployment, StateChangeEvent } from '../types'
+import type { StateChangeEvent } from '../types'
 import getDeploymentByIdOrThrow from './get-deployment-by-id-or-throw'
 
-async function* getStatusChangeFromPolling(now: Now, contextName: string, idOrHost: string): AsyncGenerator<StateChangeEvent, void, void> {
-  const pollDeployment = createPollingFn(getDeploymentByIdOrThrow, 1000)
-  let lastResult: Deployment | null = null
+const POLLING_INTERVAL = 1000
+
+async function* getStatusChangeFromPolling(
+  now: Now,
+  contextName: string,
+  idOrHost: string,
+  initialState: 'INITIALIZING' | 'FROZEN' | 'READY' | 'ERROR',
+): AsyncGenerator<StateChangeEvent, void, void> {
+  const pollDeployment = createPollingFn(getDeploymentByIdOrThrow, POLLING_INTERVAL)
+  let prevState = initialState
   for await (const deployment of pollDeployment(now, contextName, idOrHost)) {
-    if (lastResult && lastResult.state !== deployment.state) {
+    if (prevState !== deployment.state) {
+      console.log('difference', prevState, deployment.state)
       yield {
         type: 'state-change',
         created: Date.now(),
         payload: { value: deployment.state }
       }
     } else {
-      lastResult = deployment
+      prevState = deployment.state
     }
   }
 }

--- a/src/providers/sh/util/deploy/get-state-change-from-polling.js
+++ b/src/providers/sh/util/deploy/get-state-change-from-polling.js
@@ -1,4 +1,5 @@
 // @flow
+import sleep from 'then-sleep'
 import { Now } from '../../util/types'
 import createPollingFn from '../../../../util/create-polling-fn'
 import type { StateChangeEvent } from '../types'
@@ -16,7 +17,7 @@ async function* getStatusChangeFromPolling(
   let prevState = initialState
   for await (const deployment of pollDeployment(now, contextName, idOrHost)) {
     if (prevState !== deployment.state) {
-      console.log('difference', prevState, deployment.state)
+      await sleep(5000)
       yield {
         type: 'state-change',
         created: Date.now(),

--- a/src/util/noop.js
+++ b/src/util/noop.js
@@ -1,0 +1,1 @@
+export default function noop() {}


### PR DESCRIPTION
- Instead of getting the first deployment `readyState` from in the deployment state polling function and then diff, initialize the state with the value that we already have from the deployment creation. This eliminates the chances of getting stuck because of a state update between the deployment creation and the first polling function call.
- Add 5 seconds of sleep time right after we detect a state change in the deployment from the polling function. This allows the stream to keep receiving events 5 seconds after the deployment is detected as ready.
- Remove a validation rule that forces to have a fallback `dest` in path alias rules json file.
- Ignore errors coming from the deployment event stream.