### PR TITLE
feat: rollback Throw an error if  scripts contain  in package.json

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -9,8 +9,6 @@ import createOutput from '../../util/output/create-output';
 import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import dev from './dev';
-import readPackage from '../../util/read-package'
-import { Package } from '../../util/dev/types';
 
 const COMMAND_CONFIG = {
   dev: ['dev']
@@ -56,16 +54,6 @@ export default async function main(ctx: NowContext) {
   if (argv['--help']) {
     help();
     return 2;
-  }
-
-  const pkg = await readPackage();
-  if (pkg) {
-    const { scripts } = pkg as Package;
-
-    if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
-      output.error(`The ${cmd('dev')} script in ${cmd('package.json')} must not contain ${cmd('now dev')}`);
-      return 1;
-    }
   }
 
   if (argv._.length > 2) {

--- a/src/util/dev/types.ts
+++ b/src/util/dev/types.ts
@@ -132,7 +132,6 @@ export interface ShouldServeParams {
 export interface Package {
   name: string;
   version: string;
-  scripts?: { [key: string]: string };
   dependencies?: { [name: string]: string };
   devDependencies?: { [name: string]: string };
 }


### PR DESCRIPTION
**Related Issue:**
https://github.com/zeit/now-cli/issues/2546

**Descriptions:**
I think it is necessary for developers who uses `now dev` in dev scripts