### PR TITLE
Do not send `github` property to API

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -243,7 +243,8 @@ module.exports = class Now extends EventEmitter {
           // These properties are only used inside Now CLI and
           // are not supported on the API.
           const exclude = [
-            'alias'
+            'alias',
+            'github'
           ];
 
           // Request properties that are made of a combination of


### PR DESCRIPTION
Currently, we're throwing this error:

![image](https://user-images.githubusercontent.com/6170607/48940427-d6184080-ef17-11e8-9a56-223c854ac744.png)

Should not happen, of course.

The property is only used on the client (in GitHub Integration), so we can't upload it to the API.