### PR TITLE
Sort operation for `now alias ls` and `now ls`

### DIFF
--- a/src/providers/sh/commands/alias/index.js
+++ b/src/providers/sh/commands/alias/index.js
@@ -89,7 +89,7 @@ const COMMAND_CONFIG = {
   default: 'set',
   ls: ['ls', 'list'],
   rm: ['rm', 'remove'],
-  set: ['set']
+  set: ['set'],
 }
 
 module.exports = async function main(ctx: any): Promise<number> {
@@ -105,26 +105,26 @@ module.exports = async function main(ctx: any): Promise<number> {
       '-n': '--no-verify',
       '-r': '--rules',
       '-y': '--yes',
-      '-s': '--sort'
+      '-s': '--sort',
     })
   } catch (err) {
     handleError(err)
-    return 1
+    return 1;
   }
 
   if (argv['--help']) {
     help()
-    return 2
+    return 2;
   }
 
   const output: Output = createOutput({ debug: argv['--debug'] })
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG)
   switch (subcommand) {
     case 'ls':
-      return ls(ctx, argv, args, output)
+      return ls(ctx, argv, args, output);
     case 'rm':
-      return rm(ctx, argv, args, output)
+      return rm(ctx, argv, args, output);
     default:
-      return set(ctx, argv, args, output)
+      return set(ctx, argv, args, output);
   }
 }

--- a/src/providers/sh/commands/alias/index.js
+++ b/src/providers/sh/commands/alias/index.js
@@ -89,7 +89,7 @@ const COMMAND_CONFIG = {
   default: 'set',
   ls: ['ls', 'list'],
   rm: ['rm', 'remove'],
-  set: ['set'],
+  set: ['set']
 }
 
 module.exports = async function main(ctx: any): Promise<number> {
@@ -100,29 +100,31 @@ module.exports = async function main(ctx: any): Promise<number> {
       '--json': Boolean,
       '--no-verify': Boolean,
       '--rules': String,
+      '--sort': String,
       '--yes': Boolean,
       '-n': '--no-verify',
       '-r': '--rules',
       '-y': '--yes',
+      '-s': '--sort'
     })
   } catch (err) {
     handleError(err)
-    return 1;
+    return 1
   }
 
   if (argv['--help']) {
     help()
-    return 2;
+    return 2
   }
 
   const output: Output = createOutput({ debug: argv['--debug'] })
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG)
   switch (subcommand) {
     case 'ls':
-      return ls(ctx, argv, args, output);
+      return ls(ctx, argv, args, output)
     case 'rm':
-      return rm(ctx, argv, args, output);
+      return rm(ctx, argv, args, output)
     default:
-      return set(ctx, argv, args, output);
+      return set(ctx, argv, args, output)
   }
 }

--- a/src/providers/sh/commands/alias/ls.js
+++ b/src/providers/sh/commands/alias/ls.js
@@ -13,51 +13,37 @@ import strlen from '../../util/strlen'
 import wait from '../../../../util/output/wait'
 import type { CLIAliasOptions, Alias, PathAliasRule } from '../../util/types'
 
-export default async function ls(
-  ctx: CLIContext,
-  opts: CLIAliasOptions,
-  args: string[],
-  output: Output
-): Promise<number> {
-  const { authConfig: { credentials }, config: { sh } } = ctx
-  const { currentTeam } = sh
-  const { apiUrl } = ctx
-  const contextName = getContextName(sh)
-  const { ['--debug']: debugEnabled } = opts
-  const sortOption = opts['--sort']
+export default async function ls(ctx: CLIContext, opts: CLIAliasOptions, args: string[], output: Output): Promise<number> {
+  const {authConfig: { credentials }, config: { sh }} = ctx
+  const { currentTeam } = sh;
+  const { apiUrl } = ctx;
+  const contextName = getContextName(sh);
+  const {['--debug']: debugEnabled} = opts;
+  const {['--sort']: sortOption} = opts;
 
   // $FlowFixMe
-  const { token } = credentials.find(item => item.provider === 'sh')
+  const {token} = credentials.find(item => item.provider === 'sh')
   const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam })
   const lsStamp = stamp()
