### PR TITLE
[now dev] Allow a builder `watch` array to contain "./" prefixed paths

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -102,6 +102,16 @@ export async function executeBuild(
     devServer.restoreOriginalEnv();
   }
 
+  // The `watch` array must not have "./" prefix, so if the builder returned
+  // watched files that contain "./" strip them here for ease of writing the
+  // builder.
+  result.watch = ((result as BuildResultV2).watch || []).map((w: string) => {
+    if (w.startsWith('./')) {
+      return w.substring(2);
+    }
+    return w;
+  });
+
   // Enforce the lambda zip size soft watermark
   const { maxLambdaSize = '5mb' } = { ...builderConfig, ...config };
   let maxLambdaBytes: number;


### PR DESCRIPTION
The file watcher logic expects that there is no `'./'` prefix on the watched file paths/patterns, but `path.dirname('foo')` returns `'.'` which turns into `'./foo'` with `path.join()`. So this allows those file paths to be returned from the builder and `now dev` normalizes the paths after the build has completed.