### PR TITLE
[now dev] Add `output` to DevServer class

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -24,7 +24,8 @@ export default async function dev(
   const debug = Boolean(opts['-d'] || opts['--debug']);
 
   const devServer = new DevServer(cwd, {
-    debug
+    debug,
+    output
   });
 
   process.once('SIGINT', devServer.stop.bind(devServer));

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -10,6 +10,7 @@ import serveHandler from 'serve-handler';
 import { basename, dirname, relative } from 'path';
 import { lookup as lookupMimeType } from 'mime-types';
 
+import { Output } from '../../../util/output';
 import error from '../../../util/output/error';
 import success from '../../../util/output/success';
 import getNowJsonPath from '../../../util/config/local-path';
@@ -37,6 +38,7 @@ export default class DevServer {
   public cwd: string;
   public assets: BuilderOutputs;
 
+  private output: Output;
   private debug: boolean;
   private server: http.Server;
   private status: DevServerStatus;
@@ -45,6 +47,7 @@ export default class DevServer {
   constructor(cwd: string, options: DevServerOptions) {
     this.cwd = cwd;
     this.debug = options.debug;
+    this.output = options.output;
     this.assets = {};
     this.server = http.createServer(this.devServerHandler);
     this.status = DevServerStatus.busy;
@@ -132,6 +135,7 @@ export default class DevServer {
         this.logDebug(`Got listen error: ${err.code}`);
         if (err.code === 'EADDRINUSE') {
           // Increase port and try again
+          this.output.note(`Requested port ${port} is already in use`);
           port++;
         } else {
           throw err;
@@ -142,7 +146,7 @@ export default class DevServer {
     this.logSuccess(
       `${chalk.bold(
         '`now dev`'
-      )} server listening at ${chalk.blue.bold.underline(
+      )} server listening at ${chalk.blue.underline(
         address.replace('[::]', 'localhost')
       )}`
     );

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { Output } from '../../../util/output';
 import { Lambda as FunLambda } from '@zeit/fun';
 import { FileBlob, FileFsRef, Lambda } from '@now/build-utils';
 
@@ -10,6 +11,7 @@ export enum DevServerStatus {
 
 export interface DevServerOptions {
   debug: boolean;
+  output: Output;
 }
 
 export interface EnvConfig {


### PR DESCRIPTION
This is the preferred way of outputting standardized logging in now-cli.