### PR TITLE
Help users to deal with secrets starting with dash

### DIFF
--- a/src/commands/secrets.js
+++ b/src/commands/secrets.js
@@ -237,9 +237,9 @@ async function run({ token, contextName, currentTeam }) {
       );
 
       if (args.length > 2) {
-        const example = chalk.cyan(`$ now secret add ${args[0]}`);
+        const example = chalk.cyan(`$ now secret add -- "${args[0]}"`);
         console.log(
-          `> If your secret has spaces, make sure to wrap it in quotes. Example: \n  ${example} `
+          `> If your secret has spaces or starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
         );
       }
 


### PR DESCRIPTION
People are often trying to store secrets starting with dashes such as 
private keys. These dashes get interpreted as command line options which
effectively prevents a storage of private keys.

Fortunately, this is easily resolved by using bash -- convention to mark
an end of options, such as:

```
now secret add google-secret-key -- "-----BEGIN PRIVATE KEY-----
abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVXYZ+/a
-----END PRIVATE KEY-----"
```

The problem is also discussed in following issues: 
https://github.com/zeit/now-cli/issues/749
https://github.com/zeit/now-cli/issues/80