### PR TITLE
[now dev] Remove leftover `console.error()` call

### DIFF
--- a/src/util/dev/server.ts
+++ b/src/util/dev/server.ts
@@ -714,7 +714,6 @@ export default class DevServer {
 
     let address: string | null = null;
     while (typeof address !== 'string') {
-      console.error({ listenSpec });
       try {
         address = await listen(this.server, ...listenSpec);
       } catch (err) {


### PR DESCRIPTION
Accidentally added in #2720.