### PR TITLE
Show all aliases instead of just the first one

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -110,7 +110,7 @@ const printDeploymentStatus = async (
               await copy(`https://${alias}`);
               output.print(`- ${chalk.bold(chalk.cyan(prepareAlias(alias)))} ${chalk.gray('[in clipboard]')}\n`);
 
-              return 0;
+              continue;
             } catch (err) {
               output.debug(`Error copying to clipboard: ${err}`);
             }


### PR DESCRIPTION
Right now we only show one alias after the deployment is done, but we want to show all of them.