### PR TITLE
Dont try to generate always wildcard certs when aliasing

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -19,6 +19,7 @@ const NOW_SH_REGEX = /\.now\.sh$/
 
 async function assignAlias(output: Output, now: Now, deployment: Deployment, alias: string, contextName: string, noVerify: boolean) {
   const prevAlias = await getPreviousAlias(output, now, alias)
+  let externalDomain = false
 
   // If there was a previous deployment, we should fetch it to scale and downscale later
   const prevDeployment = await fetchDeploymentFromAlias(output, now, contextName, prevAlias, deployment)
@@ -65,10 +66,13 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
     ) {
       return result
     }
+
+    // Assign if the domain is external to request wildcard or normal certificate
+    externalDomain = result.isExternal
   }
 
   // Create the alias and the certificate if it's missing
-  const record = await createAlias(output, now, contextName, deployment, alias)
+  const record = await createAlias(output, now, contextName, deployment, alias, externalDomain)
   if (
     (record instanceof Errors.AliasInUse) ||
     (record instanceof Errors.DeploymentNotFound) ||

--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -68,7 +68,7 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   }
 
   // Create the alias and the certificate if it's missing
-  const record = await createAlias(output, now, deployment, alias, contextName)
+  const record = await createAlias(output, now, contextName, deployment, alias)
   if (
     (record instanceof Errors.AliasInUse) ||
     (record instanceof Errors.DeploymentNotFound) ||

--- a/src/providers/sh/commands/alias/create-alias.js
+++ b/src/providers/sh/commands/alias/create-alias.js
@@ -1,9 +1,9 @@
 // @flow
 import wait from '../../../../util/output/wait'
-import type { AliasRecord, Deployment } from '../../util/types'
 import { Now, Output } from '../../util/types'
 import * as Errors from '../../util/errors'
 import createCertForAlias from './create-cert-for-alias'
+import type { AliasRecord, Deployment } from '../../util/types'
 
 async function createAlias(
   output: Output,
@@ -11,6 +11,7 @@ async function createAlias(
   contextName: string,
   deployment: Deployment,
   alias: string,
+  externalDomain: boolean
 ) {
   const cancelMessage = wait(`Creating alias`)
   try {
@@ -26,7 +27,7 @@ async function createAlias(
     // If the certificate is missing we create it without expecting failures
     // then we call back the createAlias function
     if (error.code === 'cert_missing' || error.code === 'cert_expired') {
-      const cert = await createCertForAlias(output, now, alias, contextName)
+      const cert = await createCertForAlias(output, now, contextName, alias, !externalDomain)
       if (
         (cert instanceof Errors.DomainConfigurationError) ||
         (cert instanceof Errors.DomainPermissionDenied) ||
@@ -38,7 +39,7 @@ async function createAlias(
       ) {
         return cert
       } else {
-        return createAlias(output, now, contextName, deployment, alias)
+        return createAlias(output, now, contextName, deployment, alias, !externalDomain)
       }
     }
 

--- a/src/providers/sh/commands/alias/create-alias.js
+++ b/src/providers/sh/commands/alias/create-alias.js
@@ -8,9 +8,9 @@ import createCertForAlias from './create-cert-for-alias'
 async function createAlias(
   output: Output,
   now: Now,
+  contextName: string,
   deployment: Deployment,
   alias: string,
-  contextName: string,
 ) {
   const cancelMessage = wait(`Creating alias`)
   try {
@@ -38,7 +38,7 @@ async function createAlias(
       ) {
         return cert
       } else {
-        return createAlias(output, now, deployment, alias, contextName)
+        return createAlias(output, now, contextName, deployment, alias)
       }
     }
 

--- a/src/providers/sh/commands/alias/create-cert-for-alias.js
+++ b/src/providers/sh/commands/alias/create-cert-for-alias.js
@@ -7,8 +7,8 @@ import { Now, Output } from '../../util/types'
 import createCertForCns from '../../util/certs/create-cert-for-cns'
 import getWildcardCnsForAlias from './get-wildcard-cns-for-alias'
 
-async function createCertificateForAlias(output: Output, now: Now, alias: string, context: string) {
-  const cns = getWildcardCnsForAlias(alias)
+async function createCertificateForAlias(output: Output, now: Now, context: string, alias: string, shouldBeWildcard: boolean) {
+  const cns = shouldBeWildcard ? getWildcardCnsForAlias(alias) : [alias]
   const cancelMessage = wait(`Generating a certificate...`)
   const certStamp = stamp()
 

--- a/src/providers/sh/commands/alias/setup-domain.js
+++ b/src/providers/sh/commands/alias/setup-domain.js
@@ -2,7 +2,8 @@
 import chalk from 'chalk'
 import psl from 'psl'
 
-// Internal utils
+// Internal utis
+
 import getDomainInfo from './get-domain-info'
 import getDomainNameservers from './get-domain-nameservers'
 import maybeSetupDNSRecords from './maybe-setup-dns-records'
@@ -76,6 +77,12 @@ async function setupDomain(output: Output, now: Now, alias: string, contextName:
           return result
         }
       }
+
+      const domainInfo = await getDomainInfo(now, domain, contextName)
+      return domainInfo === null
+        ? new Errors.DomainNotFound(domain)
+        : domainInfo
+
     } else {
       // If we couldn't find nameservers we try to purchase the domain
       const purchased = await purchaseDomainIfAvailable(output, now, alias, contextName)
@@ -96,6 +103,11 @@ async function setupDomain(output: Output, now: Now, alias: string, contextName:
       if ((result instanceof Errors.DNSPermissionDenied)) {
         return result
       }
+
+      const domainInfo = await getDomainInfo(now, domain, contextName)
+      return domainInfo === null
+        ? new Errors.DomainNotFound(domain)
+        : domainInfo
     }
   } else {
     // If we have records from the domain we have to try to verify in case it is not
@@ -120,6 +132,8 @@ async function setupDomain(output: Output, now: Now, alias: string, contextName:
         return result
       }
     }
+
+    return info
   }
 }
 

--- a/src/providers/sh/commands/alias/setup-domain.js
+++ b/src/providers/sh/commands/alias/setup-domain.js
@@ -2,8 +2,7 @@
 import chalk from 'chalk'
 import psl from 'psl'
 
-// Internal utis
-
+// Internal utils
 import getDomainInfo from './get-domain-info'
 import getDomainNameservers from './get-domain-nameservers'
 import maybeSetupDNSRecords from './maybe-setup-dns-records'


### PR DESCRIPTION
Until now we were always trying to generate a wildcard cert but we know upfront if it will be possible if we check the domain info. This PR changes the signature of `createCertForAlias` to admit a new parameter that tells if the domain is pointing to zeit.world so we request the cert accordingly.