### PR TITLE
add @zeit/dockerignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@babel/preset-env": "7.0.0-beta.44",
     "@babel/runtime": "7.0.0-beta.44",
     "@google/maps": "0.4.3",
+    "@zeit/dockerignore": "0.0.1",
     "@zeit/schemas": "1.1.0",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.4.0",

--- a/src/providers/sh/util/get-files.js
+++ b/src/providers/sh/util/get-files.js
@@ -4,6 +4,7 @@ const { resolve } = require('path')
 // Packages
 const flatten = require('arr-flatten')
 const ignore = require('ignore')
+const dockerignore = require('@zeit/dockerignore')
 const _glob = require('glob')
 const { stat, readdir, readFile } = require('fs-extra')
 
@@ -87,7 +88,7 @@ const getFilesInWhitelist = async function(
 
 /**
  * Remove leading `./` from the beginning of ignores
- * because our parser doesn't like them :|
+ * because ignore doesn't like them :|
  */
 
 const clearRelative = function(str) {
@@ -347,7 +348,7 @@ async function docker(
         : dockerIgnore
     )
 
-    const filter = ignore()
+    const filter = (dockerIgnore === null ? ignore : dockerignore)()
       .add(IGNORED + '\n' + ignoredFiles)
       .createFilter()
 

--- a/test/fixtures/unit/dockerfile-negation/.dockerignore
+++ b/test/fixtures/unit/dockerfile-negation/.dockerignore
@@ -1,0 +1,4 @@
+*
+!a.js
+!build
+!./c.js

--- a/test/fixtures/unit/dockerfile-negation/Dockerfile
+++ b/test/fixtures/unit/dockerfile-negation/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+
+WORKDIR /app
+COPY . .
+RUN ls
+RUN ls build
+RUN ls build/a
+CMD echo "hello world"

--- a/test/fixtures/unit/dockerfile-negation/a.js
+++ b/test/fixtures/unit/dockerfile-negation/a.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/fixtures/unit/dockerfile-negation/b.js
+++ b/test/fixtures/unit/dockerfile-negation/b.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/fixtures/unit/dockerfile-negation/build/a/c.js
+++ b/test/fixtures/unit/dockerfile-negation/build/a/c.js
@@ -1,0 +1,1 @@
+// should be included

--- a/test/unit.js
+++ b/test/unit.js
@@ -78,6 +78,18 @@ test('`files` + `.*.swp` + `.npmignore`', async t => {
   t.is(base(files[3]), 'files-in-package-ignore/package.json')
 })
 
+test('`.dockerignore` files are parsed correctly', async t => {
+  const path = 'dockerfile-negation'
+  let files = await getDockerFiles(fixture(path))
+  files = files.sort(alpha)
+
+  t.is(files.length, 4)
+  t.is(base(files[0]), `${path}/Dockerfile`)
+  t.is(base(files[1]), `${path}/a.js`)
+  t.is(base(files[2]), `${path}/build/a/c.js`)
+  t.is(base(files[3]), `${path}/c.js`)
+})
+
 test('`files` overrides `.gitignore`', async t => {
   let files = await getNpmFiles(fixture('files-overrides-gitignore'))
   files = files.sort(alpha)

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,10 @@
   dependencies:
     samsam "1.3.0"
 
+"@zeit/dockerignore@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/@zeit/dockerignore/-/dockerignore-0.0.1.tgz#729b9c70b873f5d6a41308925d1e5091bf16e92e"
+
 "@zeit/schemas@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-1.1.0.tgz#12447ba2497b7533db67c58a0792c8ba2f674a12"


### PR DESCRIPTION
Using ignore (which is a parser for `.gitignore`) on `.dockerignore` files doesn't work well since there are quite a few semantic differences.

This change moves us to using the new `@zeit/dockerignore` package and fixes a few bugs along with it:

Fixes #1352 
Fixes #1368 
Fixes #456

