### PR TITLE
Do not use certs and aliases in `now domains rm`

### DIFF
--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import psl from 'psl';
 
-import { NowContext, Domain, DomainExtra } from '../../types';
+import { NowContext, Domain } from '../../types';
 import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import addDomain from '../../util/domains/add-domain';
@@ -104,11 +104,7 @@ export default async function add(
   }
 
   // We can cast the information because we've just added the domain and it should be there
-  const domainInfo = (await getDomainByName(
-    client,
-    contextName,
-    domain
-  )) as Domain & DomainExtra;
+  const domainInfo = await getDomainByName(client, contextName, domain) as Domain;
   console.log(
     `${chalk.cyan('> Success!')} Domain ${chalk.bold(
       domainInfo.name
@@ -128,8 +124,8 @@ export default async function add(
     );
     output.print(
       `\n${formatNSTable(
-        domainInfo.intendedNameServers,
-        domainInfo.nameServers,
+        domainInfo.intendedNameservers,
+        domainInfo.nameservers,
         { extraSpace: '     ' }
       )}\n\n`
     );

--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -4,6 +4,7 @@ import { NowContext } from '../../types';
 import { Output } from '../../util/output';
 import Client from '../../util/client';
 import cmd from '../../util/output/cmd';
+import stamp from '../../util/output/stamp';
 import dnsTable from '../../util/format-dns-table';
 import formatDate from '../../util/format-date';
 import formatNSTable from '../../util/format-ns-table';
@@ -27,6 +28,7 @@ export default async function inspect(
   const client = new Client({ apiUrl, token, currentTeam, debug });
   const { contextName } = await getScope(client);
   const [domainName] = args;
+  const inspectStamp = stamp();
 
   if (!domainName) {
     output.error(`${cmd('now domains inspect <domain>')} expects one argument`);
@@ -62,6 +64,7 @@ export default async function inspect(
     return 1;
   }
 
+  output.log(`Domain ${domainName} found under ${chalk.bold(contextName)} ${chalk.gray(inspectStamp())}`);
   output.print('\n');
   output.print(chalk.bold('  Domain Info\n'));
   output.print(`    ${chalk.dim('name')}\t\t${domain.name}\n`);
@@ -82,12 +85,11 @@ export default async function inspect(
     `    ${chalk.dim('txtVerifiedAt')}\t${formatDate(domain.txtVerifiedAt)}\n`
   );
   output.print(`    ${chalk.dim('cdnEnabled')}\t\t${domain.cdnEnabled}\n`);
-  output.print(`    ${chalk.dim('suffix')}\t\t${domain.suffix}\n`);
   output.print('\n');
 
   output.print(chalk.bold('  Nameservers\n'));
   output.print(
-    `${formatNSTable(domain.intendedNameServers, domain.nameServers, {
+    `${formatNSTable(domain.intendedNameservers, domain.nameservers, {
       extraSpace: '    '
     })}\n`
   );
@@ -123,7 +125,7 @@ export default async function inspect(
         'now domains verify <domain>'
       )}\n`
     );
-    output.print('  Read more: https://err.sh/now-cli/domain-verification\n');
+    output.print('  Read more: https://err.sh/now-cli/domain-verification\n\n');
   }
 
   return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,27 +72,14 @@ export type Domain = {
   verified: boolean;
   nsVerifiedAt: number | null;
   txtVerifiedAt: number | null;
+  verificationRecord: string;
+  nameservers: string[];
+  intendedNameservers: string[];
   creator: {
     id: string;
     username: string;
     email: string;
   };
-};
-
-export type DomainExtra = {
-  suffix: boolean;
-  nameServers: string[];
-  verificationRecord: string;
-  intendedNameServers: string[];
-  aliases: Array<{
-    id: string;
-    alias: string;
-    created: number;
-  }>;
-  certs: Array<{
-    id: string;
-    cns: string[];
-  }>;
 };
 
 export type Cert = {

--- a/src/util/alias/get-domain-aliases.ts
+++ b/src/util/alias/get-domain-aliases.ts
@@ -1,0 +1,9 @@
+import psl from 'psl';
+import Client from '../client';
+import getAliases from './get-aliases';
+import { Alias } from '../../types';
+
+export default async function getDomainAliases(client: Client, domain: string) {
+  const aliases = await getAliases(client);
+  return aliases.filter((alias: Alias) => alias.alias.endsWith(domain));
+}

--- a/src/util/domains/get-domain-by-name.ts
+++ b/src/util/domains/get-domain-by-name.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import Client from '../client';
 import wait from '../output/wait';
-import { Domain, DomainExtra } from '../../types';
+import { Domain } from '../../types';
 import { DomainPermissionDenied, DomainNotFound } from '../errors-ts';
 
 type Response = {
-  domain: Domain & DomainExtra;
+  domain: Domain;
 };
 
 async function getDomainByName(

--- a/src/util/format-ns-table.ts
+++ b/src/util/format-ns-table.ts
@@ -4,22 +4,22 @@ import strlen from './strlen';
 import chars from './output/chars';
 
 export default function formatNSTable(
-  intendedNameServers: string[],
-  currentNameServers: string[],
+  intendedNameservers: string[],
+  currentNameservers: string[],
   { extraSpace = '' } = {}
 ) {
-  const sortedIntended = getSortedItems(intendedNameServers);
-  const sortedCurrent = getSortedItems(currentNameServers);
+  const sortedIntended = intendedNameservers.sort();
+  const sortedCurrent = currentNameservers.sort();
   const maxLength = Math.max(
-    intendedNameServers.length,
-    currentNameServers.length
+    intendedNameservers.length,
+    currentNameservers.length
   );
   const rows = [];
 
   for (let i = 0; i < maxLength; i++) {
     rows.push([
-      sortedIntended[i] || '',
-      sortedCurrent[i] || '',
+      sortedIntended[i] || chalk.gray('-'),
+      sortedCurrent[i] || chalk.gray('-'),
       sortedIntended[i] === sortedCurrent[i]
         ? chalk.green(chars.tick)
         : chalk.red(chars.cross)
@@ -37,10 +37,4 @@ export default function formatNSTable(
       stringLength: strlen
     }
   ).replace(/^(.*)/gm, `${extraSpace}$1`);
-}
-
-function getSortedItems(items: string[] = []) {
-  return items.length === 0
-    ? [chalk.gray('-')]
-    : items.sort();
 }


### PR DESCRIPTION
Right now we are using in canary `aliases` and `certs` that are coming from the single domain response. In order to increase performance we are going to deprecate it in API v4 so `now domains rm` should not consume those properties. Instead, we will fetch aliases and certs separately and warn about deletion just like we were doing before.

Also this PR update types to the new contract we just released in the upcoming domains v4 API.