### PR TITLE
[now dev] Exit the process upon `ERR_SERVER_NOT_RUNNING`

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -501,7 +501,15 @@ export default class DevServer {
       this.watcher.close();
     }
 
-    await Promise.all(ops);
+    try {
+      await Promise.all(ops);
+    } catch (err) {
+      if (err.code === 'ERR_SERVER_NOT_RUNNING') {
+        process.exit(0);
+      } else {
+        throw err;
+      }
+    }
   }
 
   shouldRebuild(req: http.IncomingMessage): boolean {


### PR DESCRIPTION
This error happens when Ctrl+C is pressed before the `http.Server` instance is listening, meaning that the user attempted to quit very quickly after starting `now dev`.

This change makes the process exit immediately instead of throwing, which also causes the error to be sent to Sentry (which we do not want).