### PR TITLE
Made `now domains inspect` match `now inspect`

### DIFF
--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -79,21 +79,21 @@ export default async function inspect(
 
   output.log(`Domain ${domainName} found under ${chalk.bold(contextName)} ${chalk.gray(inspectStamp())}`);
   output.print('\n');
-  output.print(chalk.bold('  Domain Info\n'));
-  output.print(`    ${chalk.dim('name')}\t\t${domain.name}\n`);
-  output.print(`    ${chalk.dim('serviceType')}\t\t${domain.serviceType}\n`);
-  output.print(`    ${chalk.dim('orderedAt')}\t\t${formatDate(domain.orderedAt)}\n`);
-  output.print(`    ${chalk.dim('createdAt')}\t\t${formatDate(domain.createdAt)}\n`);
-  output.print(`    ${chalk.dim('boughtAt')}\t\t${formatDate(domain.boughtAt)}\n`);
-  output.print(`    ${chalk.dim('expiresAt')}\t\t${formatDate(domain.expiresAt)}\n`);
-  output.print(`    ${chalk.dim('nsVerifiedAt')}\t${formatDate(domain.nsVerifiedAt)}\n`);
+  output.print(chalk.bold('  General\n\n'));
+  output.print(`    ${chalk.cyan('name')}\t\t${domain.name}\n`);
+  output.print(`    ${chalk.cyan('serviceType')}\t\t${domain.serviceType}\n`);
+  output.print(`    ${chalk.cyan('orderedAt')}\t\t${formatDate(domain.orderedAt)}\n`);
+  output.print(`    ${chalk.cyan('createdAt')}\t\t${formatDate(domain.createdAt)}\n`);
+  output.print(`    ${chalk.cyan('boughtAt')}\t\t${formatDate(domain.boughtAt)}\n`);
+  output.print(`    ${chalk.cyan('expiresAt')}\t\t${formatDate(domain.expiresAt)}\n`);
+  output.print(`    ${chalk.cyan('nsVerifiedAt')}\t${formatDate(domain.nsVerifiedAt)}\n`);
   output.print(
-    `    ${chalk.dim('txtVerifiedAt')}\t${formatDate(domain.txtVerifiedAt)}\n`
+    `    ${chalk.cyan('txtVerifiedAt')}\t${formatDate(domain.txtVerifiedAt)}\n`
   );
-  output.print(`    ${chalk.dim('cdnEnabled')}\t\t${domain.cdnEnabled}\n`);
+  output.print(`    ${chalk.cyan('cdnEnabled')}\t\t${domain.cdnEnabled}\n`);
   output.print('\n');
 
-  output.print(chalk.bold('  Nameservers\n'));
+  output.print(chalk.bold('  Nameservers\n\n'));
   output.print(
     `${formatNSTable(domain.intendedNameservers, domain.nameservers, {
       extraSpace: '    '
@@ -101,7 +101,7 @@ export default async function inspect(
   );
   output.print('\n');
 
-  output.print(chalk.bold('  Verification Record\n'));
+  output.print(chalk.bold('  Verification Record\n\n'));
   output.print(
     `${dnsTable([['_now', 'TXT', domain.verificationRecord]], {
       extraSpace: '    '

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -44,7 +44,7 @@ const help = () => {
 
   ${chalk.gray('-')} Get information about the deployment an alias points to
 
-    ${chalk.cyan('$ now scale my-deployment.now.sh')}
+    ${chalk.cyan('$ now inspect my-deployment.now.sh')}
   `);
 };
 
@@ -170,7 +170,7 @@ export default async function main(ctx) {
   );
 
   print('\n');
-  print(chalk.bold('  Meta\n\n'));
+  print(chalk.bold('  General\n\n'));
   print(`    ${chalk.cyan('version')}\t${version}\n`);
   print(`    ${chalk.cyan('id')}\t\t${finalId}\n`);
   print(`    ${chalk.cyan('name')}\t${name}\n`);


### PR DESCRIPTION
This improves the UI of `now domains inspect` and makes it match `now inspect`:

![screenshot 2019-01-09 at 15 28 08](https://user-images.githubusercontent.com/6170607/50905487-3d844400-1423-11e9-91f7-b7ecd162b9a9.png)

Furthermore, it removes `now scale` from the `now inspect` help:

![image](https://user-images.githubusercontent.com/6170607/50905224-9a332f00-1422-11e9-83d8-d866047e95b3.png)
