### PR TITLE
Fix config file message

### DIFF
--- a/src/util/config/get-default.js
+++ b/src/util/config/get-default.js
@@ -3,7 +3,7 @@ export const getDefaultConfig = async existingCopy => {
 
   const config = {
     _:
-      'This is your Now config file. See `now config help`. More: https://bit.ly/2qAK8bb'
+      'This is your Now config file. For more information see the global configuration documentation: https://bit.ly/2qAK8bb'
   };
 
   if (existingCopy) {


### PR DESCRIPTION
This pull request removes the suggestion of using `now config help` since the command does not exist. Instead, it offers the documentation for global configuration as a single source of truth for information on the file.