### PR TITLE
Add `unhandledRejection` and `uncaughtException` handlers to scripts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -4,12 +4,7 @@ import execa from 'execa';
 import { join } from 'path';
 import pipe from 'promisepipe';
 import { createGzip } from 'zlib';
-import {
-  createWriteStream,
-  mkdirp,
-  remove,
-  writeJSON
-} from 'fs-extra';
+import { createWriteStream, mkdirp, remove, writeJSON } from 'fs-extra';
 
 import { getDistTag } from '../src/util/dev/builder-cache';
 import pkg from '../package.json';
@@ -103,6 +98,18 @@ async function main() {
 
   console.log('Finished building `now-cli`');
 }
+
+process.on('unhandledRejection', (err: any) => {
+  console.error('Unhandled Rejection:');
+  console.error(err);
+  process.exit(1);
+});
+
+process.on('uncaughtException', (err: any) => {
+  console.error('Uncaught Exception:');
+  console.error(err);
+  process.exit(1);
+});
 
 main().catch(err => {
   console.error(err);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -6,7 +6,7 @@ import pipe from 'promisepipe';
 import { createGzip } from 'zlib';
 import { createWriteStream, mkdirp, remove, writeJSON } from 'fs-extra';
 
-import { getDistTag } from '../src/util/dev/builder-cache';
+import { getDistTag } from '../src/util/get-dist-tag';
 import pkg from '../package.json';
 
 const dirRoot = join(__dirname, '..');

--- a/scripts/compile-templates.js
+++ b/scripts/compile-templates.js
@@ -72,6 +72,18 @@ async function main() {
   }
 }
 
+process.on('unhandledRejection', err => {
+  console.error('Unhandled Rejection:');
+  console.error(err);
+  process.exit(1);
+});
+
+process.on('uncaughtException', err => {
+  console.error('Uncaught Exception:');
+  console.error(err);
+  process.exit(1);
+});
+
 main().catch(err => {
   console.error(err);
   process.exit(1);

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -116,8 +116,6 @@ async function main() {
 
     process.exit(1);
   }
-
-  process.exit(0);
 }
 
 process.on('unhandledRejection', err => {
@@ -132,7 +130,9 @@ process.on('uncaughtException', err => {
   process.exit(1);
 });
 
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -15,7 +15,10 @@ function error(command) {
 }
 
 function debug(str) {
-  if (process.argv.find(str => str === '--debug') || process.env.PREINSTALL_DEBUG) {
+  if (
+    process.argv.find(str => str === '--debug') ||
+    process.env.PREINSTALL_DEBUG
+  ) {
     console.log(`[debug] [${new Date().toISOString()}]`, str);
   }
 }
@@ -113,6 +116,23 @@ async function main() {
 
     process.exit(1);
   }
+
+  process.exit(0);
 }
 
-main().then(() => process.exit(0));
+process.on('unhandledRejection', err => {
+  console.error('Unhandled Rejection:');
+  console.error(err);
+  process.exit(1);
+});
+
+process.on('uncaughtException', err => {
+  console.error('Uncaught Exception:');
+  console.error(err);
+  process.exit(1);
+});
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/util/dev/builder-cache.ts
+++ b/src/util/dev/builder-cache.ts
@@ -22,6 +22,7 @@ import pkg from '../../../package.json';
 import { NoBuilderCacheError, BuilderCacheCleanError } from '../errors-ts';
 import wait from '../output/wait';
 import { Output } from '../output';
+import { getDistTag } from '../get-dist-tag';
 import { devDependencies } from '../../../package.json';
 
 import * as staticBuilder from './static-builder';
@@ -70,14 +71,6 @@ async function readFileOrNull(
     }
     throw err;
   }
-}
-
-export function getDistTag(version: string): string {
-  const parsed = semver.parse(version);
-  if (parsed && typeof parsed.prerelease[0] === 'string') {
-    return parsed.prerelease[0] as string;
-  }
-  return 'latest';
 }
 
 /**

--- a/src/util/get-dist-tag.ts
+++ b/src/util/get-dist-tag.ts
@@ -1,0 +1,10 @@
+import semver from 'semver';
+
+export function getDistTag(version: string): string {
+  const parsed = semver.parse(version);
+  if (parsed && typeof parsed.prerelease[0] === 'string') {
+    return parsed.prerelease[0] as string;
+  }
+  return 'latest';
+}
+


### PR DESCRIPTION
This is to prevent false-positives like this from occurring, and fixes the warning from `node`:

```
$ ts-node ./scripts/build.ts
Creating builders tarball with: @now/build-utils@canary, @now/go@canary, @now/next@canary, @now/node@canary, @now/php@canary, @now/static-build@canary
(node:156) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/home/circleci/repo/assets/builders.tar.gz'
    at ReadStream.evt.error.err (/home/circleci/repo/node_modules/promisepipe/index.js:30:23)
    at ReadStream.emit (events.js:198:13)
    at ReadStream.EventEmitter.emit (domain.js:448:20)
    at /home/circleci/repo/node_modules/graceful-fs/graceful-fs.js:207:14
    at /home/circleci/repo/node_modules/graceful-fs/graceful-fs.js:258:16
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
(node:156) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:156) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```