### PR TITLE
Throw an error if `dev` scripts contain `now dev` in package.json

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -10,6 +10,7 @@ import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import dev from './dev';
 import readPackage from '../../util/read-package'
+import { Package } from '../../util/dev/types';
 
 const COMMAND_CONFIG = {
   dev: ['dev']
@@ -59,10 +60,9 @@ export default async function main(ctx: NowContext) {
 
   const pkg = await readPackage();
   if (pkg) {
-    // @ts-ignore
-    const { scripts } = pkg;
+    const { scripts } = pkg as Package;
 
-    if (scripts.dev && scripts.dev === 'now dev') {
+    if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
       output.error(`package.json ${chalk.gray('dev')} scripts must not contain ${chalk.gray('now dev')}`);
       return 1;
     }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -9,6 +9,7 @@ import createOutput from '../../util/output/create-output';
 import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import dev from './dev';
+import readPackage from '../../util/read-package'
 
 const COMMAND_CONFIG = {
   dev: ['dev']
@@ -54,6 +55,17 @@ export default async function main(ctx: NowContext) {
   if (argv['--help']) {
     help();
     return 2;
+  }
+
+  const pkg = await readPackage();
+  if (pkg) {
+    // @ts-ignore
+    const { scripts } = pkg;
+
+    if (scripts.dev && scripts.dev === 'now dev') {
+      output.error(`package.json ${chalk.gray('dev')} scripts must not contain ${chalk.gray('now dev')}`);
+      return 1;
+    }
   }
 
   if (argv._.length > 2) {

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -63,7 +63,7 @@ export default async function main(ctx: NowContext) {
     const { scripts } = pkg as Package;
 
     if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
-      output.error(`package.json ${chalk.gray('dev')} scripts must not contain ${chalk.gray('now dev')}`);
+      output.error(`The ${cmd('dev')} script in ${cmd('package.json')} must not contain ${cmd('now dev')}`);
       return 1;
     }
   }

--- a/src/util/dev/types.ts
+++ b/src/util/dev/types.ts
@@ -133,6 +133,7 @@ export interface ShouldServeParams {
 export interface Package {
   name?: string;
   version: string;
+  scripts?: { [key: string]: string };
   dependencies?: { [name: string]: string };
   devDependencies?: { [name: string]: string };
 }


### PR DESCRIPTION
This PR throw an error message if `dev` scripts contain `now dev` in user `package.json`.