### PR TITLE
Correctly log when setting up Builders

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -1,7 +1,9 @@
 import path from 'path';
+import chalk from 'chalk';
 
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
+import pkg from '../../../package.json';
 
 import DevServer from './lib/dev-server';
 
@@ -18,11 +20,14 @@ export default async function dev(
   args: string[],
   output: Output
 ) {
+  output.dim(`Now CLI ${pkg.version} dev (beta) — https://zeit.co/support`);
+
   const [dir = '.'] = args;
   const cwd = path.join(process.cwd(), dir);
   const port = opts['-p'] || opts['--port'];
   const debug = opts['-d'] || opts['--debug'];
   const devServer = new DevServer(cwd, { output, debug });
+
   process.once('SIGINT', devServer.stop.bind(devServer));
 
   await devServer.start(port);

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -129,8 +129,8 @@ export async function executeBuild(
   await mkdirp(workPath);
 
   const startTime = Date.now();
+
   if (match.use !== '@now/static') {
-    devServer.output.log(`Building ${match.use}:${entrypoint}`);
     devServer.output.debug(
       `${pkg.version ? `v${pkg.version} ` : ''}(workPath = ${workPath})`
     );
@@ -138,6 +138,7 @@ export async function executeBuild(
 
   const builderConfig = builder.config || {};
   const config = match.config || {};
+
   let result: BuildResult;
 
   let { buildProcess } = match;
@@ -162,7 +163,7 @@ export async function executeBuild(
   if (buildProcess) {
     let logsListener: (b: any) => void = devServer.output.debug;
 
-    if (!devServer.debug && process.stdout.isTTY && false) {
+    if (!devServer.debug && process.stdout.isTTY) {
       const logTitle = `${chalk.bold(`Setting up Builder for ${chalk.underline(entrypoint)}`)}:`;
       const fullLogs: string[] = [];
       const spinner = ora(logTitle).start();
@@ -348,13 +349,6 @@ export async function executeBuild(
 
   match.buildResults.set(requestPath, result);
   Object.assign(match.buildOutput, result.output);
-
-  if (match.use !== '@now/static') {
-    const endTime = Date.now();
-    devServer.output.log(
-      `Built ${match.use}:${entrypoint} [${ms(endTime - startTime)}]`
-    );
-  }
 }
 
 export async function getBuildMatches(

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -428,7 +428,7 @@ export default class DevServer {
     );
     if (needsInitialBuild.length > 0) {
       this.output.log(
-        `Running ${needsInitialBuild.length} initial build${
+        `Setting up ${needsInitialBuild.length} Builder${
           needsInitialBuild.length === 1 ? '' : 's'
         }`
       );
@@ -437,7 +437,7 @@ export default class DevServer {
         await executeBuild(nowJson, this, this.files, match, null);
       }
 
-      this.output.success('Initial builds complete');
+      this.output.success('Builder setup complete');
     }
 
     await this.nsfw.start();

--- a/src/util/output/create-output.ts
+++ b/src/util/output/create-output.ts
@@ -13,6 +13,10 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     print(`${color('>')} ${str}\n`);
   }
 
+  function dim(str: string, color = chalk.grey) {
+    print(`${color(`> ${str}`)}\n`);
+  }
+
   function warn(str: string, slug: string | null = null) {
     log(chalk`{yellow.bold WARN!} ${str}`);
     if (slug !== null) {
@@ -79,6 +83,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     ready,
     success,
     debug,
+    dim,
     time,
     note
   };


### PR DESCRIPTION
This will ensure we print this:

![image](https://user-images.githubusercontent.com/6170607/56894876-8ff77800-6a87-11e9-8efd-b2f9d272b33b.png)

And this:

![image](https://user-images.githubusercontent.com/6170607/56894880-94239580-6a87-11e9-8ade-e978c3c3f621.png)

Instead of "running initial builds", which is really confusing.