### PR TITLE
Respect users config when `--public` not present on static deployments

### DIFF
--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -500,7 +500,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         debug(`Forcing \`deploymentType\` = \`static\``)
         deploymentType = 'static'
       }
-    } else if (deploymentType === 'static') {
+    } else if (deploymentType === 'static' && firstRun) {
       debug(`Forcing \`deploymentType\` = \`static\` automatically`)
 
       meta = {


### PR DESCRIPTION
Please forgive my relative unfamiliarity with the code base.

Right now when making a deployment without the `--public` CLI flag,
a second call to sync() happens with `deploymentType` set.  This in
turn triggers the overwriting of the user's config in the else/if
starting on line 503.

My proposed fix is to skip this block whenever it is not the firstRun.
This fixes the problem without creating/modifying any other state,
so seemed safest.

While I didn't have the time/inclination to check the knock-on effects,
another potential fix is simply not to pass in `deploymentType` on that
second call to sync (line 905) after confirmation the user wants a public
deployment. But my instinct was that could be more distruptive than this.

Note that the integration tests are failing hard on my machine, but that
happens on canary's HEAD before this proposed commit, so I'm hoping it is
something with my env and circleCI can do the work for me.

I'll follow up with an necessary patches flagged by CI.

Or, maybe ya'lls testing is just borked.  If you're hiring less experienced devs to fix
that sort of thing, look me up :innocent:!
