### PR TITLE
Support env NOW_BUILDER_CACHE_DIR for debugging builders

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -9,7 +9,7 @@ import cacheDirectory from 'cache-or-tmp-directory';
 import wait from '../../../util/output/wait';
 import { Output } from '../../../util/output';
 import { devDependencies as nowCliDeps } from '../../../../package.json';
-import { Builder, BuilderWithPackage } from './types';
+import { BuilderWithPackage } from './types';
 import {
   NoBuilderCacheError,
   BuilderCacheCleanError
@@ -31,7 +31,8 @@ export const builderDirPromise = prepareBuilderDir();
  * Prepare cache directory for installing now-builders
  */
 export async function prepareCacheDir() {
-  const designated = cacheDirectory('co.zeit.now');
+  const { NOW_BUILDER_CACHE_DIR } = process.env;
+  const designated = NOW_BUILDER_CACHE_DIR || cacheDirectory('co.zeit.now');
 
   if (!designated) {
     throw new NoBuilderCacheError();

--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import execa from 'execa';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import npa from 'npm-package-arg';
 import mkdirp from 'mkdirp-promise';
 import { funCacheDir } from '@zeit/fun';
@@ -32,7 +32,9 @@ export const builderDirPromise = prepareBuilderDir();
  */
 export async function prepareCacheDir() {
   const { NOW_BUILDER_CACHE_DIR } = process.env;
-  const designated = NOW_BUILDER_CACHE_DIR || cacheDirectory('co.zeit.now');
+  const designated = NOW_BUILDER_CACHE_DIR
+    ? resolve(NOW_BUILDER_CACHE_DIR)
+    : cacheDirectory('co.zeit.now');
 
   if (!designated) {
     throw new NoBuilderCacheError();


### PR DESCRIPTION
Prefer `NOW_BUILDER_CACHE_DIR` whithin `prepareCacheDir`, so we can debug builders locally in a fixed folder, without publish them.