### PR TITLE
Prevent a user error from being reported

### DIFF
--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -411,7 +411,15 @@ async function sync({
           sessionAffinity
         ));
       } catch (err) {
-        if (err.code === 'config_prop_and_file' || err.code === 'dockerfile_missing' || err.code === 'no_dockerfile_commands' || err.code === 'unsupported_deployment_type') {
+        const print = [
+          'config_prop_and_file',
+          'dockerfile_missing',
+          'no_dockerfile_commands',
+          'unsupported_deployment_type',
+          'multiple_manifests'
+        ];
+
+        if (err.code && print.includes(err.code)) {
           error(err.message);
           return 1;
         }

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -1039,7 +1039,7 @@ async function readMeta(
       sessionAffinity: _sessionAffinity
     };
   } catch (err) {
-    if (isTTY && err.code === 'MULTIPLE_MANIFESTS') {
+    if (isTTY && err.code === 'multiple_manifests') {
       debug('Multiple manifests found, disambiguating');
       log(
         `Two manifests found. Press [${chalk.bold(

--- a/src/util/read-metadata.js
+++ b/src/util/read-metadata.js
@@ -1,16 +1,10 @@
-// Native
 import { basename, resolve as resolvePath } from 'path';
-
-// Packages
 import chalk from 'chalk';
-
 import loadJSON from 'load-json-file';
 import loadPackageJSON from 'read-pkg';
 import fs from 'fs';
 import { parse as parseDockerfile } from 'docker-file-parser';
 import determineType from 'deployment-type';
-
-// Utilities
 import getLocalConfigPath from './config/local-path';
 
 export default readMetaData;
@@ -74,7 +68,7 @@ async function readMetaData(
           'Please supply `--npm` or `--docker` to disambiguate.'
       );
 
-      err.code = 'MULTIPLE_MANIFESTS';
+      err.code = 'multiple_manifests';
 
       throw err;
     }

--- a/test/unit.js
+++ b/test/unit.js
@@ -362,7 +362,7 @@ test('throws when `package.json` and `Dockerfile` exist', async t => {
   } catch (err) {
     e = err;
   }
-  t.is(e.code, 'MULTIPLE_MANIFESTS');
+  t.is(e.code, 'multiple_manifests');
   t.pass(/ambiguous deployment/i.test(e.message));
 });
 


### PR DESCRIPTION
This prevents an error about multiple manifests from being reported to Sentry (user error).