### PR TITLE
Add --json and --raw options to deploy command

### DIFF
--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -63,6 +63,7 @@ const mriOpts = {
     'force',
     'links',
     'json',
+    'raw',
     'C',
     'clipboard',
     'forward-npm',

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -1185,14 +1185,12 @@ function handleCreateDeployError<OtherError>(output: Output, error: CreateDeploy
 }
 
 function logDeployment(deployment) {
+  const url = `https://${deployment.url}`
   if (argv.json) {
-    const data = {
-      uid: deployment.deploymentId,
-      url: deployment.url
-    }
+    const data = {uid: deployment.deploymentId, url}
     process.stdout.write(JSON.stringify(data, null, 2))
   } else if (raw) {
-    process.stdout.write(deployment.url)
+    process.stdout.write(url)
   }
 }
 

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -437,7 +437,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
               gitRepo.main
             )}" ${gitRef}on ${gitRepo.type}`)
         } else {
-          error(`The specified directory "${basename(paths[0])}" doesn't exist.`)
+          output.error(`The specified directory "${basename(paths[0])}" doesn't exist.`)
           await exit(1)
         }
       }
@@ -552,7 +552,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
 
     // Read scale and fail if we have both regions and scale
     if (regions.length > 0 && Object.keys(scaleFromConfig).length > 0) {
-      error("Can't set both `regions` and `scale` options simultaneously", 'regions-and-scale-at-once')
+      output.error("Can't set both `regions` and `scale` options simultaneously", 'regions-and-scale-at-once')
       await exit(1)
     }
 
