### PR TITLE
Change `now update` to display npm or yarn command

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,39 +1,12 @@
 import chalk from 'chalk';
-import { tmpdir } from 'os';
-import pipe from 'promisepipe';
-import fetch from 'node-fetch';
-import Progress from 'progress';
-import { createGunzip } from 'zlib';
-import { parse, format } from 'url';
-import { basename, join } from 'path';
-import { spawnSync } from 'child_process';
-import {
-  createReadStream,
-  createWriteStream,
-  chmod,
-  chown,
-  copyFile,
-  move,
-  remove,
-  stat
-} from 'fs-extra';
+import {  join } from 'path';
+import { pathExists } from 'fs-extra';
 
-import pkg from '../util/pkg';
 import logo from '../util/output/logo';
-import promptBool from '../util/prompt-bool';
 import handleError from '../util/handle-error';
 import getArgs from '../util/get-args';
 import { NowContext } from '../types';
-import createOutput, { Output } from '../util/output';
-
-const isWin = process.platform.startsWith('win');
-const versionEndpoint = 'https://install-now-cli.zeit.sh/version';
-
-const platformMap: Map<string, string> = new Map([
-  ['darwin', 'macos'],
-  ['linux', 'linux'],
-  ['win32', 'win']
-]);
+import createOutput from '../util/output';
 
 const help = () => {
   console.log(`
@@ -59,120 +32,12 @@ const help = () => {
   `);
 };
 
