### PR TITLE
[now-client] Yield an error event if path provided is not absolute

### DIFF
--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -62,7 +62,7 @@ export default function buildCreateDeployment(
 
       return;
     } else if (!isAbsolute(path)) {
-      yield { type: 'error', message: 'Provided path is not absolute' };
+      yield { type: 'error', message: `Provided path ${path} is not absolute` };
 
       return;
     }

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -56,11 +56,13 @@ export default function buildCreateDeployment(
     if (Array.isArray(path)) {
       for (const filePath of path) {
         if (!isAbsolute(filePath)) {
-          yield { type: 'error', message: `Provided path ${filePath} is not absolute` };
+          yield {
+            type: 'error',
+            message: `Provided path ${filePath} is not absolute`,
+          };
+          return;
         }
       }
-
-      return;
     } else if (!isAbsolute(path)) {
       yield { type: 'error', message: `Provided path ${path} is not absolute` };
 

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -56,7 +56,7 @@ export default function buildCreateDeployment(
     if (Array.isArray(path)) {
       for (const filePath of path) {
         if (!isAbsolute(filePath)) {
-          yield { type: 'error', message: 'Provided path is not absolute' };
+          yield { type: 'error', message: `Provided path ${filePath} is not absolute` };
         }
       }
 

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -56,17 +56,17 @@ export default function buildCreateDeployment(
     if (Array.isArray(path)) {
       for (const filePath of path) {
         if (!isAbsolute(filePath)) {
-          yield {
-            type: 'error',
+          throw new DeploymentError({
+            code: 'invalid_path',
             message: `Provided path ${filePath} is not absolute`,
-          };
-          return;
+          });
         }
       }
     } else if (!isAbsolute(path)) {
-      yield { type: 'error', message: `Provided path ${path} is not absolute` };
-
-      return;
+      throw new DeploymentError({
+        code: 'invalid_path',
+        message: `Provided path ${path} is not absolute`,
+      });
     }
 
     if (isDirectory && !Array.isArray(path)) {

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -1,7 +1,7 @@
 import { readdir as readRootFolder, lstatSync } from 'fs-extra';
 
 import readdir from 'recursive-readdir';
-import { relative, join } from 'path';
+import { relative, join, isAbsolute } from 'path';
 import hashes, { mapToObject } from './utils/hashes';
 import uploadAndDeploy from './upload';
 import { getNowIgnore, createDebug, parseNowJSON } from './utils';
@@ -52,6 +52,20 @@ export default function buildCreateDeployment(
     const isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory();
 
     let rootFiles: string[];
+
+    if (Array.isArray(path)) {
+      for (const filePath of path) {
+        if (!isAbsolute(filePath)) {
+          yield { type: 'error', message: 'Provided path is not absolute' };
+        }
+      }
+
+      return;
+    } else if (!isAbsolute(path)) {
+      yield { type: 'error', message: 'Provided path is not absolute' };
+
+      return;
+    }
 
     if (isDirectory && !Array.isArray(path)) {
       debug(`Provided 'path' is a directory. Reading subpaths... `);

--- a/packages/now-client/tests/paths.test.ts
+++ b/packages/now-client/tests/paths.test.ts
@@ -1,0 +1,32 @@
+import { generateNewToken } from './common';
+import { createDeployment } from '../src/index';
+
+describe('path handling', () => {
+  let token = '';
+
+  beforeEach(async () => {
+    token = await generateNewToken();
+  });
+
+  it('will fali with a relative path', async () => {
+    try {
+      await createDeployment('./fixtures/v2/now.json', {
+        token,
+        name: 'now-client-tests-v2',
+      });
+    } catch (e) {
+      expect(e.code).toEqual('invalid_path');
+    }
+  });
+
+  it('will fali with an array of relative paths', async () => {
+    try {
+      await createDeployment(['./fixtures/v2/now.json'], {
+        token,
+        name: 'now-client-tests-v2',
+      });
+    } catch (e) {
+      expect(e.code).toEqual('invalid_path');
+    }
+  });
+});


### PR DESCRIPTION
This adds an `error` event when provided path to `now-client` isn't absolute