### PR TITLE
Render a proper error when offline

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -520,6 +520,13 @@ const main = async argv_ => {
   try {
     exitCode = await commands[subcommand](ctx);
   } catch (err) {
+    if (err.code === 'ENOTFOUND' && err.hostname === 'api.zeit.co') {
+      output.error('You are offline. Please ensure your device has an active internet connection.');
+      output.debug(err.stack);
+
+      return;
+    }
+
     Sentry.captureException(err);
 
     const client = Sentry.getCurrentHub().getClient();
@@ -542,10 +549,7 @@ const main = async argv_ => {
 
     // Otherwise it is an unexpected error and we should show the trace
     // and an unexpected error message
-    console.error(
-      error(`An unexpected error occurred in ${subcommand}: ${err.stack}`)
-    );
-
+    output.error(`An unexpected error occurred in ${subcommand}: ${err.stack}`);
     return 1;
   }
 

--- a/src/now.js
+++ b/src/now.js
@@ -524,7 +524,7 @@ const main = async argv_ => {
       output.error('You are offline. Please ensure your device has an active internet connection.');
       output.debug(err.stack);
 
-      return;
+      return 1;
     }
 
     Sentry.captureException(err);


### PR DESCRIPTION
**BEFORE**

![image](https://user-images.githubusercontent.com/6170607/49107154-3f37e500-f285-11e8-989e-e7ff1be254f8.png)

**AFTER**

![image](https://user-images.githubusercontent.com/6170607/49107163-46f78980-f285-11e8-969e-64cf621f63fc.png)

This also makes `--debug` work in `src/now.js`. Previously, it seemed not have been malfunctioning.