### PR TITLE
Update `pkg` to v4.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "nyc": "13.2.0",
     "ora": "1.3.0",
     "pcre-to-regexp": "0.0.5",
-    "pkg": "4.3.7",
+    "pkg": "4.3.8",
     "pluralize": "7.0.0",
     "pre-commit": "1.2.2",
     "prettier": "1.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5225,10 +5225,10 @@ pkg-fetch@2.5.7:
     semver "~5.6.0"
     unique-temp-dir "~1.0.0"
 
-pkg@4.3.7:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.7.tgz#a80767283d728adbcdf668ad99250af440efd8e3"
-  integrity sha512-/BvtFft1nKKtnTuOm/0es0sk1cOs7ZtWgJpqdtszJ4348jYJ8owVyCB/iuGhI3YJFX/ZFIv4Rmra9ETUgpnnfA==
+pkg@4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-4.3.8.tgz#f90017fe27539e6a9c446d455b885b554600b3c1"
+  integrity sha512-HhnMcHvGFf0VR4fJygqo1WTKztEK6m3UKS+O4NIM9tzbdgCfsAEpNncPlO9Gj6wAMbe9JC48UmzPBErpYSwckQ==
   dependencies:
     "@babel/parser" "7.2.3"
     babel-runtime "6.26.0"


### PR DESCRIPTION
Which includes this fix: https://github.com/zeit/pkg/issues/671

Relevant to `now dev` invoking `yarn` when a package includes
a postinstall script that invokes `node`.