### PR TITLE
Add release notes script to PUBLISHING.md

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -29,6 +29,9 @@ git cherry-pick <PR504_COMMIT_SHA>
 # Verify the only difference is "version" in package.json
 git diff origin/canary
 
+# Generate release notes since previous publish
+git log --pretty=format:"- %s [%an] %H" `git log --pretty=format:"%s %H" | grep "^Publish" | head -n 1 | awk '{ print $NF }'`...HEAD
+
 # Ship it
 yarn publish-stable
 ```


### PR DESCRIPTION
This script can be used every time we publish.

It obviously wont create a GitHub release but it can be used to generate the text to copy/pasta into a GitHub release.

This will work for canary or master, as long as we run it each time before lerna publishes.

It is the responsibility of the person publishing to select the proper tag, probably always use `now@*` for stable releases.