### PR TITLE
Ensure `name` in `package.json` works for Now 1.0

### DIFF
--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -656,7 +656,7 @@ async function sync({
     let syncCount;
 
     try {
-      meta.name = getProjectName({argv, nowConfig, isFile, paths});
+      meta.name = getProjectName({argv, nowConfig, isFile, paths, pre: meta.name});
       log(`Using project ${chalk.bold(meta.name)}`);
       // $FlowFixMe
       const createArgs = Object.assign(

--- a/src/util/get-project-name.js
+++ b/src/util/get-project-name.js
@@ -1,6 +1,6 @@
 import {basename} from 'path';
 
-export default function getProjectName({argv, nowConfig, isFile, paths}) {
+export default function getProjectName({argv, nowConfig, isFile, paths, pre}) {
   const nameCli = argv['--name'] || argv.name;
 
   if (nameCli) {
@@ -9,6 +9,12 @@ export default function getProjectName({argv, nowConfig, isFile, paths}) {
 
   if (nowConfig.name) {
     return nowConfig.name;
+  }
+
+  // For the legacy deployment pipeline, the name might have already
+  // been determined using `package.json`.
+  if (pre) {
+    return pre;
   }
 
   if (isFile || paths.length > 1) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -146,6 +146,25 @@ test('deploy a node microservice', async t => {
   t.is(content.id, session);
 });
 
+test('deploy a node microservice and infer name from `package.json`', async t => {
+  const target = fixture('node');
+
+  const { stdout, code } = await execa(
+    binaryPath,
+    [target, '--public', ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { host } = new URL(stdout);
+  t.is(host.split('-')[0], `node-test-${session}`);
+});
+
 test('find deployment in list', async t => {
   const { stdout, code } = await execa(binaryPath, ['ls', ...defaultArgs], {
     reject: false

--- a/test/integration.js
+++ b/test/integration.js
@@ -162,7 +162,7 @@ test('deploy a node microservice and infer name from `package.json`', async t =>
 
   // Test if the output is really a URL
   const { host } = new URL(stdout);
-  t.is(host.split('-')[0], `node-test-${session}`);
+  t.true(host.startsWith(`node-test-${session}`));
 });
 
 test('find deployment in list', async t => {


### PR DESCRIPTION
This will ensure defining `name` in `package.json` works for Now 1.0 deployments.