### PR TITLE
[now dev] Reuse the same `workPath` for subsequent builds

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -21,7 +21,7 @@ import {
   BuilderInputs,
   BuilderOutput,
   BuilderOutputs,
-  CacheOutputs,
+  CacheOutputs
 } from './types';
 
 const tmpDir = tmpdir();
@@ -49,10 +49,7 @@ export async function executeBuild(
     builderWithPkg: { builder, package: pkg }
   } = match;
   const { env } = devServer;
-  const {
-    src: entrypoint,
-    workPath
-  } = match;
+  const { src: entrypoint, workPath } = match;
   await mkdirp(workPath);
 
   if (match.builderCachePromise) {

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -22,7 +22,6 @@ import {
   BuilderOutput,
   BuilderOutputs,
   CacheOutputs,
-  PrepareCacheParams
 } from './types';
 
 const tmpDir = tmpdir();
@@ -37,32 +36,6 @@ const getWorkPath = () =>
       .slice(-8)
   );
 
-export async function executePrepareCache(
-  devServer: DevServer,
-  buildMatch: BuildMatch,
-  params: PrepareCacheParams
-): Promise<CacheOutputs> {
-  const { builderWithPkg } = buildMatch;
-  if (!builderWithPkg) {
-    throw new Error('No builder');
-  }
-  const { builder } = builderWithPkg;
-  if (!builder.prepareCache) {
-    throw new Error('Builder has no `prepareCache()` function');
-  }
-
-  // Since the `prepareCache()` function may be computationally expensive, and
-  // its run in the same process as `now dev` (for now), defer executing it
-  // until after there has been time for the current HTTP request to complete.
-  await new Promise(r => setTimeout(r, 3000));
-
-  const startTime = Date.now();
-  const results = await builder.prepareCache(params);
-  const cacheTime = Date.now() - startTime;
-  devServer.output.debug(`\`prepareCache()\` took ${cacheTime}ms`);
-  return results;
-}
-
 export async function executeBuild(
   nowJson: NowConfig,
   devServer: DevServer,
@@ -76,9 +49,10 @@ export async function executeBuild(
     builderWithPkg: { builder, package: pkg }
   } = match;
   const { env } = devServer;
-  const entrypoint = match.src;
-
-  const workPath = getWorkPath();
+  const {
+    src: entrypoint,
+    workPath
+  } = match;
   await mkdirp(workPath);
 
   if (match.builderCachePromise) {
@@ -117,19 +91,6 @@ export async function executeBuild(
       result = { output: r as BuilderOutputs };
     }
     outputs = result.output;
-
-    if (typeof builder.prepareCache === 'function') {
-      const cachePath = getWorkPath();
-      await mkdirp(cachePath);
-      match.builderCachePromise = executePrepareCache(devServer, match, {
-        files,
-        entrypoint,
-        workPath,
-        cachePath,
-        config,
-        meta: { isDev: true, requestPath }
-      });
-    }
   } finally {
     devServer.restoreOriginalEnv();
   }
@@ -215,7 +176,8 @@ export async function getBuildMatches(
         builderWithPkg,
         buildOutput: {},
         buildResults: new Map(),
-        buildTimestamp: 0
+        buildTimestamp: 0,
+        workPath: getWorkPath()
       });
     }
   }

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -23,6 +23,7 @@ export interface BuildMatch extends BuildConfig {
   buildResults: Map<string | null, BuildResult>;
   builderCachePromise?: Promise<CacheOutputs>;
   buildTimestamp: number;
+  workPath: string;
 }
 
 export interface RouteConfig {


### PR DESCRIPTION
Reusing the same `workPath` for subsequent builds makes rebuilding faster, as well as it's necessary for webpack's watcher to work correctly as it relies on the full filesystem paths being intact.

`prepareCache()` also no longer needs to be invoked, since the previous `workPath` directory will already contain the necessary files that the cache would otherwise produce.