### PR TITLE
Handles `no-change` domain transfer policy

### DIFF
--- a/src/commands/domains/transfer-in.ts
+++ b/src/commands/domains/transfer-in.ts
@@ -64,7 +64,7 @@ export default async function transferIn(
   }
 
   const availableStamp = stamp();
-  const [domainPrice, { transferable }] = await Promise.all([
+  const [domainPrice, { transferable, transferPolicy }] = await Promise.all([
     getDomainPrice(client, domainName, 'renewal'),
     checkTransfer(client, domainName)
   ]);
@@ -89,7 +89,9 @@ export default async function transferIn(
   const authCode = await getAuthCode(opts['--code']);
 
   const shouldTransfer = await promptBool(
-    `Transfer now with 1yr renewal for ${chalk.bold(`$${price}`)}?`
+    transferPolicy === 'no-change'
+      ? `Transfer now for ${chalk.bold(`$${price}`)}?`
+      : `Transfer now with 1yr renewal for ${chalk.bold(`$${price}`)}?`
   );
   if (!shouldTransfer) {
     return 0;

--- a/src/util/domains/check-transfer.ts
+++ b/src/util/domains/check-transfer.ts
@@ -13,6 +13,12 @@ type Response = {
   transferable: boolean;
   status: Status;
   reason: string;
+  transferPolicy:
+    | 'charge-and-renew'
+    | 'not-supported'
+    | 'no-change'
+    | 'new-term'
+    | null;
 };
 
 export default async function checkTransfer(client: Client, name: string) {


### PR DESCRIPTION
`no-change` domain transfer policies (TLD specific) do not renew domains on transfer, but are still charged for the transfer. This PR removes the `"with a 1 year renewal` copy for `no-change` domain transfers