### PR TITLE
[now update] Render the proper tag and improve `yarn` detection logic

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,15 +1,11 @@
 import chalk from 'chalk';
-import { Stats } from 'fs';
-import { dirname, join, resolve } from 'path';
-import { readJSON, lstat, readlink } from 'fs-extra';
 
-import cmd from '../util/output/cmd';
 import logo from '../util/output/logo';
 import handleError from '../util/handle-error';
 import getArgs from '../util/get-args';
 import { NowContext } from '../types';
 import createOutput from '../util/output';
-import { version } from '../../package.json';
+import getUpdateCommand from '../util/get-update-command';
 
 const help = () => {
   console.log(`
@@ -35,31 +31,6 @@ const help = () => {
   `);
 };
 
-// `npm` tacks a bunch of extra properties on the `package.json` file,
-// so check for one of them to determine yarn vs. npm.
-async function isYarn(): Promise<boolean> {
-  let s: Stats;
-  let binPath = process.argv[1];
-  while (true) {
-    s = await lstat(binPath);
-    if (s.isSymbolicLink()) {
-      binPath = resolve(dirname(binPath), await readlink(binPath));
-    } else {
-      break;
-    }
-  }
-  const pkgPath = join(dirname(binPath), '..', 'package.json');
-  const pkg = await readJSON(pkgPath);
-  return !('_id' in pkg);
-}
-
-export async function getUpgradeCommand(): Promise<string> {
-  const tag = version.includes('canary') ? 'canary' : 'latest';
-  return (await isYarn())
-    ? `Please run ${cmd(`yarn global add now@${tag}`)} to update Now CLI.`
-    : `Please run ${cmd(`npm install -g now@${tag}`)} to update Now CLI.`;
-}
-
 export default async function main(ctx: NowContext): Promise<number> {
   let argv;
 
@@ -84,6 +55,6 @@ export default async function main(ctx: NowContext): Promise<number> {
 
   const debugEnabled = argv['--debug'];
   const output = createOutput({ debug: debugEnabled });
-  output.log(await getUpgradeCommand());
+  output.log(await getUpdateCommand());
   return 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ import * as ERRORS from './util/errors-ts';
 import { NowError } from './util/now-error';
 import { SENTRY_DSN } from './util/constants.ts';
 import { metrics, shouldCollectMetrics } from './util/metrics.ts';
-import { getUpgradeCommand } from './commands/update';
+import getUpdateCommand from './util/get-update-command';
 
 const NOW_DIR = getNowDir();
 const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -138,7 +138,7 @@ const main = async argv_ => {
       )
     );
     console.log(
-      info(await getUpgradeCommand())
+      info(await getUpdateCommand())
     );
     console.log(
       info(

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -1,0 +1,31 @@
+import { Stats } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { readJSON, lstat, readlink } from 'fs-extra';
+
+import cmd from './output/cmd';
+import { version } from '../../package.json';
+
+// `npm` tacks a bunch of extra properties on the `package.json` file,
+// so check for one of them to determine yarn vs. npm.
+async function isYarn(): Promise<boolean> {
+  let s: Stats;
+  let binPath = process.argv[1];
+  while (true) {
+    s = await lstat(binPath);
+    if (s.isSymbolicLink()) {
+      binPath = resolve(dirname(binPath), await readlink(binPath));
+    } else {
+      break;
+    }
+  }
+  const pkgPath = join(dirname(binPath), '..', 'package.json');
+  const pkg = await readJSON(pkgPath);
+  return !('_id' in pkg);
+}
+
+export default async function getUpdateCommand(): Promise<string> {
+  const tag = version.includes('canary') ? 'canary' : 'latest';
+  return (await isYarn())
+    ? `Please run ${cmd(`yarn global add now@${tag}`)} to update Now CLI.`
+    : `Please run ${cmd(`npm install -g now@${tag}`)} to update Now CLI.`;
+}

--- a/test/integration.js
+++ b/test/integration.js
@@ -1448,6 +1448,11 @@ test('fail `now dev` dev script without now.json', async t => {
   );
 });
 
+test('detect update command', async t => {
+  const { code, stderr } = await execute(['update']);
+  t.regex(stderr, /yarn global add now@/gm, `Received: "${stderr}"`);
+});
+
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);

--- a/test/unit.js
+++ b/test/unit.js
@@ -20,7 +20,6 @@ import {
   staticFiles as getStaticFiles_
 } from '../src/util/get-files';
 import didYouMean from '../src/util/init/did-you-mean';
-import getUpdateCommand from '../src/util/get-update-command';
 
 const output = createOutput({ debug: false });
 const prefix = `${join(__dirname, 'fixtures', 'unit')}/`;
@@ -897,9 +896,4 @@ test('guess user\'s intention with custom didYouMean', async t => {
   t.is(didYouMean('koa', examples, 0.7), 'nodejs-koa');
   t.is(didYouMean('node', examples, 0.7), 'nodejs');
   t.is(didYouMean('12345', examples, 0.7), undefined);
-});
-
-test('update command detection', async t => {
-  const command = await getUpdateCommand();
-  t.regex(/yarn global add now@/, command);
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -20,6 +20,7 @@ import {
   staticFiles as getStaticFiles_
 } from '../src/util/get-files';
 import didYouMean from '../src/util/init/did-you-mean';
+import getUpdateCommand from '../src/util/get-update-command';
 
 const output = createOutput({ debug: false });
 const prefix = `${join(__dirname, 'fixtures', 'unit')}/`;
@@ -896,4 +897,9 @@ test('guess user\'s intention with custom didYouMean', async t => {
   t.is(didYouMean('koa', examples, 0.7), 'nodejs-koa');
   t.is(didYouMean('node', examples, 0.7), 'nodejs');
   t.is(didYouMean('12345', examples, 0.7), undefined);
+});
+
+test('update command detection', async t => {
+  const command = await getUpdateCommand();
+  t.regex(/yarn global add now@/, command);
 });


### PR DESCRIPTION
Before this the suggested command would always have you install the stable version of `now`.

With this change the `@canary` tag will be suggested if the version of `now` is from the canary release channel.

Also updates the `isYarn` detection logic to not consider the cwd, and instead check the installed version of now's `package.json` for clues.