### PR TITLE
[CircleCI] Add seperate jobs for `now dev` integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,6 @@ jobs:
       - run:
           name: Running Integration Tests
           command: yarn test-integration --clean false
-      - run:
-          name: Downloading Hugo
-          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.56.0/hugo_0.56.0_macOS-64bit.tar.gz && tar -xzf hugo_0.56.0_macOS-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
-      - run:
-          name: Running Integration Tests for `now dev`
-          command: yarn test-integration-now-dev --clean false
 
   test-integration-node-8:
     docker:
@@ -109,12 +103,6 @@ jobs:
       - run:
           name: Running Integration Tests
           command: yarn test-integration --clean false
-      - run:
-          name: Downloading Hugo
-          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
-      - run:
-          name: Running Integration Tests for `now dev`
-          command: yarn test-integration-now-dev --clean false
 
   test-integration-node-10:
     docker:
@@ -130,12 +118,6 @@ jobs:
       - run:
           name: Running Integration Tests
           command: yarn test-integration --clean false
-      - run:
-          name: Downloading Hugo
-          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
-      - run:
-          name: Running Integration Tests for `now dev`
-          command: yarn test-integration-now-dev --clean false
 
   test-integration-node-12:
     docker:
@@ -151,6 +133,72 @@ jobs:
       - run:
           name: Running Integration Tests
           command: yarn test-integration --clean false
+
+  test-integration-now-dev-macos:
+    macos:
+      xcode: '10.0.0'
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Downloading Hugo
+          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.56.0/hugo_0.56.0_macOS-64bit.tar.gz && tar -xzf hugo_0.56.0_macOS-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
+  test-integration-now-dev-node-8:
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Downloading Hugo
+          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
+  test-integration-now-dev-node-10:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
+      - run:
+          name: Downloading Hugo
+          command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
+      - run:
+          name: Running Integration Tests for `now dev`
+          command: yarn test-integration-now-dev --clean false
+
+  test-integration-now-dev-node-12:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Output version
+          command: node --version
       - run:
           name: Downloading Hugo
           command: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz && mv ./hugo test/dev/fixtures/08-hugo
@@ -271,6 +319,30 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-integration-now-dev-macos:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test-integration-now-dev-node-8:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test-integration-now-dev-node-10:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test-integration-now-dev-node-12:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
       - coverage:
           requires:
             - test-unit
@@ -278,6 +350,10 @@ workflows:
             - test-integration-node-8
             - test-integration-node-10
             - test-integration-node-12
+            - test-integration-now-dev-macos
+            - test-integration-now-dev-node-8
+            - test-integration-now-dev-node-10
+            - test-integration-now-dev-node-12
             - test-lint
           filters:
             tags:


### PR DESCRIPTION
Run the `now dev` integration tests in parallel with the "standard" integration tests, since they both take a long time. This should cut the CI testing time in about half.

**BEFORE:** ~26m

<img width="966" alt="Screen Shot 2019-07-29 at 6 26 19 PM" src="https://user-images.githubusercontent.com/71256/62093528-786a8f80-b22e-11e9-80cf-1a14a13bc412.png">

**AFTER:** ~15m

<img width="972" alt="Screen Shot 2019-07-29 at 6 26 48 PM" src="https://user-images.githubusercontent.com/71256/62093535-7ef90700-b22e-11e9-8d7e-44ba08064e1a.png">
