### PR TITLE
Bump @zeit/fun to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.1.0",
     "@zeit/dockerignore": "0.0.5",
-    "@zeit/fun": "0.8.1",
+    "@zeit/fun": "0.9.0",
     "@zeit/git-hooks": "0.1.4",
     "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,10 +691,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.5.tgz#b12a693f6ee79aaeffd97914457dc874d5f8386e"
   integrity sha512-SQ9/wXM1sjv8HnjbAWVSl6KOgitAWiPpjk5AZFXP6rBpmevsLWqtR1L0COIYnHY2UrHC5yXuUG/jh+Sqq0kK8Q==
 
-"@zeit/fun@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.8.1.tgz#7390303a4094d43d9927de0f3f1083f710efaf18"
-  integrity sha512-06xzRuUOm6rrAchIuFO3GhmZ1RtJsi4YsACDmmmFSFGbdnPmJuVnn+vubmB34b8OytWFHf2NgTIYdzC7T7ow8A==
+"@zeit/fun@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.9.0.tgz#599bcbb182e6dd971fd2fdba76c0e64d9a452bd6"
+  integrity sha512-2KBorPLpl5W1bjRRwvcRKhZVPFvZQrLtom2e/79eyn40SL0aE6tgK1jwKoUrgu3LOg+hWPkYLc8KUI3OMmYTeg==
   dependencies:
     async-listen "1.0.0"
     cache-or-tmp-directory "1.0.0"


### PR DESCRIPTION
This bumps the `@zeit/fun` dependency to the latest version which adds support for `nodejs10.x` with `now dev`.

Related to https://github.com/zeit/now-builders/issues/500