### PR TITLE
[now dev] Install missing builders during runtime

### DIFF
--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -376,6 +376,7 @@ export async function executeBuild(
 export async function getBuildMatches(
   nowJson: NowConfig,
   cwd: string,
+  yarnDir: string,
   output: Output
 ): Promise<BuildMatch[]> {
   const matches: BuildMatch[] = [];
@@ -395,7 +396,7 @@ export async function getBuildMatches(
 
     for (const file of files) {
       src = relative(cwd, file);
-      const builderWithPkg = await getBuilder(use);
+      const builderWithPkg = await getBuilder(use, yarnDir, output);
       matches.push({
         ...buildConfig,
         src,

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -247,7 +247,12 @@ export default class DevServer {
   }
 
   async updateBuildMatches(nowJson: NowConfig): Promise<void> {
-    const matches = await getBuildMatches(nowJson, this.cwd, this.output);
+    const matches = await getBuildMatches(
+      nowJson,
+      this.cwd,
+      this.yarnPath,
+      this.output
+    );
     const sources = matches.map(m => m.src);
 
     // Delete build matches that no longer exists


### PR DESCRIPTION
Before this change, the `installBuilders()` function was only run at bootup, so if you modify `now.json` during runtime and add a builder that's not installed, then a `MODULE_NOT_FOUND` error occurs.

Now the `installBuilders()` function is run with the missing builder so that the builder can be properly loaded.