### PR TITLE
Add Line Break to Init Success Message

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 
 // @ts-ignore
 import listInput from '../../util/input/list';
+import listItem from '../../util/output/list-item';
 import promptBool from '../../util/input/prompt-bool';
 import toHumanPath from '../../util/humanize-path';
 import wait from '../../util/output/wait';
@@ -131,13 +132,19 @@ async function extractExample(name: string, dir: string, force?: boolean) {
         name
       )}" example in ${chalk.bold(toHumanPath(folder))}.`;
       const folderRel = path.relative(process.cwd(), folder);
+      const developHint =
+        folderRel === ''
+          ? listItem(`To develop, run ${cmd('now dev')}.`)
+          : listItem(
+              `To develop, ${cmd(`cd ${folderRel}`)} and run ${cmd('now dev')}.`
+            );
       const deployHint =
         folderRel === ''
-          ? `To develop, run ${cmd('now dev')}. To deploy, run ${cmd('now')}.`
-          : `To develop, ${cmd(`cd ${folderRel}`)} and run ${cmd(
-              'now dev'
-            )}. To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`;
-      console.log(success(`${successLog} \n ${deployHint}`));
+          ? listItem(`To deploy, run ${cmd('now')}.`)
+          : listItem(
+              `To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`
+            );
+      console.log(success(`${successLog} \n ${developHint} \n ${deployHint}`));
       return 0;
     })
     .catch(e => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -144,7 +144,7 @@ async function extractExample(name: string, dir: string, force?: boolean) {
           : listItem(
               `To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`
             );
-      console.log(success(`${successLog} \n ${developHint} \n ${deployHint}`));
+      console.log(success(`${successLog}\n${developHint}\n${deployHint}`));
       return 0;
     })
     .catch(e => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -50,7 +50,6 @@ export default async function init(
     return extractExample(chosen, dir, force);
   }
 
-
   if (exampleList.includes(name)) {
     return extractExample(name, dir, force);
   }
@@ -128,12 +127,17 @@ async function extractExample(name: string, dir: string, force?: boolean) {
         resp.body.pipe(extractor);
       });
 
-      const successLog = `Initialized "${chalk.bold(name)}" example in ${chalk.bold(toHumanPath(folder))}.`;
+      const successLog = `Initialized "${chalk.bold(
+        name
+      )}" example in ${chalk.bold(toHumanPath(folder))}.`;
       const folderRel = path.relative(process.cwd(), folder);
-      const deployHint = folderRel === ''
-        ? `To develop, run ${cmd('now dev')}. To deploy, run ${cmd('now')}.`
-        : `To develop, ${cmd(`cd ${folderRel}`)} and run ${cmd('now dev')}. To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`;
-      console.log(success(`${successLog} ${deployHint}`));
+      const deployHint =
+        folderRel === ''
+          ? `To develop, run ${cmd('now dev')}. To deploy, run ${cmd('now')}.`
+          : `To develop, ${cmd(`cd ${folderRel}`)} and run ${cmd(
+              'now dev'
+            )}. To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd('now')}.`;
+      console.log(success(`${successLog} \n ${deployHint}`));
       return 0;
     })
     .catch(e => {
@@ -151,21 +155,27 @@ function prepareFolder(cwd: string, folder: string, force?: boolean) {
   if (fs.existsSync(dest)) {
     if (!fs.lstatSync(dest).isDirectory()) {
       throw new Error(
-        `Destination path "${chalk.bold(folder)}" already exists and is not a directory.`
+        `Destination path "${chalk.bold(
+          folder
+        )}" already exists and is not a directory.`
       );
     }
     if (!force && fs.readdirSync(dest).length !== 0) {
       throw new Error(
-        `Destination path "${chalk.bold(folder)}" already exists and is not an empty directory. You may use ${cmd('--force')} or ${cmd('--f')} to override it.`
+        `Destination path "${chalk.bold(
+          folder
+        )}" already exists and is not an empty directory. You may use ${cmd(
+          '--force'
+        )} or ${cmd('--f')} to override it.`
       );
     }
   } else if (dest !== cwd) {
-      try {
-        fs.mkdirSync(dest);
-      } catch (e) {
-        throw new Error(`Could not create directory "${chalk.bold(folder)}".`);
-      }
+    try {
+      fs.mkdirSync(dest);
+    } catch (e) {
+      throw new Error(`Could not create directory "${chalk.bold(folder)}".`);
     }
+  }
 
   return dest;
 }

--- a/src/util/output/list-item.ts
+++ b/src/util/output/list-item.ts
@@ -1,17 +1,16 @@
-import { gray } from 'chalk';
+import gray from 'chalk';
 
 // listItem('woot') === '- woot'
 // listItem('->', 'woot') === '-> woot'
 // listItem(1, 'woot') === '1. woot'
-const listItem = (n, msg) => {
-  if (!msg) {
-    msg = n;
+const listItem = (msg: string, n?: string | number) => {
+  if (!n) {
     n = '-';
   }
-  if (!isNaN(n)) {
+  if (Number(n)) {
     n += '.';
   }
-  return `${gray(n)} ${msg}`;
+  return `${gray(n.toString())} ${msg}`;
 };
 
 export default listItem;


### PR DESCRIPTION
Currently, the init success message often spills over onto the next line, this is due to the addition of the now dev development message.

This PR forces a line break between the successLog and deployHint - this ensures no further issues with line wrapping and separates two very different pieces of information.

Edit: Due to Prettier formatting, line 140 is key with the addition of \n.