### PR TITLE
Remove leftover references to `pkg`

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -58,7 +58,7 @@ async function main() {
 
   // `now dev` uses chokidar to watch the filesystem, but opts-out of the
   // `fsevents` feature using `useFsEvents: false`, so delete the module here so
-  // that it is not compiled by ncc, which makes the pkg'd binary size larger
+  // that it is not compiled by ncc, which makes the npm package size larger
   // than necessary.
   await remove(join(dirRoot, 'node_modules/fsevents'));
 
@@ -82,7 +82,7 @@ async function main() {
   // should be copied into the output runtimes dir, specifically the `index.js`
   // files (correctly) do not get copied into the output bundle because they
   // get compiled into the final ncc bundle file, however, we want them to be
-  // present on pkg's snapshot fs because the contents of those files are involved
+  // present in the npm package because the contents of those files are involved
   // with `fun`'s cache invalidation mechanism and they need to be shasum'd.
   const runtimes = join(dirRoot, 'node_modules/@zeit/fun/dist/src/runtimes');
   const dest = join(dirRoot, 'dist/runtimes');

--- a/src/index.js
+++ b/src/index.js
@@ -43,16 +43,8 @@ const NOW_CONFIG_PATH = configFiles.getConfigFilePath();
 const NOW_AUTH_CONFIG_PATH = configFiles.getAuthConfigFilePath();
 
 const GLOBAL_COMMANDS = new Set(['help']);
-const insidePkg = process.pkg;
 
 epipebomb();
-
-// we only enable source maps while developing, since
-// they have a small performance hit. for this, we
-// look for `pkg`, which is only present in the final bin
-if (!insidePkg) {
-  sourceMap.install();
-}
 
 // Configure the error reporting system
 Sentry.init({

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,8 @@ const GLOBAL_COMMANDS = new Set(['help']);
 
 epipebomb();
 
+sourceMap.install();
+
 // Configure the error reporting system
 Sentry.init({
   dsn: SENTRY_DSN,

--- a/src/util/report-error.js
+++ b/src/util/report-error.js
@@ -3,11 +3,6 @@ import getScope from './get-scope.ts';
 import getArgs from './get-args';
 
 export default async (sentry, error, apiUrl, configFiles) => {
-  // Do not report errors in development
-  if (!process.pkg) {
-    return;
-  }
-
   let user = null;
   let team = null;
 


### PR DESCRIPTION
We are no longer compiling `now-cli` with `pkg` so this is dead code.