### PR TITLE
[now-cli] Update `now alias` warning for `--prod`

### DIFF
--- a/packages/now-cli/src/util/alias/get-inferred-targets.ts
+++ b/packages/now-cli/src/util/alias/get-inferred-targets.ts
@@ -7,7 +7,7 @@ export default async function getInferredTargets(
   output: Output,
   config: Config
 ) {
-  output.warn(`The ${cmd('now alias')} command (no arguments) was deprecated in favour of ${cmd('now --target production')}.`);
+  output.warn(`The ${cmd('now alias')} command (no arguments) was deprecated in favour of ${cmd('now --prod')}.`);
 
   // This field is deprecated, warn about it
   if (config.aliases) {


### PR DESCRIPTION
Today, `now --prod` is recommended instead of `now --target production`. 
Those who happen to enter `now alias` command should understand `now --prod` is best.