### PR TITLE
[now dev] Set the same `MemorySize` on the lambdas as production

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -124,6 +124,7 @@ export async function executeBuild(
           Code: { ZipFile: asset.zipBuffer },
           Handler: asset.handler,
           Runtime: asset.runtime,
+          MemorySize: 3008,
           Environment: {
             Variables: {
               ...nowJson.env,
@@ -253,6 +254,7 @@ async function executeBuilds(
           Code: { ZipFile: asset.zipBuffer },
           Handler: asset.handler,
           Runtime: asset.runtime,
+          MemorySize: 3008,
           Environment: {
             Variables: {
               ...nowJson.env,


### PR DESCRIPTION
This should fix https://spectrum.chat/zeit/now/now-dev-javascript-heap-out-of-memory~3fd6e823-59de-426b-ade0-af48d18f3494