### PR TITLE
[now dev] Revert "Add `etag` response header for Lambda invocations"

### DIFF
--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import execa from 'execa';
 import npa from 'npm-package-arg';
+import { createHash } from 'crypto';
 import { join, resolve } from 'path';
 import { funCacheDir } from '@zeit/fun';
 import cacheDirectory from 'cache-or-tmp-directory';
@@ -11,7 +12,6 @@ import {
   BuilderCacheCleanError
 } from '../errors-ts';
 import wait from '../output/wait';
-import { getSha } from '../sha';
 import { Output } from '../output';
 
 import * as staticBuilder from './static-builder';
@@ -236,4 +236,10 @@ function getPackageName(
     }
   }
   return null;
+}
+
+function getSha(buffer: Buffer): string {
+  const hash = createHash('sha256');
+  hash.update(buffer);
+  return hash.digest('hex');
 }

--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -11,7 +11,6 @@ import chalk from 'chalk';
 import which from 'which';
 import ora, { Ora } from 'ora';
 
-import { getSha } from '../sha';
 import { Output } from '../output';
 import { relative } from '../path-helpers';
 import { LambdaSizeExceededError } from '../errors-ts';
@@ -355,7 +354,6 @@ export async function executeBuild(
             }
           }
         });
-        asset.sha = getSha(asset.zipBuffer, 'sha1');
       }
 
       match.buildTimestamp = Date.now();

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -941,7 +941,7 @@ export default class DevServer {
         return;
 
       case 'Lambda':
-        if (!asset.fn || !asset.sha) {
+        if (!asset.fn) {
           // This is mostly to appease TypeScript since `fn` is an optional prop,
           // but this shouldn't really ever happen since we run the builds before
           // responding to HTTP requests.
@@ -996,7 +996,6 @@ export default class DevServer {
 
         res.statusCode = result.statusCode;
         this.setResponseHeaders(res, nowRequestId, result.headers);
-        res.setHeader('etag', `W/"${asset.sha}"`);
 
         let resBody: Buffer | string | undefined;
         if (result.encoding === 'base64' && typeof result.body === 'string') {

--- a/src/util/dev/types.ts
+++ b/src/util/dev/types.ts
@@ -59,7 +59,6 @@ export interface BuilderInputs {
 
 export type BuiltLambda = Lambda & {
   fn?: FunLambda;
-  sha?: string;
 };
 
 export type BuilderOutput = BuiltLambda | FileFsRef | FileBlob;

--- a/src/util/sha.ts
+++ b/src/util/sha.ts
@@ -1,7 +1,0 @@
-import { createHash } from 'crypto';
-
-export function getSha(buffer: Buffer, cypher: string = 'sha256'): string {
-  const hash = createHash(cypher);
-  hash.update(buffer);
-  return hash.digest('hex');
-}

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -62,7 +62,6 @@ test(
   testFixture('now-dev-query-invoke', async (t, server) => {
     const res = await fetch(`${server.address}/something?url-param=a`);
     validateResponseHeaders(t, res);
-    t.truthy(/^W\/"[0-9a-f]{40}"$/.test(res.headers.get('etag')));
 
     const text = await res.text();
     const parsed = url.parse(text, true);


### PR DESCRIPTION
This reverts commit f80f1f79a6c27767590df4733c730e7f54b3b77c (#2502).

`ETag` header is only sent in production when the lambda function sets the "stale-while-revalidate" cache-control header, which will be implemented in a separate PR.