### PR TITLE
[now-static-build] Add test for `BUNDLE_WITHOUT` env var

### DIFF
--- a/packages/now-static-build/test/fixtures/35-bundle-without/Gemfile
+++ b/packages/now-static-build/test/fixtures/35-bundle-without/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gem "dimples", "6.5.2"
+
+group :development do
+  gem "jekyll", "3.8.6"
+end
+
+group :test do
+  gem "middleman", "4.3.5"
+end

--- a/packages/now-static-build/test/fixtures/35-bundle-without/build.sh
+++ b/packages/now-static-build/test/fixtures/35-bundle-without/build.sh
@@ -1,0 +1,8 @@
+get_program_path() {
+  which $1 || echo 'not found'
+}
+
+mkdir public
+get_program_path 'jekyll' > public/jekyll.txt
+get_program_path 'middelman' > public/middleman.txt
+get_program_path 'dimples' > public/dimples.txt

--- a/packages/now-static-build/test/fixtures/35-bundle-without/now.json
+++ b/packages/now-static-build/test/fixtures/35-bundle-without/now.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "zeroConfig": true }
+    }
+  ],
+  "build": {
+    "env": {
+      "BUNDLE_WITHOUT": "development:test"
+    }
+  },
+  "probes": [
+    { "path": "/jekyll.txt", "mustContain": "not found" },
+    { "path": "/middleman.txt", "mustContain": "not found" },
+    { "path": "/dimples.txt", "mustContain": "dimples" }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/35-bundle-without/package.json
+++ b/packages/now-static-build/test/fixtures/35-bundle-without/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "./build.sh"
+  }
+}


### PR DESCRIPTION
This adds a test which confirms that `BUNDLE_WITHOUT="test:development"` works properly.

This env var is equivalent to `bundle install --without test development`.

There's no code change here because groups are defined by the user, therefore they must define which ones to ignore (if any).

- Groups Guide: https://bundler.io/v2.0/guides/groups.html
- BUNDLER_WITHOUT: https://bundler.io/v2.0/bundle_config.html#LIST-OF-AVAILABLE-KEYS
- Example Gemfile: https://github.com/thoughtbot/administrate/blob/master/Gemfile

PRODUCT-133 #close