### PR TITLE
[now-build-utils] Make grouping prerenders optional

### DIFF
--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -23,7 +23,7 @@ export class Prerender {
     this.lambda = lambda;
     this.fallback = fallback;
     
-    if (group <= 0 || !Number.isInteger(group)) {
+    if (group && group <= 0 || !Number.isInteger(group)) {
       throw new Error('The `group` argument for `Prerender` needs to be a natural number.');
     }
     

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -23,7 +23,10 @@ export class Prerender {
     this.lambda = lambda;
     this.fallback = fallback;
     
-    if (group && group <= 0 || !Number.isInteger(group)) {
+    if (
+      typeof group !== 'undefined' &&
+      (group <= 0 || !Number.isInteger(group))
+    ) {
       throw new Error('The `group` argument for `Prerender` needs to be a natural number.');
     }
     

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -23,8 +23,10 @@ export class Prerender {
     this.lambda = lambda;
     this.fallback = fallback;
     
-    if (group) {
-      this.group = group;
+    if (group <= 0 || !Number.isInteger(group)) {
+      throw new Error('The `group` argument for `Prerender` needs to be a natural number.');
     }
+    
+    this.group = group;
   }
 }

--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -7,7 +7,7 @@ interface PrerenderOptions {
   expiration: number;
   lambda: Lambda;
   fallback: FileBlob | FileFsRef | FileRef;
-  group: number;
+  group?: number;
 }
 
 export class Prerender {
@@ -15,13 +15,16 @@ export class Prerender {
   public expiration: number;
   public lambda: Lambda;
   public fallback: FileBlob | FileFsRef | FileRef;
-  public group: number;
+  public group?: number;
 
   constructor({ expiration, lambda, fallback, group }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
     this.lambda = lambda;
     this.fallback = fallback;
-    this.group = group;
+    
+    if (group) {
+      this.group = group;
+    }
   }
 }


### PR DESCRIPTION
As of https://github.com/zeit/now/pull/3081, we make it necessary to group `Prerenders` together for being invalidated at the same time.

However, you might not want that. In turn, we'll make it optional.