### PR TITLE
Add ability to import a zone file

### DIFF
--- a/src/commands/dns/import.ts
+++ b/src/commands/dns/import.ts
@@ -1,0 +1,70 @@
+import chalk from 'chalk';
+import { NowContext } from '../../types';
+import { Output } from '../../util/output';
+import Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { DomainNotFound, InvalidDomain } from '../../util/errors-ts';
+import stamp from '../../util/output/stamp';
+import importZonefile from '../../util/dns/import-zonefile';
+
+type Options = {
+  '--debug': boolean;
+  '--zone-file': string;
+};
+
+export default async function add(
+  ctx: NowContext,
+  opts: Options,
+  args: string[],
+  output: Output
+) {
+  const { authConfig: { token }, config } = ctx;
+  const { currentTeam } = config;
+  const { apiUrl } = ctx;
+  const debug = opts['--debug'];
+  const client = new Client({ apiUrl, token, currentTeam, debug });
+  let contextName = null;
+
+  try {
+    ({ contextName } = await getScope(client));
+  } catch (err) {
+    if (err.code === 'not_authorized') {
+      output.error(err.message);
+      return 1;
+    }
+
+    throw err;
+  }
+
+  const addStamp = stamp();
+  const [domain] = args;
+  const { '--zone-file': zonefilePath } = opts;
+
+  const recordIds = await importZonefile(client, contextName, domain, zonefilePath);
+  if (recordIds instanceof DomainNotFound) {
+    output.error(
+      `The domain ${domain} can't be found under ${chalk.bold(
+        contextName
+      )} ${chalk.gray(addStamp())}`
+    );
+    return 1;
+  }
+
+  if (recordIds instanceof InvalidDomain) {
+    output.error(
+      `The domain ${domain} doesn't match with the one found in the Zone file ${
+        chalk.gray(addStamp())
+      }`
+    );
+    return 1;
+  }
+
+  console.log(
+    `${chalk.cyan('> Success!')} ${recordIds.length} DNS records for domain ${chalk.bold(
+      domain
+    )} created under ${chalk.bold(
+      contextName
+    )} ${chalk.gray(addStamp())}`
+  );
+  return 0;
+}

--- a/src/commands/dns/import.ts
+++ b/src/commands/dns/import.ts
@@ -9,7 +9,6 @@ import importZonefile from '../../util/dns/import-zonefile';
 
 type Options = {
   '--debug': boolean;
-  '--zone-file': string;
 };
 
 export default async function add(
@@ -36,9 +35,17 @@ export default async function add(
     throw err;
   }
 
+  if (args.length !== 2) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        '`now dns import <domain> <zonefile>`'
+      )}`
+    );
+    return 1;
+  }
+
   const addStamp = stamp();
-  const [domain] = args;
-  const { '--zone-file': zonefilePath } = opts;
+  const [domain, zonefilePath] = args;
 
   const recordIds = await importZonefile(client, contextName, domain, zonefilePath);
   if (recordIds instanceof DomainNotFound) {

--- a/src/commands/dns/index.ts
+++ b/src/commands/dns/index.ts
@@ -68,7 +68,7 @@ const help = () => {
   ${chalk.gray('–')} Import a Zone file
 
       ${chalk.cyan(
-        '$ now dns import <DOMAIN> --zone-file <FILE>'
+        '$ now dns import <DOMAIN> <FILE>'
       )}
       ${chalk.cyan(`$ now dns add zeit.rocks '@' SRV 10 0 389 zeit.party`)}
 
@@ -87,9 +87,7 @@ export default async function main(ctx: NowContext) {
   let argv;
 
   try {
-    argv = getArgs(ctx.argv.slice(2), {
-      '--zone-file': String,
-    });
+    argv = getArgs(ctx.argv.slice(2), {});
   } catch (error) {
     handleError(error);
     return 1;

--- a/src/commands/dns/index.ts
+++ b/src/commands/dns/index.ts
@@ -8,6 +8,7 @@ import handleError from '../../util/handle-error';
 import logo from '../../util/output/logo';
 
 import add from './add';
+import importZone from './import';
 import ls from './ls';
 import rm from './rm';
 
@@ -63,11 +64,21 @@ const help = () => {
         `$ now dns add <DOMAIN> <NAME> CAA '<FLAGS> <TAG> "<VALUE>"'`
       )}
       ${chalk.cyan(`$ now dns add zeit.rocks '@' CAA '0 issue "zeit.co"'`)}
+
+  ${chalk.gray('–')} Import a Zone file
+
+      ${chalk.cyan(
+        '$ now dns import <DOMAIN> --zone-file <FILE>'
+      )}
+      ${chalk.cyan(`$ now dns add zeit.rocks '@' SRV 10 0 389 zeit.party`)}
+
+
 `);
 };
 
 const COMMAND_CONFIG = {
   add: ['add'],
+  import: ['import'],
   ls: ['ls', 'list'],
   rm: ['rm', 'remove']
 };
@@ -76,7 +87,9 @@ export default async function main(ctx: NowContext) {
   let argv;
 
   try {
-    argv = getArgs(ctx.argv.slice(2), {});
+    argv = getArgs(ctx.argv.slice(2), {
+      '--zone-file': String,
+    });
   } catch (error) {
     handleError(error);
     return 1;
@@ -92,6 +105,8 @@ export default async function main(ctx: NowContext) {
   switch (subcommand) {
     case 'add':
       return add(ctx, argv, args, output);
+    case 'import':
+      return importZone(ctx, argv, args, output);
     case 'rm':
       return rm(ctx, argv, args, output);
     default:

--- a/src/util/client.ts
+++ b/src/util/client.ts
@@ -8,7 +8,7 @@ import responseError from './response-error';
 import ua from './ua';
 
 export type FetchOptions = {
-  body?: NodeJS.ReadableStream | object;
+  body?: NodeJS.ReadableStream | object | string;
   headers?: { [key: string]: string };
   json?: boolean;
   method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';

--- a/src/util/dns/import-zonefile.ts
+++ b/src/util/dns/import-zonefile.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { Response } from 'fetch-h2'
+import { DomainNotFound, InvalidDomain } from '../errors-ts';
+import Client from '../client';
+import wait from '../output/wait';
+
+type JSONResponse = {
+  recordIds: string[]
+}
+
+export default async function importZonefile(
+  client: Client,
+  contextName: string,
+  domain: string,
+  zonefilePath: string,
+) {
+  const cancelWait = wait(`Importing Zone file for domain ${domain} under ${chalk.bold(contextName)}`);
+  const zonefile = readFileSync(resolve(zonefilePath), 'utf8');
+
+  try {
+    const res = await client.fetch<Response>(`/v3/domains/${domain}/records`, {
+      headers: { 'Content-Type': 'text/dns' },
+      body: zonefile,
+      method: 'PUT',
+      json: false,
+    });
+
+    const { recordIds } = await res.json() as JSONResponse;
+    cancelWait();
+    return recordIds;
+  } catch (error) {
+    cancelWait();
+    if (error.code === 'not_found') {
+      return new DomainNotFound(domain);
+    } else if (error.code === 'invalid_domain') {
+      return new InvalidDomain(domain);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
This PR introduces a new command to Now CLI: `now dns import`. It will allow us to pass a Zone file as an argument and create all records it includes for the domain given in the command. The API is as follows:

```
now-cli ❯ now-dev dns import arrakis.online --zone-file ~/arrakis.online.txt
> Success! 3 DNS records for domain arrakis.online created under javivelasco [13s]
```