### PR TITLE
[now dev] Remove useless `debug()` call

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -171,11 +171,6 @@ export default class DevServer {
       }
     }
 
-    if (filesChanged.has('now.json') || filesRemoved.has('now.json')) {
-      // The `now.json` file was changed, so invalidate the in-memory copy
-      this.output.debug('Invalidating cached `now.json`');
-    }
-
     // Update the build matches in case an entrypoint was created or deleted
     const nowConfig = await this.getNowConfig(false);
     await this.updateBuildMatches(nowConfig);


### PR DESCRIPTION
The `getNowConfig(false)` used to be within this `if` branch, so the debug call made sense there at the time, but as of zero config it got moved to always be invoked, so this `debug()` call doesn't make sense anymore.