### PR TITLE
[now dev] Add support for `.env` file to define Now secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "@types/async-retry": "1.2.1",
     "@types/bytes": "3.0.0",
     "@types/debug": "0.0.31",
+    "@types/dotenv": "6.1.1",
     "@types/execa": "0.9.0",
     "@types/fs-extra": "5.0.5",
     "@types/glob": "7.1.1",

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -70,13 +70,19 @@ export async function executeBuild(
   const builderConfig = builder.config || {};
   const files = await collectProjectFiles('**', cwd);
   const config = buildConfig.config || {};
-  const output = await builder.build({
-    files,
-    entrypoint,
-    workPath,
-    config,
-    isDev: true
-  });
+  let output: BuilderOutputs;
+  try {
+    devServer.applyBuildEnv(nowJson);
+    output = await builder.build({
+      files,
+      entrypoint,
+      workPath,
+      config,
+      isDev: true
+    });
+  } finally {
+    devServer.restoreOriginalEnv();
+  }
 
   // enforce the lambda zip size soft watermark
   const { maxLambdaSize = '5mb' } = { ...builderConfig, ...config };
@@ -176,13 +182,19 @@ async function executeBuilds(
         devServer.output.debug(
           `Building ${entry.fsPath} (workPath = ${workPath})`
         );
-        const output = await builder.build({
-          files,
-          entrypoint,
-          workPath,
-          config,
-          isDev: true
-        });
+        let output: BuilderOutputs;
+        try {
+          devServer.applyBuildEnv(nowJson);
+          output = await builder.build({
+            files,
+            entrypoint,
+            workPath,
+            config,
+            isDev: true
+          });
+        } finally {
+          devServer.restoreOriginalEnv();
+        }
 
         // enforce the lambda zip size soft watermark
         const builderConfig = builder.config || {};

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -52,7 +52,7 @@ export async function executeBuild(
   if (!buildConfig || !buildEntry) {
     throw new Error("Asset has not been built yet, can't rebuild");
   }
-  const { cwd } = devServer;
+  const { cwd, env } = devServer;
   const entrypoint = relative(cwd, buildEntry.fsPath);
 
   const cacheDir = await cacheDirPromise;
@@ -117,9 +117,9 @@ export async function executeBuild(
           Runtime: asset.runtime,
           Environment: {
             Variables: {
-              // TODO: resolve secret env vars
               ...nowJson.env,
               ...asset.environment,
+              ...env,
               NOW_REGION: 'dev1'
             }
           }
@@ -144,7 +144,7 @@ async function executeBuilds(
     return;
   }
 
-  const { cwd } = devServer;
+  const { cwd, env } = devServer;
   const [files, cacheDir] = await Promise.all([
     collectProjectFiles('**', cwd),
     cacheDirPromise
@@ -222,9 +222,9 @@ async function executeBuilds(
           Runtime: asset.runtime,
           Environment: {
             Variables: {
-              // TODO: resolve secret env vars
               ...nowJson.env,
               ...asset.environment,
+              ...env,
               NOW_REGION: 'dev1'
             }
           }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -26,9 +26,7 @@ import {
   createIgnoreList
 } from './dev-builder';
 
-import {
-  MissingDotenvVarsError
-} from '../../../util/errors-ts';
+import { MissingDotenvVarsError } from '../../../util/errors-ts';
 
 import {
   EnvConfig,
@@ -119,10 +117,18 @@ export default class DevServer {
       throw new Error('Only `version: 2` is supported by `now dev`');
     }
     this.validateEnvConfig('.env', config.env, this.env);
-    this.validateEnvConfig('.env.build', config.build && config.build.env, this.buildEnv);
+    this.validateEnvConfig(
+      '.env.build',
+      config.build && config.build.env,
+      this.buildEnv
+    );
   }
 
-  validateEnvConfig(type: string, env: EnvConfig = {}, localEnv: EnvConfig = {}): void {
+  validateEnvConfig(
+    type: string,
+    env: EnvConfig = {},
+    localEnv: EnvConfig = {}
+  ): void {
     const missing: string[] = Object.entries(env)
       .filter(([name, value]) => value.startsWith('@') && !(name in localEnv))
       .map(([name, value]) => name);
@@ -136,7 +142,7 @@ export default class DevServer {
    */
   async start(port: number = 3000): Promise<void> {
     let address: string | null = null;
-    const [ env, buildEnv ] = await Promise.all([
+    const [env, buildEnv] = await Promise.all([
       this.getLocalEnv('.env'),
       this.getLocalEnv('.env.build')
     ]);
@@ -385,17 +391,25 @@ export default class DevServer {
       if (buildPromise) {
         // A build for `entrypoint` is already in progress, so don't trigger
         // another rebuild for this request - just wait on the existing one.
-        this.output.debug(`De-duping build "${entrypoint}" for "${req.method} ${req.url}"`);
+        this.output.debug(
+          `De-duping build "${entrypoint}" for "${req.method} ${req.url}"`
+        );
       } else if (Date.now() - buildTimestamp < ms('2s')) {
         // If the built asset was created less than 2s ago, then don't trigger
         // a rebuild. The purpose of this threshold is because once an HTML page
         // is rebuilt, then the CSS/JS/etc. assets on the page are also refreshed
         // with a `no-cache` header, so this avoids *two* rebuilds for that case.
-        this.output.debug(`Skipping rebuild for "${entrypoint}" (not older than 2s) for "${req.method} ${req.url}"`);
+        this.output.debug(
+          `Skipping rebuild for "${entrypoint}" (not older than 2s) for "${
+            req.method
+          } ${req.url}"`
+        );
       } else {
-        this.output.debug(`Rebuilding asset "${entrypoint}" for "${req.method} ${req.url}"`);
+        this.output.debug(
+          `Rebuilding asset "${entrypoint}" for "${req.method} ${req.url}"`
+        );
         buildPromise = executeBuild(nowJson, this, asset);
-        this.inProgressBuilds.set(entrypoint, buildPromise)
+        this.inProgressBuilds.set(entrypoint, buildPromise);
       }
       try {
         await buildPromise;

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -130,7 +130,10 @@ export default class DevServer {
     localEnv: EnvConfig = {}
   ): void {
     const missing: string[] = Object.entries(env)
-      .filter(([name, value]) => value.startsWith('@') && !(name in localEnv))
+      .filter(
+        ([name, value]) =>
+          value.startsWith('@') && !hasOwnProperty(localEnv, name)
+      )
       .map(([name, value]) => name);
     if (missing.length >= 1) {
       throw new MissingDotenvVarsError(type, missing);
@@ -600,4 +603,8 @@ function generateRequestId(): string {
     Date.now(),
     randomBytes(16).toString('hex')
   ].join('-');
+}
+
+function hasOwnProperty(obj: any, prop: string) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
 }

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -14,7 +14,7 @@ export interface DevServerOptions {
 }
 
 export interface EnvConfig {
-  [name: string]: string;
+  [name: string]: string | undefined;
 }
 
 export interface BuildConfig {

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -3,6 +3,7 @@ import { Response } from 'fetch-h2';
 import { NowError } from './now-error';
 import param from './output/param';
 import cmd from './output/cmd';
+import code from './output/code';
 
 /**
  * This error is thrown when there is an API error with a payload. The error
@@ -1035,10 +1036,10 @@ export class MissingDotenvVarsError extends NowError<
   constructor(type: string, missing: string[]) {
     let message: string;
     if (missing.length === 1) {
-      message = `Env var ${JSON.stringify(missing[0])} is not defined in \`${type}\``;
+      message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(type)}`;
     } else {
       message = [
-        `The following env vars are not defined in \`${type}\`:`,
+        `The following env vars are not defined in ${code(type)}:`,
         ...missing.map(name => ` - ${JSON.stringify(name)}`)
       ].join('\n');
     }

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1038,8 +1038,8 @@ export class MissingDotenvVarsError extends NowError<
       message = `Env var ${JSON.stringify(missing[0])} is not defined in \`${type}\``;
     } else {
       message = [
-        `The following env vars are not defined in \`${type}\``,
-        ...missing.map(name => ` - "${JSON.stringify(name)}`)
+        `The following env vars are not defined in \`${type}\`:`,
+        ...missing.map(name => ` - ${JSON.stringify(name)}`)
       ].join('\n');
     }
     super({

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1027,3 +1027,25 @@ export class LambdaSizeExceededError extends NowError<
     });
   }
 }
+
+export class MissingDotenvVarsError extends NowError<
+  'MISSING_DOTENV_VARS',
+  { type: string, missing: string[] }
+> {
+  constructor(type: string, missing: string[]) {
+    let message: string;
+    if (missing.length === 1) {
+      message = `Env var ${JSON.stringify(missing[0])} is not defined in \`${type}\``;
+    } else {
+      message = [
+        `The following env vars are not defined in \`${type}\``,
+        ...missing.map(name => ` - "${JSON.stringify(name)}`)
+      ].join('\n');
+    }
+    super({
+      code: 'MISSING_DOTENV_VARS',
+      message,
+      meta: { type, missing }
+    });
+  }
+}

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1036,10 +1036,10 @@ export class MissingDotenvVarsError extends NowError<
   constructor(type: string, missing: string[]) {
     let message: string;
     if (missing.length === 1) {
-      message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(type)}`;
+      message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(type)} file`;
     } else {
       message = [
-        `The following env vars are not defined in ${code(type)}:`,
+        `The following env vars are not defined in ${code(type)} file:`,
         ...missing.map(name => ` - ${JSON.stringify(name)}`)
       ].join('\n');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,13 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
   integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
 
+"@types/dotenv@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-6.1.1.tgz#f7ce1cc4fe34f0a4373ba99fefa437b0bec54b46"
+  integrity sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"


### PR DESCRIPTION
If a `now.json` files relies on secret env vars, then they must be defined in the user's local `.env` file otherwise `now dev` exits with an error.