### PR TITLE
[now init] Add suggestions for old examples

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -25,11 +25,11 @@ type Options = {
 
 type Example = {
   name: string,
-  found: boolean,
+  visible: boolean,
   suggestions: string[]
 }
 
-const EXAMPLE_API = 'https://api-examples-8n760qy10.zeit.sh'; // TODO revert
+const EXAMPLE_API = 'https://now-example-files.zeit.sh';
 
 export default async function init(
   ctx: NowContext,
@@ -46,7 +46,7 @@ export default async function init(
     throw new Error(`Could not fetch example list.`);
   }
 
-  const exampleList = examples.filter(x => x.found).map(x => x.name);
+  const exampleList = examples.filter(x => x.visible).map(x => x.name);
 
   if (!name) {
     const chosen = await chooseFromDropdown('Select example:', exampleList);
@@ -63,7 +63,7 @@ export default async function init(
     return extractExample(name, dir, force);
   }
 
-  const oldExample = examples.find(x => !x.found && x.name === name);
+  const oldExample = examples.find(x => !x.visible && x.name === name);
   if (oldExample) {
     const chosen = await chooseFromDropdown('Not found. Select a suggestion:', oldExample.suggestions, );
 

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -65,7 +65,7 @@ export default async function init(
 
   const oldExample = examples.find(x => !x.found && x.name === name);
   if (oldExample) {
-    const chosen = await chooseFromDropdown(oldExample.suggestions, 'No found. Select a suggestion:');
+    const chosen = await chooseFromDropdown(oldExample.suggestions, 'Not found. Select a suggestion:');
 
     if (!chosen) {
       output.log('Aborted');

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -65,10 +65,7 @@ export default async function init(
 
   const oldExample = examples.find(x => !x.found && x.name === name);
   if (oldExample) {
-    if (oldExample.suggestions.length === 1) {
-      return extractExample(oldExample.suggestions[0], dir, force);
-    }
-    const chosen = await chooseFromDropdown(oldExample.suggestions, 'No example found. Suggestions:');
+    const chosen = await chooseFromDropdown(oldExample.suggestions, 'No found. Select a suggestion:');
 
     if (!chosen) {
       output.log('Aborted');

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -68,8 +68,7 @@ export default async function init(
     if (oldExample.suggestions.length === 1) {
       return extractExample(oldExample.suggestions[0], dir, force);
     }
-
-    const chosen = await chooseFromDropdown(oldExample.suggestions);
+    const chosen = await chooseFromDropdown(oldExample.suggestions, 'No example found. Suggestions:');
 
     if (!chosen) {
       output.log('Aborted');
@@ -117,7 +116,7 @@ async function fetchExampleList() {
 /**
  * Prompt user for choosing which example to init
  */
-async function chooseFromDropdown(exampleList: string[]) {
+async function chooseFromDropdown(exampleList: string[], message='Select example:') {
   const choices = exampleList.map(name => ({
     name,
     value: name,
@@ -125,7 +124,7 @@ async function chooseFromDropdown(exampleList: string[]) {
   }));
 
   return listInput({
-    message: 'Select example:',
+    message,
     separator: false,
     choices
   });

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -29,7 +29,7 @@ type Example = {
   suggestions: string[]
 }
 
-const EXAMPLE_API = 'https://api-examples-527czhfis.zeit.sh'; // TODO revert
+const EXAMPLE_API = 'https://api-examples-6ypbtbkt2.zeit.sh'; // TODO revert
 
 export default async function init(
   ctx: NowContext,
@@ -90,14 +90,10 @@ export default async function init(
  */
 async function fetchExampleList() {
   const stopSpinner = wait('Fetching examples');
-  const url = `${EXAMPLE_API}/list.json`;
+  const url = `${EXAMPLE_API}/v2/list.json`;
 
   try {
-    const resp = await fetch(url, {
-      headers: {
-        'x-api-examples-version': '2'
-      }
-    });
+    const resp = await fetch(url);
     stopSpinner();
 
     if (resp.status !== 200) {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -29,7 +29,7 @@ type Example = {
   suggestions: string[]
 }
 
-const EXAMPLE_API = 'https://api-examples-6ypbtbkt2.zeit.sh'; // TODO revert
+const EXAMPLE_API = 'https://api-examples-8n760qy10.zeit.sh'; // TODO revert
 
 export default async function init(
   ctx: NowContext,
@@ -130,7 +130,7 @@ async function extractExample(name: string, dir: string, force?: boolean) {
   const folder = prepareFolder(process.cwd(), dir || name, force);
   const stopSpinner = wait(`Fetching ${name}`);
 
-  const url = `${EXAMPLE_API}/download/${name}.tar.gz`;
+  const url = `${EXAMPLE_API}/v2/download/${name}.tar.gz`;
 
   return fetch(url)
     .then(async resp => {

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -23,7 +23,13 @@ type Options = {
   '-f': boolean;
 };
 
-const EXAMPLE_API = 'https://now-example-files.zeit.sh';
+type Example = {
+  name: string,
+  found: boolean,
+  suggestions: string[]
+}
+
+const EXAMPLE_API = 'https://api-examples-527czhfis.zeit.sh'; // TODO revert
 
 export default async function init(
   ctx: NowContext,
@@ -73,14 +79,18 @@ async function fetchExampleList() {
   const url = `${EXAMPLE_API}/list.json`;
 
   try {
-    const resp = await fetch(url);
+    const resp = await fetch(url, {
+      headers: {
+        'x-api-examples-version': '2'
+      }
+    });
     stopSpinner();
 
     if (resp.status !== 200) {
       throw new Error(`Failed fetching list.json (${resp.statusText}).`);
     }
 
-    return resp.json();
+    return await resp.json() as Example[];
   } catch (e) {
     stopSpinner();
   }
@@ -89,11 +99,11 @@ async function fetchExampleList() {
 /**
  * Prompt user for choosing which example to init
  */
-async function chooseFromDropdown(exampleList: string[]) {
-  const choices = exampleList.map(name => ({
-    name,
-    value: name,
-    short: name
+async function chooseFromDropdown(exampleList: Example[]) {
+  const choices = exampleList.filter(example => example.found).map(example => ({
+    name: example.name,
+    value: example.name,
+    short: example.name
   }));
 
   return listInput({

--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -49,7 +49,7 @@ export default async function init(
   const exampleList = examples.filter(x => x.found).map(x => x.name);
 
   if (!name) {
-    const chosen = await chooseFromDropdown(exampleList);
+    const chosen = await chooseFromDropdown('Select example:', exampleList);
 
     if (!chosen) {
       output.log('Aborted');
@@ -65,7 +65,7 @@ export default async function init(
 
   const oldExample = examples.find(x => !x.found && x.name === name);
   if (oldExample) {
-    const chosen = await chooseFromDropdown(oldExample.suggestions, 'Not found. Select a suggestion:');
+    const chosen = await chooseFromDropdown('Not found. Select a suggestion:', oldExample.suggestions, );
 
     if (!chosen) {
       output.log('Aborted');
@@ -109,7 +109,7 @@ async function fetchExampleList() {
 /**
  * Prompt user for choosing which example to init
  */
-async function chooseFromDropdown(exampleList: string[], message='Select example:') {
+async function chooseFromDropdown(message: string, exampleList: string[]) {
   const choices = exampleList.map(name => ({
     name,
     value: name,


### PR DESCRIPTION
This adds support for `now init` suggestions when an example was deleted from the [now-examples](https://github.com/zeit/now-examples) repository.

Depends on https://github.com/zeit/api-examples/pull/8

Here's what it looks like when I run `now init markdown`

<img src="https://user-images.githubusercontent.com/229881/61560892-97ea0700-aa3b-11e9-87f6-790eea7752ed.png" width="400" />
