### PR TITLE
[now dev] Resolve built routes after matching builder

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -226,37 +226,3 @@ export async function createIgnoreList(cwd: string): Promise<Ignore> {
 
   return ig;
 }
-
-/**
-  * Combine builder's output routes with Now Config's routes
-  */
-export async function combineRoutes (
-  nowJson: NowConfig,
-  devServer: DevServer,
-  match: BuildMatch,
-  requestPath: string,
-): Promise<RouteConfig[]> {
-  let routes: RouteConfig[] = nowJson.routes || [];
-  const builds = nowJson.builds || [];
-
-  await Promise.all(builds.map(async buildConfig => {
-    const { builder } = await getBuilder(buildConfig.use);
-    const { files } = devServer;
-
-    if (builder.version === 2) {
-      await executeBuild(
-        nowJson,
-        devServer,
-        files,
-        match,
-        requestPath
-      );
-      const buildResult = match.buildResults.get(requestPath) as BuildResultV2;
-      if (buildResult.routes) {
-        routes = [...routes, ...buildResult.routes];
-      }
-    }
-  }));
-
-  return routes;
-};

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -34,7 +34,8 @@ function mergeRoutes(
   }
 
   return {
-    dest: fresh.userDest ? fresh.dest : (existing.dest || fresh.dest),
+    found: true,
+    dest: fresh.userDest ? fresh.dest : existing.dest || fresh.dest,
     status: fresh.status || existing.status,
     headers: fresh.headers || existing.headers,
     uri_args: fresh.uri_args || existing.uri_args || {},
@@ -95,6 +96,7 @@ export default async function(
 
         if (isURL(destPath)) {
           found = mergeRoutes(found, {
+            found: true,
             dest: destPath,
             userDest: false,
             status: routeConfig.status,
@@ -107,6 +109,7 @@ export default async function(
           const { pathname, query } = url.parse(destPath, true);
 
           found = mergeRoutes(found, {
+            found: true,
             dest: pathname || '/',
             userDest: Boolean(routeConfig.dest),
             status: routeConfig.status,
@@ -122,6 +125,7 @@ export default async function(
 
   if (!found) {
     found = {
+      found: false,
       dest: reqPathname,
       uri_args: query
     };

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -22,7 +22,6 @@ import { installBuilders } from './builder-cache';
 import getModuleForNSFW from './nsfw-module';
 import {
   executeBuild,
-  combineRoutes,
   collectProjectFiles,
   createIgnoreList,
   getBuildMatches
@@ -41,7 +40,8 @@ import {
   BuilderOutput,
   HttpHandler,
   InvokePayload,
-  InvokeResult
+  InvokeResult,
+  RouteConfig
 } from './types';
 
 export default class DevServer {
@@ -117,7 +117,10 @@ export default class DevServer {
 
     // Trigger rebuilds of any existing builds that are dependent
     // on one of the files that has changed
-    const needsRebuild: Map<BuildResult, [string|null, BuildMatch]> = new Map();
+    const needsRebuild: Map<
+      BuildResult,
+      [string | null, BuildMatch]
+    > = new Map();
     for (const match of this.buildMatches.values()) {
       for (const [requestPath, result] of match.buildResults) {
         // If the `BuildResult` is already queued for a re-build,
@@ -142,7 +145,10 @@ export default class DevServer {
       this.output.debug(`Files changed: ${filesChangedArray.join(', ')}`);
       this.output.debug(`Files removed: ${filesRemovedArray.join(', ')}`);
       for (const [result, [requestPath, match]] of needsRebuild) {
-        if (requestPath === null || await shouldServe(match, this.files, requestPath)) {
+        if (
+          requestPath === null ||
+          (await shouldServe(match, this.files, requestPath))
+        ) {
           this.triggerBuild(
             match,
             requestPath,
@@ -547,7 +553,7 @@ export default class DevServer {
 
   async triggerBuild(
     match: BuildMatch,
-    requestPath: string|null,
+    requestPath: string | null,
     req: http.IncomingMessage | null,
     previousBuildResult?: BuildResult,
     filesChanged?: string[],
@@ -555,7 +561,8 @@ export default class DevServer {
   ) {
     // If the requested asset wasn't found in the match's outputs, or
     // a hard-refresh was detected, then trigger a build
-    const buildKey = requestPath === null ? match.src : `${match.src}-${requestPath}`;
+    const buildKey =
+      requestPath === null ? match.src : `${match.src}-${requestPath}`;
     let buildPromise = this.inProgressBuilds.get(buildKey);
     if (buildPromise) {
       // A build for `buildKey` is already in progress, so don't trigger
@@ -673,18 +680,10 @@ export default class DevServer {
     req: http.IncomingMessage,
     res: http.ServerResponse,
     nowRequestId: string,
-    nowJson: NowConfig
+    nowJson: NowConfig,
+    routes: RouteConfig[] | undefined = nowJson.routes
   ) => {
     await this.updateBuildMatches(nowJson);
-
-    let routes = nowJson.routes;
-
-    const reqPath = (req.url || '').replace(/^\//, '');
-    const _match = await findBuildMatch(this.buildMatches, this.files, reqPath);
-
-    if (_match) {
-      routes = await combineRoutes(nowJson, this, _match, reqPath);
-    }
 
     const {
       dest,
@@ -721,9 +720,30 @@ export default class DevServer {
       return;
     }
 
+    const buildRequestPath = match.buildResults.has(null) ? null : requestPath;
+    const buildResult = match.buildResults.get(buildRequestPath);
+
+    if (buildResult && Array.isArray(buildResult.routes)) {
+      const newUrl = `/${requestPath}`;
+      this.output.debug(`Checking build result's ${buildResult.routes.length} \`routes\` to match ${newUrl}`);
+      const matchedRoute = await devRouter(newUrl, buildResult.routes, this);
+      if (matchedRoute.found) {
+        this.output.debug(`Found matching route ${matchedRoute.dest} for ${newUrl}`);
+        req.url = newUrl;
+        await this.serveProjectAsNowV2(
+          req,
+          res,
+          nowRequestId,
+          nowJson,
+          buildResult.routes
+        );
+        return;
+      }
+    }
+
     let foundAsset = findAsset(match, requestPath);
     if (!foundAsset || this.shouldRebuild(req)) {
-      await this.triggerBuild(match, requestPath, req);
+      await this.triggerBuild(match, buildRequestPath, req);
 
       // Since the `asset` was re-built, resolve it again to get the new asset
       foundAsset = findAsset(match, requestPath);

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -699,7 +699,7 @@ export default class DevServer {
     });
 
     if (isURL(dest)) {
-      this.output.debug(`ProxyPass: ${JSON.stringify(matched_route)}`);
+      this.output.debug(`ProxyPass: ${dest}`);
       return proxyPass(req, res, dest, this.output);
     }
 
@@ -723,7 +723,7 @@ export default class DevServer {
     const buildRequestPath = match.buildResults.has(null) ? null : requestPath;
     const buildResult = match.buildResults.get(buildRequestPath);
 
-    if (buildResult && Array.isArray(buildResult.routes)) {
+    if (buildResult && Array.isArray(buildResult.routes) && buildResult.routes.length > 0) {
       const newUrl = `/${requestPath}`;
       this.output.debug(`Checking build result's ${buildResult.routes.length} \`routes\` to match ${newUrl}`);
       const matchedRoute = await devRouter(newUrl, buildResult.routes, this);

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -12,10 +12,9 @@ export function build({ files, entrypoint }: BuilderParams): BuildResult {
   const output = {
     [entrypoint]: files[entrypoint]
   };
-  const routes: RouteConfig[] = [{ src: entrypoint, dest: entrypoint }];
   const watch = [entrypoint];
 
-  return { output, routes, watch };
+  return { output, routes: [], watch };
 }
 
 export function shouldServe({

--- a/src/commands/dev/lib/static-builder.ts
+++ b/src/commands/dev/lib/static-builder.ts
@@ -1,5 +1,10 @@
 import { basename, extname, join } from 'path';
-import { BuilderParams, BuildResult, RouteConfig, ShouldServeParams } from './types';
+import {
+  BuilderParams,
+  BuildResult,
+  RouteConfig,
+  ShouldServeParams
+} from './types';
 
 export const version = 2;
 
@@ -7,9 +12,7 @@ export function build({ files, entrypoint }: BuilderParams): BuildResult {
   const output = {
     [entrypoint]: files[entrypoint]
   };
-  const routes: RouteConfig[] = [
-    { src: entrypoint, dest: entrypoint }
-  ];
+  const routes: RouteConfig[] = [{ src: entrypoint, dest: entrypoint }];
   const watch = [entrypoint];
 
   return { output, routes, watch };

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -21,7 +21,7 @@ export interface BuildConfig {
 export interface BuildMatch extends BuildConfig {
   builderWithPkg: BuilderWithPackage;
   buildOutput: BuilderOutputs;
-  buildResults: Map<string|null, BuildResult>;
+  buildResults: Map<string | null, BuildResult>;
   builderCachePromise?: Promise<CacheOutputs>;
   buildTimestamp: number;
   workPath: string;
@@ -106,9 +106,7 @@ export interface Builder {
     | BuildResult
     | Promise<BuilderOutputs>
     | Promise<BuildResult>;
-  shouldServe?(
-    params: ShouldServeParams
-  ): boolean | Promise<boolean>;
+  shouldServe?(params: ShouldServeParams): boolean | Promise<boolean>;
   prepareCache?(
     params: PrepareCacheParams
   ): CacheOutputs | Promise<CacheOutputs>;
@@ -143,6 +141,8 @@ export interface HttpHeadersConfig {
 }
 
 export interface RouteResult {
+  // `true` if a route was matched, `false` otherwise
+  found: boolean;
   // "dest": <string of the dest, either file for lambda or full url for remote>
   dest: string;
   // "status": <integer in case exit code is intended to be changed>

--- a/test/dev-router.unit.js
+++ b/test/dev-router.unit.js
@@ -9,6 +9,7 @@ test('[dev-router] 301 redirection', async (t) => {
   const result = await devRouter('/redirect', routesConfig);
 
   t.deepEqual(result, {
+    found: true,
     dest: '/redirect',
     status: 301,
     headers: { 'Location': 'https://zeit.co' },
@@ -26,6 +27,7 @@ test('[dev-router] captured groups', async (t) => {
   const result = await devRouter('/api/user', routesConfig);
 
   t.deepEqual(result, {
+    found: true,
     dest: '/endpoints/user.js',
     status: undefined,
     headers: undefined,
@@ -43,6 +45,7 @@ test('[dev-router] named groups', async (t) => {
   const result = await devRouter('/user/123', routesConfig);
 
   t.deepEqual(result, {
+    found: true,
     dest: '/user.js',
     status: undefined,
     headers: undefined,
@@ -64,6 +67,7 @@ test('[dev-router] unreached route', async (t) => {
   // We need to match the last route. We read from
   // top to bottom and every route can overwrite each other.
   t.deepEqual(result, {
+    found: true,
     dest: '/hidden.js',
     status: undefined,
     headers: undefined,
@@ -81,6 +85,7 @@ test('[dev-router] proxy_pass', async (t) => {
   const result = await devRouter('/proxy', routesConfig);
 
   t.deepEqual(result, {
+    found: true,
     dest: 'https://zeit.co',
     status: undefined,
     headers: undefined,


### PR DESCRIPTION
This removes the `combineRoutes()` function since it was problematic and triggered rebuilds upon every HTTP request, which is not necessary and makes development slower.

Now, when an HTTP request comes in, the `now.json` routes are resolved first, and then the matched build is checked if it defines any `routes` in the build output. If it does, and a matching route is found then the route is handled accordingly.