### PR TITLE
[now-node] Add support for AWS Gateway Event

### DIFF
--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -85,8 +85,9 @@ exports.launcher = bridge.launcher;`;
 
 export function makeAwsLauncher({
   entrypointPath,
-  awsLambdaHandler
+  awsLambdaHandler = ''
 }: LauncherConfiguration): string {
+  const funcName = awsLambdaHandler.split('.').pop();
   return `const url = require("url");
   exports.${funcName} = function (e, context, callback) {
     const zeitNowEvent = JSON.parse(e.body);

--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -110,6 +110,6 @@ export function makeAwsLauncher({
       "headers": headers
     };
     const { ${funcName} } = require("${entrypointPath}");
-    ${funcName}(awsGatewayEvent, context, callback);
+    return ${funcName}(awsGatewayEvent, context, callback);
   }`;
 }

--- a/packages/now-node/src/launcher.ts
+++ b/packages/now-node/src/launcher.ts
@@ -89,7 +89,7 @@ export function makeAwsLauncher({
 }: LauncherConfiguration): string {
   const funcName = awsLambdaHandler.split('.').pop();
   return `const url = require("url");
-  exports.${funcName} = function (e, context, callback) {
+  exports.launcher = function (e, context, callback) {
     const zeitNowEvent = JSON.parse(e.body);
     const { path, method: httpMethod, body, headers } = zeitNowEvent;
     const { query } = url.parse(path, true);

--- a/packages/now-node/test/fixtures/25-aws-api/graphql/index.js
+++ b/packages/now-node/test/fixtures/25-aws-api/graphql/index.js
@@ -1,0 +1,21 @@
+const { GraphQLServerLambda } = require('graphql-yoga');
+
+const typeDefs = `
+  type Query {
+    hello(name: String): String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello: (_, { name }) => `Hello ${name || "world"}`
+  }
+};
+
+const lambda = new GraphQLServerLambda({
+  typeDefs,
+  resolvers,
+  playground: true,
+});
+
+exports.handler = lambda.handler;

--- a/packages/now-node/test/fixtures/25-aws-api/now.json
+++ b/packages/now-node/test/fixtures/25-aws-api/now.json
@@ -10,6 +10,11 @@
       "src": "callback/index.js",
       "use": "@now/node",
       "config": { "awsLambdaHandler": "callback/index.handler" }
+    },
+    {
+      "src": "graphql/index.js",
+      "use": "@now/node",
+      "config": { "awsLambdaHandler": "graphql/index.handler" }
     }
   ],
   "probes": [
@@ -17,6 +22,10 @@
     {
       "path": "/callback",
       "mustContain": "aws-api-callback:RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/graphql",
+      "mustContain": "GraphQL Playground"
     }
   ]
 }

--- a/packages/now-node/test/fixtures/25-aws-api/package.json
+++ b/packages/now-node/test/fixtures/25-aws-api/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "cowsay": "1.4.0"
+    "cowsay": "1.4.0",
+    "graphql-yoga": "1.18.3"
   }
 }


### PR DESCRIPTION
This is a follow up PR to https://github.com/zeit/now-builders/pull/742

The `event` object that ZEIT Now uses is very different than the one used by the [AWS Gateway Proxy](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html).

This PR converts the `event` object when `awsLambdaHandler` config is enabled because the assumption is that the user is porting code to ZEIT Now and would expect the AWS Gateway format.

I added a test for one such package that expects this format: `graphql-yoga`.

```json
{
  "version": 2,
  "builds": [
    {
      "src": "index.js",
      "use": "@now/node",
      "config": { "awsLambdaHandler": "index.handler" }
    }
  ]
}
```

Thanks to @coetry for noticing this bug.