### PR TITLE
Group builds with similar paths together to reduce the output

### DIFF
--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -313,7 +313,7 @@ export default (builds, times) => {
     ));
 
     if (outputs.length > MAX_OUTPUTS_PER_GROUP) {
-      final.push(chalk.grey(`└── ${outputs.length - MAX_OUTPUTS_PER_GROUP} hidden\n`));
+      final.push(chalk.grey(`└── ${outputs.length - MAX_OUTPUTS_PER_GROUP} builds hidden\n`));
     }
 
     return buildGroup;
@@ -321,7 +321,7 @@ export default (builds, times) => {
 
   if (hiddenBuildGroup.length) {
     final.push(`${styleHiddenBuilds(
-      `${hiddenBuildGroup.length} hidden`,
+      `${hiddenBuildGroup.length} output items hidden`,
       hiddenBuildGroup,
       times,
       longestSource,

--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -88,7 +88,7 @@ const styleHiddenBuilds =  (commonPath, buildGroup, times, longestSource, isHidd
       return null;
     }
 
-    return `${counter > 9 ? '+9' : counter} ${name}`;
+    return `${counter > 9 ? '9+' : counter} ${name}`;
   }).filter(s => s).join(' ')
 
   // Since the longestState might still be shorter

--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -89,7 +89,7 @@ const styleHiddenBuilds =  (commonPath, buildGroup, times, longestSource, isHidd
     }
 
     return `${counter > 9 ? '9+' : counter} ${name}`;
-  }).filter(s => s).join(' ')
+  }).filter(s => s).join(', ')
 
   // Since the longestState might still be shorter
   // than multiple states we still want to ensure

--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -80,7 +80,7 @@ const styleHiddenBuilds =  (commonPath, buildGroup, times, longestSource, isHidd
     return readyState;
   });
 
-  const state = Object.keys(stateMap).map((readyState) => {
+  let state = Object.keys(stateMap).map((readyState) => {
     const counter = stateMap[readyState];
     const name = prepareState(readyState);
 
@@ -89,7 +89,12 @@ const styleHiddenBuilds =  (commonPath, buildGroup, times, longestSource, isHidd
     }
 
     return `${counter > 9 ? '+9' : counter} ${name}`;
-  }).filter(s => s).join(' ').padEnd(longestState + padding);
+  }).filter(s => s).join(' ')
+
+  // Since the longestState might still be shorter
+  // than multiple states we still want to ensure
+  // a space between the states and the time
+  state = `${state} `.padEnd(longestState + padding);
 
   let pathColor = chalk.cyan;
   let stateColor = chalk.grey;

--- a/src/util/output/builds.js
+++ b/src/util/output/builds.js
@@ -313,7 +313,7 @@ export default (builds, times) => {
     ));
 
     if (outputs.length > MAX_OUTPUTS_PER_GROUP) {
-      final.push(chalk.grey(`└── ${outputs.length - MAX_OUTPUTS_PER_GROUP} builds hidden\n`));
+      final.push(chalk.grey(`└── ${outputs.length - MAX_OUTPUTS_PER_GROUP} output items hidden\n`));
     }
 
     return buildGroup;
@@ -321,7 +321,7 @@ export default (builds, times) => {
 
   if (hiddenBuildGroup.length) {
     final.push(`${styleHiddenBuilds(
-      `${hiddenBuildGroup.length} output items hidden`,
+      `${hiddenBuildGroup.length} builds hidden`,
       hiddenBuildGroup,
       times,
       longestSource,


### PR DESCRIPTION
This caps the total output of builds during deployment so that everything fits into the terminal window.

It will always show the first five outputs of one or more builds.

### Before:
![image](https://user-images.githubusercontent.com/16088670/55196112-b5eedb80-51ae-11e9-9734-625c47a9c4e8.png)

### After:
![image](https://user-images.githubusercontent.com/16088670/55196122-bc7d5300-51ae-11e9-8c30-728f6aa01310.png)

`now-examples` has a lot of builds that just uses the `package.json` for building, that's why there are not a lot of groups.

But a for aproject like `serverless-ssr-reddit` which has multiple builds inside of nested subdirectories it would look like this:
![image](https://user-images.githubusercontent.com/16088670/55196362-72e13800-51af-11e9-8755-58aab9b4f37a.png)
