### PR TITLE
Made `-S` short flag work properly

### DIFF
--- a/src/util/arg-common.ts
+++ b/src/util/arg-common.ts
@@ -12,7 +12,7 @@ const ARG_COMMON = {
   '-t': '--token',
 
   '--scope': String,
-  '-s': '--scope',
+  '-S': '--scope',
 
   '--team': String,
   '-T': '--team',


### PR DESCRIPTION
By mistake, the PR for `--scope` included `-s` instead of the intended `-S`.