### PR TITLE
Update legacy note structure

### DIFF
--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -817,7 +817,7 @@ async function sync({
           note(
             `You can use ${cmd(
               'now --public'
-            )} or upgrade your plan (${url}) to skip this prompt`
+            )} or upgrade your plan to skip this prompt. More: ${url}`
           );
 
           if (!proceed) {


### PR DESCRIPTION
Legacy accounts get the following note during deployment:

```sh
NOTE: You can use `now --public` or upgrade your plan (https://zeit.co/account/plan) to skip this prompt
```
This will a) move the account link to the end of the note and b) remove the enclosing parenthesis, to avoid breaking the hyperlink on [hyper](https://github.com/zeit/hyper). A similar case was also mentioned in https://github.com/zeit/now-cli/pull/990#issuecomment-345058368.