### PR TITLE
Update `pcre-to-regexp` to v0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "npm-package-arg": "6.1.0",
     "nyc": "13.2.0",
     "ora": "1.3.0",
-    "pcre-to-regexp": "0.0.4",
+    "pcre-to-regexp": "0.0.5",
     "pkg": "4.3.7",
     "pluralize": "7.0.0",
     "pre-commit": "1.2.2",

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -14,6 +14,10 @@ export default function(reqPath = '', routes?: RouteConfig[]): RouteResult {
   if (routes) {
     routes.find((routeConfig: RouteConfig, idx: number) => {
       let { src } = routeConfig;
+      if (!src) {
+        // ignore { "handler" } routes for now
+        return false;
+      }
 
       if (!src.startsWith('^')) {
         src = `^${src}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,10 +5455,10 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-pcre-to-regexp@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/pcre-to-regexp/-/pcre-to-regexp-0.0.4.tgz#a19c3fc6af540349f915367a4776c75c651dae05"
-  integrity sha1-oZw/xq9UA0n5FTZ6R3bHXGUdrgU=
+pcre-to-regexp@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/pcre-to-regexp/-/pcre-to-regexp-0.0.5.tgz#95ba2462c12aeb375c7f8de1168c85c6eef61cdd"
+  integrity sha512-0FCWn56OoWhaEeekT+C8z+vYBgZdGj05Auu3KeKkzj+CWQ6jTtHGdffaoU7WH/f37ZyHAHnRmFvKYZwR31DByg==
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
For `now dev`, this fixes an edge case in named capture groups
in some `routes` definitions that would lead to an error being thrown:

```
Cannot read property '1' of null
```

Also ignoring "handler" routes for now.