### PR TITLE
Do not send `alias` to the API

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -240,6 +240,12 @@ module.exports = class Now extends EventEmitter {
 
       if (Object.keys(nowConfig).length > 0) {
         if (isBuilds) {
+          // These properties are only used inside Now CLI and
+          // are not supported on the API.
+          const exclude = [
+            'alias'
+          ];
+
           // Request properties that are made of a combination of
           // command flags and config properties were already set
           // earlier. Here, we are setting request properties that
@@ -247,7 +253,7 @@ module.exports = class Now extends EventEmitter {
           for (const key of Object.keys(nowConfig)) {
             const value = nowConfig[key];
 
-            if (!requestBody[key]) {
+            if (!requestBody[key] && !exclude.includes(key)) {
               requestBody[key] = value;
             }
           }

--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -120,6 +120,10 @@ module.exports = async session => {
       'second.png',
       'now.json'
     ],
+    'config-alias-property': {
+      'now.json': '{ "alias": "test.now.sh", "builds": [ { "src": "*.html", "use": "@now/static" } ] }',
+      'index.html': '<span>test alias</span'
+    },
     'builds-wrong': {
       'now.json': '{"builder": 1, "type": "static"}',
       'index.html': '<span>test</span'

--- a/test/integration.js
+++ b/test/integration.js
@@ -335,8 +335,43 @@ test('set platform version using `--platform-version` to `2`', async t => {
     reject: false
   });
 
-  console.log(stdout);
-  console.log(stderr);
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Ensure the listing includes the necessary parts
+  const wanted = [
+    session,
+    'index.html'
+  ];
+
+  t.true(wanted.every(item => stderr.includes(item)));
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href);
+  const contentType = response.headers.get('content-type');
+
+  t.is(contentType, 'text/html; charset=utf-8');
+
+  await removeDeployment(t, binaryPath, defaultArgs, stdout);
+});
+
+test('ensure the `alias` property is not sent to the API', async t => {
+  const directory = fixture('config-alias-property');
+
+  const { stderr, stdout, code } = await execa(binaryPath, [
+    directory,
+    '--public',
+    '--name',
+    session,
+    ...defaultArgs,
+    '--force'
+  ], {
+    reject: false
+  });
 
   // Ensure the exit code is right
   t.is(code, 0);


### PR DESCRIPTION
This is a follow-up to https://github.com/zeit/now-cli/pull/1689 and ensures we're not sending `alias` because we're not using it on the API.