### PR TITLE
[now dev] Add `xfwd` option to `http-proxy`

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -900,6 +900,7 @@ function proxyPass(
   const proxy = httpProxy.createProxyServer({
     changeOrigin: true,
     ws: true,
+    xfwd: true,
     ignorePath: true,
     target: dest
   });


### PR DESCRIPTION
This makes the `http-proxy` module set the `X-Forwarded-*` HTTP request headers to the destination endpoint.