### PR TITLE
Display `handle` in `now inspect`

### DIFF
--- a/src/util/output/routes.js
+++ b/src/util/output/routes.js
@@ -27,6 +27,11 @@ export default routes => {
   const arrow = chalk.grey('->')
 
   for (const item of routes) {
+    if (item.handle) {
+      toPrint += `${chalk.grey('╶')} ${chalk.cyan(item.handle)}`;
+      continue;
+    }
+
     const { src, dest, status, headers } = item;
     const last = routes.indexOf(item) === (routes.length - 1);
     const suffix = last ? '' : `\n`;


### PR DESCRIPTION
Fixes https://github.com/zeit/now-cli/issues/2264

Will add
```
╶ filesystem
```

to the `Routes` output in `now inspect` if it is set instead of throwing.