### PR TITLE
[now-cli] Use `PackageJson` and `Builder` types from `@now/build-utils`

### DIFF
--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import chalk from 'chalk';
+import { PackageJson } from '@now/build-utils';
 
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
@@ -11,11 +12,10 @@ import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import dev from './dev';
 import readPackage from '../../util/read-package';
-import { Package } from '../../util/dev/types';
 import readConfig from '../../util/config/read-config';
 
 const COMMAND_CONFIG = {
-  dev: ['dev']
+  dev: ['dev'],
 };
 
 const help = () => {
@@ -54,7 +54,7 @@ export default async function main(ctx: NowContext) {
 
       // Deprecated
       '--port': Number,
-      '-p': '--port'
+      '-p': '--port',
     });
     const debug = argv['--debug'];
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
@@ -90,7 +90,7 @@ export default async function main(ctx: NowContext) {
     const pkg = await readPackage(path.join(dir, 'package.json'));
 
     if (pkg) {
-      const { scripts } = pkg as Package;
+      const { scripts } = pkg as PackageJson;
 
       if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
         output.error(
@@ -98,9 +98,7 @@ export default async function main(ctx: NowContext) {
             'package.json'
           )} must not contain ${cmd('now dev')}`
         );
-        output.error(
-          `More details: http://err.sh/now/now-dev-as-dev-script`
-        );
+        output.error(`More details: http://err.sh/now/now-dev-as-dev-script`);
         return 1;
       }
     }

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -8,6 +8,7 @@ import { createHash } from 'crypto';
 import { createGunzip } from 'zlib';
 import { join, resolve } from 'path';
 import { funCacheDir } from '@zeit/fun';
