### PR TITLE
Print missing line when stopping server

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -463,6 +463,8 @@ export default class DevServer {
     this.stopping = true;
 
     if (this.serverUrlPrinted) {
+      // This makes it look cleaner
+      process.stdout.write('\n');
       this.output.log(`Stopping ${chalk.bold('`now dev`')} server`);
     }
 


### PR DESCRIPTION
This was missing from https://github.com/zeit/now-cli/pull/2249, I forgot to push it.