### PR TITLE
Fix formatting issues on "projects rm" confirmation.

### DIFF
--- a/src/commands/projects.js
+++ b/src/commands/projects.js
@@ -206,8 +206,8 @@ process.on('uncaughtException', err => {
 function readConfirmation(projectName) {
   return new Promise(resolve => {
     process.stdout.write(
-      ` The project: ${chalk.bold(projectName)} will be removed permanently\n` +
-      ` It will also delete everything under the project including deployments\n.`
+      `The project: ${chalk.bold(projectName)} will be removed permanently.\n` +
+      `It will also delete everything under the project including deployments.\n`
     );
 
     process.stdout.write(


### PR DESCRIPTION
This is how it looks now (after this change).

<img width="553" alt="screen shot 2019-01-17 at 4 19 17 am" src="https://user-images.githubusercontent.com/50838/51283769-42428c80-1a0f-11e9-9244-a6bd7a093065.png">
