### PR TITLE
[now dev] Pass in the builder-specific `workPath` to `shouldServe()`

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -989,6 +989,7 @@ async function shouldServe(
   const {
     src: entrypoint,
     config,
+    workPath,
     builderWithPkg: { builder, package: pkg }
   } = match;
   if (typeof builder.shouldServe === 'function') {
@@ -997,7 +998,7 @@ async function shouldServe(
       files,
       config,
       requestPath,
-      workPath: devServer.cwd
+      workPath
     });
     if (shouldServe) {
       return true;


### PR DESCRIPTION
The dev server `cwd` is not correct working path of a build match, so pass in the correct one. This property will be used by `@now/static-build`'s dev mode.