### PR TITLE
Improve the progress bar during upload

### DIFF
--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -340,13 +340,13 @@ async function main(ctx: any) {
 
 async function sync({ contextName, output, token, config: { currentTeam, user }, firstRun, deploymentType }) {
   return new Promise(async (_resolve, reject) => {
-    const deployStamp = stamp()
     const rawPath = argv._[0]
-
+    
     let meta
     let deployment: NewDeployment | null = null
     let isFile
     let atlas = false
+    let deployStamp
 
     if (paths.length === 1) {
       try {
@@ -747,6 +747,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       deployment = firstDeployCall
 
       if (now.syncFileCount > 0) {
+        const uploadStamp = stamp();
         await new Promise((resolve) => {
           if (now.syncFileCount !== now.fileCount) {
             debug(`Total files ${now.fileCount}, ${now.syncFileCount} changed`)
@@ -786,8 +787,10 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         })
 
         if (!quiet && syncCount) {
-          log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${deployStamp()}`)
+          log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${uploadStamp()}`)
         }
+
+        deployStamp = stamp()
 
         const secondDeployCall = await createDeploy(output, now, contextName, paths, createArgs)
         if (

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -777,15 +777,17 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
             bar.tick(progress);
           })
 
-          now.on('complete', () => {
-            resolve()
-          })
+          now.on('complete', resolve)
 
           now.on('error', err => {
             error('Upload failed')
             reject(err)
           })
         })
+
+        if (!quiet && syncCount) {
+          log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${deployStamp()}`)
+        }
 
         const secondDeployCall = await createDeploy(output, now, contextName, paths, createArgs)
         if (
@@ -878,10 +880,6 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       }
 
       await stopDeployment(err)
-    }
-
-    if (!quiet && syncCount) {
-      log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${deployStamp()}`)
     }
 
     const { url } = now

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -763,7 +763,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
               complete: '=',
               incomplete: '',
               total: now.syncAmount,
-              clear: false
+              clear: true
             }
           )
 
@@ -880,6 +880,10 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       await stopDeployment(err)
     }
 
+    if (!quiet && syncCount) {
+      log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${deployStamp()}`)
+    }
+
     const { url } = now
     // $FlowFixMe
     const dcs = (deploymentType !== 'static' && deployment.scale)
@@ -901,10 +905,6 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       }
     } else {
       process.stdout.write(url)
-    }
-
-    if (!quiet && syncCount) {
-      log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${deployStamp()}`)
     }
 
     // Show build logs

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -764,7 +764,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
               complete: '=',
               incomplete: '',
               total: now.syncAmount,
-              clear: true
+              clear: false
             }
           )
 

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -721,6 +721,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         meta
       )
 
+      deployStamp = stamp()
       const firstDeployCall = await createDeploy(output, now, contextName, paths, createArgs)
       if (
         (firstDeployCall instanceof Errors.CantGenerateWildcardCert) ||
@@ -791,7 +792,6 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         }
 
         deployStamp = stamp()
-
         const secondDeployCall = await createDeploy(output, now, contextName, paths, createArgs)
         if (
           (secondDeployCall instanceof Errors.CantGenerateWildcardCert) ||

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -340,13 +340,13 @@ async function main(ctx: any) {
 
 async function sync({ contextName, output, token, config: { currentTeam, user }, firstRun, deploymentType }) {
   return new Promise(async (_resolve, reject) => {
+    let deployStamp = stamp()
     const rawPath = argv._[0]
     
     let meta
     let deployment: NewDeployment | null = null
     let isFile
     let atlas = false
-    let deployStamp
 
     if (paths.length === 1) {
       try {

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -23,6 +23,7 @@ const { tick } = require('../../../../util/output/chars')
 const checkPath = require('../../util/check-path')
 const cmd = require('../../../../util/output/cmd')
 const createOutput = require('../../../../util/output')
+const wait = require('../../../../util/output/wait')
 const exit = require('../../../../util/exit')
 const isELF = require('../../util/is-elf')
 const logo = require('../../../../util/output/logo')
@@ -773,10 +774,18 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
             debug(`Uploaded: ${names.join(' ')} (${bytes(data.length)})`)
           })
 
+          let completeUpload;
+          now.on('uploadProgress', progress => {
+            bar.tick(progress);
+            if (bar.complete && !completeUpload) {
+              completeUpload = wait('Completing upload…')
+            }
+          })
 
-          now.on('uploadProgress', bar.tick.bind(bar))
-
-          now.on('complete', resolve)
+          now.on('complete', () => {
+            completeUpload()
+            resolve()
+          })
 
           now.on('error', err => {
             error('Upload failed')

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -23,7 +23,6 @@ const { tick } = require('../../../../util/output/chars')
 const checkPath = require('../../util/check-path')
 const cmd = require('../../../../util/output/cmd')
 const createOutput = require('../../../../util/output')
-const wait = require('../../../../util/output/wait')
 const exit = require('../../../../util/exit')
 const isELF = require('../../util/is-elf')
 const logo = require('../../../../util/output/logo')
@@ -758,7 +757,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
             ? 's'
             : ''}`
           const bar = new Progress(
-            `> Upload [:bar] :percent :etas (${size}) [${syncCount}]`,
+            `${chalk.gray('>')} Upload [:bar] :percent :etas (${size}) [${syncCount}]`,
             {
               width: 20,
               complete: '=',
@@ -774,16 +773,11 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
             debug(`Uploaded: ${names.join(' ')} (${bytes(data.length)})`)
           })
 
-          let completeUpload;
           now.on('uploadProgress', progress => {
             bar.tick(progress);
-            if (bar.complete && !completeUpload) {
-              completeUpload = wait('Completing upload…')
-            }
           })
 
           now.on('complete', () => {
-            completeUpload()
             resolve()
           })
 

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -336,12 +336,11 @@ module.exports = class Now extends EventEmitter {
             const stream = createReadStream(fPath);
             const { data } = file
 
-            const fstreamRead = stream.read;
+            const fstreamPush = stream.push;
 
-            stream.read = (...args) => {
-              const chunk = fstreamRead.apply(stream, args)
-              chunk && this.emit('uploadProgress', chunk.length)
-              return chunk;
+            stream.push = chunk => {
+              chunk && this.emit('uploadProgress', chunk.length);
+              return fstreamPush.call(stream, chunk);
             };
 
             const url = atlas ? '/v1/now/images' : '/v2/now/files'


### PR DESCRIPTION
This does 3 things: 

1. switch from hooking into `stream.read` into `stream.push` to draw the progress bar exactly when the data was actually pushed into the buffer. This makes the progress bar itself less accurate (since a `push` call doesn't imply the data was read) but more reliable (because we don't always know when data was read)
2. Since it's less accurate, it'll hang before publishing an update event on the last chunk of the file upload
3. We *always* render the progress bar, even if all the files have made it through so the progress is a little more obvious