### PR TITLE
Changed 'error' to 'log' to avoid breaking automatic deployments

### DIFF
--- a/src/providers/sh/commands/remove.js
+++ b/src/providers/sh/commands/remove.js
@@ -143,7 +143,7 @@ module.exports = async function main (ctx: any): Promise<number>{
   })
 
   if (matches.length === 0) {
-    error(
+    log(
       `Could not find ${argv.safe
         ? 'unaliased'
         : 'any'} deployments matching ${ids


### PR DESCRIPTION
throwing an error re-opened this issue:
https://github.com/zeit/now-cli/issues/1044

breaks automation when no deployments are found or deployment name is changed