-  let cancelWait
+  let cancelWait;
 
   if (args.length > 1) {
-    output.error(
-      `Invalid number of arguments. Usage: ${chalk.cyan(
-        '`now alias ls [alias]`'
-      )}`
-    )
+    output.error(`Invalid number of arguments. Usage: ${chalk.cyan('`now alias ls [alias]`')}`)
     return 1
   }
 
   if (!opts['--json']) {
-    cancelWait = wait(
-      args[0]
-        ? `Fetching alias details for "${args[0]}" under ${chalk.bold(
-            contextName
-          )}`
-        : `Fetching aliases under ${chalk.bold(contextName)}`
-    )
+    cancelWait = wait(args[0]
+      ? `Fetching alias details for "${args[0]}" under ${chalk.bold(contextName)}`
+      : `Fetching aliases under ${chalk.bold(contextName)}`
+    );
   }
 
   const aliases: Alias[] = await getAliases(now)
-  if (cancelWait) cancelWait()
+  if (cancelWait) cancelWait();
 
   if (args[0]) {
-    const alias = aliases.find(
-      item => item.uid === args[0] || item.alias === args[0]
-    )
+    const alias = aliases.find(item => (item.uid === args[0] || item.alias === args[0]))
     if (!alias) {
       output.error(`Could not match path alias for: ${args[0]}`)
       now.close()
@@ -68,21 +54,12 @@ export default async function ls(
       output.print(JSON.stringify({ rules: alias.rules }, null, 2))
     } else {
       const rules: PathAliasRule[] = alias.rules || []
-      output.log(
-        `${rules.length} path alias ${plural(
-          'rule',
-          rules.length
-        )} found under ${chalk.bold(contextName)} ${lsStamp()}`
-      )
+      output.log(`${rules.length} path alias ${plural('rule', rules.length)} found under ${chalk.bold(contextName)} ${lsStamp()}`)
       output.print(`${printPathAliasTable(rules)}\n`)
     }
   } else {
     aliases.sort(sort(sortOption))
-    output.log(
-      `${plural('alias', aliases.length, true)} found under ${chalk.bold(
-        contextName
-      )} ${lsStamp()}`
-    )
+    output.log(`${plural('alias', aliases.length, true)} found under ${chalk.bold(contextName)} ${lsStamp()}`)
     console.log(printAliasTable(aliases))
   }
 
@@ -121,50 +98,45 @@ function sortByAge() {
 }
 
 function printAliasTable(aliases: Alias[]): string {
-  return (
-    table(
-      [
-        ['source', 'url', 'age'].map(h => chalk.gray(h)),
-        ...aliases.map(a => [
-          a.rules && a.rules.length
-            ? chalk.cyan(`[${plural('rule', a.rules.length, true)}]`)
-            : // for legacy reasons, we might have situations
-              // where the deployment was deleted and the alias
-              // not collected appropriately, and we need to handle it
-              a.deployment && a.deployment.url
-              ? a.deployment.url
-              : chalk.gray('–'),
-          a.alias,
-          ms(Date.now() - new Date(a.created))
-        ])
-      ],
-      {
-        align: ['l', 'l', 'r'],
-        hsep: ' '.repeat(4),
-        stringLength: strlen
-      }
-    ).replace(/^/gm, '  ') + '\n\n'
-  )
+  return table([
+    ['source', 'url', 'age'].map(h => chalk.gray(h)),
+    ...aliases.map(
+      a => ([
+        a.rules && a.rules.length
+          ? chalk.cyan(`[${plural('rule', a.rules.length, true)}]`)
+          // for legacy reasons, we might have situations
+          // where the deployment was deleted and the alias
+          // not collected appropriately, and we need to handle it
+          : a.deployment && a.deployment.url ?
+              a.deployment.url :
+              chalk.gray('–'),
+        a.alias,
+        ms(Date.now() - new Date(a.created))
+      ])
+    )
+  ], {
+    align: ['l', 'l', 'r'],
+    hsep: ' '.repeat(4),
+    stringLength: strlen
+  }).replace(/^/gm, '  ') + '\n\n'
 }
 
 function printPathAliasTable(rules: PathAliasRule[]): string {
   const header = [['pathname', 'method', 'dest'].map(s => chalk.gray(s))]
-  return (
-    table(
-      header.concat(
-        rules.map(rule => {
-          return [
-            rule.pathname ? rule.pathname : chalk.cyan('[fallthrough]'),
-            rule.method ? rule.method : '*',
-            rule.dest
-          ]
-        })
-      ),
-      {
-        align: ['l', 'l', 'l', 'l'],
-        hsep: ' '.repeat(6),
-        stringLength: strlen
-      }
-    ).replace(/^(.*)/gm, '  $1') + '\n'
-  )
+  return table(
+    header.concat(
+      rules.map(rule => {
+        return [
+          rule.pathname ? rule.pathname : chalk.cyan('[fallthrough]'),
+          rule.method ? rule.method : '*',
+          rule.dest
+        ]
+      })
+    ),
+    {
+      align: ['l', 'l', 'l', 'l'],
+      hsep: ' '.repeat(6),
+      stringLength: strlen
+    }
+  ).replace(/^(.*)/gm, '  $1') + '\n'
 }

--- a/src/providers/sh/commands/alias/ls.js
+++ b/src/providers/sh/commands/alias/ls.js
@@ -105,17 +105,17 @@ function sort(sortOption: ?string) {
   }
 }
 
