### PR TITLE
[CircleCI] Run integration tests on multiple versions of Node.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,27 @@ jobs:
           paths:
             - .nyc_output
 
-  test-integration:
+  test-integration-macos:
     macos:
       xcode: '10.0.0'
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Running Integration Tests
+          command: yarn test-integration --clean false
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
+  test-integration-node-8:
+    docker:
+      - image: circleci/node:8
     working_directory: ~/repo
     steps:
       - checkout
@@ -181,7 +199,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-integration:
+      - test-integration-macos:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test-integration-node-8:
           requires:
             - build
           filters:
@@ -190,7 +214,8 @@ workflows:
       - coverage:
           requires:
             - test-unit
-            - test-integration
+            - test-integration-macos
+            - test-integration-node-8
             - test-lint
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,42 @@ jobs:
           name: Running Integration Tests for `now dev`
           command: yarn test-integration-now-dev --clean false
 
+  test-integration-node-10:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Running Integration Tests
+          command: yarn test-integration --clean false
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
+  test-integration-node-12:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Running Integration Tests
+          command: yarn test-integration --clean false
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
   coverage:
     docker:
       - image: circleci/node:10
@@ -211,11 +247,25 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-integration-node-10:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test-integration-node-12:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
       - coverage:
           requires:
             - test-unit
             - test-integration-macos
             - test-integration-node-8
+            - test-integration-node-10
+            - test-integration-node-12
             - test-lint
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,24 +92,6 @@ jobs:
           name: Running Integration Tests for `now dev`
           command: yarn test-integration-now-dev --clean false
 
-  test-integration-node-8:
-    docker:
-      - image: circleci/node:8
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Output version
-          command: node --version
-      - run:
-          name: Running Integration Tests
-          command: yarn test-integration --clean false
-      - run:
-          name: Running Integration Tests for `now dev`
-          command: yarn test-integration-now-dev --clean false
-
   test-integration-node-10:
     docker:
       - image: circleci/node:10
@@ -241,12 +223,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-integration-node-8:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
       - test-integration-node-10:
           requires:
             - build
@@ -263,7 +239,6 @@ workflows:
           requires:
             - test-unit
             - test-integration-macos
-            - test-integration-node-8
             - test-integration-node-10
             - test-integration-node-12
             - test-lint

--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -4,8 +4,7 @@ const { randomBytes } = require('crypto');
 
 // Packages
 const { imageSync: getImageFile } = require('qr-image');
-const { promises: { writeFile } } = require('fs');
-const { mkdirp } = require('fs-extra');
+const { mkdirp, writeFile } = require('fs-extra');
 
 const getDockerFile = session => `
   FROM mhart/alpine-node:latest

--- a/test/integration.js
+++ b/test/integration.js
@@ -7,6 +7,7 @@ import { homedir } from 'os';
 import execa from 'execa';
 import fetch from 'node-fetch';
 import tmp from 'tmp-promise';
+import { writeFile, readFile } from 'fs-extra';
 import logo from '../src/util/output/logo';
 import sleep from '../src/util/sleep';
 import pkg from '../package';
@@ -119,7 +120,7 @@ test.before(async () => {
     if (!fs.existsSync(location)) {
       await createDirectory(location);
     }
-    await fs.promises.writeFile(
+    await writeFile(
       path.join(location, `auth.json`),
       JSON.stringify({ token })
     );
@@ -1084,7 +1085,7 @@ test('deploy single static file', async t => {
   const contentType = response.headers.get('content-type');
 
   t.is(contentType, 'image/png');
-  t.deepEqual(await fs.promises.readFile(file), await response.buffer());
+  t.deepEqual(await readFile(file), await response.buffer());
 });
 
 test('deploy a static directory', async t => {


### PR DESCRIPTION
<strike>The tests are currently failing due to Node 8 syntax errors. Will fix.</strike>

Removed Node 8, it won't be supported