### PR TITLE
Only block deployment exit if not error

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -550,7 +550,7 @@ export default async function main(
     if (buildsCompleted) {
       const deploymentResponse = await now.fetch(deploymentUrl);
 
-      if (isDone(deploymentResponse) && isAliasReady(deploymentResponse)) {
+      if ((isReady(deploymentResponse) && isAliasReady(deploymentResponse)) || isFailed(deploymentResponse)) {
         deployment = deploymentResponse;
 
         if (typeof deploymentSpinner === 'function') {


### PR DESCRIPTION
This change was missing in https://github.com/zeit/now-cli/pull/1997. It allows Now CLI to exit if the deployment errored, instead of retrying forever.