### PR TITLE
Do not render that status was inferred

### DIFF
--- a/src/util/output/routes.js
+++ b/src/util/output/routes.js
@@ -29,7 +29,7 @@ export default routes => {
 
     const finalSrc = chalk.cyan(src.padEnd(longestSrc + padding));
     const finalDest = dest ? `${arrow}${space}${dest}` : `  ${space}${destSpace}`;
-    const finalStatus = chalk.grey(status ? `[${status}]` : '[status inferred]');
+    const finalStatus = status ? chalk.grey(`[${status}]`) : '';
 
     let finalHeaders = null;
 


### PR DESCRIPTION
This hides `[status inferred]` from `now inspect`, as it might cause confusion. Instead, we simply show nothing instead.