### PR TITLE
[now dev] Remove `requiresInitialBuild` and make `shouldServe()` optional for v2 Builders

### DIFF
--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -25,25 +25,6 @@ export function resolveRouteParameters(
   });
 }
 
-function mergeRoutes(
-  existing: RouteResult | undefined,
-  fresh: RouteResult
-): RouteResult {
-  if (!existing) {
-    return fresh;
-  }
-
-  return {
-    found: true,
-    dest: fresh.userDest ? fresh.dest : existing.dest || fresh.dest,
-    status: fresh.status || existing.status,
-    headers: fresh.headers || existing.headers,
-    uri_args: fresh.uri_args || existing.uri_args || {},
-    matched_route: fresh.matched_route,
-    matched_route_idx: fresh.matched_route_idx
-  };
-}
-
 export default async function(
   reqPath = '',
   routes?: RouteConfig[],
@@ -95,7 +76,7 @@ export default async function(
         }
 
         if (isURL(destPath)) {
-          found = mergeRoutes(found, {
+          found = {
             found: true,
             dest: destPath,
             userDest: false,
@@ -104,11 +85,11 @@ export default async function(
             uri_args: {},
             matched_route: routeConfig,
             matched_route_idx: idx
-          });
+          };
+          break;
         } else {
           const { pathname, query } = url.parse(destPath, true);
-
-          found = mergeRoutes(found, {
+          found = {
             found: true,
             dest: pathname || '/',
             userDest: Boolean(routeConfig.dest),
@@ -117,7 +98,8 @@ export default async function(
             uri_args: query,
             matched_route: routeConfig,
             matched_route_idx: idx
-          });
+          };
+          break;
         }
       }
     }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -728,12 +728,22 @@ export default class DevServer {
     const buildRequestPath = match.buildResults.has(null) ? null : requestPath;
     const buildResult = match.buildResults.get(buildRequestPath);
 
-    if (buildResult && Array.isArray(buildResult.routes) && buildResult.routes.length > 0) {
+    if (
+      buildResult &&
+      Array.isArray(buildResult.routes) &&
+      buildResult.routes.length > 0
+    ) {
       const newUrl = `/${requestPath}`;
-      this.output.debug(`Checking build result's ${buildResult.routes.length} \`routes\` to match ${newUrl}`);
+      this.output.debug(
+        `Checking build result's ${
+          buildResult.routes.length
+        } \`routes\` to match ${newUrl}`
+      );
       const matchedRoute = await devRouter(newUrl, buildResult.routes, this);
       if (matchedRoute.found) {
-        this.output.debug(`Found matching route ${matchedRoute.dest} for ${newUrl}`);
+        this.output.debug(
+          `Found matching route ${matchedRoute.dest} for ${newUrl}`
+        );
         req.url = newUrl;
         await this.serveProjectAsNowV2(
           req,
@@ -869,7 +879,9 @@ export default class DevServer {
 
   async hasFilesystem(dest: string): Promise<boolean> {
     const requestPath = dest.replace(/^\//, '');
-    if (await findBuildMatch(this.buildMatches, this.files, requestPath, this)) {
+    if (
+      await findBuildMatch(this.buildMatches, this.files, requestPath, this)
+    ) {
       return true;
     }
     return false;
@@ -1009,7 +1021,11 @@ async function findMatchingRoute(
 ): Promise<RouteResult | void> {
   const reqUrl = `/${requestPath}`;
   for (const buildResult of match.buildResults.values()) {
-    const route = await devRouter(reqUrl, (buildResult as BuildResultV2).routes, devServer);
+    const route = await devRouter(
+      reqUrl,
+      (buildResult as BuildResultV2).routes,
+      devServer
+    );
     if (route.found) {
       return route;
     }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -996,7 +996,8 @@ async function shouldServe(
       entrypoint,
       files,
       config,
-      requestPath
+      requestPath,
+      workPath: devServer.cwd
     });
     if (shouldServe) {
       return true;

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -984,7 +984,6 @@ async function shouldServe(
     // If there's no `shouldServe()` function and no matched asset, then look
     // up if there's a matching build route on the `match` that has already
     // been built.
-    console.error('found matching route');
     return true;
   }
   return false;
@@ -998,7 +997,6 @@ async function findMatchingRoute(
   const reqUrl = `/${requestPath}`;
   for (const buildResult of match.buildResults.values()) {
     const route = await devRouter(reqUrl, (buildResult as BuildResultV2).routes, devServer);
-    console.error({ route, reqUrl });
     if (route.found) {
       return route;
     }

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -97,7 +97,6 @@ export interface BuilderConfigAttr {
 
 export interface Builder {
   version?: 2;
-  requiresInitialBuild?: boolean;
   config?: BuilderConfigAttr;
   build(
     params: BuilderParams
@@ -132,6 +131,7 @@ export interface ShouldServeParams {
 export interface BuilderWithPackage {
   builder: Builder;
   package: {
+    name?: string;
     version: string;
   };
 }

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -126,6 +126,7 @@ export interface ShouldServeParams {
   entrypoint: string;
   config?: object;
   requestPath: string;
+  workPath: string
 }
 
 export interface BuilderWithPackage {

--- a/test/dev-router.unit.js
+++ b/test/dev-router.unit.js
@@ -56,27 +56,6 @@ test('[dev-router] named groups', async (t) => {
   });
 });
 
-test('[dev-router] unreached route', async (t) => {
-  const routesConfig = [
-    { src: '/.*', dest: '/index.js' },
-    { src: '/hidden', dest: '/hidden.js' }
-  ];
-
-  const result = await devRouter('/hidden', routesConfig);
-
-  // We need to match the last route. We read from
-  // top to bottom and every route can overwrite each other.
-  t.deepEqual(result, {
-    found: true,
-    dest: '/hidden.js',
-    status: undefined,
-    headers: undefined,
-    uri_args: {},
-    matched_route: routesConfig[1],
-    matched_route_idx: 1
-  });
-});
-
 test('[dev-router] proxy_pass', async (t) => {
   const routesConfig = [
     { src: '/proxy', dest: 'https://zeit.co' }


### PR DESCRIPTION
`@now/next` will be removing `shouldServe()` in favor of returning a `routes` config array upon bootup. This makes now dev's `shouldServe()` wrapper function support matching a `routes` config entry when `shouldServe()` is not defined.