### PR TITLE
[wip] Make nsfw binary module survive node upgrade

### DIFF
--- a/src/commands/dev/lib/nsfw-module.ts
+++ b/src/commands/dev/lib/nsfw-module.ts
@@ -59,8 +59,18 @@ const prepareModule = async (output: Output): Promise<string> => {
   const full = join(dirName, fileName);
 
   if (await pathExists(full)) {
-    output.debug('The nsfw module is already cached, not re-downloading');
-    return full;
+    try {
+      require(full);
+      output.debug('The nsfw module is already cached, not re-downloading');
+      return full;
+    } catch (error) {
+      if (/NODE_MODULE_VERSION \d+/.test(error.message)) {
+        output.debug('The nsfw module is outdated, re-installing');
+      } else {
+        output.debug(error.stack);
+        output.debug('The nsfw module is corrupt, re-installing');
+      }
+    }
   }
 
   output.debug(`Creating ${dirName} for the nsfw module`);


### PR DESCRIPTION
Verify installed module in `prepareModule`. For fixing this error:

```
> Error! The module '/path/to/nsfw-2.0.2.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 64. This version of Node.js requires
NODE_MODULE_VERSION 72. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
```

### TODO

- [ ] Make the install process aware of node-version. Currently it always download the binary for Node 10.