### PR TITLE
[now dev] Add `meta.env` and `meta.buildEnv` for builders

### DIFF
--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -82,6 +82,8 @@ export interface BuilderParamsBase {
     requestPath?: string | null;
     filesChanged?: string[];
     filesRemoved?: string[];
+    env?: EnvConfig;
+    buildEnv?: EnvConfig;
   };
 }
 


### PR DESCRIPTION
Some builders require access to the runtime env vars, i.e. `@now/next` since it spawns a `next dev` subprocess and should be passing the runtime env vars to that.