### PR TITLE
[now dev] use `tar-fs` to pack/extract the `prepareCache()` results

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -216,7 +216,9 @@ export default class DevServer {
       this.output.debug(`File renamed: ${oldName} -> ${name}`);
     } catch (err) {
       if (err.code === 'ENOENT') {
-        this.output.debug(`File renamed, but has since been deleted: ${oldName} -> ${name}`);
+        this.output.debug(
+          `File renamed, but has since been deleted: ${oldName} -> ${name}`
+        );
       } else {
         throw err;
       }
@@ -549,9 +551,7 @@ export default class DevServer {
         if (previousBuildResult) {
           // Tear down any `output` assets from a previous build, so that they
           // are not available to be served while the rebuild is in progress.
-          for (const [name] of Object.entries(
-            previousBuildResult.output
-          )) {
+          for (const name of Object.keys(previousBuildResult.output)) {
             this.output.debug(`Removing asset "${name}"`);
             delete match.buildOutput[name];
             // TODO: shut down Lambda instance
@@ -579,7 +579,7 @@ export default class DevServer {
     try {
       await buildPromise;
     } finally {
-      this.output.debug(`Built asset ${buildKey}`);
+      this.output.debug(`Built asset "${buildKey}"`);
       this.inProgressBuilds.delete(buildKey);
     }
   }
@@ -704,7 +704,7 @@ export default class DevServer {
     }
 
     const { asset, assetKey } = foundAsset;
-    this.output.debug(`Serve asset: [${asset.type}] ${assetKey}`);
+    this.output.debug(`Serving asset: [${asset.type}] ${assetKey}`);
     /* eslint-disable no-case-declarations */
     switch (asset.type) {
       case 'FileFsRef':
@@ -766,7 +766,7 @@ export default class DevServer {
           body: body.toString('base64')
         };
 
-        this.output.debug(`Invode lambda: "${assetKey}" with ${path}`);
+        this.output.debug(`Invoking lambda: "${assetKey}" with ${path}`);
 
         let result: InvokeResult;
         try {

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -21,7 +21,7 @@ export interface BuildMatch extends BuildConfig {
   builderWithPkg: BuilderWithPackage;
   buildOutput: BuilderOutputs;
   buildResults: Map<string | null, BuildResult>;
-  builderCachePromise?: Promise<CacheOutputs>;
+  builderCachePromise?: Promise<Buffer>;
   buildTimestamp: number;
 }
 
@@ -62,10 +62,8 @@ export interface BuilderOutputs {
   [path: string]: BuilderOutput;
 }
 
-export type CacheOutput = FileFsRef | FileBlob;
-
 export interface CacheOutputs {
-  [path: string]: CacheOutput;
+  [path: string]: FileFsRef;
 }
 
 export interface BuilderParamsBase {

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,0 +1,24 @@
+import { Readable } from 'stream'
+
+export function bufferToReadable(buffer: Buffer): Readable {
+  const readable = new Readable();
+  readable._read = () => {}; // `_read()` is required, but you can noop it
+  readable.push(buffer);
+  readable.push(null);
+  return readable;
+}
+
+export function readableToBuffer(readable: Readable): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    readable.on('data', (chunk) => {
+      size += chunk.length;
+      chunks.push(chunk);
+    });
+    readable.on('end', () => {
+      resolve(Buffer.concat(chunks, size));
+    });
+    readable.on('error', reject);
+  });
+}


### PR DESCRIPTION
This fixes the issue where on really big cache outputs the `download()` function would get stuck.