### PR TITLE
Improved Sentry error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "devDependencies": {
     "@sentry/node": "4.3.0",
     "@zeit/dockerignore": "0.0.3",
-    "@zeit/ncc": "0.1.18",
+    "@zeit/ncc": "0.4.1",
     "@zeit/source-map-support": "0.6.2",
     "alpha-sort": "2.0.1",
     "ansi-escapes": "3.0.0",

--- a/src/commands/billing/index.js
+++ b/src/commands/billing/index.js
@@ -78,12 +78,7 @@ export default async ctx => {
   try {
     return run({ token, config });
   } catch (err) {
-    if (err.userError) {
-      console.error(error(err.message));
-    } else {
-      console.error(error(`Unknown error: ${err.stack}`));
-    }
-
+    console.error(error(`Unknown error: ${err.stack}`));
     return 1;
   }
 };

--- a/src/commands/billing/index.js
+++ b/src/commands/billing/index.js
@@ -75,12 +75,7 @@ export default async ctx => {
 
   const { authConfig: { token }, config } = ctx;
 
-  try {
-    return run({ token, config });
-  } catch (err) {
-    console.error(error(`Unknown error: ${err.stack}`));
-    return 1;
-  }
+  return run({ token, config });
 };
 
 // Builds a `choices` object that can be passesd to inquirer.prompt()

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -181,7 +181,7 @@ const readEmail = async () => {
       throw new Error(aborted('No changes made.'));
     }
 
-    if (err.message.includes('setRawMode')) {
+    if (err.message === 'stdin lacks setRawMode support') {
       throw new Error(
         error(
           `Interactive mode not supported – please run ${cmd(

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -181,7 +181,7 @@ const readEmail = async () => {
       throw new Error(aborted('No changes made.'));
     }
 
-    if (err.message === 'stdin lacks setRawMode support') {
+    if (err.message.includes('setRawMode')) {
       throw new Error(
         error(
           `Interactive mode not supported – please run ${cmd(

--- a/src/commands/teams.js
+++ b/src/commands/teams.js
@@ -91,12 +91,7 @@ const main = async ctx => {
   try {
     return run({ token, config });
   } catch (err) {
-    if (err.userError) {
-      console.error(error(err.message));
-    } else {
-      console.error(error(`Unknown error: ${err.stack}`));
-    }
-
+    console.error(error(`Unknown error: ${err.stack}`));
     return 1;
   }
 };

--- a/src/commands/teams.js
+++ b/src/commands/teams.js
@@ -88,12 +88,7 @@ const main = async ctx => {
 
   const { authConfig: { token }, config } = ctx;
 
-  try {
-    return run({ token, config });
-  } catch (err) {
-    console.error(error(`Unknown error: ${err.stack}`));
-    return 1;
-  }
+  return run({ token, config });
 };
 
 export default async ctx => {

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -105,7 +105,7 @@ const downgradeToFree = async ({ error }, now) => {
 };
 
 export default async function main(ctx     )                  {
-  let argv                   ;
+  let argv;
 
   try {
     argv = getArgs(ctx.argv.slice(2), {

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -104,7 +104,7 @@ const downgradeToFree = async ({ error }, now) => {
   cancelWait();
 };
 
-export default async function main(ctx     )                  {
+export default async function main(ctx) {
   let argv;
 
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import getArgs from './util/get-args';
 import getUser from './util/get-user';
 import NowTeams from './util/teams';
 import highlight from './util/output/highlight';
-import reportError from './util/report-error';
+import { handleError, reportError } from './util/error';
 
 const NOW_DIR = getNowDir();
 const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -45,22 +45,28 @@ Sentry.init({ dsn: 'https://417d8c347b324670b668aca646256352@sentry.io/1323225' 
 let debug = () => {};
 
 const main = async argv_ => {
-  // $FlowFixMe
   const { isTTY } = process.stdout;
 
-  const argv = getArgs(
-    argv_,
-    {
-      '--version': Boolean,
-      '-v': '--version',
-      '--debug': Boolean,
-      '-d': '--debug'
-    },
-    { permissive: true }
-  );
+  let argv = null;
+
+  try {
+    argv = getArgs(
+      argv_,
+      {
+        '--version': Boolean,
+        '-v': '--version',
+        '--debug': Boolean,
+        '-d': '--debug'
+      },
+      { permissive: true }
+    );
+  } catch (err) {
+    handleError(err);
+    return 1;
+  }
 
   const isDebugging = argv['--debug'];
-  const output         = createOutput({ debug: isDebugging });
+  const output = createOutput({ debug: isDebugging });
 
   debug = output.debug;
 

--- a/src/util/domain-records.js
+++ b/src/util/domain-records.js
@@ -105,7 +105,6 @@ export default class DomainRecords extends Now {
 
         if (body.error.code === 'not_found') {
           err = new Error(`The domain "${domain}" was not found`);
-          err.userError = true;
           return bail(err);
         }
       }
@@ -144,7 +143,6 @@ export default class DomainRecords extends Now {
 
         if (body.error.code === 'not_found') {
           err = new Error(body.error.message);
-          err.userError = true;
           return bail(err);
         }
       }

--- a/src/util/domains.js
+++ b/src/util/domains.js
@@ -1,12 +1,6 @@
-// Native
 import { encode as encodeQuery } from 'querystring';
-
-// Packages
 import chalk from 'chalk';
-
-// Ours
 import Now from '.';
-
 import isValidDomain from './domains/is-valid-domain';
 import cmd from './output/param';
 
@@ -105,7 +99,6 @@ export default class Domains extends Now {
       const err = new Error(
         `The supplied value ${chalk.bold(`"${domain}"`)} is not a valid domain.`
       );
-      err.userError = true;
       throw err;
     }
 

--- a/src/util/error.js
+++ b/src/util/error.js
@@ -32,7 +32,7 @@ export function handleError(err, { debug = false } = {}) {
         )
       );
     }
-  } else if (err.userError || err.message) {
+  } else if (err.message) {
     console.error(errorOutput(err.message));
   } else if (err.status === 500) {
     console.error(errorOutput('Unexpected server error. Please retry.'));
@@ -49,7 +49,6 @@ export const error = errorOutput;
 
 export async function responseError(res, fallbackMessage = null, parsedBody = {}) {
   let message;
-  let userError;
   let bodyError;
 
   if (res.status >= 400 && res.status < 500) {
@@ -64,9 +63,6 @@ export async function responseError(res, fallbackMessage = null, parsedBody = {}
     // Some APIs wrongly return `err` instead of `error`
     bodyError = body.error || body.err || {};
     message = bodyError.message;
-    userError = true;
-  } else {
-    userError = false;
   }
 
   if (message == null) {
@@ -76,7 +72,6 @@ export async function responseError(res, fallbackMessage = null, parsedBody = {}
   const err = new Error(`${message} (${res.status})`);
 
   err.status = res.status;
-  err.userError = userError;
   err.serverMessage = message;
 
   // Copy every field that was added manually to the error

--- a/src/util/error.js
+++ b/src/util/error.js
@@ -116,3 +116,13 @@ export async function responseErrorMessage(res, fallbackMessage = null) {
 
   return `${message} (${res.status})`;
 }
+
+export async function reportError(sentry, error) {
+  sentry.captureException(error);
+
+  const client = sentry.getCurrentHub().getClient();
+
+  if (client) {
+    await client.close();
+  }
+};

--- a/src/util/error.js
+++ b/src/util/error.js
@@ -118,7 +118,10 @@ export async function responseErrorMessage(res, fallbackMessage = null) {
 }
 
 export async function reportError(sentry, error) {
-  sentry.captureException(error);
+  // Do not report errors while developing
+  if (process.pkg) {
+    sentry.captureException(error);
+  }
 
   const client = sentry.getCurrentHub().getClient();
 

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -1,14 +1,11 @@
-//      
+//
 import { NowError } from './now-error';
 
 /**
  * General CLI errors
  */
-export class ConflictingOption extends NowError 
-                      
-                  
-  {
-  constructor(name        ) {
+export class ConflictingOption extends NowError {
+  constructor(name) {
     super({
       code: 'CONFICTING_OPTION',
       meta: { name },
@@ -20,8 +17,8 @@ export class ConflictingOption extends NowError
 /**
  * Create Alias Errors
  */
-export class AliasInUse extends NowError                                    {
-  constructor(alias        ) {
+export class AliasInUse extends NowError {
+  constructor(alias) {
     super({
       code: 'ALIAS_IN_USE',
       meta: { alias },
@@ -30,8 +27,8 @@ export class AliasInUse extends NowError                                    {
   }
 }
 
-export class InvalidAlias extends NowError                                     {
-  constructor(alias        ) {
+export class InvalidAlias extends NowError {
+  constructor(alias) {
     super({
       code: 'INVALID_ALIAS',
       meta: { alias },
@@ -40,7 +37,7 @@ export class InvalidAlias extends NowError                                     {
   }
 }
 
-export class CDNNeedsUpgrade extends NowError                          {
+export class CDNNeedsUpgrade extends NowError {
   constructor() {
     super({
       code: 'CDN_NEEDS_UPGRADE',
@@ -50,9 +47,9 @@ export class CDNNeedsUpgrade extends NowError                          {
   }
 }
 
-export class DeploymentNotFound extends NowError 
-                         
-                                 
+export class DeploymentNotFound extends NowError
+
+
   {
   constructor(id        , context        ) {
     super({
@@ -66,9 +63,9 @@ export class DeploymentNotFound extends NowError
 /**
  * SetupDomainErrors
  */
-export class DomainPermissionDenied extends NowError 
-                             
-                                     
+export class DomainPermissionDenied extends NowError
+
+
   {
   constructor(domain        , context        ) {
     super({
@@ -79,9 +76,9 @@ export class DomainPermissionDenied extends NowError
   }
 }
 
-export class DeploymentPermissionDenied extends NowError 
-                                 
-                                 
+export class DeploymentPermissionDenied extends NowError
+
+
   {
   constructor(id        , context        ) {
     super({
@@ -92,9 +89,9 @@ export class DeploymentPermissionDenied extends NowError
   }
 }
 
-export class DomainAlreadyExists extends NowError 
-                          
-                                                  
+export class DomainAlreadyExists extends NowError
+
+
   {
   constructor(uid        , domain        , context        ) {
     super({
@@ -105,9 +102,9 @@ export class DomainAlreadyExists extends NowError
   }
 }
 
-export class DNSPermissionDenied extends NowError 
-                          
-                    
+export class DNSPermissionDenied extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -118,11 +115,8 @@ export class DNSPermissionDenied extends NowError
   }
 }
 
-export class DomainVerificationFailed extends NowError 
-                               
-                                                      
-  {
-  constructor(domain        , subdomain        , token        ) {
+export class DomainVerificationFailed extends NowError {
+  constructor(domain, subdomain, token) {
     super({
       code: 'DOMAIN_VERIFICATION_FAILED',
       meta: { domain, subdomain, token },
@@ -131,11 +125,8 @@ export class DomainVerificationFailed extends NowError
   }
 }
 
-export class SchemaValidationFailed extends NowError 
-                             
-                                                                     
-  {
-  constructor(message        , keyword        , dataPath        , params     ) {
+export class SchemaValidationFailed extends NowError {
+  constructor(message, keyword, dataPath, params) {
     super({
       code: 'SCHEMA_VALIDATION_FAILED',
       meta: { message, keyword, dataPath, params },
@@ -144,11 +135,8 @@ export class SchemaValidationFailed extends NowError
   }
 }
 
-export class DomainNotVerified extends NowError 
-                        
-                    
-  {
-  constructor(domain        ) {
+export class DomainNotVerified extends NowError {
+  constructor(domain) {
     super({
       code: 'DOMAIN_NOT_VERIFIED',
       meta: { domain },
@@ -157,9 +145,9 @@ export class DomainNotVerified extends NowError
   }
 }
 
-export class DomainNotFound extends NowError 
-                     
-                    
+export class DomainNotFound extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -183,11 +171,8 @@ export class UserAborted extends NowError                     {
 /**
  * Alias configuration errors
  */
-export class InvalidAliasInConfig extends NowError 
-                            
-                            
-  {
-  constructor(value     ) {
+export class InvalidAliasInConfig extends NowError {
+  constructor(value) {
     super({
       code: 'INVALID_ALIAS_IN_CONFIG',
       meta: { value },
@@ -216,9 +201,9 @@ export class FileNotFound extends NowError                                     {
   }
 }
 
-export class CantFindConfig extends NowError 
-                     
-                     
+export class CantFindConfig extends NowError
+
+
   {
   constructor(paths          ) {
     super({
@@ -229,9 +214,9 @@ export class CantFindConfig extends NowError
   }
 }
 
-export class DomainNameserversNotFound extends NowError 
-                          
-                    
+export class DomainNameserversNotFound extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -242,9 +227,9 @@ export class DomainNameserversNotFound extends NowError
   }
 }
 
-export class PaymentSourceNotFound extends NowError 
-                             
-    
+export class PaymentSourceNotFound extends NowError
+
+
   {
   constructor() {
     super({
@@ -255,9 +240,9 @@ export class PaymentSourceNotFound extends NowError
   }
 }
 
-export class CantParseJSONFile extends NowError 
-                         
-                  
+export class CantParseJSONFile extends NowError
+
+
   {
   constructor(file        ) {
     super({
@@ -268,9 +253,9 @@ export class CantParseJSONFile extends NowError
   }
 }
 
-export class DomainConfigurationError extends NowError 
-                               
-                                                          
+export class DomainConfigurationError extends NowError
+
+
   {
   constructor(domain        , subdomain        , external         ) {
     super({
@@ -281,9 +266,9 @@ export class DomainConfigurationError extends NowError
   }
 }
 
-export class CantGenerateWildcardCert extends NowError 
-                                
-    
+export class CantGenerateWildcardCert extends NowError
+
+
   {
   constructor() {
     super({
@@ -294,9 +279,9 @@ export class CantGenerateWildcardCert extends NowError
   }
 }
 
-export class CertOrderNotFound extends NowError 
-                         
-                   
+export class CertOrderNotFound extends NowError
+
+
   {
   constructor(cns          ) {
     super({
@@ -307,9 +292,9 @@ export class CertOrderNotFound extends NowError
   }
 }
 
-export class TooManyCertificates extends NowError 
-                          
-                       
+export class TooManyCertificates extends NowError
+
+
   {
   constructor(domains          ) {
     super({
@@ -322,9 +307,9 @@ export class TooManyCertificates extends NowError
   }
 }
 
-export class DomainValidationRunning extends NowError 
-                              
-                    
+export class DomainValidationRunning extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -335,9 +320,9 @@ export class DomainValidationRunning extends NowError
   }
 }
 
-export class RulesFileValidationError extends NowError 
-                                
-                                       
+export class RulesFileValidationError extends NowError
+
+
   {
   constructor(location        , message        ) {
     super({
@@ -348,9 +333,9 @@ export class RulesFileValidationError extends NowError
   }
 }
 
-export class RuleValidationFailed extends NowError 
-                           
-                     
+export class RuleValidationFailed extends NowError
+
+
   {
   constructor(message        ) {
     super({
@@ -371,9 +356,9 @@ export class InvalidCert extends NowError                     {
   }
 }
 
-export class TooManyRequests extends NowError 
-                      
-                                     
+export class TooManyRequests extends NowError
+
+
   {
   constructor({ api, retryAfter }                                     ) {
     super({
@@ -384,9 +369,9 @@ export class TooManyRequests extends NowError
   }
 }
 
-export class DomainsShouldShareRoot extends NowError 
-                          
-                 
+export class DomainsShouldShareRoot extends NowError
+
+
   {
   constructor(api        ) {
     super({
@@ -397,9 +382,9 @@ export class DomainsShouldShareRoot extends NowError
   }
 }
 
-export class InvalidWildcardDomain extends NowError 
-                            
-                    
+export class InvalidWildcardDomain extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -410,9 +395,9 @@ export class InvalidWildcardDomain extends NowError
   }
 }
 
-export class CantSolveChallenge extends NowError 
-                         
-                                                
+export class CantSolveChallenge extends NowError
+
+
   {
   constructor(domain        , type                      ) {
     super({
@@ -423,9 +408,9 @@ export class CantSolveChallenge extends NowError
   }
 }
 
-export class VerifyScaleTimeout extends NowError 
-                         
-                     
+export class VerifyScaleTimeout extends NowError
+
+
   {
   constructor(timeout        ) {
     super({
@@ -446,9 +431,9 @@ export class InvalidAllForScale extends NowError                              {
   }
 }
 
-export class InvalidRegionOrDCForScale extends NowError 
-                                   
-                        
+export class InvalidRegionOrDCForScale extends NowError
+
+
   {
   constructor(regionOrDC        ) {
     super({
@@ -459,9 +444,9 @@ export class InvalidRegionOrDCForScale extends NowError
   }
 }
 
-export class InvalidMinForScale extends NowError 
-                          
-                   
+export class InvalidMinForScale extends NowError
+
+
   {
   constructor(value        ) {
     super({
@@ -472,9 +457,9 @@ export class InvalidMinForScale extends NowError
   }
 }
 
-export class InvalidMaxForScale extends NowError 
-                          
-                   
+export class InvalidMaxForScale extends NowError
+
+
   {
   constructor(value        ) {
     super({
@@ -485,9 +470,9 @@ export class InvalidMaxForScale extends NowError
   }
 }
 
-export class InvalidArgsForMinMaxScale extends NowError 
-                                   
-                          
+export class InvalidArgsForMinMaxScale extends NowError
+
+
   {
   constructor(min                 ) {
     super({
@@ -498,9 +483,9 @@ export class InvalidArgsForMinMaxScale extends NowError
   }
 }
 
-export class ForbiddenScaleMinInstances extends NowError 
-                                  
-                              
+export class ForbiddenScaleMinInstances extends NowError
+
+
   {
   constructor(url        , min        ) {
     super({
@@ -511,9 +496,9 @@ export class ForbiddenScaleMinInstances extends NowError
   }
 }
 
-export class ForbiddenScaleMaxInstances extends NowError 
-                                  
-                              
+export class ForbiddenScaleMaxInstances extends NowError
+
+
   {
   constructor(url        , max        ) {
     super({
@@ -524,9 +509,9 @@ export class ForbiddenScaleMaxInstances extends NowError
   }
 }
 
-export class InvalidScaleMinMaxRelation extends NowError 
-                                   
-                 
+export class InvalidScaleMinMaxRelation extends NowError
+
+
   {
   constructor(url        ) {
     super({
@@ -537,9 +522,9 @@ export class InvalidScaleMinMaxRelation extends NowError
   }
 }
 
-export class NotSupportedMinScaleSlots extends NowError 
-                                  
-                 
+export class NotSupportedMinScaleSlots extends NowError
+
+
   {
   constructor(url        ) {
     super({
@@ -550,9 +535,9 @@ export class NotSupportedMinScaleSlots extends NowError
   }
 }
 
-export class InvalidCoupon extends NowError 
-                   
-                    
+export class InvalidCoupon extends NowError
+
+
   {
   constructor(coupon        ) {
     super({
@@ -573,9 +558,9 @@ export class UsedCoupon extends NowError                                    {
   }
 }
 
-export class UnsupportedTLD extends NowError 
-                    
-                  
+export class UnsupportedTLD extends NowError
+
+
   {
   constructor(name        ) {
     super({
@@ -596,9 +581,9 @@ export class MissingCreditCard extends NowError                            {
   }
 }
 
-export class DomainNotAvailable extends NowError 
-                         
-                    
+export class DomainNotAvailable extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -609,9 +594,9 @@ export class DomainNotAvailable extends NowError
   }
 }
 
-export class InvalidDomain extends NowError 
-                   
-                    
+export class InvalidDomain extends NowError
+
+
   {
   constructor(domain        ) {
     super({
@@ -622,9 +607,9 @@ export class InvalidDomain extends NowError
   }
 }
 
-export class DomainServiceNotAvailable extends NowError 
-                                 
-    
+export class DomainServiceNotAvailable extends NowError
+
+
   {
   constructor() {
     super({
@@ -635,9 +620,9 @@ export class DomainServiceNotAvailable extends NowError
   }
 }
 
-export class UnexpectedDomainPurchaseError extends NowError 
-                                     
-    
+export class UnexpectedDomainPurchaseError extends NowError
+
+
   {
   constructor() {
     super({
@@ -648,9 +633,9 @@ export class UnexpectedDomainPurchaseError extends NowError
   }
 }
 
-export class PremiumDomainForbidden extends NowError 
-                             
-    
+export class PremiumDomainForbidden extends NowError
+
+
   {
   constructor() {
     super({

--- a/src/util/get-args.js
+++ b/src/util/get-args.js
@@ -1,24 +1,30 @@
-//      
 import arg from 'arg';
-
 import getCommonArgs from './arg-common';
 
-
-
-
-
 function getArgs(
-  argv          ,
-  argsOptions          = {},
-  argOptions              = {}
+  argv,
+  argsOptions = {},
+  argOptions = {}
 ) {
-  return arg(
-    {
-      ...getCommonArgs(),
-      ...argsOptions
-    },
-    { ...argOptions, argv }
-  );
+  let list = null;
+
+  try {
+    list = arg(
+      {
+        ...getCommonArgs(),
+        ...argsOptions
+      },
+      { ...argOptions, argv }
+    );
+  } catch (err) {
+    // If an error occures here, it's because the user
+    // passed wrong arguments to Now CLI. In turn, we should
+    // not report to Sentry.
+    err.userError = true;
+    throw err;
+  }
+
+  return list;
 }
 
 export default getArgs;

--- a/src/util/get-args.js
+++ b/src/util/get-args.js
@@ -6,25 +6,13 @@ function getArgs(
   argsOptions = {},
   argOptions = {}
 ) {
-  let list = null;
-
-  try {
-    list = arg(
-      {
-        ...getCommonArgs(),
-        ...argsOptions
-      },
-      { ...argOptions, argv }
-    );
-  } catch (err) {
-    // If an error occures here, it's because the user
-    // passed wrong arguments to Now CLI. In turn, we should
-    // not report to Sentry.
-    err.userError = true;
-    throw err;
-  }
-
-  return list;
+  return arg(
+    {
+      ...getCommonArgs(),
+      ...argsOptions
+    },
+    { ...argOptions, argv }
+  );
 }
 
 export default getArgs;

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -196,7 +196,6 @@ export const isRepoPath = path => {
 
     const err = new Error(`Host "${urlParts.host}" is unsupported.`);
     err.code = 'INVALID_URL';
-    err.userError = true;
     throw err;
   }
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -99,7 +99,6 @@ export default class Now extends EventEmitter {
             'Missing `start` (or `now-start`) script in `package.json`. ' +
               'See: https://docs.npmjs.com/cli/start'
           );
-          err.userError = true;
           throw err;
         }
 
@@ -356,7 +355,6 @@ export default class Now extends EventEmitter {
           err.message = 'Not able to create deployment';
         }
 
-        err.userError = true;
         return bail(err);
       }
 
@@ -689,7 +687,6 @@ export default class Now extends EventEmitter {
 
     if (!last) {
       const e = Error(`No deployments found for "${app}"`);
-      e.userError = true;
       throw e;
     }
 
@@ -783,7 +780,6 @@ export default class Now extends EventEmitter {
             `Not authorized to access domain ${name} http://err.sh/now-cli/unauthorized-domain`
           );
         }
-        err.userError = true;
         return bail(err);
       } if (res.status === 409) {
         // Domain already exists
@@ -832,12 +828,10 @@ export default class Now extends EventEmitter {
               'The certificate issuer failed to verify ownership of the domain. ' +
                 'This likely has to do with DNS propagation and caching issues. Please retry later!'
             );
-            err.userError = true;
             // Retry
             throw err;
           } else if (code === 'rate_limited') {
             const err = new Error(body.error.message);
-            err.userError = true;
             // Dont retry
             return bail(err);
           }
@@ -868,7 +862,6 @@ export default class Now extends EventEmitter {
 
         if (res.status !== 200) {
           const err = new Error(res.body.error.message);
-          err.userError = false;
 
           if (res.status === 400 || res.status === 404) {
             return bail(err);

--- a/src/util/input/prompt-bool.js
+++ b/src/util/input/prompt-bool.js
@@ -15,19 +15,12 @@ export default (
 ) => new Promise(resolve => {
     const isRaw = stdin.isRaw;
 
-    if (process.stdin.setRawMode) {
-      stdin.setRawMode(true);
-    }
-
+    stdin.setRawMode(true);
     stdin.resume();
 
     function restore() {
       stdout.write(trailing);
-
-      if (process.stdin.setRawMode) {
-        stdin.setRawMode(isRaw);
-      }
-
+      stdin.setRawMode(isRaw);
       stdin.pause();
       stdin.removeListener('data', onData);
     }

--- a/src/util/input/prompt-bool.js
+++ b/src/util/input/prompt-bool.js
@@ -15,12 +15,19 @@ export default (
 ) => new Promise(resolve => {
     const isRaw = stdin.isRaw;
 
-    stdin.setRawMode(true);
+    if (process.stdin.setRawMode) {
+      stdin.setRawMode(true);
+    }
+
     stdin.resume();
 
     function restore() {
       stdout.write(trailing);
-      stdin.setRawMode(isRaw);
+
+      if (process.stdin.setRawMode) {
+        stdin.setRawMode(isRaw);
+      }
+
       stdin.pause();
       stdin.removeListener('data', onData);
     }

--- a/src/util/input/prompt-options.js
+++ b/src/util/input/prompt-options.js
@@ -12,7 +12,10 @@ function promptOptions(opts) {
       const s = v.toString();
 
       const cleanup = () => {
-        process.stdin.setRawMode(false);
+        if (process.stdin.setRawMode) {
+          process.stdin.setRawMode(false);
+        }
+
         process.stdin.removeListener('data', ondata);
       };
 
@@ -31,7 +34,10 @@ function promptOptions(opts) {
       }
     };
 
-    process.stdin.setRawMode(true);
+    if (process.stdin.setRawMode) {
+      process.stdin.setRawMode(true);
+    }
+
     process.stdin.resume();
     process.stdin.on('data', ondata);
   });

--- a/src/util/input/prompt-options.js
+++ b/src/util/input/prompt-options.js
@@ -12,10 +12,7 @@ function promptOptions(opts) {
       const s = v.toString();
 
       const cleanup = () => {
-        if (process.stdin.setRawMode) {
-          process.stdin.setRawMode(false);
-        }
-
+        process.stdin.setRawMode(false);
         process.stdin.removeListener('data', ondata);
       };
 
@@ -34,10 +31,7 @@ function promptOptions(opts) {
       }
     };
 
-    if (process.stdin.setRawMode) {
-      process.stdin.setRawMode(true);
-    }
-
+    process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.on('data', ondata);
   });

--- a/src/util/input/prompt-options.js
+++ b/src/util/input/prompt-options.js
@@ -1,4 +1,3 @@
-// Packages
 import chalk from 'chalk';
 
 export default promptOptions;
@@ -21,10 +20,7 @@ function promptOptions(opts) {
       if (s === '\u0003') {
         cleanup();
         const err = new Error('Aborted');
-
         err.code = 'USER_ABORT';
-        err.userError = true;
-
         return reject(err);
       }
 

--- a/src/util/input/prompt-options.js
+++ b/src/util/input/prompt-options.js
@@ -21,7 +21,10 @@ function promptOptions(opts) {
       if (s === '\u0003') {
         cleanup();
         const err = new Error('Aborted');
+
         err.code = 'USER_ABORT';
+        err.userError = true;
+
         return reject(err);
       }
 

--- a/src/util/input/text.js
+++ b/src/util/input/text.js
@@ -99,11 +99,17 @@ export default function(
       regex = new RegExp(`(${regex})`, 'g');
     }
 
-    stdin.setRawMode(true);
+    if (stdin.setRawMode) {
+      stdin.setRawMode(true);
+    }
+
     stdin.resume();
 
     function restore() {
-      stdin.setRawMode(isRaw);
+      if (stdin.setRawMode) {
+        stdin.setRawMode(isRaw);
+      }
+
       stdin.pause();
       stdin.removeListener('data', onData);
 

--- a/src/util/input/text.js
+++ b/src/util/input/text.js
@@ -99,17 +99,11 @@ export default function(
       regex = new RegExp(`(${regex})`, 'g');
     }
 
-    if (stdin.setRawMode) {
-      stdin.setRawMode(true);
-    }
-
+    stdin.setRawMode(true);
     stdin.resume();
 
     function restore() {
-      if (stdin.setRawMode) {
-        stdin.setRawMode(isRaw);
-      }
-
+      stdin.setRawMode(isRaw);
       stdin.pause();
       stdin.removeListener('data', onData);
 

--- a/src/util/input/text.js
+++ b/src/util/input/text.js
@@ -123,7 +123,9 @@ export default function(
 
       if (abortSequences.has(data)) {
         restore();
-        return reject(new Error('USER_ABORT'));
+        const error = new Error('USER_ABORT');
+        error.userError = true;
+        return reject(error);
       }
 
       if (forceLowerCase) {

--- a/src/util/input/text.js
+++ b/src/util/input/text.js
@@ -1,11 +1,7 @@
-// Packages
 import ansiEscapes from 'ansi-escapes';
-
 import ansiRegex from 'ansi-regex';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
-
-// Utilities
 import eraseLines from '../output/erase-lines';
 
 const ESCAPES = {
@@ -124,7 +120,6 @@ export default function(
       if (abortSequences.has(data)) {
         restore();
         const error = new Error('USER_ABORT');
-        error.userError = true;
         return reject(error);
       }
 

--- a/src/util/now-error.js
+++ b/src/util/now-error.js
@@ -5,6 +5,5 @@ export class NowError extends Error {
 
     this.code = code;
     this.meta = meta;
-    this.userError = true;
   }
 }

--- a/src/util/now-error.js
+++ b/src/util/now-error.js
@@ -1,19 +1,10 @@
-//      
-
-                           
-          
-          
-                 
-  
-
 // A generic error to rule them all
-export class NowError       extends Error {
-          
-          
-
-  constructor({ code, message, meta }                    ) {
+export class NowError extends Error {
+  constructor({ code, message, meta }) {
     super(message);
+
     this.code = code;
     this.meta = meta;
+    this.userError = true;
   }
 }

--- a/src/util/prompt-options.js
+++ b/src/util/prompt-options.js
@@ -12,7 +12,10 @@ function promptOptions(opts) {
       const s = v.toString();
 
       const cleanup = () => {
-        process.stdin.setRawMode(false);
+        if (process.stdin.setRawMode) {
+          process.stdin.setRawMode(false);
+        }
+
         process.stdin.removeListener('data', ondata);
       };
 
@@ -31,7 +34,10 @@ function promptOptions(opts) {
       }
     };
 
-    process.stdin.setRawMode(true);
+    if (process.stdin.setRawMode) {
+      process.stdin.setRawMode(true);
+    }
+
     process.stdin.resume();
     process.stdin.on('data', ondata);
   });

--- a/src/util/prompt-options.js
+++ b/src/util/prompt-options.js
@@ -12,10 +12,7 @@ function promptOptions(opts) {
       const s = v.toString();
 
       const cleanup = () => {
-        if (process.stdin.setRawMode) {
-          process.stdin.setRawMode(false);
-        }
-
+        process.stdin.setRawMode(false);
         process.stdin.removeListener('data', ondata);
       };
 
@@ -34,10 +31,7 @@ function promptOptions(opts) {
       }
     };
 
-    if (process.stdin.setRawMode) {
-      process.stdin.setRawMode(true);
-    }
-
+    process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.on('data', ondata);
   });

--- a/src/util/prompt-options.js
+++ b/src/util/prompt-options.js
@@ -1,4 +1,3 @@
-// Packages
 import chalk from 'chalk';
 
 export default promptOptions;
@@ -21,10 +20,7 @@ function promptOptions(opts) {
       if (s === '\u0003') {
         cleanup();
         const err = new Error('Aborted');
-
         err.code = 'USER_ABORT';
-        err.userError = true;
-
         return reject(err);
       }
 

--- a/src/util/prompt-options.js
+++ b/src/util/prompt-options.js
@@ -21,7 +21,10 @@ function promptOptions(opts) {
       if (s === '\u0003') {
         cleanup();
         const err = new Error('Aborted');
+
         err.code = 'USER_ABORT';
+        err.userError = true;
+
         return reject(err);
       }
 

--- a/src/util/read-metadata.js
+++ b/src/util/read-metadata.js
@@ -46,7 +46,6 @@ async function readMetaData(
           'but configuration is also present in `now.json`! ' +
           "Please ensure there's a single source of configuration by removing one."
       );
-      err.userError = true;
       throw err;
     } else {
       nowConfig = pkg.now;
@@ -74,7 +73,6 @@ async function readMetaData(
           'Please supply `--npm` or `--docker` to disambiguate.'
       );
 
-      err.userError = true;
       err.code = 'MULTIPLE_MANIFESTS';
 
       throw err;
@@ -104,8 +102,6 @@ async function readMetaData(
   } else if (type === 'docker') {
     if (strict && dockerfile.length <= 0) {
       const err = new Error('No commands found in `Dockerfile`');
-      err.userError = true;
-
       throw err;
     }
 
@@ -125,7 +121,6 @@ async function readMetaData(
             `Error parsing value for LABEL ${key} in \`Dockerfile\``
           );
 
-          e.userError = true;
           throw e;
         }
       }
@@ -187,7 +182,6 @@ function decorateUserErrors(fn) {
     } catch (err) {
       // If the file doesn't exist then that's fine; any other error bubbles up
       if (err.code !== 'ENOENT') {
-        err.userError = true;
         throw err;
       }
     }

--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -1,0 +1,12 @@
+export default async (sentry, error) => {
+  if (!error.userError) {
+    sentry.captureException(error);
+  }
+
+  const client = sentry.getCurrentHub().getClient();
+
+  // Ensure all Sentry events are flushed
+  if (client) {
+    await client.close();
+  }
+};

--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -1,7 +1,5 @@
 export default async (sentry, error) => {
-  if (!error.userError) {
-    sentry.captureException(error);
-  }
+  sentry.captureException(error);
 
   const client = sentry.getCurrentHub().getClient();
 

--- a/src/util/secrets.js
+++ b/src/util/secrets.js
@@ -1,7 +1,4 @@
-// Ours
 import Now from '.';
-
-const isUserError = res => ((res.status / 100) | 0) === 4;
 
 export default class Secrets extends Now {
   ls() {
@@ -29,12 +26,6 @@ export default class Secrets extends Now {
       const body = await res.json();
 
       if (res.status !== 200) {
-        if (isUserError(res)) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
-        }
-
         throw new Error(body.error.message);
       }
 
@@ -67,12 +58,6 @@ export default class Secrets extends Now {
       const body = await res.json();
 
       if (res.status !== 200) {
-        if (isUserError(res)) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
-        }
-
         throw new Error(body.error.message);
       }
 
@@ -104,12 +89,6 @@ export default class Secrets extends Now {
       const body = await res.json();
 
       if (res.status !== 200) {
-        if (isUserError(res)) {
-          const err = new Error(body.error.message);
-          err.userError = true;
-          return bail(err);
-        }
-
         throw new Error(body.error.message);
       }
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -343,7 +343,6 @@ test('throws when both `now.json` and `package.json:now` exist', async t => {
     e = err;
   }
   t.is(e.name, 'Error');
-  t.is(e.userError, true);
   t.pass(
     /please ensure there's a single source of configuration/i.test(e.message)
   );
@@ -359,7 +358,6 @@ test('throws when `package.json` and `Dockerfile` exist', async t => {
   } catch (err) {
     e = err;
   }
-  t.is(e.userError, true);
   t.is(e.code, 'MULTIPLE_MANIFESTS');
   t.pass(/ambiguous deployment/i.test(e.message));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,11 +50,11 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/generator@^7.0.0", "@babel/generator@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.6.tgz#001303cf87a5b9d093494a4bf251d7b5d03d3999"
-  integrity sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.0.tgz#eaf3821fa0301d9d4aef88e63d4bcc19b73ba16c"
+  integrity sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
   dependencies:
-    "@babel/types" "^7.1.6"
+    "@babel/types" "^7.2.0"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -92,10 +92,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.1.6", "@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
+"@babel/parser@7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.6.tgz#16e97aca1ec1062324a01c5a6a7d0df8dd189854"
   integrity sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
+  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0":
   version "7.1.2"
@@ -121,10 +126,10 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.6.tgz#0adb330c3a281348a190263aceb540e10f04bcce"
-  integrity sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==
+"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
+  integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -238,10 +243,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.3.tgz#b50071e6d37848205e5cf81b4ca2c347ae6ec8ca"
   integrity sha512-tO000RCJxEbRBhQpWEaTF+aAIkMRSuQVnC1g7Y1l/duhxjp6CotepHcUerQBFa5lgjVesh/zlblq2t1GvfAEbQ==
 
-"@zeit/ncc@0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.1.18.tgz#5c8e5be91a9a0c7215f5ce0c983a9d52a42dc899"
-  integrity sha512-ymWv9m/E22loFWXV+7MY/fxREbD3J3ksxqJCkAQ1Po4tJTt/lx7zGRnVxvILWs7T/K2OEj7v7x704zBnOSDnUQ==
+"@zeit/ncc@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.4.1.tgz#d275157024bc306ffd429918dc645a9368c62f68"
+  integrity sha512-8S71zRmnKpup8OjmIhVjN+McQmqCNI1tCjknXyZJriA7ULFr5vCiug5K7pHQlsDf2LgLLciEivJph0XbC0Fq7w==
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"
@@ -296,9 +301,9 @@ alpha-sort@2.0.1:
   integrity sha1-UNNTiUfPcOvMFaa0YfsE//O/Htk=
 
 already@1.x:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/already/-/already-1.3.5.tgz#854a1f0b7c7e95a41203e121b4881bf3a2a829bb"
-  integrity sha512-uoi72uOKv+M8D8xKvOe1OO1ioFd6v8SiOLSHbYRMbstD87MZV+nrCJpWH6BhlrvGm3lCKWEY36zz1J3Qudv/2w==
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/already/-/already-1.3.6.tgz#5e76bcfafed09cd8fb6e41a1d0dbe6151420e65c"
+  integrity sha512-ifInpRE81behq4DU2osiTcZMVyXZeJPhRedsa2BNYSEKT3w+hkPhc8f8eQhzFUrO/aFepremgpj4SoFg5LVnIg==
   dependencies:
     throat "4.x"
 
@@ -1675,9 +1680,9 @@ core-assert@^0.2.0:
     is-error "^2.2.0"
 
 core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
+  integrity sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5343,10 +5348,15 @@ progress@2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
-progress@2.0.1, progress@^2.0.0:
+progress@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prop-types@^15.6.2:
   version "15.6.2"


### PR DESCRIPTION
This PR:

- ...bumps `@zeit/ncc` to the latest version, so we can enjoy minification
- ...handles global arg parsing errors better (see below)
- ...removes all occurances of `userError` (bad engineering practice)
- ...makes Sentry use a shared utility for reporting errors
- ...prevents errors from being reported while developing

BEFORE

![image](https://user-images.githubusercontent.com/6170607/49538515-e7742c00-f8cb-11e8-89e4-8f2b36fdbe64.png)

AFTER

![image](https://user-images.githubusercontent.com/6170607/49538523-f0fd9400-f8cb-11e8-8030-89ecd0d58a23.png)