-// sorts by most recent alias url
+// sort by alias url, ascending
 function sortByAlias() {
   return (a, b) => a.alias.localeCompare(b.alias)
 }
 
-// sorts by most recent source url
+// sorts by source url, ascending
 function sortBySource() {
   return (a, b) => a.deployment.url.localeCompare(b.deployment.url)
 }
 
-// sorts by most recent alias
+// sorts by most recent alias, new first
 function sortByAge() {
   return (a, b) => new Date(b.created) - new Date(a.created)
 }

--- a/src/providers/sh/commands/alias/ls.js
+++ b/src/providers/sh/commands/alias/ls.js
@@ -13,36 +13,51 @@ import strlen from '../../util/strlen'
 import wait from '../../../../util/output/wait'
 import type { CLIAliasOptions, Alias, PathAliasRule } from '../../util/types'
 
-export default async function ls(ctx: CLIContext, opts: CLIAliasOptions, args: string[], output: Output): Promise<number> {
-  const {authConfig: { credentials }, config: { sh }} = ctx
-  const { currentTeam } = sh;
-  const { apiUrl } = ctx;
-  const contextName = getContextName(sh);
-  const {['--debug']: debugEnabled} = opts;
+export default async function ls(
+  ctx: CLIContext,
+  opts: CLIAliasOptions,
+  args: string[],
+  output: Output
+): Promise<number> {
+  const { authConfig: { credentials }, config: { sh } } = ctx
+  const { currentTeam } = sh
+  const { apiUrl } = ctx
+  const contextName = getContextName(sh)
+  const { ['--debug']: debugEnabled } = opts
+  const sortOption = opts['--sort']
 
   // $FlowFixMe
-  const {token} = credentials.find(item => item.provider === 'sh')
+  const { token } = credentials.find(item => item.provider === 'sh')
   const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam })
   const lsStamp = stamp()
