### PR TITLE
Add the command to sentry

### DIFF
--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -43,8 +43,7 @@ export default async (sentry, error, apiUrl, configFiles) => {
         scope.setTag('currentTeam', team.id);
       }
 
-      const argv = process.argv.join(' ');
-      scope.setExtra('argv', argv);
+      scope.setExtra('argv', process.argv);
 
       sentry.captureException(error);
     });

--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -43,8 +43,8 @@ export default async (sentry, error, apiUrl, configFiles) => {
         scope.setTag('currentTeam', team.id);
       }
 
-      const command = process.argv.slice(2).join(' ');
-      scope.setTag('command', `now ${command}`);
+      const argv = process.argv.join(' ');
+      scope.setExtra('argv', argv);
 
       sentry.captureException(error);
     });

--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -43,6 +43,9 @@ export default async (sentry, error, apiUrl, configFiles) => {
         scope.setTag('currentTeam', team.id);
       }
 
+      const command = process.argv.slice(2).join(' ');
+      scope.setTag('command', `now ${command}`);
+
       sentry.captureException(error);
     });
   } else {


### PR DESCRIPTION
Adds a `command` tag to sentry which includes the command the user entered.

This will make it easier to reproduce errors.