### PR TITLE
[bot] Use PR description for merge commit body

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -12,5 +12,6 @@ optimistic_updates = true
 
 [merge.message]
 title = "pull_request_title"
+body = "pull_request_body"
 include_pr_number = true
 body_type = "markdown"


### PR DESCRIPTION
This changes the settings for Kodiak Bot to use the PR description instead of the GitHub default (which is basically concatenated commit messages).

This is important for the Jira integration so that we can properly close tickets by mentioning it in the PR description (which is how it works for GitHub issues too).

Docs: https://github.com/chdsbd/kodiak#config-with-comments-and-all-options-set