### PR TITLE
Don't use `fs.promises` to prevent warnings

### DIFF
--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -1,5 +1,5 @@
+import fs from 'fs-extra';
 import { resolve, basename, parse } from 'path';
-import { promises as fs } from 'fs';
 import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
 import createOutput from '../../util/output';

--- a/src/commands/deploy/legacy.js
+++ b/src/commands/deploy/legacy.js
@@ -4,7 +4,7 @@ import { write as copy } from 'clipboardy';
 import bytes from 'bytes';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
-import { promises as fs } from 'fs';
+import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import mri from 'mri';
 import ms from 'ms';

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -617,7 +617,7 @@ export default class DevServer {
     const results: { [filePath: string]: FileFsRef } = {};
     for (const fsPath of files) {
       const path = relative(this.cwd, fsPath);
-      const { mode } = await fs.promises.stat(fsPath);
+      const { mode } = await fs.stat(fsPath);
       results[path] = new FileFsRef({ mode, fsPath });
     }
     this.files = results;

--- a/src/util/git.js
+++ b/src/util/git.js
@@ -5,7 +5,7 @@ import url from 'url';
 import childProcess from 'child_process';
 
 // Packages
-import { promises as fs } from 'fs';
+import fs from 'fs-extra';
 
 import download from 'download';
 import tmp from 'tmp-promise';

--- a/src/util/hash.js
+++ b/src/util/hash.js
@@ -2,7 +2,7 @@
 import { createHash } from 'crypto';
 
 // Packages
-import fs from 'fs';
+import fs from 'fs-extra';
 
 /**
   * Computes hashes for the contents of each file given.
@@ -16,7 +16,7 @@ async function hashes(files) {
 
   await Promise.all(
     files.map(async name => {
-      const data = await fs.promises.readFile(name);
+      const data = await fs.readFile(name);
 
       const h = hash(data);
       const entry = map.get(h);

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -7,7 +7,8 @@ import bytes from 'bytes';
 import chalk from 'chalk';
 import retry from 'async-retry';
 import { parse as parseIni } from 'ini';
-import { createReadStream, promises } from 'fs';
+import { createReadStream } from 'fs';
+import fs from 'fs-extra';
 import ms from 'ms';
 import { URLSearchParams } from 'url';
 import {
@@ -177,7 +178,7 @@ export default class Now extends EventEmitter {
             [],
             await Promise.all(
               Array.from(this._files).map(async ([sha, { data, names }]) => {
-                const statFn = followSymlinks ? promises.stat : promises.lstat;
+                const statFn = followSymlinks ? fs.stat : fs.lstat;
 
                 return names.map(async name => {
                   const getMode = async () => {
@@ -861,7 +862,7 @@ function hasFile(base, files, name) {
 
 async function readAuthToken(path, name = '.npmrc') {
   try {
-    const contents = await promises.readFile(resolvePath(path, name), 'utf8');
+    const contents = await fs.readFile(resolvePath(path, name), 'utf8');
     const npmrc = parseIni(contents);
     return npmrc['//registry.npmjs.org/:_authToken'];
   } catch (err) {

--- a/src/util/read-json-file.ts
+++ b/src/util/read-json-file.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs-extra';
 import { CantParseJSONFile } from './errors-ts';
 
 export default async function readJSONFile(
@@ -19,7 +19,7 @@ export default async function readJSONFile(
 
 async function readFileSafe(file: string) {
   if (fs.existsSync(file)) {
-    const content = await fs.promises.readFile(file);
+    const content = await fs.readFile(file);
     return content.toString();
   }
 

--- a/src/util/read-metadata.js
+++ b/src/util/read-metadata.js
@@ -2,7 +2,7 @@ import { basename, resolve as resolvePath } from 'path';
 import chalk from 'chalk';
 import loadJSON from 'load-json-file';
 import loadPackageJSON from 'read-pkg';
-import fs from 'fs';
+import fs from 'fs-extra';
 import { parse as parseDockerfile } from 'docker-file-parser';
 import determineType from 'deployment-type';
 import getLocalConfigPath from './config/local-path';
@@ -179,6 +179,6 @@ function decorateUserErrors(fn) {
 const readPkg = decorateUserErrors(loadPackageJSON);
 const readJSON = decorateUserErrors(loadJSON);
 const readDockerfile = decorateUserErrors(async (path, name = 'Dockerfile') => {
-  const contents = await fs.promises.readFile(resolvePath(path, name), 'utf8');
+  const contents = await fs.readFile(resolvePath(path, name), 'utf8');
   return parseDockerfile(contents, { includeComments: true });
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -149,6 +149,7 @@ test('print the deploy help message', async t => {
 
   t.is(code, 2);
   t.true(stderr.includes(deployHelpMessage));
+  t.false(stderr.includes('ExperimentalWarning'));
 });
 
 test('output the version', async t => {


### PR DESCRIPTION
Don't use `fs.promises` to prevent warnings from node.