### PR TITLE
[now-cli] Temporarily force `TooTallNate/signal-exit#update/sighub-to-sigint-on-windows` for "signal-exit" module

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "resolutions": {
+    "signal-exit": "TooTallNate/signal-exit#update/sighub-to-sigint-on-windows"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9645,10 +9645,9 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+  resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 
 sinon@4.4.2:
   version "4.4.2"


### PR DESCRIPTION
Fixes https://github.com/zeit/now/issues/2564.

Upstream fix PR: https://github.com/tapjs/signal-exit/pull/55.