### PR TITLE
Support for Custom Deployment Suffix

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -12,6 +12,7 @@ import deploymentShouldDowscale from './deployment-should-dowscale'
 import fetchDeploymentFromAlias from './get-deployment-from-alias'
 import getDeploymentDownscalePresets from './get-deployment-downscale-presets'
 import getPreviousAlias from './get-previous-alias'
+import purchaseDomainIfAvailable from './purchase-domain-if-available'
 import setupDomain from './setup-domain'
 
 // $FlowFixMe
@@ -47,17 +48,25 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   // Check if the alias is a custom domain and if case we have a positive
   // we have to configure the DNS records and certificate
   if (!NOW_SH_REGEX.test(alias)) {
+    // In case the domain is avilable, we have to purchase
+    const purchased = await purchaseDomainIfAvailable(output, now, alias, contextName)
+    if (
+      (purchased instanceof Errors.UserAborted) ||
+      (purchased instanceof Errors.PaymentSourceNotFound) ||
+      (purchased instanceof Errors.DomainNotFound)
+    ) {
+      return purchased
+    }
+
+    // Now the domain shouldn't be available and it might or might not belong to the user
     const result = await setupDomain(output, now, alias, contextName)
     if (
       (result instanceof Errors.DNSPermissionDenied) ||
       (result instanceof Errors.DomainNameserversNotFound) ||
-      (result instanceof Errors.DomainNotFound) ||
       (result instanceof Errors.DomainNotVerified) ||
       (result instanceof Errors.DomainPermissionDenied) ||
       (result instanceof Errors.DomainVerificationFailed) ||
-      (result instanceof Errors.NeedUpgrade) ||
-      (result instanceof Errors.PaymentSourceNotFound) ||
-      (result instanceof Errors.UserAborted)
+      (result instanceof Errors.NeedUpgrade)
     ) {
       return result
     }

--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -47,7 +47,7 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
 
   // Check if the alias is a custom domain and if case we have a positive
   // we have to configure the DNS records and certificate
-  if (!NOW_SH_REGEX.test(alias)) {
+  if (alias.indexOf('.') !== -1 && !NOW_SH_REGEX.test(alias)) {
     // In case the domain is avilable, we have to purchase
     const purchased = await purchaseDomainIfAvailable(output, now, alias, contextName)
     if (

--- a/src/providers/sh/commands/alias/create-cert-for-alias.js
+++ b/src/providers/sh/commands/alias/create-cert-for-alias.js
@@ -7,6 +7,7 @@ import * as Errors from '../../util/errors'
 import { Now, Output } from '../../util/types'
 import type { HTTPChallengeInfo } from '../../util/types'
 import createCertForCns from '../../util/certs/create-cert-for-cns'
+import getCertRequestSettings from './get-cert-request-settings'
 
 async function createCertificateForAlias(output: Output, now: Now, alias: string, context: string, httpChallengeInfo?: HTTPChallengeInfo) {
   const { domain, subdomain } = psl.parse(alias)
@@ -56,33 +57,6 @@ async function createCertificateForAlias(output: Output, now: Now, alias: string
   cancelMessage()
   output.log(`Certificate for ${joinWords(cns)} (${cert.uid}) created ${certStamp()}`)
   return cert
-}
-
-function getCertRequestSettings(alias: string, domain: string, subdomain: string | null, httpChallengeInfo?: HTTPChallengeInfo) {
-  if (httpChallengeInfo) {
-    if (subdomain === null) {
-      if (httpChallengeInfo.canSolveForRootDomain) {
-        return { cns: [domain, `*.${domain}`], preferDNS: false }
-      } else {
-        return { cns: [alias], preferDNS: true }
-      }
-    } else {
-      if (httpChallengeInfo.canSolveForRootDomain) {
-        return { cns: [domain, `*.${domain}`], preferDNS: false }
-      } else if (httpChallengeInfo.canSolveForSubdomain) {
-        return { cns: [alias], preferDNS: false }
-      } else {
-        return { cns: [alias], preferDNS: true }
-      }
-    }
-  } else {
-    if(subdomain && subdomain.includes('.')) {
-      // Nested subdomains can't use wildcards
-      return { cns: [alias], preferDNS: false }
-    } else {
-      return { cns: [domain, `*.${domain}`], preferDNS: false }
-    }
-  }
 }
 
 export default createCertificateForAlias

--- a/src/providers/sh/commands/alias/find-alias-by-alias-or-id.js
+++ b/src/providers/sh/commands/alias/find-alias-by-alias-or-id.js
@@ -1,24 +1,7 @@
 // @flow
-import toHost from '../../util/to-host'
-import getAliases from '../../util/alias/get-aliases'
 import { Now, Output } from '../../util/types'
 import type { Alias } from '../../util/types'
 
-export default async function findAliasByAliasOrId(output: Output, now: Now, aliasOrId: string) {
-  const aliases: Alias[] = await getAliases(now)
-  const [key, val] = /\./.test(aliasOrId)
-    ? ['alias', toHost(aliasOrId)]
-    : ['uid', aliasOrId]
-
-  return aliases.find(alias => {
-    if (alias[key] === val) {
-      output.debug(`matched alias ${alias.uid} by ${key} ${val}`)
-      return true
-    } else if (`${val}.now.sh` === alias.alias) {
-      output.debug(`matched alias ${alias.uid} by url ${alias.alias}`)
-      return true
-    } else {
-      return false
-    }
-  })
+export default async function findAliasByAliasOrId(output: Output, now: Now, aliasOrId: string): Promise<Alias> {
+  return now.fetch(`/now/aliases/${encodeURIComponent(aliasOrId)}`);
 }

--- a/src/providers/sh/commands/alias/get-cert-request-settings.js
+++ b/src/providers/sh/commands/alias/get-cert-request-settings.js
@@ -1,0 +1,29 @@
+// @flow
+import type { HTTPChallengeInfo } from '../../util/types'
+
+export default function getCertRequestSettings(
+  alias: string,
+  domain: string,
+  subdomain: string,
+  httpChallengeInfo?: HTTPChallengeInfo,
+) {
+  if (httpChallengeInfo) {
+    if (subdomain === null) {
+      if (httpChallengeInfo.canSolveForRootDomain) {
+        return { cns: [domain, `*.${domain}`], preferDNS: false }
+      } else {
+        return { cns: [alias], preferDNS: true }
+      }
+    } else {
+      if (httpChallengeInfo.canSolveForRootDomain) {
+        return { cns: [domain, `*.${domain}`], preferDNS: false }
+      } else if (httpChallengeInfo.canSolveForSubdomain) {
+        return { cns: [alias], preferDNS: false }
+      } else {
+        return { cns: [alias], preferDNS: true }
+      }
+    }
+  } else {
+    return { cns: [domain, `*.${domain}`], preferDNS: false }
+  }
+}

--- a/src/providers/sh/commands/alias/get-previous-alias.js
+++ b/src/providers/sh/commands/alias/get-previous-alias.js
@@ -8,15 +8,11 @@ async function getPreviousAlias(output: Output, now: Now, alias: string): Promis
 }
 
 function getSafeAlias(alias: string) {
-  const _alias = alias
+  return alias
     .replace(/^https:\/\//i, '')
     .replace(/^\.+/, '')
     .replace(/\.+$/, '')
     .toLowerCase()
-
-  return _alias.indexOf('.') === -1
-    ? `${_alias}.now.sh`
-    : _alias
 }
 
 export default getPreviousAlias

--- a/src/providers/sh/commands/alias/get-targets-for-alias.js
+++ b/src/providers/sh/commands/alias/get-targets-for-alias.js
@@ -1,10 +1,8 @@
 // @flow
 import toHost from '../../util/to-host'
-
 import { Output } from '../../util/types'
 import * as Errors from '../../util/errors'
 import getInferredTargets from './get-inferred-targets'
-import isValidDomain from '../../util/domains/is-valid-domain'
 
 async function getTargetsForAlias(output: Output, args: string[], localConfigPath?: string | void) {
   const targets = await getTargets(output, args, localConfigPath)
@@ -16,20 +14,12 @@ async function getTargetsForAlias(output: Output, args: string[], localConfigPat
   ) {
     return targets
   }
-  
-  // Append zeit if needed or convert to host in case is a full URL
-  const hostTargets: string[] = targets.map(target => {
-    return target.indexOf('.') === -1
-      ? `${target}.now.sh`
-      : toHost(target)
-  })
 
-  // Validate the targets
-  for (const target of hostTargets) {
-    if (!isValidDomain(target)) {
-      return new Errors.InvalidAliasTarget(target)
-    }
-  }
+  const hostTargets: string[] = targets.map(target => {
+    return target.indexOf('.') !== -1
+      ? toHost(target)
+      : target
+  })
 
   return hostTargets
 }

--- a/src/providers/sh/commands/alias/set.js
+++ b/src/providers/sh/commands/alias/set.js
@@ -78,9 +78,6 @@ export default async function set(ctx: CLIContext, opts: CLIAliasOptions, args: 
   } else if (targets instanceof Errors.CantParseJSONFile) {
     output.error(`Couldn't parse JSON file ${targets.meta.file}.`);
     return 1
-  } else if (targets instanceof Errors.InvalidAliasTarget) {
-    output.error(`Invalid target to alias ${targets.meta.target}`);
-    return 1
   }
 
   if (rules) {
@@ -110,8 +107,9 @@ export default async function set(ctx: CLIContext, opts: CLIAliasOptions, args: 
     for (const target of targets) {
       output.log(`Assigning alias ${target} to deployment ${deployment.url}`)
       const record = await assignAlias(output, now, deployment, target, contextName, noVerify)
-      if (handleSetupDomainErrorImpl(output, handleCreateAliasErrorImpl(output, record)) !== 1) {
-        console.log(`${chalk.cyan('> Success!')} ${target} now points to ${chalk.bold(deployment.url)} ${setStamp()}`)
+      const handleResult = handleSetupDomainErrorImpl(output, handleCreateAliasErrorImpl(output, record));
+      if (handleResult !== 1) {
+        console.log(`${chalk.cyan('> Success!')} ${handleResult.alias} now points to ${chalk.bold(deployment.url)} ${setStamp()}`)
       }
     }
   }

--- a/src/providers/sh/commands/alias/set.js
+++ b/src/providers/sh/commands/alias/set.js
@@ -1,16 +1,16 @@
 // @flow
 import chalk from 'chalk'
 import ms from 'ms'
-import table from 'text-table'
 
 import { CLIContext, Output } from '../../util/types'
 import * as Errors from '../../util/errors'
 import cmd from '../../../../util/output/cmd'
+import dnsTable from '../../util/dns-table'
 import getContextName from '../../util/get-context-name'
 import humanizePath from '../../../../util/humanize-path'
 import Now from '../../util'
 import stamp from '../../../../util/output/stamp'
-import strlen from '../../util/strlen'
+import zeitWorldTable from '../../util/zeit-world-table'
 import type { CLIAliasOptions } from '../../util/types'
 
 import assignAlias from './assign-alias'
@@ -166,29 +166,6 @@ function handleSetupDomainErrorImpl<Other>(output: Output, error: SetupDomainErr
   } else {
     return error
   }
-}
-
-function zeitWorldTable() {
-  return table([
-    [chalk.underline('a.zeit.world'), chalk.dim('96.45.80.1')],
-    [chalk.underline('b.zeit.world'), chalk.dim('46.31.236.1')],
-    [chalk.underline('c.zeit.world'), chalk.dim('43.247.170.1')],
-  ], {
-    align: ['l', 'l'],
-    hsep: ' '.repeat(8),
-    stringLength: strlen
-  }).replace(/^(.*)/gm, '    $1')
-}
-
-function dnsTable(rows, extraSpace = '') {
-  return table([
-    ['name', 'type', 'value'].map(v => chalk.gray(v)),
-    ...rows
-  ], {
-    align: ['l', 'l', 'l'],
-    hsep: ' '.repeat(8),
-    stringLength: strlen
-  }).replace(/^(.*)/gm, `${extraSpace}  $1`)
 }
 
 type CreateAliasError =

--- a/src/providers/sh/commands/alias/setup-domain.js
+++ b/src/providers/sh/commands/alias/setup-domain.js
@@ -5,7 +5,6 @@ import psl from 'psl'
 // Internal utils
 import getDomainInfo from './get-domain-info'
 import getDomainNameservers from './get-domain-nameservers'
-import purchaseDomainIfAvailable from './purchase-domain-if-available'
 import maybeSetupDNSRecords from './maybe-setup-dns-records'
 import verifyDomain from './verify-domain'
 
@@ -15,18 +14,6 @@ import * as Errors from '../../util/errors'
 
 async function setupDomain(output: Output, now: Now, alias: string, contextName: string) {
   const { domain, subdomain }: { domain: string, subdomain: string | null } = psl.parse(alias)
-
-  // In case the domain is avilable, we have to purchase
-  const purchased = await purchaseDomainIfAvailable(output, now, domain, contextName)
-  if (
-    (purchased instanceof Errors.UserAborted) ||
-    (purchased instanceof Errors.PaymentSourceNotFound) ||
-    (purchased instanceof Errors.DomainNotFound)
-  ) {
-    return purchased
-  }
-
-  // Now the domain shouldn't be available and it might or might not belong to the user
   const info = await getDomainInfo(now, domain, contextName)
   if (info instanceof Errors.DomainPermissionDenied) {
     return info

--- a/src/providers/sh/util/deploy/create-deploy.js
+++ b/src/providers/sh/util/deploy/create-deploy.js
@@ -1,0 +1,71 @@
+// @flow
+import { Now, Output } from '../types'
+import generateCertForDeploy from './generate-cert-for-deploy'
+import * as Errors from '../errors'
+
+export type CreateDeployError = 
+  Errors.CantGenerateWildcardCert |
+  Errors.DNSPermissionDenied |
+  Errors.DomainConfigurationError |
+  Errors.DomainNameserversNotFound |
+  Errors.DomainNotFound |
+  Errors.DomainNotVerified |
+  Errors.DomainPermissionDenied |
+  Errors.DomainsShouldShareRoot |
+  Errors.DomainValidationRunning |
+  Errors.DomainVerificationFailed |
+  Errors.InvalidWildcardDomain |
+  Errors.MissingDomainDNSRecords |
+  Errors.NeedUpgrade |
+  Errors.TooManyCertificates |
+  Errors.TooManyRequests
+
+export default async function createDeploy(output: Output, now: Now, contextName: string, paths: string[], createArgs: Object) {
+  try {
+    return await now.create(paths, createArgs)
+  } catch (error) {
+    // Means that the domain used as a suffix no longer exists
+    if (error.code === 'domain_missing') {
+      return new Errors.DomainNotFound(error.value)
+    }
+
+    // If the domain used as a suffix is not verified, we fail
+    if (error.code === 'domain_not_verified') {
+      return new Errors.DomainNotVerified(error.value)
+    }
+
+    // If the user doesn't have permissions over the domain used as a suffix we fail
+    if (error.code === 'forbidden') {
+      return new Errors.DomainPermissionDenied(error.value, contextName)
+    }
+
+    // If the cert is missing we try to generate a new one and the retry
+    if (error.code === 'cert_missing') {
+      const result = await generateCertForDeploy(output, now, contextName, error.value)
+      if (
+        (result instanceof Errors.CantGenerateWildcardCert) ||
+        (result instanceof Errors.DNSPermissionDenied) ||
+        (result instanceof Errors.DomainConfigurationError) ||
+        (result instanceof Errors.DomainNameserversNotFound) ||
+        (result instanceof Errors.DomainNotVerified) ||
+        (result instanceof Errors.DomainPermissionDenied) ||
+        (result instanceof Errors.DomainsShouldShareRoot) ||
+        (result instanceof Errors.DomainValidationRunning) ||
+        (result instanceof Errors.DomainVerificationFailed) ||
+        (result instanceof Errors.InvalidWildcardDomain) ||
+        (result instanceof Errors.MissingDomainDNSRecords) ||
+        (result instanceof Errors.MissingDomainDNSRecords) ||
+        (result instanceof Errors.NeedUpgrade) ||
+        (result instanceof Errors.TooManyCertificates) ||
+        (result instanceof Errors.TooManyRequests)
+      ) {
+        return result
+      } else {
+        return createDeploy(output, now, contextName, paths, createArgs)
+      }
+    }
+
+    // If the error is unknown, we just throw
+    throw error
+  }  
+}

--- a/src/providers/sh/util/deploy/generate-cert-for-deploy.js
+++ b/src/providers/sh/util/deploy/generate-cert-for-deploy.js
@@ -1,0 +1,38 @@
+// @flow
+import psl from 'psl'
+import * as Errors from '../errors'
+import { Now, Output } from '../types'
+import createCertForCns from '../certs/create-cert-for-cns'
+import setupDomain from '../../commands/alias/setup-domain'
+
+export default async function generateCertForDeploy(output: Output, now: Now, contextName: string, deployURL: string) {
+  const {domain} = psl.parse(deployURL)
+  const result = await setupDomain(output, now, domain, contextName)
+  if (
+    (result instanceof Errors.DNSPermissionDenied) ||
+    (result instanceof Errors.DomainNameserversNotFound) ||
+    (result instanceof Errors.DomainNotVerified) ||
+    (result instanceof Errors.DomainPermissionDenied) ||
+    (result instanceof Errors.DomainVerificationFailed) ||
+    (result instanceof Errors.MissingDomainDNSRecords) ||
+    (result instanceof Errors.NeedUpgrade)
+  ) {
+    return result
+  }
+
+  // Generate the certificate with the given parameters
+  let cert = await createCertForCns(now, [domain, `*.${domain}`], contextName, { preferDNS: false })
+  if (
+    (cert instanceof Errors.CantGenerateWildcardCert) ||
+    (cert instanceof Errors.DomainConfigurationError) ||
+    (cert instanceof Errors.DomainPermissionDenied) ||
+    (cert instanceof Errors.DomainsShouldShareRoot) ||
+    (cert instanceof Errors.DomainsShouldShareRoot) ||
+    (cert instanceof Errors.DomainValidationRunning) ||
+    (cert instanceof Errors.InvalidWildcardDomain) ||
+    (cert instanceof Errors.TooManyCertificates) ||
+    (cert instanceof Errors.TooManyRequests)
+  ) {
+    return cert
+  }
+}

--- a/src/providers/sh/util/dns-table.js
+++ b/src/providers/sh/util/dns-table.js
@@ -1,0 +1,14 @@
+import chalk from 'chalk'
+import table from 'table'
+import strlen from './strlen'
+
+export default function dnsTable(rows, extraSpace = '') {
+  return table([
+    ['name', 'type', 'value'].map(v => chalk.gray(v)),
+    ...rows
+  ], {
+    align: ['l', 'l', 'l'],
+    hsep: ' '.repeat(8),
+    stringLength: strlen
+  }).replace(/^(.*)/gm, `${extraSpace}  $1`)
+}

--- a/src/providers/sh/util/error.js
+++ b/src/providers/sh/util/error.js
@@ -44,7 +44,7 @@ function handleError(err, { debug = false } = {}) {
   }
 }
 
-async function responseError(res, fallbackMessage = null) {
+async function responseError(res, fallbackMessage = null, parsedBody = {}) {
   let message
   let userError
   let bodyError
@@ -55,7 +55,7 @@ async function responseError(res, fallbackMessage = null) {
     try {
       body = await res.json()
     } catch (err) {
-      body = {}
+      body = parsedBody
     }
 
     // Some APIs wrongly return `err` instead of `error`
@@ -75,7 +75,7 @@ async function responseError(res, fallbackMessage = null) {
   err.status = res.status
   err.userError = userError
   err.serverMessage = message
-  
+
   // Copy every field that was added manually to the error
   if (bodyError) {
     for (const field of Object.keys(bodyError)) {

--- a/src/providers/sh/util/errors.js
+++ b/src/providers/sh/util/errors.js
@@ -120,16 +120,6 @@ export class UserAborted extends NowError<'USER_ABORTED', {}> {
 /**
  * Alias configuration errors
  */
-export class InvalidAliasTarget extends NowError<'INVALID_ALIAS_TARGET', {target: string}> {
-  constructor(target: string) {
-    super({
-      code: 'INVALID_ALIAS_TARGET',
-      meta: { target },
-      message: `The target ${target} is not valid to be used as alias.`
-    })
-  }
-}
-
 export class InvalidAliasInConfig extends NowError<'INVALID_ALIAS_IN_CONFIG', {value: number | Object}> {
   constructor(value: any) {
     super({

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -202,7 +202,7 @@ module.exports = class Now extends EventEmitter {
         requestBody.config = nowConfig
       }
 
-      const res = await this._fetch('/v5/now/deployments', {
+      const res = await this._fetch('/v4/now/deployments', {
         method: 'POST',
         body: requestBody
       })

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -202,7 +202,7 @@ module.exports = class Now extends EventEmitter {
         requestBody.config = nowConfig
       }
 
-      const res = await this._fetch('/v4/now/deployments', {
+      const res = await this._fetch('/v5/now/deployments', {
         method: 'POST',
         body: requestBody
       })
@@ -225,6 +225,11 @@ module.exports = class Now extends EventEmitter {
         err.retryAfter = 'never'
 
         return bail(err)
+      }
+
+      // If the deployment domain is missing a cert, bail with the error
+      if (res.status === 400 && body.error && body.error.code === 'cert_missing') {
+        bail(await responseError(res, null, body))
       }
 
       if (

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -865,10 +865,17 @@ module.exports = class Now extends EventEmitter {
       }
       const res = await this._fetch(url, opts)
       if (res.ok) {
-        return false === opts.json ? res :
-          res.headers.get('content-type').includes('application/json')
-            ? res.json()
-            : res
+        if (opts.json === false) {
+          return res;
+        }
+
+        if (!res.headers.get('content-type')) {
+          return null;
+        }
+
+        return res.headers.get('content-type').includes('application/json')
+          ? res.json()
+          : res
       } else {
         const err = await responseError(res);
         if (res.status >= 400 && res.status < 500) {

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -5,6 +5,7 @@ type FetchOptions = {
 }
 
 export interface Now {
+  create(paths: string[], createArgs: Object): Promise<NewDeployment>,
   fetch(url: string, options?: FetchOptions): Promise<any>,
   list(appName: string, {version: number}): Deployment[],
 }

--- a/src/providers/sh/util/zeit-world-table.js
+++ b/src/providers/sh/util/zeit-world-table.js
@@ -1,0 +1,15 @@
+import chalk from 'chalk'
+import table from 'table'
+import strlen from './strlen'
+
+export default function zeitWorldTable() {
+  return table([
+    [chalk.underline('a.zeit.world'), chalk.dim('96.45.80.1')],
+    [chalk.underline('b.zeit.world'), chalk.dim('46.31.236.1')],
+    [chalk.underline('c.zeit.world'), chalk.dim('43.247.170.1')],
+  ], {
+    align: ['l', 'l'],
+    hsep: ' '.repeat(8),
+    stringLength: strlen
+  }).replace(/^(.*)/gm, '    $1')
+}

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -12,11 +12,6 @@ exports.normalizeURL = u => {
   // `url` should match the hostname of the deployment
   u = u.replace(/^https:\/\//i, '')
 
-  if (!u.includes('.')) {
-    // `.now.sh` domain is implied if just the subdomain is given
-    u += '.now.sh'
-  }
-
   return u
 }
 


### PR DESCRIPTION
This PR brings support to our new feature Custom Deployment Suffix. Among other changes:

- Moves purchase domain if available to the `alias` flow.
- Extracts `getCertRequestSettings` to be used in the `deploy` flow since the suffix domain could be now a custom domain without a certificate.
- Changes `findAliasByAliasOrId` to use the new endpoint `/aliases/:idOrAlias` so we don't have to infer the domain in the client when searching for aliases.
- Removes references to `now.sh` as the default domain alias, keeping it in some places where is not damaging.
- Adds `createDeploy` function to include the logic where a deploy could miss a certificate in the same way we do with alias.
- Fixes an issue with the generic `fetch` where now we consider empty responses from the server.