### PR TITLE
Add a hint about `-f` in `now init` error message

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -157,7 +157,7 @@ function prepareFolder(cwd: string, folder: string, force?: boolean) {
     }
     if (!force && fs.readdirSync(dest).length !== 0) {
       throw new Error(
-        `Destination path "${chalk.bold(folder)}" already exists and is not an empty directory.`
+        `Destination path "${chalk.bold(folder)}" already exists and is not an empty directory. You may use ${cmd('--force')} or ${cmd('--f')} to override it.`
       );
     }
   } else {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1251,7 +1251,7 @@ test('try to initialize example to existing directory', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    '> Error! Destination path "apollo" already exists and is not an empty directory.';
+    '> Error! Destination path "apollo" already exists and is not an empty directory. You may use `--force` or `--f` to override it.';
 
   createDirectory(path.join(cwd, 'apollo'));
   createFile(path.join(cwd, 'apollo', '.gitignore'));


### PR DESCRIPTION
Add a hint about `-f` in init error (“You may use `--force` or `--f` to override it.”)

![image](https://user-images.githubusercontent.com/215282/54470672-00537e00-47e7-11e9-9a27-5d79a1d19310.png)