### PR TITLE
Fix routes definition in `now-dev-static-routes` test fixture

### DIFF
--- a/test/fixtures/unit/now-dev-static-routes/now.json
+++ b/test/fixtures/unit/now-dev-static-routes/now.json
@@ -4,6 +4,6 @@
     { "src": "www/**/*", "use": "@now/static" }
   ],
   "routes": [
-    { "src": "(.*)", "dest": "www/$1" }
+    { "src": "(.*)", "dest": "www$1" }
   ]
 }


### PR DESCRIPTION
This is the proper way to define this route because of the capture of the initial `/`.

Matches how it works in production.