### PR TITLE
Revert "Add a logout test case"

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -1342,10 +1342,6 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
   }
 });
 
-test('log out', async t => {
-  await execa(binaryPath, ['logout', ...defaultArgs]);
-});
-
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);


### PR DESCRIPTION
Before https://github.com/zeit/now-cli/pull/2201 was merged, @OlliV slipped in a commit that broke the CI tests. This PR reverts that commit.