### PR TITLE
[now dev] Use a different `workPath` for every build

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -3,7 +3,6 @@ import url from 'url';
 import http from 'http';
 import fs from 'fs-extra';
 import chalk from 'chalk';
-import qs from 'querystring';
 import rawBody from 'raw-body';
 import { inspect } from 'util';
 import listen from 'async-listen';


### PR DESCRIPTION
This is more inline with how a fresh Now deployment works, where is has to download fresh files each time. This will also fix the issue with `@now/next` that deleted the `.next` output dir and deleting static files upon subsequent builds.

This is still a bit unoptimized because `prepareCache()` from the builder is not yet being invoked, but it's still more correct than reusing the `workPath`.