### PR TITLE
[now dev] add a default shouldServe for builder v2 api

### DIFF
--- a/src/commands/dev/lib/default-should-serve.ts
+++ b/src/commands/dev/lib/default-should-serve.ts
@@ -7,7 +7,8 @@ export default function shouldServe({
   files,
   requestPath
 }: ShouldServeParams): boolean {
-  requestPath = requestPath.replace(/\/$/, '');
+  requestPath = requestPath.replace(/\/$/, ''); // sanitize trailing '/'
+  entrypoint = entrypoint.replace(/\\/, '/'); // windows compatibility
 
   if (entrypoint === requestPath) {
     return true;

--- a/src/commands/dev/lib/default-should-serve.ts
+++ b/src/commands/dev/lib/default-should-serve.ts
@@ -1,0 +1,29 @@
+import { parse, basename, extname } from 'path';
+// @ts-ignore
+import { ShouldServeParams } from '@now/build-utils';
+
+export default function shouldServe({
+  entrypoint,
+  files,
+  requestPath
+}: ShouldServeParams): boolean {
+  requestPath = requestPath.replace(/\/$/, '');
+
+  if (entrypoint === requestPath) {
+    return true;
+  }
+
+  if (isIndex(entrypoint)) {
+    if (parse(entrypoint).dir === requestPath) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isIndex(path: string): boolean {
+  const ext = extname(path);
+  const name = basename(path, ext);
+  return name === 'index';
+}

--- a/src/commands/dev/lib/default-should-serve.ts
+++ b/src/commands/dev/lib/default-should-serve.ts
@@ -1,4 +1,4 @@
-import { parse, basename, extname } from 'path';
+import { parse } from 'path';
 // @ts-ignore
 import { ShouldServeParams } from '@now/build-utils';
 
@@ -13,17 +13,10 @@ export default function shouldServe({
     return true;
   }
 
-  if (isIndex(entrypoint)) {
-    if (parse(entrypoint).dir === requestPath) {
-      return true;
-    }
+  const { dir, name } = parse(entrypoint);
+  if (name === 'index' && dir === requestPath) {
+    return true;
   }
 
   return false;
-}
-
-function isIndex(path: string): boolean {
-  const ext = extname(path);
-  const name = basename(path, ext);
-  return name === 'index';
 }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -671,13 +671,15 @@ async function findBuildMatch(
 ): Promise<BuildMatch | null> {
   for (const match of matches.values()) {
     const {
+      src,
+      config,
       builderWithPkg: { builder }
     } = match;
     const shouldServe =
       typeof builder.shouldServe === 'function'
         ? builder.shouldServe
         : defaultShouldServe;
-    if (shouldServe({ requestPath, entrypoint: match.src, files })) {
+    if (shouldServe({ requestPath, entrypoint: src, files, config })) {
       return match;
     }
   }

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,29 +1,8 @@
-import { basename, extname, dirname, join } from 'path';
-import { BuilderParams, BuildResult, ShouldServeParams } from './types';
+import { BuilderParams, BuildResult } from './types';
 
 export function build({ files, entrypoint }: BuilderParams): BuildResult {
   const output = {
     [entrypoint]: files[entrypoint]
   };
   return { output };
-}
-
-export function shouldServe({
-  entrypoint,
-  files,
-  requestPath
-}: ShouldServeParams) {
-  if (isIndex(entrypoint)) {
-    const indexPath = join(requestPath, basename(entrypoint));
-    if (entrypoint === indexPath && indexPath in files) {
-      return true;
-    }
-  }
-  return entrypoint === requestPath && requestPath in files;
-}
-
-function isIndex(path: string): boolean {
-  const ext = extname(path);
-  const name = basename(path, ext);
-  return name === 'index';
 }

--- a/test/dev-should-serve.unit.js
+++ b/test/dev-should-serve.unit.js
@@ -1,0 +1,46 @@
+import path from 'path';
+import test from 'ava';
+import * as buildUtils from '@now/build-utils';
+import shouldServe from '../src/commands/dev/lib/default-should-serve';
+
+test('shouldServe on should-serve-nodejs', async (t) => {
+  const cwd = path.resolve(__dirname, 'fixture/unit/should-serve-nodejs');
+  const files = await buildUtils.glob('**', cwd);
+
+  t.is(shouldServe({
+    files,
+    entrypoint: 'index.js',
+    requestPath: 'index.js'
+  }), true);
+
+  t.is(shouldServe({
+    files,
+    entrypoint: 'index.js',
+    requestPath: '/'
+  }), true);
+
+  // This is same behavior as in production
+  t.is(shouldServe({
+    files,
+    entrypoint: 'index.js',
+    requestPath: 'index.js/'
+  }), true);
+
+  t.is(shouldServe({
+    files,
+    entrypoint: 'index.js',
+    requestPath: 'index'
+  }), false);
+
+  t.is(shouldServe({
+    files,
+    entrypoint: 'subdir/index.js',
+    requestPath: 'subdir'
+  }), true);
+
+  t.is(shouldServe({
+    files,
+    entrypoint: 'subdir/index.js',
+    requestPath: 'subdir/'
+  }), true);
+});

--- a/test/fixtures/unit/should-serve-nodejs/.nowignore
+++ b/test/fixtures/unit/should-serve-nodejs/.nowignore
@@ -1,0 +1,1 @@
+README.md

--- a/test/fixtures/unit/should-serve-nodejs/index.js
+++ b/test/fixtures/unit/should-serve-nodejs/index.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end(`Hello from Node.js on Now 2.0!`);
+};

--- a/test/fixtures/unit/should-serve-nodejs/now.json
+++ b/test/fixtures/unit/should-serve-nodejs/now.json
@@ -1,0 +1,7 @@
+{
+    "version": 2,
+    "builds": [
+      { "src": "index.js", "use": "@now/node" },
+      { "src": "subdir/index.js", "use": "@now/node" }
+    ]
+  }

--- a/test/fixtures/unit/should-serve-nodejs/subdir/index.js
+++ b/test/fixtures/unit/should-serve-nodejs/subdir/index.js
@@ -1,0 +1,8 @@
+const yodasay = require('yodasay').say;
+
+// test that process.env is not replaced by webpack
+process.env.NODE_ENV = 'development';
+
+module.exports = (req, resp) => {
+  resp.end(yodasay({ text: 'yoda:RANDOMNESS_PLACEHOLDER' }));
+};


### PR DESCRIPTION
Since this `shouldServe` is for `now dev`'s use case, we won't use it in production, so the best place to add a default `shouldServe` would be in `now dev`.

This PR:
- Added a default `shouldServe`
- Removed the redundant one in built-in static builder
- Added some tests to copy our production behavior