### PR TITLE
On instance verification, Poll every 5s

### DIFF
--- a/src/providers/sh/util/scale/verify-deployment-scale.js
+++ b/src/providers/sh/util/scale/verify-deployment-scale.js
@@ -20,7 +20,7 @@ async function* verifyDeploymentScale(
   options: Options = {}
 ): AsyncGenerator<[string, number] | VerifyScaleTimeout, void, void> {
   const { timeout = ms('3m') } = options
-  const { pollingInterval = 1000 } = options
+  const { pollingInterval = 5000 } = options
   const getPollDeploymentInstances = createPollingFn(getDeploymentInstances, pollingInterval)
   const pollDeploymentInstances = getPollDeploymentInstances(now, deploymentId, uuid())
   const currentInstancesCount = getInitialInstancesCountForScale(scale)


### PR DESCRIPTION
per @rauchg 
for `verify-deployment-scale`, we poll every 1s. Instead, let's poll every 5s