### PR TITLE
Allow to deploy and alias when non essential APIs are down

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -12,7 +12,6 @@ import deploymentShouldDowscale from './deployment-should-dowscale'
 import fetchDeploymentFromAlias from './get-deployment-from-alias'
 import getDeploymentDownscalePresets from './get-deployment-downscale-presets'
 import getPreviousAlias from './get-previous-alias'
-import purchaseDomainIfAvailable from './purchase-domain-if-available'
 import setupDomain from './setup-domain'
 
 // $FlowFixMe
@@ -47,29 +46,22 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   // Check if the alias is a custom domain and if case we have a positive
   // we have to configure the DNS records and certificate
   if (alias.indexOf('.') !== -1 && !NOW_SH_REGEX.test(alias)) {
-    // In case the domain is avilable, we have to purchase
-    const purchased = await purchaseDomainIfAvailable(output, now, alias, contextName)
-    if (
-      (purchased instanceof Errors.DomainNotFound) ||
-      (purchased instanceof Errors.InvalidCoupon) ||
-      (purchased instanceof Errors.MissingCreditCard) ||
-      (purchased instanceof Errors.PaymentSourceNotFound) ||
-      (purchased instanceof Errors.UnsupportedTLD) ||
-      (purchased instanceof Errors.UsedCoupon) ||
-      (purchased instanceof Errors.UserAborted)
-    ) {
-      return purchased
-    }
-
     // Now the domain shouldn't be available and it might or might not belong to the user
     const result = await setupDomain(output, now, alias, contextName)
     if (
       (result instanceof Errors.DNSPermissionDenied) ||
       (result instanceof Errors.DomainNameserversNotFound) ||
+      (result instanceof Errors.DomainNotFound) ||
       (result instanceof Errors.DomainNotVerified) ||
       (result instanceof Errors.DomainPermissionDenied) ||
       (result instanceof Errors.DomainVerificationFailed) ||
-      (result instanceof Errors.NeedUpgrade)
+      (result instanceof Errors.InvalidCoupon) ||
+      (result instanceof Errors.MissingCreditCard) ||
+      (result instanceof Errors.NeedUpgrade) ||
+      (result instanceof Errors.PaymentSourceNotFound) ||
+      (result instanceof Errors.UnsupportedTLD) ||
+      (result instanceof Errors.UsedCoupon) ||
+      (result instanceof Errors.UserAborted)
     ) {
       return result
     }

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -52,6 +52,7 @@ import stamp from '../../../../util/output/stamp'
 import verifyDeploymentScale from '../../util/scale/verify-deployment-scale'
 import verifyDeploymentShallow from '../../util/deploy/verify-deployment-shallow'
 import zeitWorldTable from '../../util/zeit-world-table'
+import type { Readable } from 'stream'
 import type { NewDeployment, DeploymentEvent } from '../../util/types'
 import type { CreateDeployError } from '../../util/deploy/create-deploy'
 
@@ -920,11 +921,8 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       if (deployment.readyState !== 'READY') {
         require('assert')(deployment) // mute linter
         const instanceIndex = getInstanceIndex()
-        const eventsStream = await getEventsStream(now, deployment.deploymentId, { direction: 'forward', follow: true })
-        const eventsGenerator: AsyncGenerator<DeploymentEvent, void, void> = combineAsyncGenerators(
-          eventListenerToGenerator('data', eventsStream),
-          getStateChangeFromPolling(now, contextName, deployment.deploymentId, deployment.readyState)
-        )
+        const eventsStream = await maybeGetEventsStream(now, deployment)
+        const eventsGenerator = getEventsGenerator(now, contextName, deployment, eventsStream)
 
         for await (const event of eventsGenerator) {
           // Stop when the deployment is ready
@@ -949,7 +947,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           }
         }
 
-        if (!noVerify) {
+        if (!noVerify && eventsStream !== null) {
           output.log(`Verifying instantiation in ${joinWords(Object.keys(deployment.scale).map(dc => chalk.bold(dc)))}`)
           const verifyStamp = stamp()
 
@@ -1042,6 +1040,28 @@ function getRegionsFromConfig(config = {}): Array<string> {
 function getScaleFromConfig(config = {}): Object {
   return config.scale || {}
 }
+
+async function maybeGetEventsStream(now: Now, deployment: NewDeployment) {
+  try {
+    return await getEventsStream(now, deployment.deploymentId, { direction: 'forward', follow: true })
+  } catch (error) {
+    return null
+  }
+}
+
+function getEventsGenerator(now: Now, contextName: string, deployment: NewDeployment, eventsStream: null | Readable): AsyncGenerator<DeploymentEvent, void, void> {
+  const stateChangeFromPollingGenerator = getStateChangeFromPolling(now, contextName, deployment.deploymentId, deployment.readyState)
+  if (eventsStream !== null) {
+    return combineAsyncGenerators(
+      eventListenerToGenerator('data', eventsStream),
+      stateChangeFromPollingGenerator
+    );
+  }
+
+  return stateChangeFromPollingGenerator
+}
+
+
 
 module.exports = main
 


### PR DESCRIPTION
This PR introduces two changes:

- In `alias` we were trying to purchase a domain by checking if it was available right when we started alias. In case the API was down the CLI would fail, no matter the domain you were aliasing. Now, we only try to purchase the domain in two of the following scenarios:
  1. When we don't have information about the domain and we can't query its nameservers.
  2. When we don't have information about the domain and nameservers are external so we try to add the domain but verification fails.

- In `deploy` we were trying to get the events stream to both log the events and to verify instantiation in DCs define by the deployment parameters. If the deployment events API is down, the deployments wouldn't work. Now, getting the events stream is _optional_ so in case the API doesn't work we will try to figure out when the deployment is ready by _only_ polling the deployment state. With a similar approach, verification would be performed only with `verifyDeploymentScale` when the stream is `null`. 