### PR TITLE
Print full validation error message

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -707,7 +707,7 @@ function handleCreateDeployError(output, error) {
     output.error(
       `Failed to validate ${highlight(
         'now.json'
-      )}: ${message}\nFull list of allowed properties: ${link}`
+      )}: ${message}\nDocumentation: ${link}`
     );
 
     return 1;

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -668,14 +668,17 @@ function handleCreateDeployError(output, error) {
     return 1;
   }
   if (error instanceof SchemaValidationFailed) {
-    const { params, keyword, dataPath } = error.meta;
+    const { message, params, keyword, dataPath } = error.meta;
+
     if (params && params.additionalProperty) {
       const prop = params.additionalProperty;
+
       output.error(
         `The property ${code(prop)} is not allowed in ${highlight(
           'now.json'
         )} when using Now 2.0 – please remove it.`
       );
+
       if (prop === 'build.env' || prop === 'builds.env') {
         output.note(
           `Do you mean ${code('build')} (object) with a property ${code(
@@ -683,23 +686,30 @@ function handleCreateDeployError(output, error) {
           )} (object) instead of ${code(prop)}?`
         );
       }
+
       return 1;
     }
+
     if (keyword === 'type') {
       const prop = dataPath.substr(1, dataPath.length);
+
       output.error(
         `The property ${code(prop)} in ${highlight(
           'now.json'
         )} can only be of type ${code(title(params.type))}.`
       );
+
       return 1;
     }
+
     const link = 'https://zeit.co/docs/v2/deployments/configuration/';
+
     output.error(
       `Failed to validate ${highlight(
         'now.json'
-      )}. Only use properties mentioned here: ${link}`
+      )}: ${message}\nFull list of allowed properties: ${link}`
     );
+
     return 1;
   }
   if (error instanceof TooManyCertificates) {

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -1245,7 +1245,7 @@ function handleCreateDeployError(output, error) {
     output.error(
       `Failed to validate ${highlight(
         'now.json'
-      )}: ${message}\nFull list of allowed properties: ${link}`
+      )}: ${message}\nDocumentation: ${link}`
     );
 
     return 1;

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -1206,14 +1206,17 @@ function handleCreateDeployError(output, error) {
     return 1;
   }
   if (error instanceof SchemaValidationFailed) {
-    const { params, keyword, dataPath } = error.meta;
+    const { message, params, keyword, dataPath } = error.meta;
+
     if (params && params.additionalProperty) {
       const prop = params.additionalProperty;
+
       output.error(
         `The property ${code(prop)} is not allowed in ${highlight(
           'now.json'
         )} when using Now 1.0 – please remove it.`
       );
+
       if (prop === 'build.env' || prop === 'builds.env') {
         output.note(
           `Do you mean ${code('build')} (object) with a property ${code(
@@ -1221,23 +1224,30 @@ function handleCreateDeployError(output, error) {
           )} (object) instead of ${code(prop)}?`
         );
       }
+
       return 1;
     }
+
     if (keyword === 'type') {
       const prop = dataPath.substr(1, dataPath.length);
+
       output.error(
         `The property ${code(prop)} in ${highlight(
           'now.json'
         )} can only be of type ${code(title(params.type))}.`
       );
+
       return 1;
     }
-    const link = 'https://zeit.co/docs/v1/features/configuration/#settings';
+
+    const link = 'https://zeit.co/docs/v2/deployments/configuration/';
+
     output.error(
       `Failed to validate ${highlight(
         'now.json'
-      )}. Only use properties mentioned here: ${link}`
+      )}: ${message}\nFull list of allowed properties: ${link}`
     );
+
     return 1;
   }
   if (error instanceof TooManyCertificates) {


### PR DESCRIPTION
This ensures we print the full error message if no error handlers are matched.

**BEFORE:**

```
> Error! Failed to validate now.json. Only use properties mentioned here: https://zeit.co/docs/v2/deployments/configuration/
```

**AFTER:**

```
> Error! Failed to validate now.json: Invalid request: alias should NOT have more than 10 items
Documentation: https://zeit.co/docs/v2/deployments/configuration/
```