### PR TITLE
Handle --safe

### DIFF
--- a/src/util/deploy/get-deployments-by-project-id.ts
+++ b/src/util/deploy/get-deployments-by-project-id.ts
@@ -42,7 +42,7 @@ export default async function getDeploymentsByProjectId(
   const { deployments } = await client.fetch<Response>(`/v4/now/deployments?${query}`);
   total += deployments.length;
 
-  if (options.max && options.max > deployments.length) {
+  if (options.max && total > options.max) {
     return deployments;
   }
 

--- a/src/util/deploy/get-deployments-by-project-id.ts
+++ b/src/util/deploy/get-deployments-by-project-id.ts
@@ -20,12 +20,14 @@ interface Options {
   from: number | null;
   limit: number | null;
   continue: boolean;
+  max?: number;
 }
 
 export default async function getDeploymentsByProjectId(
   client: Client,
   projectId: string,
-  options: Options = { from: null, limit: 100, continue: false }
+  options: Options = { from: null, limit: 100, continue: false },
+  total: number = 0
 ) {
   const limit = options.limit || 100;
 
@@ -38,11 +40,16 @@ export default async function getDeploymentsByProjectId(
   }
 
   const { deployments } = await client.fetch<Response>(`/v4/now/deployments?${query}`);
+  total += deployments.length;
+
+  if (options.max && options.max > deployments.length) {
+    return deployments;
+  }
 
   if (options.continue && deployments.length === limit) {
     const nextFrom = deployments[deployments.length - 1].created;
     const nextOptions = Object.assign({}, options, { from: nextFrom });
-    deployments.push(...(await getDeploymentsByProjectId(client, projectId, nextOptions)));
+    deployments.push(...(await getDeploymentsByProjectId(client, projectId, nextOptions, total)));
   }
 
   return deployments;


### PR DESCRIPTION
Handle `--safe` correctly on `now rm`.

Instead of just checking the project when `--safe` is active, we'll fetch the first 201 deployments for a project and delete them. The user will be notified that there are more deployments left that they need to delete later on.