### PR TITLE
Bump `@now/build-utils` to 0.9.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node": ">= 8.11"
   },
   "devDependencies": {
-    "@now/build-utils": "0.9.12",
+    "@now/build-utils": "0.9.13",
     "@now/go": "latest",
     "@now/next": "latest",
     "@now/node": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,10 +307,10 @@
     "@nodelib/fs.scandir" "2.1.1"
     fastq "^1.6.0"
 
-"@now/build-utils@0.9.12":
-  version "0.9.12"
-  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.9.12.tgz#75d84e491436ddaa985996868a0d696df23fa6ee"
-  integrity sha512-v9IsdxjwSRxf/5/ZnocfDYRldvNLbWRDeRblp5JX+g0tohoKrPGT05nYlBBknxzRVojavUE4mPl5lqI2bhrURQ==
+"@now/build-utils@0.9.13":
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.9.13.tgz#46fb6e5b54ab651622cb14fcf44f649d0e223fb6"
+  integrity sha512-PtS143R6OcZfmkh7z3vo8za5OQnik5BdrNA6V4ntih4VolWwnAwJvN9M5ZVL5DYR+gXv72jhwpCL/x2SW/UrXA==
 
 "@now/go@latest":
   version "0.5.6"


### PR DESCRIPTION
Fixes `canary@canary` bug for `now dev`