### PR TITLE
Allow re-using aliases that point to deleted deployments

### DIFF
--- a/src/commands/alias/assign-alias.js
+++ b/src/commands/alias/assign-alias.js
@@ -29,13 +29,19 @@ async function assignAlias(
   let externalDomain = false;
 
   // If there was a previous deployment, we should fetch it to scale and downscale later
-  const prevDeployment = await fetchDeploymentFromAlias(
+  let prevDeployment = await fetchDeploymentFromAlias(
     output,
     now,
     contextName,
     prevAlias,
     deployment
   );
+
+  // If there is an alias laying around that points to a deleted
+  // deployment, we need to account for it here.
+  if (prevDeployment instanceof Errors.DeploymentNotFound) {
+    prevDeployment = null;
+  }
 
   if (
     prevDeployment instanceof Errors.DeploymentPermissionDenied ||

--- a/src/commands/alias/assign-alias.js
+++ b/src/commands/alias/assign-alias.js
@@ -44,8 +44,7 @@ async function assignAlias(
   }
 
   if (
-    prevDeployment instanceof Errors.DeploymentPermissionDenied ||
-    prevDeployment instanceof Errors.DeploymentNotFound
+    prevDeployment instanceof Errors.DeploymentPermissionDenied
   ) {
     return prevDeployment;
   }


### PR DESCRIPTION
If a deployment is deleted that is used by an alias, re-using that alias would throw this error:

![image](https://user-images.githubusercontent.com/6170607/48447821-5c58b800-e79d-11e8-84f4-96931dc0c3b0.png)

With this PR, we prevent this from happening by allowing re-using an alias that points to a deleted deployment.