### PR TITLE
[now-build-utils] Throw error on Next.js pages/api and api/

### DIFF
--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -6,11 +6,11 @@ const { createZip } = require('../dist/lambda');
 const { glob, download, detectBuilders, detectRoutes } = require('../');
 const {
   getSupportedNodeVersion,
-  defaultSelection
+  defaultSelection,
 } = require('../dist/fs/node-version');
 const {
   packAndDeploy,
-  testDeployment
+  testDeployment,
 } = require('../../../test/lib/deployment/test-deployment');
 
 jest.setTimeout(4 * 60 * 1000);
@@ -38,7 +38,7 @@ it('should re-create symlinks properly', async () => {
 
   const [linkStat, aStat] = await Promise.all([
     fs.lstat(path.join(outDir, 'link.txt')),
-    fs.lstat(path.join(outDir, 'a.txt'))
+    fs.lstat(path.join(outDir, 'a.txt')),
   ]);
   assert(linkStat.isSymbolicLink());
   assert(aStat.isFile());
@@ -60,7 +60,7 @@ it('should create zip files with symlinks properly', async () => {
 
   const [linkStat, aStat] = await Promise.all([
     fs.lstat(path.join(outDir, 'link.txt')),
-    fs.lstat(path.join(outDir, 'a.txt'))
+    fs.lstat(path.join(outDir, 'a.txt')),
   ]);
   assert(linkStat.isSymbolicLink());
   assert(aStat.isFile());
@@ -120,7 +120,7 @@ it('should support require by path for legacy builders', () => {
   const glob2 = require('@now/build-utils/fs/glob.js');
   const rename2 = require('@now/build-utils/fs/rename.js');
   const {
-    runNpmInstall: runNpmInstall2
+    runNpmInstall: runNpmInstall2,
   } = require('@now/build-utils/fs/run-user-scripts.js');
   const streamToBuffer2 = require('@now/build-utils/fs/stream-to-buffer.js');
 
@@ -206,7 +206,7 @@ it('Test `detectBuilders`', async () => {
     // package.json + no build + next
     const pkg = {
       scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' }
+      dependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'pages/index.js'];
     const { builders, errors } = await detectBuilders(files, pkg);
@@ -218,7 +218,7 @@ it('Test `detectBuilders`', async () => {
     // package.json + no build + next
     const pkg = {
       scripts: { build: 'next build' },
-      devDependencies: { next: '9.0.0' }
+      devDependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'pages/index.js'];
     const { builders, errors } = await detectBuilders(files, pkg);
@@ -282,7 +282,7 @@ it('Test `detectBuilders`', async () => {
     const files = [
       'api/_utils/handler.js',
       'api/[endpoint]/.helper.js',
-      'api/[endpoint]/[id].js'
+      'api/[endpoint]/[id].js',
     ];
 
     const { builders } = await detectBuilders(files);
@@ -295,7 +295,7 @@ it('Test `detectBuilders`', async () => {
     // api + next + public
     const pkg = {
       scripts: { build: 'next build' },
-      devDependencies: { next: '9.0.0' }
+      devDependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'api/endpoint.js', 'public/index.html'];
 
@@ -311,7 +311,7 @@ it('Test `detectBuilders`', async () => {
     // api + next + raw static
     const pkg = {
       scripts: { build: 'next build' },
-      devDependencies: { next: '9.0.0' }
+      devDependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'api/endpoint.js', 'index.html'];
 
@@ -343,7 +343,7 @@ it('Test `detectBuilders`', async () => {
       'api/endpoint.js',
       'public/index.html',
       'public/favicon.ico',
-      'README.md'
+      'README.md',
     ];
 
     const { builders } = await detectBuilders(files);
@@ -367,7 +367,7 @@ it('Test `detectBuilders`', async () => {
     // next + public
     const pkg = {
       scripts: { build: 'next build' },
-      devDependencies: { next: '9.0.0' }
+      devDependencies: { next: '9.0.0' },
     };
     const files = ['package.json', 'public/index.html', 'README.md'];
 
@@ -381,7 +381,7 @@ it('Test `detectBuilders`', async () => {
     // nuxt
     const pkg = {
       scripts: { build: 'nuxt build' },
-      dependencies: { nuxt: '2.8.1' }
+      dependencies: { nuxt: '2.8.1' },
     };
     const files = ['package.json', 'pages/index.js'];
 
@@ -433,12 +433,12 @@ it('Test `detectBuilders`', async () => {
     // package.json + api + canary
     const pkg = {
       scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' }
+      dependencies: { next: '9.0.0' },
     };
     const files = [
       'pages/index.js',
       'api/[endpoint].js',
-      'api/[endpoint]/[id].js'
+      'api/[endpoint]/[id].js',
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'canary' });
@@ -452,12 +452,12 @@ it('Test `detectBuilders`', async () => {
     // package.json + api + latest
     const pkg = {
       scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' }
+      dependencies: { next: '9.0.0' },
     };
     const files = [
       'pages/index.js',
       'api/[endpoint].js',
-      'api/[endpoint]/[id].js'
+      'api/[endpoint]/[id].js',
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'latest' });
@@ -471,12 +471,12 @@ it('Test `detectBuilders`', async () => {
     // package.json + api + random tag
     const pkg = {
       scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' }
+      dependencies: { next: '9.0.0' },
     };
     const files = [
       'pages/index.js',
       'api/[endpoint].js',
-      'api/[endpoint]/[id].js'
+      'api/[endpoint]/[id].js',
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'haha' });
@@ -484,6 +484,20 @@ it('Test `detectBuilders`', async () => {
     expect(builders[1].use).toBe('@now/node@haha');
     expect(builders[2].use).toBe('@now/next@haha');
     expect(builders.length).toBe(3);
+  }
+
+  {
+    // next.js pages/api + api
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = ['api/user.js', 'pages/api/user.js'];
+
+    const { errors, builders } = await detectBuilders(files, pkg);
+    expect(errors).toBeDefined();
+    expect(errors[0].code).toBe('conflicting_files');
+    expect(builders).toBe(null);
   }
 });
 
@@ -545,7 +559,7 @@ it('Test `detectRoutes`', async () => {
     const files = [
       'public/index.html',
       'api/[endpoint].js',
-      'api/[endpoint]/[id].js'
+      'api/[endpoint]/[id].js',
     ];
 
     const { builders } = await detectBuilders(files);
@@ -560,7 +574,7 @@ it('Test `detectRoutes`', async () => {
   {
     const pkg = {
       scripts: { build: 'next build' },
-      devDependencies: { next: '9.0.0' }
+      devDependencies: { next: '9.0.0' },
     };
     const files = ['public/index.html', 'api/[endpoint].js'];
 
@@ -617,7 +631,7 @@ it('Test `detectRoutes`', async () => {
       'api/users/index.ts',
       'api/users/index.d.ts',
       'api/food.ts',
-      'api/ts/gold.ts'
+      'api/ts/gold.ts',
     ];
     const { builders } = await detectBuilders(files);
     const { defaultRoutes } = await detectRoutes(files, builders);
@@ -641,39 +655,39 @@ it('Test `detectBuilders` and `detectRoutes`', async () => {
     {
       path: '/api/my-endpoint',
       mustContain: 'my-endpoint',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/other-endpoint',
       mustContain: 'other-endpoint',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/team/zeit',
       mustContain: 'team/zeit',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/user/myself',
       mustContain: 'user/myself',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/not-okay/',
-      status: 404
+      status: 404,
     },
     {
       path: '/api',
-      status: 404
+      status: 404,
     },
     {
       path: '/api/',
-      status: 404
+      status: 404,
     },
     {
       path: '/',
-      mustContain: 'hello from index.txt'
-    }
+      mustContain: 'hello from index.txt',
+    },
   ];
 
   const { builders } = await detectBuilders(files, pkg);
@@ -701,32 +715,32 @@ it('Test `detectBuilders` and `detectRoutes` with `index` files', async () => {
   const probes = [
     {
       path: '/api/not-okay',
-      status: 404
+      status: 404,
     },
     {
       path: '/api',
       mustContain: 'hello from api/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/',
       mustContain: 'hello from api/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/index',
       mustContain: 'hello from api/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/index.js',
       mustContain: 'hello from api/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/date.js',
       mustContain: 'hello from api/date.js',
-      status: 200
+      status: 200,
     },
     {
       // Someone might expect this to be `date.js`,
@@ -735,27 +749,27 @@ it('Test `detectBuilders` and `detectRoutes` with `index` files', async () => {
       // so it is not special cased
       path: '/api/date',
       mustContain: 'hello from api/date/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/date/',
       mustContain: 'hello from api/date/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/date/index',
       mustContain: 'hello from api/date/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/api/date/index.js',
       mustContain: 'hello from api/date/index.js',
-      status: 200
+      status: 200,
     },
     {
       path: '/',
-      mustContain: 'hello from index.txt'
-    }
+      mustContain: 'hello from index.txt',
+    },
   ];
 
   const { builders } = await detectBuilders(files, pkg);


### PR DESCRIPTION
There can be an unexpected outcome when using Next.js pages/api and api/ at the same time, because of this we want to error when we see that both exist.

Fixes https://github.com/zeit/now/issues/2887