### PR TITLE
[now-cli][now-client] Add optional HTTP/2

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -156,7 +156,7 @@
     "raw-body": "2.4.1",
     "read-pkg": "2.0.0",
     "rx-lite-aggregates": "4.0.8",
-    "semver": "5.5.0",
+    "semver": "6.3.0",
     "serve-handler": "6.1.1",
     "sinon": "4.4.2",
     "strip-ansi": "5.2.0",

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -5,7 +5,6 @@ import { createDeployment, createLegacyDeployment } from 'now-client';
 import wait from '../output/wait';
 import createOutput from '../output';
 import semver from 'semver';
-import pkg from '../pkg';
 
 export default async function processDeployment({
   now,
@@ -20,7 +19,7 @@ export default async function processDeployment({
 }: any) {
   const { warn, log } = createOutput({ debug });
   let bar: Progress | null = null;
-  const useHttp2 = semver.satisfies(pkg.version, '>10');
+  const useHttp2 = semver.satisfies(process.version, '>10');
 
   if (!legacy) {
     let buildSpinner = null;

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -5,7 +5,7 @@ import { createDeployment, createLegacyDeployment } from 'now-client';
 import wait from '../output/wait';
 import createOutput from '../output';
 import semver from 'semver';
-import pkg from '../../../package.json';
+import pkg from '../pkg';
 
 export default async function processDeployment({
   now,

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -4,6 +4,8 @@ import chalk from 'chalk';
 import { createDeployment, createLegacyDeployment } from 'now-client';
 import wait from '../output/wait';
 import createOutput from '../output';
+import semver from 'semver';
+import pkg from '../../../package.json';
 
 export default async function processDeployment({
   now,
@@ -18,12 +20,17 @@ export default async function processDeployment({
 }: any) {
   const { warn, log } = createOutput({ debug });
   let bar: Progress | null = null;
+  const useHttp2 = semver.satisfies(pkg.version, '>10');
 
   if (!legacy) {
     let buildSpinner = null;
     let deploySpinner = null;
 
-    for await (const event of createDeployment(paths[0], requestBody)) {
+    for await (const event of createDeployment(
+      paths[0],
+      requestBody,
+      useHttp2
+    )) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }
@@ -120,7 +127,11 @@ export default async function processDeployment({
       }
     }
   } else {
-    for await (const event of createLegacyDeployment(paths[0], requestBody)) {
+    for await (const event of createLegacyDeployment(
+      paths[0],
+      requestBody,
+      useHttp2
+    )) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -1,58 +1,61 @@
-import { readdir as readRootFolder, lstatSync } from 'fs-extra'
+import { readdir as readRootFolder, lstatSync } from 'fs-extra';
 
-import readdir from 'recursive-readdir'
-import hashes, { mapToObject } from './utils/hashes'
-import uploadAndDeploy from './upload'
-import { getNowIgnore } from './utils'
-import { DeploymentError } from './errors'
+import readdir from 'recursive-readdir';
+import hashes, { mapToObject } from './utils/hashes';
+import uploadAndDeploy from './upload';
+import { getNowIgnore } from './utils';
+import { DeploymentError } from './errors';
 
-export { EVENTS } from './utils'
+export { EVENTS } from './utils';
 
-export default function buildCreateDeployment(version: number): CreateDeploymentFunction {
+export default function buildCreateDeployment(
+  version: number
+): CreateDeploymentFunction {
   return async function* createDeployment(
     path: string | string[],
-    options: DeploymentOptions = {}
+    options: DeploymentOptions = {},
+    useHttp2?: boolean
   ): AsyncIterableIterator<any> {
     if (typeof path !== 'string' && !Array.isArray(path)) {
       throw new DeploymentError({
         code: 'missing_path',
-        message: 'Path not provided'
-      })
+        message: 'Path not provided',
+      });
     }
 
     if (typeof options.token !== 'string') {
       throw new DeploymentError({
         code: 'token_not_provided',
-        message: 'Options object must include a `token`'
-      })
+        message: 'Options object must include a `token`',
+      });
     }
 
-    const isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory()
+    const isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory();
 
     // Get .nowignore
-    let rootFiles
+    let rootFiles;
 
     if (isDirectory && !Array.isArray(path)) {
-      rootFiles = await readRootFolder(path)
+      rootFiles = await readRootFolder(path);
     } else if (Array.isArray(path)) {
-      rootFiles = path
+      rootFiles = path;
     } else {
-      rootFiles = [path]
+      rootFiles = [path];
     }
 
-    let ignores: string[] = await getNowIgnore(rootFiles, path)
+    let ignores: string[] = await getNowIgnore(rootFiles, path);
 
-    let fileList
+    let fileList;
 
     if (isDirectory && !Array.isArray(path)) {
       // Directory path
-      fileList = await readdir(path, ignores)
+      fileList = await readdir(path, ignores);
     } else if (Array.isArray(path)) {
       // Array of file paths
-      fileList = path
+      fileList = path;
     } else {
       // Single file
-      fileList = [path]
+      fileList = [path];
     }
 
     // This is a useful warning because it prevents people
@@ -61,24 +64,28 @@ export default function buildCreateDeployment(version: number): CreateDeployment
       fileList.length === 0 ||
       fileList.every((item): boolean => {
         if (!item) {
-          return true
+          return true;
         }
 
-        const segments = item.split('/')
+        const segments = item.split('/');
 
-        return segments[segments.length - 1].startsWith('.')
-      }))
-    {
-      yield { type: 'warning', payload: 'There are no files (or only files starting with a dot) inside your deployment.' }
+        return segments[segments.length - 1].startsWith('.');
+      })
+    ) {
+      yield {
+        type: 'warning',
+        payload:
+          'There are no files (or only files starting with a dot) inside your deployment.',
+      };
     }
 
-    const files = await hashes(fileList)
+    const files = await hashes(fileList);
 
-    yield { type: 'hashes-calculated', payload: mapToObject(files) }
+    yield { type: 'hashes-calculated', payload: mapToObject(files) };
 
-    const { token, teamId, force, defaultName, ...metadata } = options
+    const { token, teamId, force, defaultName, ...metadata } = options;
 
-    metadata.version = version
+    metadata.version = version;
 
     const deploymentOpts = {
       totalFiles: files.size,
@@ -88,11 +95,12 @@ export default function buildCreateDeployment(version: number): CreateDeployment
       teamId,
       force,
       defaultName,
-      metadata
-    }
+      metadata,
+      useHttp2,
+    };
 
     for await (const event of uploadAndDeploy(files, deploymentOpts)) {
-      yield event
+      yield event;
     }
-  }
+  };
 }

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -19,6 +19,7 @@ export interface Options {
   isDirectory?: boolean;
   defaultName?: string;
   preflight?: boolean;
+  useHttp2?: boolean;
 }
 
 async function* createDeployment(
@@ -44,6 +45,7 @@ async function* createDeployment(
           ...metadata,
           files: preparedFiles,
         }),
+        useHttp2: options.useHttp2,
       }
     );
 
@@ -172,7 +174,8 @@ export default async function* deploy(
         deployment,
         options.token,
         metadata.version,
-        options.teamId
+        options.teamId,
+        options.useHttp2
       )) {
         yield event;
       }

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -88,6 +88,7 @@ export default async function* upload(
             },
             body: stream,
             teamId,
