### PR TITLE
[now-cli] Bump `@zeit/fun` to 0.10.0

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -98,7 +98,7 @@
     "@types/which": "1.3.1",
     "@types/write-json-file": "2.2.1",
     "@zeit/dockerignore": "0.0.5",
-    "@zeit/fun": "0.9.3",
+    "@zeit/fun": "0.10.0",
     "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,10 +2049,10 @@
     agentkeepalive "3.4.1"
     debug "3.1.0"
 
-"@zeit/fun@0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.9.3.tgz#031b82b8fcb9ada9656d3dded2b701b4a86e5a40"
-  integrity sha512-bdcF2l0pSxQyJxi5wmrverNTPxHQic3uCSPfBwYJDmaFumNhrsyqWMjPUdxO2rx4e3aLlqBBiJyrSb0ZGNTwMw==
+"@zeit/fun@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.10.0.tgz#03f97e7886dd2b565c921ca066ed48cf40d18531"
+  integrity sha512-eCfu2v1imJzRbl6nAgDNok3rKV3MN0R0Mwawv9zKKcBtWoocvbfTnzI5aCRd84P/Td49zHK9F3mzCEX81a9dgQ==
   dependencies:
     async-listen "1.0.0"
     debug "4.1.1"
@@ -8014,7 +8014,7 @@ normalize-url@^4.1.0:
   integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
 now-client@./packages/now-client:
-  version "5.1.1-canary.1"
+  version "5.1.1-canary.2"
   dependencies:
     "@zeit/fetch" "5.1.0"
     async-retry "1.2.3"


### PR DESCRIPTION
This PR bumps `@zeit/fun` to version [0.10.0](https://github.com/zeit/fun/releases/tag/0.10.0)