### PR TITLE
[now-client] Fix `ENOENT` regression in `now-client`

### DIFF
--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -68,7 +68,7 @@ export default function buildCreateDeployment(
     // Get .nowignore
     let { ig, ignores } = await getNowIgnore(path);
 
-    debug(`Found ${ig.ig.ignores.length} rules in .nowignore`);
+    debug(`Found ${ig.ignores.length} rules in .nowignore`);
 
     let fileList: string[];
 
@@ -76,11 +76,11 @@ export default function buildCreateDeployment(
 
     if (isDirectory && !Array.isArray(path)) {
       // Directory path
-      const dirContents = await readdir(path, ig.ignores);
+      const dirContents = await readdir(path, ignores);
       const relativeFileList = dirContents.map(filePath =>
         relative(process.cwd(), filePath)
       );
-      fileList = ig.ig
+      fileList = ig
         .filter(relativeFileList)
         .map((relativePath: string) => join(process.cwd(), relativePath));
 

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -66,7 +66,7 @@ export default function buildCreateDeployment(
     }
 
     // Get .nowignore
-    let ig = await getNowIgnore(path);
+    let { ig, ignores } = await getNowIgnore(path);
 
     debug(`Found ${ig.ig.ignores.length} rules in .nowignore`);
 

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -68,7 +68,7 @@ export default function buildCreateDeployment(
     // Get .nowignore
     let ig = await getNowIgnore(path);
 
-    debug(`Found ${ig.ignores.length} rules in .nowignore`);
+    debug(`Found ${ig.ig.ignores.length} rules in .nowignore`);
 
     let fileList: string[];
 
@@ -76,11 +76,11 @@ export default function buildCreateDeployment(
 
     if (isDirectory && !Array.isArray(path)) {
       // Directory path
-      const dirContents = await readdir(path);
+      const dirContents = await readdir(path, ig.ignores);
       const relativeFileList = dirContents.map(filePath =>
         relative(process.cwd(), filePath)
       );
-      fileList = ig
+      fileList = ig.ig
         .filter(relativeFileList)
         .map((relativePath: string) => join(process.cwd(), relativePath));
 

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -96,7 +96,7 @@ export async function getNowIgnore(path: string | string[]): Promise<any> {
 
   const ig = ignore().add(`${ignores.join('\n')}\n${nowIgnore}`);
 
-  return ig;
+  return { ig, ignores };
 }
 
 export const fetch = async (


### PR DESCRIPTION
This PR should fixes `ENOENT` related errors

```
> Error! ENOENT: no such file or directory, stat '.../node_modules/.bin/...'
```

Related: https://github.com/zeit/now/issues/3104 