### PR TITLE
[now-client] Export TypeScript types

### DIFF
--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -5,6 +5,7 @@ import hashes, { mapToObject } from './utils/hashes';
 import uploadAndDeploy from './upload';
 import { getNowIgnore, createDebug } from './utils';
 import { DeploymentError } from './errors';
+import { CreateDeploymentFunction, DeploymentOptions } from './types';
 
 export { EVENTS } from './utils';
 

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -9,6 +9,7 @@ import {
 } from './utils';
 import checkDeploymentStatus from './deployment-status';
 import { generateQueryString } from './utils/query-string';
+import { Deployment, DeploymentOptions, NowJsonOptions } from './types';
 
 export interface Options {
   metadata: DeploymentOptions;

--- a/packages/now-client/src/deployment-status.ts
+++ b/packages/now-client/src/deployment-status.ts
@@ -2,6 +2,7 @@ import sleep from 'sleep-promise';
 import ms from 'ms';
 import { fetch, API_DEPLOYMENTS, API_DEPLOYMENTS_LEGACY } from './utils';
 import { isDone, isReady, isFailed } from './utils/ready-state';
+import { Deployment, DeploymentBuild } from './types';
 
 interface DeploymentStatus {
   type: string;

--- a/packages/now-client/src/errors.ts
+++ b/packages/now-client/src/errors.ts
@@ -1,8 +1,8 @@
 export class DeploymentError extends Error {
   constructor(err: { code: string; message: string }) {
-    super(err.message)
-    this.code = err.code
-    this.name = 'DeploymentError'
+    super(err.message);
+    this.code = err.code;
+    this.name = 'DeploymentError';
   }
 
   code: string;

--- a/packages/now-client/src/index.ts
+++ b/packages/now-client/src/index.ts
@@ -1,11 +1,12 @@
 // Polyfill Node 8 and below
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#the-for-await-of-statement
 if (!Symbol.asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for('Symbol.asyncIterator')
+  (Symbol as any).asyncIterator = Symbol.for('Symbol.asyncIterator');
 }
 
-import buildCreateDeployment from './create-deployment'
+import buildCreateDeployment from './create-deployment';
 
-export const createDeployment = buildCreateDeployment(2)
-export const createLegacyDeployment = buildCreateDeployment(1)
-export * from './errors'
+export const createDeployment = buildCreateDeployment(2);
+export const createLegacyDeployment = buildCreateDeployment(1);
+export * from './errors';
+export * from './types';

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -1,4 +1,4 @@
-declare interface Route {
+export interface Route {
   src: string;
   dest: string;
   headers?: {
@@ -8,12 +8,12 @@ declare interface Route {
   methods?: string[];
 }
 
-declare interface Build {
+export interface Build {
   src: string;
   use: string;
 }
 
-declare interface Deployment {
+export interface Deployment {
   id: string;
   deploymentId?: string;
   url: string;
@@ -56,7 +56,7 @@ declare interface Deployment {
   alias: string[];
 }
 
-declare interface DeploymentBuild {
+export interface DeploymentBuild {
   id: string;
   use: string;
   createdIn: string;
@@ -79,14 +79,14 @@ declare interface DeploymentBuild {
   path: string;
 }
 
-declare interface DeploymentGithubData {
+export interface DeploymentGithubData {
   enabled: boolean;
   autoAlias: boolean;
   silent: boolean;
   autoJobCancelation: boolean;
 }
 
-declare interface DeploymentOptions {
+export interface DeploymentOptions {
   version?: number;
   regions?: string[];
   routes?: Route[];
@@ -119,14 +119,14 @@ declare interface DeploymentOptions {
   debug?: boolean;
 }
 
-declare interface NowJsonOptions {
+export interface NowJsonOptions {
   github?: DeploymentGithubData;
   scope?: string;
   type?: 'NPM' | 'STATIC' | 'DOCKER';
   version?: number;
 }
 
-declare type CreateDeploymentFunction = (
+export type CreateDeploymentFunction = (
   path: string | string[],
   options?: DeploymentOptions
 ) => AsyncIterableIterator<any>;

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -6,6 +6,7 @@ import { join, sep } from 'path';
 import qs from 'querystring';
 import pkg from '../../package.json';
 import { Options } from '../deploy';
+import { NowJsonOptions } from '../types';
 import { Sema } from 'async-sema';
 const semaphore = new Sema(10);
 

--- a/packages/now-client/src/utils/query-string.ts
+++ b/packages/now-client/src/utils/query-string.ts
@@ -1,13 +1,13 @@
-import { Options } from "../deploy"
+import { Options } from '../deploy';
 
 export const generateQueryString = (options: Options): string => {
   if (options.force && options.teamId) {
-    return `?teamId=${options.teamId}&forceNew=1`
+    return `?teamId=${options.teamId}&forceNew=1`;
   } else if (options.teamId) {
-    return `?teamId=${options.teamId}`
+    return `?teamId=${options.teamId}`;
   } else if (options.force) {
-    return `?forceNew=1`
+    return `?forceNew=1`;
   }
 
-  return ''
-}
+  return '';
+};

--- a/packages/now-client/src/utils/ready-state.ts
+++ b/packages/now-client/src/utils/ready-state.ts
@@ -1,3 +1,16 @@
-export const isReady = ({ readyState, state }: Deployment | DeploymentBuild): boolean => readyState === 'READY' || state === 'READY'
-export const isFailed = ({ readyState, state }: Deployment | DeploymentBuild): boolean => readyState ? (readyState.endsWith('_ERROR') || readyState === 'ERROR') : (state && state.endsWith('_ERROR') || state === 'ERROR')
-export const isDone = (buildOrDeployment: Deployment | DeploymentBuild): boolean => isReady(buildOrDeployment) || isFailed(buildOrDeployment)
+import { Deployment, DeploymentBuild } from '../types';
+export const isReady = ({
+  readyState,
+  state,
+}: Deployment | DeploymentBuild): boolean =>
+  readyState === 'READY' || state === 'READY';
+export const isFailed = ({
+  readyState,
+  state,
+}: Deployment | DeploymentBuild): boolean =>
+  readyState
+    ? readyState.endsWith('_ERROR') || readyState === 'ERROR'
+    : (state && state.endsWith('_ERROR')) || state === 'ERROR';
+export const isDone = (
+  buildOrDeployment: Deployment | DeploymentBuild
+): boolean => isReady(buildOrDeployment) || isFailed(buildOrDeployment);

--- a/packages/now-client/tsconfig.json
+++ b/packages/now-client/tsconfig.json
@@ -13,8 +13,7 @@
     "noUnusedParameters": true,
     "strict": true,
     "target": "ES2015",
-    "downlevelIteration": true,
-    "typeRoots": ["./node_modules/@types", "./types"]
+    "downlevelIteration": true
   },
   "include": ["./src", "./types"]
 }


### PR DESCRIPTION
This makes downstream compilation with `tsc` work correctly.

Otherwise, compilation fails with errors such as:

```
../now-client/dist/src/index.d.ts:1:40 - error TS2304: Cannot find name 'CreateDeploymentFunction'.

1 export declare const createDeployment: CreateDeploymentFunction;
                                         ~~~~~~~~~~~~~~~~~~~~~~~~
````