### PR TITLE
Less cryptic invalid alias message

### DIFF
--- a/src/providers/sh/commands/alias/set.js
+++ b/src/providers/sh/commands/alias/set.js
@@ -209,7 +209,7 @@ function handleCreateAliasErrorImpl<OtherError>(output: Output, error: CreateAli
     output.error(`Failed to find deployment ${chalk.dim(error.meta.id)} under ${chalk.bold(error.meta.context)}`)
     return 1
   } else if (error instanceof Errors.InvalidAlias ) {
-    output.error(`Invalid alias. Please confirm that the alias you provided is a valid URL. Note: Nested domains are not supported.`)
+    output.error(`Invalid alias. Please confirm that the alias you provided is a valid hostname. Note: Nested domains are not supported.`)
     return 1
   } else if (error instanceof Errors.DomainPermissionDenied) {
     output.error(`No permission to access domain ${chalk.underline(error.meta.domain)} under ${chalk.bold(error.meta.context)}`)

--- a/src/providers/sh/commands/alias/set.js
+++ b/src/providers/sh/commands/alias/set.js
@@ -209,7 +209,7 @@ function handleCreateAliasErrorImpl<OtherError>(output: Output, error: CreateAli
     output.error(`Failed to find deployment ${chalk.dim(error.meta.id)} under ${chalk.bold(error.meta.context)}`)
     return 1
   } else if (error instanceof Errors.InvalidAlias ) {
-    output.error(`Invalid alias. Nested domains are not supported.`)
+    output.error(`Invalid alias. Please confirm that the alias you provided is a valid URL. Note: Nested domains are not supported.`)
     return 1
   } else if (error instanceof Errors.DomainPermissionDenied) {
     output.error(`No permission to access domain ${chalk.underline(error.meta.domain)} under ${chalk.bold(error.meta.context)}`)


### PR DESCRIPTION
We generate aliases from pr names in a script, and spent a bit of time trying to figure out that we had an invalid char in the alias URL we were generating. Might help someone else! =)