### PR TITLE
Fixed error message for minimum instance count

### DIFF
--- a/src/commands/scale.js
+++ b/src/commands/scale.js
@@ -234,7 +234,7 @@ module.exports = async function main(ctx: CLIContext): Promise<number> {
   if (result instanceof Errors.ForbiddenScaleMinInstances) {
     output.error(
       `You can't scale to more than ${result.meta
-        .max} min instances with your current plan.`
+        .min} min instances with your current plan.`
     );
     now.close();
     return 1;

--- a/src/util/scale/patch-deployment-scale.js
+++ b/src/util/scale/patch-deployment-scale.js
@@ -31,7 +31,7 @@ async function patchDeploymentScale(
   } catch (error) {
     cancelWait();
     if (error.code === 'forbidden_min_instances') {
-      return new Errors.ForbiddenScaleMinInstances(url, error.min);
+      return new Errors.ForbiddenScaleMinInstances(url, error.max);
     } else if (error.code === 'forbidden_max_instances') {
       return new Errors.ForbiddenScaleMaxInstances(url, error.max);
     } else if (error.code === 'wrong_min_max_relation') {


### PR DESCRIPTION
Without this fix, it would look like this:

> Error! You can't scale to more than undefined min instances with your current plan.