### PR TITLE
Fixed `GET /v3/now/certs`

### DIFF
--- a/src/commands/certs/index.js
+++ b/src/commands/certs/index.js
@@ -59,7 +59,7 @@ const help = () => {
 
   ${chalk.gray('–')} Remove a certificate
 
-      ${chalk.cyan('$ now certs rm acme.com')}
+      ${chalk.cyan('$ now certs rm id')}
   `);
 };
 

--- a/src/commands/certs/rm.js
+++ b/src/commands/certs/rm.js
@@ -43,12 +43,12 @@ async function rm(ctx, opts, args, output) {
     return 1;
   }
 
-  const idOrCn = args[0];
-  const certs = await getCertsToDelete(output, now, idOrCn);
+  const id = args[0];
+  const certs = await getCertsToDelete(output, now, id);
 
   if (certs.length === 0) {
     output.error(
-      `No certificates found by id or cn "${idOrCn}" under ${chalk.bold(
+      `No certificates found by id "${id}" under ${chalk.bold(
         contextName
       )}`
     );
@@ -76,9 +76,9 @@ async function rm(ctx, opts, args, output) {
   return 0;
 }
 
-async function getCertsToDelete(output, now, idOrCn) {
-  const cert = await getCertById(output, now, idOrCn);
-  return !cert ? getCerts(output, now, [idOrCn]) : [cert];
+async function getCertsToDelete(output, now, id) {
+  const cert = await getCertById(output, now, id);
+  return !cert ? getCerts(output, now, id) : [cert];
 }
 
 function readConfirmation(output, msg, certs) {

--- a/src/util/certs/get-cert-by-id.ts
+++ b/src/util/certs/get-cert-by-id.ts
@@ -13,5 +13,8 @@ export default async function getCertById(
   client: Client,
   id: string
 ) {
-  return client.fetch<CertDetails>(`/v3/now/certs/${id}`);
+  const cert = await client.fetch<CertDetails>(`/v3/now/certs/${id}?limit=1`);
+  // If `id` isn't a valid id the API responds with a set of certificates instead
+  if (!cert || !cert.key) return null;
+  return cert;
 }

--- a/src/util/certs/get-certs.ts
+++ b/src/util/certs/get-certs.ts
@@ -12,10 +12,7 @@ export default async function getCerts(
   client: Client,
   domain?: string
 ) {
-  const query = stringify({
-    ...domain ? { domain } : {},
-    limit: 20
-  });
+  const query = domain ? stringify({ domain }) : '';
   const { certs } = await client.fetch<Response>(`/v3/now/certs?${query}`);
   return certs;
 }

--- a/src/util/certs/get-certs.ts
+++ b/src/util/certs/get-certs.ts
@@ -12,7 +12,10 @@ export default async function getCerts(
   client: Client,
   domain?: string
 ) {
-  const query = domain ? stringify({ domain }) : '';
+  const query = stringify({
+    ...domain ? { domain } : {},
+    limit: 20
+  });
   const { certs } = await client.fetch<Response>(`/v3/now/certs?${query}`);
   return certs;
 }


### PR DESCRIPTION
- Limit the response size to 20 because the endpoint doesn't have a default limit
- If the id in `/v3/now/certs/{id}` isn't a valid id the endpoint responds with a set or certs instead
- The route `/v3/now/certs/{idOrCn}` isn't supported any more