### PR TITLE
[now-next] Upload build-time generated static artifacts

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -37,7 +37,6 @@ import {
   EnvConfig,
   excludeFiles,
   ExperimentalTraceVersion,
-  filesFromDirectory,
   getDynamicRoutes,
   getNextConfig,
   getPathsInside,
@@ -636,6 +635,9 @@ export const build = async ({
     '**',
     path.join(entryPath, '.next', 'static')
   );
+  const staticFolderFiles = await glob('**', path.join(entryPath, 'static'));
+  const publicFolderFiles = await glob('**', path.join(entryPath, 'public'));
+
   const staticFiles = Object.keys(nextStaticFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,
@@ -645,16 +647,24 @@ export const build = async ({
     }),
     {}
   );
-
-  const staticDirectoryFiles = await glob('**', path.join(entryPath, 'static'));
-  const publicDirectoryFiles = await glob('**', path.join(entryPath, 'public'));
-  const publicFiles = Object.keys(publicDirectoryFiles).reduce(
+  const staticDirectoryFiles = Object.keys(staticFolderFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,
-      [file.replace(/public[/\\]+/, '')]: publicDirectoryFiles[file],
+      [path.join(entryDirectory, 'static', file)]: staticFolderFiles[file],
     }),
     {}
   );
+  const publicDirectoryFiles = Object.keys(publicFolderFiles).reduce(
+    (mappedFiles, file) => ({
+      ...mappedFiles,
+      [path.join(
+        entryDirectory,
+        file.replace(/public[/\\]+/, '')
+      )]: publicFolderFiles[file],
+    }),
+    {}
+  );
+
   let dynamicPrefix = path.join('/', entryDirectory);
   dynamicPrefix = dynamicPrefix === '/' ? '' : dynamicPrefix;
 
@@ -674,7 +684,7 @@ export const build = async ({
 
   return {
     output: {
-      ...publicFiles,
+      ...publicDirectoryFiles,
       ...lambdas,
       ...staticPages,
       ...staticFiles,

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -42,7 +42,6 @@ import {
   getNextConfig,
   getPathsInside,
   getRoutes,
-  includeOnlyEntryDirectory,
   isDynamicRoute,
   normalizePackageJson,
   normalizePage,
@@ -647,15 +646,8 @@ export const build = async ({
     {}
   );
 
-  const entryDirectoryFiles = includeOnlyEntryDirectory(files, entryDirectory);
-  const staticDirectoryFiles = filesFromDirectory(
-    entryDirectoryFiles,
-    path.join(entryDirectory, 'static')
-  );
-  const publicDirectoryFiles = filesFromDirectory(
-    entryDirectoryFiles,
-    path.join(entryDirectory, 'public')
-  );
+  const staticDirectoryFiles = await glob('**', path.join(entryPath, 'static'));
+  const publicDirectoryFiles = await glob('**', path.join(entryPath, 'public'));
   const publicFiles = Object.keys(publicDirectoryFiles).reduce(
     (mappedFiles, file) => ({
       ...mappedFiles,

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -75,17 +75,6 @@ function excludeLockFiles(files: Files): Files {
 }
 
 /**
- * Include only the files from a selected directory
- */
-function filesFromDirectory(files: Files, dir: string): Files {
-  function matcher(filePath: string) {
-    return !filePath.startsWith(dir.replace(/\\/g, '/'));
-  }
-
-  return excludeFiles(files, matcher);
-}
-
-/**
  * Enforce specific package.json configuration for smallest possible lambda
  */
 function normalizePackageJson(
@@ -468,7 +457,6 @@ export {
   validateEntrypoint,
   excludeLockFiles,
   normalizePackageJson,
-  filesFromDirectory,
   getNextConfig,
   getPathsInside,
   getRoutes,

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -61,24 +61,6 @@ function excludeFiles(
 }
 
 /**
- * Creates a new Files object holding only the entrypoint files
- */
-function includeOnlyEntryDirectory(
-  files: Files,
-  entryDirectory: string
-): Files {
-  if (entryDirectory === '.') {
-    return files;
-  }
-
-  function matcher(filePath: string) {
-    return !filePath.startsWith(entryDirectory);
-  }
-
-  return excludeFiles(files, matcher);
-}
-
-/**
  * Exclude package manager lockfiles from files
  */
 function excludeLockFiles(files: Files): Files {
@@ -484,7 +466,6 @@ export async function createLambdaFromPseudoLayers({
 export {
   excludeFiles,
   validateEntrypoint,
-  includeOnlyEntryDirectory,
   excludeLockFiles,
   normalizePackageJson,
   filesFromDirectory,

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -122,6 +122,7 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'public-files'));
     expect(output['robots.txt']).toBeDefined();
+    expect(output['generated.txt']).toBeDefined();
   },
   FOUR_MINUTES
 );

--- a/packages/now-next/test/integration/public-files/create-public-file.js
+++ b/packages/now-next/test/integration/public-files/create-public-file.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+
+// Adds a new file to the public folder at build time
+fs.writeFileSync('public/generated.txt', 'Generated');

--- a/packages/now-next/test/integration/public-files/package.json
+++ b/packages/now-next/test/integration/public-files/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
-    "now-build": "next build"
+    "now-build": "node create-public-file.js && next build"
   },
   "dependencies": {
-    "next": "8",
+    "next": "9",
     "react": "16",
     "react-dom": "16"
   }

--- a/packages/now-next/test/unit/utils.test.js
+++ b/packages/now-next/test/unit/utils.test.js
@@ -2,9 +2,8 @@ const path = require('path');
 const {
   excludeFiles,
   validateEntrypoint,
-  includeOnlyEntryDirectory,
   normalizePackageJson,
-  getNextConfig
+  getNextConfig,
 } = require('@now/next/dist/utils');
 const { FileRef } = require('@now/build-utils');
 
@@ -33,7 +32,7 @@ describe('excludeFiles', () => {
     const files = {
       'pages/index.js': new FileRef({ digest: 'index' }),
       'package.json': new FileRef({ digest: 'package' }),
-      'package-lock.json': new FileRef({ digest: 'package-lock' })
+      'package-lock.json': new FileRef({ digest: 'package-lock' }),
     };
     const result = excludeFiles(
       files,
@@ -63,21 +62,6 @@ describe('validateEntrypoint', () => {
   });
 });
 
-describe('includeOnlyEntryDirectory', () => {
-  it('should include files outside entry directory', () => {
-    const entryDirectory = 'frontend';
-    const files = {
-      'frontend/pages/index.js': new FileRef({ digest: 'index' }),
-      'package.json': new FileRef({ digest: 'package' }),
-      'package-lock.json': new FileRef({ digest: 'package-lock' })
-    };
-    const result = includeOnlyEntryDirectory(files, entryDirectory);
-    expect(result['frontend/pages/index.js']).toBeDefined();
-    expect(result['package.json']).toBeUndefined();
-    expect(result['package-lock.json']).toBeUndefined();
-  });
-});
-
 describe('normalizePackageJson', () => {
   it('should work without a package.json being supplied', () => {
     const result = normalizePackageJson();
@@ -85,15 +69,15 @@ describe('normalizePackageJson', () => {
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
-          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-      }
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+      },
     });
   });
 
@@ -102,29 +86,29 @@ describe('normalizePackageJson', () => {
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
-        'now-build': 'next build'
-      }
+        'now-build': 'next build',
+      },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
-          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-      }
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+      },
     });
   });
 
@@ -133,23 +117,23 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'latest'
-      }
+        next: 'latest',
+      },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
-          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-      }
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+      },
     });
   });
 
