### PR TITLE
[now-cli] Use `xdg-app-paths` for `now dev` cache dir

### DIFF
--- a/packages/now-cli/@types/cache-or-tmp-directory/index.d.ts
+++ b/packages/now-cli/@types/cache-or-tmp-directory/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'cache-or-tmp-directory' {
-  export default function (appName: string) : string | null
-}

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -98,7 +98,7 @@
     "@types/which": "1.3.1",
     "@types/write-json-file": "2.2.1",
     "@zeit/dockerignore": "0.0.5",
-    "@zeit/fun": "0.9.1",
+    "@zeit/fun": "0.9.3",
     "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.10.2",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -111,7 +111,6 @@
     "async-sema": "2.1.4",
     "ava": "2.2.0",
     "bytes": "3.0.0",
-    "cache-or-tmp-directory": "1.0.0",
     "chalk": "2.4.2",
     "chokidar": "2.1.6",
     "clipboardy": "2.1.0",

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -8,7 +8,7 @@ import { createHash } from 'crypto';
 import { createGunzip } from 'zlib';
 import { join, resolve } from 'path';
 import { funCacheDir } from '@zeit/fun';
-import cacheDirectory from 'cache-or-tmp-directory';
+import XDGAppPaths from 'xdg-app-paths';
 import {
   createReadStream,
   mkdirp,
@@ -80,7 +80,7 @@ export async function prepareCacheDir() {
   const { NOW_BUILDER_CACHE_DIR } = process.env;
   const designated = NOW_BUILDER_CACHE_DIR
     ? resolve(NOW_BUILDER_CACHE_DIR)
-    : cacheDirectory('co.zeit.now');
+    : XDGAppPaths('co.zeit.now').cache();
 
   if (!designated) {
     throw new NoBuilderCacheError();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2037,20 +2037,19 @@
     agentkeepalive "3.4.1"
     debug "3.1.0"
 
-"@zeit/fun@0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.9.1.tgz#3e456880b5df26622ec6f658ddd32a3a2d00693b"
-  integrity sha512-Rq3vWmTcnNA9GkT1E+oy1WB7R7yC3+eQ1DpTMUP3P6aIPM3EpwUwK9rC7/y226WHng6+eZFHyEjOCmB1TxhXPQ==
+"@zeit/fun@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.9.3.tgz#031b82b8fcb9ada9656d3dded2b701b4a86e5a40"
+  integrity sha512-bdcF2l0pSxQyJxi5wmrverNTPxHQic3uCSPfBwYJDmaFumNhrsyqWMjPUdxO2rx4e3aLlqBBiJyrSb0ZGNTwMw==
   dependencies:
     async-listen "1.0.0"
-    cache-or-tmp-directory "1.0.0"
     debug "4.1.1"
     execa "1.0.0"
     fs-extra "7.0.1"
     generic-pool "3.4.2"
     micro "9.3.5-canary.3"
     ms "2.1.1"
-    node-fetch "2.3.0"
+    node-fetch "2.6.0"
     path-match "1.2.4"
     promisepipe "3.0.0"
     stat-mode "0.3.0"
@@ -2058,6 +2057,7 @@
     tar "4.4.8"
     uid-promise "1.0.0"
     uuid "3.3.2"
+    xdg-app-paths "5.1.0"
     yauzl-promise "2.1.3"
 
 "@zeit/ncc@0.18.5":
@@ -3019,20 +3019,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-cache-directory@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cache-directory/-/cache-directory-2.0.0.tgz#0d8efa1abbb6d1dd926d255ce733b4f7c5ab2892"
-  integrity sha512-7YKEapH+2Uikde8hySyfobXBqPKULDyHNl/lhKm7cKf/GJFdG/tU/WpLrOg2y9aUrQrWUilYqawFIiGJPS6gDA==
-  dependencies:
-    xdg-basedir "^3.0.0"
-
-cache-or-tmp-directory@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cache-or-tmp-directory/-/cache-or-tmp-directory-1.0.0.tgz#07834b808f250a307cc77991dc757eca869d8c29"
-  integrity sha512-EuGx1xcSEpPSI2YgivZNvbCgCepc4hyAAFgDO1FRuZ/BYrgnZR4NIQFrcHhawyXxXv/yAtk9ck47qB0Pfhzg8Q==
-  dependencies:
-    cache-directory "^2.0.0"
 
 cacheable-request@^6.0.0:
   version "6.1.0"
@@ -7906,11 +7892,6 @@ node-fetch@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
   integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
-
-node-fetch@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-fetch@2.6.0, node-fetch@^2.2.1, node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"


### PR DESCRIPTION
For consistency, because #2877 uses this module. No need for multiple modules that do the same thing.

~~Don't merge this for now, I would like https://github.com/zeit/fun/pull/33 to land first so that we can remove the `cache-or-tmp-directory` module completely from the `yarn.lock` file.~~ Done!