### PR TITLE
[now deploy] Determine platform version through `Dockerfile` and `package.json`

### DIFF
--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -24,7 +24,7 @@ async function hasPkgStartScript(cwd) {
     return false;
   }
 
-  const { scripts } = pkg;
+  const { scripts = {} } = pkg;
 
   if (scripts.start || scripts['now-start']) {
     return true;

--- a/src/util/prefer-v2-deployment.ts
+++ b/src/util/prefer-v2-deployment.ts
@@ -24,7 +24,7 @@ export default async function preferV2Deployment({
   localConfig: Config | undefined
 }): Promise<null | string> {
   if (localConfig && localConfig.version) {
-    // We will prefere anything that is set here
+    // We will prefer anything that is set here
     return null;
   }
 

--- a/src/util/prefer-v2-deployment.ts
+++ b/src/util/prefer-v2-deployment.ts
@@ -1,0 +1,46 @@
+import { join } from 'path';
+import { exists } from 'fs-extra';
+import { Config } from '../types';
+import { Package } from './dev/types';
+import {CantParseJSONFile } from './errors-ts';
+
+import cmd from './output/cmd';
+import code from './output/code';
+import highlight from './output/highlight';
+
+export async function hasDockerfile(cwd: string) {
+  return new Promise(res => exists(join(cwd, 'Dockerfile'), res));
+}
+
+const PREFIX = `Changing platform version to ${code('2')}`;
+
+export default async function preferV2Deployment({
+  hasDockerfile,
+  pkg,
+  localConfig
+}: {
+  hasDockerfile: boolean,
+  pkg: Package | CantParseJSONFile | null,
+  localConfig: Config | undefined
+}): Promise<null | string> {
+  if (localConfig && localConfig.version) {
+    // We will prefere anything that is set here
+    return null;
+  }
+
+  if (localConfig && localConfig.type) {
+    return null;
+  }
+
+  if (pkg && !(pkg instanceof Error) && !hasDockerfile) {
+    const { scripts = {} } = pkg;
+
+    if (!scripts.start && !scripts['now-start']) {
+      return `${PREFIX}: ${highlight('package.json')} has no ${cmd('start')} script`;
+    }
+  } else if (!pkg && !hasDockerfile) {
+    return `${PREFIX}: no ${highlight('Dockerfile')} found`;
+  }
+
+  return null;
+}

--- a/test/unit.js
+++ b/test/unit.js
@@ -905,7 +905,7 @@ test('check platform version chanage with `preferV2Deployment`', async t => {
     const pkg = null;
     const hasDockerfile = false;
     const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
-    t.regex(reason, /no Dockerfile found/);
+    t.regex(reason, /no `?Dockerfile`? found/);
   }
 
   {

--- a/test/unit.js
+++ b/test/unit.js
@@ -905,7 +905,7 @@ test('check platform version chanage with `preferV2Deployment`', async t => {
     const pkg = null;
     const hasDockerfile = false;
     const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
-    t.regex(reason, /no `?Dockerfile`? found/);
+    t.regex(reason, /Dockerfile/gm);
   }
 
   {
@@ -945,6 +945,6 @@ test('check platform version chanage with `preferV2Deployment`', async t => {
     const pkg = { scripts: { 'build': 'echo hi' } };
     const hasDockerfile = false;
     const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
-    t.regex(reason, /package\.json/);
+    t.regex(reason, /package\.json/gm);
   }
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -20,6 +20,7 @@ import {
   staticFiles as getStaticFiles_
 } from '../src/util/get-files';
 import didYouMean from '../src/util/init/did-you-mean';
+import preferV2Deployment from '../src/util/prefer-v2-deployment';
 
 const output = createOutput({ debug: false });
 const prefix = `${join(__dirname, 'fixtures', 'unit')}/`;
@@ -896,4 +897,54 @@ test('guess user\'s intention with custom didYouMean', async t => {
   t.is(didYouMean('koa', examples, 0.7), 'nodejs-koa');
   t.is(didYouMean('node', examples, 0.7), 'nodejs');
   t.is(didYouMean('12345', examples, 0.7), undefined);
+});
+
+test('check platform version chanage with `preferV2Deployment`', async t => {
+  {
+    const localConfig = undefined;
+    const pkg = null;
+    const hasDockerfile = false;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.regex(reason, /no `Dockerfile` found/);
+  }
+
+  {
+    const localConfig = undefined;
+    const pkg = { scripts: { 'start': 'echo hi' } };
+    const hasDockerfile = false;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.is(reason, null);
+  }
+
+  {
+    const localConfig = undefined;
+    const pkg = { scripts: { 'now-start': 'echo hi' } };
+    const hasDockerfile = false;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.is(reason, null);
+  }
+
+  {
+    const localConfig = { 'version': 1 };
+    const pkg = null;
+    const hasDockerfile = false;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.is(reason, null);
+  }
+
+  {
+    const localConfig = undefined;
+    const pkg = null;
+    const hasDockerfile = true;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.is(reason, null);
+  }
+
+  {
+    const localConfig = undefined;
+    const pkg = { scripts: { 'build': 'echo hi' } };
+    const hasDockerfile = false;
+    const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
+    t.regex(reason, /package\.json/);
+  }
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -905,7 +905,7 @@ test('check platform version chanage with `preferV2Deployment`', async t => {
     const pkg = null;
     const hasDockerfile = false;
     const reason = await preferV2Deployment({ localConfig, pkg, hasDockerfile });
-    t.regex(reason, /no `Dockerfile` found/);
+    t.regex(reason, /no Dockerfile found/);
   }
 
   {


### PR DESCRIPTION
When the users platform version is set to `1`, but the project is missing a `Dockerfile` and / or a `package.json` with a `start` script, or if it was not set otherwise, then we'll default to `2` instead.