-const permError = (dest: string): string => {
-  const admin = isWin ? 'an Administrator Command Prompt' : '`sudo`';
-  return `Permission denied to modify file "${dest}". Please run again with ${admin}.`;
-};
+async function getUpgradeCommand() {
+  const isYarn = await pathExists(join(process.cwd(), 'yarn.lock'));
 
-const isBusyError = ({ message }: Error): boolean => {
-  return message.startsWith('ETXTBSY') || message.startsWith('EBUSY');
-};
-
-const isPermissionsError = ({ message }: Error): boolean => {
-  return message.startsWith('EACCES') || message.startsWith('EPERM');
-};
-
-function detectAlpine() {
-  // https://github.com/sass/node-sass/issues/1589#issuecomment-265292579
-  const ldd = spawnSync('ldd', [process.execPath]).stdout.toString();
-  return /\bmusl\b/.test(ldd);
-}
-
-function getDefaultChannel(): string {
-  const m = pkg.version.match(/-(.+)\./);
-  return m ? m[1] : 'stable';
-}
-
-function getPlatform(nodePlatform: string): string {
-  let platform = platformMap.get(nodePlatform);
-  if (!platform) {
-    throw new Error(`Unsupported platform: ${platform}`);
-  }
-  if (platform === 'linux' && detectAlpine()) {
-    platform = 'alpine';
-  }
-  return platform;
-}
-
-function getReleaseUrl(version: string, platform: string): string {
-  const ext = platform === 'win' ? '.exe' : '';
-  return `https://github.com/zeit/now-cli/releases/download/${version}/now-${platform}${ext}.gz`;
-}
-
-function isNpmInstall(binaryPath: string): boolean {
-  return binaryPath.includes('node_modules');
-}
-
-async function getLatestVersion(
-  { debug }: Output,
-  channel: string
-): Promise<string> {
-  const parsed = parse(versionEndpoint, true);
-  parsed.query.channel = channel;
-  const url = format(parsed);
-  debug(`GET ${url}`);
-  const res = await fetch(url);
-  const body = await res.text();
-  debug(`Resolved latest version "${body}" from channel "${channel}"`);
-  return body.trim();
-}
-
-async function downloadNowCli({ debug, print }: Output, url: string, dest: string) {
-  debug(`GET ${url}`);
-  debug(`Downloading to path: ${dest}`);
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok) {
-    throw new Error(`Got ${res.status} status code while downloading Now CLI`);
-  }
-  const total = parseInt(res.headers.get('content-length') || '0', 10);
-  const bar = new Progress(':bar :percent', {
-    complete: '#',
-    incomplete: ' ',
-    width: 80,
-    clear: true,
-    total
-  });
-  const pipePromise = pipe(
-    res.body,
-    createGunzip(),
-    createWriteStream(dest)
-  );
-  res.body.on('data', (buf: Buffer) => {
-    bar.tick(buf.length);
-  });
-  await pipePromise;
-}
-
-async function updateNowCli(src: string, dest: string): Promise<number> {
-  await pipe(
-    createReadStream(src),
-    createWriteStream(dest)
-  );
-  return 0;
-}
-
-async function removeAndMove({ debug, error }: Output, src: string, dest: string): Promise<number> {
-  try {
-    const { mode, uid, gid } = await stat(dest);
-    await remove(dest);
-    await move(src, dest);
-    const afterStat = await stat(dest);
-    if (mode !== afterStat.mode) {
-      debug(`Updating mode to "o${mode.toString(8)}"`);
-      await chmod(dest, mode);
-    }
-    if (uid !== afterStat.uid || gid !== afterStat.gid) {
-      debug(`Updating ownership to "${uid}:${gid}"`);
-      await chown(dest, uid, gid);
-    }
-  } catch (err) {
-    if (isPermissionsError(err)) {
-      error(permError(dest));
-      return 1;
-    }
-    throw err;
-  }
-  return 0;
+  return isYarn
+  ? 'Please run `yarn global upgrade now` to update Now CLI.'
+  : 'Please run `npm update -g now` to update Now CLI.'
 }
 
 export default async function main(ctx: NowContext): Promise<number> {
@@ -192,102 +57,15 @@ export default async function main(ctx: NowContext): Promise<number> {
     return 1;
   }
 
-  const skipConfirmation: boolean = argv['--yes'] || false;
-
   if (argv['--help']) {
     help();
     return 2;
   }
 
-  let explicitVersion = false;
-  let version: string = argv['--release'];
-  const location = process.execPath;
-  const { updateChannel = '' } = ctx.config || {};
   const debugEnabled = argv['--debug'];
-  const channel: string = argv['--channel'] || updateChannel || getDefaultChannel();
   const output = createOutput({ debug: debugEnabled });
-  const { log, error, note, success, print, debug } = output;
+  const { log } = output;
 
-  if (isWin) {
-    error('The `now update` command is not supported on Windows.');
-    log(`To get the latest version, please re-install Now CLI: ${chalk.cyan.underline('https://zeit.co/download')}`);
-    return 1;
-  }
-
-  output.dim(`Now CLI ${pkg.version} update (beta) — https://zeit.co/feedback/update`);
-
-  // Don't update if executing with `node` (i.e. during development)
-  if (!basename(location).startsWith('now')) {
-    note(`Refusing to update file "${location}" because it does not appear to be a \`now\` binary`);
-    return 1;
-  }
-
-  log('Updating Now CLI...');
-
-  if (version) {
-    explicitVersion = true;
-  } else {
-    version = await getLatestVersion(output, channel);
-  }
-
-  if (version === pkg.version) {
-    note(`Now CLI is already the latest version (${chalk.green(version)})`);
-    return 0;
-  }
-
-  const platform = getPlatform(process.platform);
-  const url = getReleaseUrl(version, platform);
-
-  const config: { [name: string]: string } = {
-    platform,
-    arch: 'x64',
-    location,
-    version
-  };
-
-  if (!explicitVersion) {
-    config.version += ` (latest ${chalk.green(channel)} release)`;
-  }
-
-  print(`\n  ${chalk.bold('Configuration')}\n\n`);
-  for (const name of Object.keys(config)) {
-    print(`    ${chalk.cyan(name)}\t${config[name]}\n`);
-  }
-
-  print('\n');
-  log('Downloading `now` binary...');
-  log(`Binary URL: ${chalk.underline.blue(url)}`);
-
-  const confirmed = skipConfirmation || await promptBool(output, 'Update Now CLI?');
-  if (!confirmed) {
-    log('Aborting');
-    return 0;
-  }
-
-  const tmpBin: string = join(tmpdir(), `now-${Math.random().toString(32).slice(-10)}`);
-  let rtn = 0;
-  try {
-    await downloadNowCli(output, url, tmpBin);
-    rtn = await updateNowCli(tmpBin, location);
-  } catch(err) {
-    if (isBusyError(err)) {
-      debug(`Got busy error - falling back to unlink + rename method`);
-      rtn = await removeAndMove(output, tmpBin, location);
-    } else if (isPermissionsError(err)) {
-      error(permError(location));
-      rtn = 1;
-    } else if (err.message.includes('unexpected end of file')) {
-      error('The file download failed. Please check your internet connection and try again.');
-      rtn = 1;
-    } else {
-      throw err;
-    }
-  } finally {
-    await remove(tmpBin);
-  }
-
-  if (rtn === 0) {
-    success(`Updated Now CLI to ${chalk.green(version)}`);
-  }
-  return rtn;
+  log(await getUpgradeCommand());
+  return 0;
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -32,7 +32,7 @@ const help = () => {
   `);
 };
 
-async function getUpgradeCommand() {
+export async function getUpgradeCommand() {
   const isYarn = await pathExists(join(process.cwd(), 'yarn.lock'));
 
   return isYarn

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import * as ERRORS from './util/errors-ts';
 import { NowError } from './util/now-error';
 import { SENTRY_DSN } from './util/constants.ts';
 import { metrics, shouldCollectMetrics } from './util/metrics.ts';
+import { getUpgradeCommand } from './commands/update';
 
 const NOW_DIR = getNowDir();
 const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -135,7 +136,7 @@ const main = async argv_ => {
       )
     );
     console.log(
-      info(`Run ${cmd('npm i -g now')} to update to the latest version`)
+      info(await getUpgradeCommand())
     );
     console.log(
       info(

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ const main = async argv_ => {
       )
     );
     console.log(
-      info(`Run the ${cmd('now update')} command to update to the latest version`)
+      info(`Run ${cmd('npm i -g now')} to update to the latest version`)
     );
     console.log(
       info(

--- a/test/integration.js
+++ b/test/integration.js
@@ -1427,16 +1427,6 @@ test('fail `now dev` dev script without now.json', async t => {
   t.true(stderr.includes('must not contain `now dev`'), `Received instead: "${stderr}"`);
 });
 
-// Make sure to run this test last,
-// otherwise it will overwrite the currently installed version
-test('try to update now to canary', async t => {
-  const { code } = await execute(['update', '--channel', 'canary', '--yes']);
-  t.is(code, 0);
-
-  const { stdout } = await execute(['--version']);
-  t.true(stdout.includes('canary'));
-});
-
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);


### PR DESCRIPTION
Change `now update` to display npm or yarn command, since we'll change it with https://github.com/zeit/now-cli/pull/2567