@@ -158,23 +142,23 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'latest'
-      }
+        next: 'latest',
+      },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
-          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-      }
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+      },
     });
   });
 
@@ -183,23 +167,23 @@ describe('normalizePackageJson', () => {
       dependencies: {
         react: 'latest',
         'react-dom': 'latest',
-        next: 'latest'
-      }
+        next: 'latest',
+      },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: 'latest',
-        'react-dom': 'latest'
+        'react-dom': 'latest',
       },
       devDependencies: {
-        next: 'v7.0.2-canary.49'
+        next: 'v7.0.2-canary.49',
       },
       scripts: {
         'now-build':
-          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas'
-      }
+          'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
+      },
     });
   });
 
@@ -211,7 +195,7 @@ describe('normalizePackageJson', () => {
         dev: 'next',
         build: 'next build',
         start: 'next start',
-        test: "xo && stylelint './pages/**/*.js' && jest"
+        test: "xo && stylelint './pages/**/*.js' && jest",
       },
       main: 'pages/index.js',
       license: 'MIT',
@@ -226,7 +210,7 @@ describe('normalizePackageJson', () => {
         'stylelint-config-recommended': '^2.1.0',
         'stylelint-config-styled-components': '^0.1.1',
         'stylelint-processor-styled-components': '^1.5.1',
-        xo: '^0.23.0'
+        xo: '^0.23.0',
       },
       dependencies: {
         consola: '^2.2.6',
@@ -234,7 +218,7 @@ describe('normalizePackageJson', () => {
         next: '^7.0.2',
         react: '^16.6.3',
         'react-dom': '^16.6.3',
-        'styled-components': '^4.1.1'
+        'styled-components': '^4.1.1',
       },
       xo: {
         extends: 'xo-react',
@@ -244,15 +228,15 @@ describe('normalizePackageJson', () => {
           'test',
           'pages/_document.js',
           'pages/index.js',
-          'pages/home.js'
+          'pages/home.js',
         ],
         rules: {
-          'react/no-unescaped-entities': null
-        }
+          'react/no-unescaped-entities': null,
+        },
       },
       jest: {
-        testEnvironment: 'node'
-      }
+        testEnvironment: 'node',
+      },
     };
     const result = normalizePackageJson(defaultPackage);
     expect(result).toEqual({
@@ -263,7 +247,7 @@ describe('normalizePackageJson', () => {
         'now-build':
           'NODE_OPTIONS=--max_old_space_size=3000 next build --lambdas',
         start: 'next start',
-        test: "xo && stylelint './pages/**/*.js' && jest"
+        test: "xo && stylelint './pages/**/*.js' && jest",
       },
       main: 'pages/index.js',
       license: 'MIT',
@@ -283,12 +267,12 @@ describe('normalizePackageJson', () => {
         xo: '^0.23.0',
         consola: '^2.2.6',
         fontfaceobserver: '^2.0.13',
-        'styled-components': '^4.1.1'
+        'styled-components': '^4.1.1',
       },
       dependencies: {
         'next-server': 'v7.0.2-canary.49',
         react: '^16.6.3',
-        'react-dom': '^16.6.3'
+        'react-dom': '^16.6.3',
       },
       xo: {
         extends: 'xo-react',
@@ -298,15 +282,15 @@ describe('normalizePackageJson', () => {
           'test',
           'pages/_document.js',
           'pages/index.js',
-          'pages/home.js'
+          'pages/home.js',
         ],
         rules: {
-          'react/no-unescaped-entities': null
-        }
+          'react/no-unescaped-entities': null,
+        },
       },
       jest: {
-        testEnvironment: 'node'
-      }
+        testEnvironment: 'node',
+      },
     });
   });
 });


### PR DESCRIPTION
For context, when you have a script that generates a new static file at build time (`sitemap.xml` for example), it has to be inside `.next/static`, and then you'll need a Now route for it, with this change you could generate the file inside `public`/`static` and the builder will now take care of it.

The util `includeOnlyEntryDirectory` is no longer being used after this change, should I remove it?