### PR TITLE
Update `@zeit/dockerignore` to v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@babel/plugin-transform-runtime": "7.0.0-beta.44",
     "@babel/preset-env": "7.0.0-beta.44",
     "@babel/runtime": "7.0.0-beta.44",
-    "@zeit/dockerignore": "0.0.1",
+    "@zeit/dockerignore": "0.0.2",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.4.0",
     "alpha-sort": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@babel/plugin-transform-runtime": "7.0.0-beta.44",
     "@babel/preset-env": "7.0.0-beta.44",
     "@babel/runtime": "7.0.0-beta.44",
-    "@zeit/dockerignore": "0.0.2",
+    "@zeit/dockerignore": "0.0.3",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.4.0",
     "alpha-sort": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,9 +661,9 @@
   dependencies:
     samsam "1.3.0"
 
-"@zeit/dockerignore@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.1.tgz#729b9c70b873f5d6a41308925d1e5091bf16e92e"
+"@zeit/dockerignore@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.3.tgz#b50071e6d37848205e5cf81b4ca2c347ae6ec8ca"
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"


### PR DESCRIPTION
To fix https://github.com/zeit/now-cli/issues/1441.