### PR TITLE
Made default value for `--dotenv` (v1) work again

### DIFF
--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -66,7 +66,8 @@ const mriOpts = {
     'npm',
     'static',
     'public',
-    'no-verify'
+    'no-verify',
+    'dotenv'
   ],
   default: {
     C: false,


### PR DESCRIPTION
This fixes https://github.com/zeit/now-cli/issues/1646.