### PR TITLE
[now-init] Add a deploy hint after init.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Documentation
+# https://help.github.com/en/articles/about-code-owners
+
+/src/commands/init/     @amio

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -11,9 +11,9 @@ import toHumanPath from '../../util/humanize-path';
 import wait from '../../util/output/wait';
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
-// @ts-ignore
 import success from '../../util/output/success';
 import info from '../../util/output/info';
+import cmd from '../../util/output/cmd';
 import didYouMean from '../../util/init/did-you-mean';
 
 type Options = {
@@ -128,9 +128,13 @@ async function extractExample(name: string, dir: string, force?: boolean) {
         resp.body.pipe(extractor);
       });
 
-      console.log(success(
-        `Initialized "${chalk.bold(name)}" example in ${chalk.bold(toHumanPath(folder))}.`
-      ));
+      const successLog = `Initialized "${chalk.bold(name)}" example in ${chalk.bold(toHumanPath(folder))}.`;
+      const folderRel = path.relative(process.cwd(), folder);
+      const deployHint = folderRel === ''
+        ? `To deploy, run ${cmd('now')}.`
+        : `To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`;
+      console.log(success(`${successLog} ${deployHint}`));
+
       return 0;
     })
     .catch(e => {

--- a/src/util/output/success.js
+++ b/src/util/output/success.js
@@ -1,5 +1,0 @@
-import { cyan } from 'chalk';
-
-const success = msg => `${cyan('> Success!')} ${msg}`;
-
-export default success;

--- a/src/util/output/success.ts
+++ b/src/util/output/success.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk';
+
+const success = (msg:string) => `${chalk.cyan('> Success!')} ${msg}`;
+
+export default success;


### PR DESCRIPTION
The full log would be:

```
> Success! Initialized "nodejs" example in /private/tmp/aab. To deploy, `cd aab` and run `now`.
```