### PR TITLE
[now deploy] Respect `--debug` flag for API Client

### DIFF
--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -41,7 +41,8 @@ export default async ctx => {
   }
 
   const localConfig = readLocalConfig(paths[0]);
-  const output = createOutput({ debug: argv['--debug'] });
+  const debugEnabled = argv['--debug'];
+  const output = createOutput({ debug: debugEnabled });
   const stats = {};
   const versionFlag = argv['--platform-version'];
 
@@ -82,7 +83,7 @@ export default async ctx => {
       apiUrl,
       token: authConfig.token,
       currentTeam,
-      debug: false
+      debug: debugEnabled
     });
     try {
       ({ contextName, platformVersion } = await getScope(client));

--- a/src/commands/deploy/latest.js
+++ b/src/commands/deploy/latest.js
@@ -366,7 +366,8 @@ export default async function main(
         new Client({
           apiUrl: ctx.apiUrl,
           token: ctx.authConfig.token,
-          currentTeam: ctx.config.currentTeam
+          currentTeam: ctx.config.currentTeam,
+          debug: debugEnabled
         }),
         firstDeployCall.meta.domain,
         contextName


### PR DESCRIPTION
While debugging #2606, I noticed that the `Client` instances for `now deploy` were not being supplied the appropriate `debug` flag based on the command line args.