### PR TITLE
 Use short-form for the update command

### DIFF
--- a/src/util/get-update-command.ts
+++ b/src/util/get-update-command.ts
@@ -88,10 +88,10 @@ export default async function getUpdateCommand(): Promise<string> {
   if (await isGlobal()) {
     return (await isYarn())
       ? `yarn global add now@${tag}`
-      : `npm install -g now@${tag}`;
+      : `npm i -g now@${tag}`;
   }
 
   return (await isYarn())
     ? `yarn add now@${tag}`
-    : `npm install now@${tag}`;
+    : `npm i now@${tag}`;
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -249,7 +249,7 @@ test('detect update command', async t => {
 
     t.regex(
       stderr,
-      /npm install -g now@/gm,
+      /npm i -g now@/gm,
       `Received:\n"${stderr}"\n"${stdout}"`
     );
   }


### PR DESCRIPTION
Recommend `npm i` instead of `npm install`.

Fixes https://github.com/zeit/now-cli/issues/2800