### PR TITLE
Fix getCertsById + handle cert not found by id error

### DIFF
--- a/src/commands/certs/rm.js
+++ b/src/commands/certs/rm.js
@@ -9,6 +9,7 @@ import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
 import Now from '../../util';
 import stamp from '../../util/output/stamp.ts';
+import param from '../../util/output/param';
 
 async function rm(ctx, opts, args, output) {
   const { authConfig: { token }, config } = ctx;
@@ -44,7 +45,16 @@ async function rm(ctx, opts, args, output) {
   }
 
   const id = args[0];
-  const certs = await getCertsToDelete(output, now, id);
+  let certs;
+  try {
+    certs = await getCertsToDelete(output, now, id);
+  } catch (error) {
+    if (error.code === 'cert_not_found') {
+      output.error(`Cert not found by ${param(id)}`);
+      process.exit(1);
+    }
+    throw error;
+  }
 
   if (certs.length === 0) {
     output.error(

--- a/src/commands/certs/rm.ts
+++ b/src/commands/certs/rm.ts
@@ -2,17 +2,31 @@ import chalk from 'chalk';
 import ms from 'ms';
 import plural from 'pluralize';
 import table from 'text-table';
+import { NowContext, Cert } from '../../types';
+import * as ERRORS from '../../util/errors-ts';
+import { Output } from '../../util/output';
 import deleteCertById from '../../util/certs/delete-cert-by-id';
 import getCertById from '../../util/certs/get-cert-by-id';
-import getCerts from '../../util/certs/get-certs';
-import Client from '../../util/client.ts';
-import getScope from '../../util/get-scope.ts';
-import Now from '../../util';
-import stamp from '../../util/output/stamp.ts';
+import getCertsForDomain from '../../util/certs/get-certs-for-domain';
+import Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import stamp from '../../util/output/stamp';
 import param from '../../util/output/param';
 
-async function rm(ctx, opts, args, output) {
-  const { authConfig: { token }, config } = ctx;
+type Options = {
+  '--debug': boolean;
+};
+
+async function rm(
+  ctx: NowContext,
+  opts: Options,
+  args: string[],
+  output: Output
+) {
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const rmStamp = stamp();
@@ -32,37 +46,28 @@ async function rm(ctx, opts, args, output) {
     throw err;
   }
 
-  const now = new Now({ apiUrl, token, debug, currentTeam });
-
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
         '`now certs rm <id or cn>`'
       )}`
     );
-    now.close();
     return 1;
   }
 
   const id = args[0];
-  let certs;
-  try {
-    certs = await getCertsToDelete(output, now, id);
-  } catch (error) {
-    if (error.code === 'cert_not_found') {
-      output.error(`Cert not found by ${param(id)}`);
-      process.exit(1);
-    }
-    throw error;
+  const certs = await getCertsToDelete(output, client, contextName, id);
+  if (certs instanceof ERRORS.CertsPermissionDenied) {
+    output.error(
+      `You don't have access to ${param(id)}'s certs under ${contextName}.`
+    );
+    return 1;
   }
 
   if (certs.length === 0) {
     output.error(
-      `No certificates found by id "${id}" under ${chalk.bold(
-        contextName
-      )}`
+      `No certificates found by id "${id}" under ${chalk.bold(contextName)}`
     );
-    now.close();
     return 1;
   }
 
@@ -73,11 +78,12 @@ async function rm(ctx, opts, args, output) {
   );
 
   if (!yes) {
-    now.close();
     return 0;
   }
 
-  await Promise.all(certs.map(cert => deleteCertById(output, now, cert.uid)));
+  await Promise.all(
+    certs.map(cert => deleteCertById(output, client, cert.uid))
+  );
   output.success(
     `${chalk.bold(
       plural('Certificate', certs.length, true)
@@ -86,16 +92,28 @@ async function rm(ctx, opts, args, output) {
   return 0;
 }
 
-async function getCertsToDelete(output, now, id) {
-  const cert = await getCertById(output, now, id);
-  return !cert ? getCerts(output, now, id) : [cert];
+async function getCertsToDelete(
+  output: Output,
+  client: Client,
+  contextName: string,
+  id: string
+) {
+  const cert = await getCertById(output, client, id);
+  if (cert instanceof ERRORS.CertNotFound) {
+    const certs = await getCertsForDomain(output, client, contextName, id);
+    if (certs instanceof ERRORS.CertsPermissionDenied) {
+      return certs;
+    }
+    return certs;
+  }
+  return [cert];
 }
 
-function readConfirmation(output, msg, certs) {
+function readConfirmation(output: Output, msg: string, certs: Cert[]) {
   return new Promise(resolve => {
     output.log(msg);
     output.print(
-      `${table([...certs.map(formatCertRow)], {
+      `${table(certs.map(formatCertRow), {
         align: ['l', 'r', 'l'],
         hsep: ' '.repeat(6)
       }).replace(/^(.*)/gm, '  $1')}\n`
@@ -117,13 +135,13 @@ function readConfirmation(output, msg, certs) {
   });
 }
 
-function formatCertRow(cert) {
+function formatCertRow(cert: Cert) {
   return [
     cert.uid,
     chalk.bold(cert.cns ? cert.cns.join(', ') : '–'),
-    ...cert.created
-      ? [chalk.gray(`${ms(new Date() - new Date(cert.created))} ago`)]
-      : []
+    ...(cert.created
+      ? [chalk.gray(`${ms(Date.now() - new Date(cert.created).getTime())} ago`)]
+      : [])
   ];
 }
 

--- a/src/util/certs/get-cert-by-id.ts
+++ b/src/util/certs/get-cert-by-id.ts
@@ -1,18 +1,19 @@
 import { Cert } from '../../types';
 import { Output } from '../output/create-output';
 import Client from '../client';
-
-type CertDetails = Cert & {
-  key: string;
-  ca: string;
-  crt: string;
-};
+import * as ERRORS from '../errors-ts';
 
 export default async function getCertById(
   output: Output,
   client: Client,
   id: string
 ) {
-  const cert = await client.fetch<CertDetails>(`/v3/now/certs/${id}?limit=1`);
-  return cert || null;
+  try {
+    return await client.fetch<Cert>(`/v3/now/certs/${id}`);
+  } catch (error) {
+    if (error.code === 'cert_not_found') {
+      return new ERRORS.CertNotFound(id);
+    }
+    throw error;
+  }
 }

--- a/src/util/certs/get-cert-by-id.ts
+++ b/src/util/certs/get-cert-by-id.ts
@@ -14,7 +14,5 @@ export default async function getCertById(
   id: string
 ) {
   const cert = await client.fetch<CertDetails>(`/v3/now/certs/${id}?limit=1`);
-  // If `id` isn't a valid id the API responds with a set of certificates instead
-  if (!cert || !cert.key) return null;
-  return cert;
+  return cert || null;
 }

--- a/src/util/certs/get-certs-for-domain.ts
+++ b/src/util/certs/get-certs-for-domain.ts
@@ -1,13 +1,28 @@
 import { Cert } from '../../types';
 import { Output } from '../output';
+import * as ERRORS from '../errors-ts';
 import Client from '../client';
-import getCerts from './get-certs';
+import { stringify } from 'querystring';
+
+type Response = {
+  certs: Cert[];
+};
 
 export default async function getCertsForDomain(
   output: Output,
   client: Client,
+  context: string,
   domain: string
 ) {
-  const certs = await getCerts(output, client);
-  return certs.filter((cert: Cert) => cert.cns[0].endsWith(domain));
+  try {
+    const { certs } = await client.fetch<Response>(
+      `/v3/now/certs?${stringify({ domain })}`
+    );
+    return certs;
+  } catch (error) {
+    if (error.code === 'forbidden') {
+      return new ERRORS.CertsPermissionDenied(context, domain);
+    }
+    throw error;
+  }
 }

--- a/src/util/certs/get-certs.ts
+++ b/src/util/certs/get-certs.ts
@@ -1,4 +1,3 @@
-import { stringify } from 'querystring';
 import Client from '../client';
 import { Output } from '../output';
 import { Cert } from '../../types';
@@ -7,12 +6,7 @@ type Response = {
   certs: Cert[];
 };
 
-export default async function getCerts(
-  output: Output,
-  client: Client,
-  domain?: string
-) {
-  const query = domain ? stringify({ domain }) : '';
-  const { certs } = await client.fetch<Response>(`/v3/now/certs?${query}`);
+export default async function getCerts(output: Output, client: Client) {
+  const { certs } = await client.fetch<Response>(`/v3/now/certs`);
   return certs;
 }

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -415,6 +415,29 @@ export class DomainConfigurationError extends NowError<
   }
 }
 
+export class CertNotFound extends NowError<'CERT_NOT_FOUND', { id: string }> {
+  constructor(id: string) {
+    super({
+      code: 'CERT_NOT_FOUND',
+      meta: { id },
+      message: `The cert ${id} can't be found.`
+    });
+  }
+}
+
+export class CertsPermissionDenied extends NowError<
+  'CERTS_PERMISSION_DENIED',
+  { domain: string }
+> {
+  constructor(context: string, domain: string) {
+    super({
+      code: 'CERTS_PERMISSION_DENIED',
+      meta: { domain },
+      message: `You don't have access to ${domain}'s certs under ${context}.`
+    });
+  }
+}
+
 export class CertOrderNotFound extends NowError<
   'CERT_ORDER_NOT_FOUND',
   { cns: string[] }
@@ -876,7 +899,7 @@ export class DNSConflictingRecord extends NowError<
       code: 'DNS_CONFLICTING_RECORD',
       meta: { record },
       message: ` A conflicting record exists "${record}".`
-    })
+    });
   }
 }
 
@@ -986,10 +1009,7 @@ export class InvalidMoveToken extends NowError<
   }
 }
 
