### PR TITLE
[now deploy] Change link for legacy warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "ava": "1.4.1",
     "bytes": "3.0.0",
     "cache-or-tmp-directory": "1.0.0",
-    "chalk": "2.3.1",
+    "chalk": "2.4.2",
     "chokidar": "2.1.6",
     "clipboardy": "1.1.4",
     "codecov": "3.1.0",

--- a/src/commands/deploy/legacy.ts
+++ b/src/commands/deploy/legacy.ts
@@ -1,4 +1,4 @@
-import { resolve, basename } from 'path';
+import { resolve, basename, join } from 'path';
 import { eraseLines } from 'ansi-escapes';
 // @ts-ignore
 import { write as copy } from 'clipboardy';
@@ -78,6 +78,8 @@ import {
 } from '../../util/errors';
 import { SchemaValidationFailed } from '../../util/errors';
 import handleCertError from '../../util/certs/handle-cert-error';
+import readPackage from '../../util/read-package';
+import { Package } from '../../util/dev/types';
 
 interface Env {
   [name: string]: string | null | undefined;
@@ -221,6 +223,43 @@ const promptForEnvFields = async (list: string[]) => {
   return answers;
 };
 
+async function canUseZeroConfig(cwd: string): Promise<boolean> {
+  try {
+    const pkg = (await readPackage(join(cwd, 'package.json'))) as null | Error | Package;
+
+    if (!pkg || pkg instanceof Error) {
+      return false;
+    }
+
+    const deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+
+    // We can only check for a few frontends,
+    // since can never be sure if APIs will work
+    // with zero-config
+    if (
+      deps.next ||
+      deps.nuxt ||
+      deps.gatsby ||
+      deps.hexo ||
+      deps.gridsome ||
+      deps.umi ||
+      deps.docusaurus ||
+      deps['@docusaurus/core'] ||
+      deps['preact-cli'] ||
+      deps['ember-cli'] ||
+      deps['@vue/cli-service'] ||
+      deps['@angular/cli'] ||
+      deps['polymer-cli'] ||
+      deps['sirv-cli'] ||
+      deps['react-scripts']
+    ) {
+      return true;
+    }
+  } catch(_) {}
+
+  return false;
+}
+
 export default async function main(
   ctx: any,
   contextName: string,
@@ -262,11 +301,11 @@ export default async function main(
   quiet = !isTTY;
   ({ log, error, note, debug, warn } = output);
 
-  warn(
-    `You are using an old version of the Now Platform. More: ${
-      link('https://zeit.co/guides/migrate-to-zeit-now')
-    }`
-  );
+  const infoUrl = await canUseZeroConfig(paths[0])
+    ? 'https://zeit.co/guides/migrate-to-zeit-now'
+    : 'https://zeit.co/docs/v2/advanced/platform/changes-in-now-2-0'
+
+  warn(`You are using an old version of the Now Platform. More: ${link(infoUrl)}`);
 
   const {
     authConfig: { token },
@@ -1258,12 +1297,12 @@ function handleCreateDeployError(output: Output, error: Error) {
       return 1;
     }
 
-    const link = 'https://zeit.co/docs/v2/deployments/configuration/';
-
     output.error(
       `Failed to validate ${highlight(
         'now.json'
-      )}: ${message}\nDocumentation: ${link}`
+      )}: ${message}\nDocumentation: ${
+        link('https://zeit.co/docs/v2/deployments/configuration/')
+      }`
     );
 
     return 1;

--- a/src/commands/deploy/legacy.ts
+++ b/src/commands/deploy/legacy.ts
@@ -264,7 +264,7 @@ export default async function main(
 
   warn(
     `You are using an old version of the Now Platform. More: ${
-      link('https://zeit.co/guides/migrate-to-zeit-now/')
+      link('https://zeit.co/guides/migrate-to-zeit-now')
     }`
   );
 

--- a/src/commands/deploy/legacy.ts
+++ b/src/commands/deploy/legacy.ts
@@ -22,6 +22,7 @@ import checkPath from '../../util/check-path';
 import cmd from '../../util/output/cmd';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
+import link from '../../util/output/link';
 // @ts-ignore
 import exit from '../../util/exit';
 // @ts-ignore
@@ -262,7 +263,9 @@ export default async function main(
   ({ log, error, note, debug, warn } = output);
 
   warn(
-    'You are using an old version of the Now Platform. More: https://zeit.co/docs/v1-upgrade'
+    `You are using an old version of the Now Platform. More: ${
+      link('https://zeit.co/guides/migrate-to-zeit-now/')
+    }`
   );
 
   const {

--- a/src/commands/deploy/legacy.ts
+++ b/src/commands/deploy/legacy.ts
@@ -1301,7 +1301,7 @@ function handleCreateDeployError(output: Output, error: Error) {
       `Failed to validate ${highlight(
         'now.json'
       )}: ${message}\nDocumentation: ${
-        link('https://zeit.co/docs/v2/deployments/configuration/')
+        link('https://zeit.co/docs/v2/advanced/configuration')
       }`
     );
 

--- a/src/commands/deploy/legacy.ts
+++ b/src/commands/deploy/legacy.ts
@@ -225,7 +225,7 @@ const promptForEnvFields = async (list: string[]) => {
 
 async function canUseZeroConfig(cwd: string): Promise<boolean> {
   try {
-    const pkg = (await readPackage(join(cwd, 'package.json'))) as null | Error | Package;
+    const pkg = (await readPackage(join(cwd, 'package.json')));
 
     if (!pkg || pkg instanceof Error) {
       return false;

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -23,6 +23,7 @@ import {
 } from '@now/build-utils';
 
 import { once } from '../once';
+import link from '../output/link';
 import { Output } from '../output';
 import { relative } from '../path-helpers';
 import getNowConfigPath from '../config/local-path';
@@ -708,7 +709,7 @@ export default class DevServer {
     }
 
     this.address = address.replace('[::]', 'localhost');
-    this.output.ready(`Available at ${chalk.cyan.underline(this.address)}`);
+    this.output.ready(`Available at ${link(this.address)}`);
 
     this.serverUrlPrinted = true;
   }

--- a/src/util/output/link.js
+++ b/src/util/output/link.js
@@ -1,5 +1,0 @@
-import { underline } from 'chalk';
-
-const highlight = text => underline(text);
-
-export default highlight;

--- a/src/util/output/link.ts
+++ b/src/util/output/link.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk';
+
+const link = (text: string) => chalk.cyan.underline(text);
+
+export default link;

--- a/src/util/output/link.ts
+++ b/src/util/output/link.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
 
-const link = (text: string) => chalk.cyan.underline(text);
+const link = chalk.cyan.underline;
 
 export default link;

--- a/src/util/read-package.ts
+++ b/src/util/read-package.ts
@@ -2,11 +2,11 @@ import path from 'path';
 import { CantParseJSONFile } from './errors-ts';
 import readJSONFile from './read-json-file';
 import { Config } from '../types';
+import { Package } from './dev/types';
 
-type Package = {
-  name: string;
-  now?: Config;
-};
+interface CustomPackage extends Package {
+  now?: Config
+}
 
 export default async function readPackage(file?: string) {
   const pkgFilePath = file || path.resolve(process.cwd(), 'package.json');
@@ -17,7 +17,7 @@ export default async function readPackage(file?: string) {
   }
 
   if (result){
-    return result as Package
+    return result as CustomPackage
   }
 
   return null;

--- a/test/helpers/prepare.js
+++ b/test/helpers/prepare.js
@@ -204,6 +204,16 @@ RUN echo $NONCE > /public/index.html
           dev: 'now dev'
         }
       }, null, 2)
+    },
+    'v1-warning-link': {
+      'now.json': JSON.stringify({
+        version: 1
+      }),
+      'package.json': JSON.stringify({
+        dependencies: {
+          next: '9.0.0'
+        }
+      })
     }
   };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1454,3 +1454,15 @@ test.after.always(async () => {
   // Remove config directory entirely
   tmpDir.removeCallback();
 });
+
+test('print correct link in legacy warning', async t => {
+  const deploymentPath = fixture('v1-warning-link');
+  const { code, stderr } = await execute([deploymentPath]);
+
+  console.log(stderr);
+
+  // It is expected to fail,
+  // since the package.json does not have a start script
+  t.is(code, 1);
+  t.regex(stderr, /migrate-to-zeit-now/);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,16 +1484,7 @@ chalk@2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
-  integrity sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==
-  dependencies:
-    ansi-styles "^3.2.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.2.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6142,7 +6133,7 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.3.0:
+supports-color@^5.1.0, supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
This changes the link for the legacy warning to https://zeit.co/guides/migrate-to-zeit-now or https://zeit.co/docs/v2/advanced/platform/changes-in-now-2-0 when we can't detect zero-config.

It further bumps `chalk` to `2.4.2` and adjusts the `link` output function.

![image](https://user-images.githubusercontent.com/16088670/62236871-3aa56c80-b3d0-11e9-90b4-7d36669e8980.png)

Fixes #2667
