### PR TITLE
[tests] Fix unit tests & coverage step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Compiling `now dev` HTML error templates
+          command: node packages/now-cli/scripts/compile-templates.js
+      - run:
           name: Run unit tests
           command: yarn workspace now run test-unit
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,24 +107,24 @@ jobs:
           name: Linting Code
           command: yarn test-lint
 
-  test-unit:
-    docker:
-      - image: circleci/node:10
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Compiling `now dev` HTML error templates
-          command: node packages/now-cli/scripts/compile-templates.js
-      - run:
-          name: Running Unit Tests
-          command: yarn test-unit --clean false
-      - persist_to_workspace:
-          root: .
-          paths:
-            - packages/now-cli/.nyc_output
+  # test-unit:
+  #   docker:
+  #     - image: circleci/node:10
+  #   working_directory: ~/repo
+  #   steps:
+  #     - checkout
+  #     - attach_workspace:
+  #         at: .
+  #     - run:
+  #         name: Compiling `now dev` HTML error templates
+  #         command: node packages/now-cli/scripts/compile-templates.js
+  #     - run:
+  #         name: Running Unit Tests
+  #         command: yarn test-unit --clean false
+  #     - persist_to_workspace:
+  #         root: .
+  #         paths:
+  #           - packages/now-cli/.nyc_output
 
   test-integration-macos-node-8:
     macos:
@@ -354,6 +354,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Run unit tests
+          command: yarn workspace now run test-unit
+      - run:
           name: Run coverage report
           command: yarn workspace now run coverage
 
@@ -428,12 +431,12 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-unit:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
+      # - test-unit:
+      #     requires:
+      #       - build
+      #     filters:
+      #       tags:
+      #         only: /.*/
       - test-integration-macos-node-8:
           requires:
             - build
@@ -514,7 +517,7 @@ workflows:
               only: /.*/
       - coverage:
           requires:
-            - test-unit
+            #- test-unit
             - test-integration-macos-node-8
             - test-integration-macos-node-10
             - test-integration-macos-node-12


### PR DESCRIPTION
This combines the `test-unit` and `coverage` steps into one.

This fixes the issue where the `now-cli` package is unmodified and the `test-unit` step fails with the following error:

> The specified paths did not match any files in /home/circleci/repo

![image](https://user-images.githubusercontent.com/229881/63719488-01b7b680-c81b-11e9-9ffe-3a125a9a462a.png)
