### PR TITLE
Fix `now rm` and decrease total projects for `now ls` 

### DIFF
--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -124,7 +124,7 @@ export default async function main(ctx) {
   const findStart = Date.now();
 
   try {
-    deployments = await now.list(null, { version: 3 });
+    deployments = await now.list(null, { version: 4 });
   } catch (err) {
     cancelWait();
     throw err;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -579,22 +579,11 @@ export default class Now extends EventEmitter {
     };
 
     if (!app && !Object.keys(meta).length) {
-      // Get the 50 latest projects and their latest deployment
-      const query = new URLSearchParams({ limit: 50 });
+      // Get the 35 latest projects and their latest deployment
+      const query = new URLSearchParams({ limit: 35 });
       const projects = await fetchRetry(`/projects/list?${query}`);
 
-      const deployments = await Promise.all(projects.map(async ({ id: projectId, name, recentDeployments }) => {
-        if (recentDeployments && recentDeployments.length) {
-          const [deployment] = recentDeployments;
-
-          // These properties are needed in addition
-          // since recentDeployment only contains a few
-          return Object.assign(deployment, {
-            name,
-            created: deployment.createdAt
-          });
-        }
-
+      const deployments = await Promise.all(projects.map(async ({ id: projectId }) => {
         const query = new URLSearchParams({ limit: 1, projectId });
         const { deployments } = await fetchRetry(`/v${version}/now/deployments?${query}`);
         return deployments[0];

--- a/test/integration.js
+++ b/test/integration.js
@@ -1198,6 +1198,11 @@ const verifyExampleApollo = (cwd, dir) =>
   fs.existsSync(path.join(cwd, dir, 'package.json')) &&
   fs.existsSync(path.join(cwd, dir, 'now.json')) &&
   fs.existsSync(path.join(cwd, dir, 'index.js'));
+const verifyExampleAmp = (cwd, dir) =>
+  fs.existsSync(path.join(cwd, dir, 'favicon.png')) &&
+  fs.existsSync(path.join(cwd, dir, 'index.html')) &&
+  fs.existsSync(path.join(cwd, dir, 'logo.png')) &&
+  fs.existsSync(path.join(cwd, dir, 'now.json'));
 
 test('initialize example "apollo"', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
@@ -1223,16 +1228,16 @@ test('initialize example ("apollo") to specified directory', async t => {
   t.true(verifyExampleApollo(cwd, 'apo'));
 });
 
-test('initialize selected example ("apollo")', async t => {
+test('initialize selected example ("amp")', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
-  const goal = '> Success! Initialized "apollo" example in';
+  const goal = '> Success! Initialized "amp" example in';
 
   const { stdout, code } = await execute(['init'], { cwd, input: '\n' });
 
   t.is(code, 0);
   t.true(stdout.includes(goal));
-  t.true(verifyExampleApollo(cwd, 'apollo'));
+  t.true(verifyExampleAmp(cwd, 'amp'));
 });
 
 test('initialize example to existing directory with "-f"', async t => {


### PR DESCRIPTION
Currently `now rm` uses the v3 endpoint which seems to output the same deployment multiple times.
And decrease the total number of projects for `now ls` to 35 to stay in the bounds of the rate limit.