### PR TITLE
Overhauled `now inspect`

### DIFF
--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -136,7 +136,9 @@ export default async function main(ctx) {
     url,
     created,
     limits,
-    version
+    version,
+    routes,
+    readyState
   } = deployment;
 
   const isBuilds = version === 2;
@@ -170,7 +172,7 @@ export default async function main(ctx) {
   print(`    ${chalk.dim('version')}\t${version}\n`);
   print(`    ${chalk.dim('id')}\t\t${finalId}\n`);
   print(`    ${chalk.dim('name')}\t${name}\n`);
-  print(`    ${chalk.dim('readyState')}\t${stateString(state)}\n`);
+  print(`    ${chalk.dim('readyState')}\t${stateString(state || readyState)}\n`);
   if (!isBuilds) {
     print(`    ${chalk.dim('type')}\t${type}\n`);
   }
@@ -181,12 +183,14 @@ export default async function main(ctx) {
     print(`    ${chalk.dim('affinity')}\t${sessionAffinity}\n`);
   }
   print(`    ${chalk.dim('url')}\t\t${url}\n`);
-  print(
-    `    ${chalk.dim('createdAt')}\t${new Date(created)} ${elapsed(
-      Date.now() - created,
-      true
-    )}\n`
-  );
+  if (created) {
+    print(
+      `    ${chalk.dim('createdAt')}\t${new Date(created)} ${elapsed(
+        Date.now() - created,
+        true
+      )}\n`
+    );
+  }
   print('\n');
 
   if (builds.length > 0) {
@@ -200,6 +204,23 @@ export default async function main(ctx) {
     print(chalk.bold('  Builds\n'));
     print(buildsList(builds, times, true).toPrint);
     print('\n');
+  }
+
+  if (Array.isArray(routes) && routes.length > 0) {
+    let toPrint = chalk.bold('  Routes\n');
+
+    const longestRoute = routes.sort((a, b) => b.src.length - a.src.length)[0];
+    const longestSrc = longestRoute.src.length;
+
+    const padding = 6;
+
+    for (const item of routes) {
+      const src = item.src.padEnd(longestSrc + padding);
+
+      toPrint += `    ${src}${chalk.grey('->')}${' '.repeat(padding)}${item.dest}\n`;
+    }
+
+    print(`${toPrint}\n\n`);
   }
 
   if (limits) {

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -171,23 +171,23 @@ export default async function main(ctx) {
 
   print('\n');
   print(chalk.bold('  Meta\n\n'));
-  print(`    ${chalk.dim('version')}\t${version}\n`);
-  print(`    ${chalk.dim('id')}\t\t${finalId}\n`);
-  print(`    ${chalk.dim('name')}\t${name}\n`);
-  print(`    ${chalk.dim('readyState')}\t${stateString(state || readyState)}\n`);
+  print(`    ${chalk.cyan('version')}\t${version}\n`);
+  print(`    ${chalk.cyan('id')}\t\t${finalId}\n`);
+  print(`    ${chalk.cyan('name')}\t${name}\n`);
+  print(`    ${chalk.cyan('readyState')}\t${stateString(state || readyState)}\n`);
   if (!isBuilds) {
-    print(`    ${chalk.dim('type')}\t${type}\n`);
+    print(`    ${chalk.cyan('type')}\t${type}\n`);
   }
   if (slot) {
-    print(`    ${chalk.dim('slot')}\t${slot}\n`);
+    print(`    ${chalk.cyan('slot')}\t${slot}\n`);
   }
   if (sessionAffinity) {
-    print(`    ${chalk.dim('affinity')}\t${sessionAffinity}\n`);
+    print(`    ${chalk.cyan('affinity')}\t${sessionAffinity}\n`);
   }
-  print(`    ${chalk.dim('url')}\t\t${url}\n`);
+  print(`    ${chalk.cyan('url')}\t\t${url}\n`);
   if (created) {
     print(
-      `    ${chalk.dim('createdAt')}\t${new Date(created)} ${elapsed(
+      `    ${chalk.cyan('createdAt')}\t${new Date(created)} ${elapsed(
         Date.now() - created,
         true
       )}\n`

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -216,7 +216,6 @@ export default async function main(ctx) {
 
     for (const item of routes) {
       const src = item.src.padEnd(longestSrc + padding);
-
       toPrint += `    ${src}${chalk.grey('->')}${' '.repeat(padding)}${item.dest}\n`;
     }
 

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import table from 'text-table';
 import getArgs from '../util/get-args';
 import buildsList from '../util/output/builds';
+import routesList from '../util/output/routes';
+import indent from '../util/output/indent';
 import cmd from '../util/output/cmd.ts';
 import createOutput from '../util/output';
 import Now from '../util';
@@ -168,7 +170,7 @@ export default async function main(ctx) {
   );
 
   print('\n');
-  print(chalk.bold('  Meta\n'));
+  print(chalk.bold('  Meta\n\n'));
   print(`    ${chalk.dim('version')}\t${version}\n`);
   print(`    ${chalk.dim('id')}\t\t${finalId}\n`);
   print(`    ${chalk.dim('name')}\t${name}\n`);
@@ -191,7 +193,7 @@ export default async function main(ctx) {
       )}\n`
     );
   }
-  print('\n');
+  print('\n\n');
 
   if (builds.length > 0) {
     const times = {};
@@ -201,29 +203,19 @@ export default async function main(ctx) {
       times[id] = createdAt ? elapsed(readyStateAt - createdAt) : null;
     }
 
-    print(chalk.bold('  Builds\n'));
-    print(buildsList(builds, times, true).toPrint);
-    print('\n');
+    print(chalk.bold('  Builds\n\n'));
+    print(indent(buildsList(builds, times).toPrint, 4));
+    print('\n\n');
   }
 
   if (Array.isArray(routes) && routes.length > 0) {
-    let toPrint = chalk.bold('  Routes\n');
-
-    const longestRoute = routes.sort((a, b) => b.src.length - a.src.length)[0];
-    const longestSrc = longestRoute.src.length;
-
-    const padding = 6;
-
-    for (const item of routes) {
-      const src = item.src.padEnd(longestSrc + padding);
-      toPrint += `    ${src}${chalk.grey('->')}${' '.repeat(padding)}${item.dest}\n`;
-    }
-
-    print(`${toPrint}\n\n`);
+    print(chalk.bold('  Routes\n\n'));
+    print(indent(routesList(routes), 4));
+    print(`\n\n`);
   }
 
   if (limits) {
-    print(chalk.bold('  Limits\n'));
+    print(chalk.bold('  Limits\n\n'));
     print(
       `    ${chalk.dim('duration')}\t\t${limits.duration} ${elapsed(
         limits.duration
@@ -244,7 +236,7 @@ export default async function main(ctx) {
     return 0;
   }
 
-  print(chalk.bold('  Scale\n'));
+  print(chalk.bold('  Scale\n\n'));
 
   let exitCode = 0;
 
@@ -269,7 +261,7 @@ export default async function main(ctx) {
     print('\n');
   }
 
-  print(chalk.bold('  Events\n'));
+  print(chalk.bold('  Events\n\n'));
   if (events instanceof Error) {
     error(`Events unavailable: ${scale}`);
     exitCode = 1;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -584,7 +584,9 @@ export default class Now extends EventEmitter {
 
   async findDeployment(hostOrId) {
     const { debug } = this._output;
+
     let id = !hostOrId.includes('.') && hostOrId;
+    let isBuilds = null;
 
     if (!id) {
       let host = hostOrId.replace(/^https:\/\//i, '');
@@ -619,9 +621,10 @@ export default class Now extends EventEmitter {
       );
 
       id = deployment.id;
+      isBuilds = deployment.type === 'LAMBDAS';
     }
 
-    const url = `/v5/now/deployments/${encodeURIComponent(id)}`;
+    const url = `/${isBuilds ? 'v6' : 'v5'}/now/deployments/${encodeURIComponent(id)}`;
 
     return this.retry(
       async bail => {

--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -11,13 +11,13 @@ const longestState = 12;
 // That's the spacing between the source, state and time
 const padding = 8;
 
-const styleBuild = (build, times, inspecting, longestSource) => {
+const styleBuild = (build, times, longestSource) => {
   const { entrypoint, readyState, id, hasOutput } = build;
   const state = prepareState(readyState).padEnd(longestState + padding);
   const time = typeof times[id] === 'string' ? times[id] : '';
 
   let stateColor = chalk.grey;
-  let pathColor = inspecting ? chalk.grey : chalk.cyan;
+  let pathColor = chalk.cyan;
 
   if (isReady({ readyState })) {
     stateColor = item => item;
@@ -29,12 +29,12 @@ const styleBuild = (build, times, inspecting, longestSource) => {
   const entry = entrypoint.padEnd(longestSource + padding);
   const prefix = hasOutput ? '┌' : '╶';
 
-  return `${inspecting ? `    ` : `${chalk.grey(prefix)} `}${pathColor(
+  return `${chalk.grey(prefix)} ${pathColor(
     entry
   )}${stateColor(state)}${time}`;
 };
 
-const styleOutput = (output, inspecting) => {
+const styleOutput = (output) => {
   const { type, path, readyState, size, isLast, lambda } = output;
   const prefix = type === 'lambda' ? 'λ ' : '';
   const finalSize = size ? ` ${chalk.grey(`(${bytes(size)})`)}` : '';
@@ -59,10 +59,10 @@ const styleOutput = (output, inspecting) => {
   const corner = isLast ? '└──' : '├──';
   const main = prefix + path + finalSize + finalRegion;
 
-  return `${inspecting ? `      ` : `${chalk.grey(corner)} `}${color(main)}`;
+  return `${chalk.grey(corner)} ${color(main)}`;
 };
 
-export default (builds, times, inspecting) => {
+export default (builds, times) => {
   const buildsAndOutput = [];
 
   for (const build of builds) {
@@ -94,9 +94,9 @@ export default (builds, times, inspecting) => {
     let log = null;
 
     if (item.isOutput) {
-      log = styleOutput(item, inspecting);
+      log = styleOutput(item);
     } else {
-      log = styleBuild(item, times, inspecting, longestSource);
+      log = styleBuild(item, times, longestSource);
     }
 
     const newline = index === buildsAndOutput.length - 1 ? '' : '\n';

--- a/src/util/output/indent.js
+++ b/src/util/output/indent.js
@@ -1,0 +1,4 @@
+export default (input, level) => {
+  const fill = ' '.repeat(level);
+  return `${fill}${input.replace(/\n/g, `\n${fill}`)}`;
+};

--- a/src/util/output/routes.js
+++ b/src/util/output/routes.js
@@ -1,0 +1,58 @@
+import chalk from 'chalk';
+
+const longestProperty = (routes, name) => {
+  const longestItem = routes.sort((a, b) => {
+    const firstItem = a[name] ? a[name].length : 0;
+    const secondItem = b[name] ? b[name].length : 0;
+
+    return secondItem - firstItem
+  })[0];
+
+  return longestItem[name].length;
+};
+
+export default routes => {
+  let toPrint = '';
+
+  const longestSrc = longestProperty(routes, 'src');
+  const longestDest = longestProperty(routes, 'dest');
+
+  const padding = 6;
+  const space = ' '.repeat(padding);
+  const destSpace = ' '.repeat(longestDest);
+  const arrow = chalk.grey('->')
+
+  for (const item of routes) {
+    const { src, dest, status, headers } = item;
+    const last = routes.indexOf(item) === (routes.length - 1);
+    const suffix = last ? '' : `\n`;
+
+    const finalSrc = chalk.cyan(src.padEnd(longestSrc + padding));
+    const finalDest = dest ? `${arrow}${space}${dest}` : `  ${space}${destSpace}`;
+    const finalStatus = chalk.grey(status ? `[${status}]` : '[status inferred]');
+
+    let finalHeaders = null;
+
+    if (headers) {
+      finalHeaders = `\n`;
+
+      const headerKeys = Object.keys(headers);
+
+      for (const header of headerKeys) {
+        const value = headers[header];
+        const last = headerKeys.indexOf(header) === (headerKeys.length - 1);
+        const suffix = last ? '' : `\n`;
+        const prefix = chalk.grey(last ? '└──' : '├──');
+
+        finalHeaders += `${prefix} ${header}: ${value}${suffix}`;
+      }
+    }
+
+    const prefix = chalk.grey(finalHeaders ? '┌' : '╶');
+    const fill = `${finalSrc}${finalDest}${space}${finalStatus}`;
+
+    toPrint += `${prefix} ${fill}${finalHeaders || ''}${suffix}`;
+  }
+
+  return toPrint;
+};


### PR DESCRIPTION
This PR:

- Ensures we're using the v6 API instead of v5 in `now inspect` for 2.0 deployments
- Changes the section design in `now inspect` (more spacing)
- Introduces a new design for "Builds" and adds a "Routes" section for 2.0 deployments

---

![image](https://user-images.githubusercontent.com/6170607/50787614-2de7ec80-12b7-11e9-9709-ec1ee62bca17.png)

