### PR TITLE
[now-python] Use `debug()` from build-utils

### DIFF
--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -11,11 +11,12 @@ import {
   createLambda,
   shouldServe,
   BuildOptions,
+  debug,
 } from '@now/build-utils';
 
 async function pipInstall(pipPath: string, workDir: string, ...args: string[]) {
   const target = '.';
-  console.log(
+  debug(
     `running "pip install --disable-pip-version-check --target ${target} --upgrade ${args.join(
       ' '
     )}"...`
@@ -33,7 +34,7 @@ async function pipInstall(pipPath: string, workDir: string, ...args: string[]) {
       ],
       {
         cwd: workDir,
-        stdio: 'inherit',
+        stdio: 'pipe',
       }
     );
   } catch (err) {
@@ -47,7 +48,7 @@ async function pipInstall(pipPath: string, workDir: string, ...args: string[]) {
 }
 
 async function pipenvConvert(cmd: string, srcDir: string) {
-  console.log('running pipfile2req');
+  debug('running pipfile2req');
   try {
     const out = await execa.stdout(cmd, [], {
       cwd: srcDir,
@@ -66,7 +67,7 @@ export const build = async ({
   meta = {},
   config,
 }: BuildOptions) => {
-  console.log('downloading files...');
+  debug('downloading files...');
   let downloadedFiles = await download(originalFiles, workPath, meta);
 
   if (meta.isDev) {
@@ -116,7 +117,7 @@ export const build = async ({
     : null;
 
   if (pipfileLockDir) {
-    console.log('found "Pipfile.lock"');
+    debug('found "Pipfile.lock"');
 
     // Convert Pipenv.Lock to requirements.txt.
     // We use a different`workPath` here because we want `pipfile-requirements` and it's dependencies
@@ -141,11 +142,11 @@ export const build = async ({
   const requirementsTxt = join(entryDirectory, 'requirements.txt');
 
   if (fsFiles[requirementsTxt]) {
-    console.log('found local "requirements.txt"');
+    debug('found local "requirements.txt"');
     const requirementsTxtPath = fsFiles[requirementsTxt].fsPath;
     await pipInstall(pipPath, workPath, '-r', requirementsTxtPath);
   } else if (fsFiles['requirements.txt']) {
-    console.log('found global "requirements.txt"');
+    debug('found global "requirements.txt"');
     const requirementsTxtPath = fsFiles['requirements.txt'].fsPath;
     await pipInstall(pipPath, workPath, '-r', requirementsTxtPath);
   }
@@ -155,7 +156,7 @@ export const build = async ({
 
   // will be used on `from $here import handler`
   // for example, `from api.users import handler`
-  console.log('entrypoint is', entrypoint);
+  debug('entrypoint is', entrypoint);
   const userHandlerFilePath = entrypoint
     .replace(/\//g, '.')
     .replace(/\.py$/, '');


### PR DESCRIPTION
This PR is cherry-pick commit from previous `now-builders` canary.

* Use `debug()` from build-utils

* Apply suggestions from code review
