### PR TITLE
[now-cli] Allow to fetch more certificates with paging

### DIFF
--- a/packages/now-cli/src/commands/certs/index.js
+++ b/packages/now-cli/src/commands/certs/index.js
@@ -79,6 +79,7 @@ export default async function main(ctx) {
       '--challenge-only': Boolean,
       '--overwrite': Boolean,
       '--output': String,
+      '--after': String,
       '--crt': String,
       '--key': String,
       '--ca': String

--- a/packages/now-cli/src/commands/certs/ls.js
+++ b/packages/now-cli/src/commands/certs/ls.js
@@ -65,7 +65,7 @@ async function ls(ctx, opts, args, output) {
   );
 
   if (certs.length >= 100) {
-    output.note(`There might be more certificates can be retrieved with ${cmd(`now ${process.argv.slice(2).join(' ')} --after=${lastCert}`)}.`);
+    output.note(`There may be more certificates that can be retrieved with ${cmd(`now ${process.argv.slice(2).join(' ')} --after=${lastCert}`)}.`);
   }
 
   if (certs.length > 0) {

--- a/packages/now-cli/src/commands/certs/ls.js
+++ b/packages/now-cli/src/commands/certs/ls.js
@@ -49,7 +49,9 @@ async function ls(ctx, opts, args, output) {
   if (certificates instanceof CertNotFound) {
     output.error(certificates.message);
     return 1;
-  } else if (certificates instanceof Error) {
+  }
+
+  if (certificates instanceof Error) {
     throw certificates;
   }
 

--- a/packages/now-cli/src/commands/certs/ls.js
+++ b/packages/now-cli/src/commands/certs/ls.js
@@ -4,10 +4,12 @@ import plural from 'pluralize';
 import psl from 'psl';
 import table from 'text-table';
 import Now from '../../util';
+import cmd from '../../util/output/cmd';
 import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
 import stamp from '../../util/output/stamp.ts';
 import getCerts from '../../util/certs/get-certs';
+import { CertNotFound } from '../../util/errors-ts';
 import strlen from '../../util/strlen.ts';
 
 async function ls(ctx, opts, args, output) {
@@ -15,6 +17,7 @@ async function ls(ctx, opts, args, output) {
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
+  const after = opts['--after'];
   const client = new Client({ apiUrl, token, currentTeam, debug });
   let contextName = null;
 
@@ -41,16 +44,32 @@ async function ls(ctx, opts, args, output) {
   }
 
   // Get the list of certificates
-  const certs = sortByCn(await getCerts(output, now));
+  const certificates = await getCerts(output, now, { after }).catch(err => err);
+
+  if (certificates instanceof CertNotFound) {
+    output.error(certificates.message);
+    return 1;
+  } else if (certificates instanceof Error) {
+    throw certificates;
+  }
+
+  const { uid: lastCert } = certificates[certificates.length - 1];
+  const certs = sortByCn(certificates);
+
   output.log(
     `${plural('certificate', certs.length, true)} found under ${chalk.bold(
       contextName
     )} ${lsStamp()}`
   );
 
+  if (certs.length >= 100) {
+    output.note(`There might be more certificates can be retrieved with ${cmd(`now ${process.argv.slice(2).join(' ')} --after=${lastCert}`)}.`);
+  }
+
   if (certs.length > 0) {
     console.log(formatCertsTable(certs));
   }
+
   return 0;
 }
 

--- a/packages/now-cli/src/util/certs/get-certs.ts
+++ b/packages/now-cli/src/util/certs/get-certs.ts
@@ -1,7 +1,7 @@
+import { URLSearchParams } from 'url';
 import Client from '../client';
 import { Output } from '../output';
 import { Cert } from '../../types';
-import { URLSearchParams } from 'url';
 import getCertById from './get-cert-by-id';
 import { CertNotFound } from '../errors-ts';
 

--- a/packages/now-cli/src/util/certs/get-certs.ts
+++ b/packages/now-cli/src/util/certs/get-certs.ts
@@ -1,12 +1,43 @@
 import Client from '../client';
 import { Output } from '../output';
 import { Cert } from '../../types';
+import { URLSearchParams } from 'url';
+import getCertById from './get-cert-by-id';
+import { CertNotFound } from '../errors-ts';
 
 type Response = {
   certs: Cert[];
 };
 
-export default async function getCerts(output: Output, client: Client) {
-  const { certs } = await client.fetch<Response>(`/v3/now/certs`);
-  return certs;
+function sortByCreated(a: Cert, b: Cert) {
+  const dateA = new Date(a.created);
+  const dateB = new Date(b.created);
+
+  if (dateA > dateB) {
+    return -1;
+  }
+
+  if (dateA < dateB) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export default async function getCerts(output: Output, client: Client, options?: { after?: string; }) {
+  const query = new URLSearchParams({ limit: '100' });
+
+  if (options && options.after) {
+    const lastCert = await getCertById(output, client, options.after);
+
+    if (lastCert instanceof CertNotFound) {
+      throw lastCert;
+    }
+
+    query.set('until', new Date(lastCert.created).getTime().toString());
+  }
+
+  const { certs } = await client.fetch<Response>(`/v3/now/certs?${query}`);
+
+  return certs.sort(sortByCreated);
 }

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1663,6 +1663,13 @@ test('render build errors', async t => {
   t.regex(output.stderr, /Build failed/gm, formatOutput(output));
 });
 
+test('now cert ls --after=cert_test', async t => {
+  const output = await execute(['certs', 'ls', '--after=cert_test']);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(output.stderr, /The cert cert_test can't be found\./gm, formatOutput(output));
+});
+
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);


### PR DESCRIPTION
Allow to fetch more certificates with paging by using `--after`.
When the API returns more than 100 certs we'll show a notification and the command to continue.

Fixes https://github.com/zeit/now/issues/2786