### PR TITLE
Fallback to descriptive api error message if we cannot resolve domain rm|move conflict

### DIFF
--- a/src/commands/domains/move.ts
+++ b/src/commands/domains/move.ts
@@ -95,9 +95,24 @@ export default async function move(
     return moveOutDomain(client, context, domainName, destination);
   });
   if (moveTokenResult instanceof ERRORS.DomainMoveConflict) {
-    output.error(
-      `Please remove custom suffix for ${param(domainName)} before moving out`
-    );
+    const { suffix, pendingAsyncPurchase } = moveTokenResult.meta;
+    if (suffix) {
+      output.error(
+        `Please remove custom suffix for ${param(domainName)} before moving out`
+      );
+      return 1;
+    }
+
+    if (pendingAsyncPurchase) {
+      output.error(
+        `Cannot remove ${param(
+          domain.name
+        )} because it is still in the process of being purchased.`
+      );
+      return 1;
+    }
+
+    output.error(moveTokenResult.message);
     return 1;
   }
   if (moveTokenResult instanceof ERRORS.DomainNotFound) {

--- a/src/commands/domains/rm.ts
+++ b/src/commands/domains/rm.ts
@@ -145,13 +145,34 @@ async function removeDomain(
   }
 
   if (removeResult instanceof ERRORS.DomainRemovalConflict) {
-    const { aliases, certs, suffix, transferring } = removeResult.meta;
+    const {
+      aliases,
+      certs,
+      suffix,
+      transferring,
+      pendingAsyncPurchase,
+      resolvable
+    } = removeResult.meta;
     if (transferring) {
       output.error(
         `${param(
           domain.name
         )} transfer should be declined or approved before removing.`
       );
+      return 1;
+    }
+
+    if (pendingAsyncPurchase) {
+      output.error(
+        `Cannot remove ${param(
+          domain.name
+        )} because it is still in the process of being purchased.`
+      );
+      return 1;
+    }
+
+    if (!resolvable) {
+      output.error(removeResult.message);
       return 1;
     }
 

--- a/src/commands/domains/rm.ts
+++ b/src/commands/domains/rm.ts
@@ -103,7 +103,8 @@ async function removeDomain(
   domain: Domain,
   aliasIds: string[] = [],
   certIds: string[] = [],
-  suffix: boolean = false
+  suffix: boolean = false,
+  attempt: number = 1
 ): Promise<number> {
   const removeStamp = stamp();
   output.debug(`Removing domain`);
@@ -145,6 +146,11 @@ async function removeDomain(
   }
 
   if (removeResult instanceof ERRORS.DomainRemovalConflict) {
+    if (attempt >= 2) {
+      output.error(removeResult.message);
+      return 1;
+    }
+
     const {
       aliases,
       certs,
@@ -218,14 +224,11 @@ async function removeDomain(
       domain,
       aliases,
       certs,
-      suffix
+      suffix,
+      attempt + 1
     );
   }
 
-  console.log(
-    `${chalk.cyan('> Success!')} Domain ${chalk.bold(
-      domain.name
-    )} removed ${removeStamp()}`
-  );
+  output.success(`Domain ${chalk.bold(domain.name)} removed ${removeStamp()}`);
   return 0;
 }

--- a/src/util/domains/move-out-domain.ts
+++ b/src/util/domains/move-out-domain.ts
@@ -29,8 +29,13 @@ export default async function moveOutDomain(
       return new ERRORS.InvalidMoveDestination(destination);
     }
     if (error.code === 'domain_move_conflict') {
-      const { suffix } = error;
-      return new ERRORS.DomainMoveConflict({ domain: name, suffix });
+      const { pendingAsyncPurchase, resolvable, suffix, message } = error;
+      return new ERRORS.DomainMoveConflict({
+        message,
+        pendingAsyncPurchase,
+        resolvable,
+        suffix
+      });
     }
     throw error;
   }

--- a/src/util/domains/remove-domain-by-name.ts
+++ b/src/util/domains/remove-domain-by-name.ts
@@ -16,23 +16,14 @@ export default async function removeDomainByName(
       return new ERRORS.DomainPermissionDenied(domain, contextName);
     }
     if (error.code === 'domain_removal_conflict') {
-      const {
-        aliases,
-        certs,
-        message,
-        pendingAsyncPurchase,
-        resolvable,
-        suffix,
-        transferring
-      } = error;
       return new ERRORS.DomainRemovalConflict({
-        aliases,
-        certs,
-        message,
-        pendingAsyncPurchase,
-        resolvable,
-        suffix,
-        transferring
+        aliases: error.aliases,
+        certs: error.certs,
+        message: error.message,
+        pendingAsyncPurchase: error.pendingAsyncPurchase,
+        resolvable: error.resolvable,
+        suffix: error.suffix,
+        transferring: error.transferring
       });
     }
     throw error;

--- a/src/util/domains/remove-domain-by-name.ts
+++ b/src/util/domains/remove-domain-by-name.ts
@@ -16,11 +16,21 @@ export default async function removeDomainByName(
       return new ERRORS.DomainPermissionDenied(domain, contextName);
     }
     if (error.code === 'domain_removal_conflict') {
-      const { aliases, certs, suffix, transferring } = error;
+      const {
+        aliases,
+        certs,
+        message,
+        pendingAsyncPurchase,
+        resolvable,
+        suffix,
+        transferring
+      } = error;
       return new ERRORS.DomainRemovalConflict({
         aliases,
         certs,
-        domain,
+        message,
+        pendingAsyncPurchase,
+        resolvable,
         suffix,
         transferring
       });

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -792,18 +792,29 @@ export class DNSPermissionDenied extends NowError<
 
 export class DomainRemovalConflict extends NowError<
   'domain_removal_conflict',
-  { aliases: string[]; certs: string[]; suffix: boolean; transferring: boolean }
+  {
+    aliases: string[];
+    certs: string[];
+    pendingAsyncPurchase: boolean;
+    suffix: boolean;
+    transferring: boolean;
+    resolvable: boolean;
+  }
 > {
   constructor({
     aliases,
     certs,
-    domain,
+    message,
+    pendingAsyncPurchase,
+    resolvable,
     suffix,
     transferring
   }: {
     aliases: string[];
     certs: string[];
-    domain: string;
+    message: string;
+    pendingAsyncPurchase: boolean;
+    resolvable: boolean;
     suffix: boolean;
     transferring: boolean;
   }) {
@@ -812,25 +823,39 @@ export class DomainRemovalConflict extends NowError<
       meta: {
         aliases,
         certs,
+        pendingAsyncPurchase,
         suffix,
-        transferring
+        transferring,
+        resolvable
       },
-      message: `Conflicts should be resolved before attempting to remove ${domain}`
+      message: message
     });
   }
 }
 
 export class DomainMoveConflict extends NowError<
   'domain_move_conflict',
-  { suffix: boolean }
+  { pendingAsyncPurchase: boolean; suffix: boolean; resolvable: boolean }
 > {
-  constructor({ domain, suffix }: { domain: string; suffix: boolean }) {
+  constructor({
+    message,
+    pendingAsyncPurchase,
+    resolvable,
+    suffix
+  }: {
+    message: string;
+    pendingAsyncPurchase: boolean;
+    resolvable: boolean;
+    suffix: boolean;
+  }) {
     super({
       code: 'domain_move_conflict',
       meta: {
+        pendingAsyncPurchase,
+        resolvable,
         suffix
       },
-      message: `Conflicts should be resolved before attempting to move ${domain}`
+      message: message
     });
   }
 }


### PR DESCRIPTION
On domain conflict error (`rm` or `move`), use more descriptive api error message in output when we cannot resolve the conflict locally.