### PR TITLE
don't forget to do a `yarn install` before linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ For details on how to use Now CLI, check out our [documentation](https://zeit.co
 ## Caught a Bug?
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
-2. Link the package to the global module directory: `yarn run link` (not `yarn link`)
-3. You can now start using `now` anywhere inside the command line
+2. Install dependencies with `yarn install`
+3. Link the package to the global module directory: `yarn run link` (not `yarn link`)
+4. You can now start using `now` anywhere inside the command line
 
 As always, you should use `yarn test` to run the tests and see if your changes have broken anything.
 


### PR DESCRIPTION
## Caught a Bug?

1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
2. Install dependencies with `yarn install`
3. Link the package to the global module directory: `yarn run link` (not `yarn link`)
4. You can now start using `now` anywhere inside the command line