### PR TITLE
Stop indicating whether CDN is enabled

### DIFF
--- a/src/commands/domains/inspect.ts
+++ b/src/commands/domains/inspect.ts
@@ -115,7 +115,6 @@ export default async function inspect(
   output.print(
     `    ${chalk.cyan('TXT Verified At')}\t\t${formatDate(domain.txtVerifiedAt)}\n`
   );
-  output.print(`    ${chalk.cyan('Cloudflare Enabled')}\t\t${domain.cdnEnabled}\n`);
   output.print('\n');
 
   output.print(chalk.bold('  Nameservers\n\n'));

--- a/src/commands/domains/ls.ts
+++ b/src/commands/domains/ls.ts
@@ -74,10 +74,9 @@ function formatDomainsTable(domains: Domain[]) {
         chalk.gray('age')
       ].map(s => chalk.dim(s)),
       ...domains.map(domain => {
-        const cf = domain.cdnEnabled || false;
         const url = chalk.bold(domain.name);
         const time = chalk.gray(ms(current.getTime() - domain.createdAt));
-        return ['', url, domain.serviceType, domain.verified, cf, time];
+        return ['', url, domain.serviceType, domain.verified, time];
       })
     ],
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,6 @@ export type Domain = {
   transferredAt?: number | null;
   orderedAt?: number;
   serviceType: 'zeit.world' | 'external' | 'na';
-  cdnEnabled: boolean;
   verified: boolean;
   nsVerifiedAt: number | null;
   txtVerifiedAt: number | null;


### PR DESCRIPTION
Since the CDN (our own, not Cloudflare anymore) is not enabled by default, there's no need to indicate whether it is enabled anymore.