### PR TITLE
Handle the `DomainNotVerified` error for deployments

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -26,6 +26,7 @@ import {
   CantSolveChallenge,
   DomainConfigurationError,
   DomainNotFound,
+  DomainNotVerified,
   DomainPermissionDenied,
   DomainsShouldShareRoot,
   DomainValidationRunning,
@@ -362,6 +363,7 @@ export default async function main(
       firstDeployCall instanceof CantSolveChallenge ||
       firstDeployCall instanceof DomainConfigurationError ||
       firstDeployCall instanceof DomainNotFound ||
+      firstDeployCall instanceof DomainNotVerified ||
       firstDeployCall instanceof DomainPermissionDenied ||
       firstDeployCall instanceof DomainsShouldShareRoot ||
       firstDeployCall instanceof DomainValidationRunning ||
@@ -708,6 +710,14 @@ function handleCreateDeployError(output, error) {
       `The domain used as a suffix ${chalk.underline(
         error.meta.domain
       )} no longer exists. Please update or remove your custom suffix.`
+    );
+    return 1;
+  }
+  if (error instanceof DomainNotVerified) {
+    output.error(
+      `The domain used as an alias ${
+        chalk.underline(error.meta.domain)
+      } is not verified yet. Please verify it.`
     );
     return 1;
   }

--- a/src/util/deploy/create-deploy.js
+++ b/src/util/deploy/create-deploy.js
@@ -17,8 +17,14 @@ export default async function createDeploy(
       return new ERRORS_TS.DomainNotFound(error.value);
     }
 
+    // This error occures when a domain used in the `alias`
+    // is not yet verified
+    if (error.code === 'domain_not_verified' && error.domain) {
+      return new ERRORS_TS.DomainNotVerified(error.domain);
+    }
+
     // If the domain used as a suffix is not verified, we fail
-    if (error.code === 'domain_not_verified') {
+    if (error.code === 'domain_not_verified' && error.value) {
       return new ERRORS_TS.DomainVerificationFailed(error.value);
     }
 


### PR DESCRIPTION
This handles the `domain_not_verified` error from deployments when used with `--target production`.

The output will look like this:
```
> Deploying ~/projects/zeit/date-test under artzbitz
> Using project date-test
> Error! The domain amazon.com (defined in `alias`) is not verified yet. Please verify it and try again.
```