### PR TITLE
[now-cli][now-client] Fix v1 `files` when defining a directory

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -287,6 +287,8 @@ const svr = createServer((req, res) => {
 svr.listen(3000);`,
       'main.html': '<h1>hello main</h1>',
       'test.html': '<h1>hello test</h1>',
+      'folder/file1.txt': 'file1',
+      'folder/sub/file2.txt': 'file2',
       Dockerfile: `FROM mhart/alpine-node:latest
 LABEL name "now-cli-dockerfile-${session}"
 
@@ -303,7 +305,7 @@ CMD ["node", "index.js"]`,
         features: {
           cloud: 'v1',
         },
-        files: ['.gitignore', 'index.js', 'main.html'],
+        files: ['.gitignore', 'folder', 'index.js', 'main.html'],
       }),
       'now-test.json': JSON.stringify({
         version: 1,
@@ -311,7 +313,7 @@ CMD ["node", "index.js"]`,
         features: {
           cloud: 'v1',
         },
-        files: ['.gitignore', 'index.js', 'test.html'],
+        files: ['.gitignore', 'folder', 'index.js', 'test.html'],
       }),
     },
     'local-config-v2': {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -260,6 +260,14 @@ test('deploy using --local-config flag type cloud v1', async t => {
   const testText = await testRes.text();
   t.true(testText.includes('hello test'));
 
+  const file1Res = await fetch(`https://${host}/folder/file1.txt`);
+  const file1Text = await file1Res.text();
+  t.true(file1Text.includes('file1'));
+
+  const file2Res = await fetch(`https://${host}/folder/sub/file2.txt`);
+  const file2Text = await file2Res.text();
+  t.true(file2Text.includes('file2'));
+
   const mainRes = await fetch(`https://${host}/main.html`);
   t.is(mainRes.status, 404, 'Should not deploy/build main now.json');
 });

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -223,7 +223,7 @@ test('deploy using --local-config flag v2', async t => {
 
   const testRes = await fetch(`https://${host}/test-${contextName}.html`);
   const testText = await testRes.text();
-  t.true(testText.includes('hello test'));
+  t.is(testText, '<h1>hello test</h1>');
 
   const anotherTestRes = await fetch(`https://${host}/another-test`);
   const anotherTestText = await anotherTestRes.text();
@@ -258,15 +258,15 @@ test('deploy using --local-config flag type cloud v1', async t => {
 
   const testRes = await fetch(`https://${host}/test.html`);
   const testText = await testRes.text();
-  t.true(testText.includes('hello test'));
+  t.is(testText, '<h1>hello test</h1>');
 
   const file1Res = await fetch(`https://${host}/folder/file1.txt`);
   const file1Text = await file1Res.text();
-  t.true(file1Text.includes('file1'));
+  t.is(file1Text, 'file1');
 
   const file2Res = await fetch(`https://${host}/folder/sub/file2.txt`);
   const file2Text = await file2Res.text();
-  t.true(file2Text.includes('file2'));
+  t.is(file2Text, 'file2');
 
   const mainRes = await fetch(`https://${host}/main.html`);
   t.is(mainRes.status, 404, 'Should not deploy/build main now.json');


### PR DESCRIPTION
This is a follow up to #3117 which added a fix for `files` but did not observe directories.

This PR fixes the scenario where a directory is defined such that all files inside the directory should be added uploaded (recursively).

Thanks to @williamli 

[PRODUCT-350] #close

[PRODUCT-350]: https://zeit.atlassian.net/browse/PRODUCT-350