### PR TITLE
[now dev] Use the dev server `cwd` as builder's `workPath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ]
   },
   "devDependencies": {
-    "@now/build-utils": "0.5.2-canary.0",
+    "@now/build-utils": "0.5.5-canary.1",
     "@sentry/node": "4.5.3",
     "@types/ansi-escapes": "3.0.0",
     "@types/ansi-regex": "4.0.0",

--- a/src/commands/dev/lib/dev-builder.ts
+++ b/src/commands/dev/lib/dev-builder.ts
@@ -137,7 +137,7 @@ export async function executeBuild(
   if (showBuildTimestamp) {
     devServer.output.log(`Building ${match.use}:${entrypoint}`);
     devServer.output.debug(
-      `Using \`${pkg.name}${pkg.version ? `v${pkg.version} ` : ''}\``
+      `Using \`${pkg.name}${pkg.version ? `@${pkg.version}` : ''}\``
     );
   }
 

--- a/src/commands/dev/lib/dev-server.ts
+++ b/src/commands/dev/lib/dev-server.ts
@@ -1043,7 +1043,6 @@ async function shouldServe(
   const {
     src: entrypoint,
     config,
-    workPath,
     builderWithPkg: { builder, package: pkg }
   } = match;
   if (typeof builder.shouldServe === 'function') {
@@ -1052,7 +1051,7 @@ async function shouldServe(
       files,
       config,
       requestPath,
-      workPath
+      workPath: devServer.cwd
     });
     if (shouldServe) {
       return true;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -25,7 +25,6 @@ export interface BuildMatch extends BuildConfig {
   buildResults: Map<string | null, BuildResult>;
   buildTimestamp: number;
   buildProcess?: ChildProcess;
-  workPath: string;
 }
 
 export interface RouteConfig {

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -75,6 +75,25 @@ test(
   })
 );
 
+test(
+  '[DevServer] Maintains query when builder defines routes',
+  testFixture('now-dev-next', async (t, server) => {
+    const res = await fetch(`${server.address}/something?url-param=a`);
+    const text = await res.text();
+
+    // Hacky way of getting the page payload from the response
+    // HTML since we don't have a HTML parser handy.
+    const json = text
+      .match(/<div>(.*)<\/div>/)[1]
+      .replace('</div>', '')
+      .replace(/&quot;/g, '"');
+    const parsed = JSON.parse(json);
+
+    t.is(parsed.query['url-param'], 'a');
+    t.is(parsed.query['route-param'], 'b');
+  })
+);
+
 test('[DevServer] Does not install builders if there are no builds', async t => {
   const handler = data => {
     if (data.includes('installing')) {

--- a/test/fixtures/unit/now-dev-next/.gitignore
+++ b/test/fixtures/unit/now-dev-next/.gitignore
@@ -1,0 +1,2 @@
+.next
+yarn.lock

--- a/test/fixtures/unit/now-dev-next/next.config.js
+++ b/test/fixtures/unit/now-dev-next/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless'
+}

--- a/test/fixtures/unit/now-dev-next/now.json
+++ b/test/fixtures/unit/now-dev-next/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "name": "now-dev-next",
+  "builds": [
+    { "src": "package.json", "use": "@now/next" }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index?route-param=b"
+    }
+  ]
+}

--- a/test/fixtures/unit/now-dev-next/package.json
+++ b/test/fixtures/unit/now-dev-next/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "build": "next build",
+    "dev": "next",
+    "now-build": "next build"
+  },
+  "dependencies": {
+    "next": "^8.0.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/test/fixtures/unit/now-dev-next/pages/index.js
+++ b/test/fixtures/unit/now-dev-next/pages/index.js
@@ -1,0 +1,11 @@
+import { withRouter } from 'next/router';
+
+function Index({ router }) {
+  const data = {
+    pathname: router.pathname,
+    query: router.query
+  };
+  return <div>{ JSON.stringify(data) }</div>;
+}
+
+export default withRouter(Index);

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,10 +343,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/build-utils@0.5.2-canary.0":
-  version "0.5.2-canary.0"
-  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.5.2-canary.0.tgz#eec8c2b93094188fafdd9af64ec4336110e942d1"
-  integrity sha512-VAnrJNpO8DO2O0YV4I4r7FuEK2hV34OYUJO/9mX/F6bilaVdQN85Ho0STWRnYpMLlgbj/rm4nk7uYaqlgVWhaA==
+"@now/build-utils@0.5.5-canary.1":
+  version "0.5.5-canary.1"
+  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.5.5-canary.1.tgz#85cfb6d5e7d99f8d7e70006d8885573b46b0c447"
+  integrity sha512-z6wX90HBT/BF++vPhNxDsTUGA6xehuXOv+rjsfHNEF/5+qomBwn577nVNcUx93ilFDarlzHZyiqobUK2tiXCUg==
   dependencies:
     "@types/cross-spawn" "6.0.0"
     async-retry "1.2.3"


### PR DESCRIPTION
Rather than copying the source files into a temporary directory, simply use the existing source files in the `cwd`. This will make subsequent boots of `now dev` be faster (i.e. because the `node_modules` directory will already be in place), as well as use much less space on the filesystem because temporary directory are no longer being used.

This will require some changes to the builders and `@now/build-utils`, to ensure that the `download()` function is always installing into `workPath`, and that the `meta` object passed to the `build()` function is also passed into the `download()` function.

For example:

 - https://github.com/zeit/now-builders/pull/474
 - https://github.com/zeit/now-builders/pull/475

**Blockers:**

 - Since the builders will be installing stuff to the same directory as the `cwd` dir being watched by `nsfw` (i.e. `node_modules`), the watcher will error on some platforms (for example Windows) because there's too many files. `nsfw` currently does not have "ignore" capabilities, see https://github.com/Axosoft/nsfw/issues/54.