### PR TITLE
Ignore `__pycache__` directories

### DIFF
--- a/src/util/ignored.ts
+++ b/src/util/ignored.ts
@@ -16,4 +16,5 @@ export default `.hg
 npm-debug.log
 config.gypi
 node_modules
+__pycache__
 CVS`;


### PR DESCRIPTION
The `__pycache__` directories are basically temp folders created by python for the purpose of caching and should probably be ignored during deployments.

> When a Python source file is imported for the first time, a `__pycache__` directory will be created in the package directory, if one does not already exist. The pyc file for the imported source will be written to the `__pycache__` directory, using the magic-tag formatted name.

[PEP 3147](https://www.python.org/dev/peps/pep-3147/)