### PR TITLE
Add "engines" field to `package.json` for Node 10 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
       "esm"
     ]
   },
+  "engines": {
+    "node": ">= 10"
+  },
   "devDependencies": {
     "@now/build-utils": "0.9.2",
     "@now/go": "latest",


### PR DESCRIPTION
`now-cli` does not work on Node 8 and below because generator functions are not supported.