### PR TITLE
[now update] Show correct global or local install command

### DIFF
--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -1,6 +1,6 @@
 import { Stats } from 'fs';
 import { dirname, join, resolve } from 'path';
-import { readJSON, lstat, readlink, readFile } from 'fs-extra';
+import { readJSON, lstat, readlink, readFile, realpath } from 'fs-extra';
 
 import { version } from '../../package.json';
 
@@ -61,7 +61,7 @@ async function isGlobal() {
     const isWindows = process.platform === 'win32';
     const defaultPath = isWindows ? process.env.APPDATA : '/usr/local/lib'
 
-    const installPath = resolve(__dirname);
+    const installPath = await realpath(resolve(__dirname));
 
     const prefixPath = (
       process.env.PREFIX ||
@@ -75,9 +75,11 @@ async function isGlobal() {
       return true;
     }
 
-    return installPath.startsWith(prefixPath);
+    return installPath.startsWith(await realpath(prefixPath));
   } catch (_) {
     // Default to global
+    console.error(_);
+
     return true;
   }
 }

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -1,6 +1,6 @@
 import { Stats } from 'fs';
 import { dirname, join, resolve } from 'path';
-import fs, { readJSON, lstat, readlink, readFile } from 'fs-extra';
+import { readJSON, lstat, readlink, readFile } from 'fs-extra';
 
 import { version } from '../../package.json';
 
@@ -24,19 +24,6 @@ async function isYarn(): Promise<boolean> {
   return !('_id' in pkg);
 }
 
-async function canRead(file: string) {
-  return new Promise((res) => {
-    fs.access(file, fs.constants.F_OK | fs.constants.R_OK, (err) => {
-      if (err) {
-        res(false);
-        return;
-      }
-
-      res(true);
-    });
-  });
-}
-
 async function getConfigPrefix() {
   const paths = [
     process.env.npm_config_userconfig || process.env.NPM_CONFIG_USERCONFIG,
@@ -46,10 +33,6 @@ async function getConfigPrefix() {
 
   for (const configPath of paths) {
     if (!configPath) {
-      continue;
-    }
-
-    if (await canRead(configPath) === false) {
       continue;
     }
 

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -59,7 +59,7 @@ async function getConfigPrefix() {
 async function isGlobal() {
   try {
     const isWindows = process.platform === 'win32';
-    const defaultPath = isWindows ? process.env.APPDATA : '/usr/local/bin'
+    const defaultPath = isWindows ? process.env.APPDATA : '/usr/local/lib'
 
     const installPath = resolve(__dirname);
 

--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -78,8 +78,6 @@ async function isGlobal() {
     return installPath.startsWith(await realpath(prefixPath));
   } catch (_) {
     // Default to global
-    console.error(_);
-
     return true;
   }
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -177,7 +177,7 @@ test('output the version', async t => {
 test('detect update command', async t => {
   {
     const { stderr } = await execute(['update']);
-    t.regex(stderr, /yarn global add now@/gm, `Received: "${stderr}"`);
+    t.regex(stderr, /yarn add now@/gm, `Received: "${stderr}"`);
   }
 
   if (process.version.startsWith('v8.')) {


### PR DESCRIPTION
Display the correct update command for local and global installations.

Fixes https://github.com/zeit/now-cli/issues/2683