### PR TITLE
Output deployment URL after isntantiation verified

### DIFF
--- a/src/providers/sh/commands/deploy/deploy.js
+++ b/src/providers/sh/commands/deploy/deploy.js
@@ -1014,7 +1014,7 @@ async function sync({ contextName, output, token, config: { currentTeam, user },
         }
       }
 
-      output.success(`Deployment ready`)
+      output.success(`Deployment ready at ${url}`)
       await exit(0)
     }
   })


### PR DESCRIPTION
Improves DX by not forcing a scroll-back to discover the URL.

The particular use-case is long-ish running build steps which also contain a lot of output. I often find myself switching away while the deploy happens, often copying other things to my clipboard before returning to then have to scroll back to find the url.