### PR TITLE
Add tests for the new automatic aliasing in the v9 API

### DIFF
--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -81,6 +81,19 @@ http_request(
 <marquee>Thanks for your feedback!</marquee>
 `;
 
+const getRevertAliasConfigFile = () => {
+  return JSON.stringify({
+      'version': 2,
+      'name': 'now-revert-alias',
+      'builds': [
+        {
+          'src': '*.json',
+          'use': '@now/static'
+        }
+      ]
+  });
+};
+
 module.exports = async session => {
   const files = {
     Dockerfile: getDockerFile(session),
@@ -174,6 +187,14 @@ ARG NONCE
 RUN mkdir /public
 RUN echo $NONCE > /public/index.html
       `
+    },
+    'now-revert-alias-1': {
+      'index.json': JSON.stringify({ name: 'now-revert-alias-1' }),
+      'now.json': getRevertAliasConfigFile()
+    },
+    'now-revert-alias-2': {
+      'index.json': JSON.stringify({ name: 'now-revert-alias-2' }),
+      'now.json': getRevertAliasConfigFile()
     }
   };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1301,7 +1301,12 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
-    t.is(result.name, 'now-revert-alias-1');
+
+    t.is(
+      result.name,
+      'now-revert-alias-1',
+      `Received ${result.name} instead on ${url} (${deploymentUrl})`
+    );
   }
 
   {
@@ -1311,7 +1316,12 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
-    t.is(result.name, 'now-revert-alias-2');
+
+    t.is(
+      result.name,
+      'now-revert-alias-2',
+      `Received ${result.name} instead on ${url} (${deploymentUrl})`
+    );
   }
 
   {
@@ -1321,7 +1331,12 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
-    t.is(result.name, 'now-revert-alias-1');
+
+    t.is(
+      result.name,
+      'now-revert-alias-1',
+      `Received ${result.name} instead on ${url} (${deploymentUrl})`
+    );
   }
 });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1287,6 +1287,44 @@ test('try to initialize example "example-404"', async t => {
   t.true(stdout.includes(goal));
 });
 
+test('try to revert a deployment and assign the automatic aliases', async t => {
+  const firstDeployment = fixture('now-revert-alias-1');
+  const secondDeployment = fixture('now-revert-alias-2');
+
+  const { stdout: username } = await execute(['whoami']);
+  let url = `https://now-revert-alias.${username}.now.sh`;
+
+  {
+    const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
+    t.is(code, 0);
+
+    await waitForDeployment(deploymentUrl);
+
+    const result = await fetch(url).then(r => r.json());
+    t.is(result.name, 'now-revert-alias-1');
+  }
+
+  {
+    const { stdout: deploymentUrl, code } = await execute([secondDeployment]);
+    t.is(code, 0);
+
+    await waitForDeployment(deploymentUrl);
+
+    const result = await fetch(url).then(r => r.json());
+    t.is(result.name, 'now-revert-alias-2');
+  }
+
+  {
+    const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
+    t.is(code, 0);
+
+    await waitForDeployment(deploymentUrl);
+
+    const result = await fetch(url).then(r => r.json());
+    t.is(result.name, 'now-revert-alias-1');
+  }
+});
+
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);

--- a/test/integration.js
+++ b/test/integration.js
@@ -38,7 +38,7 @@ const waitForDeployment = async href => {
       break;
     }
 
-    sleep(2000);
+    await sleep(2000);
   }
 };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1298,6 +1298,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
     t.is(code, 0);
 
+    await sleep(70000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
@@ -1313,6 +1314,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([secondDeployment]);
     t.is(code, 0);
 
+    await sleep(70000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
@@ -1328,6 +1330,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
     t.is(code, 0);
 
+    await sleep(70000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());

--- a/test/integration.js
+++ b/test/integration.js
@@ -1298,7 +1298,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
     t.is(code, 0);
 
-    await sleep(70000);
+    await sleep(10000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
@@ -1314,7 +1314,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([secondDeployment]);
     t.is(code, 0);
 
-    await sleep(70000);
+    await sleep(10000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());
@@ -1330,7 +1330,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);
     t.is(code, 0);
 
-    await sleep(70000);
+    await sleep(10000);
     await waitForDeployment(deploymentUrl);
 
     const result = await fetch(url).then(r => r.json());


### PR DESCRIPTION
This adds a new test case for the automatic aliasing. It primarily checks if the aliases are assigned again after reverting, but checks the automatic aliasing as a site effect.

The short sleep statements are here to ensure that the deployments are ready, since it worked locally without them but not on circleci.