### PR TITLE
[now-next] Add monorepo autosetup support

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -298,7 +298,7 @@ export const build = async ({
   }
 
   if (!isLegacy) {
-    await createServerlessConfig(workPath, realNextVersion);
+    await createServerlessConfig(workPath, entryPath, realNextVersion);
   }
 
   debug('running user script...');

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -55,7 +55,7 @@ function excludeFiles(
     }
     return {
       ...newFiles,
-      [filePath]: files[filePath]
+      [filePath]: files[filePath],
     };
   }, {});
 }
@@ -116,7 +116,7 @@ function normalizePackageJson(
   const dependencies: stringMap = {};
   const devDependencies: stringMap = {
     ...defaultPackageJson.dependencies,
-    ...defaultPackageJson.devDependencies
+    ...defaultPackageJson.devDependencies,
   };
 
   if (devDependencies.react) {
@@ -139,17 +139,18 @@ function normalizePackageJson(
       'react-dom': 'latest',
       ...dependencies, // override react if user provided it
       // next-server is forced to canary
-      'next-server': 'v7.0.2-canary.49'
+      'next-server': 'v7.0.2-canary.49',
     },
     devDependencies: {
       ...devDependencies,
       // next is forced to canary
-      next: 'v7.0.2-canary.49'
+      next: 'v7.0.2-canary.49',
     },
     scripts: {
       ...defaultPackageJson.scripts,
-      'now-build': 'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-    }
+      'now-build':
+        'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+    },
   };
 }
 
@@ -218,12 +219,12 @@ function getRoutes(
   const routes: Route[] = [
     {
       src: `${prefix}_next/(.*)`,
-      dest: `${url}/_next/$1`
+      dest: `${url}/_next/$1`,
     },
     {
       src: `${prefix}static/(.*)`,
-      dest: `${url}/static/$1`
-    }
+      dest: `${url}/static/$1`,
+    },
   ];
   const filePaths = Object.keys(filesInside);
   const dynamicPages = [];
@@ -251,7 +252,7 @@ function getRoutes(
 
     routes.push({
       src: `${prefix}${pageName}`,
-      dest: `${url}/${pageName}`
+      dest: `${url}/${pageName}`,
     });
 
     if (pageName.endsWith('index')) {
@@ -259,7 +260,7 @@ function getRoutes(
 
       routes.push({
         src: `${prefix}${resolvedIndex}`,
-        dest: `${url}/${resolvedIndex}`
+        dest: `${url}/${resolvedIndex}`,
       });
     }
   }
@@ -288,7 +289,7 @@ function getRoutes(
     const fileName = path.relative('public', relativePath);
     const route = {
       src: `${prefix}${fileName}`,
-      dest: `${url}/${fileName}`
+      dest: `${url}/${fileName}`,
     };
 
     // Only add the route if a page is not already using it
@@ -327,6 +328,18 @@ export function getDynamicRoutes(
   } catch (_) {} // eslint-disable-line no-empty
 
   if (!getRouteRegex || !getSortedRoutes) {
+    try {
+      ({ getRouteRegex, getSortedRoutes } = require(resolveFrom(
+        entryPath,
+        'next/dist/next-server/lib/router/utils'
+      )));
+      if (typeof getRouteRegex !== 'function') {
+        getRouteRegex = undefined;
+      }
+    } catch (_) {} // eslint-disable-line no-empty
+  }
+
+  if (!getRouteRegex || !getSortedRoutes) {
     throw new Error(
       'Found usage of dynamic routes but not on a new enough version of Next.js.'
     );
@@ -334,7 +347,7 @@ export function getDynamicRoutes(
 
   const pageMatchers = getSortedRoutes(dynamicPages).map(pageName => ({
     pageName,
-    matcher: getRouteRegex && getRouteRegex(pageName).re
+    matcher: getRouteRegex && getRouteRegex(pageName).re,
   }));
 
   const routes: { src: string; dest: string }[] = [];
@@ -347,7 +360,7 @@ export function getDynamicRoutes(
     if (pageMatcher && pageMatcher.matcher) {
       routes.push({
         src: pageMatcher.matcher.source,
-        dest
+        dest,
       });
     }
   });
@@ -403,7 +416,7 @@ export async function createPseudoLayer(files: {
     pseudoLayer[fileName] = {
       compBuffer,
       crc32: crc32.unsigned(origBuffer),
-      uncompressedSize: origBuffer.byteLength
+      uncompressedSize: origBuffer.byteLength,
     };
   }
 
@@ -427,7 +440,7 @@ export async function createLambdaFromPseudoLayers({
   layers,
   handler,
   runtime,
-  environment = {}
+  environment = {},
 }: CreateLambdaFromPseudoLayersOptions) {
   await createLambdaSema.acquire();
   const zipFile = new ZipFile();
@@ -441,7 +454,7 @@ export async function createLambdaFromPseudoLayers({
       // @ts-ignore: `addDeflatedBuffer` is a valid function, but missing on the type
       zipFile.addDeflatedBuffer(compBuffer, seedKey, {
         crc32,
-        uncompressedSize
+        uncompressedSize,
       });
 
       addedFiles.add(seedKey);
@@ -464,7 +477,7 @@ export async function createLambdaFromPseudoLayers({
     handler,
     runtime,
     zipBuffer,
-    environment
+    environment,
   });
 }
 
@@ -481,5 +494,5 @@ export {
   stringMap,
   syncEnvVars,
   normalizePage,
-  isDynamicRoute
+  isDynamicRoute,
 };

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -186,7 +186,7 @@ it(
     expect(hasUnderScoreErrorStaticFile).toBeTruthy();
     expect(serverlessError).toBeTruthy();
 
-    const contents = await fs.readdir(workPath);
+    const contents = await fs.readdir(path.join(workPath, 'nested'));
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
   },
@@ -219,7 +219,7 @@ it(
     expect(hasUnderScoreErrorStaticFile).toBeTruthy();
     expect(serverlessError).toBeTruthy();
 
-    const contents = await fs.readdir(workPath);
+    const contents = await fs.readdir(path.join(workPath, 'nested'));
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -189,9 +189,6 @@ it(
     const contents = await fs.readdir(workPath);
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
-    expect(
-      contents.some(name => name.includes('next.config.original.'))
-    ).toBeTruthy();
   },
   FOUR_MINUTES
 );

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -170,8 +170,8 @@ it(
       path.join(__dirname, 'serverless-config-monorepo-missing')
     );
 
-    expect(output.index).toBeDefined();
-    expect(output.goodbye).toBeDefined();
+    expect(output['nested/index']).toBeDefined();
+    expect(output['nested/goodbye']).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -203,8 +203,8 @@ it(
       path.join(__dirname, 'serverless-config-monorepo-present')
     );
 
-    expect(output.index).toBeDefined();
-    expect(output.goodbye).toBeDefined();
+    expect(output['nested/index']).toBeDefined();
+    expect(output['nested/goodbye']).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -8,7 +8,7 @@ it(
   'Should build the standard example',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'standard'));
     expect(output['index.html']).toBeDefined();
     expect(output.goodbye).toBeDefined();
@@ -33,7 +33,7 @@ it(
   'Should build the monorepo example',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'monorepo'));
     expect(output['www/index']).toBeDefined();
     expect(output['www/static/test.txt']).toBeDefined();
@@ -55,7 +55,7 @@ it(
   'Should build the legacy standard example',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'legacy-standard'));
     expect(output.index).toBeDefined();
     const filePaths = Object.keys(output);
@@ -75,7 +75,7 @@ it(
   'Should build the legacy custom dependency test',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'legacy-custom-dependency'));
     expect(output.index).toBeDefined();
   },
@@ -97,7 +97,7 @@ it(
   'Should build the static-files test on legacy',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'legacy-static-files'));
     expect(output['static/test.txt']).toBeDefined();
   },
