### PR TITLE
[now dev] Add `server: now` response header

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -812,6 +812,7 @@ export default class DevServer {
     const allHeaders = {
       'cache-control': 'public, max-age=0, must-revalidate',
       ...headers,
+      'server': 'now',
       'x-now-trace': 'dev1',
       'x-now-id': nowRequestId,
       'x-now-cache': 'MISS'

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -43,6 +43,7 @@ function testFixture(name, fn) {
 
 function validateResponseHeaders(t, res) {
   t.is(res.headers.get('x-now-trace'), 'dev1');
+  t.is(res.headers.get('server'), 'now');
   t.truthy(res.headers.get('cache-control').length > 0);
   t.truthy(
     /^dev1:[0-9a-z]{5}-[1-9][0-9]+-[a-f0-9]{12}$/.test(


### PR DESCRIPTION
Matches production.