### PR TITLE
Suppresses the warning of a dependency based on an expression

### DIFF
--- a/src/util/pkg.js
+++ b/src/util/pkg.js
@@ -8,7 +8,7 @@ const pkg = require('../../package.json')
 
 try {
   const distDir = path.dirname(process.execPath)
-  pkg._npmPkg = require(path.join(distDir, '../../package.json'))
+  pkg._npmPkg = require(`${path.join(distDir, '../../package.json')}`)
 } catch (err) {
   pkg._npmPkg = null
 }


### PR DESCRIPTION
## Summary 🌮 

While webpack is a great resource for statically bundling imports, this issue arises when a 3rd-party library uses a `require()` expression to e.g. load a `JSON` or `JS` config file at runtime. This warning is annoying **every time the project is built**, there are other alternatives to ignore the warning message. But the solution I use seems to me to be the best for the moment 😺 ❤️ 


<img width="612" alt="screen shot 2018-09-18 at 02 35 24" src="https://user-images.githubusercontent.com/16585386/45674777-65a60b00-baf3-11e8-824e-a4e5ebc328f5.png">

> [More info](https://github.com/webpack/webpack/issues/196)

I would like to know your opinion @leo @rauchg 
