### PR TITLE
[now dev] Refactor to support `shouldServe()` in Now Builders

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -86,7 +86,7 @@ export async function installBuilders(
   update: boolean = false
 ): Promise<void> {
   if (packages.length === 1 && Object.hasOwnProperty.call(localBuilders, packages[0])) {
-    // Static deployment, no bulders to install
+    // Static deployment, no builders to install
     return;
   }
   const cacheDir = await builderDirPromise;

--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -85,6 +85,10 @@ export async function installBuilders(
   packages: string[],
   update: boolean = false
 ): Promise<void> {
+  if (packages.length === 1 && localBuilders.hasOwnProperty(packages[0])) {
+    // Static deployment, no bulders to install
+    return;
+  }
   const cacheDir = await builderDirPromise;
   const buildersPkg = join(cacheDir, 'package.json');
   const pkg = await readJSON(buildersPkg);

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -39,22 +39,6 @@ const getWorkPath = () =>
       .slice(-8)
   );
 
-/**
- * Build project to statics & lambdas
- */
-/*
-export async function executeInitialBuilds(
-  nowJson: NowConfig,
-  devServer: DevServer
-): Promise<void> {
-  const builds = nowJson.builds || [];
-  await installBuilders(builds.map(build => build.use));
-
-  devServer.setStatusBusy('Building lambdas');
-  await executeBuilds(nowJson, devServer);
-}
- */
-
 export async function executePrepareCache(
   devServer: DevServer,
   buildMatch: BuildMatch,
@@ -84,9 +68,13 @@ export async function executePrepareCache(
 export async function executeBuild(
   nowJson: NowConfig,
   devServer: DevServer,
+  files: BuilderInputs,
   match: BuildMatch,
   requestPath: string | null = null
 ): Promise<void> {
+  if (!match.buildOutput) {
+    match.buildOutput = {};
+  }
   const { builderWithPkg: { builder, package: pkg } } = match;
   const { cwd, env } = devServer;
   const entrypoint = match.src;
@@ -104,12 +92,11 @@ export async function executeBuild(
   }
 
   devServer.output.debug(
-    `Building ${entrypoint} with "${match.use}" v${
-      pkg.version
+    `Building ${entrypoint} with "${match.use}"${
+      pkg.version ? ` v${pkg.version}` : ''
     } (workPath = ${workPath})`
   );
   const builderConfig = builder.config || {};
-  const files = await collectProjectFiles('**', cwd);
   const config = match.config || {};
   let outputs: BuilderOutputs;
   let result: BuildResult;
@@ -164,9 +151,6 @@ export async function executeBuild(
         throw new LambdaSizeExceededError(size, maxLambdaBytes);
       }
     }
-
-    //asset.buildMatch = buildMatch;
-    //asset.buildEntry = buildEntry;
   }
 
   await Promise.all(
@@ -176,7 +160,7 @@ export async function executeBuild(
 
       if (asset.type === 'Lambda') {
         // Tear down the previous `fun` Lambda instance for this asset
-        const oldAsset = devServer.assets[path];
+        const oldAsset = match.buildOutput && match.buildOutput[path];
         if (oldAsset && oldAsset.type === 'Lambda' && oldAsset.fn) {
           await oldAsset.fn.destroy();
         }
@@ -201,147 +185,8 @@ export async function executeBuild(
     })
   );
 
-  // TODO: remove previous assets, i.e. if the rebuild has different outputs that
-  // don't include some of the previous ones. For example, deleting a page in
-  // a Next.js build
-  if (!match.buildOutput) {
-    match.buildOutput = {};
-  }
   Object.assign(match.buildOutput, outputs);
 }
-
-/*
-async function executeBuilds(
-  nowJson: NowConfig,
-  devServer: DevServer
-): Promise<void> {
-  if (!nowJson.builds) {
-    return;
-  }
-
-  const { cwd, env, output } = devServer;
-  const files = await collectProjectFiles('**', cwd);
-
-  for (const buildConfig of nowJson.builds) {
-    try {
-      output.debug(`Build ${JSON.stringify(buildConfig)}`);
-      const builderWithPkg = await getBuilder(buildConfig.use);
-      const { builder, package: pkg } = builderWithPkg;
-
-      let { src } = buildConfig;
-      if (src[0] === '/') {
-        // Remove a leading slash so that the globbing is relative to `cwd`
-        // instead of the root of the filesystem. This matches the behavior
-        // of Now deployments.
-        src = src.substring(1);
-      }
-      const entries = Object.values(await collectProjectFiles(src, cwd));
-
-      for (const buildEntry of entries) {
-        const entrypoint = relative(cwd, buildEntry.fsPath);
-        const buildMatch: BuildMatch = {
-          ...buildConfig,
-          src: entrypoint,
-          builderWithPkg
-        };
-        const config = buildMatch.config || {};
-
-        const workPath = getWorkPath();
-        await mkdirp(workPath);
-
-        let buildResult: BuildResult;
-        let outputs: BuilderOutputs;
-        try {
-          devServer.applyBuildEnv(nowJson);
-          const buildParams: BuilderParamsBase = {
-            files,
-            entrypoint,
-            config,
-            meta: { isDev: true, requestPath: null }
-          };
-          output.debug(
-            `Building ${buildEntry.fsPath} with "${buildConfig.use}" v${
-              pkg.version
-            } (workPath = ${workPath})`
-          );
-          if (builder.version === 2) {
-          } else {
-            outputs = await builder.build({ ...buildMatch, workPath });
-          }
-
-          if (typeof builder.prepareCache === 'function') {
-            const cachePath = getWorkPath();
-            await mkdirp(cachePath);
-            buildMatch.builderCachePromise = executePrepareCache(
-              devServer,
-              buildMatch,
-              {
-                files,
-                entrypoint,
-                workPath,
-                cachePath,
-                config,
-                meta: { isDev: true, requestPath: null }
-              }
-            );
-          }
-        } finally {
-          devServer.restoreOriginalEnv();
-        }
-
-        // enforce the lambda zip size soft watermark
-        const builderConfig = builder.config || {};
-        const { maxLambdaSize = '5mb' } = { ...builderConfig, ...config };
-        let maxLambdaBytes: number;
-        if (typeof maxLambdaSize === 'string') {
-          maxLambdaBytes = bytes(maxLambdaSize);
-        } else {
-          maxLambdaBytes = maxLambdaSize;
-        }
-
-        for (const asset of Object.values(outputs)) {
-          if (asset.type === 'Lambda') {
-            const size = asset.zipBuffer.length;
-            if (size > maxLambdaBytes) {
-              throw new LambdaSizeExceededError(size, maxLambdaBytes);
-            }
-          }
-
-          asset.buildMatch = buildMatch;
-          asset.buildEntry = buildEntry;
-        }
-
-        Object.assign(devServer.assets, outputs);
-      }
-    } catch (err) {
-      throw err;
-    }
-  }
-
-  await Promise.all(
-    Object.values(devServer.assets).map(async (asset: BuilderOutput) => {
-      if (asset.type === 'Lambda') {
-        asset.fn = await createFunction({
-          Code: { ZipFile: asset.zipBuffer },
-          Handler: asset.handler,
-          Runtime: asset.runtime,
-          MemorySize: 3008,
-          Environment: {
-            Variables: {
-              ...nowJson.env,
-              ...asset.environment,
-              ...env,
-              NOW_REGION: 'dev1'
-            }
-          }
-        });
-      }
-
-      asset.buildTimestamp = Date.now();
-    })
-  );
-}
-*/
 
 export async function getBuildMatches(
   nowJson: NowConfig,
@@ -359,8 +204,8 @@ export async function getBuildMatches(
     }
     const entries = Object.values(await collectProjectFiles(src, cwd));
 
-    for (const buildEntry of entries) {
-      src = relative(cwd, buildEntry.fsPath);
+    for (const fileRef of entries) {
+      src = relative(cwd, fileRef.fsPath);
       const builderWithPkg = await getBuilder(use);
       matches.push({ ...buildConfig, src, builderWithPkg });
     }

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -75,7 +75,9 @@ export async function executeBuild(
   if (!match.buildOutput) {
     match.buildOutput = {};
   }
-  const { builderWithPkg: { builder, package: pkg } } = match;
+  const {
+    builderWithPkg: { builder, package: pkg }
+  } = match;
   const { cwd, env } = devServer;
   const entrypoint = match.src;
 
@@ -118,18 +120,14 @@ export async function executeBuild(
     if (typeof builder.prepareCache === 'function') {
       const cachePath = getWorkPath();
       await mkdirp(cachePath);
-      match.builderCachePromise = executePrepareCache(
-        devServer,
-        match,
-        {
-          files,
-          entrypoint,
-          workPath,
-          cachePath,
-          config,
-          meta: { isDev: true, requestPath }
-        }
-      );
+      match.builderCachePromise = executePrepareCache(devServer, match, {
+        files,
+        entrypoint,
+        workPath,
+        cachePath,
+        config,
+        meta: { isDev: true, requestPath }
+      });
     }
   } finally {
     devServer.restoreOriginalEnv();

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -29,7 +29,7 @@ export default async function(
   reqPath = '',
   routes?: RouteConfig[],
   devServer?: DevServer,
-  files?: BuilderInputs,
+  files?: BuilderInputs
 ): Promise<RouteResult> {
   let found: RouteResult | undefined;
   const { pathname: reqPathname = '/', query } = url.parse(reqPath, true);

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -4,7 +4,7 @@ import PCRE from 'pcre-to-regexp';
 import isURL from './is-url';
 import DevServer from './dev-server';
 
-import { RouteConfig, RouteResult } from './types';
+import { BuilderInputs, RouteConfig, RouteResult } from './types';
 
 export function resolveRouteParameters(
   str: string,
@@ -25,23 +25,28 @@ export function resolveRouteParameters(
   });
 }
 
-export default function(
+export default async function(
   reqPath = '',
   routes?: RouteConfig[],
-  devServer?: DevServer
-): RouteResult {
+  devServer?: DevServer,
+  files?: BuilderInputs,
+): Promise<RouteResult> {
   let found: RouteResult | undefined;
   const { pathname: reqPathname = '/', query } = url.parse(reqPath, true);
 
   // try route match
   if (routes) {
-    routes.find((routeConfig: RouteConfig, idx: number) => {
+    let idx = -1;
+    for (const routeConfig of routes) {
+      idx++;
       let { src, headers, handle } = routeConfig;
       if (handle) {
-        if (handle === 'filesystem' && devServer) {
-          return devServer.hasFilesystem(reqPathname);
+        if (handle === 'filesystem' && devServer && files) {
+          if (await devServer.hasFilesystem(files, reqPathname)) {
+            break;
+          }
         }
-        return false;
+        continue;
       }
 
       if (!src.startsWith('^')) {
@@ -92,11 +97,9 @@ export default function(
           };
         }
 
-        return true;
+        break;
       }
-
-      return false;
-    });
+    }
   }
 
   if (!found) {

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -598,10 +598,7 @@ export default class DevServer {
     }
   };
 
-  async hasFilesystem(
-    files: BuilderInputs,
-    dest: string
-  ): Promise<boolean> {
+  async hasFilesystem(files: BuilderInputs, dest: string): Promise<boolean> {
     const requestPath = dest.replace(/^\//, '');
     if (await findBuildMatch(this.buildMatches, files, requestPath)) {
       return true;
@@ -676,9 +673,13 @@ async function findBuildMatch(
   requestPath: string
 ): Promise<BuildMatch | null> {
   for (const match of matches.values()) {
-    const { builderWithPkg: { builder } } = match;
+    const {
+      builderWithPkg: { builder }
+    } = match;
     if (typeof builder.shouldServe === 'function') {
-      if (await builder.shouldServe({ entrypoint: match.src, files, requestPath })) {
+      if (
+        await builder.shouldServe({ entrypoint: match.src, files, requestPath })
+      ) {
         return match;
       }
     } else {
@@ -695,7 +696,7 @@ async function findBuildMatch(
 function findAsset(
   match: BuildMatch,
   requestPath: string
-): { asset: BuilderOutput, assetKey: string } | void {
+): { asset: BuilderOutput; assetKey: string } | void {
   if (!match.buildOutput) {
     return;
   }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -431,7 +431,7 @@ export default class DevServer {
       headers = {},
       uri_args,
       matched_route
-    } = devRouter(req.url, nowJson.routes, this);
+    } = await devRouter(req.url, nowJson.routes, this, files);
 
     // Set any headers defined in the matched `route` config
     Object.entries(headers).forEach(([name, value]) => {
@@ -598,18 +598,14 @@ export default class DevServer {
     }
   };
 
-  hasFilesystem(dest: string): boolean {
-    /*
-    const { subscription } = resolveSubscription(this.subscriptions, dest);
-    if (subscription) {
+  async hasFilesystem(
+    files: BuilderInputs,
+    dest: string
+  ): Promise<boolean> {
+    const requestPath = dest.replace(/^\//, '');
+    if (await findBuildMatch(this.buildMatches, files, requestPath)) {
       return true;
     }
-    const { asset } = resolveDest(this.assets, dest);
-    if (asset) {
-      return true;
-    }
-    */
-    // TODO: iterate over the `buildMatches` and call `findAsset()` on the outputs
     return false;
   }
 }

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,7 +1,10 @@
-import { BuilderParams, BuilderOutputs } from './types';
+import { BuilderParams, BuildResult } from './types';
 
-export function build({ files, entrypoint }: BuilderParams): BuilderOutputs {
-  return {
+export const version = 2;
+
+export function build({ files, entrypoint }: BuilderParams): BuildResult {
+  const output = {
     [entrypoint]: files[entrypoint]
   };
+  return { output };
 }

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,10 +1,29 @@
-import { BuilderParams, BuildResult } from './types';
-
-export const version = 2;
+import { basename, extname, dirname, join } from 'path';
+import { BuilderParams, BuildResult, ShouldServeParams } from './types';
 
 export function build({ files, entrypoint }: BuilderParams): BuildResult {
   const output = {
     [entrypoint]: files[entrypoint]
   };
   return { output };
+}
+
+export function shouldServe({
+  entrypoint,
+  files,
+  requestPath,
+}: ShouldServeParams) {
+  if (isIndex(entrypoint)) {
+    const indexPath = join(requestPath, basename(entrypoint));
+    if (entrypoint === indexPath && indexPath in files) {
+      return true;
+    }
+  }
+  return entrypoint === requestPath && requestPath in files;
+}
+
+function isIndex(path: string): boolean {
+  const ext = extname(path);
+  const name = basename(path, ext);
+  return name === 'index';
 }

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -11,7 +11,7 @@ export function build({ files, entrypoint }: BuilderParams): BuildResult {
 export function shouldServe({
   entrypoint,
   files,
-  requestPath,
+  requestPath
 }: ShouldServeParams) {
   if (isIndex(entrypoint)) {
     const indexPath = join(requestPath, basename(entrypoint));

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -19,7 +19,10 @@ export interface BuildConfig {
 
 export interface BuildMatch extends BuildConfig {
   builderWithPkg: BuilderWithPackage;
+  buildOutput?: BuilderOutputs;
+  buildResult?: BuildResult;
   builderCachePromise?: Promise<CacheOutputs>;
+  buildTimestamp?: number;
 }
 
 export interface RouteConfig {
@@ -53,7 +56,6 @@ export interface BuilderInputs {
 export interface BuiltAsset {
   buildEntry?: FileFsRef;
   buildMatch?: BuildMatch;
-  buildTimestamp?: number;
 }
 
 export type BuiltFileFsRef = FileFsRef & BuiltAsset;
@@ -92,12 +94,12 @@ export interface PrepareCacheParams extends BuilderParams {
   cachePath: string;
 }
 
-export interface BuilderV1 {
+export interface Builder {
   config?: {
     maxLambdaSize?: string | number;
   };
-  version: 1;
-  build(params: BuilderParams): BuilderOutputs | Promise<BuilderOutputs>;
+  build(params: BuilderParams): BuilderOutputs | BuildResult | Promise<BuilderOutputs> | Promise<BuildResult>;
+  shouldServe?(params: ShouldServeParams): boolean | Promise<boolean>;
   prepareCache?(
     params: PrepareCacheParams
   ): CacheOutputs | Promise<CacheOutputs>;
@@ -115,20 +117,6 @@ export interface ShouldServeParams {
   config?: object;
   requestPath: string;
 }
-
-export interface BuilderV2 {
-  config?: {
-    maxLambdaSize?: string | number;
-  };
-  version: 2;
-  build(params: BuilderParams): BuildResult | Promise<BuildResult>;
-  shouldServe(params: ShouldServeParams): boolean | Promise<boolean>;
-  prepareCache?(
-    params: PrepareCacheParams
-  ): CacheOutputs | Promise<CacheOutputs>;
-}
-
-export type Builder = BuilderV1 | BuilderV2;
 
 export interface BuilderWithPackage {
   builder: Builder;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -53,24 +53,16 @@ export interface BuilderInputs {
   [path: string]: FileFsRef;
 }
 
-export interface BuiltAsset {
-  buildEntry?: FileFsRef;
-  buildMatch?: BuildMatch;
-}
-
-export type BuiltFileFsRef = FileFsRef & BuiltAsset;
-export type BuiltFileBlob = FileBlob & BuiltAsset;
-export type BuiltLambda = Lambda &
-  BuiltAsset & {
-    fn?: FunLambda;
-  };
-export type BuilderOutput = BuiltLambda | BuiltFileFsRef | BuiltFileBlob;
+export type BuiltLambda = Lambda & {
+  fn?: FunLambda;
+};
+export type BuilderOutput = BuiltLambda | FileFsRef | FileBlob;
 
 export interface BuilderOutputs {
   [path: string]: BuilderOutput;
 }
 
-export type CacheOutput = BuiltFileFsRef | BuiltFileBlob;
+export type CacheOutput = FileFsRef | FileBlob;
 
 export interface CacheOutputs {
   [path: string]: CacheOutput;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -90,7 +90,13 @@ export interface Builder {
   config?: {
     maxLambdaSize?: string | number;
   };
-  build(params: BuilderParams): BuilderOutputs | BuildResult | Promise<BuilderOutputs> | Promise<BuildResult>;
+  build(
+    params: BuilderParams
+  ):
+    | BuilderOutputs
+    | BuildResult
+    | Promise<BuilderOutputs>
+    | Promise<BuildResult>;
   shouldServe?(params: ShouldServeParams): boolean | Promise<boolean>;
   prepareCache?(
     params: PrepareCacheParams

--- a/test/dev-router.unit.js
+++ b/test/dev-router.unit.js
@@ -2,11 +2,11 @@ import test from 'ava';
 
 import devRouter from '../src/commands/dev/lib/dev-router';
 
-test('[dev-router] 301 redirection', t => {
+test('[dev-router] 301 redirection', async (t) => {
   const routesConfig = [
     { src: '/redirect', status: 301, headers: { 'Location': 'https://zeit.co' } }
   ];
-  const result = devRouter('/redirect', routesConfig);
+  const result = await devRouter('/redirect', routesConfig);
 
   t.deepEqual(result, {
     dest: '/redirect',
@@ -18,11 +18,11 @@ test('[dev-router] 301 redirection', t => {
   });
 });
 
-test('[dev-router] captured groups', t => {
+test('[dev-router] captured groups', async (t) => {
   const routesConfig = [
     { src: '/api/(.*)', dest: '/endpoints/$1.js' }
   ];
-  const result = devRouter('/api/user', routesConfig);
+  const result = await devRouter('/api/user', routesConfig);
 
   t.deepEqual(result, {
     dest: '/endpoints/user.js',
@@ -34,11 +34,11 @@ test('[dev-router] captured groups', t => {
   });
 });
 
-test('[dev-router] named groups', t => {
+test('[dev-router] named groups', async (t) => {
   const routesConfig = [
     { src: '/user/(?<id>.+)', dest: '/user.js?id=$id' }
   ];
-  const result = devRouter('/user/123', routesConfig);
+  const result = await devRouter('/user/123', routesConfig);
 
   t.deepEqual(result, {
     dest: '/user.js',
@@ -50,13 +50,13 @@ test('[dev-router] named groups', t => {
   });
 });
 
-test('[dev-router] unreached route', t => {
+test('[dev-router] unreached route', async (t) => {
   const routesConfig = [
     { src: '/.*', dest: '/index.js' },
     { src: '/hidden', dest: '/hidden.js' }
   ];
 
-  const result = devRouter('/hidden', routesConfig);
+  const result = await devRouter('/hidden', routesConfig);
 
   t.deepEqual(result, {
     dest: '/index.js',
@@ -69,12 +69,12 @@ test('[dev-router] unreached route', t => {
 });
 
 
-test('[dev-router] proxy_pass', t => {
+test('[dev-router] proxy_pass', async (t) => {
   const routesConfig = [
     { src: '/proxy', dest: 'https://zeit.co' }
   ];
 
-  const result = devRouter('/proxy', routesConfig);
+  const result = await devRouter('/proxy', routesConfig);
 
   t.deepEqual(result, {
     dest: 'https://zeit.co',


### PR DESCRIPTION
Adds support for when the builder has `shouldServe()` defined, so the initial build maybe skipped and run lazily upon the first HTTP request that should go to that builder.

This also is a pretty hefty refactor of the `now dev` codebase to improve correctness, help with readability, and makes it more DRY.