### PR TITLE
[now dev] Allow custom 404 pages via `routes`

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -1076,12 +1076,8 @@ export default class DevServer {
       if ([301, 302, 303].includes(status)) {
         this.output.debug(`Redirect: ${matched_route}`);
         res.end(`Redirecting (${status}) to ${res.getHeader('location')}`);
-      } else if (status === 404) {
-        await this.send404(req, res, nowRequestId);
-      } else {
-        res.end(`${status} status code from routes config`);
+        return;
       }
-      return;
     }
 
     const requestPath = dest.replace(/^\//, '');
@@ -1236,7 +1232,9 @@ export default class DevServer {
           return;
         }
 
-        res.statusCode = result.statusCode;
+        if (!status) {
+          res.statusCode = result.statusCode;
+        }
         this.setResponseHeaders(res, nowRequestId, result.headers);
 
         let resBody: Buffer | string | undefined;

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -343,10 +343,39 @@ test(
 
     {
       // Plain text response
-      const res = await fetch(`${server.address}/does-not-exists`);
+      const res = await fetch(`${server.address}/does-not-exist`);
       t.is(res.status, 404);
       const body = await res.text();
       t.is(res.headers.get('content-type'), 'text/plain; charset=utf-8');
+      t.is(body, 'The page could not be found.\n\nFILE_NOT_FOUND\n');
+    }
+  })
+);
+
+test(
+  '[DevServer] custom 404 routes',
+  testFixture('now-dev-custom-404', async (t, server) => {
+    {
+      // Test custom 404 with static dest
+      const res = await fetch(`${server.address}/error.html`);
+      t.is(res.status, 404);
+      const body = await res.text();
+      t.is(body, '<div>Custom 404 page</div>\n');
+    }
+
+    {
+      // Test custom 404 with lambda dest
+      const res = await fetch(`${server.address}/error.js`);
+      t.is(res.status, 404);
+      const body = await res.text();
+      t.is(body, 'Custom 404 Lambda\n');
+    }
+
+    {
+      // Test regular 404 still works
+      const res = await fetch(`${server.address}/does-not-exists`);
+      t.is(res.status, 404);
+      const body = await res.text();
       t.is(body, 'The page could not be found.\n\nFILE_NOT_FOUND\n');
     }
   })

--- a/test/dev-server.unit.js
+++ b/test/dev-server.unit.js
@@ -269,7 +269,7 @@ test(
       t.is(body, 'Hello from Lambda!');
 
       // Trigger a 404
-      res = await fetch(`${server.address}/does-not-exists`);
+      res = await fetch(`${server.address}/does-not-exist`);
       t.is(res.status, 404);
     }
   })
@@ -314,7 +314,7 @@ test(
   testFixture('now-dev-directory-listing', async (t, server) => {
     {
       // HTML response
-      const res = await fetch(`${server.address}/does-not-exists`, {
+      const res = await fetch(`${server.address}/does-not-exist`, {
         headers: {
           Accept: 'text/html'
         }
@@ -327,7 +327,7 @@ test(
 
     {
       // JSON response
-      const res = await fetch(`${server.address}/does-not-exists`, {
+      const res = await fetch(`${server.address}/does-not-exist`, {
         headers: {
           Accept: 'application/json'
         }
@@ -373,7 +373,7 @@ test(
 
     {
       // Test regular 404 still works
-      const res = await fetch(`${server.address}/does-not-exists`);
+      const res = await fetch(`${server.address}/does-not-exist`);
       t.is(res.status, 404);
       const body = await res.text();
       t.is(body, 'The page could not be found.\n\nFILE_NOT_FOUND\n');

--- a/test/fixtures/unit/now-dev-custom-404/error.html
+++ b/test/fixtures/unit/now-dev-custom-404/error.html
@@ -1,0 +1,1 @@
+<div>Custom 404 page</div>

--- a/test/fixtures/unit/now-dev-custom-404/error.js
+++ b/test/fixtures/unit/now-dev-custom-404/error.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.end('Custom 404 Lambda\n');
+};

--- a/test/fixtures/unit/now-dev-custom-404/now.json
+++ b/test/fixtures/unit/now-dev-custom-404/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "*.js", "use": "@now/node" },
+    { "src": "*.html", "use": "@now/static" }
+  ],
+  "routes": [
+    { "src": "/error.js", "dest": "/error.js", "status": 404 },
+    { "src": "/error.html", "dest": "/error.html", "status": 404 }
+  ]
+}


### PR DESCRIPTION
This matches the behavior in production, which allows a `dest` to be
provided when defining a `status: 404` in the routes configuration.

Related to #2638.