### PR TITLE
[now dev] Don't run every build when a v1 builder is detected

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -216,7 +216,7 @@ export default class DevServer {
       if (needsInitialBuild.length > 0) {
         this.output.log('Running initial builds');
         const files = await this.getProjectFiles();
-        for (const match of this.buildMatches.values()) {
+        for (const match of needsInitialBuild) {
           await executeBuild(nowJson, this, files, match);
         }
         this.output.success('Initial builds complete');


### PR DESCRIPTION
Before this, if a v1 builder was detected then every build match was built instead of only the matches that use a v1 builder.