### PR TITLE
now dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,5 +173,8 @@
     "update-check": "1.5.0",
     "which-promise": "1.0.0",
     "write-json-file": "2.2.0"
+  },
+  "dependencies": {
+    "auto-bind": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "write-json-file": "2.2.0"
   },
   "dependencies": {
-    "auto-bind": "^1.2.1"
+    "auto-bind": "^1.2.1",
+    "raw-body": "2.3.3"
   }
 }

--- a/src/commands/dev/.prettierrc
+++ b/src/commands/dev/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -187,7 +187,7 @@ export default class Dev {
       const event = {
         host: req.headers.host,
         path: req.url,
-        method: req.method,
+        httpMethod: req.method,
         headers: req.headers,
         body: req.body,
       };

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -160,6 +160,7 @@ export default class Dev {
 
   async handle(req, res) {
     const FileBlob = this.require('@now/build-utils/file-blob');
+    const FileFsRef = this.require('@now/build-utils/file-fs-ref');
 
     // When no routes are defined, we default to 1-to-1 mappings
     const defaultRoutes = [
@@ -213,7 +214,7 @@ export default class Dev {
         'X-Content-Type-Options': 'nosniff',
       });
 
-      if (artifact instanceof FileBlob) {
+      if (artifact instanceof FileBlob || artifact instanceof FileFsRef) {
         return artifact.toStream().pipe(res);
       }
 

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -101,7 +101,7 @@ export default class Dev {
     return this.workspace;
   }
 
-  async findNewPort(port = 3000) {
+  async findNewPort(port = 4000) {
     return new Promise((resolve, reject) => {
       const server = new Server();
 

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -120,9 +120,6 @@ export default class Dev {
   }
 
   async handle(req, res) {
-    // This will be painfully slow until builders optimize
-    await this.build();
-
     const FileBlob = this.require('@now/build-utils/file-blob');
 
     // When no routes are defined, we default to 1-to-1 mappings
@@ -222,6 +219,9 @@ export default class Dev {
 
     res.write(`No routes match ${req.url}`);
     res.end();
+
+    // Hopefully the 404 is caused unbuilt artifacts
+    this.build();
   }
 
   async installBuilders() {

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -220,9 +220,6 @@ export default class Dev {
 
     res.write(`No routes match ${req.url}. Try refreshing.`);
     res.end();
-
-    // Hopefully the 404 is caused unbuilt artifacts
-    this.build();
   }
 
   async installBuilders() {

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -209,7 +209,8 @@ export default class Dev {
       this.output.log(`Serving ${chalk.bold(target)}...`);
 
       res.writeHead(200, {
-        'Content-Type': mime.contentType(target) || 'text/html; charset=utf-8',
+        'Content-Type':
+          mime.contentType(path.basename(target)) || 'text/html; charset=utf-8',
         'Transfer-Encoding': 'chunked',
         'X-Content-Type-Options': 'nosniff',
       });

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -220,6 +220,7 @@ export default class Dev {
 
       // ! Temporary requirement of executing lambdas.
       if (typeof artifact !== 'function') {
+        console.error(artifact);
         throw new Error(`Only functional lambdas are supported in dev.`);
       }
 

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -292,25 +292,24 @@ export default class Dev {
         childProcesses.delete(handler);
       }
 
-      return async event => {
-        const child = fork(launcherFile, [], {
-          cwd: this.workspace.path,
-          env: {
-            ...environment,
-            NODE_ENV: 'development',
-            PORT: await this.findNewPort(),
-          },
-          execArgv: [],
-        });
+      const child = fork(launcherFile, [], {
+        cwd: this.workspace.path,
+        env: {
+          ...environment,
+          NODE_ENV: 'development',
+          PORT: await this.findNewPort(),
+        },
+        execArgv: [],
+      });
 
-        // Store it so we can disconnect when replaced
-        childProcesses.set(handler, child);
+      // Store it so we can disconnect when replaced
+      childProcesses.set(handler, child);
 
-        return new Promise(resolve => {
+      return event =>
+        new Promise(resolve => {
           child.send(event);
           child.on('message', resolve);
         });
-      };
     };
   }
 

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -1,0 +1,356 @@
+import autoBind from 'auto-bind';
+import chalk from 'chalk';
+import { fork, spawn } from 'child_process';
+import onDeath from 'death';
+import { Server } from 'http';
+import mime from 'mime-types';
+import { dir } from 'tmp-promise';
+import path from 'path';
+
+import { readLocalConfig } from '../../util/config/files';
+import createOutput from '../../util/output';
+
+// Sure, this could be done in a "functional" way, but there is so
+// much statefulness to it (e.g. `output`, tmp dir, processes, etc.)
+// it's easier to encapsulate it in a class than have argument explosion.
+export default class Dev {
+  constructor({
+    config = readLocalConfig(process.cwd()),
+    debug = false,
+    output = createOutput(),
+  }) {
+    this.artifacts = new Map();
+    this.config = config;
+    this.debug = debug;
+    this.output = output;
+
+    autoBind(this);
+  }
+
+  async cleanup() {
+    this.output.print('\n');
+    this.output.note(
+      `Cleaning up ${this.workspace.path}... (Pass ${chalk.bold(
+        '--debug'
+      )} to keep)`
+    );
+    return this.workspace.cleanup();
+  }
+
+  async build() {
+    // This version of `glob` returns `FileFsRef`s
+    const glob = this.require('@now/build-utils/fs/glob');
+
+    for (const build of this.config.builds) {
+      const { src, use } = build;
+
+      let builder;
+
+      try {
+        // ! Attempt to use the `dev` version of a builder
+        const useDev = path.join(use, 'dev');
+        const builderPath = this.resolve(useDev);
+
+        this.output.log(`Initializing ${chalk.cyan(useDev)}...`);
+        builder = this.require(builderPath);
+      } catch (error) {
+        // ! Until all builders can run their `build` locally,
+        // we should prevent them from running.
+        this.output.error(`${use} does not support "now dev"`);
+        throw error;
+        // ! After which, we can re-enable this functionality:
+        // output.log(`Initializing ${chalk.cyan(use)}...`);
+        // builder = this.require(use);
+      }
+
+      const entrypoints = await glob(src, process.cwd());
+      const files = await glob('**', process.cwd());
+
+      for (const [entrypoint] of Object.entries(entrypoints)) {
+        this.output.log(
+          `Building ${chalk.bold(entrypoint)} with ${chalk.dim(use)}...`
+        );
+
+        const builderArtifacts = await builder.build({
+          entrypoint,
+          files,
+          workPath: this.workspace.path,
+        });
+
+        // Track targets (string) to artifacts (lambda/fileref) from their builders
+        for (const [target, artifact] of Object.entries(builderArtifacts)) {
+          this.artifacts.set(target, artifact);
+        }
+      }
+    }
+  }
+
+  async createWorkspace() {
+    // Create & switch to a clean working directory
+    // (Costly, but "correct")
+    this.workspace = await dir({ unsafeCleanup: true });
+
+    this.output.note(`Created workspace at ${chalk.cyan(this.workspace.path)}`);
+
+    // Ensure we cleanup on exit properly
+    onDeath(async signal => {
+      if (!this.debug) await this.cleanup();
+      process.exit(signal);
+    });
+
+    return this.workspace;
+  }
+
+  async findNewPort(port = 3000) {
+    return new Promise((resolve, reject) => {
+      const server = new Server();
+
+      server.on('error', err => {
+        if (err.code !== 'EADDRINUSE') {
+          return reject(err);
+        }
+
+        server.listen(++port);
+      });
+
+      server.on('listening', () => server.close(() => resolve(port)));
+
+      server.listen(port);
+    });
+  }
+
+  async handle(req, res) {
+    const FileBlob = this.require('@now/build-utils/file-blob');
+
+    // When no routes are defined, we default to 1-to-1 mappings
+    const defaultRoutes = [
+      {
+        src: '/(.*)',
+        dest: '/$1',
+      },
+      // Fallback to /index.*
+      {
+        src: '/',
+        dest: '/index.html',
+      },
+      {
+        src: '/',
+        dest: '/index.js',
+      },
+    ];
+
+    const { routes = defaultRoutes } = this.config;
+
+    // Match request to the build artifact
+    for (const route of routes) {
+      // We can skip this route if it doesn't map to a destination
+      if (!req.url.match(route.src)) {
+        continue;
+      }
+
+      let target = req.url.replace(route.src, route.dest);
+
+      // Remove "/" prefix from destination targets
+      if (target.charAt(0) === '/') {
+        target = target.slice(1);
+      }
+
+      let artifact = this.artifacts.get(target);
+
+      this.output.debug(
+        `Routing ${chalk.cyan(req.url)} to ${chalk.bold(target)}`
+      );
+
+      // Skip this route
+      if (!artifact) {
+        continue;
+      }
+
+      res.writeHead(200, {
+        'Content-Type': mime.contentType(target) || 'text/html; charset=utf-8',
+        'Transfer-Encoding': 'chunked',
+        'X-Content-Type-Options': 'nosniff',
+      });
+
+      if (artifact instanceof FileBlob) {
+        return artifact.toStream().pipe(res);
+      }
+
+      // ! of executing lambdas.
+      if (typeof artifact !== 'function') {
+        throw new Error(`Only functional lambdas are supported in dev.`);
+      }
+
+      const event = {
+        host: req.headers.host,
+        path: req.url,
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      };
+
+      const { body, encoding, headers, statusCode } = await artifact(event);
+
+      res.writeHead(statusCode, {
+        'Content-Type': 'text/html; charset=utf-8',
+        ...headers,
+      });
+
+      if (encoding === 'base64') {
+        res.write(Buffer.from(body, encoding));
+      } else if (encoding === undefined) {
+        res.write(Buffer.from(body));
+      } else {
+        throw new Error(`Unsupported encoding: ${encoding}`);
+      }
+
+      return res.end();
+    }
+
+    // TODO Rebuild all builders?
+
+    this.output.debug(`No artifact built for ${chalk.bold(req.url)}`);
+
+    res.writeHead(404, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Transfer-Encoding': 'chunked',
+      'X-Content-Type-Options': 'nosniff',
+    });
+
+    res.write(`No routes match ${req.url}`);
+    res.end();
+  }
+
+  async installBuilders() {
+    const dependencies = [
+      '@now/build-utils',
+      ...this.config.builds.map(build => build.use),
+    ];
+
+    // Install all dependencies
+    for (const dependency of dependencies) {
+      // Attempt to find the dependency first, before installing...
+      try {
+        this.resolve(dependency);
+        continue;
+      } catch (error) {
+        // Doesn't exist, keep installing it
+      }
+
+      const options = { cwd: this.workspace.path, stdio: 'ignore' };
+
+      try {
+        // Prefer linking local dependency over external dependency
+        await this.spawn('yarn', ['link', dependency], options);
+        this.output.log(`Linked ${chalk.bold(dependency)}...`);
+      } catch (error) {
+        // Does not exist locally, so install as usual
+        try {
+          this.output.log(`Installing ${chalk.bold(dependency)}...`);
+          await this.spawn(
+            'yarn',
+            ['add', '--dev', '--prefer-offline', dependency],
+            options
+          );
+        } catch (error) {
+          this.output.error(error.message);
+        }
+      }
+    }
+
+    this.mockCreateLambda();
+  }
+
+  listen(port) {
+    const server = new Server();
+
+    server.on('request', this.handle);
+    server.listen(port, () => {
+      this.output.log(`🚀 Ready! http://localhost:${server.address().port}/`);
+    });
+  }
+
+  mockCreateLambda() {
+    const download = this.require('@now/build-utils/fs/download');
+    const lambdaExports = this.require('@now/build-utils/lambda');
+
+    const childProcesses = new Map();
+
+    // ! By overriding the lambda creation, we can choose to
+    // ! write the files to the `workPath`, & handle requests this way.
+    // ! Otherwise, we don't have access to the launcher at all.
+    // ! Note, this still fails because the launchers **aren't closing**.
+    lambdaExports.createLambda = async ({
+      files,
+      handler,
+      // runtime,
+      environment = {},
+    }) => {
+      await download(files, this.workspace.path);
+
+      const [launcherFile] = handler.split('.');
+
+      // Close existing lambas
+      if (childProcesses.has(handler)) {
+        childProcesses.get(handler).disconnect();
+        childProcesses.delete(handler);
+      }
+
+      return async event => {
+        // Store it so we can disconnect when replaced
+        if (!childProcesses.has(handler)) {
+          childProcesses.set(
+            handler,
+            fork(launcherFile, [], {
+              cwd: this.workspace.path,
+              env: {
+                ...environment,
+                NODE_ENV: 'development',
+                PORT: await this.findNewPort(),
+              },
+              execArgv: [],
+            })
+          );
+        }
+
+        const child = childProcesses.get(handler);
+
+        return new Promise(resolve => {
+          child.send(event);
+          child.on('message', resolve);
+        });
+      };
+    };
+  }
+
+  // Because `require.resolve` doesn't know of our tmp directory, we need to resolve dynamically
+  require(moduleName) {
+    return require(this.resolve(moduleName));
+  }
+
+  resolve(moduleName) {
+    const modulePath = require.resolve(moduleName, {
+      // Exclude all modules paths to avoid untracked dependencies
+      paths: [this.workspace.path],
+    });
+
+    // Every time we resolve a file, we ensure it's not cached
+    delete require.cache[modulePath];
+
+    return modulePath;
+  }
+
+  spawn(command, args, options = { stdio: 'inherit' }) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, options);
+      child.on('error', reject);
+      child.on(
+        'close',
+        (code, signal) =>
+          code !== 0
+            ? reject(new Error(`Exited with ${code || signal}`))
+            : resolve()
+      );
+    });
+  }
+}

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -176,7 +176,7 @@ export default class Dev {
         return artifact.toStream().pipe(res);
       }
 
-      // ! of executing lambdas.
+      // ! Temporary requirement of executing lambdas.
       if (typeof artifact !== 'function') {
         throw new Error(`Only functional lambdas are supported in dev.`);
       }
@@ -273,13 +273,8 @@ export default class Dev {
   mockCreateLambda() {
     const download = this.require('@now/build-utils/fs/download');
     const lambdaExports = this.require('@now/build-utils/lambda');
-
     const childProcesses = new Map();
 
-    // ! By overriding the lambda creation, we can choose to
-    // ! write the files to the `workPath`, & handle requests this way.
-    // ! Otherwise, we don't have access to the launcher at all.
-    // ! Note, this still fails because the launchers **aren't closing**.
     lambdaExports.createLambda = async ({
       files,
       handler,

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -6,6 +6,7 @@ import { Server } from 'http';
 import mime from 'mime-types';
 import { dir } from 'tmp-promise';
 import path from 'path';
+import rawBody from 'raw-body';
 
 import { readLocalConfig } from '../../util/config/files';
 import createOutput from '../../util/output';
@@ -189,7 +190,7 @@ export default class Dev {
         path: req.url,
         httpMethod: req.method,
         headers: req.headers,
-        body: req.body,
+        body: (await rawBody(req)).toString('utf8'),
       };
 
       const { body, encoding, headers, statusCode } = await artifact(event);

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -213,6 +213,7 @@ export default class Dev {
           mime.contentType(path.basename(target)) || 'text/html; charset=utf-8',
         'Transfer-Encoding': 'chunked',
         'X-Content-Type-Options': 'nosniff',
+        ...route.headers,
       });
 
       if (artifact instanceof FileBlob || artifact instanceof FileFsRef) {

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -149,18 +149,18 @@ export default class Dev {
         continue;
       }
 
-      let target = req.url.replace(route.src, route.dest);
-
-      // Remove "/" prefix from destination targets
-      if (target.charAt(0) === '/') {
-        target = target.slice(1);
-      }
-
-      let artifact = this.artifacts.get(target);
+      let target = req.url.replace(new RegExp(route.src), route.dest);
 
       this.output.debug(
         `Routing ${chalk.cyan(req.url)} to ${chalk.bold(target)}`
       );
+
+      let artifact = this.artifacts.get(target);
+
+      // Try target without a "/" prefix
+      if (!artifact && target.charAt(0) === '/') {
+        artifact = this.artifacts.get(target.slice(1));
+      }
 
       // Skip this route
       if (!artifact) {

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -166,6 +166,8 @@ export default class Dev {
         continue;
       }
 
+      this.output.log(`Serving ${chalk.bold(target)}...`);
+
       res.writeHead(200, {
         'Content-Type': mime.contentType(target) || 'text/html; charset=utf-8',
         'Transfer-Encoding': 'chunked',
@@ -207,9 +209,7 @@ export default class Dev {
       return res.end();
     }
 
-    // TODO Rebuild all builders?
-
-    this.output.debug(`No artifact built for ${chalk.bold(req.url)}`);
+    this.output.warn(`No artifact built for ${chalk.bold(req.url)}`);
 
     res.writeHead(404, {
       'Content-Type': 'text/html; charset=utf-8',
@@ -217,7 +217,7 @@ export default class Dev {
       'X-Content-Type-Options': 'nosniff',
     });
 
-    res.write(`No routes match ${req.url}`);
+    res.write(`No routes match ${req.url}. Try refreshing.`);
     res.end();
 
     // Hopefully the 404 is caused unbuilt artifacts

--- a/src/commands/dev/Dev.js
+++ b/src/commands/dev/Dev.js
@@ -80,6 +80,7 @@ export default class Dev {
         // Track targets (string) to artifacts (lambda/fileref) from their builders
         for (const [target, artifact] of Object.entries(builderArtifacts)) {
           this.artifacts.set(target, artifact);
+          this.output.log(`Built ${chalk.dim(target)}`);
         }
       }
     }

--- a/src/commands/dev/help.js
+++ b/src/commands/dev/help.js
@@ -1,0 +1,35 @@
+import chalk from 'chalk';
+
+import logo from '../../util/output/logo';
+
+module.exports = () => `
+  ${chalk.bold(`${logo} now`)} dev [options] [provider]
+
+  ${chalk.dim('Options:')}
+
+    -h, --help                     Output usage information
+    -n, --name                     Set the name of the deployment
+    -d, --debug                    Debug mode [off]
+
+  ${chalk.dim('Examples:')}
+
+  ${chalk.gray(
+    '–'
+  )} Develop using native binaries (e.g. go/node/php/etc.) ${chalk.bold(
+  '(default)'
+)}
+
+    ${chalk.cyan('$ now dev')}
+    or
+    ${chalk.cyan('$ now dev local')}
+
+  ${chalk.gray('–')} Develop using Docker containers
+
+    ${chalk.cyan('$ now dev docker')}
+
+  ${chalk.gray('–')} Develop using a proxy to production ${chalk.bold(
+  `${logo} now`
+)}
+
+    ${chalk.cyan('$ now dev production')}
+`;

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -27,7 +27,11 @@ module.exports = async function main(ctx) {
 
   await dev.createWorkspace();
   await dev.installBuilders();
-  await dev.listen(process.env.PORT || 3000);
+
+  dev.listen(process.env.PORT || 3000);
+
+  // Eagerly build while the server's starting
+  await dev.build();
 };
 
 // If we're running this file directly, pretend we went through `now`

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -1,0 +1,46 @@
+import createOutput from '../../util/output';
+import { handleError } from '../../util/error';
+import getArgs from '../../util/get-args';
+
+import Dev from './Dev';
+
+module.exports = async function main(ctx) {
+  let argv = null;
+
+  try {
+    // Slice after ['node', 'now', 'dev']
+    argv = getArgs(ctx.argv.slice(3));
+  } catch (error) {
+    handleError(error);
+    return 1;
+  }
+
+  const output = createOutput({ debug: argv['--debug'] });
+
+  if (argv['--help']) {
+    output.print(require('./help')());
+    return 2;
+  }
+
+  const debug = argv['--debug'];
+  const dev = new Dev({ debug, output });
+
+  await dev.createWorkspace();
+  await dev.installBuilders();
+  await dev.build();
+  await dev.listen(process.env.PORT || 3000);
+};
+
+// If we're running this file directly, pretend we went through `now`
+if (process.module === module.main) {
+  module.exports({
+    argv: [
+      // [node, entry]
+      ...process.argv.slice(0, 2),
+      // This command
+      'dev',
+      // and all other args/flags
+      ...process.argv.slice(2),
+    ],
+  });
+}

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -27,7 +27,6 @@ module.exports = async function main(ctx) {
 
   await dev.createWorkspace();
   await dev.installBuilders();
-  await dev.build();
   await dev.listen(process.env.PORT || 3000);
 };
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -27,11 +27,9 @@ module.exports = async function main(ctx) {
 
   await dev.createWorkspace();
   await dev.installBuilders();
+  await dev.build();
 
   dev.listen(process.env.PORT || 3000);
-
-  // Eagerly build while the server's starting
-  await dev.build();
 };
 
 // If we're running this file directly, pretend we went through `now`

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,5 +1,6 @@
 export default {
   deploy: 'deploy',
+  dev: 'dev',
   help: 'help',
   list: 'list',
   remove: 'remove',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,6 +1968,11 @@ depd@1.1.1:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
   integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
 deployment-type@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deployment-type/-/deployment-type-1.0.1.tgz#5f47e338bf5d2cd26abee971c60c584ea4af9bc1"
@@ -3238,6 +3243,16 @@ http-errors@1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+http-errors@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3271,6 +3286,13 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
+
+iconv-lite@0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -5423,6 +5445,16 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
+    unpipe "1.0.0"
+
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -5905,6 +5937,11 @@ setprototypeof@1.0.3:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
   integrity sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
 
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -6159,7 +6196,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2":
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-bind@^1.1.0:
+auto-bind@^1.1.0, auto-bind@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-1.2.1.tgz#807f7910b0210db9eefe133f3492c28e89698b96"
   integrity sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA==


### PR DESCRIPTION
I've spent ~24 working hours on this over the course of a month (~8-12 of which are what you see today compared to #1672 to solve for #1681).

Sadly, I'm not in a position to continue the work.

## Getting <kbd>now dev</kbd> to work locally

Before #1710 landed, you could `yarn run link` (to establish `now` globally) and then `yarn dev` to re-build the binary upon execution.

I didn't discover a great way of working within an example without _constantly_ tabbing back-and-forth to rebuild.

Since #1710 was relatively new to me, I settled on...

1. Clone `now-cli`, `now-examples`, and `now-builders` under `.../zeit/{now-cli,now-examples,now-builders}` so that they have consistent paths.  (Of course, there's a related branch for those: https://github.com/zeit/now-builders/pull/138 & https://github.com/zeit/now-examples/pull/203)

2. From within an example (e.g. `zeit/now-examples/nodejs`), you could run:

    ```shell
    # This folder needs `npm install esm`
    node -r esm ../../now-cli/src/commands/dev --debug
    ```

    I put in a short-cut to run the `dev.js` command directly as if it came from `now dev`, purely in response to lacking the `now` re-build.  The unfortunate byproduct of this is that, since the files are ES modules, it requires `esm` being in the `require-`able path.

3. But, by default this will `yarn install @now/build-utils` & other builders.  To work on files locally, go into each builder directory and run:

    ```shell
    yarn link .
    ```

    The `dev` script will automatically prefer linked packages & not install them!

4. Running `node -r esm ../../now-cli/src/commands/dev --debug` in `now-examples/nodejs` should launch a server at http://localhost:3000/ that rebuilds on each request.

<details><summary>Sample Output</summary>
<pre>
$ node -r esm ../../now-cli/src/commands/dev --debug
> NOTE: Created workspace at /var/folders/xk/rb5_2vv11wb6fcm6vyhtkzk00000gn/T/tmp-87105cCJhWk7R1JTs
> Linked @now/build-utils...
> Linked @now/node...
(node:87105) ExperimentalWarning: The fs.promises API is experimental
> [debug] [2018-12-20T03:03:28.979Z] Locating files /Users/eric/Projects/ericclemmons/now-examples/nodejs
> [debug] [2018-12-20T03:03:28.980Z] Ignoring /Users/eric/Projects/ericclemmons/now-examples/nodejs/node_modules
> [debug] [2018-12-20T03:03:28.981Z] Locating files /Users/eric/Projects/ericclemmons/now-examples/nodejs: 1.600ms
> Initializing @now/node/dev...
> Building index.js with @now/node...
downloading user files...
running npm install for user...
installing to /var/folders/xk/rb5_2vv11wb6fcm6vyhtkzk00000gn/T/tmp-87105cCJhWk7R1JTs/user
npm WARN user No repository field.
npm WARN user No license field.

added 8 packages from 4 contributors and audited 8 packages in 1.125s
found 0 vulnerabilities

npm WARN using --force I sure hope you know what you are doing.
writing ncc package.json...
running npm install for ncc...
installing to /var/folders/xk/rb5_2vv11wb6fcm6vyhtkzk00000gn/T/tmp-87105cCJhWk7R1JTs/ncc
yarn install v1.12.3
warning package.json: No license field
info No lockfile found.
warning No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
✨  Done in 1.21s.
yarn cache v1.12.3
warning package.json: No license field
success Cleared cache.
✨  Done in 0.06s.
running user script...
compiling entrypoint with ncc...
> Built index.js
> 🚀 Ready! http://localhost:3000/
> [debug] [2018-12-20T03:03:41.151Z] Routing / to /
> [debug] [2018-12-20T03:03:41.151Z] Routing / to /index.html
> [debug] [2018-12-20T03:03:41.151Z] Routing / to /index.js
> Serving /index.js...
> [debug] [2018-12-20T03:03:41.344Z] Routing /favicon.ico to /favicon.ico
> [debug] [2018-12-20T03:03:41.344Z] Routing /favicon.ico to /index.htmlfavicon.ico
> [debug] [2018-12-20T03:03:41.345Z] Routing /favicon.ico to /index.jsfavicon.ico
> WARN! No artifact built for /favicon.ico
</pre>
</details>

## Supported Examples

_Note: these run, but aren't optimized for DX_.

- [x] `apollo`
- [x] `create-react-app`
- [ ] `gatsby`
- [ ] `go`
- [x] `html-minifier`
- [ ] `mdx-deck`
- [ ] `monorepo`
- [ ] `nextjs`
- [ ] `nextjs-news`
- [ ] `nextjs-static`
- [x] `node-server`
- [x] `nodejs`
- [x] `nodejs-express`
- [x] `nodejs-hapi`
- [x] `nodejs-koa`
- _👇 I didn't get a chance to run the rest of these..._
- [ ] `nuxt-static`
- [ ] `optipng`
- [ ] `php-7`
- [ ] `python`
- [ ] `redirect`
- [ ] `serverless-ssr-reddit`
- [ ] `static`
- [ ] `vue`
- [ ] `vue-ssr`
- [ ] `vuepress`

## Recommended Next Steps

Note that there are some design decisions I made with the latest revision:

- Most of the command logic is encapsulated in `class DevCommand`.  The reality is, `output` and other properties are so routinely shared, it's easier to use `this` as a bag vs. polluting function signatures when trying to be "pure" about it. (Especially with so movement). But, it's fairly easy to tell what orchestration steps `now dev` takes to _work_.  (This can be de-coupled later on)
- The `now-builders/packages/now-{builder}/dev.js` file exists as a way to error out until _all_ builders are supported.  Currently, most are simply a pass-through to existing behavior.  _However_, builders like `now-next` will want to instead return their own Lambda (server) that is basically just `next` to avoid expensive rebuilds.
- The `node` bridge for the examples all rely on `process.send` and `process.on("message")` to communicate to the `child_process.fork`'d process.  This is because _there's no guarantee which `PORT` they may be listening on_. This _should_ be enforced (and you can see that I'm setting `process.env.PORT` to a free one), but I found that talking directly to the process vs. proxying a request worked better. (_Especially_ as ports are thrown away & created with each build_)
- I have a `mockCreateLambda` that changes the `createLambda` behavior to use this `process.send` bridge.
- Eventually, **rebuilding will be so quick that the difference between `production` and `development` won't require any dev-specific optimizations**.

Now, with that out of the way, what I had next up:

- [ ] Fix `now dev` DX to pre-#1710 days.  Rebuilding on change is essential.
- [ ] When a `request.url` is hit, these can often map 1-to-1 to a single artifact. In these situations, instead or rebuilding everything, we can rebuild that single target file.
- [ ] Bypass building targets unless they've changed.
- [ ] When we `404`, perhaps we should build all artifacts before error'ing out.
- [ ] Eventually, remove need for `now-{builder}/dev.js`.
- [ ] Update `go`, `python`, `php` (read: all non-Node builders) to:
    - [ ] Not download binaries every time.
    - [ ] Communicate to the `lambda` / `handler` the same way we can with `node` via an event bridge (e.g. RPC/IPC over stdin/stdout).
    - Ship a `dev` binary for macOS/Windows to avoid this for devs?

<details>
<summary>Diff of me trying to get `go` working...</summary>
diff --git a/packages/now-go/bridge.go b/packages/now-go/bridge.go
new file mode 100644
index 0000000..a843d9c
--- /dev/null
+++ b/packages/now-go/bridge.go
@@ -0,0 +1,128 @@
+package bridge
+
+import (
+       "bytes"
+       "encoding/base64"
+       "encoding/json"
+       "net/http"
+       "strconv"
+       "strings"
+
+       "github.com/aws/aws-lambda-go/events"
+       "github.com/aws/aws-lambda-go/lambda"
+)
+
+type Request struct {
+       Host     string            `json:"host"`
+       Path     string            `json:"path"`
+       Method   string            `json:"method"`
+       Headers  map[string]string `json:"headers"`
+       Encoding string            `json:"encoding,omitempty"`
+       Body     string            `json:"body"`
+}
+
+type Response struct {
+       StatusCode int               `json:"statusCode"`
+       Headers    map[string]string `json:"headers"`
+       Encoding   string            `json:"encoding,omitemtpy"`
+       Body       string            `json:"body"`
+}
+
+type ResponseWriter struct {
+       http.ResponseWriter
+       statusCode int
+       headers    http.Header
+       body       *bytes.Buffer
+}
+
+func (w *ResponseWriter) Header() http.Header {
+       return w.headers
+}
+
+func (w *ResponseWriter) Write(p []byte) (n int, err error) {
+       n, err = w.body.Write(p)
+       return
+}
+
+func (w *ResponseWriter) WriteHeader(statusCode int) {
+       w.statusCode = statusCode
+}
+
+var userHandler http.Handler
+
+func Serve(handler http.Handler, req *Request) (res Response, err error) {
+       var body []byte
+       if req.Encoding == "base64" {
+               body, err = base64.StdEncoding.DecodeString(req.Body)
+               if err != nil {
+                       return
+               }
+       } else {
+               body = []byte(req.Body)
+       }
+
+       r, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
+       if err != nil {
+               return
+       }
+
+       for k, v := range req.Headers {
+               r.Header.Add(k, v)
+               switch strings.ToLower(k) {
+               case "host":
+                       // we need to set `Host` in the request
+                       // because Go likes to ignore the `Host` header
+                       // see https://github.com/golang/go/issues/7682
+                       r.Host = v
+               case "content-length":
+                       contentLength, _ := strconv.ParseInt(v, 10, 64)
+                       r.ContentLength = contentLength
+               case "x-forwarded-for":
+               case "x-real-ip":
+                       r.RemoteAddr = v
+               }
+       }
+
+       var bodyBuf bytes.Buffer
+       w := &ResponseWriter{
+               nil,
+               http.StatusOK,
+               make(http.Header),
+               &bodyBuf,
+       }
+
+       handler.ServeHTTP(w, r)
+       defer r.Body.Close()
+
+       headers := make(map[string]string)
+       for k, v := range w.headers {
+               for _, s := range v {
+                       headers[k] = s
+               }
+       }
+
+       res = Response{
+               StatusCode: w.statusCode,
+               Headers:    headers,
+               Encoding:   "base64",
+               Body:       base64.StdEncoding.EncodeToString(bodyBuf.Bytes()),
+       }
+       return
+}
+
+// Maps the `APIGatewayProxyRequest` to a `Request` instance and invokes `Serve()`
+func handler(event events.APIGatewayProxyRequest) (res Response, err error) {
+       var req Request
+       err = json.Unmarshal([]byte(event.Body), &req)
+       if err != nil {
+               return
+       }
+       res, err = Serve(userHandler, &req)
+       return
+}
+
+// Starts the Lambda
+func Start(h http.Handler) {
+       userHandler = h
+       lambda.Start(handler)
+}
diff --git a/packages/now-go/build.sh b/packages/now-go/build.sh
index a327ea5..488c8fd 100755
--- a/packages/now-go/build.sh
+++ b/packages/now-go/build.sh
@@ -2,6 +2,6 @@

 mkdir -p bin
 cd util
-GOOS=linux GOARCH=amd64 go build get-exported-function-name.go
+GOOS=darwin GOARCH=amd64 go build get-exported-function-name.go
 mv get-exported-function-name ../bin/

diff --git a/packages/now-go/dev.js b/packages/now-go/dev.js
new file mode 100644
index 0000000..e6e13eb
--- /dev/null
+++ b/packages/now-go/dev.js
@@ -0,0 +1 @@
+module.exports = require('./index');
diff --git a/packages/now-go/download-go-bin.js b/packages/now-go/download-go-bin.js
index 2b69d13..19fe5cb 100644
--- a/packages/now-go/download-go-bin.js
+++ b/packages/now-go/download-go-bin.js
@@ -1,13 +1,29 @@
 const path = require('path');

+const fs = require('fs');
 const fetch = require('node-fetch');
 const tar = require('tar');
 const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js');

-const url = 'https://dl.google.com/go/go1.11.1.linux-amd64.tar.gz';
+const url = 'https://dl.google.com/go/go1.11.1.darwin-amd64.tar.gz';

 module.exports = async () => {
-  const res = await fetch(url);
+  console.log('downloading go binary...');
+
+  // const res = await fetch(url);
+  const res = await new Promise((resolve) => {
+    const filePath = '/Users/eric/Downloads/go1.11.1.darwin-amd64.tar.gz';
+    const stream = fs.createReadStream(filePath);
+    stream.on('open', () => {
+      resolve(new fetch.Response(stream, {
+        url,
+        status: 200,
+        statustext: 'OK',
+        size: fs.statSync(filePath).size,
+      }));
+    });
+  });
+
   const dir = await getWritableDirectory();

   if (!res.ok) {
diff --git a/packages/now-go/index.js b/packages/now-go/index.js
index 551d52a..308c61a 100644
--- a/packages/now-go/index.js
+++ b/packages/now-go/index.js
@@ -14,7 +14,7 @@ const downloadGoBin = require('./download-go-bin');
 // without this, Go won't recognize the `$GOPATH`
 async function createGoPathTree(goPath) {
   await mkdirp(path.join(goPath, 'bin'));
-  await mkdirp(path.join(goPath, 'pkg', 'linux_amd64'));
+  await mkdirp(path.join(goPath, 'pkg', 'darwin_amd64'));
 }

 exports.config = {
@@ -32,18 +32,35 @@ exports.build = async ({ files, entrypoint }) => {
   await createGoPathTree(goPath);

   const downloadedFiles = await download(files, srcPath);
+  const downloadedUtils = await download(
+    await glob('bridge.go', __dirname),
+    path.join(goPath, 'src', 'vendor', 'now', 'bridge')
+  );
+
+  const localGoBin = execa.shellSync('which go').stdout.toString().trim();
+  let goBin;
+
+  if (localGoBin) {
+    goBin = await downloadGoBin();
+    // const dir = await getWritableDirectory();
+    // goBin = path.join(dir, 'bin', 'go');

-  console.log('downloading go binary...');
-  const goBin = await downloadGoBin();
+    // await execa.shellSync(`mkdir -p ${path.dirname(goBin)}`);
+    // await execa.shellSync(`ln -s $(which go) ${goBin}`);
+  } else {
+    goBin = await downloadGoBin();
+  }

   console.log('downloading git binary...');
   // downloads a git binary that works on Amazon Linux and sets
   // `process.env.GIT_EXEC_PATH` so `go(1)` can see it
-  await downloadGit({ targetDirectory: gitPath });
+  // if (!execa.shellSync('which git').stdout.toString().trim()) {
+  // await downloadGit({ targetDirectory: gitPath });
+  // }

   const goEnv = {
     ...process.env,
-    GOOS: 'linux',
+    GOOS: 'darwin',
     GOARCH: 'amd64',
     GOPATH: goPath,
   };
@@ -91,6 +108,9 @@ exports.build = async ({ files, entrypoint }) => {
   // so now we place `main.go` together with the user code
   await writeFile(path.join(entrypointDirname, mainGoFileName), mainGoContents);

+  console.log({ goEnv, goBin, gitPath, goPath, entrypointDirname });
+
+
   console.log('installing dependencies');
   // `go get` will look at `*.go` (note we set `cwd`), parse
   // the `import`s and download any packages that aren't part of the stdlib
diff --git a/packages/now-go/main.go b/packages/now-go/main.go
index c1817a1..abf3b16 100644
--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -1,8 +1,8 @@
 package main

 import (
-       now "../../utils/go/bridge"
        "net/http"
+       now "now/bridge"
 )

 func main() {
</details>


---

I'm excited to see this work continue, as there is a lot of power (and DX) to be found with working on monorepos with scalable deployments as a natural byproduct (via `now.json`).