### PR TITLE
[now-cli] Fix fetch body and add secrets tests

### DIFF
--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -70,10 +70,11 @@ let subcommand;
 
 const main = async ctx => {
   argv = mri(ctx.argv.slice(2), {
-    boolean: ['help', 'debug'],
+    boolean: ['help', 'debug', 'yes'],
     alias: {
       help: 'h',
       debug: 'd',
+      yes: 'y',
     },
   });
 
@@ -188,7 +189,7 @@ async function run({ output, token, contextName, currentTeam }) {
     const theSecret = list.find(secret => secret.name === args[0]);
 
     if (theSecret) {
-      const yes = await readConfirmation(theSecret);
+      const yes = argv.yes || (await readConfirmation(theSecret));
       if (!yes) {
         console.error(error('User abort'));
         return exit(0);

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -583,10 +583,17 @@ export default class Now extends EventEmitter {
     opts.headers.Authorization = `Bearer ${this._token}`;
     opts.headers['user-agent'] = ua;
 
+    if (
+      opts.body &&
+      typeof opts.body === 'object' &&
+      opts.body.constructor === Object
+    ) {
+      opts.body = JSON.stringify(opts.body);
+      opts.headers['Content-Type'] = 'application/json';
+    }
+
     return this._output.time(
-      `${opts.method || 'GET'} ${this._apiUrl}${_url} ${JSON.stringify(
-        opts.body
-      ) || ''}`,
+      `${opts.method || 'GET'} ${this._apiUrl}${_url} ${opts.body || ''}`,
       fetch(`${this._apiUrl}${_url}`, opts)
     );
   }

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1893,6 +1893,43 @@ test('create zero-config deployment', async t => {
   t.true(validBuilders, JSON.stringify(data, null, 2));
 });
 
+test('now secret add', async t => {
+  context.secretName = `my-secret-${Date.now().toString(36)}`;
+  const value = 'https://my-secret-endpoint.com';
+
+  const output = await execute(['secret', 'add', context.secretName, value]);
+
+  t.is(output.code, 0, formatOutput(output));
+});
+
+test('now secret ls', async t => {
+  const output = await execute(['secret', 'ls']);
+
+  t.is(output.code, 0, formatOutput(output));
+  t.regex(output.stdout, /secrets? found under/gm, formatOutput(output));
+  t.regex(output.stdout, new RegExp(), formatOutput(output));
+});
+
+test('now secret rename', async t => {
+  const nextName = `renamed-secret-${Date.now().toString(36)}`;
+  const output = await execute([
+    'secret',
+    'rename',
+    context.secretName,
+    nextName,
+  ]);
+
+  t.is(output.code, 0, formatOutput(output));
+
+  context.secretName = nextName;
+});
+
+test('now secret rm', async t => {
+  const output = await execute(['secret', 'rm', context.secretName, '-y']);
+
+  t.is(output.code, 0, formatOutput(output));
+});
+
 test.after.always(async () => {
   // Make sure the token gets revoked
   await execa(binaryPath, ['logout', ...defaultArgs]);


### PR DESCRIPTION
Fix fetch body and add secrets tests.

When `http2` was removed the `_fetch` function changed their behaviour for the `body`.