### PR TITLE
[now-cli] fix login test

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -177,7 +177,7 @@ test('login', async t => {
   const logoutOutput = await execute(['logout']);
   t.is(logoutOutput.code, 0, formatOutput(logoutOutput));
 
-  const loginOutput = await execa(binaryPath, ['login', email]);
+  const loginOutput = await execa(binaryPath, ['login', email, ...defaultArgs]);
   t.is(loginOutput.code, 0, formatOutput(loginOutput));
   t.regex(loginOutput.stdout, /You are now logged in\./gm, formatOutput(loginOutput));
 


### PR DESCRIPTION
Without `defaultArgs`, it doesn't store the token to expected location.