@@ -560,11 +560,11 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
     if (regions.length > 0) {
       dcIds = normalizeRegionsList(regions)
       if (dcIds instanceof Errors.InvalidRegionOrDCForScale) {
-        error(`The value "${dcIds.meta.regionOrDC}" is not a valid region or DC identifier`)
+        output.error(`The value "${dcIds.meta.regionOrDC}" is not a valid region or DC identifier`)
         await exit(1)
         return 1
       } else if (dcIds instanceof Errors.InvalidAllForScale) {
-        error(`You can't use all in the regions list mixed with other regions`)
+        output.error(`You can't use all in the regions list mixed with other regions`)
         await exit(1)
         return 1
       }
@@ -577,7 +577,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       for (const regionOrDc of Object.keys(scaleFromConfig)) {
         const dc = regionOrDCToDc(regionOrDc)
         if (dc === undefined) {
-          error(`The value "${regionOrDc}" in \`scale\` settings is not a valid region or DC identifier`, 'deploy-invalid-dc')
+          output.error(`The value "${regionOrDc}" in \`scale\` settings is not a valid region or DC identifier`, 'deploy-invalid-dc')
           await exit(1)
           return 1
         } else {
@@ -607,7 +607,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         dotenvConfig = dotenv.parse(dotenvFile)
       } catch (err) {
         if (err.code === 'ENOENT') {
-          error(
+          output.error(
             `--dotenv flag is set but ${dotenvFileName} file is missing`,
             'missing-dotenv-target'
           )
@@ -672,7 +672,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
     const env_ = await Promise.all(
       Object.keys(deploymentEnv).map(async key => {
         if (!key) {
-          error(
+          output.error(
             'Environment variable name is missing',
             'missing-env-key-value'
           )
@@ -681,7 +681,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         }
 
         if (/[^A-z0-9_]/i.test(key)) {
-          error(
+          output.error(
             `Invalid ${chalk.dim('-e')} key ${chalk.bold(
               `"${chalk.bold(key)}"`
             )}. Only letters, digits and underscores are allowed.`
@@ -698,13 +698,13 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
 
           if (_secrets.length === 0) {
             if (uidOrName === '') {
-              error(
+              output.error(
                 `Empty reference provided for env key ${chalk.bold(
                   `"${chalk.bold(key)}"`
                 )}`
               )
             } else {
-              error(
+              output.error(
                 `No secret found by uid or name ${chalk.bold(`"${uidOrName}"`)}`,
                 'env-no-secret'
               )
@@ -712,7 +712,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
 
             await exit(1)
           } else if (_secrets.length > 1) {
-            error(
+            output.error(
               `Ambiguous secret ${chalk.bold(
                 `"${uidOrName}"`
               )} (matches ${chalk.bold(_secrets.length)} secrets)`
@@ -817,7 +817,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           now.on('complete', resolve)
 
           now.on('error', err => {
-            error('Upload failed')
+            output.error('Upload failed')
             reject(err)
           })
         })
@@ -857,7 +857,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         }
 
         if (deployment === null) {
-          error('Uploading failed. Please try again.')
+          output.error('Uploading failed. Please try again.')
           await exit(1)
           return
         }
@@ -887,7 +887,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           if (!proceed) {
             if (typeof proceed === 'undefined') {
               const message = `If you agree with that, please run again with ${cmd('--public')}.`
-              error(message)
+              output.error(message)
 
               await exit(1)
             } else {
@@ -923,7 +923,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         const message = regions.length
           ? `Invalid regions: ${additionalProperty.slice(0, -1)}`
           : `Invalid DC name for the scale option: ${additionalProperty}`
-        error(message)
+        output.error(message)
         await exit(1)
       }
 

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -347,7 +347,7 @@ async function main(ctx: any) {
   regions = (argv.regions || '').split(',').map(s => s.trim()).filter(Boolean)
   noVerify = argv['verify'] === false
   apiUrl = ctx.apiUrl
-  raw = !isTTY || argv.raw
+  raw = argv.raw || !isTTY
   const output = createOutput({ debug: debugEnabled })
   // https://github.com/facebook/flow/issues/1825
   // $FlowFixMe
@@ -1191,8 +1191,6 @@ function handleCreateDeployError<OtherError>(output: Output, error: CreateDeploy
 }
 
 function logDeployment(deployment) {
-  // write a newline to stderr
-  process.stderr.write('\n')
   if (argv.json) {
     const data = {
       uid: deployment.deploymentId,

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -412,7 +412,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           Object.assign(gitRepo, gitParts)
 
           const searchMessage = setTimeout(() => {
-            log(`Didn't find directory. Searching on ${gitRepo.type}...`)
+            output.print(`Didn't find directory. Searching on ${gitRepo.type}...\n`)
           }, 500)
 
           try {
@@ -472,11 +472,11 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       if (gitRepo.main) {
         const gitRef = gitRepo.ref ? ` at "${chalk.bold(gitRepo.ref)}" ` : ''
 
-        log(`Deploying ${gitRepo.type} repository "${chalk.bold(
+        output.print(`Deploying ${gitRepo.type} repository "${chalk.bold(
             gitRepo.main
           )}"${gitRef} under ${chalk.bold(
             (currentTeam && currentTeam.slug) || user.username || user.email
-          )}`)
+          )}\n`)
       } else {
         const list = paths
           .map((path, index) => {
@@ -490,9 +490,9 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           })
           .join('')
 
-        log(`Deploying ${list} under ${chalk.bold(
+        output.print(`Deploying ${list} under ${chalk.bold(
             (currentTeam && currentTeam.slug) || user.username || user.email
-          )}`)
+          )}\n`)
       }
     }
 
@@ -822,7 +822,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         })
 
         if (!quiet && syncCount) {
-          log(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${uploadStamp()}`)
+          output.print(`Synced ${syncCount} (${bytes(now.syncAmount)}) ${uploadStamp()}\n`)
         }
 
         for (let i = 0; i < 4; i += 1) {
@@ -867,7 +867,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
           const who = currentTeam ? 'your team is' : 'you are'
 
           let proceed
-          log(`Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.`)
+          output.print(`Your deployment's code and logs will be publicly accessible because ${who} subscribed to the OSS plan.\n`)
 
           if (isTTY) {
             proceed = await promptBool('Are you sure you want to proceed?', {
@@ -890,7 +890,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
 
               await exit(1)
             } else {
-              log('Aborted')
+              output.print('Aborted\n')
               await exit(0)
             }
 
@@ -939,13 +939,13 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
       if (clipboard) {
         try {
           await copy(url)
-          log(`${chalk.bold(chalk.cyan(url))} [in clipboard]${dcs} ${deployStamp()}`)
+          output.print(`${chalk.bold(chalk.cyan(url))} [in clipboard]${dcs} ${deployStamp()}\n`)
         } catch (err) {
           debug(`Error copying to clipboard: ${err}`)
-          log(`${chalk.bold(chalk.cyan(url))} [in clipboard]${dcs} ${deployStamp()}`)
+          output.print(`${chalk.bold(chalk.cyan(url))} [in clipboard]${dcs} ${deployStamp()}\n`)
         }
       } else {
-        log(`${chalk.bold(chalk.cyan(url))}${dcs} ${deployStamp()}`)
+        output.print(`${chalk.bold(chalk.cyan(url))}${dcs} ${deployStamp()}\n`)
       }
     }
 
@@ -955,7 +955,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         noVerify = true
       } else {
         if (!quiet) {
-          output.log(chalk`{cyan Deployment complete!}`)
+          output.print(chalk`{cyan Deployment complete!}\n`)
         }
         logDeployment(deployment)
         await exit(0)

--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -1122,7 +1122,7 @@ function handleCreateDeployError<OtherError>(output: Output, error: CreateDeploy
       output.print(`  This might happen to new domains or domains with recent DNS changes. Please retry later.\n`)
     } else {
       output.error(`The certificate provider could not resolve the HTTP queries for ${error.meta.domain}.`)
-      output.print(`  The DNS propagation may take a few minutes, please verify your settings:\n\n`)
+      output.print(`  The DNS propagation may take a few minutes. Please verify your settings:\n\n`)
       output.print(dnsTable([['', 'ALIAS', 'alias.zeit.co']]) + '\n');
     }
     return 1


### PR DESCRIPTION
This adds `--json` and `--raw` options to the deploy (default) command so that you can process stdout with other programs. The JSON output is a subset of the deployment data that the script was already passing around, and only includes the `uid` and `url` fields that appear in deployment-related API responses. (One way to improve this situation might be to fetch the full JSON representation from the API and write that to stdout instead.)

This should help prevent race conditions when running `now` and `now alias` and another deployment finishes between the two commands, as alluded to in https://github.com/zeit/now-cli/issues/1391#issuecomment-395027384. For instance:

```bash
now --json > deployed.json
url=$(jq -r .url deployed.json)
now alias $url my-domain.com
```

The `--raw` option is a more explicit way of triggering the non-TTY behavior of writing the deployment URL to stdout, and should still be the default behavior for non-TTY processes:

```bash
now --raw > url.txt
now alias $(cat url.txt) my-domain.com
```

The options are mutually exclusive, but `--json` wins silently if you pass both so that you can get JSON output from a non-TTY.

In order to preserve the purity of stdout, I also had to replace a bunch of `output.log()` calls with `output.print()` and add a newline to the end of each message. I also fixed a grammatical issue with the DNS propagation message in c59abda.