### PR TITLE
Fix template string

### DIFF
--- a/src/resolvers/github.js
+++ b/src/resolvers/github.js
@@ -76,7 +76,7 @@ const resolveGitHubByURL = async (url: string) => {
             return join(tmpDir, `${repo}-${tree}`)
           } else {
             throw new Error(
-              'An HTTP error ${res.status} was returned ' +
+              `An HTTP error ${res.status} was returned ` +
                 `by "${downloadURL}"`
             )
           }


### PR DESCRIPTION
This error message was printing the literal res.status instead of the value of the status code.