-export class NoBuilderCacheError extends NowError<
-  'NO_BUILDER_CACHE',
-  {}
-> {
+export class NoBuilderCacheError extends NowError<'NO_BUILDER_CACHE', {}> {
   constructor() {
     super({
       code: 'NO_BUILDER_CACHE',
@@ -1014,16 +1034,16 @@ export class BuilderCacheCleanError extends NowError<
 
 export class LambdaSizeExceededError extends NowError<
   'MAX_LAMBDA_SIZE_EXCEEDED',
-  { size: number, maxLambdaSize: number }
+  { size: number; maxLambdaSize: number }
 > {
   constructor(size: number, maxLambdaSize: number) {
     super({
       code: 'MAX_LAMBDA_SIZE_EXCEEDED',
       message: `The lambda function size (${bytes(
-            size
-          ).toLowerCase()}) exceeds the configured limit (${bytes(
-            maxLambdaSize
-          ).toLowerCase()}). You may increase this by supplying \`maxLambdaSize\` to the build \`config\``,
+        size
+      ).toLowerCase()}) exceeds the configured limit (${bytes(
+        maxLambdaSize
+      ).toLowerCase()}). You may increase this by supplying \`maxLambdaSize\` to the build \`config\``,
       meta: { size, maxLambdaSize }
     });
   }
@@ -1031,12 +1051,14 @@ export class LambdaSizeExceededError extends NowError<
 
 export class MissingDotenvVarsError extends NowError<
   'MISSING_DOTENV_VARS',
-  { type: string, missing: string[] }
+  { type: string; missing: string[] }
 > {
   constructor(type: string, missing: string[]) {
     let message: string;
     if (missing.length === 1) {
-      message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(type)} file`;
+      message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(
+        type
+      )} file`;
     } else {
       message = [
         `The following env vars are not defined in ${code(type)} file:`,


### PR DESCRIPTION
* Fixes `getCertsById` and handles case when user supplies invalid cert id to remove.
* Migrates certs/rm.js to typescript