### PR TITLE
Add @AndyBitz to `now dev` CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://help.github.com/en/articles/about-code-owners
 
 *                       @tootallnate @leo
-/src/commands/dev/      @tootallnate @leo @styfle
-/src/util/dev/          @tootallnate @leo @styfle
+/src/commands/dev/      @tootallnate @leo @styfle @AndyBitz
+/src/util/dev/          @tootallnate @leo @styfle @AndyBitz
 /src/commands/domains/  @javivelasco @mglagola @anatrajkovska
 /src/commands/certs/    @javivelasco @mglagola @anatrajkovska


### PR DESCRIPTION
To help oversee changes to `now dev` related to zero-config.