### PR TITLE
Render better error when source missing

### DIFF
--- a/src/commands/domains/buy.ts
+++ b/src/commands/domains/buy.ts
@@ -92,7 +92,13 @@ export default async function buy(
   const purchaseStamp = stamp();
   const stopPurchaseSpinner = wait('Purchasing');
   const buyResult = await purchaseDomain(client, domainName, price);
+
   stopPurchaseSpinner();
+
+  if (buyResult instanceof ERRORS.SourceNotFound) {
+    output.error(`Could not purchase domain. Please add a payment method using ${cmd('now billing add')}.`);
+    return 1;
+  }
 
   if (buyResult instanceof ERRORS.InvalidDomain) {
     output.error(`The domain ${buyResult.meta.domain} is not valid.`);

--- a/src/util/domains/purchase-domain.ts
+++ b/src/util/domains/purchase-domain.ts
@@ -31,6 +31,9 @@ export default async function purchaseDomain(
     if (error.code === 'unexpected_error') {
       return new ERRORS.UnexpectedDomainPurchaseError(name);
     }
+    if (error.code === 'source_not_found') {
+      return new ERRORS.SourceNotFound();
+    }
     throw error;
   }
 }

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1,6 +1,7 @@
 import { Response } from 'fetch-h2';
 import { NowError } from './now-error';
 import param from './output/param';
+import cmd from './output/cmd';
 
 /**
  * This error is thrown when there is an API error with a payload. The error
@@ -144,6 +145,19 @@ export class DomainPermissionDenied extends NowError<
       code: 'DOMAIN_PERMISSION_DENIED',
       meta: { domain, context },
       message: `You don't have access to the domain ${domain} under ${context}.`
+    });
+  }
+}
+
+/**
+ * When information about a domain is requested but the domain doesn't exist
+ */
+export class SourceNotFound extends NowError<'SOURCE_NOT_FOUND', {}> {
+  constructor() {
+    super({
+      code: 'SOURCE_NOT_FOUND',
+      meta: {},
+      message: `Not able to purchase. Please add a payment method using ${cmd('now billing add')}.`
     });
   }
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -149,7 +149,7 @@ test('try to purchase a domain', async t => {
   );
 
   t.is(code, 1);
-  t.true(stderr.endsWith(`> Error! Could not purchase domain. Please add a payment method using \`now billing add\`.`));
+  t.true(stderr.includes(`> Error! Could not purchase domain. Please add a payment method using \`now billing add\`.`));
 });
 
 test('try to set default without existing payment method', async t => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -138,6 +138,20 @@ test('list the payment methods', async t => {
   t.true(stdout.startsWith(`> 0 cards found under ${email}`));
 });
 
+test('try to purchase a domain', async t => {
+  const { stderr, code } = await execa(
+    binaryPath,
+    ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
+    {
+      reject: false,
+      input: 'y'
+    }
+  );
+
+  t.is(code, 1);
+  t.true(stderr.endsWith(`> Error! Could not purchase domain. Please add a payment method using \`now billing add\`.`));
+});
+
 test('try to set default without existing payment method', async t => {
   const { stderr, code } = await execa(
     binaryPath,


### PR DESCRIPTION
This will render a much better error when trying to purchase a domain without a payment method:

**BEFORE:**

![image](https://user-images.githubusercontent.com/6170607/50055819-05efe800-0154-11e9-9cd4-6741f49e4b93.png)

**AFTER:**

<img width="663" alt="screenshot 2018-12-16 at 16 57 11" src="https://user-images.githubusercontent.com/6170607/50055820-0c7e5f80-0154-11e9-8c20-f78efbb98730.png">
