### PR TITLE
Domains improvements

### DIFF
--- a/src/commands/alias/set.ts
+++ b/src/commands/alias/set.ts
@@ -22,14 +22,22 @@ import stamp from '../../util/output/stamp';
 import upsertPathAlias from '../../util/alias/upsert-path-alias';
 
 type Options = {
-  '--debug': boolean,
-  '--local-config': string,
-  '--no-verify': boolean,
-  '--rules': string
-}
+  '--debug': boolean;
+  '--local-config': string;
+  '--no-verify': boolean;
+  '--rules': string;
+};
 
-export default async function set(ctx: NowContext, opts: Options, args: string[], output: Output) {
-  const { authConfig: { token }, config } = ctx;
+export default async function set(
+  ctx: NowContext,
+  opts: Options,
+  args: string[],
+  output: Output
+) {
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const setStamp = stamp();
@@ -40,7 +48,12 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
     '--rules': rulesPath
   } = opts;
 
-  const client = new Client({ apiUrl, token, currentTeam, debug: debugEnabled });
+  const client = new Client({
+    apiUrl,
+    token,
+    currentTeam,
+    debug: debugEnabled
+  });
   let contextName = null;
   let user = null;
 
@@ -57,7 +70,9 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
 
   // If there are more than two args we have to error
   if (args.length > 2) {
-    output.error(`${cmd('now alias <deployment> <target>')} accepts at most two arguments`);
+    output.error(
+      `${cmd('now alias <deployment> <target>')} accepts at most two arguments`
+    );
     return 1;
   }
 
@@ -83,14 +98,24 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
 
   // If the user provided rules and also a deployment target, we should fail
   if (args.length === 2 && rules) {
-    output.error(`You can't supply a deployment target and target rules simultaneously.`);
+    output.error(
+      `You can't supply a deployment target and target rules simultaneously.`
+    );
     return 1;
   }
 
   // Find the targets to perform the alias
-  const targets = await getTargetsForAlias(output, args, opts['--local-config']);
+  const targets = await getTargetsForAlias(
+    output,
+    args,
+    opts['--local-config']
+  );
   if (targets instanceof ERRORS.CantFindConfig) {
-    output.error(`Couldn't find a project configuration file at \n    ${targets.meta.paths.join(' or\n    ')}`);
+    output.error(
+      `Couldn't find a project configuration file at \n    ${targets.meta.paths.join(
+        ' or\n    '
+      )}`
+    );
     return 1;
   }
 
@@ -100,7 +125,9 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
   }
 
   if (targets instanceof ERRORS.InvalidAliasInConfig) {
-    output.error(`Wrong value for alias found in config. It must be a string or array of string.`);
+    output.error(
+      `Wrong value for alias found in config. It must be a string or array of string.`
+    );
     return 1;
   }
 
