### PR TITLE
Handle cert errors in create-deployment

### DIFF
--- a/src/util/certs/create-cert-for-cns.ts
+++ b/src/util/certs/create-cert-for-cns.ts
@@ -26,7 +26,7 @@ export default async function createCertForCns(
       return new ERRORS.DomainPermissionDenied(error.domain, context);
     }
 
-    const mappedError = mapCertError(cns, error);
+    const mappedError = mapCertError(error, cns);
     if (mappedError) {
       return mappedError;
     }

--- a/src/util/certs/finish-cert-order.ts
+++ b/src/util/certs/finish-cert-order.ts
@@ -31,7 +31,7 @@ export default async function startCertOrder(
       return new ERRORS.CertOrderNotFound(cns);
     }
 
-    const mappedError = mapCertError(cns, error);
+    const mappedError = mapCertError(error, cns);
     if (mappedError) {
       return mappedError;
     }

--- a/src/util/certs/map-cert-error.ts
+++ b/src/util/certs/map-cert-error.ts
@@ -1,14 +1,15 @@
 import * as ERRORS from '../errors-ts';
 
 export default function mapCertError(error: any, cns?: string[]) {
-  if (error.code === 'too_many_requests') {
+  const errorCode: string = error.code;
+  if (errorCode === 'too_many_requests') {
     return new ERRORS.TooManyRequests('certificates', error.retryAfter);
   }
-  if (error.code === 'not_found') {
+  if (errorCode === 'not_found') {
     return new ERRORS.DomainNotFound(error.domain);
   }
 
-  if (error.code === 'configuration_error') {
+  if (errorCode === 'configuration_error') {
     return new ERRORS.CertConfigurationError({
       cns: cns || error.cns || [],
       message: error.message,
@@ -17,25 +18,28 @@ export default function mapCertError(error: any, cns?: string[]) {
       type: error.statusCode === 449 ? 'http-01' : 'dns-01'
     });
   }
+
   if (
-    error.code === 'bad_domains' ||
-    error.code === 'challenge_still_pending' ||
-    error.code === 'common_name_domain_name_mismatch' ||
-    error.code === 'conflicting_caa_record' ||
-    error.code === 'domain_not_verified' ||
-    error.code === 'invalid_cn' ||
-    error.code === 'invalid_domain' ||
-    error.code === 'rate_limited' ||
-    error.code === 'should_share_root_domain' ||
-    error.code === 'unauthorized_request_error' ||
-    error.code === 'unsupported_challenge_priority' ||
-    error.code === 'wildcard_not_allowed' ||
-    error.code === 'validation_running' ||
-    error.code === 'dns_error'
+    errorCode === 'bad_domains' ||
+    errorCode === 'challenge_still_pending' ||
+    errorCode === 'common_name_domain_name_mismatch' ||
+    errorCode === 'conflicting_caa_record' ||
+    errorCode === 'domain_not_verified' ||
+    errorCode === 'invalid_cn' ||
+    errorCode === 'invalid_domain' ||
+    errorCode === 'rate_limited' ||
+    errorCode === 'should_share_root_domain' ||
+    errorCode === 'unauthorized_request_error' ||
+    errorCode === 'unsupported_challenge_priority' ||
+    errorCode === 'wildcard_not_allowed' ||
+    errorCode === 'validation_running' ||
+    errorCode === 'dns_error' ||
+    errorCode === 'challenge_error' ||
+    errorCode === 'txt_record_not_found'
   ) {
     return new ERRORS.CertError({
       cns: cns || error.cns || [],
-      code: error.code,
+      code: errorCode,
       message: error.message,
       helpUrl: error.helpUrl
     });

--- a/src/util/certs/map-cert-error.ts
+++ b/src/util/certs/map-cert-error.ts
@@ -1,6 +1,6 @@
 import * as ERRORS from '../errors-ts';
 
-export default function mapCertError(cns: string[], error: any) {
+export default function mapCertError(error: any, cns?: string[]) {
   if (error.code === 'too_many_requests') {
     return new ERRORS.TooManyRequests('certificates', error.retryAfter);
   }
@@ -10,7 +10,7 @@ export default function mapCertError(cns: string[], error: any) {
 
   if (error.code === 'configuration_error') {
     return new ERRORS.CertConfigurationError({
-      cns,
+      cns: cns || error.cns || [],
       message: error.message,
       external: error.external,
       helpUrl: error.helpUrl,
@@ -34,7 +34,7 @@ export default function mapCertError(cns: string[], error: any) {
     error.code === 'dns_error'
   ) {
     return new ERRORS.CertError({
-      cns,
+      cns: cns || error.cns || [],
       code: error.code,
       message: error.message,
       helpUrl: error.helpUrl

--- a/src/util/deploy/create-deploy.js
+++ b/src/util/deploy/create-deploy.js
@@ -3,6 +3,7 @@ import purchaseDomainIfAvailable from '../domains/purchase-domain-if-available';
 import * as ERRORS_TS from '../errors-ts';
 import * as ERRORS from '../errors';
 import { NowError } from '../now-error';
+import mapCertError from '../certs/map-cert-error';
 
 export default async function createDeploy(
   output,
@@ -67,7 +68,12 @@ export default async function createDeploy(
     }
 
     if (error.code === 'not_found') {
-      return new ERRORS_TS.DeploymentNotFound({ context: contextName })
+      return new ERRORS_TS.DeploymentNotFound({ context: contextName });
+    }
+
+    const certError = mapCertError(error)
+    if (certError) {
+      return certError;
     }
 
     // If the error is unknown, we just throw

--- a/src/util/errors-ts.ts
+++ b/src/util/errors-ts.ts
@@ -482,7 +482,9 @@ type CertErrorCode =
   | 'unsupported_challenge_priority'
   | 'wildcard_not_allowed'
   | 'validation_running'
-  | 'dns_error';
+  | 'dns_error'
+  | 'challenge_error'
+  | 'txt_record_not_found';
 export class CertError extends NowError<
   'CERT_ERROR',
   { cns: string[]; code: CertErrorCode; helpUrl?: string }


### PR DESCRIPTION
* Handles cert error in `create-deployment.js`
* Adds challenge_error and txt_record_not_found error to error mapper.