### PR TITLE
[now-build-utils] Allow a null `fallback` in `Prerender`

### DIFF
--- a/packages/now-build-utils/src/prerender.ts
+++ b/packages/now-build-utils/src/prerender.ts
@@ -6,7 +6,7 @@ import { Lambda } from './lambda';
 interface PrerenderOptions {
   expiration: number;
   lambda: Lambda;
-  fallback: FileBlob | FileFsRef | FileRef;
+  fallback: FileBlob | FileFsRef | FileRef | null;
   group?: number;
 }
 
@@ -14,22 +14,29 @@ export class Prerender {
   public type: 'Prerender';
   public expiration: number;
   public lambda: Lambda;
-  public fallback: FileBlob | FileFsRef | FileRef;
+  public fallback: FileBlob | FileFsRef | FileRef | null;
   public group?: number;
 
   constructor({ expiration, lambda, fallback, group }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
     this.lambda = lambda;
-    this.fallback = fallback;
-    
+
     if (
       typeof group !== 'undefined' &&
       (group <= 0 || !Number.isInteger(group))
     ) {
-      throw new Error('The `group` argument for `Prerender` needs to be a natural number.');
+      throw new Error(
+        'The `group` argument for `Prerender` needs to be a natural number.'
+      );
     }
-    
     this.group = group;
+
+    if (typeof fallback === 'undefined') {
+      throw new Error(
+        'The `fallback` argument for `Prerender` needs to be a `FileBlob`, `FileFsRef`, `FileRef`, or null.'
+      );
+    }
+    this.fallback = fallback;
   }
 }


### PR DESCRIPTION
This allows a `null` `fallback` to be provided to a `Prerender`. The use case is a lazily prerendered route (often meaning dynamically rendered).