### PR TITLE
[now dev] Fix "zero-config" detection

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -411,7 +411,6 @@ export default class DevServer {
         throw err;
       }
     }
-    console.error({ isZeroConfig });
 
     if (isZeroConfig) {
       // We need to delete these properties for zero config to work


### PR DESCRIPTION
Only apply the zero-config processing logic if one of these is true:

  1. No `now.json`
  2. No `builds` array in `now.json`
  3. `builds` array is empty in `now.json`