### PR TITLE
fix typo in alias command

### DIFF
--- a/src/commands/alias/set.ts
+++ b/src/commands/alias/set.ts
@@ -120,7 +120,7 @@ export default async function set(
   }
 
   if (targets instanceof ERRORS.NoAliasInConfig) {
-    output.error(`Couldn't find a an alias in config`);
+    output.error(`Couldn't find an alias in config`);
     return 1;
   }
 


### PR DESCRIPTION
Fixes a grammatical error in the `$ now alias` command output.