### PR TITLE
Added legacy `preferGlobal` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "now",
   "version": "13.0.0-canary.18",
+  "preferGlobal": true,
   "license": "Apache-2.0",
   "description": "The command-line interface for Now",
   "repository": "zeit/now-cli",


### PR DESCRIPTION
This is an attempt to make [this](https://www.npmjs.com/package/now) show `npm i -g now` instead:

![image](https://user-images.githubusercontent.com/6170607/49585667-4e8ef080-f95f-11e8-8f7d-da5a9b2392a9.png)

From the docs:

> This option used to trigger an npm warning, but it will no longer warn. It is purely there for informational purposes.