### PR TITLE
[now-client] Add `apiUrl` support

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -140,7 +140,6 @@ export default async function processDeployment({
           deploySpinner();
         }
 
-        console.log(event.payload, event.payload.stack);
         throw await now.handleDeploymentError(event.payload, { hashes, env });
       }
 

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -45,6 +45,7 @@ export default async function processDeployment({
   const opts: DeploymentOptions = {
     ...requestBody,
     debug: now._debug,
+    apiUrl: now._apiUrl,
   };
 
   if (!legacy) {
@@ -139,6 +140,7 @@ export default async function processDeployment({
           deploySpinner();
         }
 
+        console.log(event.payload, event.payload.stack);
         throw await now.handleDeploymentError(event.payload, { hashes, env });
       }
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -529,43 +529,6 @@ testv1('deploy a v1 dockerfile project', async t => {
   context.deployment = host;
 });
 
-test('deploy with a custom API URL', async t => {
-  const directory = fixture('static-single-file');
-
-  const { stdout, stderr, code } = await execa(
-    binaryPath,
-    [
-      directory,
-      '--public',
-      '--name',
-      session,
-      '--api',
-      'https://zeit.co/api',
-      ...defaultArgs,
-    ],
-    {
-      reject: false,
-    }
-  );
-
-  console.log(stderr);
-  console.log(stdout);
-  console.log(code);
-
-  // Ensure the exit code is right
-  t.is(code, 0);
-
-  // Test if the output is really a URL
-  const { href, host } = new URL(stdout);
-  t.is(host.split('-')[0], session);
-
-  // Send a test request to the deployment
-  const response = await fetch(href);
-  const contentType = response.headers.get('content-type');
-
-  t.is(contentType, 'text/html; charset=utf-8');
-});
-
 test('test invalid json alias rules', async t => {
   const fixturePath = fixture('alias-rules');
   const output = await execute(['alias', '-r', 'invalid-json-rules.json'], {
@@ -699,6 +662,43 @@ testv1('create an explicit alias for deployment', async t => {
   t.is(content.id, contextName);
 
   context.alias = hosts.alias;
+});
+
+test('deploy with a custom API URL', async t => {
+  const directory = fixture('static-single-file');
+
+  const { stdout, stderr, code } = await execa(
+    binaryPath,
+    [
+      directory,
+      '--public',
+      '--name',
+      session,
+      '--api',
+      'https://zeit.co/api',
+      ...defaultArgs,
+    ],
+    {
+      reject: false,
+    }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href);
+  const contentType = response.headers.get('content-type');
+
+  t.is(contentType, 'text/html; charset=utf-8');
 });
 
 testv1('list the aliases', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -529,7 +529,7 @@ testv1('deploy a v1 dockerfile project', async t => {
   context.deployment = host;
 });
 
-test('deploy with a custon API URL', async t => {
+test('deploy with a custom API URL', async t => {
   const directory = fixture('static-single-file');
 
   const { stdout, stderr, code } = await execa(

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -664,43 +664,6 @@ testv1('create an explicit alias for deployment', async t => {
   context.alias = hosts.alias;
 });
 
-test('deploy with a custom API URL', async t => {
-  const directory = fixture('static-single-file');
-
-  const { stdout, stderr, code } = await execa(
-    binaryPath,
-    [
-      directory,
-      '--public',
-      '--name',
-      session,
-      '--api',
-      'https://zeit.co/api',
-      ...defaultArgs,
-    ],
-    {
-      reject: false,
-    }
-  );
-
-  console.log(stderr);
-  console.log(stdout);
-  console.log(code);
-
-  // Ensure the exit code is right
-  t.is(code, 0);
-
-  // Test if the output is really a URL
-  const { href, host } = new URL(stdout);
-  t.is(host.split('-')[0], session);
-
-  // Send a test request to the deployment
-  const response = await fetch(href);
-  const contentType = response.headers.get('content-type');
-
-  t.is(contentType, 'text/html; charset=utf-8');
-});
-
 testv1('list the aliases', async t => {
   const { stdout, stderr, code } = await execa(
     binaryPath,
@@ -2506,6 +2469,43 @@ test('now secret rm', async t => {
   console.log(output.code);
 
   t.is(output.code, 0, formatOutput(output));
+});
+
+test('deploy with a custom API URL', async t => {
+  const directory = fixture('static-single-file');
+
+  const { stdout, stderr, code } = await execa(
+    binaryPath,
+    [
+      directory,
+      '--public',
+      '--name',
+      session,
+      '--api',
+      'https://zeit.co/api',
+      ...defaultArgs,
+    ],
+    {
+      reject: false,
+    }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href);
+  const contentType = response.headers.get('content-type');
+
+  t.is(contentType, 'text/html; charset=utf-8');
 });
 
 test.after.always(async () => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -529,6 +529,43 @@ testv1('deploy a v1 dockerfile project', async t => {
   context.deployment = host;
 });
 
+test('deploy with a custon API URL', async t => {
+  const directory = fixture('static-single-file');
+
+  const { stdout, stderr, code } = await execa(
+    binaryPath,
+    [
+      directory,
+      '--public',
+      '--name',
+      session,
+      '--api',
+      'https://zeit.co/api',
+      ...defaultArgs,
+    ],
+    {
+      reject: false,
+    }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  // Ensure the exit code is right
+  t.is(code, 0);
+
+  // Test if the output is really a URL
+  const { href, host } = new URL(stdout);
+  t.is(host.split('-')[0], session);
+
+  // Send a test request to the deployment
+  const response = await fetch(href);
+  const contentType = response.headers.get('content-type');
+
+  t.is(contentType, 'text/html; charset=utf-8');
+});
+
 test('test invalid json alias rules', async t => {
   const fixturePath = fixture('alias-rules');
   const output = await execute(['alias', '-r', 'invalid-json-rules.json'], {

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -171,6 +171,7 @@ export default function buildCreateDeployment(
       force,
       defaultName,
       debug: debug_,
+      apiUrl,
       ...metadata
     } = options;
 
@@ -188,6 +189,7 @@ export default function buildCreateDeployment(
       force,
       defaultName,
       metadata,
+      apiUrl,
     };
 
     debug(`Creating the deployment and starting upload...`);

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -22,6 +22,7 @@ export interface Options {
   preflight?: boolean;
   debug?: boolean;
   nowConfig?: NowJsonOptions;
+  apiUrl?: string;
 }
 
 async function* createDeployment(
@@ -50,6 +51,7 @@ async function* createDeployment(
           ...metadata,
           files: preparedFiles,
         }),
+        apiUrl: options.apiUrl,
       }
     );
 
@@ -203,7 +205,8 @@ export default async function* deploy(
         options.token,
         metadata.version,
         options.teamId,
-        debug
+        debug,
+        options.apiUrl
       )) {
         yield event;
       }

--- a/packages/now-client/src/deployment-status.ts
+++ b/packages/now-client/src/deployment-status.ts
@@ -15,7 +15,8 @@ export default async function* checkDeploymentStatus(
   token: string,
   version: number | undefined,
   teamId: string | undefined,
-  debug: Function
+  debug: Function,
+  apiUrl?: string
 ): AsyncIterableIterator<DeploymentStatus> {
   let deploymentState = deployment;
   let allBuildsCompleted = false;
@@ -38,7 +39,8 @@ export default async function* checkDeploymentStatus(
         `${apiDeployments}/${deployment.id}/builds${
           teamId ? `?teamId=${teamId}` : ''
         }`,
-        token
+        token,
+        { apiUrl }
       );
 
       const data = await buildsData.json();

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -117,6 +117,7 @@ export interface DeploymentOptions {
   sessionAffinity?: 'ip' | 'random';
   config?: { [key: string]: any };
   debug?: boolean;
+  apiUrl?: string;
 }
 
 export interface NowJsonOptions {

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -26,9 +26,9 @@ const isClientNetworkError = (err: Error | DeploymentError) => {
 
 export default async function* upload(
   files: Map<string, DeploymentFile>,
-  options: Options,
+  options: Options
 ): AsyncIterableIterator<any> {
-  const { token, teamId, debug: isDebug } = options;
+  const { token, teamId, debug: isDebug, apiUrl } = options;
   const debug = createDebug(isDebug);
 
   if (!files && !token && !teamId) {
@@ -103,6 +103,7 @@ export default async function* upload(
               },
               body: stream,
               teamId,
+              apiUrl,
             },
             isDebug
           );

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -11,11 +11,10 @@ import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
 const semaphore = new Sema(10);
 
-export const API_FILES = 'https://api.zeit.co/v2/now/files';
-export const API_DEPLOYMENTS = 'https://api.zeit.co/v9/now/deployments';
-export const API_DEPLOYMENTS_LEGACY = 'https://api.zeit.co/v3/now/deployments';
-export const API_DELETE_DEPLOYMENTS_LEGACY =
-  'https://api.zeit.co/v2/now/deployments';
+export const API_FILES = '/v2/now/files';
+export const API_DEPLOYMENTS = '/v9/now/deployments';
+export const API_DEPLOYMENTS_LEGACY = '/v3/now/deployments';
+export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
 
 export const EVENTS = new Set([
   // File events
@@ -109,6 +108,8 @@ export const fetch = async (
   const debug = createDebug(debugEnabled);
   let time: number;
 
+  url = `${opts.apiUrl || 'https://api.zeit.co'}${url}`;
+
   if (opts.teamId) {
     const parsedUrl = parseUrl(url, true);
     const query = parsedUrl.query;
@@ -116,6 +117,7 @@ export const fetch = async (
     query.teamId = opts.teamId;
     url = `${parsedUrl.href}?${qs.encode(query)}`;
     delete opts.teamId;
+    delete opts.apiUrl;
   }
 
   opts.headers = opts.headers || {};

--- a/packages/now-client/tests/setup/index.ts
+++ b/packages/now-client/tests/setup/index.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(120000)
+jest.setTimeout(240000);


### PR DESCRIPTION
This PR adds support for `apiUrl` option to `now-client` as well as a test for it