### PR TITLE
Do not print installing builders for no builds

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -122,8 +122,9 @@ export async function cleanCacheDir(output: Output): Promise<void> {
 export async function installBuilders(packagesSet: Set<string>): Promise<void> {
   const packages = Array.from(packagesSet);
   if (
+    packages.length === 0 || (
     packages.length === 1 &&
-    Object.hasOwnProperty.call(localBuilders, packages[0])
+    Object.hasOwnProperty.call(localBuilders, packages[0]))
   ) {
     // Static deployment, no builders to install
     return;


### PR DESCRIPTION
Prevents this message from getting printed if there are no Builders:

![image](https://user-images.githubusercontent.com/6170607/56891972-7867c180-6a7e-11e9-8652-1c459fa80e7c.png)

It also adds a unit test for this case.