-  let cancelWait;
+  let cancelWait
 
   if (args.length > 1) {
-    output.error(`Invalid number of arguments. Usage: ${chalk.cyan('`now alias ls [alias]`')}`)
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        '`now alias ls [alias]`'
+      )}`
+    )
     return 1
   }
 
   if (!opts['--json']) {
-    cancelWait = wait(args[0]
-      ? `Fetching alias details for "${args[0]}" under ${chalk.bold(contextName)}`
-      : `Fetching aliases under ${chalk.bold(contextName)}`
-    );
+    cancelWait = wait(
+      args[0]
+        ? `Fetching alias details for "${args[0]}" under ${chalk.bold(
+            contextName
+          )}`
+        : `Fetching aliases under ${chalk.bold(contextName)}`
+    )
   }
 
   const aliases: Alias[] = await getAliases(now)
-  if (cancelWait) cancelWait();
+  if (cancelWait) cancelWait()
 
   if (args[0]) {
-    const alias = aliases.find(item => (item.uid === args[0] || item.alias === args[0]))
+    const alias = aliases.find(
+      item => item.uid === args[0] || item.alias === args[0]
+    )
     if (!alias) {
       output.error(`Could not match path alias for: ${args[0]}`)
       now.close()
@@ -53,12 +68,21 @@ export default async function ls(ctx: CLIContext, opts: CLIAliasOptions, args: s
       output.print(JSON.stringify({ rules: alias.rules }, null, 2))
     } else {
       const rules: PathAliasRule[] = alias.rules || []
-      output.log(`${rules.length} path alias ${plural('rule', rules.length)} found under ${chalk.bold(contextName)} ${lsStamp()}`)
+      output.log(
+        `${rules.length} path alias ${plural(
+          'rule',
+          rules.length
+        )} found under ${chalk.bold(contextName)} ${lsStamp()}`
+      )
       output.print(`${printPathAliasTable(rules)}\n`)
     }
   } else {
-    aliases.sort((a, b) => new Date(b.created) - new Date(a.created))
-    output.log(`${plural('alias', aliases.length, true)} found under ${chalk.bold(contextName)} ${lsStamp()}`)
+    aliases.sort(sort(sortOption))
+    output.log(
+      `${plural('alias', aliases.length, true)} found under ${chalk.bold(
+        contextName
+      )} ${lsStamp()}`
+    )
     console.log(printAliasTable(aliases))
   }
 
@@ -66,46 +90,81 @@ export default async function ls(ctx: CLIContext, opts: CLIAliasOptions, args: s
   return 0
 }
 
+// sorting alias based on options
+function sort(sortOption: ?string) {
+  console.info(sortOption)
+  switch (sortOption) {
+    case 'source':
+      return sortBySource()
+    case 'url':
+      return sortByAlias()
+    case 'age':
+      return sortByAge()
+    default:
+      return sortByAge()
+  }
+}
+
+// sorts by most recent alias url
+function sortByAlias() {
+  return (a, b) => a.alias.localeCompare(b.alias)
+}
+
+// sorts by most recent source url
+function sortBySource() {
+  return (a, b) => a.deployment.url.localeCompare(b.deployment.url)
+}
+
+// sorts by most recent alias
+function sortByAge() {
+  return (a, b) => new Date(b.created) - new Date(a.created)
+}
+
 function printAliasTable(aliases: Alias[]): string {
-  return table([
-    ['source', 'url', 'age'].map(h => chalk.gray(h)),
-    ...aliases.map(
-      a => ([
-        a.rules && a.rules.length
-          ? chalk.cyan(`[${plural('rule', a.rules.length, true)}]`)
-          // for legacy reasons, we might have situations
-          // where the deployment was deleted and the alias
-          // not collected appropriately, and we need to handle it
-          : a.deployment && a.deployment.url ?
-              a.deployment.url :
-              chalk.gray('–'),
-        a.alias,
-        ms(Date.now() - new Date(a.created))
-      ])
-    )
-  ], {
-    align: ['l', 'l', 'r'],
-    hsep: ' '.repeat(4),
-    stringLength: strlen
-  }).replace(/^/gm, '  ') + '\n\n'
+  return (
+    table(
+      [
+        ['source', 'url', 'age'].map(h => chalk.gray(h)),
+        ...aliases.map(a => [
+          a.rules && a.rules.length
+            ? chalk.cyan(`[${plural('rule', a.rules.length, true)}]`)
+            : // for legacy reasons, we might have situations
+              // where the deployment was deleted and the alias
+              // not collected appropriately, and we need to handle it
+              a.deployment && a.deployment.url
+              ? a.deployment.url
+              : chalk.gray('–'),
+          a.alias,
+          ms(Date.now() - new Date(a.created))
+        ])
+      ],
+      {
+        align: ['l', 'l', 'r'],
+        hsep: ' '.repeat(4),
+        stringLength: strlen
+      }
+    ).replace(/^/gm, '  ') + '\n\n'
+  )
 }
 
 function printPathAliasTable(rules: PathAliasRule[]): string {
   const header = [['pathname', 'method', 'dest'].map(s => chalk.gray(s))]
-  return table(
-    header.concat(
-      rules.map(rule => {
-        return [
-          rule.pathname ? rule.pathname : chalk.cyan('[fallthrough]'),
-          rule.method ? rule.method : '*',
-          rule.dest
-        ]
-      })
-    ),
-    {
-      align: ['l', 'l', 'l', 'l'],
-      hsep: ' '.repeat(6),
-      stringLength: strlen
-    }
-  ).replace(/^(.*)/gm, '  $1') + '\n'
+  return (
+    table(
+      header.concat(
+        rules.map(rule => {
+          return [
+            rule.pathname ? rule.pathname : chalk.cyan('[fallthrough]'),
+            rule.method ? rule.method : '*',
+            rule.dest
+          ]
+        })
+      ),
+      {
+        align: ['l', 'l', 'l', 'l'],
+        hsep: ' '.repeat(6),
+        stringLength: strlen
+      }
+    ).replace(/^(.*)/gm, '  $1') + '\n'
+  )
 }

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -378,6 +378,7 @@ export type CLIOptions<T> = {
   '--local-config'?: string,
   '--global-config'?: string,
   '--api'?: string,
+  '--sort'?: string
 } & T
 
 export type CLIAliasOptions = CLIOptions<{
@@ -385,6 +386,7 @@ export type CLIAliasOptions = CLIOptions<{
   '--no-verify': boolean,
   '--rules': string,
   '--yes': boolean,
+  '--sort': string
 }>
 
 export type CLICertsOptions = CLIOptions<{

--- a/src/providers/sh/util/types.js
+++ b/src/providers/sh/util/types.js
@@ -378,7 +378,7 @@ export type CLIOptions<T> = {
   '--local-config'?: string,
   '--global-config'?: string,
   '--api'?: string,
-  '--sort'?: string
+  '--sort'?: string,
 } & T
 
 export type CLIAliasOptions = CLIOptions<{
@@ -386,7 +386,7 @@ export type CLIAliasOptions = CLIOptions<{
   '--no-verify': boolean,
   '--rules': string,
   '--yes': boolean,
-  '--sort': string
+  '--sort': string,
 }>
 
 export type CLICertsOptions = CLIOptions<{


### PR DESCRIPTION
## WIP: Need testing and input from maintainers.

### Summary

Upon request of user @mxmzb (https://github.com/zeit/now-cli/issues/1487) it was proposed to create an option called "sort".

### Checklist

- [x] `now alias ls`: ok.
- [x] `now ls --sort`.
- [ ] Update `--help` texts.
- [ ] Tests.

### Input needed

First I would like to ask for the best way to document the flag.
Second, under `now ls` I didn't have the following structure:
```
(
  ctx: CLIContext,
  opts: CLIAliasOptions,
  args: string[],
  output: Output
)
```
so I just wrote `--sort` as an `argv`, exactly like the `--app` option in the same file, to keep it with fewer changes as possible. Feedback is welcome.
All sorts default behavior will be by age.
Tests will be released soon.

Cheers :beers: 