### PR TITLE
[now dev] Don't include a file in both `filesChanged` and `filesRemoved` list

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -95,7 +95,11 @@ export default class DevServer {
           filesRemoved
         );
       } else if (event.action === nsfw.actions.DELETED) {
-        this.handleFileDeleted(event as nsfw.DeletedEvent, filesRemoved);
+        this.handleFileDeleted(
+          event as nsfw.DeletedEvent,
+          filesChanged,
+          filesRemoved
+        );
       } else if (event.action === nsfw.actions.MODIFIED) {
         await this.handleFileModified(
           event as nsfw.ModifiedEvent,
@@ -192,24 +196,26 @@ export default class DevServer {
     const name = relative(this.cwd, fsPath);
     try {
       this.files[name] = await FileFsRef.fromFsPath({ fsPath });
-      changed.add(name);
+      fileChanged(name, changed, removed);
       this.output.debug(`File created: ${name}`);
     } catch (err) {
       if (err.code === 'ENOENT') {
         this.output.debug(`File created, but has since been deleted: ${name}`);
-        delete this.files[name];
-        removed.add(name);
+        fileRemoved(name, this.files, changed, removed);
       } else {
         throw err;
       }
     }
   }
 
-  handleFileDeleted(event: nsfw.DeletedEvent, removed: Set<string>): void {
+  handleFileDeleted(
+    event: nsfw.DeletedEvent,
+    changed: Set<string>,
+    removed: Set<string>
+  ): void {
     const name = relative(this.cwd, join(event.directory, event.file));
     this.output.debug(`File deleted: ${name}`);
-    delete this.files[name];
-    removed.add(name);
+    fileRemoved(name, this.files, changed, removed);
   }
 
   async handleFileModified(
@@ -221,13 +227,12 @@ export default class DevServer {
     const name = relative(this.cwd, fsPath);
     try {
       this.files[name] = await FileFsRef.fromFsPath({ fsPath });
-      changed.add(name);
+      fileChanged(name, changed, removed);
       this.output.debug(`File modified: ${name}`);
     } catch (err) {
       if (err.code === 'ENOENT') {
         this.output.debug(`File modified, but has since been deleted: ${name}`);
-        delete this.files[name];
-        removed.add(name);
+        fileRemoved(name, this.files, changed, removed);
       } else {
         throw err;
       }
@@ -240,23 +245,21 @@ export default class DevServer {
     removed: Set<string>
   ): Promise<void> {
     const oldName = relative(this.cwd, join(event.directory, event.oldFile));
-    removed.add(oldName);
-    delete this.files[oldName];
+    fileRemoved(oldName, this.files, changed, removed);
 
     const fsPath = join(event.newDirectory, event.newFile);
     const name = relative(this.cwd, fsPath);
 
     try {
       this.files[name] = await FileFsRef.fromFsPath({ fsPath });
-      changed.add(name);
+      fileChanged(name, changed, removed);
       this.output.debug(`File renamed: ${oldName} -> ${name}`);
     } catch (err) {
       if (err.code === 'ENOENT') {
         this.output.debug(
           `File renamed, but has since been deleted: ${oldName} -> ${name}`
         );
-        delete this.files[name];
-        removed.add(name);
+        fileRemoved(oldName, this.files, changed, removed);
       } else {
         throw err;
       }
@@ -1091,4 +1094,24 @@ function isIndex(path: string): boolean {
 
 function minimatches(files: string[], pattern: string): boolean {
   return files.some(file => minimatch(file, pattern));
+}
+
+function fileChanged(
+  name: string,
+  changed: Set<string>,
+  removed: Set<string>
+): void {
+  changed.add(name);
+  removed.delete(name);
+}
+
+function fileRemoved(
+  name: string,
+  files: BuilderInputs,
+  changed: Set<string>,
+  removed: Set<string>
+): void {
+  delete files[name];
+  changed.delete(name);
+  removed.add(name);
 }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -158,8 +158,12 @@ export default class DevServer {
 
     if (needsRebuild.size > 0) {
       this.output.debug(`Triggering ${needsRebuild.size} rebuilds`);
-      this.output.debug(`Files changed: ${filesChangedArray.join(', ')}`);
-      this.output.debug(`Files removed: ${filesRemovedArray.join(', ')}`);
+      if (filesChangedArray.length > 0) {
+        this.output.debug(`Files changed: ${filesChangedArray.join(', ')}`);
+      }
+      if (filesRemovedArray.length > 0) {
+        this.output.debug(`Files removed: ${filesRemovedArray.join(', ')}`);
+      }
       for (const [result, [requestPath, match]] of needsRebuild) {
         if (
           requestPath === null ||


### PR DESCRIPTION
This makes it so that if a file is added to the "changed" array, then it is also removed from the "deleted" array, and vice-versa.