### PR TITLE
Enable `cleanUrls` for entirely static projects

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -975,7 +975,6 @@ function serveStaticFile(
 ) {
   return serveHandler(req, res, {
     public: cwd,
-    cleanUrls: false,
     ...opts
   });
 }


### PR DESCRIPTION
We're bringing back this property in order to mimic the production behaviour for 100% static projects.

Like this, if a `index.html` file exists, we render it for `/`.