### PR TITLE
Continue with original command after login

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -255,7 +255,7 @@ const login = async ctx => {
     )
   );
 
-  return ctx;
+  return 0;
 };
 
 export default login;

--- a/src/index.js
+++ b/src/index.js
@@ -385,12 +385,15 @@ const main = async argv_ => {
     if (isTTY) {
       console.log(info(`No existing credentials found. Please log in:`));
 
-      subcommand = 'login';
-      ctx.argv[2] = 'login';
-
-      // Ensure that subcommands lead to login as well, if
-      // no credentials are defined
-      ctx.argv = ctx.argv.splice(0, 3);
+      const exitCode = await runCommand({
+        subcommand: 'login',
+        ctx: {
+          ...ctx,
+          argv: [ctx.argv[0], ctx.argv[1], 'login']
+        },
+        output
+      });
+      if (exitCode !== 0) return exitCode;
     } else {
       console.error(
         error({
@@ -519,6 +522,12 @@ const main = async argv_ => {
     }
   }
 
+  return runCommand({ subcommand, ctx, output });
+};
+
+debug('start');
+
+const runCommand = async ({ subcommand, ctx, output }) => {
   const targetCommand = commands[subcommand];
 
   if (!targetCommand) {
@@ -565,8 +574,6 @@ const main = async argv_ => {
 
   return exitCode;
 };
-
-debug('start');
 
 const handleRejection = async err => {
   debug('handling rejection');


### PR DESCRIPTION
Previously if the now-cli determined you would need to log in first in order to complete an action, it would exit after the login. With this change it continues with the command the user originally wished to run.

This means for example that a new user can run `now` and go through the whole sign up _and_ deploy flow in one command.

This was implemented by creating a `runCommand` function which will be run in case we need to run the whole `login` command first.

Closes #1934.