### PR TITLE
[now-cli] Set the builder's debug env var based on `DevServer.debug`

### DIFF
--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -60,12 +60,6 @@ export default async function main(ctx: NowContext) {
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
     output = createOutput({ debug });
 
-    // Builders won't show debug logs by default
-    // the `NOW_BUILDER_DEBUG` env variable will enable them
-    if (debug) {
-      process.env.NOW_BUILDER_DEBUG = '1';
-    }
-
     if ('--port' in argv) {
       output.warn('`--port` is deprecated, please use `--listen` instead');
       argv['--listen'] = String(argv['--port']);


### PR DESCRIPTION
This makes it so that a programatically created `DevServer` instance that has `debug` mode enabled also gets set on the builder child processes as expected, rather than only when invoked via CLI.

For example, the `dev-server.unit.js` tests can set `debug: true` and with this change the builder child processes will also have debug logs enabled. See [here](https://git.io/JeW0O).