### PR TITLE
Add a hint to an error message about missing token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ const main = async argv_ => {
       console.error(
         error(
           `The content of "${hp(NOW_AUTH_CONFIG_PATH)}" is invalid. ` +
-            'No `token` property found inside'
+            'No `token` property found inside. Run `now login` to authorize.'
         )
       );
       return 1;


### PR DESCRIPTION
I wanted to deploy my app with `now` and got the error message that says: 
`> Error! The content of "~/.now/auth.json" is invalid. No token property found inside`

As its mentioning such words as auth & token, I guess its not too difficult to conclude that you have to go through some authorization process. Just to make it easier to understand that it's the case and also to give a hint how to do this, without looking into documentation, I think its a good idea to add a hint about this. Its just couple of words that clarify what is going on and what needs to be done ✌️ 