### PR TITLE
[now dev] Run `prepareCache()` asynchronous

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -21,7 +21,9 @@ import {
   BuilderInputs,
   BuilderOutput,
   BuilderOutputs,
-  BuiltLambda
+  BuiltLambda,
+  CacheOutputs,
+  PrepareCacheParams
 } from './types';
 
 const tmpDir = tmpdir();
@@ -58,6 +60,26 @@ export async function executeInitialBuilds(
   }
 }
 
+export async function executePrepareCache(
+  buildConfig: BuildConfig,
+  params: PrepareCacheParams
+): Promise<CacheOutputs> {
+  const { builder } = buildConfig;
+  if (!builder) {
+    throw new Error('No builder');
+  }
+  if (!builder.prepareCache) {
+    throw new Error('Builder has no `prepareCache()` function');
+  }
+
+  // Since the `prepareCache()` function may be computationally expensive, and
+  // its run in the same process as `now dev` (for now), defer executing it
+  // until after there has been time for the current HTTP request to complete.
+  await new Promise(r => setTimeout(r, 3000));
+
+  return await builder.prepareCache(params);
+}
+
 export async function executeBuild(
   nowJson: NowConfig,
   devServer: DevServer,
@@ -74,9 +96,10 @@ export async function executeBuild(
   const workPath = getWorkPath();
   await mkdirp(workPath);
 
-  if (buildConfig.builderCache) {
+  if (buildConfig.builderCachePromise) {
     devServer.output.debug('Restoring build cache from previous build');
-    await download(buildConfig.builderCache, workPath);
+    const builderCache = await buildConfig.builderCachePromise;
+    await download(builderCache, workPath);
   }
 
   devServer.output.debug(
@@ -103,7 +126,7 @@ export async function executeBuild(
     if (typeof builder.prepareCache === 'function') {
       const cachePath = getWorkPath();
       await mkdirp(cachePath);
-      const builderCache = await builder.prepareCache({
+      buildConfig.builderCachePromise = executePrepareCache(buildConfig, {
         files,
         entrypoint,
         workPath,
@@ -111,7 +134,6 @@ export async function executeBuild(
         config,
         meta: { isDev: true, requestPath }
       });
-      buildConfig.builderCache = builderCache;
     }
   } finally {
     devServer.restoreOriginalEnv();
@@ -243,7 +265,7 @@ async function executeBuilds(
             if (typeof builder.prepareCache === 'function') {
               const cachePath = getWorkPath();
               await mkdirp(cachePath);
-              const builderCache = await builder.prepareCache({
+              build.builderCachePromise = executePrepareCache(build, {
                 files,
                 entrypoint,
                 workPath,
@@ -251,7 +273,6 @@ async function executeBuilds(
                 config,
                 meta: { isDev: true, requestPath: null }
               });
-              build.builderCache = builderCache;
             }
           }
         } finally {

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -105,7 +105,9 @@ export interface Builder {
   };
   build(params: BuilderParams): BuilderOutputs;
   subscribe?(params: BuilderParamsBase): Promise<string[]>;
-  prepareCache?(params: PrepareCacheParams): CacheOutputs | Promise<CacheOutputs>;
+  prepareCache?(
+    params: PrepareCacheParams
+  ): CacheOutputs | Promise<CacheOutputs>;
 }
 
 export interface HttpHeadersConfig {

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -22,7 +22,7 @@ export interface BuildConfig {
   use: string;
   config?: object;
   builder?: Builder;
-  builderCache?: CacheOutputs;
+  builderCachePromise?: Promise<CacheOutputs>;
 }
 
 export interface RouteConfig {
@@ -105,7 +105,7 @@ export interface Builder {
   };
   build(params: BuilderParams): BuilderOutputs;
   subscribe?(params: BuilderParamsBase): Promise<string[]>;
-  prepareCache?(params: PrepareCacheParams): CacheOutputs;
+  prepareCache?(params: PrepareCacheParams): CacheOutputs | Promise<CacheOutputs>;
 }
 
 export interface HttpHeadersConfig {


### PR DESCRIPTION
And also wait a few seconds before running the actual logic, since the `prepareCache()` function may be computationally expensive, and its run in the same process as `now dev` (for now), so allow some time for the current HTTP request to complete.