### PR TITLE
[now-cli] Assign `process.exitCode`

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -672,9 +672,7 @@ process.on('uncaughtException', handleUnexpected);
 // subcommands waiting for further data won't work (like `logs` and `logout`)!
 main(process.argv)
   .then(exitCode => {
+    process.exitCode = exitCode;
     process.emit('nowExit');
-    process.on('beforeExit', () => {
-      process.exit(exitCode);
-    });
   })
   .catch(handleUnexpected);


### PR DESCRIPTION
No real functional change here, but assigning to `process.exitCode` is the more proper Node.js way to set the exit code for the process.