### PR TITLE
Update `@zeit/ncc` to v0.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@zeit/dockerignore": "0.0.5",
     "@zeit/fun": "0.9.0",
     "@zeit/git-hooks": "0.1.4",
-    "@zeit/ncc": "0.18.5",
+    "@zeit/ncc": "0.20.2",
     "@zeit/source-map-support": "0.6.2",
     "alpha-sort": "2.0.1",
     "ansi-escapes": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,10 +729,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/git-hooks/-/git-hooks-0.1.4.tgz#70583db5dd69726a62c7963520e67f2c3a33cc5f"
   integrity sha512-NvgZgoYJ/n27Ly7lKxKttMIKSS8P4dr1EURgTmqihHVdTAEqVtkAYPT5XykZIR+GKz8WRGyEQVJekwSgvjYQLg==
 
-"@zeit/ncc@0.18.5":
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.5.tgz#5687df6c32f1a2e2486aa110b3454ccebda4fb9c"
-  integrity sha512-F+SbvEAh8rchiRXqQbmD1UmbePY7dCOKTbvfFtbVbK2xMH/tyri5YKfNxXKK7eL9EWkkbqB3NTVQO6nokApeBA==
+"@zeit/ncc@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.2.tgz#5f5f67b51d6bd1f92e334c4aeed799dc9625a459"
+  integrity sha512-pLc/iJ68//djAW3jE2xMm5vauAuN0wuq9bv4ha/AAlVOBhJXHrx7GBo8SITTZq11nT8wWzYrY0eotw4UfZBiiw==
 
 "@zeit/source-map-support@0.6.2":
   version "0.6.2"


### PR DESCRIPTION
## Minor changes 😈 

This PR focused on update of `@zeit/ncc`
   - **patches**
      -  Use isArray check for externals
       -  Fixup windows build
       - Update to webpack-asset-relocator-loader 0.5.6
        - Webpack-asset-relocator-loader@0.5.7
    

