### PR TITLE
Fix now dns ls misalignment when a domain is not found

### DIFF
--- a/src/util/dns/get-dns-records.ts
+++ b/src/util/dns/get-dns-records.ts
@@ -20,8 +20,8 @@ export default async function getDNSRecords(
   const domainsRecords = await Promise.all(
     domainNames.map(createGetDomainRecords(output, client))
   );
-  const onlyRecords = domainsRecords.filter(
-    item => !(item instanceof DomainNotFound)
+  const onlyRecords = domainsRecords.map(
+    item => ((item instanceof DomainNotFound) ? [] : item)
   ) as DNSRecord[][];
   return onlyRecords.reduce(getAddDomainName(domainNames), []);
 }


### PR DESCRIPTION
If a domain is not found the DNS record arrays are aligned
incorrectly and finally some records are shown under wrong domains.
It happens because the length of the domains array differs from the
length of array of record arrays.