### PR TITLE
Add `builders.tar.gz` to pkg "assets" configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "dist/*.js"
     ],
     "assets": [
-      "dist/runtimes"
+      "dist/runtimes",
+      "dist/builders.tar.gz"
     ],
     "targets": [
       "node10.4.1-alpine-x64",


### PR DESCRIPTION
Fixes this error from the pkg'd binary:

```
Error: File or directory '/**/now-cli/dist/builders.tar.gz'
was not included into executable at compilation stage.
Please recompile adding it as asset or script.
```