### PR TITLE
Fixed error for `.env` and `.env.build`

### DIFF
--- a/errors/missing-env-file.md
+++ b/errors/missing-env-file.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-You ran `now dev` inside a project that contains a `now.json` file with `env` or `build.env` properties.
+You ran `now dev` inside a project that contains a `now.json` file with `env` or `build.env` properties that use [Now Secrets](https://zeit.co/docs/v2/deployments/environment-variables-and-secrets).
 
 #### Possible Ways to Fix It
 

--- a/errors/missing-env-file.md
+++ b/errors/missing-env-file.md
@@ -1,0 +1,19 @@
+# Missing Env Keys While Developing
+
+#### Why This Error Occurred
+
+You ran `now dev` inside a project that contains a `now.json` file with `env` or `build.env` properties.
+
+#### Possible Ways to Fix It
+
+The error message will mention a list of environment variables and a file name (either `.env` or `.env.build`).
+
+If it does not exist yet, please create the file that the error message mentions and insert the missing environment variable into it.
+
+For example, if the error message shows that the environment variable `TEST` is missing from `.env`, then the `.env` file should look like this:
+
+```
+TEST=value
+```
+
+In the above example, `TEST` represents the name of the environment variable and `value` its value.

--- a/errors/missing-env-file.md
+++ b/errors/missing-env-file.md
@@ -1,4 +1,4 @@
-# Missing Env Keys While Developing
+# Missing Environment Variables While Developing
 
 #### Why This Error Occurred
 

--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
-import { MissingDotenvVarsError } from '../../util/errors-ts';
 
 import DevServer from './lib/dev-server';
 
@@ -26,13 +25,5 @@ export default async function dev(
   const devServer = new DevServer(cwd, { output, debug });
   process.once('SIGINT', devServer.stop.bind(devServer));
 
-  try {
-    await devServer.start(port);
-  } catch (error) {
-    if (error instanceof MissingDotenvVarsError) {
-      output.error(error.message);
-      process.exit(1);
-    }
-    throw error;
-  }
+  await devServer.start(port);
 }

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -333,7 +333,17 @@ export default class DevServer {
       }
     }
 
-    this.validateNowConfig(config);
+    try {
+      this.validateNowConfig(config);
+    } catch (err) {
+      if (err instanceof MissingDotenvVarsError) {
+        this.output.error(err.message);
+        process.exit(1);
+      } else {
+        throw err;
+      }
+    }
+
     this.cachedNowJson = config;
 
     return config;

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -1072,6 +1072,7 @@ export class MissingDotenvVarsError extends NowError<
 > {
   constructor(type: string, missing: string[]) {
     let message: string;
+
     if (missing.length === 1) {
       message = `Env var ${JSON.stringify(missing[0])} is not defined in ${code(
         type
@@ -1079,9 +1080,12 @@ export class MissingDotenvVarsError extends NowError<
     } else {
       message = [
         `The following env vars are not defined in ${code(type)} file:`,
-        ...missing.map(name => ` - ${JSON.stringify(name)}`)
+        ...missing.map(name => `  - ${JSON.stringify(name)}`)
       ].join('\n');
     }
+
+    message += '\nRead more: https://err.sh/now-cli/missing-env-file';
+
     super({
       code: 'MISSING_DOTENV_VARS',
       message,


### PR DESCRIPTION
This PR introduces two things:

- A guide for the error about missing env variables in development
- The error will not be reported to Sentry anymore