### PR TITLE
[now dev] Consider `devDependencies` when looking up package name

### DIFF
--- a/src/commands/dev/lib/builder-cache.ts
+++ b/src/commands/dev/lib/builder-cache.ts
@@ -189,7 +189,7 @@ function getPackageName(
   if (registryTypes.has(parsed.type)) {
     return parsed.name;
   }
-  const deps = buildersPkg.dependencies || {};
+  const deps = { ...buildersPkg.devDependencies, ...buildersPkg.dependencies };
   for (const [name, dep] of Object.entries(deps)) {
     if (dep === parsed.raw) {
       return name;

--- a/src/commands/dev/lib/types.ts
+++ b/src/commands/dev/lib/types.ts
@@ -132,6 +132,7 @@ export interface Package {
   name?: string;
   version: string;
   dependencies?: { [name: string]: string };
+  devDependencies?: { [name: string]: string };
 }
 
 export interface BuilderWithPackage {


### PR DESCRIPTION
Alpha versions of `now dev` that used npm instead of yarn were installing the packages to `devDependencies` rather than `dependencies`, so this fixes package name lookup when a legacy cache like that is on the user's machine.