### PR TITLE
Wait for unhandled rejections to be reported before exiting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -573,7 +573,7 @@ const handleRejection = async err => {
 
   if (err) {
     if (err instanceof Error) {
-      handleUnexpected(err);
+      await handleUnexpected(err);
     } else {
       console.error(error(`An unexpected rejection occurred\n  ${err}`));
       await reportError(Sentry, err, apiUrl, configFiles);


### PR DESCRIPTION
This will ensure that unhandled rejections are reported to Sentry before the code will exit.