### PR TITLE
[now dev] Use canary `@now/build-utils` or stable based on builders

### DIFF
--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -135,7 +135,9 @@ export async function installBuilders(
   const cacheDir = await builderDirPromise;
   const yarnPath = join(yarnDir, 'yarn');
 
-  const buildUtilsVersion = packages.some(p => p.includes('@canary')) ? 'canary' : 'latest';
+  const buildUtilsVersion = packages
+    .map(use => use.split('@').pop())
+    .some(ver => (ver || '').includes('canary')) ? 'canary' : 'latest';
 
   const stopSpinner = wait(
     `Installing builders: ${packages.sort().join(', ')}`

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -116,6 +116,12 @@ export async function cleanCacheDir(output: Output): Promise<void> {
   }
 }
 
+export function getBuildUtils(packages: string[]) {
+  return packages
+    .map(use => use.split('@').pop() || '')
+    .some(ver => ver.includes('canary')) ? '@now/build-utils@canary' : '@now/build-utils';
+}
+
 /**
  * Install a list of builders to the cache directory.
  */
@@ -136,11 +142,8 @@ export async function installBuilders(
   const cacheDir = await builderDirPromise;
   const yarnPath = join(yarnDir, 'yarn');
 
-  const buildUtilsVersion = packages
-    .map(use => use.split('@').pop() || '')
-    .some(ver => ver.includes('canary')) ? 'canary' : 'latest';
-
-  output.debug(`Using build-utils tag: ${buildUtilsVersion}`);
+  const buildUtils = getBuildUtils(packages);
+  output.debug(`Installing ${buildUtils}`);
 
   const stopSpinner = wait(
     `Installing builders: ${packages.sort().join(', ')}`
@@ -153,7 +156,7 @@ export async function installBuilders(
         'add',
         '--exact',
         '--no-lockfile',
-        `@now/build-utils@${buildUtilsVersion}`,
+        buildUtils,
         ...packages.filter(p => p !== '@now/static')
       ],
       {

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -14,7 +14,6 @@ import {
 } from '../errors-ts';
 import wait from '../output/wait';
 import { Output } from '../output';
-import { devDependencies as nowCliDeps } from '../../../package.json';
 
 import * as staticBuilder from './static-builder';
 import { BuilderWithPackage, Package } from './types';
@@ -135,11 +134,9 @@ export async function installBuilders(
   }
   const cacheDir = await builderDirPromise;
   const yarnPath = join(yarnDir, 'yarn');
-  const buildersPkg = join(cacheDir, 'package.json');
 
-  // Pull the same version of `@now/build-utils` that now-cli is using
-  const buildUtils = '@now/build-utils';
-  const buildUtilsVersion = nowCliDeps[buildUtils];
+  const buildUtilsVersion = packages.some(p => p.includes('@canary')) ? 'canary' : 'latest';
+
   const stopSpinner = wait(
     `Installing builders: ${packages.sort().join(', ')}`
   );
@@ -151,7 +148,7 @@ export async function installBuilders(
         'add',
         '--exact',
         '--no-lockfile',
-        `${buildUtils}@${buildUtilsVersion}`,
+        `$@now/build-utils@${buildUtilsVersion}`,
         ...packages.filter(p => p !== '@now/static')
       ],
       {

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -117,9 +117,11 @@ export async function cleanCacheDir(output: Output): Promise<void> {
 }
 
 export function getBuildUtils(packages: string[]) {
-  return packages
+  const version = packages
     .map(use => use.split('@').pop() || '')
-    .some(ver => ver.includes('canary')) ? '@now/build-utils@canary' : '@now/build-utils';
+    .some(ver => ver.includes('canary')) ? 'canary' : 'latest';
+
+    return `@now/build-utils@${version}`;
 }
 
 /**

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -153,7 +153,7 @@ export async function installBuilders(
         'add',
         '--exact',
         '--no-lockfile',
-        `$@now/build-utils@${buildUtilsVersion}`,
+        `@now/build-utils@${buildUtilsVersion}`,
         ...packages.filter(p => p !== '@now/static')
       ],
       {

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -121,7 +121,8 @@ export async function cleanCacheDir(output: Output): Promise<void> {
  */
 export async function installBuilders(
   packagesSet: Set<string>,
-  yarnDir: string
+  yarnDir: string,
+  output: Output
 ): Promise<void> {
   const packages = Array.from(packagesSet);
   if (
@@ -136,8 +137,10 @@ export async function installBuilders(
   const yarnPath = join(yarnDir, 'yarn');
 
   const buildUtilsVersion = packages
-    .map(use => use.split('@').pop())
-    .some(ver => (ver || '').includes('canary')) ? 'canary' : 'latest';
+    .map(use => use.split('@').pop() || '')
+    .some(ver => ver.includes('canary')) ? 'canary' : 'latest';
+
+  output.debug(`Using build-utils tag: ${buildUtilsVersion}`);
 
   const stopSpinner = wait(
     `Installing builders: ${packages.sort().join(', ')}`

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -394,7 +394,7 @@ export default class DevServer {
       (nowJson.builds || []).map((b: BuildConfig) => b.use)
     );
 
-    await installBuilders(builders, this.yarnPath);
+    await installBuilders(builders, this.yarnPath, this.output);
     await this.updateBuildMatches(nowJson);
 
     // Now Builders that do not define a `shouldServe()` function need to be

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -116,9 +116,9 @@ test('[DevServer] Does not install builders if there are no builds', async t => 
 test('[DevServer] Installs canary build-utils if one more more builders is canary', async t => {
   t.is(getBuildUtils(['@now/static', '@now/node@canary']), '@now/build-utils@canary');
   t.is(getBuildUtils(['@now/static', '@now/node@0.7.4-canary.0']), '@now/build-utils@canary');
-  t.is(getBuildUtils(['@now/static', '@now/node@0.8.0']), '@now/build-utils');
-  t.is(getBuildUtils(['@now/static', '@now/node']), '@now/build-utils');
-  t.is(getBuildUtils(['@now/static']), '@now/build-utils');
+  t.is(getBuildUtils(['@now/static', '@now/node@0.8.0']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['@now/static', '@now/node']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['@now/static']), '@now/build-utils@latest');
   t.is(getBuildUtils(['@now/md@canary']), '@now/build-utils@canary');
-  t.is(getBuildUtils(['custom-builder']), '@now/build-utils');
+  t.is(getBuildUtils(['custom-builder']), '@now/build-utils@latest');
 });

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -6,7 +6,7 @@ import listen from 'async-listen';
 import { createServer } from 'http';
 import createOutput from '../src/util/output';
 import DevServer from '../src/util/dev/server';
-import { installBuilders } from '../src/util/dev/builder-cache';
+import { installBuilders, getBuildUtils } from '../src/util/dev/builder-cache';
 
 function testFixture(name, fn) {
   return async t => {
@@ -111,4 +111,14 @@ test('[DevServer] Does not install builders if there are no builds', async t => 
   process.stderr.removeListener('data', handler);
 
   t.pass();
+});
+
+test('[DevServer] Installs canary build-utils if one more more builders is canary', async t => {
+  t.is(getBuildUtils(['@now/static', '@now/node@canary']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['@now/static', '@now/node@0.7.4-canary.0']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['@now/static', '@now/node@0.8.0']), '@now/build-utils');
+  t.is(getBuildUtils(['@now/static', '@now/node']), '@now/build-utils');
+  t.is(getBuildUtils(['@now/static']), '@now/build-utils');
+  t.is(getBuildUtils(['@now/md@canary']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['custom-builder']), '@now/build-utils');
 });

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -104,7 +104,8 @@ test('[DevServer] Does not install builders if there are no builds', async t => 
   process.stdout.addListener('data', handler);
   process.stderr.addListener('data', handler);
 
-  await installBuilders(new Set());
+  const output = createOutput({ debug: false });
+  await installBuilders(new Set(), undefined, output);
 
   process.stdout.removeListener('data', handler);
   process.stderr.removeListener('data', handler);


### PR DESCRIPTION
This should install the correct "channel" of the `@now/build-utils` based on the version of the builder.

If one or more builders uses canary, then the `@now/build-utils@canary` will be used.