### PR TITLE
[now dev] Use a consistent "pod id" for `x-now-id`

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -108,6 +108,7 @@ export default class DevServer {
   private watchAggregationEvents: FSEvent[];
   private watchAggregationTimeout: number;
   private filter: (path: string) => boolean;
+  private podId: string;
 
   private getNowConfigPromise: Promise<NowConfig> | null;
   private blockingBuildsPromise: Promise<void> | null;
@@ -141,6 +142,9 @@ export default class DevServer {
     this.watchAggregationTimeout = 500;
 
     this.filter = path => Boolean(path);
+    this.podId = Math.random()
+      .toString(32)
+      .slice(-5);
   }
 
   async exit(code = 1) {
@@ -915,7 +919,7 @@ export default class DevServer {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ) => {
-    const nowRequestId = generateRequestId();
+    const nowRequestId = generateRequestId(this.podId);
 
     if (this.stopping) {
       res.setHeader('Connection', 'close');
@@ -1387,11 +1391,9 @@ function close(server: http.Server): Promise<void> {
  *
  * Example: dev1:q4wlg-1562364135397-7a873ac99c8e
  */
-function generateRequestId(): string {
+function generateRequestId(podId: string): string {
   return `dev1:${[
-    Math.random()
-      .toString(32)
-      .slice(-5),
+    podId,
     Date.now(),
     randomBytes(6).toString('hex')
   ].join('-')}`;


### PR DESCRIPTION
This matches the behavior in production.