### PR TITLE
Update `now alias` error to mention potentially missing name config

### DIFF
--- a/src/commands/alias/set.js
+++ b/src/commands/alias/set.js
@@ -169,6 +169,7 @@ export default async function set(
       output.error(
         `Couldn't find a deployment to alias. Either configure a "name" or please provide a deployment as an argument.`
       );
+      output.log('Read more: https://zeit.co/docs/v2/deployments/configuration/#name')
       return 1;
     }
 

--- a/src/commands/alias/set.js
+++ b/src/commands/alias/set.js
@@ -167,7 +167,7 @@ export default async function set(
       return 1;
     } if (deployment === null) {
       output.error(
-        `Couldn't find a deployment to alias. Please provide one as an argument.`
+        `Couldn't find a deployment to alias. Either configure a "name" or please provide a deployment as an argument.`
       );
       return 1;
     }


### PR DESCRIPTION
Running `now alias` in a project that has no `package.json` and doesn't
have a `name` property defined in `now.json` fails with a cryptic
error currently. This, in combination with
https://github.com/zeit/docs/pull/378 tries to better guide the user.

This attempts to fix -> https://github.com/zeit/now-cli/issues/1741