### PR TITLE
[now dev] Default the `Content-Type` to "application/octet-stream"

### DIFF
--- a/src/commands/dev/lib/mime-type.ts
+++ b/src/commands/dev/lib/mime-type.ts
@@ -1,0 +1,5 @@
+import { lookup as lookupMimeType } from 'mime-types';
+
+export default function getMimeType(fileName: string) {
+  return lookupMimeType(fileName) || 'application/octet-stream';
+}

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -146,7 +146,7 @@ export interface RouteResult {
 
 export interface InvokePayload {
   method: string;
-  host?: string,
+  host?: string;
   path: string;
   headers: http.IncomingHttpHeaders;
   encoding?: string;


### PR DESCRIPTION
This matches the behavior in production, so it is more correct.

This new common `getMimeType()` function also centralizes a place where we can overwrite the `mime-types` return value to other values to match production for other future discrepancies.