+import { PackageJson } from '@now/build-utils';
 import XDGAppPaths from 'xdg-app-paths';
 import {
   createReadStream,
@@ -15,7 +16,7 @@ import {
   readFile,
   readJSON,
   writeFile,
-  remove
+  remove,
 } from 'fs-extra';
 import pkg from '../../../package.json';
 
@@ -26,7 +27,7 @@ import { getDistTag } from '../get-dist-tag';
 import { devDependencies } from '../../../package.json';
 
 import * as staticBuilder from './static-builder';
-import { BuilderWithPackage, Package } from './types';
+import { BuilderWithPackage } from './types';
 
 const registryTypes = new Set(['version', 'tag', 'range']);
 
@@ -34,8 +35,8 @@ const localBuilders: { [key: string]: BuilderWithPackage } = {
   '@now/static': {
     runInProcess: true,
     builder: Object.freeze(staticBuilder),
-    package: Object.freeze({ name: '@now/static', version: '' })
-  }
+    package: Object.freeze({ name: '@now/static', version: '' }),
+  },
 };
 
 const bundledBuilders = Object.keys(devDependencies).filter(d =>
@@ -117,7 +118,7 @@ export async function prepareBuilderDir() {
 export async function prepareBuilderModulePath() {
   const [builderDir, builderContents] = await Promise.all([
     builderDirPromise,
-    readFile(join(__dirname, 'builder-worker.js'))
+    readFile(join(__dirname, 'builder-worker.js')),
   ]);
   let needsWrite = false;
   const builderSha = getSha(builderContents);
@@ -179,7 +180,7 @@ export function getBuildUtils(packages: string[]): string {
 export function filterPackage(
   builderSpec: string,
   distTag: string,
-  buildersPkg: Package
+  buildersPkg: PackageJson
 ) {
   if (builderSpec in localBuilders) return false;
   const parsed = npa(builderSpec);
@@ -259,10 +260,10 @@ export async function installBuilders(
         '--exact',
         '--no-lockfile',
         '--non-interactive',
-        ...packagesToInstall
+        ...packagesToInstall,
       ],
       {
-        cwd: builderDir
+        cwd: builderDir,
       }
     );
   } finally {
@@ -294,10 +295,10 @@ export async function updateBuilders(
       '--exact',
       '--no-lockfile',
       '--non-interactive',
-      ...packages.filter(p => p !== '@now/static')
+      ...packages.filter(p => p !== '@now/static'),
     ],
     {
-      cwd: builderDir
+      cwd: builderDir,
     }
   );
 
@@ -336,7 +337,7 @@ export async function getBuilder(
       const pkg = require(join(dest, 'package.json'));
       builderWithPkg = {
         builder: Object.freeze(mod),
-        package: Object.freeze(pkg)
+        package: Object.freeze(pkg),
       };
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
@@ -357,7 +358,7 @@ export async function getBuilder(
 
 function getPackageName(
   parsed: npa.Result,
-  buildersPkg: Package
+  buildersPkg: PackageJson
 ): string | null {
   if (registryTypes.has(parsed.type)) {
     return parsed.name;

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -5,7 +5,7 @@ import bytes from 'bytes';
 import { delimiter, dirname, join } from 'path';
 import { fork, ChildProcess } from 'child_process';
 import { createFunction } from '@zeit/fun';
-import { File, Lambda, FileBlob, FileFsRef } from '@now/build-utils';
+import { Builder, File, Lambda, FileBlob, FileFsRef } from '@now/build-utils';
 import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
 import which from 'which';
@@ -23,12 +23,11 @@ import { builderModulePathPromise, getBuilder } from './builder-cache';
 import {
   EnvConfig,
   NowConfig,
-  BuildConfig,
   BuildMatch,
   BuildResult,
   BuilderInputs,
   BuilderOutput,
-  BuilderOutputs
+  BuilderOutputs,
 } from './types';
 
 interface BuildMessage {
@@ -69,7 +68,7 @@ async function createBuildProcess(
   }
   const [execPath, modulePath] = await Promise.all([
     nodeBinPromise,
-    builderModulePathPromise
+    builderModulePathPromise,
   ]);
   let PATH = `${dirname(execPath)}${delimiter}${process.env.PATH}`;
   if (yarnPath) {
@@ -81,11 +80,11 @@ async function createBuildProcess(
       ...process.env,
       PATH,
       ...buildEnv,
-      NOW_REGION: 'dev1'
+      NOW_REGION: 'dev1',
     },
     execPath,
     execArgv: [],
-    stdio: ['ignore', 'pipe', 'pipe', 'ipc']
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
   });
   match.buildProcess = buildProcess;
 
@@ -122,7 +121,7 @@ export async function executeBuild(
   filesRemoved?: string[]
 ): Promise<void> {
   const {
-    builderWithPkg: { runInProcess, builder, package: pkg }
+    builderWithPkg: { runInProcess, builder, package: pkg },
   } = match;
   const { src: entrypoint } = match;
   const { env, debug, buildEnv, yarnPath, cwd: workPath } = devServer;
@@ -165,8 +164,8 @@ export async function executeBuild(
       filesChanged,
       filesRemoved,
       env,
-      buildEnv
-    }
+      buildEnv,
+    },
   };
 
   let buildResultOrOutputs: BuilderOutputs | BuildResult;
@@ -203,7 +202,7 @@ export async function executeBuild(
       buildProcess.send({
         type: 'build',
         builderName: pkg.name,
-        buildParams
+        buildParams,
       });
 
       buildResultOrOutputs = await new Promise((resolve, reject) => {
@@ -260,7 +259,7 @@ export async function executeBuild(
     result = {
       output: buildResultOrOutputs as BuilderOutputs,
       routes: [],
-      watch: []
+      watch: [],
     };
   } else {
     result = buildResultOrOutputs as BuildResult;
@@ -346,9 +345,9 @@ export async function executeBuild(
               ...nowConfig.env,
               ...asset.environment,
               ...env,
-              NOW_REGION: 'dev1'
-            }
-          }
+              NOW_REGION: 'dev1',
+            },
+          },
         });
       }
 
@@ -382,7 +381,7 @@ export async function getBuildMatches(
     return matches;
   }
 
-  const noMatches: BuildConfig[] = [];
+  const noMatches: Builder[] = [];
   const builds = nowConfig.builds || [{ src: '**', use: '@now/static' }];
 
   for (const buildConfig of builds) {
@@ -420,7 +419,7 @@ export async function getBuildMatches(
         builderWithPkg,
         buildOutput: {},
         buildResults: new Map(),
-        buildTimestamp: 0
+        buildTimestamp: 0,
       });
     }
   }

--- a/packages/now-cli/src/util/dev/errors.ts
+++ b/packages/now-cli/src/util/dev/errors.ts
@@ -12,13 +12,13 @@ export const httpStatusDescriptionMap = new Map([
   [502, 'BAD_GATEWAY'],
   [503, 'SERVICE_UNAVAILABLE'],
   [504, 'GATEWAY_TIMEOUT'],
-  [508, 'INFINITE_LOOP']
+  [508, 'INFINITE_LOOP'],
 ]);
 
 export const errorMessageMap = new Map([
   [400, 'Bad request'],
   [402, 'Payment required'],
-  [403, 'You don\'t have the required permissions'],
+  [403, "You don't have the required permissions"],
   [404, 'The page could not be found'],
   [405, 'Method not allowed'],
   [410, 'The deployment has been removed'],
@@ -28,7 +28,7 @@ export const errorMessageMap = new Map([
   [501, 'Not implemented'],
   [503, 'The deployment is currently unavailable'],
   [504, 'An error occurred with your deployment'],
-  [508, 'Infinite loop detected']
+  [508, 'Infinite loop detected'],
 ]);
 
 interface ErrorMessage {
@@ -40,20 +40,20 @@ interface ErrorMessage {
 const appError = {
   title: 'An error occurred with this application.',
   subtitle: 'This is an error with the application itself, not the platform.',
-  app_error: true
+  app_error: true,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const infrastructureError = {
   title: 'An internal error occurred with ZEIT Now.',
   subtitle: 'This is an error with the platform itself, not the application.',
-  app_error: false
+  app_error: false,
 };
 
 const pageNotFoundError = {
   title: 'The page could not be found.',
   subtitle: 'The page could not be found in the application.',
-  app_error: true
+  app_error: true,
 };
 
 export function generateErrorMessage(
@@ -68,7 +68,7 @@ export function generateErrorMessage(
   }
   return {
     title: errorMessageMap.get(statusCode) || 'Error occurred',
-    app_error: false
+    app_error: false,
   };
 }
 

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -98,7 +98,7 @@ export default async function(
             headers: combinedHeaders,
             uri_args: query,
             matched_route: routeConfig,
-            matched_route_idx: idx
+            matched_route_idx: idx,
           };
           break;
         } else {
@@ -114,7 +114,7 @@ export default async function(
             headers: combinedHeaders,
             uri_args: query,
             matched_route: routeConfig,
-            matched_route_idx: idx
+            matched_route_idx: idx,
           };
           break;
         }
@@ -127,7 +127,7 @@ export default async function(
       found: false,
       dest: reqPathname,
       uri_args: query,
-      headers: combinedHeaders
+      headers: combinedHeaders,
     };
   }
 

--- a/packages/now-cli/src/util/dev/static-builder.ts
+++ b/packages/now-cli/src/util/dev/static-builder.ts
@@ -5,7 +5,7 @@ export const version = 2;
 
 export function build({ files, entrypoint }: BuilderParams): BuildResult {
   const output = {
-    [entrypoint]: files[entrypoint]
+    [entrypoint]: files[entrypoint],
   };
   const watch = [entrypoint];
 
@@ -15,7 +15,7 @@ export function build({ files, entrypoint }: BuilderParams): BuildResult {
 export function shouldServe({
   entrypoint,
   files,
-  requestPath
+  requestPath,
 }: ShouldServeParams) {
   if (isIndex(entrypoint)) {
     const indexPath = join(requestPath, basename(entrypoint));

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -1,7 +1,13 @@
 import http from 'http';
 import { ChildProcess } from 'child_process';
 import { Lambda as FunLambda } from '@zeit/fun';
-import { FileBlob, FileFsRef, Lambda } from '@now/build-utils';
+import {
+  Builder as BuildConfig,
+  FileBlob,
+  FileFsRef,
+  Lambda,
+  PackageJson,
+} from '@now/build-utils';
 import { Output } from '../output';
 
 export interface DevServerOptions {
@@ -11,12 +17,6 @@ export interface DevServerOptions {
 
 export interface EnvConfig {
   [name: string]: string | undefined;
-}
-
-export interface BuildConfig {
-  src: string;
-  use?: string;
-  config?: object;
 }
 
 export interface BuildMatch extends BuildConfig {
@@ -129,18 +129,10 @@ export interface ShouldServeParams {
   workPath: string;
 }
 
-export interface Package {
-  name: string;
-  version: string;
-  scripts?: { [key: string]: string };
-  dependencies?: { [name: string]: string };
-  devDependencies?: { [name: string]: string };
-}
-
 export interface BuilderWithPackage {
   runInProcess?: boolean;
   builder: Readonly<Builder>;
-  package: Readonly<Package>;
+  package: Readonly<PackageJson>;
 }
 
 export interface HttpHeadersConfig {

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -16,16 +16,16 @@ const buildsSchema = {
       src: {
         type: 'string',
         minLength: 1,
-        maxLength: 4096
+        maxLength: 4096,
       },
       use: {
         type: 'string',
         minLength: 3,
-        maxLength: 256
+        maxLength: 256,
       },
-      config: { type: 'object' }
-    }
-  }
+      config: { type: 'object' },
+    },
+  },
 };
 
 const validateBuilds = ajv.compile(buildsSchema);

--- a/packages/now-cli/src/util/dev/yarn-installer.ts
+++ b/packages/now-cli/src/util/dev/yarn-installer.ts
@@ -5,7 +5,7 @@ import {
   writeFile,
   statSync,
   chmodSync,
-  createReadStream
+  createReadStream,
 } from 'fs-extra';
 import pipe from 'promisepipe';
 import { join } from 'path';
@@ -63,7 +63,7 @@ async function installYarn(output: Output): Promise<string> {
   output.debug(`Downloading ${YARN_URL}`);
   const response = await fetch(YARN_URL, {
     compress: false,
-    redirect: 'follow'
+    redirect: 'follow',
   });
 
   if (response.status !== 200) {
@@ -90,7 +90,7 @@ async function installYarn(output: Output): Promise<string> {
         '@echo off',
         '@SETLOCAL',
         '@SET PATHEXT=%PATHEXT:;.JS;=;%',
-        'node "%~dp0\\yarn" %*'
+        'node "%~dp0\\yarn" %*',
       ].join('\r\n')
     );
   }

--- a/packages/now-cli/src/util/prefer-v2-deployment.ts
+++ b/packages/now-cli/src/util/prefer-v2-deployment.ts
@@ -1,8 +1,9 @@
 import { join } from 'path';
 import { exists } from 'fs-extra';
+import { PackageJson } from '@now/build-utils';
+
 import Client from './client';
 import { Config } from '../types';
-import { Package } from './dev/types';
 import { CantParseJSONFile, ProjectNotFound } from './errors-ts';
 import getProjectByIdOrName from './projects/get-project-by-id-or-name';
 
@@ -26,14 +27,14 @@ export default async function preferV2Deployment({
   hasServerfile,
   pkg,
   localConfig,
-  projectName
+  projectName,
 }: {
-  client?: Client,
-  hasDockerfile: boolean,
-  hasServerfile: boolean,
-  pkg: Package | CantParseJSONFile | null,
-  localConfig: Config | undefined,
-  projectName?: string
+  client?: Client;
+  hasDockerfile: boolean;
+  hasServerfile: boolean;
+  pkg: PackageJson | CantParseJSONFile | null;
+  localConfig: Config | undefined;
+  projectName?: string;
 }): Promise<null | string> {
   if (localConfig && localConfig.version) {
     // We will prefer anything that is set here
@@ -52,10 +53,14 @@ export default async function preferV2Deployment({
     const { scripts = {} } = pkg;
 
     if (!scripts.start && !scripts['now-start']) {
-      return `Deploying to Now 2.0, because ${highlight('package.json')} is missing a ${cmd('start')} script. ${INFO}`;
+      return `Deploying to Now 2.0, because ${highlight(
+        'package.json'
+      )} is missing a ${cmd('start')} script. ${INFO}`;
     }
   } else if (!pkg && !hasDockerfile) {
-    return `Deploying to Now 2.0, because no ${highlight('Dockerfile')} was found. ${INFO}`;
+    return `Deploying to Now 2.0, because no ${highlight(
+      'Dockerfile'
+    )} was found. ${INFO}`;
   }
 
   if (client && projectName) {

--- a/packages/now-cli/src/util/read-package.ts
+++ b/packages/now-cli/src/util/read-package.ts
@@ -2,10 +2,10 @@ import path from 'path';
 import { CantParseJSONFile } from './errors-ts';
 import readJSONFile from './read-json-file';
 import { Config } from '../types';
-import { Package } from './dev/types';
+import { PackageJson } from '@now/build-utils';
 
-interface CustomPackage extends Package {
-  now?: Config
+interface CustomPackage extends PackageJson {
+  now?: Config;
 }
 
 export default async function readPackage(file?: string) {
@@ -16,8 +16,8 @@ export default async function readPackage(file?: string) {
     return result;
   }
 
-  if (result){
-    return result as CustomPackage
+  if (result) {
+    return result as CustomPackage;
   }
 
   return null;


### PR DESCRIPTION
No functionality change here, this just removes the `Package` and `BuildConfig` types from `src/util/dev/types.ts` in favor of the matching types from `@now/build-utils`.

Also a lot of prettier formatting…