### PR TITLE
Control can't solve challenge errors

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -74,6 +74,7 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   const record = await createAlias(output, now, contextName, deployment, alias, externalDomain)
   if (
     (record instanceof Errors.AliasInUse) ||
+    (record instanceof Errors.CantSolveChallenge) ||
     (record instanceof Errors.DeploymentNotFound) ||
     (record instanceof Errors.DomainConfigurationError) ||
     (record instanceof Errors.DomainPermissionDenied) ||

--- a/src/providers/sh/commands/alias/create-alias.js
+++ b/src/providers/sh/commands/alias/create-alias.js
@@ -29,6 +29,7 @@ async function createAlias(
     if (error.code === 'cert_missing' || error.code === 'cert_expired') {
       const cert = await createCertForAlias(output, now, contextName, alias, !externalDomain)
       if (
+        (cert instanceof Errors.CantSolveChallenge) ||
         (cert instanceof Errors.DomainConfigurationError) ||
         (cert instanceof Errors.DomainPermissionDenied) ||
         (cert instanceof Errors.DomainsShouldShareRoot) ||

--- a/src/providers/sh/commands/alias/create-cert-for-alias.js
+++ b/src/providers/sh/commands/alias/create-cert-for-alias.js
@@ -15,6 +15,7 @@ async function createCertificateForAlias(output: Output, now: Now, context: stri
   // Generate the certificate with the given parameters
   let cert = await createCertForCns(now, cns, context)
   if (
+    (cert instanceof Errors.CantSolveChallenge) ||
     (cert instanceof Errors.DomainConfigurationError) ||
     (cert instanceof Errors.DomainPermissionDenied) ||
     (cert instanceof Errors.DomainsShouldShareRoot) ||
@@ -33,6 +34,7 @@ async function createCertificateForAlias(output: Output, now: Now, context: stri
     output.debug(`Falling back to a normal certificate`)
     cert = await createCertForCns(now, [alias], context)
     if (
+      (cert instanceof Errors.CantSolveChallenge) ||
       (cert instanceof Errors.DomainConfigurationError) ||
       (cert instanceof Errors.DomainPermissionDenied) ||
       (cert instanceof Errors.DomainsShouldShareRoot) ||

--- a/src/providers/sh/commands/alias/upsert-path-alias.js
+++ b/src/providers/sh/commands/alias/upsert-path-alias.js
@@ -50,6 +50,7 @@ async function upsertPathAlias(output: Output,now: Now, rules: PathRule[], alias
     if (error.code === 'cert_missing' || error.code === 'cert_expired') {
       const cert = await createCertForAlias(output, now, contextName, alias, !externalDomain)
       if (
+        (cert instanceof Errors.CantSolveChallenge) ||
         (cert instanceof Errors.DomainConfigurationError) ||
         (cert instanceof Errors.DomainPermissionDenied) ||
         (cert instanceof Errors.DomainsShouldShareRoot) ||

--- a/src/providers/sh/util/certs/create-cert-for-cns.js
+++ b/src/providers/sh/util/certs/create-cert-for-cns.js
@@ -40,6 +40,8 @@ async function createCertForCns(now: Now, cns: string[], context: string) {
       return new Errors.DomainValidationRunning(error.domain)
     } else if (error.code === 'should_share_root_domain') {
       return new Errors.DomainsShouldShareRoot(error.domains)
+    } else if (error.code === 'cant_solve_challenge') {
+      return new Errors.CantSolveChallenge(error.domain, error.type)
     } else if (error.code === 'invalid_wildcard_domain') {
       return new Errors.InvalidWildcardDomain(error.domain)
     } else {

--- a/src/providers/sh/util/deploy/create-deploy.js
+++ b/src/providers/sh/util/deploy/create-deploy.js
@@ -5,6 +5,8 @@ import * as Errors from '../errors'
 
 export type CreateDeployError =
   Errors.CantGenerateWildcardCert |
+  Errors.CantSolveChallenge |
+  Errors.CDNNeedsUpgrade |
   Errors.DomainConfigurationError |
   Errors.DomainNameserversNotFound |
   Errors.DomainNotFound |
@@ -14,7 +16,6 @@ export type CreateDeployError =
   Errors.DomainValidationRunning |
   Errors.DomainVerificationFailed |
   Errors.InvalidWildcardDomain |
-  Errors.CDNNeedsUpgrade |
   Errors.TooManyCertificates |
   Errors.TooManyRequests
 
@@ -41,6 +42,7 @@ export default async function createDeploy(output: Output, now: Now, contextName
     if (error.code === 'cert_missing') {
       const result = await generateCertForDeploy(output, now, contextName, error.value)
       if (
+        (result instanceof Errors.CantSolveChallenge) ||
         (result instanceof Errors.CantGenerateWildcardCert) ||
         (result instanceof Errors.DomainConfigurationError) ||
         (result instanceof Errors.DomainNameserversNotFound) ||

--- a/src/providers/sh/util/deploy/generate-cert-for-deploy.js
+++ b/src/providers/sh/util/deploy/generate-cert-for-deploy.js
@@ -28,6 +28,7 @@ export default async function generateCertForDeploy(output: Output, now: Now, co
   let cert = await createCertForCns(now, [domain, `*.${domain}`], contextName)
   if (
     (cert instanceof Errors.CantGenerateWildcardCert) ||
+    (cert instanceof Errors.CantSolveChallenge) ||
     (cert instanceof Errors.DomainConfigurationError) ||
     (cert instanceof Errors.DomainPermissionDenied) ||
     (cert instanceof Errors.DomainsShouldShareRoot) ||

--- a/src/providers/sh/util/errors.js
+++ b/src/providers/sh/util/errors.js
@@ -313,6 +313,16 @@ export class InvalidWildcardDomain extends NowError<'INVALID_WILDCARD_DOMAIN', {
   }
 }
 
+export class CantSolveChallenge extends NowError<'CANT_SOLVE_CHALLENGE', { domain: string, type: 'dns-01' | 'http-01' }> {
+  constructor(domain: string, type: 'dns-01' | 'http-01') {
+    super({
+      code: 'CANT_SOLVE_CHALLENGE',
+      meta: { domain, type },
+      message: `Can't solve ${type} challenge for domain ${domain}`
+    })
+  }
+}
+
 export class VerifyScaleTimeout extends NowError<'VERIFY_SCALE_TIMEOUT', { timeout: number }> {
   constructor(timeout: number) {
     super({


### PR DESCRIPTION
This PR introduces a new error handling for the case where we could solve the DNS/HTTP pretest to generate a certificate but ACME couldn't solve the challenge. It is usually happening for domains that were just purchased so we should show a nice error.