### PR TITLE
Adds `domains config <domain>` command to check if a domain is configured properly for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "printf": "0.2.5",
     "progress": "2.0.3",
     "promisepipe": "3.0.0",
-    "psl": "1.1.31",
+    "psl": "1.2.0",
     "qr-image": "3.2.0",
     "raw-body": "2.3.3",
     "read-pkg": "2.0.0",

--- a/src/commands/domains/config.ts
+++ b/src/commands/domains/config.ts
@@ -1,0 +1,90 @@
+import chalk from 'chalk';
+import psl from 'psl';
+
+import { NowContext } from '../../types';
+import { Output } from '../../util/output';
+import * as ERRORS from '../../util/errors-ts';
+import addDomain from '../../util/domains/add-domain';
+import Client from '../../util/client';
+import cmd from '../../util/output/cmd';
+import formatDnsTable from '../../util/format-dns-table';
+import formatNSTable from '../../util/format-ns-table';
+import getScope from '../../util/get-scope';
+import stamp from '../../util/output/stamp';
+import param from '../../util/output/param';
+import checkDomainConfig from '../../util/domains/check-domain-config';
+import withSpinner from '../../util/with-spinner';
+
+type Options = {
+  '--debug': boolean;
+};
+
+export default async function config(
+  ctx: NowContext,
+  opts: Options,
+  args: string[],
+  output: Output
+) {
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
+  const { currentTeam } = config;
+  const { apiUrl } = ctx;
+  const debug = opts['--debug'];
+  const client = new Client({ apiUrl, token, currentTeam, debug });
+  let contextName = null;
+
+  try {
+    ({ contextName } = await getScope(client));
+  } catch (err) {
+    if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
+      output.error(err.message);
+      return 1;
+    }
+
+    throw err;
+  }
+
+  if (args.length !== 1) {
+    output.error(`${cmd('now domains config <domain>')} expects one argument`);
+    return 1;
+  }
+
+  const argDomainName = String(args[0]);
+  const parsedDomain = psl.parse(argDomainName);
+  if (parsedDomain.error) {
+    output.error(`The provided domain name ${param(argDomainName)} is invalid`);
+    return 1;
+  }
+
+  if (!parsedDomain.domain) {
+    output.error(`The provided domain '${param(argDomainName)}' is not valid.`);
+    return 1;
+  }
+
+  const domainName = [parsedDomain.subdomain, parsedDomain.domain]
+    .filter(x => x && x.length > 0)
+    .join('.');
+
+  const domainConfig = await withSpinner('Checking domain configuration', () =>
+    checkDomainConfig(client, domainName)
+  );
+  if (domainConfig instanceof ERRORS.InvalidDomain) {
+    output.error(
+      `The provided domain name "${domainConfig.meta.domain}" is invalid`
+    );
+    return 1;
+  }
+
+  if (!domainConfig.misconfigured) {
+    output.success(`${param(domainName)} is properly configured for now`);
+    return 0;
+  }
+
+  output.error(`${param(domainName)} is not properly configured for now.`);
+  domainConfig.misconfiguredReasons.forEach((reason, index) => {
+    output.print(`> ${reason}\n`);
+  });
+  return 0;
+}

--- a/src/commands/domains/config.ts
+++ b/src/commands/domains/config.ts
@@ -86,5 +86,5 @@ export default async function config(
   domainConfig.misconfiguredReasons.forEach((reason, index) => {
     output.print(`> ${reason}\n`);
   });
-  return 0;
+  return 1;
 }

--- a/src/commands/domains/index.ts
+++ b/src/commands/domains/index.ts
@@ -15,6 +15,7 @@ import ls from './ls';
 import rm from './rm';
 import verify from './verify';
 import move from './move';
+import config from './config';
 
 const help = () => {
   console.log(`
@@ -30,6 +31,7 @@ const help = () => {
     move         [name] [destination]   Move a domain to another user or team.
     transfer-in  [name]                 Transfer in a domain to Zeit
     verify       [name]                 Run a verification for a domain
+    config       [name]                 Check if a domain is configured properly for ZEIT
 
   ${chalk.dim('Options:')}
 
@@ -67,6 +69,7 @@ const help = () => {
 const COMMAND_CONFIG = {
   add: ['add'],
   buy: ['buy'],
+  config: ['config'],
   inspect: ['inspect'],
   ls: ['ls', 'list'],
   move: ['move'],
@@ -112,6 +115,8 @@ export default async function main(ctx: NowContext) {
       return transferIn(ctx, argv, args, output);
     case 'verify':
       return verify(ctx, argv, args, output);
+    case 'config':
+      return config(ctx, argv, args, output);
     default:
       return ls(ctx, argv, args, output);
   }

--- a/src/util/domains/check-domain-config.ts
+++ b/src/util/domains/check-domain-config.ts
@@ -1,0 +1,25 @@
+import * as ERRORS from '../errors-ts';
+import Client from '../client';
+
+type Response = {
+  nameservers: string[];
+  serviceType: 'zeit.world' | 'external' | 'na';
+  expectedTXTRecord: string;
+  txtRecords: string[];
+  cnames: string[] | null;
+  expectedCNAMEValues: string[] | null;
+  aValues: string[] | null;
+  misconfigured: boolean;
+  misconfiguredReasons: string[];
+};
+
+export default async function checkDomainConfig(client: Client, name: string) {
+  try {
+    return await client.fetch<Response>(`/v3/domains/${name}/config`);
+  } catch (error) {
+    if (error.code === 'invalid_name') {
+      return new ERRORS.InvalidDomain(name);
+    }
+    throw error;
+  }
+}

--- a/test/integration.js
+++ b/test/integration.js
@@ -344,6 +344,24 @@ test('try to purchase a domain', async t => {
   );
 });
 
+test('check domain configuration', async t => {
+  const domainName = `${session}-test.org`
+  const { stderr, code } = await execa(
+    binaryPath,
+    ['domains', 'config', domainName, ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  t.true(
+    stderr.includes(
+      `> Error! "${domainName}" is not properly configured for now.`
+    )
+  );
+  t.is(code, 1);
+});
+
 test('try to transfer-in a domain with "--code" option', async t => {
   const { stderr, code } = await execa(
     binaryPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5324,7 +5324,12 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@1.1.31, psl@^1.1.24, psl@^1.1.28:
+psl@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.2.0.tgz#df12b5b1b3a30f51c329eacbdef98f3a6e136dc6"
+  integrity sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==
+
+psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
   integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==


### PR DESCRIPTION
Adds `domains config <domain>` command to ensure a domain is configured properly for now.

Successfully configured domain example:
```
now domains config test.external-test.xyz

> Success! "test.external-test.xyz" is properly configured for now
```

Incorrectly configured domain example:
```
now domains config bad.external-test.xyz

> Error! "bad.external-test.xyz" is not properly configured for now.
> CNAME record value for bad.external-test.xyz does not point to "alias.zeit.co.". Make sure the CNAME value for bad.external-test.xyz is properly configured to work with now.
```