### PR TITLE
[now dev] Pass `meta` object to Builders' `build()` function

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -46,7 +46,8 @@ export async function buildUserProject(
 export async function executeBuild(
   nowJson: NowConfig,
   devServer: DevServer,
-  asset: BuilderOutput
+  asset: BuilderOutput,
+  requestPath: string | null = null
 ): Promise<void> {
   const { buildConfig, buildEntry } = asset;
   if (!buildConfig || !buildEntry) {
@@ -78,7 +79,7 @@ export async function executeBuild(
       entrypoint,
       workPath,
       config,
-      isDev: true
+      meta: { isDev: true, requestPath }
     });
   } finally {
     devServer.restoreOriginalEnv();
@@ -190,7 +191,7 @@ async function executeBuilds(
             entrypoint,
             workPath,
             config,
-            isDev: true
+            meta: { isDev: true, requestPath: null }
           });
         } finally {
           devServer.restoreOriginalEnv();

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -435,7 +435,7 @@ export default class DevServer {
         this.output.debug(
           `Rebuilding asset "${entrypoint}" for "${req.method} ${req.url}"`
         );
-        buildPromise = executeBuild(nowJson, this, asset);
+        buildPromise = executeBuild(nowJson, this, asset, req.url);
         this.inProgressBuilds.set(entrypoint, buildPromise);
       }
       try {

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -73,7 +73,10 @@ export interface BuilderParamsBase {
   files: BuilderInputs;
   entrypoint: string;
   config: object;
-  isDev?: boolean;
+  meta?: {
+    isDev?: boolean;
+    requestPath?: string | null;
+  };
 }
 
 export interface BuilderParams extends BuilderParamsBase {


### PR DESCRIPTION
This introduces a new object called `meta` that gets passed to the Now Builders' `build()` function. The `isDev` property is moved to this object, and a new property `requestPath` is also introduced.

`requestPath` represents the URL that was requested to trigger the `build()` to be called. It may be used by builders to do incremental compilation and only re-build the assets related to the URL that was requested. For example, `@now/next` may use this property to only build the page that was requested.