### PR TITLE
Bring back `now certs add` command

### DIFF
--- a/src/providers/sh/commands/certs/add.js
+++ b/src/providers/sh/commands/certs/add.js
@@ -1,0 +1,118 @@
+// @flow
+import ms from 'ms'
+import chalk from 'chalk'
+
+import Now from '../../util'
+import getContextName from '../../util/get-context-name'
+import stamp from '../../../../util/output/stamp'
+import wait from '../../../../util/output/wait'
+import dnsTable from '../../util/dns-table'
+import { CLIContext, Output } from '../../util/types'
+import * as Errors from '../../util/errors'
+import { handleDomainConfigurationError } from '../../util/error-handlers'
+import type { CLICertsOptions } from '../../util/types'
+
+import createCertFromFile from '../../util/certs/create-cert-from-file'
+import createCertForCns from '../../util/certs/create-cert-for-cns'
+
+async function add(ctx: CLIContext, opts: CLICertsOptions, args: string[], output: Output): Promise<number> {
+  const {authConfig: { credentials }, config: { sh }} = ctx
+  const { currentTeam } = sh;
+  const { apiUrl } = ctx;
+  const contextName = getContextName(sh);
+  const addStamp = stamp()
+  let cert
+
+  const {
+    ['--overwrite']: overwite,
+    ['--debug']: debugEnabled,
+    ['--crt']: crtPath,
+    ['--key']: keyPath,
+    ['--ca']: caPath,
+  } = opts;
+
+  // $FlowFixMe
+  const {token} = credentials.find(item => item.provider === 'sh')
+  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam })
+
+  if (overwite) {
+    output.error('Overwrite option is deprecated')
+    now.close();
+    return 1;
+  }
+
+  if (crtPath || keyPath || caPath) {
+    if ((args.length !== 0) || (!crtPath || !keyPath || !caPath)) {
+      output.error(`Invalid number of arguments to create a custom certificate entry. Usage:`)
+      output.print(`  ${chalk.cyan(`now certs add --crt <domain.crt> --key <domain.key> --ca <ca.crt>`)}\n`)
+      now.close();
+      return 1
+    }
+
+    // Create a custom certificate from the given file paths
+    cert = await createCertFromFile(now, keyPath, crtPath, caPath, contextName)
+    if (cert instanceof Errors.InvalidCert) {
+      output.error(`The provided certificate is not valid and can't be added.`)
+      return 1
+    } else if (cert instanceof Errors.DomainPermissionDenied) {
+      output.error(`You don't have permissions over domain ${chalk.underline(cert.meta.domain)} under ${chalk.bold(cert.meta.context)}.`)
+      return 1
+    }
+  } else {
+    output.warn(`${chalk.cyan('now certs add')} will be soon deprecated. Please use ${chalk.cyan('now certs issue <cn> <cns>')} instead`)
+    if (args.length < 1) {
+      output.error(`Invalid number of arguments to create a custom certificate entry. Usage:`)
+      output.print(`  ${chalk.cyan(`now certs add <cn>[, <cn>]`)}\n`)
+      now.close();
+      return 1
+    }
+
+    // Create the certificate from the given array of CNs
+    const cns = args.reduce((res, item) => ([...res, ...item.split(',')]), [])
+    const cancelWait = wait(`Generating a certificate for ${chalk.bold(cns.join(', '))}`);
+    cert = await createCertForCns(now, cns, contextName)
+    cancelWait();
+    if (cert instanceof Errors.CantSolveChallenge) {
+      output.error(`We can't solve the ${cert.meta.type} challenge for domain ${cert.meta.domain}.`)
+      if (cert.meta.type === 'dns-01') {
+        output.error(`The certificate provider could not resolve the DNS queries for ${cert.meta.domain}.`)
+        output.print(`  This might happen to new domains or domains with recent DNS changes. Please retry later.\n`)
+      } else {
+        output.error(`The certificate provider could not resolve the HTTP queries for ${cert.meta.domain}.`)
+        output.print(`  The DNS propagation may take a few minutes, please verify your settings:\n\n`)
+        output.print(dnsTable([['', 'ALIAS', 'alias.zeit.co']]) + '\n');
+      }
+      return 1
+    } else if (cert instanceof Errors.TooManyRequests) {
+      output.error(`Too many requests detected for ${cert.meta.api} API. Try again in ${ms(cert.meta.retryAfter * 1000, { long: true })}.`)
+      return 1
+    } else if (cert instanceof Errors.TooManyCertificates) {
+      output.error(`Too many certificates already issued for exact set of domains: ${cert.meta.domains.join(', ')}`)
+      return 1
+    } else if (cert instanceof Errors.DomainValidationRunning) {
+      output.error(`There is a validation in course for ${chalk.underline(cert.meta.domain)}. Wait until it finishes.`)
+      return 1
+    } else if (cert instanceof Errors.DomainConfigurationError) {
+      handleDomainConfigurationError(output, cert)
+      return 1
+    } else if (cert instanceof Errors.CantGenerateWildcardCert) {
+      output.error(`Wildcard certificates are allowed only for domains in ${chalk.underline('zeit.world')}`)
+      return 1
+    } else if (cert instanceof Errors.DomainsShouldShareRoot) {
+      output.error(`All given common names should share the same root domain.`)
+      return 1
+    } else if (cert instanceof Errors.InvalidWildcardDomain) {
+      output.error(`Invalid domain ${chalk.underline(cert.meta.domain)}. Wildcard domains can only be followed by a root domain.`)
+      return 1
+    } else if (cert instanceof Errors.DomainPermissionDenied) {
+      output.error(`You don't have permissions over domain ${chalk.underline(cert.meta.domain)} under ${chalk.bold(cert.meta.context)}.`)
+      return 1
+    }
+  }
+
+  // Print success message
+  output.success(`Certificate entry for ${chalk.bold(cert.cns.join(', '))} created ${addStamp()}`)
+  return 0
+}
+
+export default add

--- a/src/providers/sh/commands/certs/index.js
+++ b/src/providers/sh/commands/certs/index.js
@@ -9,6 +9,7 @@ import getSubcommand from '../../util/get-subcommand'
 import logo from '../../../../util/output/logo'
 import type { CLICertsOptions } from '../../util/types'
 
+import add from './add'
 import issue from './issue'
 import ls from './ls'
 import rm from './rm'
@@ -105,8 +106,7 @@ module.exports = async function main(ctx: any): Promise<number> {
     case 'rm':
       return rm(ctx, argv, args, output)
     case 'add':
-      output.error(`${chalk.cyan('now certs add')} is deprecated. Please use ${chalk.cyan('now certs issue <cn> <cns>')} instead`)
-      return 1
+      return add(ctx, argv, args, output)
     case 'renew':
       output.error('Renewing certificates is deprecated, issue a new one.')
       return 1


### PR DESCRIPTION
This PR brings back `now certs add` with a warning that suggest you to use the new `now certs issue` command. We will remove it later in the future.