### PR TITLE
[now-build-utils] Add types for SPRv2

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -2,6 +2,7 @@ import FileBlob from './file-blob';
 import FileFsRef from './file-fs-ref';
 import FileRef from './file-ref';
 import { Lambda, createLambda } from './lambda';
+import Prerender from './prerender';
 import download, { DownloadedFiles } from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory';
 import glob from './fs/glob';
@@ -27,6 +28,7 @@ export {
   FileRef,
   Lambda,
   createLambda,
+  Prerender,
   download,
   DownloadedFiles,
   getWriteableDirectory,

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -2,7 +2,7 @@ import FileBlob from './file-blob';
 import FileFsRef from './file-fs-ref';
 import FileRef from './file-ref';
 import { Lambda, createLambda } from './lambda';
-import Prerender from './prerender';
+import { Prerender, PrerenderGroup } from './prerender';
 import download, { DownloadedFiles } from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory';
 import glob from './fs/glob';
@@ -29,6 +29,7 @@ export {
   Lambda,
   createLambda,
   Prerender,
+  PrerenderGroup,
   download,
   DownloadedFiles,
   getWriteableDirectory,

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -9,7 +9,7 @@ interface PrerenderOptions {
   fallback: FileBlob | FileFsRef | FileRef;
 }
 
-export class Prerender {
+export default class Prerender {
   public type: 'Prerender';
   public expiration: number;
   public lambda: Lambda;

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -1,0 +1,24 @@
+import FileBlob from './file-blob';
+import FileFsRef from './file-fs-ref';
+import FileRef from './file-ref';
+import { Lambda } from './lambda';
+
+interface PrerenderOptions {
+  expiration: number;
+  lambda: Lambda;
+  fallback: FileBlob | FileFsRef | FileRef;
+}
+
+export class Prerender {
+  public type: 'Prerender';
+  public expiration: number;
+  public lambda: Lambda;
+  public fallback: FileBlob | FileFsRef | FileRef;
+
+  constructor({ expiration, lambda, fallback }: PrerenderOptions) {
+    this.type = 'Prerender';
+    this.expiration = expiration;
+    this.lambda = lambda;
+    this.fallback = fallback;
+  }
+}

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -23,7 +23,7 @@ export class Prerender {
   }
 }
 
-interface PrerenderOptions {
+interface PrerenderGroupOptions {
   items: Array<Prerender>;
 }
 

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -9,7 +9,7 @@ interface PrerenderOptions {
   fallback: FileBlob | FileFsRef | FileRef;
 }
 
-export default class Prerender {
+export class Prerender {
   public type: 'Prerender';
   public expiration: number;
   public lambda: Lambda;
@@ -20,5 +20,19 @@ export default class Prerender {
     this.expiration = expiration;
     this.lambda = lambda;
     this.fallback = fallback;
+  }
+}
+
+interface PrerenderOptions {
+  items: Array<Prerender>;
+}
+
+export class PrerenderGroup {
+  public type: 'PrerenderGroup';
+  public items: Array<Prerender>;
+
+  constructor({ items }: PrerenderGroupOptions) {
+    this.type = 'PrerenderGroup';
+    this.items = items;
   }
 }


### PR DESCRIPTION
This pull request adds two new types in preparation for Serverless Prerendering v2.

The first one is `Prerender`, which represents a pre-rendering bundle:

```
interface Prerender {
  expiration: number;
  lambda: Lambda;
  fallback: FileBlob | FileFsRef | FileRef;
}
```

The second one is `PrerenderGroup`, which defines a list of `Prerender` that should be invalidated at the same time – if one of them is invalidated:

```
interface PrerenderGroup {
  items: Array<Prerender>;
}
```