### PR TITLE
[now update] Remove `is-installed-globally`

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "http-proxy": "1.17.0",
     "ini": "1.3.4",
     "inquirer": "3.3.0",
-    "is-installed-globally": "0.2.0",
     "is-url": "1.2.2",
     "jaro-winkler": "0.2.8",
     "jsonlines": "0.1.1",

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -1,7 +1,6 @@
 import { Stats } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { readJSON, lstat, readlink } from 'fs-extra';
-import isInstalledGlobally from 'is-installed-globally';
 
 import { version } from '../../package.json';
 
@@ -27,12 +26,6 @@ async function isYarn(): Promise<boolean> {
 
 export default async function getUpdateCommand(): Promise<string> {
   const tag = version.includes('canary') ? 'canary' : 'latest';
-
-  if (isInstalledGlobally) {
-    return (await isYarn())
-      ? `yarn global add now@${tag}`
-      : `npm install -g now@${tag}`;
-  }
 
   return (await isYarn())
     ? `yarn add now@${tag}`

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -28,6 +28,6 @@ export default async function getUpdateCommand(): Promise<string> {
   const tag = version.includes('canary') ? 'canary' : 'latest';
 
   return (await isYarn())
-    ? `yarn add now@${tag}`
-    : `npm install now@${tag}`;
+    ? `yarn global add now@${tag}`
+    : `npm install -g now@${tag}`;
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -173,7 +173,7 @@ test('output the version', async t => {
 test('detect update command', async t => {
   {
     const { stderr } = await execute(['update']);
-    t.regex(stderr, /yarn add now@/gm, `Received: "${stderr}"`);
+    t.regex(stderr, /yarn global add now@/gm, `Received: "${stderr}"`);
   }
 
   if (process.version.startsWith('v8.')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,7 +3105,7 @@ glob@^7.0.3, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-dirs@^0.1.0, global-dirs@^0.1.1:
+global-dirs@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
@@ -3660,14 +3660,6 @@ is-glob@^4.0.0:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-installed-globally@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.2.0.tgz#8cde07ade508458b51f14bcda315ffaf4898de30"
-  integrity sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==
-  dependencies:
-    global-dirs "^0.1.1"
-    is-path-inside "^2.1.0"
 
 is-installed-globally@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Remove `is-installed-globally` since it breaks for installations where node was installed differently.