### PR TITLE
Add .next and .cache to default ignore

### DIFF
--- a/src/util/ignored.ts
+++ b/src/util/ignored.ts
@@ -4,6 +4,8 @@ export default `.hg
 .git
 .gitmodules
 .svn
+.cache
+.next
 .npmignore
 .dockerignore
 .gitignore


### PR DESCRIPTION
From our phone call (@leo and @dav-is), we don't need each builder ignoring files. 

Let's add Next.js default ignore to the CLI.

cc @TooTallNate and @timneutkens to keep in the loop