+            useHttp2: options.useHttp2,
           });
 
           if (res.status === 200) {

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -1,6 +1,6 @@
 import { DeploymentFile } from './hashes';
 import { parse as parseUrl } from 'url';
-import { fetch as fetch_ } from 'fetch-h2';
+import { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { readFile } from 'fs-extra';
 import { join, sep } from 'path';
 import qs from 'querystring';
@@ -99,11 +99,22 @@ export async function getNowIgnore(
   return ignores;
 }
 
+type FetchFunction = (
+  url: RequestInfo,
+  init?: RequestInit
+) => Promise<Response>;
+
 export const fetch = (
   url: string,
   token: string,
   opts: any = {}
 ): Promise<any> => {
+  const fetch_: FetchFunction = opts.useHttp2
+    ? require('node-fetch')
+    : require('fetch-h2');
+
+  delete opts.useHttp2;
+
   if (opts.teamId) {
     const parsedUrl = parseUrl(url, true);
     const query = parsedUrl.query;

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -110,7 +110,7 @@ export const fetch = (
   opts: any = {}
 ): Promise<any> => {
   const fetch_: FetchFunction = opts.useHttp2
-    ? require('node-fetch')
+    ? require('node-fetch').default
     : require('fetch-h2');
 
   delete opts.useHttp2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7985,7 +7985,7 @@ normalize-url@^4.1.0:
   integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
 now-client@./packages/now-client:
-  version "5.1.1-canary.2"
+  version "5.1.1-canary.3"
   dependencies:
     "@zeit/fetch" "5.1.0"
     async-retry "1.2.3"
@@ -9607,17 +9607,12 @@ semver-diff@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-
 semver@6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
   integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
+semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
This PR implements two things:

- HTTP/2 optionality in `now-client` (now HTTP/2 is off by default)
- Makes `now-cli` use HTTP/2 on `^10` Node versions that have stable support

## HTTP/2 `now-client` API

```ts
import { createDeployment,createLegacyDeployment } from 'now-client'

const useHttp2 = true

for await(event for createDeployment(path, opts, useHttp2)) {
  // ...
}

for await(event for createLegacyDeployment(path, opts, useHttp2)) {
  // ...
}
```