### PR TITLE
Remove ncc "-m" option in build-dev

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 NCC_OPTS=""
 if [ -z "${DEV-}" ]; then
-  NCC_OPTS="-m -s"
+  NCC_OPTS="-s"
 fi
 
 # Do the initial `ncc` build


### PR DESCRIPTION
With this change we can `npm run build-dev` then `node --inspect path/to/now-cli/dist/index.js` to inspect now-cli during runtime.