### PR TITLE
[now dev] Use empty string for missing matches

### DIFF
--- a/src/commands/dev/lib/dev-router.ts
+++ b/src/commands/dev/lib/dev-router.ts
@@ -21,7 +21,7 @@ export function resolveRouteParameters(
       // match up with the RegExp group matches
       matchIndex++;
     }
-    return match[matchIndex];
+    return match[matchIndex] || '';
   });
 }
 

--- a/test/dev-router.unit.js
+++ b/test/dev-router.unit.js
@@ -52,6 +52,25 @@ test('[dev-router] named groups', async t => {
   });
 });
 
+test('[dev-router] optional named groups', async t => {
+  const routesConfig = [{
+    src: '/api/hello(/(?<name>[^/]+))?',
+    dest: '/api/functions/hello/index.js?name=$name'
+  }];
+  const result = await devRouter('/api/hello', 'GET', routesConfig);
+
+  t.deepEqual(result, {
+    found: true,
+    dest: '/api/functions/hello/index.js',
+    status: undefined,
+    headers: undefined,
+    uri_args: { name: '' },
+    matched_route: routesConfig[0],
+    matched_route_idx: 0,
+    userDest: true
+  });
+});
+
 test('[dev-router] proxy_pass', async t => {
   const routesConfig = [{ src: '/proxy', dest: 'https://zeit.co' }];
 


### PR DESCRIPTION
Rather than `undefined`. This matches the behavior in production.

Fixes #2375.