### PR TITLE
Fix transfer-in price for some TLDs

### DIFF
--- a/src/commands/domains/transfer-in.ts
+++ b/src/commands/domains/transfer-in.ts
@@ -65,7 +65,7 @@ export default async function transferIn(
 
   const availableStamp = stamp();
   const [domainPrice, { transferable }] = await Promise.all([
-    getDomainPrice(client, domainName),
+    getDomainPrice(client, domainName, 'renewal'),
     checkTransfer(client, domainName)
   ]);
 

--- a/src/util/domains/get-domain-price.ts
+++ b/src/util/domains/get-domain-price.ts
@@ -7,11 +7,14 @@ type Response = {
   period: number;
 };
 
-export default async function getDomainPrice(client: Client, name: string) {
+export default async function getDomainPrice(
+  client: Client,
+  name: string,
+  type?: 'new' | 'renewal'
+) {
   try {
-    return await client.fetch<Response>(
-      `/v3/domains/price?${stringify({ name })}`
-    );
+    const querystr = type ? stringify({ name, type }) : stringify({ name });
+    return await client.fetch<Response>(`/v3/domains/price?${querystr}`);
   } catch (error) {
     if (error.code === 'unsupported_tld') {
       return new UnsupportedTLD(name);


### PR DESCRIPTION
Using `renewal` price for transfers which fixes some price mismatch issues for some TLDs (like .co premium domains).