### PR TITLE
[now-cli] Default to empty string for undefined env var when checking

### DIFF
--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -655,8 +655,9 @@ async function sync({
     }
 
     const hasSecrets = Object.keys(deploymentEnv).some(key =>
-      deploymentEnv[key].startsWith('@')
+      (deploymentEnv[key] || '').startsWith('@')
     );
+
     const secretsPromise = hasSecrets ? now.listSecrets() : null;
 
     const findSecret = async (uidOrName: string) => {


### PR DESCRIPTION
Fixes https://sentry.io/organizations/zeithq/issues/1221187879/