### PR TITLE
Add missing error: InvalidAuthCode

### DIFF
--- a/src/commands/domains/transfer-in.ts
+++ b/src/commands/domains/transfer-in.ts
@@ -92,7 +92,7 @@ export default async function transferIn(
   }
 
   const transferStamp = stamp();
-  const transferInResult = await withSpinner('Initiating transfer', () =>
+  const transferInResult = await withSpinner(`Initiating transfer for domain ${domainName}`, () =>
     transferInDomain(client, domainName, authCode, price)
   );
 
@@ -108,6 +108,11 @@ export default async function transferIn(
     output.error(
       `The domain "${transferInResult.meta.domain}" is not transferable.`
     );
+    return 1;
+  }
+
+  if (transferInResult instanceof ERRORS.InvalidTransferAuthCode) {
+    output.error(`The provided auth code does not match with the one expected by the current registar`);
     return 1;
   }
 

--- a/src/util/domains/transfer-in-domain.ts
+++ b/src/util/domains/transfer-in-domain.ts
@@ -18,7 +18,6 @@ export default async function transferInDomain(
       method: 'POST'
     });
   } catch (error) {
-    console.error(error.code, error);
     if (error.code === 'invalid_name') {
       return new ERRORS.InvalidDomain(name);
     }
@@ -27,6 +26,9 @@ export default async function transferInDomain(
     }
     if (error.code === 'not_transferable') {
       return new ERRORS.DomainNotTransferable(name);
+    }
+    if (error.code === 'invalid_auth_code') {
+      return new ERRORS.InvalidTransferAuthCode(name, authCode);
     }
     throw error;
   }

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -164,6 +164,19 @@ export class SourceNotFound extends NowError<'SOURCE_NOT_FOUND', {}> {
   }
 }
 
+export class InvalidTransferAuthCode extends NowError<
+  'INVALID_TRANSFER_AUTH_CODE',
+  { domain: string, authCode: string }
+> {
+  constructor(domain: string, authCode: string) {
+    super({
+      code: 'INVALID_TRANSFER_AUTH_CODE',
+      meta: { domain, authCode },
+      message: `The provided auth code does not match with the one expected by the current registar`
+    })
+  }
+}
+
 /**
  * When information about a domain is requested but the domain doesn't exist
  */


### PR DESCRIPTION
This PR controls a new error that wasn't being controlled for when the user provides a wrong `authCode` for a transfer