### PR TITLE
Domains enhancements

### DIFF
--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -83,8 +83,6 @@ export default async function inspect(
   );
   output.print(`    ${chalk.dim('cdnEnabled')}\t\t${domain.cdnEnabled}\n`);
   output.print(`    ${chalk.dim('suffix')}\t\t${domain.suffix}\n`);
-  output.print(`    ${chalk.dim('aliases')}\t\t${domain.aliases.length}\n`);
-  output.print(`    ${chalk.dim('certs')}\t\t${domain.certs.length}\n`);
   output.print('\n');
 
   output.print(chalk.bold('  Nameservers\n'));

--- a/src/commands/domains/ls.ts
+++ b/src/commands/domains/ls.ts
@@ -66,13 +66,12 @@ function formatDomainsTable(domains: Domain[]) {
   const current = new Date();
   return table(
     [
-      ['', 'domain', 'dns', 'verified', 'cdn', 'age'].map(s => chalk.dim(s)),
+      ['', 'domain', 'serviceType', 'verified', 'cdn', 'age'].map(s => chalk.dim(s)),
       ...domains.map(domain => {
         const cdnEnabled = domain.cdnEnabled || false;
-        const ns = isDomainExternal(domain) ? 'external' : 'zeit.world';
         const url = chalk.bold(domain.name);
         const time = chalk.gray(ms(current.getTime() - domain.createdAt));
-        return ['', url, ns, domain.verified, cdnEnabled, time];
+        return ['', url, domain.serviceType, domain.verified, cdnEnabled, time];
       })
     ],
     {

--- a/src/commands/domains/ls.ts
+++ b/src/commands/domains/ls.ts
@@ -66,7 +66,7 @@ function formatDomainsTable(domains: Domain[]) {
   const current = new Date();
   return table(
     [
-      ['', 'domain', 'serviceType', 'verified', 'cdn', 'age'].map(s => chalk.dim(s)),
+      ['', chalk.gray('domain'), chalk.gray('serviceType'), chalk.gray('verified'), chalk.gray('cdn'), chalk.gray('age')].map(s => chalk.dim(s)),
       ...domains.map(domain => {
         const cdnEnabled = domain.cdnEnabled || false;
         const url = chalk.bold(domain.name);
@@ -76,7 +76,7 @@ function formatDomainsTable(domains: Domain[]) {
     ],
     {
       align: ['l', 'l', 'l', 'l', 'l'],
-      hsep: ' '.repeat(2),
+      hsep: ' '.repeat(4),
       stringLength: strlen
     }
   );

--- a/src/util/format-ns-table.ts
+++ b/src/util/format-ns-table.ts
@@ -7,8 +7,8 @@ export default function formatNSTable(
   currentNameServers: string[],
   { extraSpace = '' } = {}
 ) {
-  const sortedIntended = intendedNameServers.sort();
-  const sortedCurrent = currentNameServers.sort();
+  const sortedIntended = getSortedItems(intendedNameServers);
+  const sortedCurrent = getSortedItems(currentNameServers);
   const maxLength = Math.max(
     intendedNameServers.length,
     currentNameServers.length
@@ -30,4 +30,10 @@ export default function formatNSTable(
       stringLength: strlen
     }
   ).replace(/^(.*)/gm, `${extraSpace}$1`);
+}
+
+function getSortedItems(items: string[] = []) {
+  return items.length === 0
+    ? [chalk.gray('-')]
+    : items.sort();
 }

--- a/src/util/format-ns-table.ts
+++ b/src/util/format-ns-table.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import table from 'text-table';
 import strlen from './strlen';
+import chars from './output/chars';
 
 export default function formatNSTable(
   intendedNameServers: string[],
@@ -16,16 +17,22 @@ export default function formatNSTable(
   const rows = [];
 
   for (let i = 0; i < maxLength; i++) {
-    rows.push([sortedIntended[i] || '', sortedCurrent[i] || '']);
+    rows.push([
+      sortedIntended[i] || '',
+      sortedCurrent[i] || '',
+      sortedIntended[i] === sortedCurrent[i]
+        ? chalk.green(chars.tick)
+        : chalk.red(chars.cross)
+    ]);
   }
 
   return table(
     [
-      [chalk.gray('Intended Nameservers'), chalk.gray('Current Nameservers')],
+      [chalk.gray('Intended Nameservers'), chalk.gray('Current Nameservers'), ''],
       ...rows
     ],
     {
-      align: ['l', 'l', 'l'],
+      align: ['l', 'l', 'l', 'l'],
       hsep: ' '.repeat(4),
       stringLength: strlen
     }

--- a/src/util/output/chars.ts
+++ b/src/util/output/chars.ts
@@ -1,7 +1,8 @@
 const chars = {
   // in some setups now.exe crashes if we use
   // the normal tick unicode character :|
-  tick: process.platform === 'win32' ? '√' : '✔'
+  tick: process.platform === 'win32' ? '√' : '✔',
+  cross: process.platform === 'win32' ? '☓' : '✘'
 };
 
 export default chars;


### PR DESCRIPTION
This PR adds some enhancements for the `domains` commands:

- Removes from `now domains inspect` aliases and certs.
- Adds ticks and crosses for the intended vs current nameservers for the comparator table.
- Adds gray headers for `now domains ls`
- Changes the title of the `dns` column to `serviceType` increasing between columns space.
- Allows to receive `serviceType` as `na` for clarity

Example of how the ticks and crosses look:

![cleanshot 2018-12-17 at 19 56 02](https://user-images.githubusercontent.com/1634922/50108553-cef20300-0235-11e9-89ee-e927ea37eba6.png)

When they don't match:

![cleanshot 2018-12-17 at 19 43 37](https://user-images.githubusercontent.com/1634922/50108404-6f93f300-0235-11e9-89dc-69def5d296ba.png)

