### PR TITLE
Better error message for rate limiting deployments

### DIFF
--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -218,7 +218,6 @@ module.exports = class Now extends EventEmitter {
       }
 
       if (res.status === 429) {
-        console.log(body)
         let msg = 'You have been creating deployments at a very fast pace. '
 
         if (body.error && body.error.limit && body.error.limit.reset) {

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -217,9 +217,7 @@ module.exports = class Now extends EventEmitter {
       }
 
       if (res.status === 429) {
-        let msg = `You reached your 20 deployments limit in the OSS plan.\n`
-        msg += `Please run ${cmd('now upgrade')} to proceed`
-        const err = new Error(msg)
+        const err = new Error('You have been creating deployments in a very fast pace. Please slow down.')
 
         err.status = res.status
         err.retryAfter = 'never'

--- a/src/providers/sh/util/index.js
+++ b/src/providers/sh/util/index.js
@@ -217,7 +217,7 @@ module.exports = class Now extends EventEmitter {
       }
 
       if (res.status === 429) {
-        const err = new Error('You have been creating deployments in a very fast pace. Please slow down.')
+        const err = new Error('You have been creating deployments at a very fast pace. Please slow down.')
 
         err.status = res.status
         err.retryAfter = 'never'


### PR DESCRIPTION
There's no "20 deployments limit" on the OSS plan and the API *always* returns 429 only for rate limiting. In turn, this must be a very old error message that needs to be replaced.

![image](https://user-images.githubusercontent.com/6170607/43564036-1a5255a2-9625-11e8-9bca-01475a1e609e.png)
