### PR TITLE
[now-static-build] Use `stdio: 'inherit'` for "dev" script child process

### DIFF
--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -19,11 +19,12 @@
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",
+    "@types/ms": "0.7.31",
     "@types/promise-timeout": "1.3.0",
     "cross-spawn": "6.0.5",
     "get-port": "5.0.0",
     "is-port-reachable": "2.0.1",
-    "promise-timeout": "1.3.0",
+    "ms": "2.1.2",
     "typescript": "3.5.2"
   }
 }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -1,7 +1,8 @@
+import ms from 'ms';
 import path from 'path';
 import spawn from 'cross-spawn';
 import getPort from 'get-port';
-import { timeout } from 'promise-timeout';
+import { SpawnOptions } from 'child_process';
 import isPortReachable from 'is-port-reachable';
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { frameworks, Framework } from './frameworks';
@@ -25,11 +26,20 @@ import {
   PrepareCacheOptions,
 } from '@now/build-utils';
 
-async function checkForPort(port: number | undefined): Promise<void> {
+const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
+
+const DEV_SERVER_PORT_BIND_TIMEOUT = ms('5m');
+
+async function checkForPort(
+  port: number | undefined,
+  timeout: number
+): Promise<void> {
+  const start = Date.now();
   while (!(await isPortReachable(port))) {
-    await new Promise(resolve => {
-      setTimeout(resolve, 100);
-    });
+    if (Date.now() - start > timeout) {
+      throw new Error(`Detecting port ${port} timed out after ${ms(timeout)}`);
+    }
+    await sleep(100);
   }
 }
 
@@ -256,32 +266,20 @@ export async function build({
         devPort = await getPort();
         nowDevScriptPorts.set(entrypoint, devPort);
 
-        const opts = {
+        const opts: SpawnOptions = {
           cwd: entrypointDir,
+          stdio: 'inherit',
           env: { ...process.env, PORT: String(devPort) },
         };
 
         const child = spawn('yarn', ['run', devScript], opts);
         child.on('exit', () => nowDevScriptPorts.delete(entrypoint));
-        if (child.stdout) {
-          child.stdout.setEncoding('utf8');
-          child.stdout.pipe(process.stdout);
-        }
-        if (child.stderr) {
-          child.stderr.setEncoding('utf8');
-          child.stderr.pipe(process.stderr);
-        }
 
         // Now wait for the server to have listened on `$PORT`, after which we
         // will ProxyPass any requests to that development server that come in
         // for this builder.
         try {
-          await timeout(
-            new Promise(resolve => {
-              checkForPort(devPort).then(resolve);
-            }),
-            5 * 60 * 1000
-          );
+          await checkForPort(devPort, DEV_SERVER_PORT_BIND_TIMEOUT);
         } catch (err) {
           throw new Error(
             `Failed to detect a server running on port ${devPort}.\nDetails: https://err.sh/zeit/now/now-static-build-failed-to-detect-a-server`

--- a/packages/now-static-build/src/typings.d.ts
+++ b/packages/now-static-build/src/typings.d.ts
@@ -1,7 +1,10 @@
 declare module 'is-port-reachable' {
-    export interface IsPortReachableOptions {
-      timeout?: number | undefined;
-      host?: string;
-    }
-    export default function(port: number | undefined, options?: IsPortReachableOptions): Promise<boolean>;
+  export interface IsPortReachableOptions {
+    timeout?: number | undefined;
+    host?: string;
   }
+  export default function(
+    port: number | undefined,
+    options?: IsPortReachableOptions
+  ): Promise<boolean>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,11 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.30.tgz#f6c38b7ecbbf698b0bbd138315a0f0f18954f85f"
   integrity sha512-OftRLCgAzJP7vmKn9by/GVjnf4hloz/pXNOwPo0vKGAfXI7GqWXJi9N2kRar4cP5s1dGwuwcagWqO6iHBTq1Mg==
 
+"@types/ms@0.7.31":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
 "@types/multistream@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/multistream/-/multistream-2.1.1.tgz#4badd2440ee3570594ea552420fe2e29ebe512bd"
@@ -8791,11 +8796,6 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
-
-promise-timeout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/promise-timeout/-/promise-timeout-1.3.0.tgz#d1c78dd50a607d5f0a5207410252a3a0914e1014"
-  integrity sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==
 
 promisepipe@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Since `@now/static-build` is no longer sniffing the stdio streams for the bound port number in `now dev`, there's no need to have separate stdio streams for the "dev" script. Instead, inherit stdio from the parent process, which will allow for ANSI colors to be used when stdout is a TTY in `now dev`.

Also simplifies the `checkForPort()` function and removes the `promise-timeout` dependency.