### PR TITLE
[now-static-build] Add support for hugo extended

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import spawn from 'cross-spawn';
 import getPort from 'get-port';
 import { timeout } from 'promise-timeout';
+import isPortReachable from 'is-port-reachable';
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { frameworks, Framework } from './frameworks';
 import {
@@ -19,9 +20,16 @@ import {
   BuildOptions,
   Config,
   debug,
-  PackageJson
+  PackageJson,
 } from '@now/build-utils';
-import isPortReachable from 'is-port-reachable'
+
+async function checkForPort(port: number | undefined): Promise<void> {
+  while (!(await isPortReachable(port))) {
+    await new Promise(resolve => {
+      setTimeout(resolve, 100);
+    });
+  }
+}
 
 function validateDistDir(
   distDir: string,
@@ -87,7 +95,7 @@ const nowDevScriptPorts = new Map();
 const getDevRoute = (srcBase: string, devPort: number, route: Route) => {
   const basic: Route = {
     src: `${srcBase}${route.src}`,
-    dest: `http://localhost:${devPort}${route.dest}`
+    dest: `http://localhost:${devPort}${route.dest}`,
   };
 
   if (route.headers) {
@@ -121,7 +129,7 @@ export async function build({
   entrypoint,
   workPath,
   config,
-  meta = {}
+  meta = {},
 }: BuildOptions) {
   debug('Downloading user files...');
   await download(files, workPath, meta);
@@ -150,7 +158,6 @@ export async function build({
     const devScript = getCommand(pkg, 'dev', config as Config);
 
     if (config.zeroConfig) {
-
       if (existsSync(gemfilePath) && !meta.isDev) {
         debug('Detected Gemfile, executing bundle install...');
         await runBundleInstall(workPath, [], undefined, meta);
@@ -159,25 +166,27 @@ export async function build({
       const { HUGO_VERSION, ZOLA_VERSION, GUTENBERG_VERSION } = process.env;
 
       if (HUGO_VERSION && !meta.isDev) {
-        /*
         const [major, minor] = HUGO_VERSION.split('.').map(Number);
         const isOldVersion = major === 0 && minor < 43;
         const prefix = isOldVersion ? `hugo_` : `hugo_extended_`;
-        TODO: We can't currently use extended because of `libstdc++.so.6` needs to be updated.
-        */
-        const prefix = `hugo_`;
         const url = `https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${prefix}${HUGO_VERSION}_Linux-64bit.tar.gz`;
-        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], { shell: true });
+        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], {
+          shell: true,
+        });
       }
 
       if (ZOLA_VERSION && !meta.isDev) {
         const url = `https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
-        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], { shell: true });
+        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], {
+          shell: true,
+        });
       }
 
       if (GUTENBERG_VERSION && !meta.isDev) {
         const url = `https://github.com/getzola/zola/releases/download/v${GUTENBERG_VERSION}/gutenberg-v${GUTENBERG_VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
-        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], { shell: true });
+        await spawnAsync(`curl -L ${url} | tar -zx -C /usr/local/bin`, [], {
+          shell: true,
+        });
       }
 
       // `public` is the default for zero config
@@ -189,7 +198,9 @@ export async function build({
         pkg.devDependencies
       );
 
-      framework = frameworks.find(({ dependency }) => dependencies[dependency || '']);
+      framework = frameworks.find(
+        ({ dependency }) => dependencies[dependency || '']
+      );
     }
 
     if (framework) {
@@ -231,7 +242,7 @@ export async function build({
 
         const opts = {
           cwd: entrypointDir,
-          env: { ...process.env, PORT: String(devPort) }
+          env: { ...process.env, PORT: String(devPort) },
         };
 
         const child = spawn('yarn', ['run', devScript], opts);
@@ -243,15 +254,6 @@ export async function build({
         if (child.stderr) {
           child.stderr.setEncoding('utf8');
           child.stderr.pipe(process.stderr);
-        }
-
-
-        async function checkForPort(port: number | undefined): Promise<void> {
-          while (!(await isPortReachable(port))) {
-            await new Promise(resolve => {
-              setTimeout(resolve, 100);
-            });
-          }
         }
 
         // Now wait for the server to have listened on `$PORT`, after which we
@@ -285,7 +287,7 @@ export async function build({
       routes.push(
         getDevRoute(srcBase, devPort, {
           src: '/(.*)',
-          dest: '/$1'
+          dest: '/$1',
         })
       );
     } else {
@@ -359,7 +361,7 @@ export async function build({
     return {
       output,
       routes: [],
-      watch: []
+      watch: [],
     };
   }
 


### PR DESCRIPTION
This adds support for [Hugo Extended](https://gohugo.io/getting-started/installing/#linux) which supports Sass/SCSS.

~~This PR depends on changes to fargate which will be deployed tomorrow morning.~~ Done
