### PR TITLE
[now dev] Enable `cleanUrls` option when deployment is all static

### DIFF
--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -931,7 +931,7 @@ export default class DevServer {
     }
 
     this.setResponseHeaders(res, nowRequestId);
-    return serveStaticFile(req, res, this.cwd);
+    return serveStaticFile(req, res, this.cwd, { cleanUrls: true });
   };
 
   async hasFilesystem(dest: string): Promise<boolean> {


### PR DESCRIPTION
So that rendering `index.html` as root works as expected.