### PR TITLE
Make `now teams add` work

### DIFF
--- a/src/commands/teams.js
+++ b/src/commands/teams.js
@@ -145,7 +145,7 @@ async function run({ token, config }) {
     }
     case 'add':
     case 'create': {
-      exitCode = await add({ teams, config });
+      exitCode = await add({ apiUrl, token, teams, config });
       break;
     }
 

--- a/src/commands/teams/add.js
+++ b/src/commands/teams/add.js
@@ -40,7 +40,7 @@ const gracefulExit = () => {
 const teamUrlPrefix = rightPad('Team URL', 14) + chalk.gray('zeit.co/');
 const teamNamePrefix = rightPad('Team Name', 14);
 
-module.exports = async function({ teams, config }) {
+module.exports = async function({ apiUrl, token, teams, config }) {
   let slug;
   let team;
   let elapsed;
@@ -128,7 +128,13 @@ module.exports = async function({ teams, config }) {
 
   // Update config file
   const configCopy = Object.assign({}, config);
-  configCopy.sh.currentTeam = team;
+
+  if (configCopy.sh) {
+    configCopy.sh.currentTeam = team;
+  } else {
+    configCopy.currentTeam = team.id;
+  }
+
   writeToConfigFile(configCopy);
 
   stopSpinner();
@@ -136,6 +142,8 @@ module.exports = async function({ teams, config }) {
   await invite({
     teams,
     args: [],
+    token,
+    apiUrl,
     config,
     introMsg: 'Invite your teammates! When done, press enter on an empty field',
     noopMsg: `You can invite teammates later by running ${cmd(

--- a/test/integration.js
+++ b/test/integration.js
@@ -119,6 +119,19 @@ test('log in', async t => {
   t.is(last, goal);
 });
 
+test('try creating a team', async t => {
+  const { stdout, code } = await execa(binaryPath, [
+    'teams',
+    'add',
+    ...defaultArgs
+  ], {
+    reject: false
+  });
+
+  t.is(code, 0);
+  t.true(stdout.startsWith(`> Pick a team identifier for its url`));
+});
+
 test('list the payment methods', async t => {
   const { stdout, code } = await execa(binaryPath, [
     'billing',

--- a/test/integration.js
+++ b/test/integration.js
@@ -128,7 +128,9 @@ test('try creating a team', async t => {
     reject: false
   });
 
-  t.is(code, 0);
+  // The error code is `1` because the command is expecting TTY
+  // because it provides an interactive interface.
+  t.is(code, 1);
   t.true(stdout.startsWith(`> Pick a team identifier for its url`));
 });
 


### PR DESCRIPTION
Currently, it's failing like this:

```
$ now team add
> Success! Team created [439ms]
✔ Team URL zeit.co/nate-created-at-test
> Success! Team name saved [132ms]
✔ Team Name createdAt Test
> Error! An unexpected error occurred in team: TypeError: Cannot set property 'currentTeam' of undefined
at module.exports (/snapshot/now-cli-staging/dist/now.js:17301:29)
at process._tickCallback (internal/process/next_tick.js:68:7)
```

This is fixed now.