### PR TITLE
[now-cli] Remove `dev: "now dev"` script detection logic in `now dev`

### DIFF
--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -1,7 +1,5 @@
 import path from 'path';
 import chalk from 'chalk';
-import { PackageJson } from '@now/build-utils';
-
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { NowContext } from '../../types';
@@ -11,8 +9,6 @@ import createOutput from '../../util/output/create-output';
 import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import dev from './dev';
-import readPackage from '../../util/read-package';
-import readConfig from '../../util/config/read-config';
 
 const COMMAND_CONFIG = {
   dev: ['dev'],

--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -82,28 +82,6 @@ export default async function main(ctx: NowContext) {
 
   const [dir = '.'] = args;
 
-  const nowJson = await readConfig(path.join(dir, 'now.json'));
-  // @ts-ignore: Because `nowJson` could be one of three different types
-  const hasBuilds = nowJson && nowJson.builds && nowJson.builds.length > 0;
-
-  if (!nowJson || !hasBuilds) {
-    const pkg = await readPackage(path.join(dir, 'package.json'));
-
-    if (pkg) {
-      const { scripts } = pkg as PackageJson;
-
-      if (scripts && scripts.dev && /\bnow\b\W+\bdev\b/.test(scripts.dev)) {
-        output.error(
-          `The ${cmd('dev')} script in ${cmd(
-            'package.json'
-          )} must not contain ${cmd('now dev')}`
-        );
-        output.error(`More details: http://err.sh/now/now-dev-as-dev-script`);
-        return 1;
-      }
-    }
-  }
-
   if (argv._.length > 2) {
     output.error(`${cmd('now dev [dir]')} accepts at most one argument`);
     return 1;

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -221,17 +221,6 @@ module.exports = (req, res) => {
       'index.json': JSON.stringify({ name: 'now-revert-alias-2' }),
       'now.json': getRevertAliasConfigFile(),
     },
-    'now-dev-fail-dev-script': {
-      'package.json': JSON.stringify(
-        {
-          scripts: {
-            dev: 'now dev',
-          },
-        },
-        null,
-        2
-      ),
-    },
     'v1-warning-link': {
       'now.json': JSON.stringify({
         version: 1,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2140,17 +2140,6 @@ test('whoami', async t => {
   t.is(stdout, contextName, formatOutput({ stdout, stderr }));
 });
 
-test('fail `now dev` dev script without now.json', async t => {
-  const deploymentPath = fixture('now-dev-fail-dev-script');
-  const { code, stderr } = await execute(['dev', deploymentPath]);
-
-  t.is(code, 1);
-  t.true(
-    stderr.includes('must not contain `now dev`'),
-    `Received instead: "${stderr}"`
-  );
-});
-
 test('print correct link in legacy warning', async t => {
   const deploymentPath = fixture('v1-warning-link');
   const { code, stderr, stdout } = await execute([deploymentPath]);


### PR DESCRIPTION
As of https://github.com/zeit/now-builders/pull/679, this logic is unnecessary because the `@now/static-build` builder will never end up executing the `dev` script when there is a `now.json` file present (and thus, no builds present, aka zero config mode).

Also, statically detecting the `now dev` command from the script command is brittle, as the command could execute a separate shell script that ends up executing `now dev` (and this detection logic would be a false negative).