### PR TITLE
Change url for revert-alias tests to make it more reliable

### DIFF
--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -1,5 +1,6 @@
 // Native
 const { join } = require('path');
+const { randomBytes } = require('crypto');
 
 // Packages
 const { imageSync: getImageFile } = require('qr-image');
@@ -81,10 +82,12 @@ http_request(
 <marquee>Thanks for your feedback!</marquee>
 `;
 
+const randomAliasSuffix = randomBytes(6).toString('hex');
+
 const getRevertAliasConfigFile = () => {
   return JSON.stringify({
       'version': 2,
-      'name': 'now-revert-alias',
+      'name': `now-revert-alias-${randomAliasSuffix}`,
       'builds': [
         {
           'src': '*.json',

--- a/test/integration.js
+++ b/test/integration.js
@@ -1295,16 +1295,11 @@ test('try to initialize example "example-404"', async t => {
 });
 
 test('try to revert a deployment and assign the automatic aliases', async t => {
-  const random = randomBytes(6).toString('hex');
-  const projectName = `now-revert-alias-${random}`;
-
   const firstDeployment = fixture('now-revert-alias-1');
   const secondDeployment = fixture('now-revert-alias-2');
 
-  firstDeployment['now.json'].name = projectName;
-  secondDeployment['now.json'].name = projectName;
-
-  const url = `https://${projectName}.user.now.sh`;
+  const { name } = JSON.parse(fs.readFileSync(path.join(firstDeployment, 'now.json')));
+  const url = `https://${name}.user.now.sh`;
 
   {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,7 +6,6 @@ import fs from 'fs';
 import execa from 'execa';
 import fetch from 'node-fetch';
 import tmp from 'tmp-promise';
-import { randomBytes } from 'crypto';
 import logo from '../src/util/output/logo';
 import sleep from '../src/util/sleep';
 import pkg from '../package';

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,6 +6,7 @@ import fs from 'fs';
 import execa from 'execa';
 import fetch from 'node-fetch';
 import tmp from 'tmp-promise';
+import { randomBytes } from 'crypto';
 import logo from '../src/util/output/logo';
 import sleep from '../src/util/sleep';
 import pkg from '../package';
@@ -1294,10 +1295,16 @@ test('try to initialize example "example-404"', async t => {
 });
 
 test('try to revert a deployment and assign the automatic aliases', async t => {
+  const random = randomBytes(6).toString('hex');
+  const projectName = `now-revert-alias-${random}`;
+
   const firstDeployment = fixture('now-revert-alias-1');
   const secondDeployment = fixture('now-revert-alias-2');
 
-  let url = `https://now-cli.user.now.sh`;
+  firstDeployment['now.json'].name = projectName;
+  secondDeployment['now.json'].name = projectName;
+
+  const url = `https://${projectName}.user.now.sh`;
 
   {
     const { stdout: deploymentUrl, code } = await execute([firstDeployment]);


### PR DESCRIPTION
Change the url and project name for the revert-alias tests to make it more reliable.