### PR TITLE
Adjusted aliasing error message to match server

### DIFF
--- a/src/commands/alias/set.ts
+++ b/src/commands/alias/set.ts
@@ -391,7 +391,7 @@ function handleCreateAliasError<T>(
   }
   if (error instanceof ERRORS.InvalidAlias) {
     output.error(
-      `Invalid alias. Please confirm that the alias you provided is a valid hostname. Note: For `now.sh`, only sub and sub-sub domains are supported.`
+      `Invalid alias. Please confirm that the alias you provided is a valid hostname. Note: For \`now.sh\`, only sub and sub-sub domains are supported.`
     );
     return 1;
   }

--- a/src/commands/alias/set.ts
+++ b/src/commands/alias/set.ts
@@ -391,7 +391,7 @@ function handleCreateAliasError<T>(
   }
   if (error instanceof ERRORS.InvalidAlias) {
     output.error(
-      `Invalid alias. Please confirm that the alias you provided is a valid hostname. Note: Nested domains are not supported.`
+      `Invalid alias. Please confirm that the alias you provided is a valid hostname. Note: For `now.sh`, only sub and sub-sub domains are supported.`
     );
     return 1;
   }


### PR DESCRIPTION
Now that we allow sub-sub domains for `now.sh`, we need to adjust this message:

![image](https://user-images.githubusercontent.com/6170607/55188927-d3b34500-519c-11e9-902a-b7f46e270bf3.png)
