### PR TITLE
Ensure project name is always defined

### DIFF
--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -657,7 +657,7 @@ async function sync({
 
     try {
       meta.name = getProjectName({argv, nowConfig, isFile, paths});
-      log(`Using project ${chalk.bold(meta.project)}`);
+      log(`Using project ${chalk.bold(meta.name)}`);
       // $FlowFixMe
       const createArgs = Object.assign(
         {

--- a/src/util/get-project-name.js
+++ b/src/util/get-project-name.js
@@ -2,6 +2,7 @@ import {basename} from 'path';
 
 export default function getProjectName({argv, nowConfig, isFile, paths}) {
   const nameCli = argv['--name'] || argv.name;
+
   if (nameCli) {
     return nameCli;
   }


### PR DESCRIPTION
With this change, we prevent the following error:

![image](https://user-images.githubusercontent.com/6170607/51270613-b5bfac00-19c5-11e9-8703-316958907c04.png)
