### PR TITLE
[now dev] Show builder logs, even after build completes

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -434,7 +434,7 @@ export default class DevServer {
       );
 
       for (const match of needsInitialBuild) {
-        await executeBuild(nowJson, this, this.files, match, null);
+        await executeBuild(nowJson, this, this.files, match, null, true);
       }
 
       this.output.success('Builder setup complete');
@@ -633,6 +633,7 @@ export default class DevServer {
         this.files,
         match,
         requestPath,
+        false,
         filesChanged,
         filesRemoved
       );


### PR DESCRIPTION
This is important for builders like `@now/next` and `@now/static-build` which launch a child process dev server, and we want those logs to be visible from the `now dev` console output.