### PR TITLE
Include correct help command in `now domains`

### DIFF
--- a/src/providers/sh/commands/domains/buy.js
+++ b/src/providers/sh/commands/domains/buy.js
@@ -29,13 +29,13 @@ export default async function buy(ctx: CLIContext, opts: CLIDomainsOptions, args
   const domainName = args[0]
 
   if (!domainName) {
-    output.error(`Missing domain name. Run ${cmd('now domains help')}`)
+    output.error(`Missing domain name. Run ${cmd('now domains --help')}`)
     return 1
   }
 
   const {domain: rootDomain, subdomain} = psl.parse(domainName)
   if (subdomain || !rootDomain) {
-    output.error(`Invalid domain name "${domainName}". Run ${cmd('now domains help')}`)
+    output.error(`Invalid domain name "${domainName}". Run ${cmd('now domains --help')}`)
     return 1
   }
 


### PR DESCRIPTION
Changes `now domains help` error message to be the correct `now domains --help` message.
Closes #1491