### PR TITLE
[now dev] Pass `filesChanges` and `filesRemoved` array to builder's `build()`

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -71,7 +71,9 @@ export async function executeBuild(
   devServer: DevServer,
   files: BuilderInputs,
   match: BuildMatch,
-  requestPath: string | null = null
+  requestPath: string | null = null,
+  filesChanged?: string[],
+  filesRemoved?: string[]
 ): Promise<void> {
   const {
     builderWithPkg: { builder, package: pkg }
@@ -107,7 +109,7 @@ export async function executeBuild(
       entrypoint,
       workPath,
       config,
-      meta: { isDev: true, requestPath }
+      meta: { isDev: true, requestPath, filesChanged, filesRemoved }
     });
     if (r.output) {
       result = r as BuildResult;

--- a/src/commands/dev/lib/nsfw-module.ts
+++ b/src/commands/dev/lib/nsfw-module.ts
@@ -1,5 +1,11 @@
 import { tmpdir } from 'os';
-import { pathExists, mkdirp, createWriteStream, statSync, chmodSync } from 'fs-extra';
+import {
+  pathExists,
+  mkdirp,
+  createWriteStream,
+  statSync,
+  chmodSync
+} from 'fs-extra';
 import pipe from 'promisepipe';
 import { join } from 'path';
 import fetch from 'node-fetch';
@@ -46,7 +52,7 @@ const plusxSync = (file: string): void => {
   chmodSync(file, base8);
 };
 
-const prepareModule = async (output: Output): Promise<string> =>  {
+const prepareModule = async (output: Output): Promise<string> => {
   const version = devDependencies['@zeit/nsfw'];
   const fileName = `nsfw-${version}.node`;
   const dirName = join(tmpdir(), 'co.zeit.now', 'dev');
@@ -73,7 +79,10 @@ const prepareModule = async (output: Output): Promise<string> =>  {
   const target = createWriteStream(full);
 
   // Fill the body into the file
-  await pipe(response.body, target);
+  await pipe(
+    response.body,
+    target
+  );
   output.debug(`Finished downloading ${url}`);
 
   output.debug(`Making the nsfw binary executable`);
@@ -83,7 +92,7 @@ const prepareModule = async (output: Output): Promise<string> =>  {
   return full;
 };
 
-export default async (output: Output): Promise<string|undefined> => {
+export default async (output: Output): Promise<string | undefined> => {
   let modulePath = null;
 
   try {

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -75,6 +75,8 @@ export interface BuilderParamsBase {
   meta?: {
     isDev?: boolean;
     requestPath?: string | null;
+    filesChanged?: string[];
+    filesRemoved?: string[];
   };
 }
 


### PR DESCRIPTION
This will be required to implement the `@now/node` ncc watcher logic.