### PR TITLE
Show deployment url in success message

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -71,7 +71,7 @@ const printDeploymentStatus = (
   builds
 ) => {
   if (readyState === 'READY') {
-    output.success(`Deployment ready ${deployStamp()}`);
+    output.success(`Deployment ${chalk.bold(url)} ready ${deployStamp()}`);
     return 0;
   }
 


### PR DESCRIPTION
Currently the deployment address is only shown at the beginning of the deployment console output.

This PR adds the URL to the deployment success message so it's available without scrolling to the beginning of the log.

I didn't attempt to copy to clipboard again at this point as it feels too distant from the initiation of the command to do so.

Is there a reason this wasn't included at the end of the output already?

![screenshot 2019-02-17 at 13 58 06](https://user-images.githubusercontent.com/571764/52914123-68807400-32bc-11e9-8513-b1f0fa7ba083.png)