### PR TITLE
[now update] Don't check for updates on `now update`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,13 +112,20 @@ const main = async argv_ => {
     return 1;
   }
 
+  // the second argument to the command can be a path
+  // (as in: `now path/`) or a subcommand / provider
+  // (as in: `now ls`)
+  const targetOrSubcommand = argv._[2];
+
   let update = null;
 
   try {
-    update = await checkForUpdate(pkg, {
-      interval: ms('1d'),
-      distTag: pkg.version.includes('canary') ? 'canary' : 'latest'
-    });
+    if (targetOrSubcommand !== 'update') {
+      update = await checkForUpdate(pkg, {
+        interval: ms('1d'),
+        distTag: pkg.version.includes('canary') ? 'canary' : 'latest'
+      });
+    }
   } catch (err) {
     console.error(
       error(`Checking for updates failed${isDebugging ? ':' : ''}`)
@@ -148,11 +155,6 @@ const main = async argv_ => {
   }
 
   debug(`Using Now CLI ${pkg.version}`);
-
-  // the second argument to the command can be a path
-  // (as in: `now path/`) or a subcommand / provider
-  // (as in: `now ls`)
-  const targetOrSubcommand = argv._[2];
 
   // we want to handle version or help directly only
   if (!targetOrSubcommand) {


### PR DESCRIPTION
Don't check for updates on `now update`, since it would just display the command twice.