### PR TITLE
[now dev] Set "must-revalidate" cache-control response header

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -561,6 +561,7 @@ export default class DevServer {
   ): void {
     const allHeaders = {
       ...headers,
+      'cache-control': 'public, max-age=0, must-revalidate',
       'x-now-trace': 'dev1',
       'x-now-id': nowRequestId,
       'x-now-cache': 'MISS'
@@ -1007,16 +1008,16 @@ function close(server: http.Server): Promise<void> {
 /**
  * Generates a (fake) Now tracing ID for an HTTP request.
  *
- * Example: lx24t-1553895116335-784edbc9ef03e2b5534f3dc6f14c90d4
+ * Example: dev1:q4wlg-1562364135397-7a873ac99c8e
  */
 function generateRequestId(): string {
-  return [
+  return `dev1:${[
     Math.random()
       .toString(32)
       .slice(-5),
     Date.now(),
-    randomBytes(16).toString('hex')
-  ].join('-');
+    randomBytes(6).toString('hex')
+  ].join('-')}`;
 }
 
 function hasOwnProperty(obj: any, prop: string) {

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -41,10 +41,22 @@ function testFixture(name, fn) {
   };
 }
 
+function validateResponseHeaders(t, res) {
+  t.is(res.headers.get('cache-control'), 'public, max-age=0, must-revalidate');
+  t.is(res.headers.get('x-now-trace'), 'dev1');
+  t.truthy(
+    /^dev1:[0-9a-z]{5}-[1-9][0-9]+-[a-f0-9]{12}$/.test(
+      res.headers.get('x-now-id')
+    )
+  );
+}
+
 test(
   '[DevServer] Maintains query when invoking lambda',
   testFixture('now-dev-query-invoke', async (t, server) => {
     const res = await fetch(`${server.address}/something?url-param=a`);
+    validateResponseHeaders(t, res);
+
     const text = await res.text();
     const parsed = url.parse(text, true);
     t.is(parsed.pathname, '/something');
@@ -114,9 +126,18 @@ test('[DevServer] Does not install builders if there are no builds', async t => 
 });
 
 test('[DevServer] Installs canary build-utils if one more more builders is canary', async t => {
-  t.is(getBuildUtils(['@now/static', '@now/node@canary']), '@now/build-utils@canary');
-  t.is(getBuildUtils(['@now/static', '@now/node@0.7.4-canary.0']), '@now/build-utils@canary');
-  t.is(getBuildUtils(['@now/static', '@now/node@0.8.0']), '@now/build-utils@latest');
+  t.is(
+    getBuildUtils(['@now/static', '@now/node@canary']),
+    '@now/build-utils@canary'
+  );
+  t.is(
+    getBuildUtils(['@now/static', '@now/node@0.7.4-canary.0']),
+    '@now/build-utils@canary'
+  );
+  t.is(
+    getBuildUtils(['@now/static', '@now/node@0.8.0']),
+    '@now/build-utils@latest'
+  );
   t.is(getBuildUtils(['@now/static', '@now/node']), '@now/build-utils@latest');
   t.is(getBuildUtils(['@now/static']), '@now/build-utils@latest');
   t.is(getBuildUtils(['@now/md@canary']), '@now/build-utils@canary');


### PR DESCRIPTION
This matches the production router behavior, and prevents running `now dev` on a different project from serving stale content from a different project.

Also update the `x-now-id` header to match the production behavior (it changed at some point).