### PR TITLE
[now dev] Use system installed version of Node.js for builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/tar-fs": "1.16.1",
     "@types/text-table": "0.2.0",
     "@types/universal-analytics": "0.4.2",
+    "@types/which": "1.3.1",
     "@types/write-json-file": "2.2.1",
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.1.0",
@@ -200,6 +201,7 @@
     "universal-analytics": "0.4.20",
     "update-check": "1.5.3",
     "utility-types": "2.1.0",
+    "which": "1.3.1",
     "which-promise": "1.0.0",
     "write-json-file": "2.2.0",
     "yarn": "1.13.0"

--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -46,20 +46,7 @@ const isLogging = new WeakSet<ChildProcess>();
 let nodeBinPromise: Promise<string>;
 
 async function getNodeBin(): Promise<string> {
-  let nodeBin: string | undefined;
-  try {
-    nodeBin = await which('node');
-  } catch (err) {
-    if (err.message.startsWith('not found')) {
-      nodeBin = process.execPath;
-    } else {
-      throw err;
-    }
-  }
-  if (typeof nodeBin !== 'string') {
-    throw new Error('Could not determine location of `node` binary');
-  }
-  return nodeBin;
+  return (await which('node', { nothrow: true })) || process.execPath;
 }
 
 function pipeChildLogging(child: ChildProcess): void {

--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -8,9 +8,8 @@ import { createFunction, initializeRuntime } from '@zeit/fun';
 import { File, Lambda, FileBlob, FileFsRef } from '@now/build-utils';
 import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
-import _which from 'which';
+import which from 'which';
 import ora, { Ora } from 'ora';
-import { promisify } from 'util';
 
 import { Output } from '../output';
 import { relative } from '../path-helpers';
@@ -29,8 +28,6 @@ import {
   BuilderOutputs
 } from './types';
 
-const which = promisify(_which);
-
 interface BuildMessage {
   type: string;
 }
@@ -46,7 +43,7 @@ const isLogging = new WeakSet<ChildProcess>();
 let nodeBinPromise: Promise<string>;
 
 async function getNodeBin(): Promise<string> {
-  return (await which('node', { nothrow: true })) || process.execPath;
+  return which.sync('node', { nothrow: true }) || process.execPath;
 }
 
 function pipeChildLogging(child: ChildProcess): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,11 @@
   resolved "https://registry.yarnpkg.com/@types/universal-analytics/-/universal-analytics-0.4.2.tgz#d21a122a984bf8261eb206bcb7ccb1c0e8353d04"
   integrity sha512-ndv0aYA5tNPdl4KYUperlswuiSj49+o7Pwx8hrCiE9x2oeiMrn7A2jXFDdTLFIymiYZImDX02ycq0i6uQ3TL0A==
 
+"@types/which@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.1.tgz#7802c380887986ca909008afea4e08025b130f8d"
+  integrity sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==
+
 "@types/write-json-file@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/write-json-file/-/write-json-file-2.2.1.tgz#74155aaccbb0d532be21f9d66bebc4ea875a5a62"
@@ -6834,7 +6839,7 @@ which@1.2.x:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.1.2, which@^1.2.9, which@^1.3.0:
+which@1.3.1, which@^1.1.2, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
Rather than downloading the 8.10 Node.js binary, simply assume that the user has their preferred version of `node` already installed onto the system and use that version.

If there is no `node` binary in the $PATH, then `process.execPath` is used instead, meaning that the pkg binary node version will be used.

<strike>**NOTE**: DO NOT merge this until relevant changes have been made to `zeit/now-builders`, otherwise we may run into native addon version mismatch issues.</strike> https://github.com/zeit/now-builders/pull/683