### PR TITLE
Ensured `now -V 1 owner/repo` continues working

### DIFF
--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -61,6 +61,7 @@ module.exports = async (ctx: CLIContext) => {
       stats[path] = await fs.lstat(path);
     } catch (err) {
       const { ext } = parse(path);
+
       if (versionFlag === 1 && !ext) {
         // This will ensure `-V 1 zeit/serve` (GitHub deployments) work. Since
         // GitHub repositories are never just one file, we need to set

--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -1,6 +1,6 @@
 //@flow
 
-import { resolve, basename } from 'path';
+import { resolve, basename, parse } from 'path';
 import { promises as fs } from 'fs';
 import latest from './latest';
 import legacy from './legacy';
@@ -46,6 +46,7 @@ module.exports = async (ctx: CLIContext) => {
   const localConfig = readLocalConfig(paths[0]);
   const output = createOutput({ debug: argv['--debug'] });
   const stats = {};
+  const versionFlag = argv['--platform-version'];
 
   if (argv['--help']) {
     const lastArg = argv._[argv._.length - 1];
@@ -59,10 +60,20 @@ module.exports = async (ctx: CLIContext) => {
     try {
       stats[path] = await fs.lstat(path);
     } catch (err) {
-      output.error(
-        `The specified file or directory "${basename(path)}" does not exist.`
-      );
-      return 1;
+      const { ext } = parse(path);
+      if (versionFlag === 1 && !ext) {
+        // This will ensure `-V 1 zeit/serve` (GitHub deployments) work. Since
+        // GitHub repositories are never just one file, we need to set
+        // the `isFile` property accordingly.
+        stats[path] = {
+          isFile: () => false
+        };
+      } else {
+        output.error(
+          `The specified file or directory "${basename(path)}" does not exist.`
+        );
+        return 1;
+      }
     }
   }
 
@@ -115,8 +126,6 @@ module.exports = async (ctx: CLIContext) => {
       );
     }
   }
-
-  const versionFlag = argv['--platform-version'];
 
   if (versionFlag) {
     if (versionFlag !== 1 && versionFlag !== 2) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -187,6 +187,68 @@ test('try to add a payment method', async t => {
   t.true(stdout.startsWith(`> Enter your card details for ${email}`));
 });
 
+test('use `-V 1` to deploy a GitHub repository', async t => {
+  const { stdout, code } = await execa(binaryPath, [
+    '-V',
+    1,
+    '--public',
+    '--name',
+    session,
+    ...defaultArgs,
+    'leo/hub',
+  ], {
+    reject: false
+  });
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  const contentType = response.headers.get('content-type');
+  t.is(contentType, 'application/json; charset=utf-8');
+});
+
+test('use `--platform-version 1` to deploy a GitHub repository', async t => {
+  const { stdout, code } = await execa(binaryPath, [
+    '--platform-version',
+    1,
+    '--public',
+    '--name',
+    session,
+    ...defaultArgs,
+    'leo/hub',
+  ], {
+    reject: false
+  });
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  const contentType = response.headers.get('content-type');
+  t.is(contentType, 'application/json; charset=utf-8');
+});
+
 test('set platform version using `-V` to `1`', async t => {
   const directory = fixture('builds');
   const goal = '> Error! The property `builds` is only allowed on Now 2.0 — please upgrade';


### PR DESCRIPTION
As reported by @paulogdm, `now -V 1 owner/repo` is not working at the moment.

With this patch, we make it work.