### PR TITLE
[now-cli][now-client] Fix `--local-config` flag and `files` key

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -315,17 +315,17 @@ CMD ["node", "index.js"]`,
       }),
     },
     'local-config-v2': {
-      'main.html': '<h1>hello main</h1>',
-      'test.html': '<h1>hello test</h1>',
+      [`main-${session}.html`]: '<h1>hello main</h1>',
+      [`test-${session}.html`]: '<h1>hello test</h1>',
       'now.json': JSON.stringify({
         version: 2,
-        builds: [{ src: 'main.html', use: '@now/static' }],
-        routes: [{ src: '/another-main', dest: '/main.html' }],
+        builds: [{ src: `main-${session}.html`, use: '@now/static' }],
+        routes: [{ src: '/another-main', dest: `/main-${session}.html` }],
       }),
       'now-test.json': JSON.stringify({
         version: 2,
-        builds: [{ src: 'test.html', use: '@now/static' }],
-        routes: [{ src: '/another-test', dest: '/test.html' }],
+        builds: [{ src: `test-${session}.html`, use: '@now/static' }],
+        routes: [{ src: '/another-test', dest: `/test-${session}.html` }],
       }),
     },
     'alias-rules': {

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -267,7 +267,54 @@ module.exports = (req, res) => {
         Object.assign(JSON.parse(getConfigFile(true)), { alias: 'zeit.co' })
       ),
     },
-    'local-config-files': {
+    'local-config-cloud-v1': {
+      '.gitignore': '*.html',
+      'index.js': `
+const { createServer } = require('http');
+const { readFileSync } = require('fs');
+const svr = createServer((req, res) => {
+  const { url = '/' } = req;
+  const file = '.' + url;
+  console.log('reading file ' + file);
+  try {
+    let contents = readFileSync(file, 'utf8');
+    res.end(contents || '');
+  } catch (e) {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+svr.listen(3000);`,
+      'main.html': '<h1>hello main</h1>',
+      'test.html': '<h1>hello test</h1>',
+      Dockerfile: `FROM mhart/alpine-node:latest
+LABEL name "now-cli-dockerfile-${session}"
+
+RUN mkdir /app
+WORKDIR /app
+COPY . /app
+RUN yarn
+
+EXPOSE 3000
+CMD ["node", "index.js"]`,
+      'now.json': JSON.stringify({
+        version: 1,
+        type: 'docker',
+        features: {
+          cloud: 'v1',
+        },
+        files: ['.gitignore', 'main.html'],
+      }),
+      'now-test.json': JSON.stringify({
+        version: 1,
+        type: 'docker',
+        features: {
+          cloud: 'v1',
+        },
+        files: ['.gitignore', 'test.html'],
+      }),
+    },
+    'local-config-v2': {
       'main.html': '<h1>hello main</h1>',
       'test.html': '<h1>hello test</h1>',
       'now.json': JSON.stringify({

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -273,10 +273,12 @@ module.exports = (req, res) => {
       'now.json': JSON.stringify({
         version: 2,
         builds: [{ src: 'main.html', use: '@now/static' }],
+        routes: [{ src: '/another-main', dest: '/main.html' }],
       }),
       'now-test.json': JSON.stringify({
         version: 2,
         builds: [{ src: 'test.html', use: '@now/static' }],
+        routes: [{ src: '/another-test', dest: '/test.html' }],
       }),
     },
     'alias-rules': {

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -303,7 +303,7 @@ CMD ["node", "index.js"]`,
         features: {
           cloud: 'v1',
         },
-        files: ['.gitignore', 'main.html'],
+        files: ['.gitignore', 'index.js', 'main.html'],
       }),
       'now-test.json': JSON.stringify({
         version: 1,
@@ -311,7 +311,7 @@ CMD ["node", "index.js"]`,
         features: {
           cloud: 'v1',
         },
-        files: ['.gitignore', 'test.html'],
+        files: ['.gitignore', 'index.js', 'test.html'],
       }),
     },
     'local-config-v2': {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -201,8 +201,8 @@ test('login', async t => {
   t.is(typeof token, 'string');
 });
 
-test('deploy using --local-config flag', async t => {
-  const target = fixture('local-config-files');
+test('deploy using --local-config flag v2', async t => {
+  const target = fixture('local-config-v2');
 
   const { stdout, stderr, code } = await execa(
     binaryPath,
@@ -234,6 +234,34 @@ test('deploy using --local-config flag', async t => {
 
   const anotherMainRes = await fetch(`https://${host}/another-main`);
   t.is(anotherMainRes.status, 404, 'Should not deploy/build main now.json');
+});
+
+test('deploy using --local-config flag type cloud v1', async t => {
+  const target = fixture('local-config-cloud-v1');
+
+  const { stdout, stderr, code } = await execa(
+    binaryPath,
+    ['deploy', '--public', '--local-config', 'now-test.json', ...defaultArgs],
+    {
+      cwd: target,
+      reject: false,
+    }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  t.is(code, 0);
+
+  const { host } = new URL(stdout);
+
+  const testRes = await fetch(`https://${host}/test.html`);
+  const testText = await testRes.text();
+  t.true(testText.includes('hello test'));
+
+  const mainRes = await fetch(`https://${host}/main.html`);
+  t.is(mainRes.status, 404, 'Should not deploy/build main now.json');
 });
 
 test('print the deploy help message', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -219,13 +219,21 @@ test('deploy using --local-config flag', async t => {
 
   t.is(code, 0);
 
-  // Send a test request to the deployment
   const { host } = new URL(stdout);
-  const response = await fetch(`https://${host}/test.html`);
-  const content = await response.text();
-  t.true(content.includes('hello test'));
-  const response2 = await fetch(`https://${host}/main.html`);
-  t.is(response2.status, 404, 'Should not deploy/build main now.json');
+
+  const testRes = await fetch(`https://${host}/test.html`);
+  const testText = await testRes.text();
+  t.true(testText.includes('hello test'));
+
+  const anotherTestRes = await fetch(`https://${host}/another-test`);
+  const anotherTestText = await anotherTestRes.text();
+  t.is(anotherTestText.includes('hello test'));
+
+  const mainRes = await fetch(`https://${host}/main.html`);
+  t.is(mainRes.status, 404, 'Should not deploy/build main now.json');
+
+  const anotherMainRes = await fetch(`https://${host}/another-main`);
+  t.is(anotherMainRes.status, 404, 'Should not deploy/build main now.json');
 });
 
 test('print the deploy help message', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -227,7 +227,7 @@ test('deploy using --local-config flag', async t => {
 
   const anotherTestRes = await fetch(`https://${host}/another-test`);
   const anotherTestText = await anotherTestRes.text();
-  t.is(anotherTestText.includes('hello test'));
+  t.is(anotherTestText, testText);
 
   const mainRes = await fetch(`https://${host}/main.html`);
   t.is(mainRes.status, 404, 'Should not deploy/build main now.json');

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -221,7 +221,7 @@ test('deploy using --local-config flag v2', async t => {
 
   const { host } = new URL(stdout);
 
-  const testRes = await fetch(`https://${host}/test.html`);
+  const testRes = await fetch(`https://${host}/test-${contextName}.html`);
   const testText = await testRes.text();
   t.true(testText.includes('hello test'));
 
@@ -229,7 +229,7 @@ test('deploy using --local-config flag v2', async t => {
   const anotherTestText = await anotherTestRes.text();
   t.is(anotherTestText, testText);
 
-  const mainRes = await fetch(`https://${host}/main.html`);
+  const mainRes = await fetch(`https://${host}/main-${contextName}.html`);
   t.is(mainRes.status, 404, 'Should not deploy/build main now.json');
 
   const anotherMainRes = await fetch(`https://${host}/another-main`);

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -108,15 +108,13 @@ function findFile(
   fileName: string,
   files: Map<string, DeploymentFile>,
   debug: (...args: string[]) => void
-  ) {
+) {
   debug(`Trying to read ${fileName}`);
-  const deploymentFile: DeploymentFile | undefined = Array.from(files.values()).find(
-    (file) => {
-      return Boolean(
-        file.names.find((name) => name.includes(fileName))
-      );
-    }
-  );
+  const deploymentFile: DeploymentFile | undefined = Array.from(
+    files.values()
+  ).find(file => {
+    return Boolean(file.names.find(name => name.includes(fileName)));
+  });
 
   const verb = deploymentFile ? 'Found' : 'Missing';
   debug(`${verb} ${fileName}`);
@@ -128,9 +126,8 @@ export default async function* deploy(
   options: Options
 ): AsyncIterableIterator<{ type: string; payload: any }> {
   const debug = createDebug(options.debug);
-  const nowJsonMetadata = options.nowConfig || parseNowJSON(findFile('now.json', files, debug));
-  delete options.debug;
-  delete options.nowConfig;
+  const nowJsonMetadata =
+    options.nowConfig || parseNowJSON(findFile('now.json', files, debug));
   delete nowJsonMetadata.github;
   delete nowJsonMetadata.scope;
 
@@ -233,5 +230,3 @@ export default async function* deploy(
     }
   }
 }
-
-

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -1,6 +1,5 @@
 import { DeploymentFile } from './utils/hashes';
 import {
-  parseNowJSON,
   fetch,
   API_DEPLOYMENTS,
   prepareFiles,
@@ -104,30 +103,12 @@ const getDefaultName = (
   }
 };
 
-function findFile(
-  fileName: string,
-  files: Map<string, DeploymentFile>,
-  debug: (...args: string[]) => void
-) {
-  debug(`Trying to read ${fileName}`);
-  const deploymentFile: DeploymentFile | undefined = Array.from(
-    files.values()
-  ).find(file => {
-    return Boolean(file.names.find(name => name.includes(fileName)));
-  });
-
-  const verb = deploymentFile ? 'Found' : 'Missing';
-  debug(`${verb} ${fileName}`);
-  return deploymentFile;
-}
-
 export default async function* deploy(
   files: Map<string, DeploymentFile>,
   options: Options
 ): AsyncIterableIterator<{ type: string; payload: any }> {
   const debug = createDebug(options.debug);
-  const nowJsonMetadata =
-    options.nowConfig || parseNowJSON(findFile('now.json', files, debug));
+  const nowJsonMetadata = options.nowConfig || {};
   delete nowJsonMetadata.github;
   delete nowJsonMetadata.scope;
 

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -124,10 +124,11 @@ export interface NowJsonOptions {
   scope?: string;
   type?: 'NPM' | 'STATIC' | 'DOCKER';
   version?: number;
+  files?: string[];
 }
 
 export type CreateDeploymentFunction = (
   path: string | string[],
   options?: DeploymentOptions,
-  nowConfig?: NowJsonOptions,
+  nowConfig?: NowJsonOptions
 ) => AsyncIterableIterator<any>;

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -32,13 +32,13 @@ export const EVENTS = new Set([
   'build-state-changed',
 ]);
 
-export function parseNowJSON(file?: DeploymentFile): NowJsonOptions {
-  if (!file) {
+export async function parseNowJSON(filePath?: string): Promise<NowJsonOptions> {
+  if (!filePath) {
     return {};
   }
 
   try {
-    const jsonString = file.data.toString();
+    const jsonString = await readFile(filePath, 'utf8');
 
     return JSON.parse(jsonString);
   } catch (e) {


### PR DESCRIPTION
This PR is a followup to #3110 that fixes the first deployment when using the `--local-config` flag and also fixes v1 deployments using the [`files`](https://zeit.co/docs/v1/features/configuration/#files-(array)) key.

The tests have been adjusted so we don't regress in both cases.

Fixes #3099 
Fixes #3105
Fixes #3107
Fixes #3109

[PRODUCT-350] #close

[PRODUCT-350]: https://zeit.atlassian.net/browse/PRODUCT-350