### PR TITLE
[CircleCI] Fix `test/dev-server.unit.js` being run on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - bin
+            - assets
             - dist
 
   test-lint:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "yarn test-lint",
     "preinstall": "node ./scripts/preinstall.js",
-    "test-unit": "nyc ava test/*unit.js --serial --fail-fast",
+    "test-unit": "nyc ava test/*unit.js --serial --fail-fast --verbose",
     "test-integration": "ava test/integration.js --serial --fail-fast",
     "test-integration-now-dev": "ava test/dev/integration.js --serial --fail-fast --verbose",
     "test-lint": "eslint . --ext .js,.ts",


### PR DESCRIPTION
For some reason, `ava` was silently skipping these tests on CI because the process was crashing. According to sindre, this is a bug in `ava`, but with some digging I was able to determine that the root cause of the crash was that the `builders.tar.gz` file from the `assets` dir was not being persisted from the previous `build` job in CI.

With the `assets` dir being persisted I now see the `dev-server` unit tests being executed once again as expected.

Related to: https://twitter.com/sindresorhus/status/1157614353375551493