### PR TITLE
Add `now init` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@babel/preset-env": "7.0.0-beta.44",
     "@babel/runtime": "7.0.0-beta.44",
     "@zeit/dockerignore": "0.0.3",
+    "@zeit/init": "0.0.3",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.4.0",
     "alpha-sort": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "bytes": "3.0.0",
     "chalk": "2.3.1",
     "child-process-promise": "2.2.1",
+    "cli-highlight": "2.0.0",
     "clipboardy": "1.1.4",
     "convert-stream": "1.0.2",
     "copy-webpack-plugin": "4.0.1",

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -99,6 +99,7 @@ const help = () => {
 
     ${chalk.dim('Cloud')}
 
+      init                 [path]      Generates a Dockerfile for your project
       deploy               [path]      Performs a deployment ${chalk.bold('(default)')}
       ls | list            [app]       Lists deployments
       rm | remove          [id]        Removes a deployment

--- a/src/providers/sh/commands/init/index.js
+++ b/src/providers/sh/commands/init/index.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const chalk = require('chalk')
 const init = require('@zeit/init')
 const { resolve } = require('path')
+const { highlight } = require('cli-highlight')
 
 // Utilities
 const logo = require('../../../../util/output/logo')
@@ -30,6 +31,22 @@ const help = () => {
 
     ${chalk.cyan('$ now init')}
 `)
+}
+
+function indent (str, prefix = '  ') {
+  return str.split('\n').map(l => `${prefix}${l}`).join('\n')
+}
+
+async function loadJson (path) {
+  let json = {}
+  try {
+    json = await fs.readJSON(path)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+  return json
 }
 
 // Options
@@ -84,16 +101,14 @@ Deployment Type: ${chalk.cyan(deploymentType)}
 
 Dockerfile:
 
-${dockerfile.trim().split('\n').map(l => `  ${l}`).join('\n')}
+${indent(highlight(dockerfile.trim(), { language: 'dockerfile' }))}
 
 now.json:
 
-${nowJsonString.trim().split('\n').map(l => `  ${l}`).join('\n')}
+${indent(highlight(nowJsonString.trim(), { language: 'json' }))}
 `)
 
-  const confirmation = argv.yes || await promptBool('Create the files?', {
-    //trailing: '\n'
-  })
+  const confirmation = argv.yes || await promptBool('Create the files?')
 
   if (confirmation) {
     await Promise.all([
@@ -106,16 +121,4 @@ ${nowJsonString.trim().split('\n').map(l => `  ${l}`).join('\n')}
   }
 
   return 0
-}
-
-async function loadJson (path) {
-  let json = {}
-  try {
-    json = await fs.readJSON(path)
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      throw err
-    }
-  }
-  return json
 }

--- a/src/providers/sh/commands/init/index.js
+++ b/src/providers/sh/commands/init/index.js
@@ -1,0 +1,121 @@
+// @flow
+
+// Packages
+const mri = require('mri')
+const fs = require('fs-extra')
+const chalk = require('chalk')
+const init = require('@zeit/init')
+const { resolve } = require('path')
+
+// Utilities
+const logo = require('../../../../util/output/logo')
+const promptBool = require('../../../../util/input/prompt-bool')
+
+const help = () => {
+  console.log(`
+  ${chalk.bold(`${logo} now init`)}
+
+  ${chalk.dim('Options:')}
+
+    -h, --help                     Output usage information
+    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline('FILE')}   Path to the local ${'`now.json`'} file
+    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline('DIR')}    Path to the global ${'`.now`'} directory
+    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline('TOKEN')}        Login token
+    -d, --debug                    Debug mode [off]
+    -T, --team                     Set a custom team scope
+
+  ${chalk.dim('Example:')}
+
+  ${chalk.gray('–')} Generates a \`Dockerfile\` and \`now.json\` for your project
+
+    ${chalk.cyan('$ now init')}
+`)
+}
+
+// Options
+let argv
+
+module.exports = async function main (ctx: any): Promise<number> {
+  argv = mri(ctx.argv.slice(2), {
+    boolean: ['help', 'debug', 'yes'],
+    alias: {
+      help: 'h',
+      debug: 'd',
+      yes: 'y'
+    }
+  })
+
+  argv._ = argv._.slice(1)
+
+  if (argv.help || argv._[0] === 'help') {
+    help()
+    return 2
+  }
+
+  const dir = argv._[0] || process.cwd()
+
+  const {
+    dockerfile,
+    projectType,
+    deploymentType
+  } = await init(dir)
+
+  const nowJsonPath = resolve(dir, 'now.json')
+  const dockerfilePath = resolve(dir, 'Dockerfile')
+
+  // Modify the existing `now.json`, if one exists
+  const nowJson = await loadJson(nowJsonPath)
+
+  // Set the detected deployment type
+  nowJson.type = deploymentType
+
+  // Enable Cloud v2
+  if (!nowJson.features) {
+    nowJson.features = {}
+  }
+  nowJson.features.cloud = 'v2'
+  const nowJsonString = JSON.stringify(nowJson, null, 2) + '\n'
+
+  // Print results
+  console.log(`
+Detected Project Type: ${chalk.cyan(projectType)}
+
+Deployment Type: ${chalk.cyan(deploymentType)}
+
+Dockerfile:
+
+${dockerfile.trim().split('\n').map(l => `  ${l}`).join('\n')}
+
+now.json:
+
+${nowJsonString.trim().split('\n').map(l => `  ${l}`).join('\n')}
+`)
+
+  const confirmation = argv.yes || await promptBool('Create the files?', {
+    //trailing: '\n'
+  })
+
+  if (confirmation) {
+    await Promise.all([
+      fs.writeFile(nowJsonPath, nowJsonString),
+      fs.writeFile(dockerfilePath, dockerfile)
+    ])
+    console.log(`${chalk.cyan('> Success!')} Created ${chalk.bold('Dockerfile')} and ${chalk.bold('now.json')}`)
+  } else {
+    console.log()
+  }
+
+  return 0
+}
+
+async function loadJson (path) {
+  let json = {}
+  try {
+    json = await fs.readJSON(path)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+  return json
+}

--- a/src/providers/sh/index.js
+++ b/src/providers/sh/index.js
@@ -1,22 +1,23 @@
 const mainCommands = new Set([
-  'deploy',
-  'help',
-  'list',
-  'remove',
   'alias',
-  'domains',
-  'dns',
-  'certs',
-  'secrets',
   'billing',
-  'upgrade',
-  'teams',
-  'logs',
-  'scale',
+  'certs',
+  'deploy',
+  'dns',
+  'domains',
+  'help',
+  'init',
+  'inspect',
+  'list',
   'login',
   'logout',
-  'whoami',
-  'inspect'
+  'logs',
+  'remove',
+  'scale',
+  'secrets',
+  'teams',
+  'upgrade',
+  'whoami'
 ])
 
 const aliases = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,9 +661,22 @@
   dependencies:
     samsam "1.3.0"
 
+"@yarnpkg/lockfile@^1.0.2":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+
 "@zeit/dockerignore@0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.3.tgz#b50071e6d37848205e5cf81b4ca2c347ae6ec8ca"
+
+"@zeit/init@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@zeit/init/-/init-0.0.3.tgz#df65c1b118507c51c877216e38f55d5047de0289"
+  dependencies:
+    "@yarnpkg/lockfile" "^1.0.2"
+    fs.promised "^3.0.0"
+    npm-package-arg "^6.1.0"
+    semver "^5.5.1"
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"
@@ -1689,6 +1702,10 @@ builtin-modules@^1.0.0:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
 
 byline@5.0.0:
   version "5.0.0"
@@ -3215,6 +3232,10 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs.promised@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fs.promised/-/fs.promised-3.0.0.tgz#ab77379f7c1ad0939e1262a8c2ced93fa6c39d3b"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3525,7 +3546,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hosted-git-info@^2.1.4:
+hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
@@ -4800,6 +4821,15 @@ npm-conf@^1.1.0:
     config-chain "^1.1.11"
     pify "^3.0.0"
 
+npm-package-arg@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
+  dependencies:
+    hosted-git-info "^2.6.0"
+    osenv "^0.1.5"
+    semver "^5.5.0"
+    validate-npm-package-name "^3.0.0"
+
 npm-packlist@^1.1.6:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
@@ -4961,7 +4991,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@^0.1.4:
+osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
@@ -5799,6 +5829,10 @@ semver-diff@^2.0.0:
 semver@5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0, semver@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 serialize-error@^2.1.0:
   version "2.1.0"
@@ -6674,6 +6708,12 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  dependencies:
+    builtins "^1.0.3"
 
 verror@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -824,7 +824,7 @@ ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
-any-promise@^1.1.0:
+any-promise@^1.0.0, any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
@@ -1845,7 +1845,7 @@ chalk@^0.4.0:
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1951,6 +1951,16 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-highlight@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.0.0.tgz#e4ae60d46fd6a88e7d478499309b6618547991f0"
+  dependencies:
+    chalk "^2.3.0"
+    highlight.js "^9.6.0"
+    mz "^2.4.0"
+    parse5 "^4.0.0"
+    yargs "^11.0.0"
+
 cli-spinners@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
@@ -1997,6 +2007,14 @@ cliui@^3.2.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 co-with-promise@^4.6.0:
@@ -3527,6 +3545,10 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+highlight.js@^9.6.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4674,6 +4696,14 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -5111,6 +5141,10 @@ parse-ms@^0.1.0:
 parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+
+parse5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -6362,6 +6396,18 @@ then-sleep@1.0.1:
   dependencies:
     native-or-bluebird "^1.2.0"
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
+
 throat@4.x:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -6931,6 +6977,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
This command inspects a directory, and uses various heuristics
to determine the "project type" as well as generated an ideal
initial Dockerfile to use for the detected project type.

A `now.json` file is also created to set the proper "type"
(`docker` or `static`), as well as enable Cloud v2.

At the moment, only Node.js projects are supported, but the
`@zeit/init` module will be improved to support many project types,
including static site generators i.e. `next export`.