### PR TITLE
Warn if `now alias` was used

### DIFF
--- a/src/util/alias/get-inferred-targets.ts
+++ b/src/util/alias/get-inferred-targets.ts
@@ -1,11 +1,14 @@
 import { Output } from '../output';
 import * as ERRORS from '../../util/errors-ts';
 import { Config } from '../../types';
+import cmd from '../../util/output/cmd';
 
 export default async function getInferredTargets(
   output: Output,
   config: Config
 ) {
+  output.warn(`The ${cmd('now alias')} command (no arguments) was deprecated in favour of ${cmd('--target production')}.`);
+
   // This field is deprecated, warn about it
   if (config.aliases) {
     output.warn('The `aliases` field has been deprecated in favor of `alias`');

--- a/src/util/alias/get-inferred-targets.ts
+++ b/src/util/alias/get-inferred-targets.ts
@@ -7,7 +7,7 @@ export default async function getInferredTargets(
   output: Output,
   config: Config
 ) {
-  output.warn(`The ${cmd('now alias')} command (no arguments) was deprecated in favour of ${cmd('--target production')}.`);
+  output.warn(`The ${cmd('now alias')} command (no arguments) was deprecated in favour of ${cmd('now --target production')}.`);
 
   // This field is deprecated, warn about it
   if (config.aliases) {


### PR DESCRIPTION
If `now alias` is invoked, we now show this error:

![image](https://user-images.githubusercontent.com/6170607/54479380-627aa600-481c-11e9-9cf1-7064b5d2d7f1.png)
