### PR TITLE
[docs] Update CI badge to use master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![now](https://assets.zeit.co/image/upload/v1542240976/repositories/now-cli/now-cli-repo-banner-v3.png)
 
-[![Build Status](https://circleci.com/gh/zeit/now.svg?&style=shield)](https://circleci.com/gh/zeit/workflows/now)
+[![Build Status](https://badgen.net/circleci/github/zeit/now/master)](https://circleci.com/gh/zeit/workflows/now/tree/master)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)
 
 **Note**: The [canary](https://github.com/zeit/now/tree/canary) branch is under heavy development – the stable release branch is [master](https://github.com/zeit/now/tree/master).


### PR DESCRIPTION
The badge icon is currently showing the most recent PR build status.

Instead, let's make sure the badge shows the most recent master build status.