@@ -112,11 +139,25 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
   if (rules) {
     // If we have rules for path alias we assign them to the domain
     for (const target of targets) {
-      output.log(`Assigning path alias rules from ${humanizePath(rulesPath)} to ${target}`);
-      const pathAlias = await upsertPathAlias(output, client, rules, target, contextName);
+      output.log(
+        `Assigning path alias rules from ${humanizePath(
+          rulesPath
+        )} to ${target}`
+      );
+      const pathAlias = await upsertPathAlias(
+        output,
+        client,
+        rules,
+        target,
+        contextName
+      );
       const remaining = handleCreateAliasError(output, pathAlias);
       if (handleSetupDomainError(output, remaining) !== 1) {
-        console.log(`${chalk.cyan('> Success!')} ${rules.length} rules configured for ${chalk.underline(target)} ${setStamp()}`);
+        console.log(
+          `${chalk.cyan('> Success!')} ${
+            rules.length
+          } rules configured for ${chalk.underline(target)} ${setStamp()}`
+        );
       }
     }
 
@@ -124,57 +165,122 @@ export default async function set(ctx: NowContext, opts: Options, args: string[]
   }
 
   // If there are no rules for path alias we should find out a deployment and perform the alias
-  const deployment = await getDeploymentForAlias(client, output, args, opts['--local-config'], user, contextName);
+  const deployment = await getDeploymentForAlias(
+    client,
+    output,
+    args,
+    opts['--local-config'],
+    user,
+    contextName
+  );
   if (deployment instanceof ERRORS.DeploymentNotFound) {
-    output.error(`Failed to find deployment "${deployment.meta.id}" under ${chalk.bold(contextName)}`);
+    output.error(
+      `Failed to find deployment "${deployment.meta.id}" under ${chalk.bold(
+        contextName
+      )}`
+    );
     return 1;
   }
 
   if (deployment instanceof ERRORS.DeploymentPermissionDenied) {
-    output.error(`No permission to access deployment "${deployment.meta.id}" under ${chalk.bold(deployment.meta.context)}`);
+    output.error(
+      `No permission to access deployment "${
+        deployment.meta.id
+      }" under ${chalk.bold(deployment.meta.context)}`
+    );
     return 1;
   }
 
   if (deployment === null) {
-    output.error(`Couldn't find a deployment to alias. Please provide one as an argument.`);
+    output.error(
+      `Couldn't find a deployment to alias. Please provide one as an argument.`
+    );
     return 1;
   }
 
   // Assign the alias for each of the targets in the array
   for (const target of targets) {
     output.log(`Assigning alias ${target} to deployment ${deployment.url}`);
-    const record = await assignAlias(output, client, deployment, target, contextName, noVerify);
-    const handleResult = handleSetupDomainError(output, handleCreateAliasError(output, record));
+    const record = await assignAlias(
+      output,
+      client,
+      deployment,
+      target,
+      contextName,
+      noVerify
+    );
+    const handleResult = handleSetupDomainError(
+      output,
+      handleCreateAliasError(output, record)
+    );
     if (handleResult === 1) {
       return 1;
     } else {
-      console.log(`${chalk.cyan('> Success!')} ${handleResult.alias} now points to ${chalk.bold(deployment.url)} ${setStamp()}`);
+      console.log(
+        `${chalk.cyan('> Success!')} ${
+          handleResult.alias
+        } now points to ${chalk.bold(deployment.url)} ${setStamp()}`
+      );
     }
   }
 
   return 0;
 }
 
-type ThenArg<T> = T extends Promise<infer U> ? U : T
+type ThenArg<T> = T extends Promise<infer U> ? U : T;
 type SetupDomainResolve = ThenArg<ReturnType<typeof setupDomain>>;
 type SetupDomainError = Exclude<SetupDomainResolve, Domain>;
 
