### PR TITLE
Re-enable "try to create a builds deployments with wrong config" integration test

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -810,7 +810,6 @@ test('ensure the `scope` property works with username', async t => {
   t.is(contentType, 'text/html; charset=utf-8');
 });
 
-/*
 test('try to create a builds deployments with wrong config', async t => {
   const directory = fixture('builds-wrong');
 
@@ -830,7 +829,6 @@ test('try to create a builds deployments with wrong config', async t => {
     )
   );
 });
-*/
 
 test('create a builds deployments with no actual builds', async t => {
   const directory = fixture('builds-no-list');


### PR DESCRIPTION
It was temporarily disabled due to server-side issues, but that has been fixed now.