### PR TITLE
Overwrite the default batch file on windows

### DIFF
--- a/download/src/index.js
+++ b/download/src/index.js
@@ -160,6 +160,16 @@ async function main() {
         gitBashFile,
         modifyGitBashFile(fs.readFileSync(gitBashFile, 'utf8'))
       );
+
+      let npmCmdFile = path.join(globalPath, 'now.cmd');
+      if (!fs.existsSync(npmCmdFile)) {
+        npmCmdFile = path.join(process.env.APPDATA, 'npm/now.cmd');
+      }
+
+      fs.writeFileSync(
+        npmCmdFile,
+        '%~dp0\\node_modules\\now\\download\\dist\\now.exe %*'
+      );
     } catch (err) {
       if (err.code !== 'ENOENT') {
         // Not a problem. only git cmd will not work

--- a/download/src/index.js
+++ b/download/src/index.js
@@ -168,7 +168,7 @@ async function main() {
 
       fs.writeFileSync(
         npmCmdFile,
-        '%~dp0\\node_modules\\now\\download\\dist\\now.exe %*'
+        '@%~dp0\\node_modules\\now\\download\\dist\\now.exe %*'
       );
     } catch (err) {
       if (err.code !== 'ENOENT') {


### PR DESCRIPTION
This will overwrite the `now.cmd` file on windows with the path to direct executable.

This will allow us to use a default fallback script if the `postinstall` script will not execute. And since it is overwriting the default `now.cmd` file it will directly call the executable without loading `node.exe` first.

Fixes #1923 