### PR TITLE
[now dev] Upgrade `@now/build-utils` and enable more support for static sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     ]
   },
   "devDependencies": {
-    "@now/build-utils": "0.8.8",
+    "@now/build-utils": "0.9.0",
     "@now/go": "latest",
     "@now/next": "latest",
     "@now/node": "latest",

--- a/src/util/get-files.ts
+++ b/src/util/get-files.ts
@@ -401,19 +401,18 @@ export async function docker(
 }
 
 /**
- * Get a list of all files inside the `api` directory of the
- * the given path.
+ * Get a list of all files inside the project folder
  *
  * @param {String} of the current working directory
  * @param {Object} output instance
  * @return {Array} of {String}s with the found files
  */
-export async function getApiFiles(cwd: string, { debug }: Output) {
+export async function getAllProjectFiles(cwd: string, { debug }: Output) {
   // We need a slash at the end to remove it later on from the matched files
   const current = join(resolve(cwd), '/');
-  debug(`Searching files in the \`api\` directory inside of ${current}`);
+  debug(`Searching files inside of ${current}`);
 
-  const list = await glob('api/**/*', { cwd: current, absolute: true, nodir: true });
+  const list = await glob('**', { cwd: current, absolute: true, nodir: true });
 
   // We need to replace \ with / for windows
   return list.map((file) => file.replace(current.replace(/\\/g, '/'), ''));

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -259,3 +259,37 @@ test(
     }
   })
 );
+
+test(
+  '[DevServer] Test `public` directory with zero config',
+  testFixture('now-dev-api-with-public', async (t, server) => {
+    {
+      const res = await fetch(`${server.address}/api/user`);
+      const body = await res.text();
+      t.is(body, 'hello:user');
+    }
+
+    {
+      const res = await fetch(`${server.address}/`);
+      const body = await res.text();
+      t.is(body.startsWith('<h1>hello world</h1>'), true);
+    }
+  })
+);
+
+test(
+  '[DevServer] Test static files with zero config',
+  testFixture('now-dev-api-with-static', async (t, server) => {
+    {
+      const res = await fetch(`${server.address}/api/user`);
+      const body = await res.text();
+      t.is(body, 'bye:user');
+    }
+
+    {
+      const res = await fetch(`${server.address}/`);
+      const body = await res.text();
+      t.is(body.startsWith('<h1>goodbye world</h1>'), true);
+    }
+  })
+);

--- a/test/fixtures/unit/now-dev-api-with-public/api/[endpoint].js
+++ b/test/fixtures/unit/now-dev-api-with-public/api/[endpoint].js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.status(200).end(`hello:${req.query.endpoint}`);
+};

--- a/test/fixtures/unit/now-dev-api-with-public/public/index.html
+++ b/test/fixtures/unit/now-dev-api-with-public/public/index.html
@@ -1,0 +1,1 @@
+<h1>hello world</h1>

--- a/test/fixtures/unit/now-dev-api-with-static/api/[endpoint].js
+++ b/test/fixtures/unit/now-dev-api-with-static/api/[endpoint].js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.status(200).end(`bye:${req.query.endpoint}`);
+};

--- a/test/fixtures/unit/now-dev-api-with-static/index.html
+++ b/test/fixtures/unit/now-dev-api-with-static/index.html
@@ -1,0 +1,1 @@
+<h1>goodbye world</h1>

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,10 +344,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@now/build-utils@0.8.8":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.8.8.tgz#9fa8bfd44935a0cc76c01533ded37d92e85c869c"
-  integrity sha512-tnfPZVJ0HrjdOr/cfPY90zxy753lP99Gl1Xwx274WLWz3re525JPv8KI98B93sAzi3jmWV6t2I3twJovxo3v0g==
+"@now/build-utils@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.9.0.tgz#63ff0b37337eee6c568e672341f37929496181f7"
+  integrity sha512-IVdlgBsJgRsDSusuHXutVZM81lao5EOS0FNWSzQXFofbq/8/4A06oJMScjetv66jqrcuXVQX4Zl1g21YigaHZw==
   dependencies:
     async-retry "1.2.3"
     async-sema "2.1.4"


### PR DESCRIPTION
Upgrade `@now/build-utils` and enable more support for static sites

Requires: https://github.com/zeit/now-builders/pull/787