### PR TITLE
[now update] Handle `EBUSY` errors for remove and move fallback

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -251,7 +251,7 @@ export default async function main(ctx: NowContext): Promise<number> {
     await downloadNowCli(output, url, tmpBin);
     rtn = await updateNowCli(tmpBin, location);
   } catch(err) {
-    if (err.message.startsWith('ETXTBSY')) {
+    if (err.message.startsWith('ETXTBSY') || err.message.startsWith('EBUSY')) {
       debug(`Got "ETXTBSY" error - falling back to unlink + rename method`);
       rtn = await removeAndMove(output, tmpBin, location);
     } else {


### PR DESCRIPTION
Seeing reports of `EBUSY: resource busy or locked, open` on Windows, so include that error code in the check for the "remove and move" fallback update method.