### PR TITLE
Better builder logging

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -1,6 +1,7 @@
 /* disable this rule _here_ to avoid conflict with ongoing changes */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import bytes from 'bytes';
+import chalk from 'chalk';
 import { tmpdir } from 'os';
 import { join, relative } from 'path';
 import { createFunction } from '@zeit/fun';
@@ -74,10 +75,10 @@ export async function executeBuild(
 
   try {
     devServer.applyBuildEnv(nowJson);
-    let unhookIntercept;
-    if (!devServer.debug) {
-      unhookIntercept = intercept(() => '');
-    }
+    const unhookIntercept = intercept((log) => {
+      const builderName = pkg.name || 'builder';
+      return `[${chalk.yellow(builderName)}] ${log}`;
+    });
     result = await builder.build({
       files,
       entrypoint,
@@ -85,9 +86,7 @@ export async function executeBuild(
       config,
       meta: { isDev: true, requestPath, filesChanged, filesRemoved }
     });
-    if (typeof unhookIntercept === 'function') {
-      unhookIntercept();
-    }
+    unhookIntercept();
 
     // Sort out build result to builder v2 shape
     if (builder.version === undefined) {

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -17,7 +17,6 @@ import { LambdaSizeExceededError } from '../../../util/errors-ts';
 import { getBuilder } from './builder-cache';
 import {
   NowConfig,
-  RouteConfig,
   BuildMatch,
   BuildResult,
   BuildResultV2,

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -75,6 +75,10 @@ export interface BuilderParamsBase {
   files: BuilderInputs;
   entrypoint: string;
   config: object;
+  log: {
+    info: () => void;
+    debug: () => void;
+  },
   meta?: {
     isDev?: boolean;
     requestPath?: string | null;


### PR DESCRIPTION
- Added a `log: { info, debug }` argument to `BuildParams`, provided 2 utils for logging.
- Filter out build logs except ones from provided logger.
- Prefix builder logs with `[builder-name]`, yellow for `info()`, green for `debug`.

![image](https://user-images.githubusercontent.com/215282/56646060-63231980-66b1-11e9-93ab-6f743c15055f.png)
