### PR TITLE
Render more accurate error when offline

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -39,6 +39,7 @@ const configFiles = require('./util/config/files');
 const pkg = require('./util/pkg');
 const getUser = require('./util/get-user');
 const NowTeams = require('./util/teams');
+const highlight = require('./util/output/highlight');
 
 import { Output } from './util/types';
 import createOutput from './util/output';
@@ -521,7 +522,7 @@ const main = async argv_ => {
     exitCode = await commands[subcommand](ctx);
   } catch (err) {
     if (err.code === 'ENOTFOUND' && err.hostname === 'api.zeit.co') {
-      output.error('You are offline. Please ensure your device has an active internet connection.');
+      output.error(`The hostname ${highlight('api.zeit.co')} could not be resolved. Please verify your internet connectivity and DNS configuration.`);
       output.debug(err.stack);
 
       return 1;


### PR DESCRIPTION
As per [this comment](https://github.com/zeit/now-cli/pull/1702#pullrequestreview-179009129), we are now rendering a better error.