### PR TITLE
Show deployment URL at the end too

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -72,7 +72,7 @@ const printDeploymentStatus = (
   builds
 ) => {
   if (readyState === 'READY') {
-    output.success(`Deployment ready ${deployStamp()}`);
+    output.success(`Deployment ready at ${chalk.bold(chalk.cyan(url))} ${deployStamp()}`);
     return 0;
   }
 


### PR DESCRIPTION
This comes in handy when the list of builds and their output is really long:

![image](https://user-images.githubusercontent.com/6170607/51204099-0f12d700-1903-11e9-9042-6ed87f4ce637.png)
