### PR TITLE
Make the message for when the server is running shorter

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -459,7 +459,7 @@ export default class DevServer {
     }
 
     this.output.ready(
-      `Development server running at ${chalk.cyan.underline(
+      `Available at ${chalk.cyan.underline(
         address.replace('[::]', 'localhost')
       )}`
     );

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -15,7 +15,7 @@ test.before(async () => {
   const output = createOutput({})
   const origReady = output.ready
   output.ready = msg => {
-    if (msg.toString().match(/Development server running at/)) {
+    if (msg.toString().match(/Available at/)) {
       readyResolve()
     }
     origReady(msg)


### PR DESCRIPTION
This makes the message that appears when the `now dev` server is running shorter:

![image](https://user-images.githubusercontent.com/6170607/56869958-63e8e200-6a08-11e9-8ab2-041b70c3601e.png)


It's now very similar to what you see when deploying:

![image](https://user-images.githubusercontent.com/6170607/56869949-54699900-6a08-11e9-8425-8884ca30070e.png)
