### PR TITLE
[now dev] Wait for `updateBuilders()` to complete before `stop()` completes

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -315,16 +315,21 @@ export default class DevServer {
       return;
     }
 
+    const _require =
+      typeof __non_webpack_require__ === 'function'
+        ? __non_webpack_require__
+        : require;
+
     // The `require()` cache for the builder's assets must be purged
     const builderDir = await builderDirPromise;
     const updatedBuilderPaths = updatedBuilders.map(b =>
       join(builderDir, 'node_modules', b)
     );
-    for (const id of Object.keys(__non_webpack_require__.cache)) {
+    for (const id of Object.keys(_require.cache)) {
       for (const path of updatedBuilderPaths) {
         if (id.startsWith(path)) {
           this.output.debug(`Purging require cache for "${id}"`);
-          delete __non_webpack_require__.cache[id];
+          delete _require.cache[id];
         }
       }
     }

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -36,7 +36,7 @@ function testFixture(name, fn) {
 
       await fn(t, server);
     } finally {
-      server.stop();
+      await server.stop();
     }
   };
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -364,7 +364,7 @@ test('scale down the deployment directly', async t => {
 });
 
 test('list the scopes', async t => {
-  const { stdout, code } = await execa(
+  const { stdout, stderr, code } = await execa(
     binaryPath,
     ['teams', 'ls', ...defaultArgs],
     {
@@ -373,6 +373,8 @@ test('list the scopes', async t => {
   );
 
   t.is(code, 0);
+  console.log(stdout);
+  console.log({stdout, stderr});
   t.true(stdout.includes(`✔ ${contextName}     ${email}`));
 });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -364,7 +364,7 @@ test('scale down the deployment directly', async t => {
 });
 
 test('list the scopes', async t => {
-  const { stdout, stderr, code } = await execa(
+  const { stdout, code } = await execa(
     binaryPath,
     ['teams', 'ls', ...defaultArgs],
     {
@@ -373,8 +373,6 @@ test('list the scopes', async t => {
   );
 
   t.is(code, 0);
-  console.log(stdout);
-  console.log({stdout, stderr, contextName, email});
   t.true(stdout.includes(`✔ ${contextName}     ${email}`));
 });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -374,7 +374,7 @@ test('list the scopes', async t => {
 
   t.is(code, 0);
   console.log(stdout);
-  console.log({stdout, stderr});
+  console.log({stdout, stderr, contextName, email});
   t.true(stdout.includes(`✔ ${contextName}     ${email}`));
 });
 


### PR DESCRIPTION
Since #2477, the unit tests related to `now dev` have become flaky, and need to be retried a couple of times before running successfully. My theory is that this is related to having concurrent `yarn` processes operating on the builders module directory, causing corruption with yarn's cache. Waiting for the lazy updating `yarn` process to complete makes sense to me, hopefully CircleCI agrees.