### PR TITLE
[now dev] Use empty version string for `@now/static`

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -20,7 +20,7 @@ import * as staticBuilder from './static-builder';
 const localBuilders: { [key: string]: BuilderWithPackage } = {
   '@now/static': {
     builder: Object.freeze(staticBuilder),
-    package: { version: 'built-in' }
+    package: { version: '' }
   }
 };
 


### PR DESCRIPTION
This is just a cosmetic fix so that "vbuilt-in" isn't printed when `--debug` is enabled.