### PR TITLE
Enable '@typescript-eslint/no-unused-vars': 'warn'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
     'camelcase': 0,
     'no-unused-vars': 0,          // in favor of '@typescript-eslint/no-unused-vars'
     // 'indent': 0                // in favor of '@typescript-eslint/indent'
-    '@typescript-eslint/no-unused-vars': 'warn',    // this might conflict with a lot ongoing changes
+    '@typescript-eslint/no-unused-vars': 'warn',
     // '@typescript-eslint/indent': ['error', 2]        // this might conflict with a lot ongoing changes
     '@typescript-eslint/no-array-constructor': 'error',
     '@typescript-eslint/adjacent-overload-signatures': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
     'camelcase': 0,
     'no-unused-vars': 0,          // in favor of '@typescript-eslint/no-unused-vars'
     // 'indent': 0                // in favor of '@typescript-eslint/indent'
-    // '@typescript-eslint/no-unused-vars': 'error',    // this might conflict with a lot ongoing changes
+    '@typescript-eslint/no-unused-vars': 'warn',    // this might conflict with a lot ongoing changes
     // '@typescript-eslint/indent': ['error', 2]        // this might conflict with a lot ongoing changes
     '@typescript-eslint/no-array-constructor': 'error',
     '@typescript-eslint/adjacent-overload-signatures': 'error',


### PR DESCRIPTION
- `warn` as first step
- will change to `error` later

Follow-up with #2042 