### PR TITLE
[now alias] Improve alias support

### DIFF
--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -19,6 +19,7 @@ import setupDomain from '../../util/domains/setup-domain';
 import stamp from '../../util/output/stamp';
 import upsertPathAlias from '../../util/alias/upsert-path-alias';
 import handleCertError from '../../util/certs/handle-cert-error';
+import isWildcardAlias from '../../util/alias/is-wildcard-alias';
 
 type Options = {
   '--debug': boolean;
@@ -215,9 +216,12 @@ export default async function set(
     if (handleResult === 1) {
       return 1;
     }
+
+    const prefix = isWildcardAlias(handleResult.alias) ? '' : 'https://';
+
     console.log(
       `${chalk.cyan('> Success!')} ${chalk.bold(
-        `https://${handleResult.alias}`
+        `${prefix}${handleResult.alias}`
       )} now points to https://${deployment.url} ${setStamp()}`
     );
   }

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -41,6 +41,7 @@ import {
 import { SchemaValidationFailed } from '../../util/errors';
 import purchaseDomainIfAvailable from '../../util/domains/purchase-domain-if-available';
 import handleCertError from '../../util/certs/handle-cert-error';
+import isWildcardAlias from '../../util/alias/is-wildcard-alias';
 
 const addProcessEnv = async (log, env) => {
   let val;
@@ -71,7 +72,7 @@ const addProcessEnv = async (log, env) => {
 };
 
 const deploymentErrorMsg = `Your deployment failed. Please retry later. More: https://err.sh/now/deployment-error`;
-const prepareAlias = input => `https://${input}`;
+const prepareAlias = input => isWildcardAlias(input) ? input : `https://${input}`;
 
 const printDeploymentStatus = async (
   output,

--- a/packages/now-cli/src/util/alias/extract-domain.ts
+++ b/packages/now-cli/src/util/alias/extract-domain.ts
@@ -1,0 +1,5 @@
+import isWildcardAlias from './is-wildcard-alias';
+
+export default function extractDomain(alias: string) {
+  return isWildcardAlias(alias) ? alias.slice(2) : alias;
+}

--- a/packages/now-cli/src/util/alias/is-wildcard-alias.ts
+++ b/packages/now-cli/src/util/alias/is-wildcard-alias.ts
@@ -1,0 +1,3 @@
+export default function isWildcardAlias(alias: string) {
+  return alias.startsWith('*.');
+}

--- a/packages/now-cli/src/util/certs/create-cert-for-alias.ts
+++ b/packages/now-cli/src/util/certs/create-cert-for-alias.ts
@@ -2,7 +2,7 @@ import { NowError } from '../now-error';
 import { Output } from '../output';
 import Client from '../client';
 import createCertForCns from './create-cert-for-cns';
-import getWildcardCnsForDomain from './get-wildcard-cns-for-domain';
+import getWildcardCnsForAlias from './get-wildcard-cns-for-alias';
 import joinWords from '../output/join-words';
 import stamp from '../output/stamp';
 import wait from '../output/wait';
@@ -14,7 +14,7 @@ export default async function createCertificateForAlias(
   alias: string,
   shouldBeWildcard: boolean
 ) {
-  const cns = shouldBeWildcard ? getWildcardCnsForDomain(alias) : [alias];
+  const cns = shouldBeWildcard ? getWildcardCnsForAlias(alias) : [alias];
   const cancelMessage = wait(`Generating a certificate...`);
   const certStamp = stamp();
   const cert = await createCertForCns(client, cns, context);

--- a/packages/now-cli/src/util/certs/get-wildcard-cns-for-alias.ts
+++ b/packages/now-cli/src/util/certs/get-wildcard-cns-for-alias.ts
@@ -1,15 +1,21 @@
 import psl from 'psl';
 import { InvalidDomain } from '../errors-ts';
+import isWildcardAlias from '../alias/is-wildcard-alias';
+import extractDomain from '../alias/extract-domain';
 
-export default function getWildcardCNSForDomain(rawDomain: string) {
-  const parsedDomain = psl.parse(rawDomain);
+export default function getWildcardCNSForAlias(alias: string) {
+  if (isWildcardAlias(alias)) {
+    return [extractDomain(alias), alias];
+  }
+
+  const parsedDomain = psl.parse(alias);
   if (parsedDomain.error) {
-    throw new InvalidDomain(rawDomain);
+    throw new InvalidDomain(alias);
   }
 
   const { domain, subdomain } = parsedDomain;
   if (!domain) {
-    throw new InvalidDomain(rawDomain);
+    throw new InvalidDomain(alias);
   }
 
   const secondLevel =

--- a/packages/now-cli/src/util/domains/setup-domain.ts
+++ b/packages/now-cli/src/util/domains/setup-domain.ts
@@ -8,6 +8,7 @@ import Client from '../client';
 import maybeGetDomainByName from './maybe-get-domain-by-name';
 import purchaseDomainIfAvailable from './purchase-domain-if-available';
 import verifyDomain from './verify-domain';
+import extractDomain from '../alias/extract-domain';
 
 export default async function setupDomain(
   output: Output,
@@ -15,7 +16,8 @@ export default async function setupDomain(
   alias: string,
   contextName: string
 ) {
-  const parsedDomain = psl.parse(alias);
+  const aliasDomain = extractDomain(alias);
+  const parsedDomain = psl.parse(aliasDomain);
   if (parsedDomain.error) {
     return new ERRORS.InvalidDomain(alias, parsedDomain.error.message);
   }
@@ -60,7 +62,7 @@ export default async function setupDomain(
   const purchased = await purchaseDomainIfAvailable(
     output,
     client,
-    alias,
+    aliasDomain,
     contextName
   );
   if (purchased instanceof NowError) {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -849,6 +849,52 @@ test('output logs of a 2.0 deployment', async t => {
   t.is(code, 0);
 });
 
+test('create wildcard alias for deployment', async t => {
+  const hosts = {
+    deployment: context.deployment,
+    alias: `*.${contextName}.now.sh`
+  };
+
+  const { stdout, code } = await execa(
+    binaryPath,
+    ['alias', hosts.deployment, hosts.alias, ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  const goal = `> Success! ${hosts.alias} now points to https://${
+    hosts.deployment
+  }`;
+
+  t.is(code, 0);
+  t.true(stdout.startsWith(goal));
+
+  // Send a test request to the alias
+  const response = await fetch(`https://test.${contextName}.now.sh`);
+  const content = await response.text();
+
+  t.true(response.ok);
+  t.true(content.includes(contextName));
+
+  context.wildcardAlias = hosts.alias;
+});
+
+test('remove the wildcard alias', async t => {
+  const goal = `> Success! Alias ${context.wildcardAlias} removed`;
+
+  const { stdout, code } = await execa(
+    binaryPath,
+    ['alias', 'rm', context.wildcardAlias, '--yes', ...defaultArgs],
+    {
+      reject: false
+    }
+  );
+
+  t.is(code, 0);
+  t.true(stdout.startsWith(goal));
+});
+
 test('ensure type and instance count in list is right', async t => {
   const { stdout, code } = await execa(binaryPath, ['ls', ...defaultArgs], {
     reject: false


### PR DESCRIPTION
This enables https://github.com/zeit/now-cli/pull/2747 from @nkzawa again.

We had to revert the previous one, because we didn't want to include it in the next stable release.

This further makes sure that we don't display `https://` in front of a wildcard alias, since `https://*.mydomain.tld` is not a valid URL.