### PR TITLE
[now rm] Use the proper `client` so that the process does not hang

### DIFF
--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -96,7 +96,10 @@ export default async function main(ctx) {
     return 2;
   }
 
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config
+  } = ctx;
   const { currentTeam } = config;
   const client = new Client({
     apiUrl,
@@ -109,6 +112,8 @@ export default async function main(ctx) {
   try {
     ({ contextName } = await getScope(client));
   } catch (err) {
+    client.close();
+
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
       output.error(err.message);
       return 1;
@@ -116,8 +121,6 @@ export default async function main(ctx) {
 
     throw err;
   }
-
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
 
   const cancelWait = wait(
     `Fetching deployment(s) ${ids
@@ -131,43 +134,58 @@ export default async function main(ctx) {
   const findStart = Date.now();
 
   try {
-    const searchFilter = (d) => ids.some((id) => (
-      (d && !(d instanceof NowError)) && (
-      d.uid === id ||
-      d.name === id ||
-      d.url === normalizeURL(id)
-    )));
+    const searchFilter = d =>
+      ids.some(
+        id =>
+          d &&
+          !(d instanceof NowError) &&
+          (d.uid === id || d.name === id || d.url === normalizeURL(id))
+      );
 
     const [deploymentList, projectList] = await Promise.all([
-      Promise.all(ids.map((idOrHost) => getDeploymentByIdOrHost(now, contextName, idOrHost))),
-      Promise.all(ids.map(async (idOrName) => getProjectByIdOrName(now, idOrName)))
+      Promise.all(
+        ids.map(idOrHost =>
+          getDeploymentByIdOrHost(client, contextName, idOrHost)
+        )
+      ),
+      Promise.all(
+        ids.map(async idOrName => getProjectByIdOrName(client, idOrName))
+      )
     ]);
+    console.error({ deploymentList, projectList });
 
     deployments = deploymentList.filter(searchFilter);
     projects = projectList.filter(searchFilter);
 
     // When `--safe` is set we want to replace all projects
-    // with with deployments to verify the aliases
+    // with deployments to verify the aliases
     if (argv.safe) {
-      const projectDeployments = await Promise.all(projects.map((project) => {
-        return getDeploymentsByProjectId(client, project.id, { max: 201, continue: true });
-      }));
+      const projectDeployments = await Promise.all(
+        projects.map(project => {
+          return getDeploymentsByProjectId(client, project.id, {
+            max: 201,
+            continue: true
+          });
+        })
+      );
 
       projectDeployments
         .slice(0, 201)
-        .map((pDeployments) => deployments.push(...pDeployments));
+        .map(pDeployments => deployments.push(...pDeployments));
 
       projects = [];
     } else {
       // Remove all deployments that are included in the projects
-      deployments = deployments.filter((d) => !projects.some((p) => p.name === d.name));
+      deployments = deployments.filter(
+        d => !projects.some(p => p.name === d.name)
+      );
     }
 
-    aliases = await Promise.all(deployments.map(depl => getAliases(now, depl.uid)));
+    aliases = await Promise.all(
+      deployments.map(depl => getAliases(client, depl.uid))
+    );
+  } finally {
     cancelWait();
-  } catch (err) {
-    cancelWait();
-    throw err;
   }
 
   deployments = deployments.filter((match, i) => {
@@ -182,21 +200,24 @@ export default async function main(ctx) {
   if (deployments.length === 0 && projects.length === 0) {
     log(
       `Could not find ${argv.safe ? 'unaliased' : 'any'} deployments ` +
-      `or projects matching ` +
-      `${ids.map(id => chalk.bold(`"${id}"`)).join(', ')}. Run ${cmd('now ls')} to list.`
+        `or projects matching ` +
+        `${ids.map(id => chalk.bold(`"${id}"`)).join(', ')}. Run ${cmd(
+          'now ls'
+        )} to list.`
     );
-    return 0;
+    client.close();
+    return 1;
   }
 
   log(
     `Found ${deploymentsAndProjects(deployments, projects)} for removal in ` +
-    `${chalk.bold(contextName)} ${elapsed(Date.now() - findStart)}`
+      `${chalk.bold(contextName)} ${elapsed(Date.now() - findStart)}`
   );
 
   if (deployments.length > 200) {
     output.warn(
       `Only 200 deployments can get deleted at once. ` +
-      `Please continue 10 minutes after deletion to remove the rest.`
+        `Please continue 10 minutes after deletion to remove the rest.`
     );
   }
 
@@ -209,24 +230,22 @@ export default async function main(ctx) {
 
     if (confirmation !== 'y' && confirmation !== 'yes') {
       output.log('Aborted');
-      now.close();
-
-      // Hangs otherwise
-      process.exit(1);
+      client.close();
       return 1;
     }
   }
 
+  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
   const start = new Date();
 
   await Promise.all([
     ...deployments.map(depl => now.remove(depl.uid, { hard })),
-    ...projects.map(project => removeProject(now, project.id))
+    ...projects.map(project => removeProject(client, project.id))
   ]);
 
   success(
     `Removed ${deploymentsAndProjects(deployments, projects)} ` +
-    `${elapsed(Date.now() - start)}`
+      `${elapsed(Date.now() - start)}`
   );
 
   deployments.forEach(depl => {
@@ -237,14 +256,7 @@ export default async function main(ctx) {
     console.log(`${chalk.gray('-')} ${chalk.bold(project.name)}`);
   });
 
-  // if we close normally, we get a really odd error:
-  //  Error: unexpected end of file
-  //  at Zlib.zlibOnError [as onerror] (zlib.js:142:17) Error: unexpected end of file
-  //  at Zlib.zlibOnError [as onerror] (zlib.js:142:17)
-  // which seems fixable only by exiting directly here, and only
-  // impacts this command, consistently
-  // now.close()
-  process.exit(0);
+  client.close();
   return 0;
 }
 
@@ -252,8 +264,11 @@ function readConfirmation(deployments, projects, output) {
   return new Promise(resolve => {
     if (deployments.length > 0) {
       output.log(
-        `The following ${plural('deployment', deployments.length, deployments.length > 1)} ` +
-        `will be permanently removed:`
+        `The following ${plural(
+          'deployment',
+          deployments.length,
+          deployments.length > 1
+        )} will be permanently removed:`
       );
 
       const deploymentTable = table(
@@ -268,18 +283,24 @@ function readConfirmation(deployments, projects, output) {
     }
 
     for (const depl of deployments) {
-      for (const {alias} of depl.aliases) {
+      for (const { alias } of depl.aliases) {
         output.warn(
           `${chalk.underline(`https://${alias}`)} is an alias for ` +
-          `${chalk.bold(depl.url)} and will be removed`
+            `${chalk.bold(depl.url)} and will be removed`
         );
       }
     }
 
     if (projects.length > 0) {
       console.log(
-        `The following ${plural('project', projects.length, projects.length > 1)} will be permanently removed, ` +
-        `including all ${projects.length > 1 ? 'their' : 'its'} deployments and aliases:`
+        `The following ${plural(
+          'project',
+          projects.length,
+          projects.length > 1
+        )} will be permanently removed, ` +
+          `including all ${
+            projects.length > 1 ? 'their' : 'its'
+          } deployments and aliases:`
       );
 
       for (const project of projects) {
@@ -300,9 +321,13 @@ function readConfirmation(deployments, projects, output) {
   });
 }
 
-function deploymentsAndProjects(deployments = [], projects = [], conjunction = 'and') {
+function deploymentsAndProjects(
+  deployments = [],
+  projects = [],
+  conjunction = 'and'
+) {
   if (!projects || projects.length === 0) {
-    return `${plural('deployment', deployments.length, true)}`
+    return `${plural('deployment', deployments.length, true)}`;
   }
 
   if (!deployments || deployments.length === 0) {

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -152,7 +152,6 @@ export default async function main(ctx) {
         ids.map(async idOrName => getProjectByIdOrName(client, idOrName))
       )
     ]);
-    console.error({ deploymentList, projectList });
 
     deployments = deploymentList.filter(searchFilter);
     projects = projectList.filter(searchFilter);

--- a/test/integration.js
+++ b/test/integration.js
@@ -260,13 +260,13 @@ test('deploy a node microservice', async t => {
 
 
   // Test that it can be deleted via `now rm`
-  ({ stdout, stderr, code }) = await execa(
+  ({ stdout, stderr, code } = await execa(
     binaryPath,
     ['rm', '--yes', href],
     {
       reject: false
     }
-  );
+  ));
   t.is(code, 0, formatOutput({ stdout, stderr }));
 
   response = await fetch(href);

--- a/test/integration.js
+++ b/test/integration.js
@@ -244,7 +244,7 @@ test('detect update command', async t => {
   }
 });
 
-test.only('log in', async t => {
+test('log in', async t => {
   const { stdout, code } = await execa(
     binaryPath,
     ['login', `${session}@${session}.com`, ...defaultArgs],
@@ -1539,7 +1539,7 @@ test('print correct link in legacy warning', async t => {
   t.regex(stderr, /migrate-to-zeit-now/);
 });
 
-test.only('`now rm` 404 exits quickly', async t => {
+test('`now rm` 404 exits quickly', async t => {
   const start = Date.now();
   const { code, stderr } = await execute([
     'rm',

--- a/test/integration.js
+++ b/test/integration.js
@@ -48,7 +48,7 @@ const waitForDeployment = async href => {
     if (current - start > max || response.status >= 500) {
       throw new Error(
         `Waiting for "${href}" failed since it took longer than 4 minutes.\n` +
-        `Received status ${response.status}:\n"${await response.text()}"`
+          `Received status ${response.status}:\n"${await response.text()}"`
       );
     }
 
@@ -57,34 +57,44 @@ const waitForDeployment = async href => {
 };
 
 function fetchTokenWithRetry(url, retries = 3) {
-  return retry(async () => {
-    const res = await fetch(url);
+  return retry(
+    async () => {
+      const res = await fetch(url);
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${url}, received status ${res.status}`);
-    }
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch ${url}, received status ${res.status}`
+        );
+      }
 
-    const data = await res.json();
+      const data = await res.json();
 
-    return data.token;
-  }, { retries, factor: 1 });
+      return data.token;
+    },
+    { retries, factor: 1 }
+  );
 }
 
 function fetchTokenInformation(token, retries = 3) {
   const url = `https://api.zeit.co/www/user`;
   const headers = { Authorization: `Bearer ${token}` };
 
-  return retry(async () => {
-    const res = await fetch(url, { headers });
+  return retry(
+    async () => {
+      const res = await fetch(url, { headers });
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${url}, received status ${res.status}`);
-    }
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch ${url}, received status ${res.status}`
+        );
+      }
 
-    const data = await res.json();
+      const data = await res.json();
 
-    return data.user;
-  }, { retries, factor: 1 });
+      return data.user;
+    },
+    { retries, factor: 1 }
+  );
 }
 
 function formatOutput({ stderr, stdout }) {
@@ -114,26 +124,29 @@ if (!process.env.CI) {
 
 test.before(async () => {
   try {
-    await retry(async () => {
-      const location = path.join(tmpDir ? tmpDir.name : homedir(), '.now');
-      const str = 'aHR0cHM6Ly9hcGktdG9rZW4tZmFjdG9yeS56ZWl0LnNo';
-      const url = Buffer.from(str, 'base64').toString();
-      const token = await fetchTokenWithRetry(url);
+    await retry(
+      async () => {
+        const location = path.join(tmpDir ? tmpDir.name : homedir(), '.now');
+        const str = 'aHR0cHM6Ly9hcGktdG9rZW4tZmFjdG9yeS56ZWl0LnNo';
+        const url = Buffer.from(str, 'base64').toString();
+        const token = await fetchTokenWithRetry(url);
 
-      if (!fs.existsSync(location)) {
-        await createDirectory(location);
-      }
+        if (!fs.existsSync(location)) {
+          await createDirectory(location);
+        }
 
-      await writeFile(
-        path.join(location, `auth.json`),
-        JSON.stringify({ token })
-      );
+        await writeFile(
+          path.join(location, `auth.json`),
+          JSON.stringify({ token })
+        );
 
-      const user = await fetchTokenInformation(token);
+        const user = await fetchTokenInformation(token);
 
-      email = user.email;
-      contextName = user.email.split('@')[0];
-    }, { retries: 3, factor: 1 });
+        email = user.email;
+        contextName = user.email.split('@')[0];
+      },
+      { retries: 3, factor: 1 }
+    );
 
     await prepareFixtures(contextName);
   } catch (err) {
@@ -149,13 +162,20 @@ const execute = (args, options) =>
   });
 
 test('print the deploy help message', async t => {
-  const { stderr, stdout, code } = await execa(binaryPath, ['help', ...defaultArgs], {
-    reject: false
-  });
+  const { stderr, stdout, code } = await execa(
+    binaryPath,
+    ['help', ...defaultArgs],
+    {
+      reject: false
+    }
+  );
 
   t.is(code, 2);
   t.true(stderr.includes(deployHelpMessage), `Received:\n${stderr}\n${stdout}`);
-  t.false(stderr.includes('ExperimentalWarning'), `Received:\n${stderr}\n${stdout}`);
+  t.false(
+    stderr.includes('ExperimentalWarning'),
+    `Received:\n${stderr}\n${stdout}`
+  );
 });
 
 test('output the version', async t => {
@@ -203,18 +223,28 @@ test('detect update command', async t => {
     // Install now to `binPrefix`
     const pkgPath = path.resolve(`now-${pkg.version}.tgz`);
 
-    const installResult = await execa('npm', ['i', '-g', pkgPath], { env: process.env });
-    t.is(installResult.code, 0);
-
-    const { stdout, stderr } = await execa(path.join(binPrefix, 'now'), ['update'], {
+    const installResult = await execa('npm', ['i', '-g', pkgPath], {
       env: process.env
     });
+    t.is(installResult.code, 0);
 
-    t.regex(stderr, /npm install -g now@/gm, `Received:\n"${stderr}"\n"${stdout}"`);
+    const { stdout, stderr } = await execa(
+      path.join(binPrefix, 'now'),
+      ['update'],
+      {
+        env: process.env
+      }
+    );
+
+    t.regex(
+      stderr,
+      /npm install -g now@/gm,
+      `Received:\n"${stderr}"\n"${stdout}"`
+    );
   }
 });
 
-test('log in', async t => {
+test.only('log in', async t => {
   const { stdout, code } = await execa(
     binaryPath,
     ['login', `${session}@${session}.com`, ...defaultArgs],
@@ -258,15 +288,10 @@ test('deploy a node microservice', async t => {
   t.is(contentType, 'application/json; charset=utf-8');
   t.is(content.id, contextName);
 
-
   // Test that it can be deleted via `now rm`
-  ({ stdout, stderr, code } = await execa(
-    binaryPath,
-    ['rm', '--yes', href],
-    {
-      reject: false
-    }
-  ));
+  ({ stdout, stderr, code } = await execa(binaryPath, ['rm', '--yes', href], {
+    reject: false
+  }));
   t.is(code, 0, formatOutput({ stdout, stderr }));
 
   response = await fetch(href);
@@ -488,8 +513,11 @@ test('list the scopes', async t => {
 
   t.is(code, 0);
 
-  const include = `✔ ${contextName}     ${email}`
-  t.true(stdout.includes(include), `Expected: ${include}\n\nReceived instead:\n${stdout}\n${stderr}`);
+  const include = `✔ ${contextName}     ${email}`;
+  t.true(
+    stdout.includes(include),
+    `Expected: ${include}\n\nReceived instead:\n${stdout}\n${stderr}`
+  );
 });
 
 test('list the payment methods', async t => {
@@ -1334,7 +1362,10 @@ test('initialize example "angular"', async t => {
 
   t.is(code, 0, formatOutput({ stdout, stderr }));
   t.true(stdout.includes(goal), formatOutput({ stdout, stderr }));
-  t.true(verifyExampleAngular(cwd, 'angular'), formatOutput({ stdout, stderr }));
+  t.true(
+    verifyExampleAngular(cwd, 'angular'),
+    formatOutput({ stdout, stderr })
+  );
 });
 
 test('initialize example ("angular") to specified directory', async t => {
@@ -1354,7 +1385,10 @@ test('initialize selected example ("amp")', async t => {
   const cwd = tmpDir.name;
   const goal = '> Success! Initialized "amp" example in';
 
-  const { stdout, stderr, code } = await execute(['init'], { cwd, input: '\n' });
+  const { stdout, stderr, code } = await execute(['init'], {
+    cwd,
+    input: '\n'
+  });
 
   t.is(code, 0, formatOutput({ stdout, stderr }));
   t.true(stdout.includes(goal), formatOutput({ stdout, stderr }));
@@ -1503,6 +1537,26 @@ test('print correct link in legacy warning', async t => {
   // since the package.json does not have a start script
   t.is(code, 1);
   t.regex(stderr, /migrate-to-zeit-now/);
+});
+
+test.only('`now rm` 404 exits quickly', async t => {
+  const start = Date.now();
+  const { code, stderr } = await execute([
+    'rm',
+    'this.is.a.deployment.that.does.not.exist.example.com'
+  ]);
+  const delta = Date.now() - start;
+
+  // "does not exist" case is exit code 1, similar to Unix `rm`
+  t.is(code, 1);
+  t.truthy(
+    stderr.includes(
+      'Could not find any deployments or projects matching "this.is.a.deployment.that.does.not.exist.example.com"'
+    )
+  );
+
+  // "quickly" meaning < 5 seconds, because it used to hang from a previous bug
+  t.truthy(delta < 5000);
 });
 
 test.after.always(async () => {


### PR DESCRIPTION
The crux of this fix is that `getDeploymentByIdOrHost()` and `getProjectByIdOrName()` were improperly being passed the `Now` instance instead of the expected `Client` instance, and for some reason that would cause the process to hang until the underlying `http.Agent` timed out its connection to the API server.

Also ran `prettier` on this file.

Fixes #2760.