-function handleSetupDomainError<T>(output: Output, error: SetupDomainError | T): T | 1 {
+function handleSetupDomainError<T>(
+  output: Output,
+  error: SetupDomainError | T
+): T | 1 {
   if (error instanceof ERRORS.DomainVerificationFailed) {
     const { nsVerification, txtVerification, domain } = error.meta;
-    output.error(`We could not alias since the domain ${domain} could not be verified due to the following reasons:\n`);
-    output.print(`  ${chalk.gray('a)')} Nameservers verification failed since we see a different set than the intended set:`);
-    output.print(`\n${formatNSTable(nsVerification.intendedNameservers, nsVerification.nameservers, { extraSpace: '     ' })}\n\n`);
-    output.print(`  ${chalk.gray('b)')} DNS TXT verification failed since found no matching records.`);
-    output.print(`\n${formatDnsTable([['_now', 'TXT', txtVerification.verificationRecord]], { extraSpace: '     ' })}\n\n`);
-    output.print(`  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${cmd('now domains verify <domain>')}.\n`);
-    output.print(`  We will also periodically run a verification check for you and you will receive an email once your domain is verified.\n`);
+    output.error(
+      `We could not alias since the domain ${domain} could not be verified due to the following reasons:\n`
+    );
+    output.print(
+      `  ${chalk.gray(
+        'a)'
+      )} Nameservers verification failed since we see a different set than the intended set:`
+    );
+    output.print(
+      `\n${formatNSTable(
+        nsVerification.intendedNameservers,
+        nsVerification.nameservers,
+        { extraSpace: '     ' }
+      )}\n\n`
+    );
+    output.print(
+      `  ${chalk.gray(
+        'b)'
+      )} DNS TXT verification failed since found no matching records.`
+    );
+    output.print(
+      `\n${formatDnsTable(
+        [['_now', 'TXT', txtVerification.verificationRecord]],
+        { extraSpace: '     ' }
+      )}\n\n`
+    );
+    output.print(
+      `  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${cmd(
+        'now domains verify <domain>'
+      )}.\n`
+    );
+    output.print(
+      `  We will also periodically run a verification check for you and you will receive an email once your domain is verified.\n`
+    );
     output.print('  Read more: https://err.sh/now-cli/domain-verification\n');
     return 1;
   }
 
   if (error instanceof ERRORS.DomainPermissionDenied) {
-    output.error(`You don't have permissions over domain ${chalk.underline(error.meta.domain)} under ${chalk.bold(error.meta.context)}.`);
+    output.error(
+      `You don't have permissions over domain ${chalk.underline(
+        error.meta.domain
+      )} under ${chalk.bold(error.meta.context)}.`
+    );
     return 1;
   }
 
@@ -194,22 +300,30 @@ function handleSetupDomainError<T>(output: Output, error: SetupDomainError | T):
   }
 
   if (error instanceof ERRORS.UnsupportedTLD) {
-    output.error(`The TLD for domain name ${error.meta.domain} is not supported.`);
+    output.error(
+      `The TLD for domain name ${error.meta.domain} is not supported.`
+    );
     return 1;
   }
 
   if (error instanceof ERRORS.InvalidDomain) {
-    output.error(`The domain ${error.meta.domain} used for the alias is not valid.`);
+    output.error(
+      `The domain ${error.meta.domain} used for the alias is not valid.`
+    );
     return 1;
   }
 
   if (error instanceof ERRORS.DomainNotAvailable) {
-    output.error(`The domain ${error.meta.domain} is not available to be purchased.`);
+    output.error(
+      `The domain ${error.meta.domain} is not available to be purchased.`
+    );
     return 1;
   }
 
   if (error instanceof ERRORS.DomainServiceNotAvailable) {
-    output.error(`The domain purchase service is not available. Try again later.`);
+    output.error(
+      `The domain purchase service is not available. Try again later.`
+    );
     return 1;
   }
 
@@ -219,7 +333,29 @@ function handleSetupDomainError<T>(output: Output, error: SetupDomainError | T):
   }
 
   if (error instanceof ERRORS.DomainAlreadyExists) {
-    output.error(`The domain  ${error.meta.domain} exists for a different account.`);
+    output.error(
+      `The domain  ${error.meta.domain} exists for a different account.`
+    );
+    return 1;
+  }
+
+  if (error instanceof ERRORS.DomainPurchasePending) {
+    output.error(
+      `The domain ${
+        error.meta.domain
+      } is processing and will be available once the order is completed.`
+    );
+    output.print(
+      `  An email will be sent upon completion so you can alias to your new domain.\n`
+    );
+    return 1;
+  }
+
+  if (error instanceof ERRORS.SourceNotFound) {
+    output.error(
+      `You can't purchase the domain your aliasing to since you have no valid payment method.`
+    );
+    output.print(`  Please add a valid payment method and retry.\n`);
     return 1;
   }
 
@@ -228,11 +364,21 @@ function handleSetupDomainError<T>(output: Output, error: SetupDomainError | T):
 
 type AliasResolved = ThenArg<ReturnType<typeof assignAlias>>;
 type AssignAliasError = Exclude<AliasResolved, AliasRecord>;
-type RemainingAssignAliasErrors = SetDifference<AssignAliasError, SetupDomainError>
+type RemainingAssignAliasErrors = SetDifference<
+  AssignAliasError,
+  SetupDomainError
+>;
 
