### PR TITLE
[now dev] Strip prefixed `/` when doing routes matching

### DIFF
--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -101,6 +101,9 @@ export default async function(
           };
           break;
         } else {
+          if (!destPath.startsWith('/')) {
+            destPath = `/${destPath}`;
+          }
           const { pathname, query } = url.parse(destPath, true);
           found = {
             found: true,

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -32,7 +32,12 @@ export default async function(
   devServer?: DevServer
 ): Promise<RouteResult> {
   let found: RouteResult | undefined;
-  const { query, pathname: reqPathname = '/' } = url.parse(reqPath, true);
+  let { query, pathname: reqPathname = '/' } = url.parse(reqPath, true);
+
+  // If the pathname starts with a `/` then strip it
+  if (reqPathname.startsWith('/')) {
+    reqPathname = reqPathname.substring(1);
+  }
 
   // try route match
   if (routes) {
@@ -53,13 +58,13 @@ export default async function(
         continue;
       }
 
-      if (!src.startsWith('^')) {
-        src = `^${src}`;
-      }
-
-      if (!src.endsWith('$')) {
-        src = `${src}$`;
-      }
+      src = src.replace(/^\^?\/?(.*)$/, (_, path) => {
+        let p = path;
+        if (!p.endsWith('$')) {
+          p += '$';
+        }
+        return `^${p}`;
+      });
 
       const keys: string[] = [];
       const matcher = PCRE(`%${src}%i`, keys);

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -39,7 +39,7 @@ export default async function(
     reqPathname = reqPathname.substring(1);
   }
 
-  // try route match
+  // Try route match
   if (routes) {
     let idx = -1;
     for (const routeConfig of routes) {
@@ -58,13 +58,16 @@ export default async function(
         continue;
       }
 
-      src = src.replace(/^\^?\/?(.*)$/, (_, path) => {
-        let p = path;
-        if (!p.endsWith('$')) {
-          p += '$';
-        }
-        return `^${p}`;
-      });
+      // Strip leading [^/] if they exist
+      src = src.replace(/^\^?\/?/, '');
+
+      if (!src.startsWith('^')) {
+        src = `^${src}`;
+      }
+
+      if (!src.endsWith('$')) {
+        src = `${src}$`;
+      }
 
       const keys: string[] = [];
       const matcher = PCRE(`%${src}%i`, keys);

--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -71,7 +71,7 @@ export default async function(
       const match = matcher.exec(reqPathname);
 
       if (match) {
-        let destPath: string = reqPathname;
+        let destPath: string = `/${reqPathname}`;
 
         if (routeConfig.dest) {
           destPath = resolveRouteParameters(routeConfig.dest, match, keys);
@@ -118,7 +118,7 @@ export default async function(
   if (!found) {
     found = {
       found: false,
-      dest: reqPathname,
+      dest: `/${reqPathname}`,
       uri_args: query
     };
   }

--- a/test/dev-router.unit.js
+++ b/test/dev-router.unit.js
@@ -118,3 +118,19 @@ test('[dev-router] methods', async t => {
     userDest: true
   });
 });
+
+test('[dev-router] match without prefix slash', async t => {
+  const routesConfig = [{ src: 'api/(.*)', dest: 'endpoints/$1.js' }];
+  const result = await devRouter('/api/user', 'GET', routesConfig);
+
+  t.deepEqual(result, {
+    found: true,
+    dest: '/endpoints/user.js',
+    status: undefined,
+    headers: undefined,
+    uri_args: {},
+    matched_route: routesConfig[0],
+    matched_route_idx: 0,
+    userDest: true
+  });
+});


### PR DESCRIPTION
The prefixed `/` is implicit when matching routes, so strip them so that they are optional. This matches the behavior in production.