### PR TITLE
Give precise help in the console

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ const main = async argv_ => {
       )
     );
     console.log(
-      info(`Read more about how to update here: https://zeit.co/update-cli`)
+      info(`Run npm i -g now OR yarn global add now`)
     );
     console.log(
       info(


### PR DESCRIPTION
No need to redirect out of the console.
there are 3 ways to update, any one seeing this this error is probably seeing it on the console.
so we can easily strip out the Now Desktop way of updating