### PR TITLE
Return scaling validation errors on alias

### DIFF
--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -31,10 +31,17 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   if (prevDeployment !== null && prevDeployment.type !== 'STATIC' && deployment.type !== 'STATIC') {
     if (deploymentShouldCopyScale(prevDeployment, deployment)) {
       const scaleStamp = stamp()
-      const result = await setDeploymentScale(output, now, deployment.uid, prevDeployment.scale)
+      const result = await setDeploymentScale(output, now, deployment.uid, prevDeployment.scale, deployment.url)
       if (result instanceof Errors.NotSupportedMinScaleSlots) {
-        return new Errors.IncompatibleScaleSettings(prevDeployment.url);
+        return result;
+      } else if (result instanceof Errors.ForbiddenScaleMinInstances) {
+        return result;
+      } else if (result instanceof Errors.ForbiddenScaleMaxInstances) {
+        return result;
+      } else if (result instanceof Errors.InvalidScaleMinMaxRelation) {
+        return result;
       }
+
       output.log(`Scale rules copied from previous alias ${prevDeployment.url} ${scaleStamp()}`);
       if (!noVerify) {
         const result = await waitForScale(output, now, deployment.uid, prevDeployment.scale)
@@ -94,7 +101,7 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
   // Downscale if the previous deployment is not static and doesn't have the minimal presets
   if (prevDeployment !== null && prevDeployment.type !== 'STATIC') {
     if (await deploymentShouldDownscale(output, now, prevDeployment)) {
-      await setDeploymentScale(output, now, prevDeployment.uid, getDeploymentDownscalePresets(prevDeployment))
+      await setDeploymentScale(output, now, prevDeployment.uid, getDeploymentDownscalePresets(prevDeployment), prevDeployment.url)
       output.log(`Previous deployment ${prevDeployment.url} downscaled`);
     }
   }

--- a/src/providers/sh/commands/alias/assign-alias.js
+++ b/src/providers/sh/commands/alias/assign-alias.js
@@ -32,13 +32,12 @@ async function assignAlias(output: Output, now: Now, deployment: Deployment, ali
     if (deploymentShouldCopyScale(prevDeployment, deployment)) {
       const scaleStamp = stamp()
       const result = await setDeploymentScale(output, now, deployment.uid, prevDeployment.scale, deployment.url)
-      if (result instanceof Errors.NotSupportedMinScaleSlots) {
-        return result;
-      } else if (result instanceof Errors.ForbiddenScaleMinInstances) {
-        return result;
-      } else if (result instanceof Errors.ForbiddenScaleMaxInstances) {
-        return result;
-      } else if (result instanceof Errors.InvalidScaleMinMaxRelation) {
+      if (
+        result instanceof Errors.NotSupportedMinScaleSlots ||
+        result instanceof Errors.ForbiddenScaleMinInstances ||
+        result instanceof Errors.ForbiddenScaleMaxInstances ||
+        result instanceof Errors.InvalidScaleMinMaxRelation
+      ) {
         return result;
       }
 

--- a/src/providers/sh/commands/alias/set.js
+++ b/src/providers/sh/commands/alias/set.js
@@ -193,9 +193,12 @@ type CreateAliasError =
   Errors.DomainPermissionDenied |
   Errors.DomainsShouldShareRoot |
   Errors.DomainValidationRunning |
-  Errors.IncompatibleScaleSettings |
+  Errors.ForbiddenScaleMaxInstances |
+  Errors.ForbiddenScaleMinInstances |
   Errors.InvalidAlias |
+  Errors.InvalidScaleMinMaxRelation |
   Errors.InvalidWildcardDomain |
+  Errors.NotSupportedMinScaleSlots |
   Errors.RuleValidationFailed |
   Errors.TooManyCertificates |
   Errors.TooManyRequests |
@@ -267,11 +270,24 @@ function handleCreateAliasErrorImpl<OtherError>(output: Output, error: CreateAli
   } else if (error instanceof Errors.DomainsShouldShareRoot) {
     output.error(`All given common names should share the same root domain.`)
     return 1
-  }  else if (error instanceof Errors.IncompatibleScaleSettings) {
-    output.error(`Scale rules from previous alias ${chalk.dim(error.meta.alias)} could not be copied since Cloud v2 deployments cannot have a non-zero min. Update the scale settings on ${chalk.dim(error.meta.alias)} with \`now scale\` and try again`)
+  }  else if (error instanceof Errors.NotSupportedMinScaleSlots) {
+    output.error(`Scale rules from previous aliased deployment ${chalk.dim(error.meta.url)} could not be copied since Cloud v2 deployments cannot have a non-zero min`);
+    output.log(`Update the scale settings on ${chalk.dim(error.meta.url)} with \`now scale\` and try again`)
     output.log('Read more: https://err.sh/now-cli/v2-no-min')
     return 1;
+  }  else if (error instanceof Errors.ForbiddenScaleMaxInstances) {
+    output.error(`Scale rules from previous aliased deployment ${chalk.dim(error.meta.url)} could not be copied since the given number of max instances (${error.meta.max}) is not allowed.`);
+    output.log(`Update the scale settings on ${chalk.dim(error.meta.url)} with \`now scale\` and try again`)
+    return 1;
+  }  else if (error instanceof Errors.ForbiddenScaleMinInstances) {
+    output.error(`Scale rules from previous aliased deployment ${chalk.dim(error.meta.url)} could not be copied since the given number of min instances (${error.meta.min}) is not allowed.`);
+    output.log(`Update the scale settings on ${chalk.dim(error.meta.url)} with \`now scale\` and try again`)
+    return 1;
+  }  else if (error instanceof Errors.InvalidScaleMinMaxRelation) {
+    output.error(`Scale rules from previous aliased deployment ${chalk.dim(error.meta.url)} could not be copied becuase the relation between min and max instances is wrong.`);
+    output.log(`Update the scale settings on ${chalk.dim(error.meta.url)} with \`now scale\` and try again`)
+    return 1;
   } else {
-    return error
+    return error;
   }
 }

--- a/src/providers/sh/commands/scale.js
+++ b/src/providers/sh/commands/scale.js
@@ -167,7 +167,7 @@ module.exports = async function main(ctx: CLIContext): Promise<number> {
 
   // Set the deployment scale
   const scaleStamp = stamp()
-  const result = await patchDeploymentScale(output, now, deployment.uid, scaleArgs)
+  const result = await patchDeploymentScale(output, now, deployment.uid, scaleArgs, deployment.url)
   if (result instanceof Errors.ForbiddenScaleMinInstances) {
     output.error(`You can't scale to more than ${result.meta.max} min instances with your current plan.`)
     now.close();

--- a/src/providers/sh/util/errors.js
+++ b/src/providers/sh/util/errors.js
@@ -37,16 +37,6 @@ export class InvalidAlias extends NowError<'INVALID_ALIAS', {alias: string}> {
   }
 }
 
-export class IncompatibleScaleSettings extends NowError<'INCOMPATIBLE_SCALE_SETTINGS', {alias: string}> {
-  constructor(alias: string) {
-    super({
-      code: 'INCOMPATIBLE_SCALE_SETTINGS',
-      meta: { alias },
-      message: `Scale rules from previous alias ${alias} could not be copied since Cloud v2 deployments cannot have a non-zero min. Update the scale settings on ${alias} with \`now scale\` and try again.`
-    })
-  }
-}
-
 export class CDNNeedsUpgrade extends NowError<'CDN_NEEDS_UPGRADE', {}> {
   constructor() {
     super({
@@ -393,41 +383,41 @@ export class InvalidArgsForMinMaxScale extends NowError<'INVALID_ARGS_FOR_MIN_MA
   }
 }
 
-export class ForbiddenScaleMinInstances extends NowError<'FORBIDDEN_SCALE_MIN_INSTANCES', { max: number }> {
-  constructor(max: number) {
+export class ForbiddenScaleMinInstances extends NowError<'FORBIDDEN_SCALE_MIN_INSTANCES', { url: string, min: number }> {
+  constructor(url: string, min: number) {
     super({
       code: 'FORBIDDEN_SCALE_MIN_INSTANCES',
-      meta: { max },
-      message: `You can't scale to more than ${max} min instances with your current plan.`
+      meta: { url, min },
+      message: `You can't scale to more than ${min} min instances with your current plan.`
     })
   }
 }
 
-export class ForbiddenScaleMaxInstances extends NowError<'FORBIDDEN_SCALE_MAX_INSTANCES', { max: number }> {
-  constructor(max: number) {
+export class ForbiddenScaleMaxInstances extends NowError<'FORBIDDEN_SCALE_MAX_INSTANCES', { url: string, max: number }> {
+  constructor(url: string, max: number) {
     super({
       code: 'FORBIDDEN_SCALE_MAX_INSTANCES',
-      meta: { max },
+      meta: { url, max },
       message: `You can't scale to more than ${max} max instances with your current plan.`
     })
   }
 }
 
-export class InvalidScaleMinMaxRelation extends NowError<'INVALID_SCALE_MIN_MAX_RELATION', {}> {
-  constructor() {
+export class InvalidScaleMinMaxRelation extends NowError<'INVALID_SCALE_MIN_MAX_RELATION', {url: string}> {
+  constructor(url: string) {
     super({
       code: 'INVALID_SCALE_MIN_MAX_RELATION',
-      meta: {},
+      meta: {url},
       message: `Min number of instances can't be higher than max.`
     })
   }
 }
 
-export class NotSupportedMinScaleSlots extends NowError<'NOT_SUPPORTED_MIN_SCALE_SLOTS', {}> {
-  constructor() {
+export class NotSupportedMinScaleSlots extends NowError<'NOT_SUPPORTED_MIN_SCALE_SLOTS', {url: string}> {
+  constructor(url: string) {
     super({
       code: 'NOT_SUPPORTED_MIN_SCALE_SLOTS',
-      meta: {},
+      meta: {url},
       message: `Cloud v2 does not yet support setting a non-zero min scale setting.`
     })
   }

--- a/src/providers/sh/util/scale/patch-deployment-scale.js
+++ b/src/providers/sh/util/scale/patch-deployment-scale.js
@@ -6,7 +6,7 @@ import { Output, Now } from '../../util/types'
 import type { DeploymentScaleArgs, DeploymentScale } from '../../util/types'
 import * as Errors from '../errors';
 
-async function patchDeploymentScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale) {
+async function patchDeploymentScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale, url: string) {
   const cancelWait = wait(`Setting scale rules for ${joinWords(
     Object.keys(scaleArgs).map(dc => `${chalk.bold(dc)}`)
   )}`)
@@ -20,13 +20,13 @@ async function patchDeploymentScale(output: Output, now: Now, deploymentId: stri
   } catch (error) {
     cancelWait()
     if (error.code === 'forbidden_min_instances') {
-      return new Errors.ForbiddenScaleMinInstances(error.max)
+      return new Errors.ForbiddenScaleMinInstances(url, error.min)
     } else if (error.code === 'forbidden_max_instances') {
-      return new Errors.ForbiddenScaleMaxInstances(error.max)
+      return new Errors.ForbiddenScaleMaxInstances(url, error.max)
     } else if (error.code === 'wrong_min_max_relation') {
-      return new Errors.InvalidScaleMinMaxRelation()
+      return new Errors.InvalidScaleMinMaxRelation(url)
     } else if (error.code === 'not_supported_min_scale_slots') {
-      return new Errors.NotSupportedMinScaleSlots()
+      return new Errors.NotSupportedMinScaleSlots(url)
     } else {
       throw error
     }

--- a/src/providers/sh/util/scale/set-deployment-scale.js
+++ b/src/providers/sh/util/scale/set-deployment-scale.js
@@ -6,7 +6,7 @@ import { Output, Now } from '../../util/types'
 import type { DeploymentScaleArgs, DeploymentScale } from '../../util/types'
 import * as Errors from '../errors';
 
-async function setScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale) {
+async function setScale(output: Output, now: Now, deploymentId: string, scaleArgs: DeploymentScaleArgs | DeploymentScale, url: string) {
   const cancelWait = wait(`Setting scale rules for ${joinWords(
     Object.keys(scaleArgs).map(dc => `${chalk.bold(dc)}`)
   )}`)
@@ -20,13 +20,13 @@ async function setScale(output: Output, now: Now, deploymentId: string, scaleArg
   } catch (error) {
     cancelWait()
     if (error.code === 'forbidden_min_instances') {
-      return new Errors.ForbiddenScaleMinInstances(error.max)
+      return new Errors.ForbiddenScaleMinInstances(url, error.min)
     } else if (error.code === 'forbidden_max_instances') {
-      return new Errors.ForbiddenScaleMaxInstances(error.max)
+      return new Errors.ForbiddenScaleMaxInstances(url, error.max)
     } else if (error.code === 'wrong_min_max_relation') {
-      return new Errors.InvalidScaleMinMaxRelation()
+      return new Errors.InvalidScaleMinMaxRelation(url)
     } else if (error.code === 'not_supported_min_scale_slots') {
-      return new Errors.NotSupportedMinScaleSlots()
+      return new Errors.NotSupportedMinScaleSlots(url)
     } else {
       throw error
     }


### PR DESCRIPTION
We had an issue where verification timed out when doing an alias. The reason of this timeout was that copying scaling rules from a previous deployment failed silently so the CLI was expecting to a number of instances running that never get reached.

The reason why it failed silently is that, at scaling time, the CLI swallowed errors related to param validation. It was assumed that since the parameters come from a different deployment they should be valid. We had a bug/inconsistency in our API that made this error happen so, in order to prevent this in the future, and for the edge case where the user changes the plan (copying rules might not be valid in that case either) this PR handles those errors so that aliasing will fail directly with a well known error.