### PR TITLE
[now dev] Update `@zeit/fun` and `@now/build-utils` for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ]
   },
   "devDependencies": {
-    "@now/build-utils": "0.4.41-canary.8",
+    "@now/build-utils": "0.5.2-canary.0",
     "@sentry/node": "4.5.3",
     "@types/ansi-escapes": "3.0.0",
     "@types/ansi-regex": "4.0.0",
@@ -110,7 +110,7 @@
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.1.0",
     "@zeit/dockerignore": "0.0.5",
-    "@zeit/fun": "0.7.0",
+    "@zeit/fun": "0.8.0",
     "@zeit/git-hooks": "0.1.4",
     "@zeit/ncc": "0.18.1",
     "@zeit/nsfw": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,13 +343,15 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/build-utils@0.4.41-canary.8":
-  version "0.4.41-canary.8"
-  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.4.41-canary.8.tgz#afd19428079a00b226fe0c276413b47c9f10affc"
-  integrity sha512-mFx64mLpHXvNgeRaOdXLPdnOoinORpNmYjOlPVCTSwzN7YxlhttSU2G7wySYSl5MV7nvGKoJunl+poee5Brx4Q==
+"@now/build-utils@0.5.2-canary.0":
+  version "0.5.2-canary.0"
+  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.5.2-canary.0.tgz#eec8c2b93094188fafdd9af64ec4336110e942d1"
+  integrity sha512-VAnrJNpO8DO2O0YV4I4r7FuEK2hV34OYUJO/9mX/F6bilaVdQN85Ho0STWRnYpMLlgbj/rm4nk7uYaqlgVWhaA==
   dependencies:
+    "@types/cross-spawn" "6.0.0"
     async-retry "1.2.3"
     async-sema "2.1.4"
+    cross-spawn "6.0.5"
     end-of-stream "1.4.1"
     fs-extra "7.0.0"
     glob "7.1.3"
@@ -475,6 +477,13 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.0.0.tgz#549eeacd0a8fecfaa459334583a4edcee738e6db"
   integrity sha512-ZF43+CIIlzngQe8/Zo7L1kpY9W8O6rO006VDz3c5iM21ddtXWxCEyOXyft+q4pVF2tGqvrVuVrEDH1+gJEi1fQ==
+
+"@types/cross-spawn@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.0.tgz#320aaf1d1a12979f1b84fe7a5590a7e860bf3a80"
+  integrity sha512-evp2ZGsFw9YKprDbg8ySgC9NA15g3YgiI8ANkGmKKvvi0P2aDGYLPxQIC5qfeKNUOe3TjABVGuah6omPRpIYhg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/debug@0.0.31":
   version "0.0.31"
@@ -683,10 +692,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.5.tgz#b12a693f6ee79aaeffd97914457dc874d5f8386e"
   integrity sha512-SQ9/wXM1sjv8HnjbAWVSl6KOgitAWiPpjk5AZFXP6rBpmevsLWqtR1L0COIYnHY2UrHC5yXuUG/jh+Sqq0kK8Q==
 
-"@zeit/fun@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.7.0.tgz#9c8925fdd8173303a3672c836474da6e336de2f4"
-  integrity sha512-RZvD9C9ZqhD300sC6ves4J73MlN/kAAbROrtMrBnNR4+A3z1KiAbwB0XTguHfT9+LS2FGLP2RH95k3PJmebWJQ==
+"@zeit/fun@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.8.0.tgz#02b4067ef5318064e880ba5a186cf27cfbb5ab09"
+  integrity sha512-oawT161eQb5uoN8BxYzJCKdQM/DX/TBsrRwJEXemxYgyHzeeuKRZaJXdsJkTTxlgTq8iZIERk32ND4wS+Q6NuA==
   dependencies:
     async-listen "1.0.0"
     cache-or-tmp-directory "1.0.0"
@@ -1810,6 +1819,17 @@ credit-card@3.0.1:
     lodash.merge "4.6.x"
     reach "1.x.x"
 
+cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -1824,17 +1844,6 @@ cross-spawn@^5.0.1:
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
-  dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 


### PR DESCRIPTION
Not all builders will be working yet, but this adds minimal Windows support for `now dev`.

Here's a screenshot of `@now/node` working with `now dev`:

<img width="486" alt="Screen Shot 2019-05-02 at 12 23 04 AM" src="https://user-images.githubusercontent.com/71256/57061142-b3c9e200-6c70-11e9-97e7-8f07e93bfe42.png">

Closes https://github.com/zeit/now-cli/issues/2282.