### PR TITLE
Use PUT when copying scale rules in alias and PATCH on scale command

### DIFF
--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -16,7 +16,7 @@ import getDeploymentByIdOrHost from '../util/deploy/get-deployment-by-id-or-host
 import getDeploymentByIdOrThrow from '../util/deploy/get-deployment-by-id-or-throw'
 import getMaxFromArgs from '../util/scale/get-max-from-args'
 import getMinFromArgs from '../util/scale/get-min-from-args'
-import setDeploymentScale from '../util/scale/set-deployment-scale'
+import patchDeploymentScale from '../util/scale/patch-deployment-scale'
 import waitVerifyDeploymentScale from '../util/scale/wait-verify-deployment-scale'
 import type { CLIScaleOptions, DeploymentScaleArgs } from '../util/types'
 import { CLIContext, Output } from '../util/types'
@@ -167,7 +167,7 @@ module.exports = async function main(ctx: CLIContext): Promise<number> {
 
   // Set the deployment scale
   const scaleStamp = stamp()
-  const result = await setDeploymentScale(output, now, deployment.uid, scaleArgs)
+  const result = await patchDeploymentScale(output, now, deployment.uid, scaleArgs)
   if (result instanceof Errors.ForbiddenScaleMinInstances) {
     output.error(`You can't scale to more than ${result.meta.max} min instances with your current plan.`)
     now.close();

--- a/src/providers/sh/util/scale/patch-deployment-scale.js
+++ b/src/providers/sh/util/scale/patch-deployment-scale.js
@@ -6,14 +6,14 @@ import { Output, Now } from '../../util/types'
 import type { DeploymentScaleArgs, DeploymentScale } from '../../util/types'
 import * as Errors from '../errors';
 
-async function setScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale) {
+async function patchDeploymentScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale) {
   const cancelWait = wait(`Setting scale rules for ${joinWords(
     Object.keys(scaleArgs).map(dc => `${chalk.bold(dc)}`)
   )}`)
 
   try {
     await now.fetch(`/v3/now/deployments/${encodeURIComponent(deploymentId)}/instances`, {
-      method: 'PUT',
+      method: 'PATCH',
       body: scaleArgs
     })
     cancelWait()
@@ -33,4 +33,4 @@ async function setScale(output: Output, now: Now, deploymentId: string, scaleArg
   }
 }
 
-export default setScale
+export default patchDeploymentScale


### PR DESCRIPTION
We had only one function to set the scale that was used:
- When updating the scale using `now scale`
- When copying scaling rules during `now alias`

In the first case we want to update only the given DCs. For example, `now scale sfo 2` should leave scaling presets in `bru` untouched. But when copying scale parameters from one deployment to another should downscale a DC when it is not given.

This PR adds a new function `patchDeploymentScale` that uses `PATCH` method to the scale endpoint and changes `setDeploymentScale` to use `PUT`. This way we'll keep a consistent way of copying rules when aliasing.