### PR TITLE
Added support for `-V` option

### DIFF
--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -8,6 +8,7 @@ import getScope from '../../util/get-scope';
 import createOutput from '../../util/output';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
+import param from '../../util/output/param';
 import { readLocalConfig } from '../../util/config/files';
 import getArgs from '../../util/get-args';
 import { handleError } from '../../util/error';
@@ -113,6 +114,19 @@ module.exports = async (ctx: CLIContext) => {
         `Your project is missing ${prop} in ${file}. More: https://zeit.co/docs/version-config`
       );
     }
+  }
+
+  const versionFlag = argv['--platform-version'];
+
+  if (versionFlag) {
+    if (versionFlag !== 1 && versionFlag !== 2) {
+        output.error(
+          `The ${param('--platform-version')} option must be either ${code('1')} or ${code('2')}.`
+        );
+        return 1;
+    }
+
+    platformVersion = versionFlag;
   }
 
   if (platformVersion === null || platformVersion > 1) {

--- a/src/util/arg-common.js
+++ b/src/util/arg-common.js
@@ -4,6 +4,9 @@ const ARG_COMMON = {
   '--help': Boolean,
   '-h': '--help',
 
+  '--platform-version': Number,
+  '-V': '--platform-version',
+
   '--debug': Boolean,
   '-d': '--debug',
 


### PR DESCRIPTION
This flag (or `--platform-version` as the full version) will allow you to set the Platform Version, just like you would do using `version` in `now.json`.