### PR TITLE
deploymentId is optional for rules.json deployment

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -166,7 +166,7 @@ export type Alias = {
     username: string;
     email: string;
   };
-  deploymentId: string;
+  deploymentId?: string;
   rules?: PathAliasRule[];
 };
 

--- a/src/util/alias/get-deployment-from-alias.ts
+++ b/src/util/alias/get-deployment-from-alias.ts
@@ -1,5 +1,4 @@
 import Client from '../client';
-import { Output } from '../output';
 import { Deployment, Alias } from '../../types';
 import fetchDeploymentByIdOrHost from '../deploy/get-deployment-by-id-or-host';
 
@@ -9,7 +8,7 @@ export default async function fetchDeploymentFromAlias(
   prevAlias: Alias | null,
   currentDeployment: Deployment
 ) {
-  return prevAlias && prevAlias.deploymentId !== currentDeployment.uid
+  return prevAlias && prevAlias.deploymentId && prevAlias.deploymentId !== currentDeployment.uid
     ? fetchDeploymentByIdOrHost(client, contextName, prevAlias.deploymentId)
     : null;
 }


### PR DESCRIPTION
I ran into this when trying to alias a Now 2.0 deployment to nextjs.org, which was previously a rules.json deployment.