### PR TITLE
Move `dns_error` to generic CertError

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -26,7 +26,6 @@ import {
   BuildsRateLimited,
   CertConfigurationError,
   CertError,
-  CertsDNSError,
   DeploymentNotFound,
   DomainNotFound,
   DomainNotVerified,

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -44,7 +44,6 @@ import getProjectName from '../../util/get-project-name';
 import {
   CertConfigurationError,
   CertError,
-  CertsDNSError,
   DeploymentNotFound,
   DomainNotFound,
   DomainPermissionDenied,

--- a/src/util/certs/handle-cert-error.ts
+++ b/src/util/certs/handle-cert-error.ts
@@ -11,7 +11,6 @@ export default function handleCertError<T>(
     | ERRORS.CertError
     | ERRORS.TooManyRequests
     | ERRORS.DomainNotFound
-    | ERRORS.CertsDNSError
     | ERRORS.CertConfigurationError
     | T
 ): 1 | T {
@@ -37,16 +36,6 @@ export default function handleCertError<T>(
 
   if (error instanceof ERRORS.DomainNotFound) {
     output.error(error.message);
-    return 1;
-  }
-
-  if (error instanceof ERRORS.CertsDNSError) {
-    output.error(
-      `We could not solve the dns-01 challenge for cns ${error.meta.cns
-        .map(cn => chalk.underline(cn))
-        .join(', ')}.`
-    );
-    output.print('  Read more: https://err.sh/now-cli/cant-solve-challenge\n');
     return 1;
   }
 

--- a/src/util/certs/map-cert-error.ts
+++ b/src/util/certs/map-cert-error.ts
@@ -30,7 +30,8 @@ export default function mapCertError(cns: string[], error: any) {
     error.code === 'unauthorized_request_error' ||
     error.code === 'unsupported_challenge_priority' ||
     error.code === 'wildcard_not_allowed' ||
-    error.code === 'validation_running'
+    error.code === 'validation_running' ||
+    error.code === 'dns_error'
   ) {
     return new ERRORS.CertError({
       cns,
@@ -38,10 +39,6 @@ export default function mapCertError(cns: string[], error: any) {
       message: error.message,
       helpUrl: error.helpUrl
     });
-  }
-
-  if (error.code === 'dns_error') {
-    return new ERRORS.CertsDNSError(error.detail, cns);
   }
 
   return null;

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -481,7 +481,8 @@ type CertErrorCode =
   | 'unauthorized_request_error'
   | 'unsupported_challenge_priority'
   | 'wildcard_not_allowed'
-  | 'validation_running';
+  | 'validation_running'
+  | 'dns_error';
 export class CertError extends NowError<
   'CERT_ERROR',
   { cns: string[]; code: CertErrorCode; helpUrl?: string }
@@ -1056,20 +1057,6 @@ export class MissingDotenvVarsError extends NowError<
       code: 'MISSING_DOTENV_VARS',
       message,
       meta: { type, missing }
-    });
-  }
-}
-
-export class CertsDNSError extends NowError<
-  'CERTS_DNS_ERROR',
-  { detail: string; cns: string[] }
-> {
-  constructor(detail: string, cns: string[]) {
-    super({
-      code: 'CERTS_DNS_ERROR',
-      meta: { detail, cns },
-      message:
-        'There was a problem with a DNS query during identifier validation'
     });
   }
 }


### PR DESCRIPTION
The possible cert `dns_error` can be moved to use the generic `CertError` because it has a descriptive enough API error message now.