### PR TITLE
Revert "[tests] Add test all script" since it runs on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "diff": "node diff.js",
     "changelog": "node changelog.js",
     "build": "node run.js build all",
-    "test": "yarn test-lint && yarn test-unit && yarn test-integration && yarn test-integration-once && yarn test-integration-now-dev",
     "test-lint": "node run.js test-lint",
     "test-unit": "node run.js test-unit",
     "test-integration": "node run.js test-integration",


### PR DESCRIPTION
Reverts #3106 from @MAPESO 

The tests seem to be running on each commit which is going to slow down development.