### PR TITLE
[now dev] Add build deduping

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -1,3 +1,4 @@
+import ms from 'ms';
 import url from 'url';
 import http from 'http';
 import fs from 'fs-extra';
@@ -43,6 +44,7 @@ export default class DevServer {
   private server: http.Server;
   private status: DevServerStatus;
   private statusMessage: string = '';
+  private inProgressBuilds: Map<string, Promise<void>>;
 
   constructor(cwd: string, options: DevServerOptions) {
     this.cwd = cwd;
@@ -50,6 +52,7 @@ export default class DevServer {
     this.assets = {};
     this.server = http.createServer(this.devServerHandler);
     this.status = DevServerStatus.busy;
+    this.inProgressBuilds = new Map();
   }
 
   /* set dev-server status */
@@ -281,8 +284,28 @@ export default class DevServer {
     // then re-run the build that generated this asset
     if (this.shouldRebuild(req) && asset.buildEntry) {
       const entrypoint = relative(this.cwd, asset.buildEntry.fsPath);
-      this.output.debug(`Rebuilding asset: ${entrypoint}`);
-      await executeBuild(nowJson, this, asset);
+      const buildTimestamp: number = asset.buildTimestamp || 0;
+      let buildPromise = this.inProgressBuilds.get(entrypoint);
+      if (buildPromise) {
+        // A build for `entrypoint` is already in progress, so don't trigger
+        // another rebuild for this request - just wait on the existing one.
+        this.output.debug(`De-duping build "${entrypoint}" for "${req.method} ${req.url}"`);
+      } else if (Date.now() - buildTimestamp < ms('2s')) {
+        // If the built asset was created less than 2s ago, then don't trigger
+        // a rebuild. The purpose of this threshold is because once an HTML page
+        // is rebuilt, then the CSS/JS/etc. assets on the page are also refreshed
+        // with a `no-cache` header, so this avoids *two* rebuilds for that case.
+        this.output.debug(`Skipping rebuild for "${entrypoint}" (not older than 2s) for "${req.method} ${req.url}"`);
+      } else {
+        this.output.debug(`Rebuilding asset "${entrypoint}" for "${req.method} ${req.url}"`);
+        buildPromise = executeBuild(nowJson, this, asset);
+        this.inProgressBuilds.set(entrypoint, buildPromise)
+      }
+      try {
+        await buildPromise;
+      } finally {
+        this.inProgressBuilds.delete(entrypoint);
+      }
 
       // Since the `asset` was re-built, resolve it again to get the new asset
       // object

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -54,11 +54,13 @@ export interface BuilderInputs {
 export interface BuiltFileFsRef extends FileFsRef {
   buildConfig?: BuildConfig;
   buildEntry?: FileFsRef;
+  buildTimestamp?: number;
 }
 
 export interface BuiltFileBlob extends FileBlob {
   buildConfig?: BuildConfig;
   buildEntry?: FileFsRef;
+  buildTimestamp?: number;
 }
 
 export type BuilderOutput = BuiltLambda | BuiltFileFsRef | BuiltFileBlob;
@@ -94,6 +96,7 @@ export interface BuiltLambda extends Lambda {
   fn?: FunLambda;
   buildConfig?: BuildConfig;
   buildEntry?: FileFsRef;
+  buildTimestamp?: number;
 }
 
 export interface HttpHeadersConfig {


### PR DESCRIPTION
Consider the scenario where an HTML asset is built and references other files that were produced by the build (CSS/JS/img/etc. files). The build will happen and then the HTML page will be served, and then the browser will request the assets on the page also with the `no-cache` header, which would cause a second build right after the first one completed, which is bad DX and unnecessary.

This commit introduces "build deduping logic" so that this scenario is avoided by doing two things:

1. Not allowing the same entrypoint to be built at the same time (so if a concurrent request happens for an asset that was produced by the same entrypoint, the subsequent requests will wait on the already running build instead of triggering a new one in parallel.
2. Not allowing an asset to be rebuilt if the previous build completed less than two seconds ago. This is to catch the scenario where the HTML page is served and the browser quickly requests the assets on the page to avoid triggering a second rebuild.