### PR TITLE
Hot fix for `now teams ls`

### DIFF
--- a/src/commands/teams/list.js
+++ b/src/commands/teams/list.js
@@ -48,15 +48,6 @@ export default async function({ teams, config, apiUrl, token }) {
     );
     const choice = teamList.splice(index, 1)[0];
     teamList.unshift(choice);
-  } else {
-    currentTeam = list.find(team => team.id === currentTeam);
-
-    if (!currentTeam) {
-      console.error(
-        error(`You are not a part of the current team anymore`)
-      );
-      return 1;
-    }
   }
 
   // Printing

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,20 +1,12 @@
-// Native
 import path from 'path';
-
 import { URL } from 'url';
-
-// Packages
 import test from 'ava';
-
 import semVer from 'semver';
 import fs from 'fs';
 import execa from 'execa';
 import fetch from 'node-fetch';
 import tmp from 'tmp-promise';
-
-// Utilities
 import logo from '../src/util/output/logo';
-
 import sleep from '../src/util/sleep';
 import pkg from '../package';
 import parseList from './helpers/parse-list';
@@ -120,6 +112,19 @@ test('log in', async t => {
 
   t.is(code, 0);
   t.is(last, goal);
+});
+
+test('list the scopes', async t => {
+  const { stdout, code } = await execa(binaryPath, [
+    'teams',
+    'ls',
+    ...defaultArgs
+  ], {
+    reject: false
+  });
+
+  t.is(code, 0);
+  t.true(stdout.includes(`✔ ${email}     ${email}`));
 });
 
 test('list the payment methods', async t => {


### PR DESCRIPTION
This code is useless, so we can remove it. The `currentTeam` variable is not read after it is overridden in this statement.

Also adds an integration test.