### PR TITLE
Add `accept: application/json` header to API HTTP requests

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -783,6 +783,7 @@ export default class Now extends EventEmitter {
     }
 
     opts.headers = opts.headers || {};
+    opts.headers.accept = 'application/json';
     opts.headers.authorization = `Bearer ${this._token}`;
     opts.headers['user-agent'] = ua;
 


### PR DESCRIPTION
All of the APIs already support JSON by default, so this is a no-op for our APIs, however the proxy layer _does_ respect the `Accept` header to send JSON error responses, which is useful for more gracefully handling outage responses (previously they were being returned as plain text, which Now CLI blindfully tries to parse as JSON and fails with an unhelpful error message).

Related to #2681.