### PR TITLE
Add changelog link when new version is available

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -79,6 +79,7 @@ const main = async (argv_) => {
   if (update && isTTY) {
     console.log(info(`${chalk.bgRed('UPDATE AVAILABLE')} The latest version of Now CLI is ${update.latest}`))
     console.log(info(`Read more about how to update here: https://zeit.co/update-cli`))
+    console.log(info(`Changelog: https://github.com/zeit/now-cli/releases`))
   }
 
   // the second argument to the command can be a path

--- a/src/now.js
+++ b/src/now.js
@@ -79,7 +79,7 @@ const main = async (argv_) => {
   if (update && isTTY) {
     console.log(info(`${chalk.bgRed('UPDATE AVAILABLE')} The latest version of Now CLI is ${update.latest}`))
     console.log(info(`Read more about how to update here: https://zeit.co/update-cli`))
-    console.log(info(`Changelog: https://github.com/zeit/now-cli/releases`))
+    console.log(info(`Changelog: https://github.com/zeit/now-cli/releases/tag/${update.latest}`))
   }
 
   // the second argument to the command can be a path


### PR DESCRIPTION
Personally, I find myself always looking for a changelog link when an update is available for multiple reasons:

- To see new features
- To see if there are breaking-changes
- I tend not to update the same day a release is available so I check the release date.

I believe this is quite common and a quick win in user experience