### PR TITLE
Ensure there is scale rules before trying to apply

### DIFF
--- a/src/providers/sh/commands/alias/deployment-should-copy-scale.js
+++ b/src/providers/sh/commands/alias/deployment-should-copy-scale.js
@@ -3,7 +3,8 @@ import type { NpmDeployment, BinaryDeployment } from '../../util/types'
 import getScaleForDC from './get-scale-for-dc'
 
 function shouldCopyScalingAttributes(origin: NpmDeployment | BinaryDeployment, dest: NpmDeployment | BinaryDeployment) {
-  return getScaleForDC('bru1', origin).min !== getScaleForDC('bru1', dest).min ||
+  return Boolean(origin.scale) &&
+    getScaleForDC('bru1', origin).min !== getScaleForDC('bru1', dest).min ||
     getScaleForDC('bru1', origin).max !== getScaleForDC('bru1', dest).max ||
     getScaleForDC('sfo1', origin).min !== getScaleForDC('sfo1', dest).min ||
     getScaleForDC('sfo1', origin).max !== getScaleForDC('sfo1', dest).max


### PR DESCRIPTION
This PR ensures that there are scaling rules at all before trying to copy scaling rules when there is an alias. If we have any rules in the new deployment (default rules) but the previous deployment is old or for other reason has no deployment rules, we should never try to set the scale.