### PR TITLE
Checks if it is an npm deployment before getting the aliased name from package.json

### DIFF
--- a/src/providers/sh/commands/alias/get-app-name.js
+++ b/src/providers/sh/commands/alias/get-app-name.js
@@ -14,7 +14,7 @@ async function getAppName(output: Output, localConfig?: string) {
   }
 
   // Otherwise try to get it from the package
-  if (!(config instanceof NowError) && config.type === "npm") {
+  if (!(config instanceof NowError) && config.type && config.type === "npm") {
     const pkg = await readPackage()
     if (!(pkg instanceof NowError) && pkg) {
       return pkg.name

--- a/src/providers/sh/commands/alias/get-app-name.js
+++ b/src/providers/sh/commands/alias/get-app-name.js
@@ -14,9 +14,11 @@ async function getAppName(output: Output, localConfig?: string) {
   }
 
   // Otherwise try to get it from the package
-  const pkg = await readPackage()
-  if (!(pkg instanceof NowError) && pkg) {
-    return pkg.name
+  if (!(config instanceof NowError) && config.type === "npm") {
+    const pkg = await readPackage()
+    if (!(pkg instanceof NowError) && pkg) {
+      return pkg.name
+    }
   }
 
   // Finally fallback to directory

--- a/src/providers/sh/commands/alias/get-app-name.js
+++ b/src/providers/sh/commands/alias/get-app-name.js
@@ -14,7 +14,7 @@ async function getAppName(output: Output, localConfig?: string) {
   }
 
   // Otherwise try to get it from the package
-  if (!(config instanceof NowError) && config.type && config.type === "npm") {
+  if (!(config instanceof NowError) && (!config.type || config.type === "npm")) {
     const pkg = await readPackage()
     if (!(pkg instanceof NowError) && pkg) {
       return pkg.name

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -38,6 +38,7 @@ export type Config = {
   alias?: string[] | string,
   aliases?: string[] | string,
   name?: string,
+  type?: string,
 }
 
 export interface CLIContext {


### PR DESCRIPTION
## Explaining the Bug

I had a folder called test-2. In my package.json though, I called the name of the project "test-1". 
I deployed this as a nom deployment to https://test-1-xxxxx.now.sh and then aliased it to lwb-frontend-now.now.sh. 

When I changed it to a docker deployment, it instead decided the name should match the folder name, so it became  https://test-2-xxxxx.now.sh, but when I tried to alias it, it instead used the previous npm deployment, so it aliased https://test-1-xxxxx.now.sh to lwb-frontend-now.now.sh. 

The logs are in an attached screenshot below. I also put up a sample repo. (https://github.com/CodeBrew28/now-cli-now-alias-bug-repro/) In the now.json file, switch the deployment from docker to npm to replicate the changes between the two deployments. 

<img width="697" alt="screen shot 2018-07-31 at 6 12 49 pm" src="https://user-images.githubusercontent.com/21315389/43496240-30295310-94f1-11e8-8e7f-0e032b354777.png">
<img width="680" alt="screen shot 2018-07-31 at 6 14 11 pm" src="https://user-images.githubusercontent.com/21315389/43496241-31806aa0-94f1-11e8-9630-8173c1309575.png">


## What I changed

When you call "now alias" it calls a function called getAppName. Before reading from package.json, it should check that it is an npm deployment. 