### PR TITLE
[now dev] Improve tests for `@now/build-utils@canary`

### DIFF
--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -116,9 +116,17 @@ export async function cleanCacheDir(output: Output): Promise<void> {
   }
 }
 
-export function getBuildUtils(packages: string[]) {
+function getNpmVersion(use = ''): string {
+  const parsed = npa(use);
+  if (registryTypes.has(parsed.type)) {
+    return parsed.fetchSpec || '';
+  }
+  return '';
+}
+
+export function getBuildUtils(packages: string[]): string {
   const version = packages
-    .map(use => use.split('@').pop() || '')
+    .map(getNpmVersion)
     .some(ver => ver.includes('canary')) ? 'canary' : 'latest';
 
     return `@now/build-utils@${version}`;

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -121,4 +121,13 @@ test('[DevServer] Installs canary build-utils if one more more builders is canar
   t.is(getBuildUtils(['@now/static']), '@now/build-utils@latest');
   t.is(getBuildUtils(['@now/md@canary']), '@now/build-utils@canary');
   t.is(getBuildUtils(['custom-builder']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['custom-builder@canary']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['canary-bird']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['canary-bird@4.0.0']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['canary-bird@canary']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['@canary/bird']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['@canary/bird@0.1.0']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['@canary/bird@canary']), '@now/build-utils@canary');
+  t.is(getBuildUtils(['https://example.com']), '@now/build-utils@latest');
+  t.is(getBuildUtils(['']), '@now/build-utils@latest');
 });


### PR DESCRIPTION
This PR updates the algorithm from #2441 to use `npm-package-arg` and catch a few corner cases where canary build utils might be installed when they should not be.