### PR TITLE
[CircleCI] Remove `publish-stable` and `publish-canary` steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,25 +113,6 @@ jobs:
           name: Linting Code
           command: yarn test-lint
 
-  # test-unit:
-  #   docker:
-  #     - image: circleci/node:10
-  #   working_directory: ~/repo
-  #   steps:
-  #     - checkout
-  #     - attach_workspace:
-  #         at: .
-  #     - run:
-  #         name: Compiling `now dev` HTML error templates
-  #         command: node packages/now-cli/scripts/compile-templates.js
-  #     - run:
-  #         name: Running Unit Tests
-  #         command: yarn test-unit --clean false
-  #     - persist_to_workspace:
-  #         root: .
-  #         paths:
-  #           - packages/now-cli/.nyc_output
-
   test-integration-macos-node-8:
     macos:
       xcode: '9.2.0'
@@ -390,36 +371,6 @@ jobs:
           name: Finalize Sentry Release
           command: sentry-cli releases finalize now-cli@`git describe --tags`
 
-  publish-stable:
-    docker:
-      - image: circleci/node:10
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Saving Authentication Information
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run:
-          name: Publishing to Stable Channel
-          command: npm publish --tag latest
-
-  publish-canary:
-    docker:
-      - image: circleci/node:10
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Saving Authentication Information
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run:
-          name: Publishing to Canary Channel
-          command: npm publish --tag canary
-
 workflows:
   version: 2
   unscheduled:
@@ -440,12 +391,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      # - test-unit:
-      #     requires:
-      #       - build
-      #     filters:
-      #       tags:
-      #         only: /.*/
       - test-integration-macos-node-8:
           requires:
             - build
@@ -526,7 +471,6 @@ workflows:
               only: /.*/
       - coverage:
           requires:
-            #- test-unit
             - test-integration-macos-node-8
             - test-integration-macos-node-10
             - test-integration-macos-node-12
@@ -544,19 +488,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish-canary:
-          requires:
-            - coverage
-          filters:
-            tags:
-              only: /^.*canary.*($|\b)/
-            branches:
-              ignore: /.*/
-      - publish-stable:
-          requires:
-            - coverage
-          filters:
-            tags:
-              only: /^(\d+\.)?(\d+\.)?(\*|\d+)$/
-            branches:
-              ignore: /.*/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
     - '!*'
 
 jobs:
-  publish:
+  Publish:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Publishing to npm is now handled by GitHub Actions.

Aside from that, the Circle publishing was broken. See: https://circleci.com/gh/zeit/now/7213