### PR TITLE
Add --no-scale option

### DIFF
--- a/src/commands/deploy/args.js
+++ b/src/commands/deploy/args.js
@@ -90,6 +90,7 @@ export const latestArgs = {
   '--env': [String],
   '--build-env': [String],
   '--meta': [String],
+  '--no-scale': Boolean,
   // This is not an array in favor of matching
   // the config property name.
   '--regions': String,
@@ -126,6 +127,7 @@ export const legacyArgsMri = {
     'npm',
     'static',
     'public',
+    'no-scale',
     'no-verify',
     'dotenv'
   ],
@@ -235,6 +237,7 @@ export const legacyHelp = () => `
     --session-affinity             Session affinity, \`ip\` or \`random\` (default) to control session affinity
     -T, --team                     Set a custom team scope
     --regions                      Set default regions or DCs to enable the deployment on
+    --no-scale                     Skip scaling rules deploying with the default presets
     --no-verify                    Skip step of waiting until instance count meets given constraints
   ${chalk.dim(`Enforceable Types (by default, it's detected automatically):`)}
     --npm                          Node.js application

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -215,7 +215,7 @@ export default async function main(
   let deployment = null;
 
   if (argv['--no-scale']) {
-    warn(`The option --no-scale is only considered for Now 1.0 deployments`);
+    warn(`The option --no-scale is only supported on Now 1.0 deployments`);
   }
 
   const isObject = item =>

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -181,7 +181,7 @@ export default async function main(
   }
 
   const { apiUrl, authConfig: { token }, config: { currentTeam } } = ctx;
-  const { log, debug, error, print } = output;
+  const { log, debug, error, print, warn } = output;
   const paths = Object.keys(stats);
   const debugEnabled = argv['--debug'];
 
@@ -214,6 +214,9 @@ export default async function main(
   let deployStamp = stamp();
   let deployment = null;
 
+  if (argv['--no-scale']) {
+    warn(`The option --no-scale is only considered for Now 1.0 deployments`);
+  }
 
   const isObject = item =>
     Object.prototype.toString.call(item) === '[object Object]';

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -78,6 +78,7 @@ let forwardNpm;
 let followSymlinks;
 let wantsPublic;
 let regions;
+let noScale;
 let noVerify;
 let apiUrl;
 let isTTY;
@@ -211,6 +212,7 @@ export default async function main(ctx, contextName, output, mriOpts) {
     .map(s => s.trim())
     .filter(Boolean);
   noVerify = argv.verify === false;
+  noScale = argv.scale === false;
   apiUrl = ctx.apiUrl;
   // https://github.com/facebook/flow/issues/1825
   // $FlowFixMe
@@ -479,6 +481,9 @@ async function sync({
         (result, dcId) => ({ ...result, [dcId]: { min: 0, max: 1 } }),
         {}
       );
+    } else if (noScale) {
+      debug(`Option --no-scale was set. Skipping scale parameters`)
+      scale = {}
     } else if (Object.keys(scaleFromConfig).length > 0) {
       // If we have no regions list we get it from the scale keys but we have to validate
       // them becase we don't admin `all` in this scenario. Also normalize presets in scale.


### PR DESCRIPTION
This PR adds a new option `--no-scale` that will prevent from using the given scaling rules for legacy deployments. For Now 2.0 it shows a warning message to tell that the option has no effect in that version.