### PR TITLE
Added warning message about files with no deployments

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -210,6 +210,12 @@ export default class Now extends EventEmitter {
         )
       );
 
+      // This is a useful warning because it prevents people
+      // from getting confused about a deployment that renders 404.
+      if (files.length === 0 || files.every(item => item.file.startsWith('.'))) {
+        warn('There are no files (or only files starting with a dot) inside your deployment.');
+      }
+
       const queryProps = {};
       const requestBody = isBuilds
         ? {

--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -104,6 +104,9 @@ module.exports = async session => {
     builds: ['index.html', 'now.json-builds'],
     'static-single-file': ['first.png', 'now.json'],
     'static-multiple-files': ['first.png', 'second.png', 'now.json'],
+    'single-dotfile': {
+      '.testing': 'i am a dotfile'
+    },
     'config-alias-property': {
       'now.json':
         '{ "alias": "test.now.sh", "builds": [ { "src": "*.html", "use": "@now/static" } ] }',

--- a/test/integration.js
+++ b/test/integration.js
@@ -704,6 +704,34 @@ test('set platform version using `--platform-version` to `2`', async t => {
   t.is(contentType, 'text/html; charset=utf-8');
 });
 
+test('ensure we render a warning for deployments with no files', async t => {
+  const directory = fixture('single-dotfile');
+
+  const { stderr, stdout, code } = await execa(
+    binaryPath,
+    [directory, '--public', '--name', session, ...defaultArgs, '--force'],
+    {
+      reject: false
+    }
+  );
+
+  // Ensure the warning is printed
+  t.true(stderr.includes('> WARN! There are no files (or only files starting with a dot) inside your deployment.'));
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Send a test request to the deployment
+  const response = await fetch(href);
+  const contentType = response.headers.get('content-type');
+
+  t.is(contentType, 'text/html; charset=utf-8');
+});
+
 test('ensure the `alias` property is not sent to the API', async t => {
   const directory = fixture('config-alias-property');
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -729,7 +729,7 @@ test('ensure we render a warning for deployments with no files', async t => {
   const response = await fetch(href);
   const contentType = response.headers.get('content-type');
 
-  t.is(contentType, 'text/html; charset=utf-8');
+  t.is(contentType, 'text/plain; charset=utf-8');
 });
 
 test('ensure the `alias` property is not sent to the API', async t => {


### PR DESCRIPTION
This pull request introduces this warning message for deployments with no files inside:

![image](https://user-images.githubusercontent.com/6170607/54312808-20f9b900-45d8-11e9-86e4-22e5d7fb5817.png)
