### PR TITLE
[now-cli] Render "stderr" as red in `now logs`

### DIFF
--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -283,16 +283,19 @@ function printLogShort(log) {
       ` ${obj.status} ${obj.bodyBytesSent}`;
   } else if (log.type === 'event') {
     data = `EVENT ${log.event} ${JSON.stringify(log.payload)}`;
+  } else if (obj) {
+    data = JSON.stringify(obj, null, 2);
   } else {
-    data = obj
-      ? JSON.stringify(obj, null, 2)
-      : (log.text || '')
+    data = (log.text || '')
           .replace(/\n$/, '')
           .replace(/^\n/, '')
           // eslint-disable-next-line no-control-regex
           .replace(/\x1b\[1000D/g, '')
           .replace(/\x1b\[0K/g, '')
           .replace(/\x1b\[1A/g, '');
+    if (log.type === 'stderr') {
+      data = chalk.red(data);
+    }
   }
 
   const date = new Date(log.created).toISOString();


### PR DESCRIPTION
<img width="537" alt="Screen Shot 2019-09-16 at 10 42 22 PM" src="https://user-images.githubusercontent.com/71256/65014351-4642e900-d8d3-11e9-8062-5409168fd370.png">

**TODO:** Add integration test