### PR TITLE
Show aliases for deployments when listing an app

### DIFF
--- a/src/providers/sh/commands/list.js
+++ b/src/providers/sh/commands/list.js
@@ -184,6 +184,15 @@ module.exports = async function main(ctx) {
     )
   }
 
+  if (app) {
+    await Promise.all(
+      deployments.map(async ({ uid }, i) => {
+        const aliases = await getAliases(now, uid);
+        deployments[i].aliases = aliases.map(alias => alias.alias).join(', ')
+      })
+    )
+  }
+
   if (host) {
     deployments = deployments.filter(deployment => {
       return deployment.url === host
@@ -209,10 +218,16 @@ module.exports = async function main(ctx) {
     log(`To list deployment instances run ${cmd('now ls --all [app]')}`)
   }
 
+  const tableHeaders = ['app', 'url', 'inst #', 'type', 'state', 'age'];
+
+  if (app) {
+    tableHeaders.push('aliases')
+  }
+
   print('\n')
 
   console.log(table([
-    ['app', 'url', 'inst #', 'type', 'state', 'age'].map(s => chalk.dim(s)),
+    tableHeaders.map(s => chalk.dim(s)),
     ...deployments
     .sort(sortRecent())
     .map(dep => (
@@ -223,7 +238,8 @@ module.exports = async function main(ctx) {
           dep.instanceCount == null ? chalk.gray('-') : dep.instanceCount,
           dep.type,
           stateString(dep.state),
-          chalk.gray(ms(Date.now() - new Date(dep.created)))
+          chalk.gray(ms(Date.now() - new Date(dep.created))),
+          !app ? '' : dep.aliases || chalk.gray('-')
         ],
         ...(argv['--all']
           ? dep.instances.map(


### PR DESCRIPTION
Closes #1597.

With this PR, when you run `now ls <app>`, we show a new column: `aliases`.