### PR TITLE
[now dev] Invoke `prepareCache()` from Builders

### DIFF
--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -22,6 +22,7 @@ export interface BuildConfig {
   use: string;
   config?: object;
   builder?: Builder;
+  builderCache?: CacheOutputs;
 }
 
 export interface RouteConfig {
@@ -68,14 +69,16 @@ export type BuiltLambda = Lambda &
   BuiltAsset & {
     fn?: FunLambda;
   };
-export type BuilderOutput =
-  | BuildSubscription
-  | BuiltLambda
-  | BuiltFileFsRef
-  | BuiltFileBlob;
+export type BuilderOutput = BuiltLambda | BuiltFileFsRef | BuiltFileBlob;
 
 export interface BuilderOutputs {
   [path: string]: BuilderOutput;
+}
+
+export type CacheOutput = BuiltFileFsRef | BuiltFileBlob;
+
+export interface CacheOutputs {
+  [path: string]: CacheOutput;
 }
 
 export interface BuilderParamsBase {
@@ -92,7 +95,7 @@ export interface BuilderParams extends BuilderParamsBase {
   workPath: string;
 }
 
-export interface PrepareCacheParams extends BuilderParamsBase {
+export interface PrepareCacheParams extends BuilderParams {
   cachePath: string;
 }
 
@@ -102,7 +105,7 @@ export interface Builder {
   };
   build(params: BuilderParams): BuilderOutputs;
   subscribe?(params: BuilderParamsBase): Promise<string[]>;
-  prepareCache?(params: PrepareCacheParams): BuilderOutputs;
+  prepareCache?(params: PrepareCacheParams): CacheOutputs;
 }
 
 export interface HttpHeadersConfig {


### PR DESCRIPTION
If a builder defines the `prepareCache()` function, then it gets invoked after `build()` has completed to set up the initial build state of the next build for this same asset.

For example, the goal for `@now/node` if the package.json has not changed is to have yarn produce the "Already up-to-date" message on the next build, because installing dependencies ends up taking a long time on bigger projects.

<img width="780" alt="Screen Shot 2019-04-05 at 3 37 34 PM" src="https://user-images.githubusercontent.com/71256/55660118-88f78580-57b9-11e9-9156-8b54cb2b74a2.png">