### PR TITLE
Add "all" pseudo-DC to the constants mapping

### DIFF
--- a/src/providers/sh/util/scale/constants.js
+++ b/src/providers/sh/util/scale/constants.js
@@ -8,6 +8,7 @@ export type DC = {
 }
 
 export const REGION_TO_DC = {
+  all: 'all',
   bru: 'bru1',
   gru: 'gru1',
   sfo: 'sfo1',


### PR DESCRIPTION
So that "all" is accepted in the `scale` in now.json:

```
  "scale": {
    "all": {
      "min": 0,
      "max": "auto"
    }
  },
```