### PR TITLE
Handle unsupported tld when attempting to purchase domain

### DIFF
--- a/src/commands/domains/buy.ts
+++ b/src/commands/domains/buy.ts
@@ -113,6 +113,13 @@ export default async function buy(
     return 1;
   }
 
+  if (buyResult instanceof ERRORS.UnsupportedTLD) {
+    output.error(
+      `The TLD for domain name ${buyResult.meta.domain} is not supported.`
+    );
+    return 1;
+  }
+
   if (buyResult instanceof ERRORS.InvalidDomain) {
     output.error(`The domain ${buyResult.meta.domain} is not valid.`);
     return 1;

--- a/src/util/domains/purchase-domain.ts
+++ b/src/util/domains/purchase-domain.ts
@@ -38,6 +38,9 @@ export default async function purchaseDomain(
     if (error.code === 'payment_error') {
       return new ERRORS.DomainPaymentError();
     }
+    if (error.code === 'unsupported_tld') {
+      return new ERRORS.UnsupportedTLD(name);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
Shows proper error message when attempting to purchase a domain with an unsupported TLD.

```
> The domain "domain-name.uk" is available to buy under zeit!
> Buy now for $10 (1yr)? [y|N]
> Error! The TLD for domain name domain-name.uk is not supported.
```