### PR TITLE
[now dev] Allow `cache-control` header to be overwritten

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -560,8 +560,8 @@ export default class DevServer {
     headers: http.OutgoingHttpHeaders = {}
   ): void {
     const allHeaders = {
-      ...headers,
       'cache-control': 'public, max-age=0, must-revalidate',
+      ...headers,
       'x-now-trace': 'dev1',
       'x-now-id': nowRequestId,
       'x-now-cache': 'MISS'

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -3,7 +3,7 @@ import test from 'ava';
 import path from 'path';
 import fetch from 'node-fetch';
 import listen from 'async-listen';
-import { createServer } from 'http';
+import { request, createServer } from 'http';
 import createOutput from '../src/util/output';
 import DevServer from '../src/util/dev/server';
 import { installBuilders, getBuildUtils } from '../src/util/dev/builder-cache';
@@ -49,6 +49,12 @@ function validateResponseHeaders(t, res) {
       res.headers.get('x-now-id')
     )
   );
+}
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    request(url, resolve).on('error', reject).end();
+  });
 }
 
 test(
@@ -103,6 +109,14 @@ test(
 
     t.is(parsed.query['url-param'], 'a');
     t.is(parsed.query['route-param'], 'b');
+  })
+);
+
+test(
+  '[DevServer] Allow `cache-control` to be overwritten',
+  testFixture('now-dev-headers', async (t, server) => {
+    const res = await get(`${server.address}/?name=cache-control&value=immutable`);
+    t.is(res.headers['cache-control'], 'immutable');
   })
 );
 

--- a/test/fixtures/unit/now-dev-headers/index.js
+++ b/test/fixtures/unit/now-dev-headers/index.js
@@ -2,7 +2,6 @@ const { parse } = require('url');
 
 module.exports = (req, res) => {
   const { query } = parse(req.url, true);
-  console.error({ query });
   res.setHeader(query.name, query.value);
   res.end();
 };

--- a/test/fixtures/unit/now-dev-headers/index.js
+++ b/test/fixtures/unit/now-dev-headers/index.js
@@ -1,0 +1,8 @@
+const { parse } = require('url');
+
+module.exports = (req, res) => {
+  const { query } = parse(req.url, true);
+  console.error({ query });
+  res.setHeader(query.name, query.value);
+  res.end();
+};

--- a/test/fixtures/unit/now-dev-headers/now.json
+++ b/test/fixtures/unit/now-dev-headers/now.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "name": "now-dev-headers",
+  "builds": [
+    { "src": "index.js", "use": "@now/node" }
+  ]
+}


### PR DESCRIPTION
This matches the behavior in production.