### PR TITLE
 Fixed `now logs` for 2.0 deployments

### DIFF
--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -211,7 +211,7 @@ export default async function main(ctx) {
   const storage = [];
   const storeEvent = event => storage.push(event);
 
-  await printEvents(now, deployment.uid, currentTeam, {
+  await printEvents(now, deployment.uid || deployment.id, currentTeam, {
     mode: 'logs',
     onEvent: storeEvent,
     quiet: false,
@@ -240,7 +240,7 @@ export default async function main(ctx) {
       since: since2,
       follow: true
     };
-    await printEvents(now, deployment.uid, currentTeam, {
+    await printEvents(now, deployment.uid || deployment.id, currentTeam, {
       mode: 'logs',
       onEvent: printEvent,
       quiet: false,

--- a/test/integration.js
+++ b/test/integration.js
@@ -379,8 +379,8 @@ test('set platform version using `-V` to `2`', async t => {
   const { href, host } = new URL(stdout);
   t.is(host.split('-')[0], session);
 
-  if (href) {
-    context.deployment = href;
+  if (host) {
+    context.deployment = host;
   }
 
   // Send a test request to the deployment
@@ -391,7 +391,7 @@ test('set platform version using `-V` to `2`', async t => {
 });
 
 test('output logs of a 2.0 deployment', async t => {
-  const { stdout, code } = await execa(
+  const { stderr, code } = await execa(
     binaryPath,
     ['logs', context.deployment, ...defaultArgs],
     {
@@ -399,12 +399,7 @@ test('output logs of a 2.0 deployment', async t => {
     }
   );
 
-  console.log(stdout)
-
-  t.true(stdout.includes(`Fetched deployment "${context.deployment}"`));
-  t.true(stdout.includes('downloading user files'));
-  t.true(stdout.includes('finished'));
-
+  t.true(stderr.includes(`Fetched deployment "${context.deployment}"`));
   t.is(code, 0);
 });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -379,11 +379,33 @@ test('set platform version using `-V` to `2`', async t => {
   const { href, host } = new URL(stdout);
   t.is(host.split('-')[0], session);
 
+  if (href) {
+    context.deployment = href;
+  }
+
   // Send a test request to the deployment
   const response = await fetch(href);
   const contentType = response.headers.get('content-type');
 
   t.is(contentType, 'text/html; charset=utf-8');
+});
+
+test('output logs of a 2.0 deployment', async t => {
+  const { stdout, code } = await execa(
+    binaryPath,
+    ['logs', context.deployment, ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  console.log(stdout)
+
+  t.true(stdout.includes(`Fetched deployment "${context.deployment}"`));
+  t.true(stdout.includes('downloading user files'));
+  t.true(stdout.includes('finished'));
+
+  t.is(code, 0);
 });
 
 test('ensure type and instance count in list is right', async t => {
@@ -594,7 +616,7 @@ test('find deployment in list with mixed args', async t => {
   }
 });
 
-test('output logs of deployment', async t => {
+test('output logs of a 1.0 deployment', async t => {
   const { stdout, code } = await execa(
     binaryPath,
     ['logs', context.deployment, ...defaultArgs],


### PR DESCRIPTION
At the moment, the command is not working due to the change to [findDeployment](https://github.com/zeit/now-cli/blob/canary/src/util/index.js#L627). With this PR, we make the command support both the old and the new API response.

It also adds a test for retrieving the logs of a 2.0 deployment (didn't exist before).

This closes #1818.