@@ -108,7 +108,7 @@ it(
   'Should build the static-files test',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'static-files'));
     expect(output['static/test.txt']).toBeDefined();
   },
@@ -119,7 +119,7 @@ it(
   'Should build the public-files test',
   async () => {
     const {
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'public-files'));
     expect(output['robots.txt']).toBeDefined();
   },
@@ -131,8 +131,80 @@ it(
   async () => {
     const {
       workPath,
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-config'));
+
+    expect(output.index).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    const filePaths = Object.keys(output);
+    const serverlessError = filePaths.some(filePath =>
+      filePath.match(/_error/)
+    );
+    const hasUnderScoreAppStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_app\.js$/)
+    );
+    const hasUnderScoreErrorStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_error\.js$/)
+    );
+    expect(hasUnderScoreAppStaticFile).toBeTruthy();
+    expect(hasUnderScoreErrorStaticFile).toBeTruthy();
+    expect(serverlessError).toBeTruthy();
+
+    const contents = await fs.readdir(workPath);
+
+    expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
+    expect(
+      contents.some(name => name.includes('next.config.original.'))
+    ).toBeTruthy();
+  },
+  FOUR_MINUTES
+);
+
+it(
+  'Should build the serverless-config-monorepo-missing example',
+  async () => {
+    const {
+      workPath,
+      buildResult: { output },
+    } = await runBuildLambda(
+      path.join(__dirname, 'serverless-config-monorepo-missing')
+    );
+
+    expect(output.index).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    const filePaths = Object.keys(output);
+    const serverlessError = filePaths.some(filePath =>
+      filePath.match(/_error/)
+    );
+    const hasUnderScoreAppStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_app\.js$/)
+    );
+    const hasUnderScoreErrorStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_error\.js$/)
+    );
+    expect(hasUnderScoreAppStaticFile).toBeTruthy();
+    expect(hasUnderScoreErrorStaticFile).toBeTruthy();
+    expect(serverlessError).toBeTruthy();
+
+    const contents = await fs.readdir(workPath);
+
+    expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
+    expect(
+      contents.some(name => name.includes('next.config.original.'))
+    ).toBeTruthy();
+  },
+  FOUR_MINUTES
+);
+
+it(
+  'Should build the serverless-config-monorepo-present example',
+  async () => {
+    const {
+      workPath,
+      buildResult: { output },
+    } = await runBuildLambda(
+      path.join(__dirname, 'serverless-config-monorepo-present')
+    );
 
     expect(output.index).toBeDefined();
     expect(output.goodbye).toBeDefined();
@@ -197,7 +269,7 @@ it(
   async () => {
     const {
       workPath,
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-config-object'));
 
     expect(output['index.html']).toBeDefined();
@@ -231,7 +303,7 @@ it(
   async () => {
     const {
       workPath,
-      buildResult: { output }
+      buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-no-config'));
 
     expect(output['index.html']).toBeDefined();

--- a/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/package.json
+++ b/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "8.1.0",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/pages/goodbye.js
+++ b/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/pages/goodbye.js
@@ -1,0 +1,3 @@
+const F = () => 'Goodbye World!';
+F.getInitialProps = async () => ({});
+export default F;

--- a/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/pages/index.js
+++ b/packages/now-next/test/integration/serverless-config-monorepo-missing/nested/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Hello World!';

--- a/packages/now-next/test/integration/serverless-config-monorepo-missing/now.json
+++ b/packages/now-next/test/integration/serverless-config-monorepo-missing/now.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "nested/package.json", "use": "@now/next" }]
+}

--- a/packages/now-next/test/integration/serverless-config-monorepo-present/nested/next.config.js
+++ b/packages/now-next/test/integration/serverless-config-monorepo-present/nested/next.config.js
@@ -1,0 +1,1 @@
+module.exports = () => ({});

--- a/packages/now-next/test/integration/serverless-config-monorepo-present/nested/package.json
+++ b/packages/now-next/test/integration/serverless-config-monorepo-present/nested/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "8.1.0",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/now-next/test/integration/serverless-config-monorepo-present/nested/pages/goodbye.js
+++ b/packages/now-next/test/integration/serverless-config-monorepo-present/nested/pages/goodbye.js
@@ -1,0 +1,3 @@
+const F = () => 'Goodbye World!';
+F.getInitialProps = async () => ({});
+export default F;

--- a/packages/now-next/test/integration/serverless-config-monorepo-present/nested/pages/index.js
+++ b/packages/now-next/test/integration/serverless-config-monorepo-present/nested/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Hello World!';

--- a/packages/now-next/test/integration/serverless-config-monorepo-present/now.json
+++ b/packages/now-next/test/integration/serverless-config-monorepo-present/now.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "nested/package.json", "use": "@now/next" }]
+}


### PR DESCRIPTION
This fixes the `createServerlessConfig` helper to correctly use `entryPath` -- it also supports `workPath` for backwards compatibility with some special Next.js setup scenarios.

Really, we probably don't need the `workPath` support -- this is for users who do non-standard Next.js setups, but it probably doesn't hurt anyway.

---

cc @huv1k -- I told you this was fixed but I checked my Git directory and realized I had it coded but not committed haha.