### PR TITLE
[now dev] Print warning upon empty `cwd` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 /test/**/yarn.lock
 /test/**/node_modules
 /test/dev/fixtures/08-hugo/hugo
+/test/dev/fixtures/08-hugo/public

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage
 .builders
 /assets
 /src/util/dev/templates/*.ts
+/test/**/yarn.lock
+/test/**/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ coverage
 /test/**/yarn.lock
 /test/**/node_modules
 /test/dev/fixtures/08-hugo/hugo
-/test/dev/fixtures/08-hugo/public
+/test/dev/fixtures/**/dist
+/test/dev/fixtures/**/public

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage
 /src/util/dev/templates/*.ts
 /test/**/yarn.lock
 /test/**/node_modules
+/test/dev/fixtures/08-hugo/hugo

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preinstall": "node ./scripts/preinstall.js",
     "test-unit": "nyc ava test/*unit.js --serial --fail-fast",
     "test-integration": "ava test/integration.js --serial --fail-fast",
-    "test-integration-now-dev": "ava test/dev/integration.js --serial --fail-fast",
+    "test-integration-now-dev": "ava test/dev/integration.js --serial --fail-fast --verbose",
     "test-lint": "eslint . --ext .js,.ts",
     "prepublishOnly": "yarn build",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",

--- a/src/util/dev/builder.ts
+++ b/src/util/dev/builder.ts
@@ -375,8 +375,16 @@ export async function getBuildMatches(
   fileList: string[]
 ): Promise<BuildMatch[]> {
   const matches: BuildMatch[] = [];
+
+  if (fileList.length === 0) {
+    // If there's no files in the cwd then we know there won't be any build
+    // matches, so bail eagerly, and avoid printing the "no matches" message.
+    return matches;
+  }
+
   const noMatches: BuildConfig[] = [];
   const builds = nowConfig.builds || [{ src: '**', use: '@now/static' }];
+
   for (const buildConfig of builds) {
     let { src, use } = buildConfig;
 

--- a/src/util/dev/router.ts
+++ b/src/util/dev/router.ts
@@ -4,11 +4,7 @@ import PCRE from 'pcre-to-regexp';
 import isURL from './is-url';
 import DevServer from './server';
 
-import {
-  HttpHeadersConfig,
-  RouteConfig,
-  RouteResult
-} from './types';
+import { HttpHeadersConfig, RouteConfig, RouteResult } from './types';
 
 export function resolveRouteParameters(
   str: string,

--- a/src/util/dev/static-builder.ts
+++ b/src/util/dev/static-builder.ts
@@ -1,9 +1,5 @@
 import { basename, extname, join } from 'path';
-import {
-  BuilderParams,
-  BuildResult,
-  ShouldServeParams
-} from './types';
+import { BuilderParams, BuildResult, ShouldServeParams } from './types';
 
 export const version = 2;
 

--- a/test/dev/fixtures/empty/.gitignore
+++ b/test/dev/fixtures/empty/.gitignore
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -679,6 +679,10 @@ test('[now dev] render warning for empty cwd dir', async t => {
   try {
     dev.unref();
 
+    // Debugging…
+    dev.stderr.pipe(process.stderr);
+    dev.stdout.pipe(process.stderr);
+
     // Monitor `stderr` for the warning
     dev.stderr.setEncoding('utf8');
     await new Promise(resolve => {

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -680,6 +680,10 @@ test('[now dev] render warning for empty cwd dir', async t => {
   try {
     dev.unref();
 
+    // Debugging…
+    dev.stderr.pipe(process.stderr);
+    dev.stdout.pipe(process.stderr);
+
     // Monitor `stderr` for the warning
     dev.stderr.setEncoding('utf8');
     await new Promise(resolve => {

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -673,7 +673,9 @@ test('[now dev] do not recursivly check the path', async t => {
 
 test('[now dev] render warning for empty cwd dir', async t => {
   const directory = fixture('empty');
-  const { dev, port } = testFixture(directory);
+  const { dev, port } = testFixture(directory, {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
 
   try {
     dev.unref();

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -696,7 +696,6 @@ test('[now dev] render warning for empty cwd dir', async t => {
       // Issue a request to ensure a 404 response
       const response = await fetchWithRetry(`http://localhost:${port}`, 180);
       validateResponseHeaders(t, response);
-      const body = await response.text();
       t.is(response.status, 404);
     }
   } finally {

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -679,10 +679,6 @@ test('[now dev] render warning for empty cwd dir', async t => {
   try {
     dev.unref();
 
-    // Debugging…
-    dev.stderr.pipe(process.stderr);
-    dev.stdout.pipe(process.stderr);
-
     // Monitor `stderr` for the warning
     dev.stderr.setEncoding('utf8');
     await new Promise(resolve => {

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -632,7 +632,6 @@ test('[now dev] no build matches warning', async t => {
     dev.unref();
 
     dev.stderr.setEncoding('utf8');
-
     await new Promise(resolve => {
       dev.stderr.on('data', str => {
         if (str.includes('did not match any source files')) {
@@ -680,10 +679,6 @@ test('[now dev] render warning for empty cwd dir', async t => {
   try {
     dev.unref();
 
-    // Debugging…
-    dev.stderr.pipe(process.stderr);
-    dev.stdout.pipe(process.stderr);
-
     // Monitor `stderr` for the warning
     dev.stderr.setEncoding('utf8');
     await new Promise(resolve => {
@@ -698,12 +693,11 @@ test('[now dev] render warning for empty cwd dir', async t => {
       });
     });
 
-    {
-      // Issue a request to ensure a 404 response
-      const response = await fetchWithRetry(`http://localhost:${port}`, 180);
-      validateResponseHeaders(t, response);
-      t.is(response.status, 404);
-    }
+    // Issue a request to ensure a 404 response
+    await sleep(ms('3s'));
+    const response = await fetch(`http://localhost:${port}`);
+    validateResponseHeaders(t, response);
+    t.is(response.status, 404);
   } finally {
     dev.kill('SIGTERM');
   }

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -75,8 +75,10 @@ function testFixtureStdio(directory, fn) {
           readyResolve();
         }
 
-        if ( data.toString().includes('Command failed')
-          || data.toString().includes('Error!')) {
+        if (
+          data.toString().includes('Command failed') ||
+          data.toString().includes('Error!')
+        ) {
           dev.kill('SIGTERM');
           console.log(output);
           process.exit(1);
@@ -159,8 +161,8 @@ if (satisfies(process.version, '>= 10.9')) {
 
 test(
   '[now dev] 03-aurelia',
-  testFixtureStdio('03-aurelia', async(t, port) => {
-    const result = fetch(`http://localhost:${port}`)
+  testFixtureStdio('03-aurelia', async (t, port) => {
+    const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
     validateResponseHeaders(t, response);
@@ -185,7 +187,7 @@ test(
 
 test(
   '[now dev] 05-gatsby',
-  testFixtureStdio('05-gatsby', async(t, port) => {
+  testFixtureStdio('05-gatsby', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -198,7 +200,7 @@ test(
 
 test(
   '[now dev] 06-gridsome',
-  testFixtureStdio('06-gridsome', async(t, port) => {
+  testFixtureStdio('06-gridsome', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -231,7 +233,7 @@ test('[now dev] 07-hexo-node', async t => {
 
 test(
   '[now dev] 08-hugo',
-  testFixtureStdio('08-hugo', async(t, port) => {
+  testFixtureStdio('08-hugo', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -460,7 +462,7 @@ test('[now dev] double slashes redirect', async t => {
 
 test(
   '[now dev] 18-marko',
-  testFixtureStdio('18-marko', async(t, port) => {
+  testFixtureStdio('18-marko', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -473,7 +475,7 @@ test(
 
 test(
   '[now dev] 19-mithril',
-  testFixtureStdio('19-mithril', async(t, port) => {
+  testFixtureStdio('19-mithril', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -486,7 +488,7 @@ test(
 
 test(
   '[now dev] 20-riot',
-  testFixtureStdio('20-riot', async(t, port) => {
+  testFixtureStdio('20-riot', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -499,7 +501,7 @@ test(
 
 test(
   '[now dev] 21-charge',
-  testFixtureStdio('21-charge', async(t, port) => {
+  testFixtureStdio('21-charge', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -512,7 +514,7 @@ test(
 
 test(
   '[now dev] 22-brunch',
-  testFixtureStdio('22-brunch', async(t, port) => {
+  testFixtureStdio('22-brunch', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -525,7 +527,7 @@ test(
 
 test(
   '[now dev] 23-docusaurus',
-  testFixtureStdio('23-docusaurus', async(t, port) => {
+  testFixtureStdio('23-docusaurus', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -538,7 +540,7 @@ test(
 
 test(
   '[now dev] 24-ember',
-  testFixtureStdio('24-ember', async(t, port) => {
+  testFixtureStdio('24-ember', async (t, port) => {
     const result = fetch(`http://localhost:${port}`);
     const response = await result;
 
@@ -649,7 +651,7 @@ test('[now dev] do not recursivly check the path', async t => {
   const directory = fixture('handle-filesystem-missing');
   const { dev, port } = testFixture(directory);
 
-   try {
+  try {
     dev.unref();
 
     {
@@ -662,6 +664,39 @@ test('[now dev] do not recursivly check the path', async t => {
     {
       const response = await fetch(`http://localhost:${port}/favicon.txt`);
       validateResponseHeaders(t, response);
+      t.is(response.status, 404);
+    }
+  } finally {
+    dev.kill('SIGTERM');
+  }
+});
+
+test('[now dev] render warning for empty cwd dir', async t => {
+  const directory = fixture('empty');
+  const { dev, port } = testFixture(directory);
+
+  try {
+    dev.unref();
+
+    // Monitor `stderr` for the warning
+    dev.stderr.setEncoding('utf8');
+    await new Promise(resolve => {
+      dev.stderr.on('data', str => {
+        if (
+          str.includes(
+            'There are no files (or only files starting with a dot) inside your deployment'
+          )
+        ) {
+          resolve();
+        }
+      });
+    });
+
+    {
+      // Issue a request to ensure a 404 response
+      const response = await fetchWithRetry(`http://localhost:${port}`, 180);
+      validateResponseHeaders(t, response);
+      const body = await response.text();
       t.is(response.status, 404);
     }
   } finally {


### PR DESCRIPTION
The warning matches the one that `now deploy` prints, and only prints the warning once (rather then upon every HTTP request).

Closes #2696.