### PR TITLE
Update `@zeit/ncc` to v0.18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@zeit/dockerignore": "0.0.5",
     "@zeit/fun": "0.8.0",
     "@zeit/git-hooks": "0.1.4",
-    "@zeit/ncc": "0.18.1",
+    "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",
     "alpha-sort": "2.0.1",
     "ansi-escapes": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,10 +720,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/git-hooks/-/git-hooks-0.1.4.tgz#70583db5dd69726a62c7963520e67f2c3a33cc5f"
   integrity sha512-NvgZgoYJ/n27Ly7lKxKttMIKSS8P4dr1EURgTmqihHVdTAEqVtkAYPT5XykZIR+GKz8WRGyEQVJekwSgvjYQLg==
 
-"@zeit/ncc@0.18.1":
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.1.tgz#1723884210c792ba702ec6dccb390f387f0a3ba6"
-  integrity sha512-Tq13BzK+hAWBZY+VvncRZzpE5PHGks3kn2XJ+bcWSXgTZb4rTR/CTV1YYXilNNkX//jC1sziuM167FhLzFu2XA==
+"@zeit/ncc@0.18.5":
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.5.tgz#5687df6c32f1a2e2486aa110b3454ccebda4fb9c"
+  integrity sha512-F+SbvEAh8rchiRXqQbmD1UmbePY7dCOKTbvfFtbVbK2xMH/tyri5YKfNxXKK7eL9EWkkbqB3NTVQO6nokApeBA==
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"


### PR DESCRIPTION
### Minor changes

- update of @zeit/ncc 
  - Patches
     - Regenerate yarn.lock file: a2f18d7
