### PR TITLE
Style fixes for domains commands

### DIFF
--- a/src/commands/certs/issue.ts
+++ b/src/commands/certs/issue.ts
@@ -165,7 +165,7 @@ export default async function issue(
       output.print(
         `  The DNS propagation may take a few minutes, please verify your settings:\n\n`
       );
-      output.print(`${dnsTable([['', 'ALIAS', 'alias.zeit.co']])}\n\n`);
+      output.print(`  ${dnsTable([['', 'ALIAS', 'alias.zeit.co']])}\n\n`);
       output.log(
         `Alternatively, you can solve DNS challenges manually after running:\n`
       );
@@ -173,7 +173,7 @@ export default async function issue(
         `  ${chalk.cyan(`now certs issue --challenge-only ${cns.join(' ')}`)}\n`
       );
       output.print(
-        '  Read more: https://err.sh/now-cli/cant-solve-challenge\n'
+        '  Read more: https://err.sh/now-cli/cant-solve-challenge\n\n'
       );
     }
     return 1;

--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -146,7 +146,7 @@ export default async function add(
         'now domains verify <domain>'
       )}\n`
     );
-    output.print('  Read more: https://err.sh/now-cli/domain-verification\n');
+    output.print('  Read more: https://err.sh/now-cli/domain-verification\n\n');
   }
 
   return 0;

--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -69,21 +69,11 @@ export default async function inspect(
   output.print(chalk.bold('  Domain Info\n'));
   output.print(`    ${chalk.dim('name')}\t\t${domain.name}\n`);
   output.print(`    ${chalk.dim('serviceType')}\t\t${domain.serviceType}\n`);
-  output.print(
-    `    ${chalk.dim('createdAt')}\t\t${formatDate(domain.createdAt)}\n`
-  );
-  output.print(
-    `    ${chalk.dim('expiresAt')}\t\t${formatDate(domain.expiresAt)}\n`
-  );
-  output.print(
-    `    ${chalk.dim('orderedAt')}\t\t${formatDate(domain.orderedAt)}\n`
-  );
-  output.print(
-    `    ${chalk.dim('boughtAt')}\t\t${formatDate(domain.boughtAt)}\n`
-  );
-  output.print(
-    `    ${chalk.dim('nsVerifiedAt')}\t${formatDate(domain.nsVerifiedAt)}\n`
-  );
+  output.print(`    ${chalk.dim('orderedAt')}\t\t${formatDate(domain.orderedAt)}\n`);
+  output.print(`    ${chalk.dim('createdAt')}\t\t${formatDate(domain.createdAt)}\n`);
+  output.print(`    ${chalk.dim('boughtAt')}\t\t${formatDate(domain.boughtAt)}\n`);
+  output.print(`    ${chalk.dim('expiresAt')}\t\t${formatDate(domain.expiresAt)}\n`);
+  output.print(`    ${chalk.dim('nsVerifiedAt')}\t${formatDate(domain.nsVerifiedAt)}\n`);
   output.print(
     `    ${chalk.dim('txtVerifiedAt')}\t${formatDate(domain.txtVerifiedAt)}\n`
   );

--- a/src/commands/domains/verify.ts
+++ b/src/commands/domains/verify.ts
@@ -117,7 +117,7 @@ export default async function verify(
     );
     output.print(
       `  You can verify with nameservers too. Run ${cmd(
-        'now domains inspect <domain>'
+        `now domains inspect ${domain.name}`
       )} to find out the intended set.\n`
     );
     return 0;

--- a/src/util/error-handlers.ts
+++ b/src/util/error-handlers.ts
@@ -17,7 +17,7 @@ export function handleDomainConfigurationError(
       `  The propagation may take a few minutes, but please verify your settings:\n\n`
     );
     output.print(
-      `${dnsTable([
+      `${  dnsTable([
         error.meta.subdomain === null
           ? ['', 'ALIAS', 'alias.zeit.co']
           : [error.meta.subdomain, 'CNAME', 'alias.zeit.co']
@@ -35,7 +35,7 @@ export function handleDomainConfigurationError(
       `  We configured them for you, but the propagation may take a few minutes. Please try again later.\n`
     );
     output.print(
-      '  Read more: https://err.sh/now-cli/dns-configuration-error\n'
+      '  Read more: https://err.sh/now-cli/dns-configuration-error\n\n'
     );
   }
 }


### PR DESCRIPTION
This PR brings some style changes detected while testing the CLI:

- Add some missing jumplines
- Fix indentation when getting cert issuing error.
- Reorder domains inspect timestamps chronologically
- Interpolate domain name in suggested command