### PR TITLE
Use XDG standard instead of writing to home directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/glob": "7.1.1",
     "@types/http-proxy": "1.16.2",
     "@types/load-json-file": "2.0.7",
+    "@types/lodash.head": "4.0.6",
     "@types/micro": "7.3.3",
     "@types/mime-types": "2.1.0",
     "@types/minimatch": "3.0.3",
@@ -196,5 +197,9 @@
     "which-promise": "1.0.0",
     "write-json-file": "2.2.0",
     "yarn": "1.17.3"
+  },
+  "dependencies": {
+    "lodash.head": "4.0.1",
+    "xdg-portable": "7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "jaro-winkler": "0.2.8",
     "jsonlines": "0.1.1",
     "load-json-file": "3.0.0",
+    "lodash.head": "4.0.1",
     "micro": "9.1.2",
     "mime-types": "2.1.24",
     "minimatch": "3.0.4",
@@ -196,10 +197,7 @@
     "which": "1.3.1",
     "which-promise": "1.0.0",
     "write-json-file": "2.2.0",
+    "xdg-portable": "7.0.3",
     "yarn": "1.17.3"
-  },
-  "dependencies": {
-    "lodash.head": "4.0.1",
-    "xdg-portable": "7.0.3"
   }
 }

--- a/src/util/config/global-path.ts
+++ b/src/util/config/global-path.ts
@@ -1,12 +1,31 @@
 // Native
 import { homedir } from 'os';
+import fs from 'fs';
 
 import path from 'path';
 
 // Packages
 import mri from 'mri';
 
-const getNowDir = () => {
+// The `homeConfigPath` is the legacy configuration path located in the users home directory.
+const homeConfigPath: string = path.join(homedir(), '.now');
+
+// The `xdgConfigPath` is the configuration path which is based on the XDG standard.
+const xdgConfigPath: string = path.join(
+  process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share'),
+  'now'
+);
+
+// Returns wether a directory exists
+const isDirectory = (path: string): boolean => {
+  try {
+    return fs.lstatSync(path).isDirectory();
+  } catch (e) {
+    return false;
+  }
+};
+
+const getNowDir = (): string => {
   const args = mri(process.argv.slice(2), {
     string: ['global-config'],
     alias: {
@@ -15,12 +34,16 @@ const getNowDir = () => {
   });
 
   const customPath = args['global-config'];
-
-  if (!customPath) {
-    return path.join(homedir(), '.now');
+  if (customPath) {
+    return path.resolve(customPath);
   }
 
-  return path.resolve(customPath);
+  // legacy config exists
+  if (isDirectory(homeConfigPath)) {
+    return homeConfigPath;
+  }
+
+  return xdgConfigPath;
 };
 
 export default getNowDir;

--- a/src/util/config/global-path.ts
+++ b/src/util/config/global-path.ts
@@ -1,18 +1,20 @@
 // Native
 import { homedir } from 'os';
 import fs from 'fs';
-
 import path from 'path';
 
 // Packages
 import mri from 'mri';
+import xdg from 'xdg-portable';
+import head from 'lodash.head';
 
 // The `homeConfigPath` is the legacy configuration path located in the users home directory.
 const homeConfigPath: string = path.join(homedir(), '.now');
 
 // The `xdgConfigPath` is the configuration path which is based on the XDG standard.
+// the old legacy path is used as a fallback
 const xdgConfigPath: string = path.join(
-  process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share'),
+  process.env.XDG_DATA_HOME || (head(xdg.dataDirs()) || homeConfigPath),
   'now'
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,18 @@
   resolved "https://registry.yarnpkg.com/@types/load-json-file/-/load-json-file-2.0.7.tgz#c887826f5230b7507d5230994d26315c6776be06"
   integrity sha512-NrH6jPlV77QCVPhAHofWeiOr77TgpKt82c2RVxSBChWBJqyY/u4ngl3CA4mcsAg/w7rNLrkR7dkObMV0ihLLXw==
 
+"@types/lodash.head@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.head/-/lodash.head-4.0.6.tgz#5c793cfc420799174541412f24c0b0dc69652de5"
+  integrity sha512-WrbllVqxpgpEnLPNooU9q3h9vFVYUzS4sMDp0UpEnguIHFxdAA161UMnaJ92ccGSc87e901EHFwXbuNysdSaQg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.136"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
+  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
+
 "@types/micro@7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@types/micro/-/micro-7.3.3.tgz#31ead8df18ac10d58b7be1186d4b2d977b13a938"
@@ -4330,6 +4342,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.head@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.head/-/lodash.head-4.0.1.tgz#e2aa322d3ec40cd6aae186082977d993b354ed9c"
+  integrity sha1-4qoyLT7EDNaq4YYIKXfZk7NU7Zw=
+
 lodash.islength@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.islength/-/lodash.islength-4.0.1.tgz#4e9868d452575d750affd358c979543dc20ed577"
@@ -7183,6 +7200,11 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xdg-portable@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-7.0.3.tgz#f3c6a5babcb123fc9bc93a5696a8228be9a0ace3"
+  integrity sha512-52a8pF3pbBsXV7gcAd9RKNWN/A25dgxL695+HMvgX3xZ/g+d5ZzMgqP25OVkxrBqvzI2XsL6mpoSyPPjjHELNw==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
The `now-cli` places its config inside the `~` directory. This is a bad pattern as there is a standard which describes where specific types of files needed by programs should be placed.

This PR introduces that `now-cli` now uses the correct path (either `XDG_DATA_HOME/now` or `~/.local/share/now` as fallback)