### PR TITLE
Add shallow deployment verification

### DIFF
--- a/src/providers/sh/util/deploy/verify-deployment-shallow.js
+++ b/src/providers/sh/util/deploy/verify-deployment-shallow.js
@@ -16,9 +16,7 @@ async function* verifyDeploymentShallow(
   const dcs = Object.keys(deploymentScale).filter(dc => {
     return deploymentScale[dc].max > 0
   })
-  await Promise.all(dcs.map(async (dc) => {
-    return verifyDeployment(now, deploymentUrl, dc);
-  }));
+  await Promise.all(dcs.map((dc) => verifyDeployment(now, deploymentUrl, dc)))
 }
 
 // Throws an error if the deployment failed to boot.

--- a/src/providers/sh/util/deploy/verify-deployment-shallow.js
+++ b/src/providers/sh/util/deploy/verify-deployment-shallow.js
@@ -1,0 +1,45 @@
+// @flow
+import fetch from 'node-fetch'
+import { Output, Now } from '../types'
+import type { DeploymentScale } from '../types'
+
+// TODO: Refactor the `raceAsyncGenerators` function to also support regular
+//       promises without the iterator iterface, then we can remove the async
+//       generator since it doesn't yield anything
+// eslint-disable-next-line require-yield
+async function* verifyDeploymentShallow(
+  output: Output,
+  now: Now,
+  deploymentUrl: string,
+  deploymentScale: DeploymentScale
+): AsyncGenerator<void, void, void> {
+  const dcs = Object.keys(deploymentScale).filter(dc => {
+    return deploymentScale[dc].max > 0
+  })
+  await Promise.all(dcs.map(async (dc) => {
+    return verifyDeployment(deploymentUrl, dc);
+  }));
+}
+
+// Throws an error if the deployment failed to boot.
+async function verifyDeployment(
+  deploymentUrl: string,
+  dc: string
+): Promise<void> {
+  const res = await fetch(`https://alias-${dc}.zeit.co`, {
+    headers: {
+      Accept: 'application/json',
+      Connection: 'close',
+      Host: deploymentUrl,
+      'X-Now-Shallow': '1',
+    }
+  })
+  if (!res.ok) {
+    const error = await res.json()
+    throw Object.assign(new Error(error.message), error)
+  }
+
+  // TODO: add `x-now-shallow` response header verification
+}
+
+export default verifyDeploymentShallow

--- a/src/providers/sh/util/deploy/verify-deployment-shallow.js
+++ b/src/providers/sh/util/deploy/verify-deployment-shallow.js
@@ -25,9 +25,14 @@ async function verifyDeployment(
   deploymentUrl: string,
   dc: string
 ): Promise<void> {
-  await now.retry(() => shallowFetch(deploymentUrl, dc), { retries: 3 })
+  const res = await now.retry(() => shallowFetch(deploymentUrl, dc), {
+    retries: 3
+  })
 
-  // TODO: add `x-now-shallow` response header verification
+  const shallow = res.headers.get('x-now-shallow')
+  if (shallow !== '2') {
+    throw new Error(`X-Now-Shallow response header was ${shallow}`)
+  }
 }
 
 async function shallowFetch(deploymentUrl: string, dc: string) {

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -1,7 +1,7 @@
 // @flow
 type RetryFunction<T> = () => Promise<T>
 type RetryOptions = {
-  retry?: number,
+  retries?: number,
   maxTimeout?: number
 }
 
@@ -9,7 +9,6 @@ type FetchOptions = {
   body?: any,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 }
-
 
 export interface Now {
   retry<T>(fn: RetryFunction<T>, options?: RetryOptions): Promise<T>,

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -1,17 +1,18 @@
 // @flow
-type RetryFunction = () => Promise<any>;
+type RetryFunction<T> = () => Promise<T>
 type RetryOptions = {
   retry?: number,
   maxTimeout?: number
-};
+}
 
 type FetchOptions = {
   body?: any,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 }
 
+
 export interface Now {
-  retry(fn: RetryFunction, options?: RetryOptions): Promise<any>,
+  retry<T>(fn: RetryFunction<T>, options?: RetryOptions): Promise<T>,
   fetch(url: string, options?: FetchOptions): Promise<any>,
   list(appName: string, {version: number}): Deployment[],
 }

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -74,7 +74,7 @@ export type ScaleArgs = {
   max: number | 'auto'
 }
 
-export type DeploymentScale = { 
+export type DeploymentScale = {
   [dc: string]: Scale
 }
 
@@ -291,7 +291,7 @@ export type ExitEvent = GenericEvent<'exit', {
   serial: string,
 }>
 
-export type DeploymentEvent = 
+export type DeploymentEvent =
   StateChangeEvent |
   BuildStartEvent |
   BuildCompleteEvent |
@@ -309,7 +309,8 @@ export type NewDeployment = {
   url: string,
   scale: DeploymentScale,
   nodeVersion: string,
-  readyState: 'INITIALIZING' | 'READY'
+  readyState: 'INITIALIZING' | 'READY',
+  blob?: null
 }
 
 export type CLIOptions<T> = {

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -1,10 +1,17 @@
 // @flow
+type RetryFunction = () => Promise<any>;
+type RetryOptions = {
+  retry?: number,
+  maxTimeout?: number
+};
+
 type FetchOptions = {
   body?: any,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 }
 
 export interface Now {
+  retry(fn: RetryFunction, options?: RetryOptions): Promise<any>,
   fetch(url: string, options?: FetchOptions): Promise<any>,
   list(appName: string, {version: number}): Deployment[],
 }


### PR DESCRIPTION
TODO:

 - [x] Add up to 3 retries for the fetch call
 - [x] Add `x-now-shallow` response header verification
 - [ ] <strike>Refactor the `raceAsyncGenerators` function to also support regular promises / async functions</strike>