### PR TITLE
Request normal cert for deeply nested alias

### DIFF
--- a/src/providers/sh/commands/alias/get-cert-request-settings.js
+++ b/src/providers/sh/commands/alias/get-cert-request-settings.js
@@ -7,9 +7,11 @@ export default function getCertRequestSettings(
   subdomain: string,
   httpChallengeInfo?: HTTPChallengeInfo,
 ) {
+  const hasSubdomain = Boolean(subdomain);
+  const isDeeplyNested = hasSubdomain && subdomain.indexOf('.') !== -1;
   if (httpChallengeInfo) {
-    if (subdomain === null) {
-      if (httpChallengeInfo.canSolveForRootDomain) {
+    if (hasSubdomain) {
+      if (httpChallengeInfo.canSolveForRootDomain && !isDeeplyNested) {
         return { cns: [domain, `*.${domain}`], preferDNS: false }
       } else {
         return { cns: [alias], preferDNS: true }
@@ -23,7 +25,7 @@ export default function getCertRequestSettings(
         return { cns: [alias], preferDNS: true }
       }
     }
-  } else if (subdomain) {
+  } else if (isDeeplyNested) {
     return { cns: [alias], preferDNS: false }
   } else {
     return { cns: [domain, `*.${domain}`], preferDNS: false }

--- a/src/providers/sh/commands/alias/get-cert-request-settings.js
+++ b/src/providers/sh/commands/alias/get-cert-request-settings.js
@@ -23,6 +23,8 @@ export default function getCertRequestSettings(
         return { cns: [alias], preferDNS: true }
       }
     }
+  } else if (subdomain) {
+    return { cns: [alias], preferDNS: false }
   } else {
     return { cns: [domain, `*.${domain}`], preferDNS: false }
   }


### PR DESCRIPTION
We have an issue when aliasing to something like `foo.bar.javi.sh` and there was no information regarding if the challenge can be solved or the HTTP challenge can solved for root domain having a subdomain. 

In the first case, we are always requesting a certificate for the root domain regardless of the subdomain. This would work for only one subdomain level so that once the certificate is properly generated, `alias` will respond again with a missing cert in case we are aliasing to a name with more than one subdomain level. A similar issue was happening for the second case.

This PR updates the code to get the cert configuration so that when we need to request a certificate for a deeply nested domain we will always request a regular certificate for the full alias because this case is not considered yet in the current certs API. In the following days we will release a new version of the certificate API to support it and we could update the CLI to generate wildcard certs for deeply nested domains as well.