### PR TITLE
[now-build-utils] Add `env` and `buildEnv` to `Meta` type

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -1,6 +1,10 @@
 import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 
+export interface Env {
+  [name: string]: string;
+}
+
 export interface File {
   type: string;
   mode: number;
@@ -52,6 +56,8 @@ export interface Meta {
   requestPath?: string;
   filesChanged?: string[];
   filesRemoved?: string[];
+  env?: Env;
+  buildEnv?: Env;
 }
 
 export interface AnalyzeOptions {

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -2,7 +2,7 @@ import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 
 export interface Env {
-  [name: string]: string;
+  [name: string]: string | undefined;
 }
 
 export interface File {


### PR DESCRIPTION
`now dev` passes in these variables to the "meta" object.