-function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasErrors | T): 1 | T {
+function handleCreateAliasError<T>(
+  output: Output,
+  error: RemainingAssignAliasErrors | T
+): 1 | T {
   if (error instanceof ERRORS.AliasInUse) {
-    output.error(`The alias ${chalk.dim(error.meta.alias)} is a deployment URL or it's in use by a different team.`);
+    output.error(
+      `The alias ${chalk.dim(
+        error.meta.alias
+      )} is a deployment URL or it's in use by a different team.`
+    );
     return 1;
   }
 
@@ -298,16 +444,18 @@ function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasEr
   if (error instanceof ERRORS.CantSolveChallenge) {
     if (error.meta.type === 'dns-01') {
       output.error(
-        `The certificate provider could not resolve the DNS queries for ${error
-          .meta.domain}.`
+        `The certificate provider could not resolve the DNS queries for ${
+          error.meta.domain
+        }.`
       );
       output.print(
         `  This might happen to new domains or domains with recent DNS changes. Please retry later.\n`
       );
     } else {
       output.error(
-        `The certificate provider could not resolve the HTTP queries for ${error
-          .meta.domain}.`
+        `The certificate provider could not resolve the HTTP queries for ${
+          error.meta.domain
+        }.`
       );
       output.print(
         `  The DNS propagation may take a few minutes, please verify your settings:\n\n`
@@ -331,10 +479,12 @@ function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasEr
   }
   if (error instanceof ERRORS.TooManyRequests) {
     output.error(
-      `Too many requests detected for ${error.meta
-        .api} API. Try again in ${ms(error.meta.retryAfter * 1000, {
-        long: true
-      })}.`
+      `Too many requests detected for ${error.meta.api} API. Try again in ${ms(
+        error.meta.retryAfter * 1000,
+        {
+          long: true
+        }
+      )}.`
     );
     return 1;
   }
@@ -365,8 +515,9 @@ function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasEr
     output.error(
       `Scale rules from previous aliased deployment ${chalk.dim(
         error.meta.url
-      )} could not be copied since the given number of max instances (${error
-        .meta.max}) is not allowed.`
+      )} could not be copied since the given number of max instances (${
+        error.meta.max
+      }) is not allowed.`
     );
     output.log(
       `Update the scale settings on ${chalk.dim(
@@ -379,8 +530,9 @@ function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasEr
     output.error(
       `Scale rules from previous aliased deployment ${chalk.dim(
         error.meta.url
-      )} could not be copied since the given number of min instances (${error
-        .meta.min}) is not allowed.`
+      )} could not be copied since the given number of min instances (${
+        error.meta.min
+      }) is not allowed.`
     );
     output.log(
       `Update the scale settings on ${chalk.dim(
@@ -405,8 +557,16 @@ function handleCreateAliasError<T>(output: Output, error: RemainingAssignAliasEr
   }
 
   if (error instanceof ERRORS.CertMissing) {
-    output.error(`There is no certificate for the domain ${error.meta.domain} and it could not be created.`);
-    output.log(`Please generate a new certificate manually with ${cmd(`now certs issue ${error.meta.domain}`)}`);
+    output.error(
+      `There is no certificate for the domain ${
+        error.meta.domain
+      } and it could not be created.`
+    );
+    output.log(
+      `Please generate a new certificate manually with ${cmd(
+        `now certs issue ${error.meta.domain}`
+      )}`
+    );
     return 1;
   }
 

--- a/src/commands/certs/issue.ts
+++ b/src/commands/certs/issue.ts
@@ -31,7 +31,10 @@ export default async function issue(
   args: string[],
   output: Output
 ) {
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const addStamp = stamp();
@@ -142,8 +145,9 @@ export default async function issue(
 
   if (cert instanceof ERRORS.CantSolveChallenge) {
     output.error(
-      `We could not solve the ${cert.meta.type} challenge for domain ${cert.meta
-        .domain}.`
+      `We could not solve the ${cert.meta.type} challenge for domain ${
+        cert.meta.domain
+      }.`
     );
     if (cert.meta.type === 'dns-01') {
       output.log(
@@ -154,8 +158,9 @@ export default async function issue(
       );
     } else {
       output.log(
-        `The certificate provider could not resolve the HTTP queries for ${cert
-          .meta.domain}.`
+        `The certificate provider could not resolve the HTTP queries for ${
+          cert.meta.domain
+        }.`
       );
       output.print(
         `  The DNS propagation may take a few minutes, please verify your settings:\n\n`
@@ -175,10 +180,12 @@ export default async function issue(
   }
   if (cert instanceof ERRORS.TooManyRequests) {
     output.error(
-      `Too many requests detected for ${cert.meta
-        .api} API. Try again in ${ms(cert.meta.retryAfter * 1000, {
-        long: true
-      })}.`
+      `Too many requests detected for ${cert.meta.api} API. Try again in ${ms(
+        cert.meta.retryAfter * 1000,
+        {
+          long: true
+        }
+      )}.`
     );
     return 1;
   }

--- a/src/commands/domains/buy.ts
+++ b/src/commands/domains/buy.ts
@@ -25,7 +25,10 @@ export default async function buy(
   args: string[],
   output: Output
 ) {
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
@@ -80,11 +83,11 @@ export default async function buy(
     )} to buy under ${chalk.bold(contextName)}! ${availableStamp()}`
   );
   if (
-    !await promptBool(
-      `Buy now for ${chalk.bold(`$${price}`)} (${`${period}yr${period > 1
-        ? 's'
-        : ''}`})?`
-    )
+    !(await promptBool(
+      `Buy now for ${chalk.bold(`$${price}`)} (${`${period}yr${
+        period > 1 ? 's' : ''
+      }`})?`
+    ))
   ) {
     return 0;
   }
@@ -96,7 +99,11 @@ export default async function buy(
   stopPurchaseSpinner();
 
   if (buyResult instanceof ERRORS.SourceNotFound) {
-    output.error(`Could not purchase domain. Please add a payment method using ${cmd('now billing add')}.`);
+    output.error(
+      `Could not purchase domain. Please add a payment method using ${cmd(
+        'now billing add'
+      )}.`
+    );
     return 1;
   }
 
@@ -122,24 +129,39 @@ export default async function buy(
     return 1;
   }
 
-  console.log(
-    `${chalk.cyan('> Success!')} Domain ${param(
-      domainName
-    )} purchased ${purchaseStamp()}`
-  );
-  if (!buyResult.verified) {
+  if (buyResult.pending) {
+    console.log(
+      `${chalk.cyan('> Success!')} Domain ${param(
+        domainName
+      )} order was submitted ${purchaseStamp()}`
+    );
     output.note(
-      `Your domain is not fully configured yet so it may appear as not verified.`
+      `Your domain is processing and will be available once the order is completed.`
     );
     output.print(
-      `  It might take a few minutes, but you will get an email as soon as it is ready.\n`
+      `  An email will be sent upon completion for you to start using your new domain.\n`
     );
   } else {
-    output.note(
-      `You may now use your domain as an alias to your deployments. Run ${cmd(
-        'now alias --help'
-      )}`
+    console.log(
+      `${chalk.cyan('> Success!')} Domain ${param(
+        domainName
+      )} purchased ${purchaseStamp()}`
     );
+    if (!buyResult.verified) {
+      output.note(
+        `Your domain is not fully configured yet so it may appear as not verified.`
+      );
+      output.print(
+        `  It might take a few minutes, but you will get an email as soon as it is ready.\n`
+      );
+    } else {
+      output.note(
+        `You may now use your domain as an alias to your deployments. Run ${cmd(
+          'now alias --help'
+        )}`
+      );
+    }
   }
+
   return 0;
 }

--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -76,6 +76,9 @@ export default async function inspect(
     `    ${chalk.dim('expiresAt')}\t\t${formatDate(domain.expiresAt)}\n`
   );
   output.print(
+    `    ${chalk.dim('orderedAt')}\t\t${formatDate(domain.orderedAt)}\n`
+  );
+  output.print(
     `    ${chalk.dim('boughtAt')}\t\t${formatDate(domain.boughtAt)}\n`
   );
   output.print(

--- a/src/commands/domains/ls.ts
+++ b/src/commands/domains/ls.ts
@@ -6,7 +6,6 @@ import table from 'text-table';
 import Client from '../../util/client';
 import getDomains from '../../util/domains/get-domains';
 import getScope from '../../util/get-scope';
-import isDomainExternal from '../../util/domains/is-domain-external';
 import stamp from '../../util/output/stamp';
 import strlen from '../../util/strlen';
 import { Output } from '../../util/output';
@@ -22,7 +21,10 @@ export default async function ls(
   args: string[],
   output: Output
 ) {
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
@@ -56,7 +58,7 @@ export default async function ls(
     )} ${chalk.gray(lsStamp())}\n`
   );
   if (domains.length > 0) {
-    console.log(formatDomainsTable(domains));
+    console.log(`${formatDomainsTable(domains)}\n`);
   }
 
   return 0;
@@ -66,7 +68,14 @@ function formatDomainsTable(domains: Domain[]) {
   const current = new Date();
   return table(
     [
-      ['', chalk.gray('domain'), chalk.gray('serviceType'), chalk.gray('verified'), chalk.gray('cdn'), chalk.gray('age')].map(s => chalk.dim(s)),
+      [
+        '',
+        chalk.gray('domain'),
+        chalk.gray('serviceType'),
+        chalk.gray('verified'),
+        chalk.gray('cdn'),
+        chalk.gray('age')
+      ].map(s => chalk.dim(s)),
       ...domains.map(domain => {
         const cdnEnabled = domain.cdnEnabled || false;
         const url = chalk.bold(domain.name);

--- a/src/commands/domains/verify.ts
+++ b/src/commands/domains/verify.ts
@@ -21,7 +21,10 @@ export default async function verify(
   args: string[],
   output: Output
 ) {
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
@@ -67,7 +70,9 @@ export default async function verify(
   if (result instanceof ERRORS.DomainVerificationFailed) {
     const { nsVerification, txtVerification } = result.meta;
     output.error(
-      `The domain ${domain.name} could not be verified due to the following reasons: ${verifyStamp()}\n`
+      `The domain ${
+        domain.name
+      } could not be verified due to the following reasons: ${verifyStamp()}\n`
     );
     output.print(
       `  ${chalk.gray(
@@ -100,7 +105,7 @@ export default async function verify(
     output.print(
       `  We will also periodically run a verification check for you and you will receive an email once your domain is verified.\n`
     );
-    output.print('  Read more: https://err.sh/now-cli/domain-verification\n');
+    output.print('  Read more: https://err.sh/now-cli/domain-verification\n\n');
     return 1;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export type Domain = {
   boughtAt: number;
   createdAt: number;
   expiresAt: number;
+  orderedAt?: number;
   serviceType: 'zeit.world' | 'external' | 'na';
   cdnEnabled: boolean;
   verified: boolean;

--- a/src/util/alias/assign-alias.ts
+++ b/src/util/alias/assign-alias.ts
@@ -70,7 +70,9 @@ export default async function assignAlias(
       }
 
       output.log(
-        `Scale rules copied from previous alias ${prevDeployment.url} ${scaleStamp()}`
+        `Scale rules copied from previous alias ${
+          prevDeployment.url
+        } ${scaleStamp()}`
       );
       if (!noVerify) {
         const result = await waitForScale(
@@ -94,14 +96,16 @@ export default async function assignAlias(
     // Now the domain shouldn't be available and it might or might not belong to the user
     const result = await setupDomain(output, client, alias, contextName);
     if (
+      result instanceof ERRORS.CDNNeedsUpgrade ||
+      result instanceof ERRORS.DomainAlreadyExists ||
       result instanceof ERRORS.DomainNotAvailable ||
       result instanceof ERRORS.DomainNotFound ||
       result instanceof ERRORS.DomainPermissionDenied ||
+      result instanceof ERRORS.DomainPurchasePending ||
       result instanceof ERRORS.DomainServiceNotAvailable ||
       result instanceof ERRORS.DomainVerificationFailed ||
       result instanceof ERRORS.InvalidDomain ||
-      result instanceof ERRORS.CDNNeedsUpgrade ||
-      result instanceof ERRORS.DomainAlreadyExists ||
+      result instanceof ERRORS.SourceNotFound ||
       result instanceof ERRORS.UnexpectedDomainPurchaseError ||
       result instanceof ERRORS.UnsupportedTLD ||
       result instanceof ERRORS.UserAborted

--- a/src/util/alias/upsert-path-alias.ts
+++ b/src/util/alias/upsert-path-alias.ts
@@ -32,9 +32,11 @@ export default async function upsertPathAlias(
       domainInfo instanceof ERRORS.DomainNotAvailable ||
       domainInfo instanceof ERRORS.DomainNotFound ||
       domainInfo instanceof ERRORS.DomainPermissionDenied ||
+      domainInfo instanceof ERRORS.DomainPurchasePending ||
       domainInfo instanceof ERRORS.DomainServiceNotAvailable ||
       domainInfo instanceof ERRORS.DomainVerificationFailed ||
       domainInfo instanceof ERRORS.InvalidDomain ||
+      domainInfo instanceof ERRORS.SourceNotFound ||
       domainInfo instanceof ERRORS.UnexpectedDomainPurchaseError ||
       domainInfo instanceof ERRORS.UnsupportedTLD ||
       domainInfo instanceof ERRORS.UserAborted

--- a/src/util/domains/purchase-domain-if-available.ts
+++ b/src/util/domains/purchase-domain-if-available.ts
@@ -45,11 +45,11 @@ export default async function purchaseDomainIfAvailable(
     );
 
     if (
-      !await promptBool(
+      !(await promptBool(
         `Buy ${chalk.underline(domain)} for ${chalk.bold(
           `$${price}`
         )} (${plural('yr', period, true)})?`
-      )
+      ))
     ) {
       output.print(eraseLines(1));
       return new ERRORS.UserAborted();
@@ -58,12 +58,17 @@ export default async function purchaseDomainIfAvailable(
     output.print(eraseLines(1));
     const result = await purchaseDomain(client, domain, price);
     if (
+      result instanceof ERRORS.SourceNotFound ||
       result instanceof ERRORS.DomainNotAvailable ||
       result instanceof ERRORS.DomainServiceNotAvailable ||
       result instanceof ERRORS.InvalidDomain ||
       result instanceof ERRORS.UnexpectedDomainPurchaseError
     ) {
       return result;
+    }
+
+    if (result.pending) {
+      return new ERRORS.DomainPurchasePending(domain);
     }
 
     return true;

--- a/src/util/domains/purchase-domain.ts
+++ b/src/util/domains/purchase-domain.ts
@@ -5,6 +5,7 @@ type Response = {
   created: number;
   ns: string[];
   uid: string;
+  pending: boolean;
   verified: boolean;
 };
 

--- a/src/util/domains/verify-domain.ts
+++ b/src/util/domains/verify-domain.ts
@@ -41,7 +41,7 @@ async function performVerifyDomain(client: Client, domain: string) {
       client.fetch<Response>(
         `/v4/domains/${encodeURIComponent(domain)}/verify`,
         {
-          body: { domain },
+          body: {},
           method: 'POST'
         }
       ),

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -157,7 +157,9 @@ export class SourceNotFound extends NowError<'SOURCE_NOT_FOUND', {}> {
     super({
       code: 'SOURCE_NOT_FOUND',
       meta: {},
-      message: `Not able to purchase. Please add a payment method using ${cmd('now billing add')}.`
+      message: `Not able to purchase. Please add a payment method using ${cmd(
+        'now billing add'
+      )}.`
     });
   }
 }
@@ -307,6 +309,23 @@ export class UnexpectedDomainPurchaseError extends NowError<
       code: 'UNEXPECTED_DOMAIN_PURCHASE_ERROR',
       meta: { domain },
       message: `An unexpected error happened while purchasing.`
+    });
+  }
+}
+
+/**
+ * Returned during purchase in alias when the domain was purchased but the
+ * order is pending so the alias can't be completed yet
+ */
+export class DomainPurchasePending extends NowError<
+  'DOMAIN_PURCHASE_PENDING',
+  { domain: string }
+> {
+  constructor(domain: string) {
+    super({
+      code: 'DOMAIN_PURCHASE_PENDING',
+      meta: { domain },
+      message: `The domain purchase for ${domain} is pending.`
     });
   }
 }

--- a/src/util/format-date.ts
+++ b/src/util/format-date.ts
@@ -2,7 +2,7 @@ import ms from 'ms';
 import chalk from 'chalk';
 import format from 'date-fns/format';
 
-export default function formatDate(dateStrOrNumber: number | string | null) {
+export default function formatDate(dateStrOrNumber?: number | string | null) {
   if (!dateStrOrNumber) {
     return chalk.gray('-');
   }

--- a/src/util/response-error.ts
+++ b/src/util/response-error.ts
@@ -19,7 +19,7 @@ export default async function responseError(
     }
 
     // Some APIs wrongly return `err` instead of `error`
-    bodyError = body.error || body.err || {};
+    bodyError = body.error || body.err || body;
     message = bodyError.message;
   }
 


### PR DESCRIPTION
This PR delivers some improvements for the purchase workflow plus some fixes:

- Add some style changes like jump lines for the `domains ls` command.
- Takes into account pending domain purchases when buying a domain directly / aliasing.
- Fixes an issue that made API errors to be treated as unexpected errors due to the lack of error payload.
- Adds a field `orderedAt` to the `domains inspect` command.
