### PR TITLE
[now dev] Wait for blocking builds to complete before handling requests

### DIFF
--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -394,8 +394,8 @@ export async function getBuildMatches(
     src = src.replace(/(\[|\])/g, '[$1]');
 
     const files = fileList
-      .filter((name) => name === src || minimatch(name, src))
-      .map((name) => join(cwd, name));
+      .filter(name => name === src || minimatch(name, src))
+      .map(name => join(cwd, name));
 
     for (const file of files) {
       src = relative(cwd, file);

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -314,13 +314,6 @@ export default class DevServer {
       }
     }
 
-    // Sort build matches to make sure `@now/static-build` is always last
-    this.buildMatches = new Map(
-      [...this.buildMatches.entries()].sort((matchA, matchB) => {
-        return sortBuilders(matchA[1] as BuildConfig, matchB[1] as BuildConfig);
-      })
-    );
-
     // Add the new matches to the `buildMatches` map
     const blockingBuilds: Promise<void>[] = [];
     for (const match of matches) {
@@ -350,6 +343,13 @@ export default class DevServer {
         .then(cleanup)
         .catch(cleanup);
     }
+
+    // Sort build matches to make sure `@now/static-build` is always last
+    this.buildMatches = new Map(
+      [...this.buildMatches.entries()].sort((matchA, matchB) => {
+        return sortBuilders(matchA[1] as BuildConfig, matchB[1] as BuildConfig);
+      })
+    );
   }
 
   async invalidateBuildMatches(

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -107,7 +107,9 @@ export default class DevServer {
   private watchAggregationEvents: FSEvent[];
   private watchAggregationTimeout: number;
   private filter: (path: string) => boolean;
+
   private getNowConfigPromise: Promise<NowConfig> | null;
+  private blockingBuildsPromise: Promise<void> | null;
   private updateBuildersPromise: Promise<void> | null;
 
   constructor(cwd: string, options: DevServerOptions) {
@@ -123,13 +125,15 @@ export default class DevServer {
     this.yarnPath = '/';
 
     this.cachedNowConfig = null;
-    this.getNowConfigPromise = null;
-    this.updateBuildersPromise = null;
     this.server = http.createServer(this.devServerHandler);
     this.serverUrlPrinted = false;
     this.stopping = false;
     this.buildMatches = new Map();
     this.inProgressBuilds = new Map();
+
+    this.getNowConfigPromise = null;
+    this.blockingBuildsPromise = null;
+    this.updateBuildersPromise = null;
 
     this.watchAggregationId = null;
     this.watchAggregationEvents = [];
@@ -310,19 +314,42 @@ export default class DevServer {
       }
     }
 
+    // Sort build matches to make sure `@now/static-build` is always last
+    this.buildMatches = new Map(
+      [...this.buildMatches.entries()].sort((matchA, matchB) => {
+        return sortBuilders(matchA[1] as BuildConfig, matchB[1] as BuildConfig);
+      })
+    );
+
     // Add the new matches to the `buildMatches` map
+    const blockingBuilds: Promise<void>[] = [];
     for (const match of matches) {
       const currentMatch = this.buildMatches.get(match.src);
       if (!currentMatch || currentMatch.use !== match.use) {
         this.output.debug(`Adding build match for "${match.src}"`);
         this.buildMatches.set(match.src, match);
+        if (needsBlockingBuild(match)) {
+          const buildPromise = executeBuild(
+            nowConfig,
+            this,
+            this.files,
+            match,
+            null,
+            false
+          );
+          blockingBuilds.push(buildPromise);
+        }
       }
     }
 
-    // Sort build matches to make sure `@now/static-build` is always last
-    this.buildMatches = new Map([...this.buildMatches.entries()].sort((matchA, matchB) => {
-      return sortBuilders(matchA[1] as BuildConfig, matchB[1] as BuildConfig);
-    }));
+    if (blockingBuilds.length > 0) {
+      const cleanup = () => {
+        this.blockingBuildsPromise = null;
+      };
+      this.blockingBuildsPromise = Promise.all(blockingBuilds)
+        .then(cleanup)
+        .catch(cleanup);
+    }
   }
 
   async invalidateBuildMatches(
@@ -468,7 +495,10 @@ export default class DevServer {
       }
 
       if (builders) {
-        const { defaultRoutes, error: routesError } = await detectRoutes(files, builders);
+        const { defaultRoutes, error: routesError } = await detectRoutes(
+          files,
+          builders
+        );
 
         config.builds = config.builds || [];
         config.builds.push(...builders);
@@ -478,7 +508,7 @@ export default class DevServer {
           process.exit(1);
         } else {
           config.routes = config.routes || [];
-          config.routes.push(...defaultRoutes as RouteConfig[]);
+          config.routes.push(...(defaultRoutes as RouteConfig[]));
         }
       }
     }
@@ -551,8 +581,7 @@ export default class DevServer {
    * and filter them
    */
   resolveBuildFiles(files: BuilderInputs) {
-    return Object.keys(files)
-      .filter(this.filter);
+    return Object.keys(files).filter(this.filter);
   }
 
   /**
@@ -594,7 +623,9 @@ export default class DevServer {
     this.files = results;
 
     const builders: Set<string> = new Set(
-      (nowConfig.builds || []).filter((b: BuildConfig) => b.use).map((b: BuildConfig) => b.use as string)
+      (nowConfig.builds || [])
+        .filter((b: BuildConfig) => b.use)
+        .map((b: BuildConfig) => b.use as string)
     );
 
     await installBuilders(builders, this.yarnPath, this.output);
@@ -618,18 +649,15 @@ export default class DevServer {
     // Now Builders that do not define a `shouldServe()` function need to be
     // executed at boot-up time in order to get the initial assets and/or routes
     // that can be served by the builder.
-    const needsInitialBuild = Array.from(this.buildMatches.values()).filter(
-      (buildMatch: BuildMatch) => {
-        const { builder } = buildMatch.builderWithPkg;
-        return typeof builder.shouldServe !== 'function';
-      }
+    const blockingBuilds = Array.from(this.buildMatches.values()).filter(
+      needsBlockingBuild
     );
-    if (needsInitialBuild.length > 0) {
+    if (blockingBuilds.length > 0) {
       this.output.log(
-        `Creating initial ${plural('build', needsInitialBuild.length)}`
+        `Creating initial ${plural('build', blockingBuilds.length)}`
       );
 
-      for (const match of needsInitialBuild) {
+      for (const match of blockingBuilds) {
         await executeBuild(nowConfig, this, this.files, match, null, true);
       }
 
@@ -917,6 +945,13 @@ export default class DevServer {
     nowConfig: NowConfig,
     routes: RouteConfig[] | undefined = nowConfig.routes
   ) => {
+    if (this.blockingBuildsPromise) {
+      this.output.debug(
+        'Waiting for builds to complete before handling request'
+      );
+      await this.blockingBuildsPromise;
+    }
+
     await this.updateBuildMatches(nowConfig);
 
     const {
@@ -1459,4 +1494,9 @@ function fileRemoved(
   delete files[name];
   changed.delete(name);
   removed.add(name);
+}
+
+function needsBlockingBuild(buildMatch: BuildMatch): boolean {
+  const { builder } = buildMatch.builderWithPkg;
+  return typeof builder.shouldServe !== 'function';
 }

--- a/test/dev/fixtures/trigger-static-build/index.txt
+++ b/test/dev/fixtures/trigger-static-build/index.txt
@@ -1,0 +1,1 @@
+hello:index.txt

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -465,3 +465,35 @@ test('[now dev] temporary directory listing', async t => {
     dev.kill('SIGTERM');
   }
 });
+
+test('[now dev] add a `package.json` to trigger `@now/static-build`', async t => {
+  const directory = fixture('trigger-static-build');
+  const { dev, port } = testFixture(directory);
+
+   try {
+    dev.unref();
+
+     {
+      const response = await fetchWithRetry(`http://localhost:${port}`, 180);
+      validateResponseHeaders(t, response);
+      const body = await response.text();
+      t.is(body.trim(), 'hello:index.txt');
+    }
+
+     const rnd = Math.random().toString();
+    const pkg = { scripts: { build: `mkdir -p public && echo ${rnd} > public/index.txt` } };
+    await fs.writeFile(path.join(directory, 'package.json'), JSON.stringify(pkg));
+
+     // Wait until file events have been processed
+    await sleep(ms('3s'));
+
+     {
+      const response = await fetchWithRetry(`http://localhost:${port}`, 180);
+      validateResponseHeaders(t, response);
+      const body = await response.text();
+      t.is(body.trim(), rnd);
+    }
+  } finally {
+    dev.kill('SIGTERM');
+  }
+});


### PR DESCRIPTION
After the `now dev` server has already booted, if you delete a build match that previously required a build at bootup time (i.e. `@now/next`) from the `builds` array in `now.json` (i.e. change the builder to `@now/static`), and then change it back to `@now/next`, then previously the build would never execute.

With this change, the blocking build occurs as expected, and any HTTP requests that occur are blocked until that build has completed.