### PR TITLE
Use single call on aliases and certs on domain rm

### DIFF
--- a/src/util/alias/get-domain-aliases.js
+++ b/src/util/alias/get-domain-aliases.js
@@ -1,0 +1,10 @@
+//
+
+import getAliases from './get-aliases';
+
+async function getDomainAliases(output        , now     , domain        ) {
+  const aliases = await getAliases(now);
+  return aliases.filter((alias) => alias.alias.endsWith(domain));
+}
+
+export default getDomainAliases;

--- a/src/util/certs/get-certs-for-domain.js
+++ b/src/util/certs/get-certs-for-domain.js
@@ -1,4 +1,4 @@
-//      
+//
 
 import getCerts from './get-certs';
 


### PR DESCRIPTION
This will make a single call to get aliases and certs while removing a domain.