### PR TITLE
Adds warning for domains-move token expiration

### DIFF
--- a/src/commands/domains/move-out.ts
+++ b/src/commands/domains/move-out.ts
@@ -85,6 +85,7 @@ export default async function moveOut(
 
   const { domain } = moveTokenResult;
   console.log(`${chalk.cyan('> Token')} ${domain.moveToken}`);
+  output.warn(`Your token will expire in 30 minutes`);
   return 0;
 }
 


### PR DESCRIPTION
Adds warning for domains-move token expiration

Example:
```
> Token Nfdjasklfsd;agd42%3D
> WARN! Your token will expire in 30 minutes
```