### PR TITLE
[now dev] Force `@now/static` to run in-memory

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -20,6 +20,7 @@ import {
 
 const localBuilders: { [key: string]: BuilderWithPackage } = {
   '@now/static': {
+    runInProcess: true,
     builder: Object.freeze(staticBuilder),
     package: { version: '' }
   }

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -102,7 +102,7 @@ export async function executeBuild(
   filesRemoved?: string[]
 ): Promise<void> {
   const {
-    builderWithPkg: { builder, package: pkg }
+    builderWithPkg: { runInProcess, builder, package: pkg }
   } = match;
   const { env } = devServer;
   const { src: entrypoint, workPath } = match;
@@ -116,7 +116,7 @@ export async function executeBuild(
   let result: BuildResult;
 
   let { buildProcess } = match;
-  if (!buildProcess) {
+  if (!runInProcess && !buildProcess) {
     devServer.output.debug(`Creating build process for ${entrypoint}`);
     buildProcess = await createBuildProcess(
       match,
@@ -124,7 +124,7 @@ export async function executeBuild(
       devServer.output
     );
 
-    if (process.stdout.isTTY) {
+    if (!devServer.debug) {
       const logTitle = `${chalk.bold(`Setting up Builder for ${chalk.underline(entrypoint)}`)}:`;
       const fullLogs: string[] = [];
       const spinner = ora(logTitle).start();
@@ -167,21 +167,26 @@ export async function executeBuild(
     meta: { isDev: true, requestPath, filesChanged, filesRemoved }
   };
 
-  buildProcess.send({
-    type: 'build',
-    builderName: pkg.name,
-    buildParams
-  });
-
-  const buildResultOrOutputs = await new Promise((resolve, reject) => {
-    buildProcess!.once('message', ({ type, result }) => {
-      if (type === 'buildResult') {
-        resolve(result);
-      } else {
-        reject(new Error(`Got unexpected message type: ${type}`));
-      }
+  let buildResultOrOutputs: BuilderOutputs | BuildResult;
+  if (buildProcess) {
+    buildProcess.send({
+      type: 'build',
+      builderName: pkg.name,
+      buildParams
     });
-  });
+
+    buildResultOrOutputs = await new Promise((resolve, reject) => {
+      buildProcess!.once('message', ({ type, result }) => {
+        if (type === 'buildResult') {
+          resolve(result);
+        } else {
+          reject(new Error(`Got unexpected message type: ${type}`));
+        }
+      });
+    });
+  } else {
+    buildResultOrOutputs = await builder.build(buildParams);
+  }
 
   // Sort out build result to builder v2 shape
   if (builder.version === undefined) {

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -124,7 +124,7 @@ export async function executeBuild(
       devServer.output
     );
 
-    if (!devServer.debug) {
+    if (!devServer.debug && process.stdout.isTTY) {
       const logTitle = `${chalk.bold(`Setting up Builder for ${chalk.underline(entrypoint)}`)}:`;
       const fullLogs: string[] = [];
       const spinner = ora(logTitle).start();

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -127,6 +127,7 @@ export interface ShouldServeParams {
 }
 
 export interface BuilderWithPackage {
+  runInProcess?: boolean;
   builder: Builder;
   package: {
     name?: string;


### PR DESCRIPTION
The logic for `@now/static` builder is bundled into the `pkg` binary, and thus is not requireable, so it must instead be run in-memory.