### PR TITLE
[now dev] Update bootup message

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -195,7 +195,7 @@ export default class DevServer {
     }
 
     this.output.ready(
-      `${chalk.bold('`now dev`')} server listening at ${chalk.cyan.underline(
+      `Development server running at ${chalk.cyan.underline(
         address.replace('[::]', 'localhost')
       )}`
     );


### PR DESCRIPTION
This looks a bit cleaner since the user just typed `now dev` into their
CLI so no need to print the same command again.