### PR TITLE
[now dev] Use `minimatch` on the `watch` array to support globs

### DIFF
--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -126,7 +126,7 @@ export interface ShouldServeParams {
   entrypoint: string;
   config?: object;
   requestPath: string;
-  workPath: string
+  workPath: string;
 }
 
 export interface BuilderWithPackage {


### PR DESCRIPTION
This will be necessary for `@now/static-build` since it needs to watch all files in the dir containing the entrypoint. For example:

```
watch: [ path.join(path.dirname(entrypoint), '**/*') ]
```