### PR TITLE
Add GH Actions Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  push:
+    branches:
+    - master
+    - canary
+    tags:
+    - '!*'
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install
+      run: yarn install --pure-lockfile
+    - name: Build
+      run: yarn build
+    - name: Publish
+      run: yarn publish-from-github
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Ideally, we would move all CI from CircleCI to Github Actions.

But for now, we can use this to publish when `canary` or `master` branch changes.

I generated a new token for zeit-bot and added to [secrets](https://github.com/zeit/now/settings/secrets).

For reference, see [node-file-trace](https://github.com/zeit/node-file-trace/blob/49bc51ac05403d9a921c2c06b18ec49c8c2bc220/.github/workflows/ci.yml#L1) which is using the new GitHub Actions.