### PR TITLE
[now dev] Fix builder sorting when `use` is undefined

### DIFF
--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -375,6 +375,11 @@ export async function getBuildMatches(
   const builds = nowConfig.builds || [{ src: '**', use: '@now/static' }];
   for (const buildConfig of builds) {
     let { src, use } = buildConfig;
+
+    if (!use) {
+      continue;
+    }
+
     if (src[0] === '/') {
       // Remove a leading slash so that the globbing is relative to `cwd`
       // instead of the root of the filesystem. This matches the behavior

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -596,7 +596,7 @@ export default class DevServer {
     this.files = results;
 
     const builders: Set<string> = new Set(
-      (nowConfig.builds || []).map((b: BuildConfig) => b.use)
+      (nowConfig.builds || []).filter((b: BuildConfig) => b.use).map((b: BuildConfig) => b.use)
     );
 
     await installBuilders(builders, this.yarnPath, this.output);

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -76,11 +76,11 @@ interface NodeRequire {
 declare const __non_webpack_require__: NodeRequire;
 
 function sortBuilders(buildA: BuildConfig, buildB: BuildConfig) {
-  if (buildA.use.startsWith('@now/static-build')) {
+  if (buildA && buildA.use && buildA.use.startsWith('@now/static-build')) {
     return 1;
   }
 
-  if (buildB.use.startsWith('@now/static-build')) {
+  if (buildB && buildB.use && buildB.use.startsWith('@now/static-build')) {
     return -1;
   }
 

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -596,7 +596,7 @@ export default class DevServer {
     this.files = results;
 
     const builders: Set<string> = new Set(
-      (nowConfig.builds || []).filter((b: BuildConfig) => b.use).map((b: BuildConfig) => b.use)
+      (nowConfig.builds || []).filter((b: BuildConfig) => b.use).map((b: BuildConfig) => b.use as string)
     );
 
     await installBuilders(builders, this.yarnPath, this.output);

--- a/src/util/dev/types.ts
+++ b/src/util/dev/types.ts
@@ -15,7 +15,7 @@ export interface EnvConfig {
 
 export interface BuildConfig {
   src: string;
-  use: string;
+  use?: string;
   config?: object;
 }
 


### PR DESCRIPTION
Fix builder sorting when `use` is undefined