### PR TITLE
Added `-V` to the usage information

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -64,6 +64,7 @@ exports.help = () => `
 
     -h, --help                     Output usage information
     -v, --version                  Output the version number
+    -V, --platform-version         Set the platform version to deploy to
     -n, --name                     Set the name of the deployment
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -145,6 +145,7 @@ exports.help = () => `
 
     -h, --help                     Output usage information
     -v, --version                  Output the version number
+    -V, --platform-version         Set the platform version to deploy to
     -n, --name                     Set the name of the deployment
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
     'FILE'


### PR DESCRIPTION
This adds the usage information entry for https://github.com/zeit/now-cli/pull/1644.