### PR TITLE
[now-cli] Fix deployment version output

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -84,7 +84,7 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          const version = legacy ? `${chalk.grey('v1')} ` : '';
+          const version = legacy ? `${chalk.grey('[v1]')} ` : '';
           log(`https://${event.payload.url} ${version}${deployStamp()}`);
         } else {
           process.stdout.write(`https://${event.payload.url}`);
@@ -179,7 +179,8 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          log(`${event.payload.url} ${chalk.gray(`[v2]`)} ${deployStamp()}`);
+          const version = legacy ? `${chalk.grey('[v1]')} ` : '';
+          log(`${event.payload.url} ${version}${deployStamp()}`);
         } else {
           process.stdout.write(`https://${event.payload.url}`);
         }


### PR DESCRIPTION
It will print `[v2]` for 1.0 deployments when logging initially:

```
• go $ now --force
> WARN! You are using an old version of the Now Platform. More: https://zeit.co/docs/v2/advanced/platform/changes-in-now-2-0
> Deploying ~/projects/zeit/now-builder-v1/examples/docker/go under andyschneider
> Using project now-v1-go-docker
> now-v1-go-docker-xxxxxxx.now.sh [v2] [1s]
> Build completed
> https://now-v1-go-docker-xxxxxxx.now.sh [v1] [in clipboard] (sfo1) [1m]
> Verifying instantiation in sfo1
> ✔ Scaled 1 instance in sfo1 [22s]
> Success! Deployment ready
```

Expected:

```
• go $ nowl --force
> WARN! You are using an old version of the Now Platform. More: https://zeit.co/docs/v2/advanced/platform/changes-in-now-2-0
> Deploying ~/projects/zeit/now-builder-v1/examples/docker/go under andyschneider
> Using project now-v1-go-docker
> now-v1-go-docker-xxxxxxx.now.sh [v1] [2s]
> Build completed
> https://now-v1-go-docker-xxxxxxx.now.sh [v1] [in clipboard] (sfo1) [1m]
> Verifying instantiation in sfo1
> ✔ Scaled 1 instance in sfo1 [23s]
> Success! Deployment ready
```

For v2 it shouldn't print anything, as it's the default.