### PR TITLE
Exit when --target production is set but no alias was provided

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -34,7 +34,8 @@ import {
   TooManyCertificates,
   TooManyRequests,
   InvalidDomain,
-  DeploymentNotFound
+  DeploymentNotFound,
+  AliasMissing
 } from '../../util/errors-ts';
 import { SchemaValidationFailed } from '../../util/errors';
 
@@ -216,7 +217,8 @@ export default async function main(
 
   if ((localConfig.alias || []).length === 0 && argv['--target'] === 'production') {
     const flag = param('--target production');
-    output.warn(`You specified ${flag} but didn't configure a value for the ${code('alias')} configuration property.`);
+    error(`You specified ${flag} but didn't configure a value for the ${code('alias')} configuration property.`);
+    return 1;
   }
   // $FlowFixMe
   const isTTY = process.stdout.isTTY;
@@ -374,7 +376,8 @@ export default async function main(
       firstDeployCall instanceof TooManyCertificates ||
       firstDeployCall instanceof TooManyRequests ||
       firstDeployCall instanceof InvalidDomain ||
-      firstDeployCall instanceof DeploymentNotFound
+      firstDeployCall instanceof DeploymentNotFound ||
+      firstDeployCall instanceof AliasMissing
     ) {
       handleCreateDeployError(output, firstDeployCall);
       return 1;
@@ -729,6 +732,10 @@ function handleCreateDeployError(output, error) {
     return 1;
   }
   if (error instanceof DeploymentNotFound) {
+    output.error(error.message);
+    return 1;
+  }
+  if (error instanceof AliasMissing) {
     output.error(error.message);
     return 1;
   }

--- a/src/util/deploy/create-deploy.js
+++ b/src/util/deploy/create-deploy.js
@@ -28,6 +28,10 @@ export default async function createDeploy(
       return new ERRORS_TS.DomainVerificationFailed(error.value);
     }
 
+    if (error.code === 'alias_missing') {
+      return new ERRORS_TS.AliasMissing();
+    }
+
     // If the user doesn't have permissions over the domain used as a suffix we fail
     if (error.code === 'forbidden') {
       return new ERRORS_TS.DomainPermissionDenied(error.value, contextName);

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1050,3 +1050,16 @@ export class MissingDotenvVarsError extends NowError<
     });
   }
 }
+
+export class AliasMissing extends NowError<
+  'ALIAS_MISSING',
+  {}
+> {
+  constructor() {
+    super({
+      code: 'ALIAS_MISSING',
+      message: 'When using `--target production`, you need to define at least one alias in `now.json',
+      meta: {}
+    });
+  }
+}


### PR DESCRIPTION
This makes sure that the user gets a correct error message when using `--target production` without any alias.