### PR TITLE
Ignore `.env` and `.env.build` for deployments by default

### DIFF
--- a/src/util/ignored.ts
+++ b/src/util/ignored.ts
@@ -11,6 +11,8 @@ export default `.hg
 .DS_Store
 .wafpicke-*
 .lock-wscript
+.env
+.env.build
 npm-debug.log
 config.gypi
 node_modules


### PR DESCRIPTION
Because `now dev` uses these dotenv files to define the Now secrets to use, it would be bad practice to include them in the deployment files since they will be using development values instead of production values.