### PR TITLE
Improved deployment output

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -104,7 +104,7 @@ const printDeploymentStatus = async (
             }
           }
 
-          output.print(`- ${chalk.bold(chalk.cyan(alias))}\n`);
+          output.print(`- ${chalk.bold(chalk.cyan(prepareAlias(alias)))}\n`);
         }
       }
     } else {

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -211,6 +211,10 @@ export default async function main(
   const paths = Object.keys(stats);
   const debugEnabled = argv['--debug'];
 
+  if ((localConfig.alias || []).length === 0 && argv['--target'] === 'production') {
+    const flag = param('--target production');
+    output.warn(`You specified ${flag} but didn't configure a value for the ${code('alias')} configuration property.`);
+  }
   // $FlowFixMe
   const isTTY = process.stdout.isTTY;
   const quiet = !isTTY;

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -72,6 +72,7 @@ const printDeploymentStatus = async (
   { url, readyState, aliasFinal },
   deployStamp,
   clipboardEnabled,
+  localConfig,
   builds
 ) => {
   if (readyState === 'READY') {
@@ -89,11 +90,16 @@ const printDeploymentStatus = async (
       } else {
         output.ready(`Aliases assigned ${deployStamp()}`);
 
+        // If `alias` is defined in the config, we need to
+        // copy the first one to the clipboard.
+        const matching = (localConfig.alias || [])[0];
+
         for (const alias of aliasFinal) {
           const index = aliasFinal.indexOf(alias);
-          const last = index === (aliasFinal.length - 1);
+          const isLast = index === (aliasFinal.length - 1);
+          const shouldCopy = matching ? alias === matching : isLast;
 
-          if (last && clipboardEnabled) {
+          if (shouldCopy && clipboardEnabled) {
             try {
               await copy(alias);
               output.print(`- ${chalk.bold(chalk.cyan(prepareAlias(alias)))} ${chalk.gray('[in clipboard]')}\n`);
@@ -475,7 +481,7 @@ export default async function main(
   // If an error occured, we want to let it fall down to rendering
   // builds so the user can see in which build the error occured.
   if (isReady(deployment)) {
-    return printDeploymentStatus(output, deployment, deployStamp, !argv['--no-clipboard']);
+    return printDeploymentStatus(output, deployment, deployStamp, !argv['--no-clipboard'], localConfig);
   }
 
   const sleepingTime = ms('1.5s');
@@ -544,7 +550,7 @@ export default async function main(
     await sleep(sleepingTime);
   }
 
-  return printDeploymentStatus(output, deployment, deployStamp, !argv['--no-clipboard'], builds);
+  return printDeploymentStatus(output, deployment, deployStamp, !argv['--no-clipboard'], localConfig, builds);
 };
 
 function handleCreateDeployError(output, error) {

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,6 @@ import reportError from './util/report-error';
 import getConfig from './util/get-config';
 import * as ERRORS from './util/errors-ts';
 import { NowError } from './util/now-error';
-import code from './util/output/code';
 
 const NOW_DIR = getNowDir();
 const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -104,12 +103,6 @@ const main = async argv_ => {
 
   if (localConfig instanceof NowError && !(localConfig instanceof ERRORS.CantFindConfig)) {
     output.error(`Failed to load local config file: ${localConfig.message}`);
-    return 1;
-  }
-
-  if ((localConfig.alias || []).length === 0 && argv['--target'] === 'production') {
-    const flag = param('--target production');
-    output.warn(`You specified ${flag} but didn't configure a value for ${code('alias')}.`);
     return 1;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import reportError from './util/report-error';
 import getConfig from './util/get-config';
 import * as ERRORS from './util/errors-ts';
 import { NowError } from './util/now-error';
+import code from './util/output/code';
 
 const NOW_DIR = getNowDir();
 const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -103,6 +104,12 @@ const main = async argv_ => {
 
   if (localConfig instanceof NowError && !(localConfig instanceof ERRORS.CantFindConfig)) {
     output.error(`Failed to load local config file: ${localConfig.message}`);
+    return 1;
+  }
+
+  if ((localConfig.alias || []).length === 0 && argv['--target'] === 'production') {
+    const flag = param('--target production');
+    output.warn(`You specified ${flag} but didn't configure a value for ${code('alias')}.`);
     return 1;
   }
 


### PR DESCRIPTION
The PR ensures the following things:

- Copy the most important alias to the clipboard, instead of the last one
- All automatic aliases now have the `https://` prefix
- We're now printing a warning message if `--target production`, but no (or empty) `alias` was set