### PR TITLE
Add python virtual environment to default ignore

### DIFF
--- a/src/util/ignored.ts
+++ b/src/util/ignored.ts
@@ -13,8 +13,10 @@ export default `.hg
 .lock-wscript
 .env
 .env.build
+.venv
 npm-debug.log
 config.gypi
 node_modules
-__pycache__
+__pycache__/
+venv/
 CVS`;


### PR DESCRIPTION
I added `venv` to ignore along with a couple other variations.

Note that the trailing `/` makes the ignore apply recursively to subdirectories, something necessary for the `__pycache__` which shows up anywhere .py files are found.

https://gitignore.io/api/python