### PR TITLE
[tests] Add env var FORCE_BUILD_IN_REGION

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -35,6 +35,13 @@ async function nowDeploy (bodies, randomness) {
     meta: {},
   };
 
+  if (process.env.FORCE_BUILD_IN_REGION) {
+    const { builds=[] } = nowDeployPayload;
+    builds.forEach(b => {
+      b.forceBuildIn = process.env.FORCE_BUILD_IN_REGION;
+    });
+  }
+
   console.log(`posting ${files.length} files`);
 
   for (const { file: filename } of files) {

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -38,7 +38,10 @@ async function nowDeploy (bodies, randomness) {
   if (process.env.FORCE_BUILD_IN_REGION) {
     const { builds=[] } = nowDeployPayload;
     builds.forEach(b => {
-      b.forceBuildIn = process.env.FORCE_BUILD_IN_REGION;
+      if (!b.config) {
+        b.config = {};
+      }
+      b.config.forceBuildIn = process.env.FORCE_BUILD_IN_REGION;
     });
   }
 


### PR DESCRIPTION
This adds a new environment variable, `FORCE_BUILD_IN_REGION`, that is useful for running all the  Builder Tests against a specific region of Fargate (for example, staging).

### Usage

```sh
FORCE_BUILD_IN_REGION=iad1 yarn test-integration-once
```