### PR TITLE
Support Windows when downloading file watcher

### DIFF
--- a/src/commands/dev/lib/nsfw-module.ts
+++ b/src/commands/dev/lib/nsfw-module.ts
@@ -16,7 +16,8 @@ import { Output } from '../../../util/output/create-output';
 const platformToName: { [name: string]: string } = {
   alpine: 'nsfw-alpine',
   darwin: 'nsfw-macos',
-  linux: 'nsfw-linux'
+  linux: 'nsfw-linux',
+  win32: 'nsfw-win'
 };
 
 // @ts-ignore


### PR DESCRIPTION
This ensures we're downloading the file watcher on Windows.