### PR TITLE
Enable source maps for development builds of now-cli

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 NCC_OPTS=""
 if [ -z "${DEV-}" ]; then
-  NCC_OPTS="-m -s"
+  NCC_OPTS="--minify"
 fi
 
 # Do the initial `ncc` build
-ncc build $NCC_OPTS ./src
+ncc build --source-map $NCC_OPTS ./src
 
 # `ncc` has some issues with `@zeit/fun`'s runtime files:
 #   - Executable bits on the `bootstrap` files appear to be lost:


### PR DESCRIPTION
If you run `yarn build-dev`, then now source maps are enabled, allowing us to see the proper line of an error in the source code file instead of the huge `dist/index.js` file.

Previously they were only enabled for production builds.