### PR TITLE
Stop using domains v4 in stable

### DIFF
--- a/src/commands/domains/rm.js
+++ b/src/commands/domains/rm.js
@@ -114,7 +114,7 @@ async function confirmDomainRemove(
   certs
 ) {
   return new Promise(resolve => {
-    const time = chalk.gray(`${ms(new Date() - new Date(domain.createdAt))  } ago`);
+    const time = chalk.gray(`${ms(new Date() - new Date(domain.created))  } ago`);
     const tbl = table([[chalk.bold(domain.name), time]], {
       align: ['r', 'l'],
       hsep: ' '.repeat(6)

--- a/src/util/domains/get-domain-by-name.js
+++ b/src/util/domains/get-domain-by-name.js
@@ -1,4 +1,4 @@
-//
+import psl from 'psl';
 import chalk from 'chalk';
 
 import wait from '../output/wait';
@@ -24,11 +24,13 @@ async function getDomainByName(
 
 async function getDomain(now, domainName) {
   try {
-    const { domain } = await now.fetch(
-      `/v4/domains/${toHost(domainName)}`
+    const domain = await now.fetch(
+      `/v3/domains/${toHost(domainName)}`
     );
 
-    return domain;
+    return domain
+      ? { ...domain, name: psl.parse(domainName).domain }
+      : domain;
   } catch (error) {
     if (error.status === 404) {
       return new Errors.DomainNotFound(domainName);


### PR DESCRIPTION
This PR removes usage of domains `v4` and fixes a couple of warnings