### PR TITLE
[now dev] Add `--listen` / `-l` flag, deprecate `--port` / `-p`

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -6,10 +6,12 @@ import { Output } from '../../util/output';
 import { NowContext } from '../../types';
 
 type Options = {
-  '--debug': boolean;
-  '-d': boolean;
-  '--port': number;
-  '-p': number;
+  '--debug'?: boolean;
+  '-d'?: boolean;
+  '--bind'?: string;
+  '-b'?: string;
+  '--port'?: number;
+  '-p'?: number;
 };
 
 export default async function dev(
@@ -24,11 +26,12 @@ export default async function dev(
 
   const [dir = '.'] = args;
   const cwd = path.resolve(dir);
+  const bind = opts['-b'] || opts['--bind'];
   const port = opts['-p'] || opts['--port'];
-  const debug = opts['-d'] || opts['--debug'];
+  const debug = opts['-d'] || opts['--debug'] || false;
   const devServer = new DevServer(cwd, { output, debug });
 
   process.once('SIGINT', devServer.stop.bind(devServer));
 
-  await devServer.start(port);
+  await devServer.start(port, bind);
 }

--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -2,16 +2,13 @@ import path from 'path';
 
 import pkg from '../../../package.json';
 import DevServer from '../../util/dev/server';
+import parseListen from '../../util/dev/parse-listen';
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
 
 type Options = {
   '--debug'?: boolean;
-  '-d'?: boolean;
-  '--bind'?: string;
-  '-b'?: string;
-  '--port'?: number;
-  '-p'?: number;
+  '--listen'?: string;
 };
 
 export default async function dev(
@@ -26,12 +23,11 @@ export default async function dev(
 
   const [dir = '.'] = args;
   const cwd = path.resolve(dir);
-  const bind = opts['-b'] || opts['--bind'];
-  const port = opts['-p'] || opts['--port'];
-  const debug = opts['-d'] || opts['--debug'] || false;
+  const listen = parseListen(opts['--listen'] || '3000');
+  const debug = opts['--debug'] || false;
   const devServer = new DevServer(cwd, { output, debug });
 
   process.once('SIGINT', devServer.stop.bind(devServer));
 
-  await devServer.start(port, bind);
+  await devServer.start(...listen);
 }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -28,6 +28,7 @@ const help = () => {
 
     -h, --help        Output usage information
     -d, --debug       Debug mode [off]
+    -b, --bind        Network interface to bind to [127.0.0.1]
     -p, --port        Port [3000]
 
   ${chalk.dim('Examples:')}
@@ -35,6 +36,10 @@ const help = () => {
   ${chalk.gray('–')} Start the \`now dev\` server on port 8080
 
       ${chalk.cyan('$ now dev --port 8080')}
+
+  ${chalk.gray('–')} Make the \`now dev\` server bind to all network interfaces
+
+      ${chalk.cyan('$ now dev --bind 0.0.0.0')}
   `);
 };
 
@@ -45,6 +50,8 @@ export default async function main(ctx: NowContext) {
 
   try {
     argv = getArgs(ctx.argv.slice(2), {
+      '--bind': String,
+      '-b': String,
       '--port': Number,
       '-p': Number
     });
@@ -79,8 +86,14 @@ export default async function main(ctx: NowContext) {
       const { scripts } = pkg as Package;
 
       if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
-        output.error(`The ${cmd('dev')} script in ${cmd('package.json')} must not contain ${cmd('now dev')}`);
-        output.error(`More details: http://err.sh/now-cli/now-dev-as-dev-script`);
+        output.error(
+          `The ${cmd('dev')} script in ${cmd(
+            'package.json'
+          )} must not contain ${cmd('now dev')}`
+        );
+        output.error(
+          `More details: http://err.sh/now-cli/now-dev-as-dev-script`
+        );
         return 1;
       }
     }

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -68,6 +68,7 @@ export default async function main(ctx: NowContext) {
 
     if ('--port' in argv) {
       output.warn('`--port` is deprecated, please use `--listen` instead');
+      argv['--listen'] = String(argv['--port']);
     }
   } catch (err) {
     handleError(err);

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -26,20 +26,19 @@ const help = () => {
 
   ${chalk.dim('Options:')}
 
-    -h, --help        Output usage information
-    -d, --debug       Debug mode [off]
-    -b, --bind        Network interface to bind to [127.0.0.1]
-    -p, --port        Port [3000]
+    -h, --help             Output usage information
+    -d, --debug            Debug mode [off]
+    -l, --listen  [uri]    Specify a URI endpoint on which to listen [0.0.0.0:3000]
 
   ${chalk.dim('Examples:')}
 
   ${chalk.gray('–')} Start the \`now dev\` server on port 8080
 
-      ${chalk.cyan('$ now dev --port 8080')}
+      ${chalk.cyan('$ now dev --listen 8080')}
 
-  ${chalk.gray('–')} Make the \`now dev\` server bind to all network interfaces
+  ${chalk.gray('–')} Make the \`now dev\` server bind to localhost on port 5000
 
-      ${chalk.cyan('$ now dev --bind 0.0.0.0')}
+      ${chalk.cyan('$ now dev --listen 127.0.0.1:5000')}
   `);
 };
 
@@ -50,18 +49,25 @@ export default async function main(ctx: NowContext) {
 
   try {
     argv = getArgs(ctx.argv.slice(2), {
-      '--bind': String,
-      '-b': String,
+      '--listen': String,
+      '-l': '--listen',
+
+      // Deprecated
       '--port': Number,
-      '-p': Number
+      '-p': '--port'
     });
+    const debug = argv['--debug'];
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
-    output = createOutput({ debug: argv['--debug'] });
+    output = createOutput({ debug });
 
     // Builders won't show debug logs by default
     // the `NOW_BUILDER_DEBUG` env variable will enable them
-    if (argv['--debug']) {
+    if (debug) {
       process.env.NOW_BUILDER_DEBUG = '1';
+    }
+
+    if ('--port' in argv) {
+      output.warn('`--port` is deprecated, please use `--listen` instead');
     }
   } catch (err) {
     handleError(err);

--- a/src/util/dev/parse-listen.ts
+++ b/src/util/dev/parse-listen.ts
@@ -1,0 +1,40 @@
+import { parse } from 'url';
+import { ListenSpec } from './types';
+
+export default function parseListen(str: string): ListenSpec {
+  const port = Number(str);
+
+  if (!isNaN(port)) {
+    return [port];
+  }
+
+  // We cannot use `new URL` here, otherwise it will not
+  // parse the host properly and it would drop support for IPv6.
+  const url = parse(str);
+
+  switch (url.protocol) {
+    case 'pipe:': {
+      // some special handling
+      const cutStr = str.replace(/^pipe:/, '');
+
+      if (cutStr.slice(0, 4) !== '\\\\.\\') {
+        throw new Error(`Invalid Windows named pipe endpoint: ${str}`);
+      }
+
+      return [cutStr];
+    }
+    case 'unix:':
+      if (!url.pathname) {
+        throw new Error(`Invalid UNIX domain socket endpoint: ${str}`);
+      }
+
+      return [url.pathname];
+    case 'tcp:':
+      url.port = url.port || '5000';
+      return [parseInt(url.port, 10), url.hostname];
+    default:
+      throw new Error(
+        `Unknown --listen endpoint scheme (protocol): ${url.protocol}`
+      );
+  }
+}

--- a/src/util/dev/parse-listen.ts
+++ b/src/util/dev/parse-listen.ts
@@ -1,8 +1,11 @@
 import { parse } from 'url';
 import { ListenSpec } from './types';
 
-export default function parseListen(str: string): ListenSpec {
-  const port = Number(str);
+export default function parseListen(
+  str: string,
+  defaultPort = 3000
+): ListenSpec {
+  let port = Number(str);
 
   if (!isNaN(port)) {
     return [port];
@@ -30,11 +33,20 @@ export default function parseListen(str: string): ListenSpec {
 
       return [url.pathname];
     case 'tcp:':
-      url.port = url.port || '3000';
+      url.port = url.port || String(defaultPort);
       return [parseInt(url.port, 10), url.hostname];
     default:
+      if (!url.slashes) {
+        if (url.protocol === null) {
+          return [defaultPort, url.pathname];
+        }
+        port = Number(url.hostname);
+        if (url.protocol && !isNaN(port)) {
+          return [port, url.protocol.substring(0, url.protocol.length - 1)];
+        }
+      }
       throw new Error(
-        `Unknown --listen endpoint scheme (protocol): ${url.protocol}`
+        `Unknown \`--listen\` scheme (protocol): ${url.protocol}`
       );
   }
 }

--- a/src/util/dev/parse-listen.ts
+++ b/src/util/dev/parse-listen.ts
@@ -30,7 +30,7 @@ export default function parseListen(str: string): ListenSpec {
 
       return [url.pathname];
     case 'tcp:':
-      url.port = url.port || '5000';
+      url.port = url.port || '3000';
       return [parseInt(url.port, 10), url.hostname];
     default:
       throw new Error(

--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -740,9 +740,11 @@ export default class DevServer {
       }
     }
 
-    this.address = address.replace('127.0.0.1', 'localhost');
-    this.output.ready(`Available at ${link(this.address)}`);
+    this.address = address
+      .replace('[::]', 'localhost')
+      .replace('127.0.0.1', 'localhost');
 
+    this.output.ready(`Available at ${link(this.address)}`);
     this.serverUrlPrinted = true;
   }
 

--- a/src/util/dev/types.ts
+++ b/src/util/dev/types.ts
@@ -181,3 +181,7 @@ export interface InvokeResult {
   encoding?: string;
   body?: string;
 }
+
+export type SocketSpec = [string];
+export type HostPortSpec = [number, string?];
+export type ListenSpec = SocketSpec | HostPortSpec;

--- a/test/dev/integration.js
+++ b/test/dev/integration.js
@@ -46,7 +46,7 @@ function validateResponseHeaders(t, res) {
 function testFixture(directory, opts = {}) {
   port = ++port;
   return {
-    dev: execa(binaryPath, ['dev', directory, '-p', port], {
+    dev: execa(binaryPath, ['dev', directory, '-l', String(port)], {
       reject: false,
       detached: true,
       stdio: 'ignore',


### PR DESCRIPTION
Deprecates `--port` in favor of a new `--listen` flag, which matches the behavior of `serve`. This allows for binding to a specific network interface, as well as Unix socket files or Windows named pipes.