### PR TITLE
Remove "missing `alias` in now.json" warning

### DIFF
--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -204,10 +204,6 @@ export default async function main(
   const paths = Object.keys(stats);
   const debugEnabled = argv['--debug'];
 
-  if ((localConfig.alias || []).length === 0 && argv['--target'] === 'production') {
-    const flag = param('--target production');
-    output.warn(`You specified ${flag} but didn't configure a value for the ${code('alias')} configuration property.`);
-  }
   // $FlowFixMe
   const isTTY = process.stdout.isTTY;
   const quiet = !isTTY;


### PR DESCRIPTION
I ran `now --target production` and I saw this:

<img width="1083" alt="Capture d’écran 2019-07-12 à 01 17 00" src="https://user-images.githubusercontent.com/6616955/61091727-843f0f00-a443-11e9-87dd-d054117fa59a.png">

This warning is irrelevant to me because I configured the production alias through the UI 😏

This PR removes it.

@quietshu can you confirm?