### PR TITLE
Catch `SourceNotFound` error for domains transfer-in

### DIFF
--- a/src/commands/domains/transfer-in.ts
+++ b/src/commands/domains/transfer-in.ts
@@ -116,6 +116,13 @@ export default async function transferIn(
     return 1;
   }
 
+  if (transferInResult instanceof ERRORS.SourceNotFound) {
+    output.error(
+      `Could not purchase domain. Please add a payment method using ${cmd('now billing add')}.`
+    );
+    return 1;
+  }
+
   console.log(`${chalk.cyan('> Success!')} Domain ${param(domainName)} transfer started ${transferStamp()}`);
   output.print(`  To finalize the transfer, we are waiting for approval from your current registrar.\n`);
   output.print(`  You will receive an email upon completion.\n`);

--- a/src/util/domains/transfer-in-domain.ts
+++ b/src/util/domains/transfer-in-domain.ts
@@ -30,6 +30,9 @@ export default async function transferInDomain(
     if (error.code === 'invalid_auth_code') {
       return new ERRORS.InvalidTransferAuthCode(name, authCode);
     }
+    if (error.code === 'source_not_found') {
+      return new ERRORS.SourceNotFound();
+    }
     throw error;
   }
 }


### PR DESCRIPTION
This catches an error when a user does not have billing info on file and attempts to transfer-in a domain.