### PR TITLE
[now-build-utils] Allow prerender groups to be defined with an integer

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -2,7 +2,7 @@ import FileBlob from './file-blob';
 import FileFsRef from './file-fs-ref';
 import FileRef from './file-ref';
 import { Lambda, createLambda } from './lambda';
-import { Prerender, PrerenderGroup } from './prerender';
+import { Prerender } from './prerender';
 import download, { DownloadedFiles } from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory';
 import glob from './fs/glob';
@@ -31,7 +31,6 @@ export {
   Lambda,
   createLambda,
   Prerender,
-  PrerenderGroup,
   download,
   DownloadedFiles,
   getWriteableDirectory,

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -7,6 +7,7 @@ interface PrerenderOptions {
   expiration: number;
   lambda: Lambda;
   fallback: FileBlob | FileFsRef | FileRef;
+  group: number;
 }
 
 export class Prerender {
@@ -14,25 +15,13 @@ export class Prerender {
   public expiration: number;
   public lambda: Lambda;
   public fallback: FileBlob | FileFsRef | FileRef;
+  public group: number;
 
-  constructor({ expiration, lambda, fallback }: PrerenderOptions) {
+  constructor({ expiration, lambda, fallback, group }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
     this.lambda = lambda;
     this.fallback = fallback;
-  }
-}
-
-interface PrerenderGroupOptions {
-  items: Array<Prerender>;
-}
-
-export class PrerenderGroup {
-  public type: 'PrerenderGroup';
-  public items: Array<Prerender>;
-
-  constructor({ items }: PrerenderGroupOptions) {
-    this.type = 'PrerenderGroup';
-    this.items = items;
+    this.group = group;
   }
 }


### PR DESCRIPTION
This pull request removes the `PrerenderGroup` type in favor of a `group` parameter for the existing `Prerender` type.

This parameter takes in an integer that defines a group of prerenders that should be invalidated at the same time:

```
interface Prerender {
  expiration: number;
  lambda: Lambda;
  fallback: FileBlob | FileFsRef | FileRef;
  group: number;
}
```

**Example:** If two `Prerender` instances exist that have `group` set to `1`, they will both be invalidated at the same time.