### PR TITLE
Add --json option to `now ls`

### DIFF
--- a/src/providers/sh/commands/alias/ls.js
+++ b/src/providers/sh/commands/alias/ls.js
@@ -50,7 +50,7 @@ export default async function ls(ctx: CLIContext, opts: CLIAliasOptions, args: s
     }
 
     if (opts['--json']) {
-      output.print(JSON.stringify({ rules: alias.rules }, null, 2))
+      process.stdout.write(JSON.stringify({ rules: alias.rules }, null, 2))
     } else {
       const rules: PathAliasRule[] = alias.rules || []
       output.log(`${rules.length} path alias ${plural('rule', rules.length)} found under ${chalk.bold(contextName)} ${lsStamp()}`)

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -212,7 +212,7 @@ module.exports = async function main(ctx) {
   }
 
   if (argv['--json']) {
-    process.stdout.write(JSON.stringify(deployments, null, '  '))
+    process.stdout.write(JSON.stringify(deployments, null, 2))
     return 0;
   }
 

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -68,6 +68,7 @@ module.exports = async function main(ctx) {
     argv = getArgs(ctx.argv.slice(2), {
       '--all': Boolean,
       '-a': '--all',
+      '--json': Boolean,
     })
   } catch (err) {
     handleError(err)
@@ -207,6 +208,11 @@ module.exports = async function main(ctx) {
     log(`To list more deployments for an app run ${cmd('now ls [app]')}`)
   } else if (!argv['--all']) {
     log(`To list deployment instances run ${cmd('now ls --all [app]')}`)
+  }
+
+  if (argv['--json']) {
+    print(JSON.stringify(deployments, null, '  '))
+    return 0;
   }
 
   print('\n')

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -42,6 +42,7 @@ const help = () => {
   )}        Login token
     -T, --team                     Set a custom team scope
     -a, --all                      See all instances for each deployment (requires [app])
+    --json                         Write JSON data for deployments to stdout
 
   ${chalk.dim('Examples:')}
 

--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -212,7 +212,7 @@ module.exports = async function main(ctx) {
   }
 
   if (argv['--json']) {
-    print(JSON.stringify(deployments, null, '  '))
+    process.stdout.write(JSON.stringify(deployments, null, '  '))
     return 0;
   }
 


### PR DESCRIPTION
This adds a `--json` flag to the `now ls` command so that you can process the output with other tools. While I was in there and looking at how `now alias ls --json` was implemented, I went ahead and fixed #1337 by changing `output.print()` (which writes to stderr) to `process.stdout.write()`.