### PR TITLE
Made `now dns ls` work

### DIFF
--- a/src/commands/dns/index.js
+++ b/src/commands/dns/index.js
@@ -90,6 +90,7 @@ module.exports = async function main(ctx: any): Promise<number> {
 
   const output: Output = createOutput({ debug: argv['--debug'] });
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
+
   switch (subcommand) {
     case 'add':
       return add(ctx, argv, args, output);

--- a/src/commands/dns/ls.js
+++ b/src/commands/dns/ls.js
@@ -66,6 +66,7 @@ async function ls(
 
   const dnsRecords = await getDNSRecords(output, now, contextName);
   const nRecords = dnsRecords.reduce((p, r) => r.records.length + p, 0);
+
   output.log(
     `${plural('Record', nRecords, true)} found under ${chalk.bold(
       contextName


### PR DESCRIPTION
The command is currently not working because we are exiting immediately if one of the domains is using an external nameserver.