### PR TITLE
[now dev] Set Now response headers when proxy passing in `routes`

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -726,6 +726,7 @@ export default class DevServer {
       const destUrl = url.format(parsed);
 
       this.output.debug(`ProxyPass: ${destUrl}`);
+      this.setResponseHeaders(res, nowRequestId);
       return proxyPass(req, res, destUrl, this.output);
     }
 

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -42,8 +42,8 @@ function testFixture(name, fn) {
 }
 
 function validateResponseHeaders(t, res) {
-  t.is(res.headers.get('cache-control'), 'public, max-age=0, must-revalidate');
   t.is(res.headers.get('x-now-trace'), 'dev1');
+  t.truthy(res.headers.get('cache-control').length > 0);
   t.truthy(
     /^dev1:[0-9a-z]{5}-[1-9][0-9]+-[a-f0-9]{12}$/.test(
       res.headers.get('x-now-id')
@@ -76,6 +76,8 @@ test(
 
     try {
       const res = await fetch(`${server.address}/${port}?url-param=a`);
+      validateResponseHeaders(t, res);
+
       const text = await res.text();
       const parsed = url.parse(text, true);
       t.is(parsed.pathname, '/something');
@@ -91,6 +93,8 @@ test(
   '[DevServer] Maintains query when builder defines routes',
   testFixture('now-dev-next', async (t, server) => {
     const res = await fetch(`${server.address}/something?url-param=a`);
+    validateResponseHeaders(t, res);
+
     const text = await res.text();
 
     // Hacky way of getting the page payload from the response

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -44,7 +44,6 @@ function testFixture(name, fn) {
 function validateResponseHeaders(t, res) {
   t.is(res.headers.get('x-now-trace'), 'dev1');
   t.truthy(res.headers.get('cache-control').length > 0);
-  t.truthy(/^W\/"[0-9a-f]{40}"$/.test(res.headers.get('etag')));
   t.truthy(
     /^dev1:[0-9a-z]{5}-[1-9][0-9]+-[a-f0-9]{12}$/.test(
       res.headers.get('x-now-id')
@@ -63,6 +62,7 @@ test(
   testFixture('now-dev-query-invoke', async (t, server) => {
     const res = await fetch(`${server.address}/something?url-param=a`);
     validateResponseHeaders(t, res);
+    t.truthy(/^W\/"[0-9a-f]{40}"$/.test(res.headers.get('etag')));
 
     const text = await res.text();
     const parsed = url.parse(text, true);


### PR DESCRIPTION
This matches the behavior in production.