### PR TITLE
[now-build-utils][now-cli] Warn instead of throwing on `api` and `pages/api`

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -124,7 +124,7 @@ async function checkConflictingFiles(
       return {
         code: 'conflicting_files',
         message:
-          'It is not possible to use `api/` and `pages/api/` at the same time, please only use one option',
+          'It is not possible to use `api` and `pages/api` at the same time, please only use one option',
       };
     }
   }

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -141,8 +141,10 @@ export async function detectBuilders(
 ): Promise<{
   builders: Builder[] | null;
   errors: ErrorResponse[] | null;
+  warnings: ErrorResponse[];
 }> {
   const errors: ErrorResponse[] = [];
+  const warnings: ErrorResponse[] = [];
 
   // Detect all builders for the `api` directory before anything else
   let builders = await detectApiBuilders(files);
@@ -153,15 +155,14 @@ export async function detectBuilders(
     const conflictError = await checkConflictingFiles(files, builders);
 
     if (conflictError) {
-      errors.push(conflictError);
-      return { errors, builders: null };
+      warnings.push(conflictError);
     }
   } else {
     if (pkg && builders.length === 0) {
       // We only show this error when there are no api builders
       // since the dependencies of the pkg could be used for those
       errors.push(MISSING_BUILD_SCRIPT_ERROR);
-      return { errors, builders: null };
+      return { errors, warnings, builders: null };
     }
 
     // We allow a `public` directory
@@ -210,5 +211,6 @@ export async function detectBuilders(
   return {
     builders: builders.length ? builders : null,
     errors: errors.length ? errors : null,
+    warnings,
   };
 }

--- a/packages/now-build-utils/test/test.js
+++ b/packages/now-build-utils/test/test.js
@@ -494,10 +494,13 @@ it('Test `detectBuilders`', async () => {
     };
     const files = ['api/user.js', 'pages/api/user.js'];
 
-    const { errors, builders } = await detectBuilders(files, pkg);
-    expect(errors).toBeDefined();
-    expect(errors[0].code).toBe('conflicting_files');
-    expect(builders).toBe(null);
+    const { warnings, errors, builders } = await detectBuilders(files, pkg);
+    expect(errors).toBe(null);
+    expect(warnings[0].code).toBe('conflicting_files');
+    expect(builders).toBeDefined();
+    expect(builders.length).toBe(2);
+    expect(builders[0].use).toBe('@now/node');
+    expect(builders[1].use).toBe('@now/next');
   }
 });
 

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -61,11 +61,6 @@
     "node": ">= 8.11"
   },
   "devDependencies": {
-    "@now/go": "latest",
-    "@now/next": "latest",
-    "@now/node": "latest",
-    "@now/routing-utils": "latest",
-    "@now/static-build": "latest",
     "@sentry/node": "5.5.0",
     "@types/ansi-escapes": "3.0.0",
     "@types/ansi-regex": "4.0.0",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -61,7 +61,6 @@
     "node": ">= 8.11"
   },
   "devDependencies": {
-    "@now/build-utils": "latest",
     "@now/go": "latest",
     "@now/next": "latest",
     "@now/node": "latest",

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -43,7 +43,7 @@ async function createBuildersTarball() {
   await pipe(
     packer,
     createGzip(),
-    createWriteStream(buildersTarballPath, { flags: 'w' })
+    createWriteStream(buildersTarballPath)
   );
 }
 
@@ -99,13 +99,12 @@ async function main() {
   console.log('Finished building `now-cli`');
 }
 
-process.on('unhandledRejection', (err: any) => {
-  console.error('Unhandled Rejection:');
-  console.error(err);
+process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
   process.exit(1);
 });
 
-process.on('uncaughtException', (err: any) => {
+process.on('uncaughtException', err => {
   console.error('Uncaught Exception:');
   console.error(err);
   process.exit(1);

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -43,7 +43,7 @@ async function createBuildersTarball() {
   await pipe(
     packer,
     createGzip(),
-    createWriteStream(buildersTarballPath)
+    createWriteStream(buildersTarballPath, { flags: 'w' })
   );
 }
 

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -8,7 +8,7 @@ import { createWriteStream, mkdirp, remove, writeJSON } from 'fs-extra';
 
 import { getDistTag } from '../src/util/get-dist-tag';
 import pkg from '../package.json';
-import { getBundledBuilders } from '../src/util/dev/builder-cache';
+import { getBundledBuilders } from '../src/util/dev/get-bundled-builders';
 
 const dirRoot = join(__dirname, '..');
 

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -39,7 +39,13 @@ const localBuilders: { [key: string]: BuilderWithPackage } = {
 };
 
 export function getBundledBuilders() {
-  return ['@now/go', '@now/next', '@now/node', '@now/build-utils'];
+  return [
+    '@now/go',
+    '@now/next',
+    '@now/node',
+    '@now/static-build',
+    '@now/build-utils',
+  ];
 }
 
 const distTag = getDistTag(pkg.version);

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -24,7 +24,6 @@ import { NoBuilderCacheError, BuilderCacheCleanError } from '../errors-ts';
 import wait from '../output/wait';
 import { Output } from '../output';
 import { getDistTag } from '../get-dist-tag';
-import { devDependencies } from '../../../package.json';
 
 import * as staticBuilder from './static-builder';
 import { BuilderWithPackage } from './types';
@@ -39,9 +38,13 @@ const localBuilders: { [key: string]: BuilderWithPackage } = {
   },
 };
 
-const bundledBuilders = Object.keys(devDependencies).filter(d =>
+const bundledBuilders = Object.keys(pkg.devDependencies).filter(d =>
   d.startsWith('@now/')
 );
+
+export function getBundledBuilders() {
+  return ['@now/go', '@now/next', '@now/node'];
+}
 
 const distTag = getDistTag(pkg.version);
 
@@ -188,7 +191,7 @@ export function filterPackage(
     parsed.name &&
     parsed.type === 'tag' &&
     parsed.fetchSpec === distTag &&
-    bundledBuilders.includes(parsed.name) &&
+    getBundledBuilders().includes(parsed.name) &&
     buildersPkg.dependencies
   ) {
     const parsedInstalled = npa(
@@ -379,7 +382,7 @@ function getSha(buffer: Buffer): string {
 }
 
 function hasBundledBuilders(dependencies: { [name: string]: string }): boolean {
-  for (const name of bundledBuilders) {
+  for (const name of getBundledBuilders()) {
     if (!(name in dependencies)) {
       return false;
     }

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -38,12 +38,8 @@ const localBuilders: { [key: string]: BuilderWithPackage } = {
   },
 };
 
-const bundledBuilders = Object.keys(pkg.devDependencies).filter(d =>
-  d.startsWith('@now/')
-);
-
 export function getBundledBuilders() {
-  return ['@now/go', '@now/next', '@now/node'];
+  return ['@now/go', '@now/next', '@now/node', '@now/build-utils'];
 }
 
 const distTag = getDistTag(pkg.version);

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -27,6 +27,7 @@ import { getDistTag } from '../get-dist-tag';
 
 import * as staticBuilder from './static-builder';
 import { BuilderWithPackage } from './types';
+import { getBundledBuilders } from './get-bundled-builders';
 
 const registryTypes = new Set(['version', 'tag', 'range']);
 
@@ -37,18 +38,6 @@ const localBuilders: { [key: string]: BuilderWithPackage } = {
     package: Object.freeze({ name: '@now/static', version: '' }),
   },
 };
-
-export function getBundledBuilders() {
-  return [
-    '@now/go',
-    '@now/next',
-    '@now/node',
-    '@now/ruby',
-    '@now/python',
-    '@now/static-build',
-    '@now/build-utils',
-  ];
-}
 
 const distTag = getDistTag(pkg.version);
 

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -43,6 +43,8 @@ export function getBundledBuilders() {
     '@now/go',
     '@now/next',
     '@now/node',
+    '@now/ruby',
+    '@now/python',
     '@now/static-build',
     '@now/build-utils',
   ];

--- a/packages/now-cli/src/util/dev/get-bundled-builders.ts
+++ b/packages/now-cli/src/util/dev/get-bundled-builders.ts
@@ -1,0 +1,11 @@
+export function getBundledBuilders() {
+  return [
+    '@now/go',
+    '@now/next',
+    '@now/node',
+    '@now/ruby',
+    '@now/python',
+    '@now/static-build',
+    '@now/build-utils',
+  ];
+}

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -514,13 +514,17 @@ export default class DevServer {
           `filtered out ${allFiles.length - files.length} files`
       );
 
-      const { builders, errors } = await detectBuilders(files, pkg, {
+      const { builders, warnings, errors } = await detectBuilders(files, pkg, {
         tag: getDistTag(cliVersion) === 'canary' ? 'canary' : 'latest',
       });
 
       if (errors) {
         this.output.error(errors[0].message);
         await this.exit();
+      }
+
+      if (warnings && warnings.length > 0) {
+        warnings.forEach(warning => this.output.warn(warning.message));
       }
 
       if (builders) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,11 +1235,6 @@
     "@nodelib/fs.scandir" "2.1.1"
     fastq "^1.6.0"
 
-"@now/build-utils@latest":
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/@now/build-utils/-/build-utils-0.9.14.tgz#9e81828d3a2be697db0d8c44cbe9ae519003ee6f"
-  integrity sha512-fDyo/1Zb2StDhFKfoNf+M9nY5RhfuofpGXVwL8IjYUodze1VPDFX039Ut8zUVlujIFkSl8QMl8iu9fYr0H2ERg==
-
 "@now/go@latest":
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/@now/go/-/go-0.5.11.tgz#c3c6a9eaabe1de9fb4de0d6a163db8d713287dfd"


### PR DESCRIPTION
When `api` and `pages/api` is used at the same we want to show a warning instead of an error and exiting.