### PR TITLE
[now dev] exit on MissingDotenvVarsError

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
+import { MissingDotenvVarsError } from '../../util/errors-ts';
 
 import DevServer from './lib/dev-server';
 
@@ -24,5 +25,14 @@ export default async function dev(
   const debug = opts['-d'] || opts['--debug'];
   const devServer = new DevServer(cwd, { output, debug });
   process.once('SIGINT', devServer.stop.bind(devServer));
-  await devServer.start(port);
+
+  try {
+    await devServer.start(port);
+  } catch (error) {
+    if (error instanceof MissingDotenvVarsError) {
+      output.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
 }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -24,7 +24,6 @@ import getModuleForNSFW from './nsfw-module';
 import {
   executeBuild,
   collectProjectFiles,
-  createIgnoreList,
   getBuildMatches
 } from './dev-builder';
 


### PR DESCRIPTION
`now dev` will exit on this error:

```
> Error! Env var "DATABASE_NAME" is not defined in `.env` file
```