### PR TITLE
Do not check for @now/static Builder updates

### DIFF
--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -186,7 +186,7 @@ export async function executeBuild(
       };
 
       logsListener = spinLogger;
-      
+
       buildProcess!.stdout!.on('data', spinLogger);
       buildProcess!.stderr!.on('data', spinLogger);
     }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -400,7 +400,14 @@ export default class DevServer {
 
     const nowJson = await this.getNowJson();
     const builders = (nowJson.builds || []).map((b: BuildConfig) => b.use);
-    const shouldUpdate = true;
+
+    let shouldUpdate = true;
+
+    // If the project is entirely static, no need to check for Builder updates
+    if (builders.length === 0 || builders.every(item => item === '@now/static')) {
+      shouldUpdate = false;
+    }
+
     await installBuilders(builders, shouldUpdate);
     await this.updateBuildMatches(nowJson);
 


### PR DESCRIPTION
For `@now/static`, there is no point in checking for Builder updates as the Builder does not actually exist, it's just a static server in `now dev`.