### PR TITLE
[now dev] Increase default maxLambdaSize

### DIFF
--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -311,13 +311,7 @@ export async function executeBuild(
   }
 
   // Enforce the lambda zip size soft watermark
-  const { maxLambdaSize = '5mb' } = { ...builderConfig, ...config };
-  let maxLambdaBytes: number;
-  if (typeof maxLambdaSize === 'string') {
-    maxLambdaBytes = bytes(maxLambdaSize);
-  } else {
-    maxLambdaBytes = maxLambdaSize;
-  }
+  const maxLambdaBytes = bytes('50mb');
   for (const asset of Object.values(result.output)) {
     if (asset.type === 'Lambda') {
       const size = asset.zipBuffer.length;


### PR DESCRIPTION
This PR add `maxLambdaSize` `50mb` for `now dev`.

Related: 
- https://github.com/zeit/docs/pull/985
- https://github.com/zeit/now-builders/pull/741