### PR TITLE
Only run prettier for JS/TS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-download": "ncc build ./download/src --out ./download/dist",
     "link": "yarn run build && cd link && npm link",
     "build": "ncc build ./src",
-    "format-modified": "prettier --parser typescript --write --single-quote `git diff --name-only | grep \".*\\.js$\" | xargs echo`"
+    "format-modified": "prettier --parser typescript --write --single-quote `git diff --name-only | grep -e \".*\\.ts$\" -e \".*\\.js$\" | xargs echo`"
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-download": "ncc build ./download/src --out ./download/dist",
     "link": "yarn run build && cd link && npm link",
     "build": "ncc build ./src",
-    "format-modified": "prettier --parser typescript --write --single-quote `git diff --name-only | xargs echo`"
+    "format-modified": "prettier --parser typescript --write --single-quote `git diff --name-only | grep \".*\\.js$\" | xargs echo`"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Like this, we ensure to only pass modified JS/TS files to prettier.