### PR TITLE
Fix scaling v1 deployments to all DCs

### DIFF
--- a/src/providers/sh/util/scale/constants.js
+++ b/src/providers/sh/util/scale/constants.js
@@ -1,11 +1,12 @@
 // @flow
-export type RegionToDC = {
+export type DC = {
+  all: 'all',
   bru: 'bru1',
   gru: 'gru1',
   sfo: 'sfo1'
 }
 
-export const REGION_TO_DC: RegionToDC = {
+export const REGION_TO_DC = {
   bru: 'bru1',
   gru: 'gru1',
   sfo: 'sfo1',

--- a/src/providers/sh/util/scale/normalize-regions-list.js
+++ b/src/providers/sh/util/scale/normalize-regions-list.js
@@ -1,25 +1,24 @@
 // @flow
-import { REGION_TO_DC } from './constants'
 import { InvalidRegionOrDCForScale, InvalidAllForScale } from '../errors'
 import regionOrDCToDC from './region-or-dc-to-dc'
-import type { RegionToDC } from './constants'
+import type { DC } from './constants'
 
-export default function normalizeRegionsList(regionsOrDCs: string[]): InvalidRegionOrDCForScale | InvalidAllForScale | Array<$Values<RegionToDC>> {
-  const allDcs = Object.keys(REGION_TO_DC).map(key => REGION_TO_DC[key])
+export default function normalizeRegionsList(regionsOrDCs: string[]): InvalidRegionOrDCForScale | InvalidAllForScale | Array<$Values<DC>> {
   if (regionsOrDCs.includes('all')) {
-    return regionsOrDCs.length > 1
-      ? new InvalidAllForScale()
-      : allDcs
+    if (regionsOrDCs.length > 1) {
+      return new InvalidAllForScale();
+    }
+
+    return ['all'];
   }
 
-  const dcs: Set<$Values<RegionToDC>> = new Set()
+  const dcs: Set<$Values<DC>> = new Set()
   for (const regionOrDC of regionsOrDCs) {
     const dc = regionOrDCToDC(regionOrDC)
-    if (dc !== undefined) {
-      dcs.add(dc)
-    } else {
+    if (dc === undefined) {
       return new InvalidRegionOrDCForScale(regionOrDC)
     }
+    dcs.add(dc)
   }
 
   return Array.from(dcs)

--- a/src/providers/sh/util/scale/region-or-dc-to-dc.js
+++ b/src/providers/sh/util/scale/region-or-dc-to-dc.js
@@ -1,8 +1,8 @@
 // @flow
 import { REGION_TO_DC } from './constants'
-import type { RegionToDC } from './constants'
+import type { DC } from './constants'
 
-function regionOrDCToDC(regionOrDC: string): $Values<RegionToDC> | void {
+function regionOrDCToDC(regionOrDC: string): $Values<DC> | void {
   const allDcs = Object.keys(REGION_TO_DC).map(key => REGION_TO_DC[key])
   if (Object.keys(REGION_TO_DC).includes(regionOrDC)) {
     return REGION_TO_DC[regionOrDC]


### PR DESCRIPTION
```
> Error! An unexpected error occurred in scale: Error: This region (gru1) only accepts Serverless Docker Deployments (400)
```

This is happening because `now-cli` is validating DC names and
expanding "all" locally. However not all DCs have same features but
the client can't be aware of that. Instead of making the client
aware of the differing capabilities of the available DCs we should
pass "all" as a special DC selector, and let the backend handle
scaling properly.