### PR TITLE
[wip] Update now dev for updated builder v2 api

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -88,7 +88,7 @@ export async function executeBuild(
     if (builder.version === undefined) {
       // `BuilderOutputs` map was returned (Now Builder v1 behavior)
       result = {
-        outputs: result as BuilderOutputs,
+        output: result as BuilderOutputs,
         routes: [],
         watch: []
       };
@@ -105,7 +105,7 @@ export async function executeBuild(
   } else {
     maxLambdaBytes = maxLambdaSize;
   }
-  for (const asset of Object.values(result.outputs)) {
+  for (const asset of Object.values(result.output)) {
     if (asset.type === 'Lambda') {
       const size = asset.zipBuffer.length;
       if (size > maxLambdaBytes) {
@@ -116,7 +116,7 @@ export async function executeBuild(
 
   // Create function for all 'Lambda' type output
   await Promise.all(
-    Object.entries(result.outputs).map(async entry => {
+    Object.entries(result.output).map(async entry => {
       const path: string = entry[0];
       const asset: BuilderOutput = entry[1];
 
@@ -148,7 +148,7 @@ export async function executeBuild(
   );
 
   match.buildResults.set(requestPath, result);
-  Object.assign(match.buildOutput, result.outputs);
+  Object.assign(match.buildOutput, result.output);
 }
 
 export async function getBuildMatches(

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -76,7 +76,7 @@ export async function executeBuild(
     devServer.applyBuildEnv(nowJson);
 
     // Run build
-    const unhookIntercept = intercept(() => '');
+    // const unhookIntercept = intercept(() => '');
     result = await builder.build({
       files,
       entrypoint,
@@ -84,7 +84,7 @@ export async function executeBuild(
       config,
       meta: { isDev: true, requestPath, filesChanged, filesRemoved }
     });
-    unhookIntercept();
+    // unhookIntercept();
 
     // Sort out build result to builder v2 shape
     if (builder.version === undefined) {

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -239,7 +239,7 @@ export async function combineRoutes (
   await Promise.all(builds.map(async buildConfig => {
     const { builder } = await getBuilder(buildConfig.use);
     const { files } = devServer;
-    if (builder.version === 2 && builder.continuous) {
+    if (builder.version === 2) {
       await executeBuild(
         nowJson,
         devServer,

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -76,7 +76,7 @@ export async function executeBuild(
     devServer.applyBuildEnv(nowJson);
 
     // Run build
-    // const unhookIntercept = intercept(() => '');
+    const unhookIntercept = intercept(() => '');
     result = await builder.build({
       files,
       entrypoint,
@@ -84,7 +84,7 @@ export async function executeBuild(
       config,
       meta: { isDev: true, requestPath, filesChanged, filesRemoved }
     });
-    // unhookIntercept();
+    unhookIntercept();
 
     // Sort out build result to builder v2 shape
     if (builder.version === undefined) {

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -561,7 +561,7 @@ export default class DevServer {
         if (previousBuildResult) {
           // Tear down any `output` assets from a previous build, so that they
           // are not available to be served while the rebuild is in progress.
-          for (const [name] of Object.entries(previousBuildResult.output)) {
+          for (const [name] of Object.entries(previousBuildResult.outputs)) {
             this.output.debug(`Removing asset "${name}"`);
             delete match.buildOutput[name];
             // TODO: shut down Lambda instance

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -612,10 +612,6 @@ export default class DevServer {
     const method = req.method || 'GET';
     this.output.log(`${chalk.bold(method)} ${req.url}`);
 
-    // if (this.status === DevServerStatus.busy) {
-    //   return res.end(`[busy] ${this.statusMessage}...`);
-    // }
-
     try {
       const nowJson = await this.getNowJson();
       if (nowJson) {

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -22,6 +22,7 @@ import { installBuilders } from './builder-cache';
 import getModuleForNSFW from './nsfw-module';
 import {
   executeBuild,
+  combineRoutes,
   collectProjectFiles,
   createIgnoreList,
   getBuildMatches
@@ -670,13 +671,20 @@ export default class DevServer {
   ) => {
     await this.updateBuildMatches(nowJson);
 
+    let routes = nowJson.routes;
+    const reqPath = (req.url || '').replace(/^\//, '');
+    const _match = await findBuildMatch(this.buildMatches, this.files, reqPath);
+    if (_match) {
+      routes = await combineRoutes(nowJson, this, _match, reqPath);
+    }
+
     const {
       dest,
       status = 200,
       headers = {},
       uri_args,
       matched_route
-    } = await devRouter(req.url, nowJson.routes, this);
+    } = await devRouter(req.url, routes, this);
 
     // Set any headers defined in the matched `route` config
     Object.entries(headers).forEach(([name, value]) => {

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,8 +1,10 @@
 import { basename, extname, join } from 'path';
 import { BuilderParams, BuildResult, RouteConfig, ShouldServeParams } from './types';
 
+export const version = 2;
+
 export function build({ files, entrypoint }: BuilderParams): BuildResult {
-  const outputs = {
+  const output = {
     [entrypoint]: files[entrypoint]
   };
   const routes: RouteConfig[] = [
@@ -10,7 +12,7 @@ export function build({ files, entrypoint }: BuilderParams): BuildResult {
   ];
   const watch = [entrypoint];
 
-  return { outputs, routes, watch };
+  return { output, routes, watch };
 }
 
 export function shouldServe({

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,12 +1,16 @@
-import { basename, extname, dirname, join } from 'path';
-import { BuilderParams, BuildResult, ShouldServeParams } from './types';
+import { basename, extname, join } from 'path';
+import { BuilderParams, BuildResult, RouteConfig, ShouldServeParams } from './types';
 
 export function build({ files, entrypoint }: BuilderParams): BuildResult {
-  const output = {
+  const outputs = {
     [entrypoint]: files[entrypoint]
   };
+  const routes: RouteConfig[] = [
+    { src: entrypoint, dest: entrypoint }
+  ];
   const watch = [entrypoint];
-  return { output, watch };
+
+  return { outputs, routes, watch };
 }
 
 export function shouldServe({

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -116,7 +116,7 @@ export interface Builder {
 export type BuildResultV1 = BuilderOutputs;
 
 export interface BuildResultV2 {
-  outputs: BuilderOutputs;
+  output: BuilderOutputs;
   routes: RouteConfig[];
   watch: string[];
 }

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -90,11 +90,14 @@ export interface PrepareCacheParams extends BuilderParams {
   cachePath: string;
 }
 
+export interface BuilderConfigAttr {
+  maxLambdaSize?: string | number;
+}
+
 export interface Builder {
   version?: 2;
-  config?: {
-    maxLambdaSize?: string | number;
-  };
+  continuous?: boolean;
+  config?: BuilderConfigAttr;
   build(
     params: BuilderParams
   ):
@@ -102,7 +105,9 @@ export interface Builder {
     | BuildResult
     | Promise<BuilderOutputs>
     | Promise<BuildResult>;
-  shouldServe?(params: ShouldServeParams): boolean | Promise<boolean>;
+  shouldServe?(
+    params: ShouldServeParams
+  ): boolean | Promise<boolean>;
   prepareCache?(
     params: PrepareCacheParams
   ): CacheOutputs | Promise<CacheOutputs>;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -57,6 +57,7 @@ export interface BuilderInputs {
 export type BuiltLambda = Lambda & {
   fn?: FunLambda;
 };
+
 export type BuilderOutput = BuiltLambda | FileFsRef | FileBlob;
 
 export interface BuilderOutputs {
@@ -90,6 +91,7 @@ export interface PrepareCacheParams extends BuilderParams {
 }
 
 export interface Builder {
+  version?: 2;
   config?: {
     maxLambdaSize?: string | number;
   };
@@ -106,11 +108,15 @@ export interface Builder {
   ): CacheOutputs | Promise<CacheOutputs>;
 }
 
-export interface BuildResult {
-  output: BuilderOutputs;
-  routes?: RouteConfig[];
-  watch?: string[];
+export type BuildResultV1 = BuilderOutputs;
+
+export interface BuildResultV2 {
+  outputs: BuilderOutputs;
+  routes: RouteConfig[];
+  watch: string[];
 }
+
+export type BuildResult = BuildResultV1 | BuildResultV2;
 
 export interface ShouldServeParams {
   files: BuilderInputs;


### PR DESCRIPTION
For builders exposed `{ version: 2, continuous: true }`, `now dev` will:
- Invoke an initial build on start,
- Run `builder.build()` to get latest `routes` mapping, merge it with `routes` from `now.json`, then go through the routing.

Builder V2 API draft:
https://www.notion.so/zeithq/Builder-v2-API-89a205b58a904e33b8f8609a25762869

Try with:
https://latest-now-cli.now.sh/download?branch=update/now-dev-next