### PR TITLE
reuse getSafeAlias function for all callers of findAliasByAliasOrId

### DIFF
--- a/src/providers/sh/commands/alias/find-alias-by-alias-or-id.js
+++ b/src/providers/sh/commands/alias/find-alias-by-alias-or-id.js
@@ -2,6 +2,14 @@
 import { Now, Output } from '../../util/types'
 import type { Alias } from '../../util/types'
 
+function getSafeAlias(alias: string) {
+  return alias
+    .replace(/^https:\/\//i, '')
+    .replace(/^\.+/, '')
+    .replace(/\.+$/, '')
+    .toLowerCase()
+}
+
 export default async function findAliasByAliasOrId(output: Output, now: Now, aliasOrId: string): Promise<Alias> {
-  return now.fetch(`/now/aliases/${encodeURIComponent(aliasOrId)}`);
+  return now.fetch(`/now/aliases/${encodeURIComponent(getSafeAlias(aliasOrId))}`);
 }

--- a/src/providers/sh/commands/alias/get-previous-alias.js
+++ b/src/providers/sh/commands/alias/get-previous-alias.js
@@ -4,15 +4,7 @@ import findAliasByAliasOrId from './find-alias-by-alias-or-id'
 import type { Alias } from '../../util/types'
 
 async function getPreviousAlias(output: Output, now: Now, alias: string): Promise<Alias | void> {
-  return findAliasByAliasOrId(output, now, getSafeAlias(alias))
-}
-
-function getSafeAlias(alias: string) {
-  return alias
-    .replace(/^https:\/\//i, '')
-    .replace(/^\.+/, '')
-    .replace(/\.+$/, '')
-    .toLowerCase()
+  return findAliasByAliasOrId(output, now, alias)
 }
 
 export default getPreviousAlias


### PR DESCRIPTION
I found that a function that strips `https://` already exists - it is called getSafeAlias and used only for `get-previous-alias.js`. But there are two callers of `findAliasByAliasOrId`: `get-previous-alias.js` and `rm.js`. So i decided to generalize getSafeAlias by moving it to findAliasByAliasOrId. So that both callers of findAliasByAliasOrId are covered.