### PR TITLE
[now update] Add integration test

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -1348,6 +1348,11 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
   }
 });
 
+test.only('try to update now to canary', async t => {
+  const { code } = await execute(['update', '--channel', 'canary', '--yes']);
+  t.is(code, 0);
+});
+
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);

--- a/test/integration.js
+++ b/test/integration.js
@@ -1351,6 +1351,9 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
 test('try to update now to canary', async t => {
   const { code } = await execute(['update', '--channel', 'canary', '--yes']);
   t.is(code, 0);
+  
+  const { stdout } = await execute(['--version']);
+  t.true(stdout.includes('canary'));
 });
 
 test.after.always(async () => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1348,7 +1348,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
   }
 });
 
-test.only('try to update now to canary', async t => {
+test('try to update now to canary', async t => {
   const { code } = await execute(['update', '--channel', 'canary', '--yes']);
   t.is(code, 0);
 });


### PR DESCRIPTION
The test simply checks that `now update --channel canary --yes` returns code `0`.

The test fails in isolation because `The content of .now/auth.json" is invalid.` but that should be fixed by @TooTallNate 