### PR TITLE
Initial build should set `requestPath` to `null`

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -152,7 +152,7 @@ export async function executeBuild(
     })
   );
 
-  match.buildResults.set(requestPath || '', result);
+  match.buildResults.set(requestPath, result);
   Object.assign(match.buildOutput, result.output);
 }
 

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -42,7 +42,7 @@ export async function executeBuild(
   devServer: DevServer,
   files: BuilderInputs,
   match: BuildMatch,
-  requestPath: string,
+  requestPath: string | null,
   filesChanged?: string[],
   filesRemoved?: string[]
 ): Promise<void> {
@@ -152,7 +152,7 @@ export async function executeBuild(
     })
   );
 
-  match.buildResults.set(requestPath, result);
+  match.buildResults.set(requestPath || '', result);
   Object.assign(match.buildOutput, result.output);
 }
 

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -150,7 +150,7 @@ export default class DevServer {
             result,
             filesChangedArray,
             filesRemovedArray
-          ).catch((err: NodeJS.ErrnoException) => {
+          ).catch((err: Error) => {
             this.output.warn(`An error occured while rebuilding ${match.src}:`);
             console.error(err.stack);
           });

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -406,10 +406,11 @@ export default class DevServer {
       );
       if (needsInitialBuild.length > 0) {
         this.output.log('Running initial builds');
-        const requestPath = '';
+
         for (const match of needsInitialBuild) {
-          await executeBuild(nowJson, this, this.files, match, requestPath);
+          await executeBuild(nowJson, this, this.files, match, null);
         }
+
         this.output.success('Initial builds complete');
       }
     }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -117,7 +117,7 @@ export default class DevServer {
 
     // Trigger rebuilds of any existing builds that are dependent
     // on one of the files that has changed
-    const needsRebuild: Map<BuildResult, [string, BuildMatch]> = new Map();
+    const needsRebuild: Map<BuildResult, [string|null, BuildMatch]> = new Map();
     for (const match of this.buildMatches.values()) {
       for (const [requestPath, result] of match.buildResults) {
         // If the `BuildResult` is already queued for a re-build,
@@ -142,7 +142,7 @@ export default class DevServer {
       this.output.debug(`Files changed: ${filesChangedArray.join(', ')}`);
       this.output.debug(`Files removed: ${filesRemovedArray.join(', ')}`);
       for (const [result, [requestPath, match]] of needsRebuild) {
-        if (await shouldServe(match, this.files, requestPath)) {
+        if (requestPath === null || await shouldServe(match, this.files, requestPath)) {
           this.triggerBuild(
             match,
             requestPath,
@@ -150,7 +150,7 @@ export default class DevServer {
             result,
             filesChangedArray,
             filesRemovedArray
-          ).catch(err => {
+          ).catch((err: NodeJS.ErrnoException) => {
             this.output.warn(`An error occured while rebuilding ${match.src}:`);
             console.error(err.stack);
           });
@@ -547,7 +547,7 @@ export default class DevServer {
 
   async triggerBuild(
     match: BuildMatch,
-    requestPath: string,
+    requestPath: string|null,
     req: http.IncomingMessage | null,
     previousBuildResult?: BuildResult,
     filesChanged?: string[],
@@ -555,7 +555,7 @@ export default class DevServer {
   ) {
     // If the requested asset wasn't found in the match's outputs, or
     // a hard-refresh was detected, then trigger a build
-    const buildKey = `${match.src}-${requestPath}`;
+    const buildKey = requestPath === null ? match.src : `${match.src}-${requestPath}`;
     let buildPromise = this.inProgressBuilds.get(buildKey);
     if (buildPromise) {
       // A build for `buildKey` is already in progress, so don't trigger

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -21,7 +21,7 @@ export interface BuildConfig {
 export interface BuildMatch extends BuildConfig {
   builderWithPkg: BuilderWithPackage;
   buildOutput: BuilderOutputs;
-  buildResults: Map<string, BuildResult>;
+  buildResults: Map<string|null, BuildResult>;
   builderCachePromise?: Promise<CacheOutputs>;
   buildTimestamp: number;
   workPath: string;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -77,7 +77,7 @@ export interface BuilderParamsBase {
   config: object;
   meta?: {
     isDev?: boolean;
-    requestPath?: string;
+    requestPath?: string | null;
     filesChanged?: string[];
     filesRemoved?: string[];
   };


### PR DESCRIPTION
This is required for https://github.com/zeit/now-builders/pull/410 and sets the `requestPath` property that is passed to Builders to `null` for initial builds.