### PR TITLE
Update `@zeit/ncc` to v0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@zeit/dockerignore": "0.0.4",
     "@zeit/fun": "https://zeit-fun-0-5-1.zeit.sh",
     "@zeit/git-hooks": "0.1.4",
-    "@zeit/ncc": "0.16.1",
+    "@zeit/ncc": "0.17.0",
     "@zeit/source-map-support": "0.6.2",
     "alpha-sort": "2.0.1",
     "ansi-escapes": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/git-hooks/-/git-hooks-0.1.4.tgz#70583db5dd69726a62c7963520e67f2c3a33cc5f"
   integrity sha512-NvgZgoYJ/n27Ly7lKxKttMIKSS8P4dr1EURgTmqihHVdTAEqVtkAYPT5XykZIR+GKz8WRGyEQVJekwSgvjYQLg==
 
-"@zeit/ncc@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.16.1.tgz#c12257d2d919fc47447944f5021b33e5997a84fb"
-  integrity sha512-lHScAn2rl2OjBzpzFZlv9YCq9ESvcBz51NWxXV7D1nA02jceUoIqlK8YDQSmA5wa5IqL+UzFyxSpq6ZSyVSAHw==
+"@zeit/ncc@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.17.0.tgz#f6121a15cf7ec76a65c17a3aa7d38e98151ea76e"
+  integrity sha512-PEu1L+bqj5c/BbkmBu3IRKOP10jprmJu4+EtHaFBQzeTfGcXnzbrssUVhzXpGi2X6Dw5S1FvwLWFGP3X5uEKYA==
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"


### PR DESCRIPTION
The update of `ncc` supports support for the `firestore(firebase-amin)` module that previously was not compatible with `now-dev`

issue: https://github.com/zeit/ncc/issues/317