### PR TITLE
[now dev] Respond with 404 once the server is shutting down

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -49,6 +49,7 @@ export default class DevServer {
 
   private server: http.Server;
   private status: DevServerStatus;
+  private stopping: boolean;
   private statusMessage: string = '';
   private inProgressBuilds: Map<string, Promise<void>>;
   private originalEnv: EnvConfig;
@@ -61,6 +62,7 @@ export default class DevServer {
     this.buildEnv = {};
     this.server = http.createServer(this.devServerHandler);
     this.status = DevServerStatus.busy;
+    this.stopping = false;
     this.inProgressBuilds = new Map();
     this.originalEnv = { ...process.env };
   }
@@ -215,6 +217,8 @@ export default class DevServer {
    * Shuts down the `now dev` server, and cleans up any temporary resources.
    */
   async stop(): Promise<void> {
+    if (this.stopping) return;
+    this.stopping = true;
     this.output.log(`Stopping ${chalk.bold('`now dev`')} server`);
     const ops = Object.values(this.assets).map((asset: BuilderOutput) => {
       if (asset.type === 'Lambda' && asset.fn) {
@@ -316,6 +320,14 @@ export default class DevServer {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ) => {
+    const nowRequestId = generateRequestId();
+
+    if (this.stopping) {
+      res.setHeader('Connection', 'close');
+      await this.send404(req, res, nowRequestId);
+      return;
+    }
+
     const method = req.method || 'GET';
     this.output.log(`${chalk.bold(method)} ${req.url}`);
 
@@ -324,7 +336,6 @@ export default class DevServer {
     }
 
     try {
-      const nowRequestId = generateRequestId();
       const nowJson = await this.getNowJson();
       if (!nowJson) {
         await this.serveProjectAsStatic(req, res, nowRequestId);


### PR DESCRIPTION
In the case of a keep-alive connection from the web browser, and a page continuing to send HTTP requests to the dev server, sometimes the server never shuts down. So send a 404 response with `Connection: close` to force the web browser to close the connection.