### PR TITLE
Soft-deprecate the `--team` flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -474,19 +474,6 @@ const main = async argv_ => {
   }
 
   if (typeof scope === 'string' && targetCommand !== 'login' && targetCommand !== 'teams') {
-    if (scope.length === 0) {
-      const flag = argv['--scope'] ? '--scope' : (argv['--team'] ? '--team' : 'scope');
-
-      console.error(
-        error({
-          message: `You defined ${param(flag)}, but it's missing a value`,
-          slug: 'missing-scope-value'
-        })
-      );
-
-      return 1;
-    }
-
     const { authConfig: { token } } = ctx;
     const client = new Client({ apiUrl, token });
 

--- a/src/index.js
+++ b/src/index.js
@@ -466,14 +466,20 @@ const main = async argv_ => {
     }
   }
 
-  const scope = localConfig.scope || argv['--scope'];
+  const scope = localConfig.scope || argv['--scope'] || argv['--team'];
   const targetCommand = commands[subcommand];
+
+  if (argv['--team']) {
+    output.warn(`The ${param('--team')} flag is deprecated. Please use ${param('--scope')} instead.`);
+  }
 
   if (typeof scope === 'string' && targetCommand !== 'login' && targetCommand !== 'teams') {
     if (scope.length === 0) {
+      const flag = argv['--scope'] ? '--scope' : (argv['--team'] ? '--team' : 'scope');
+
       console.error(
         error({
-          message: `You defined ${param(argv['--scope'] ? '--scope' : 'scope')}, but it's missing a value`,
+          message: `You defined ${param(flag)}, but it's missing a value`,
           slug: 'missing-scope-value'
         })
       );

--- a/src/util/arg-common.ts
+++ b/src/util/arg-common.ts
@@ -14,6 +14,9 @@ const ARG_COMMON = {
   '--scope': String,
   '-s': '--scope',
 
+  '--team': String,
+  '-T': '--team',
+
   '--local-config': String,
   '-A': '--local-config',
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -881,6 +881,41 @@ test('deploy multiple static files', async t => {
   t.is(content.files.length, 3);
 });
 
+test('ensure we are getting a warning for the old team flag', async t => {
+  const directory = fixture('static-multiple-files');
+
+  const { stderr, stdout, code } = await execa(
+    binaryPath,
+    [directory, '--public', '--name', session, '--team', email, ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  // Ensure the warning is printed
+  t.true(stderr.includes('WARN! The "--team" flag is deprecated. Please use "--scope" instead.'));
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  const contentType = response.headers.get('content-type');
+  t.is(contentType, 'application/json; charset=utf-8');
+
+  const content = await response.json();
+  t.is(content.files.length, 3);
+});
+
 test('deploy multiple static files with custom scope', async t => {
   const directory = fixture('static-multiple-files');
 


### PR DESCRIPTION
This extends https://github.com/zeit/now-cli/pull/1939 and ensures we're rendering a deprecation message instead of replacing it (including a test):

![image](https://user-images.githubusercontent.com/6170607/54278849-dfdfb580-4593-11e9-98c9-76d54a0a433b.png)