### PR TITLE
[now-cli] Add support for new keys in `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -5,6 +5,7 @@ import isURL from './is-url';
 import DevServer from './server';
 
 import { HttpHeadersConfig, RouteConfig, RouteResult } from './types';
+import { isHandler } from '@now/routing-utils';
 
 export function resolveRouteParameters(
   str: string,
@@ -40,9 +41,8 @@ export default async function(
     let idx = -1;
     for (const routeConfig of routes) {
       idx++;
-      let { src, headers, methods, handle } = routeConfig;
-      if (handle) {
-        if (handle === 'filesystem' && devServer) {
+      if (isHandler(routeConfig)) {
+        if (routeConfig.handle === 'filesystem' && devServer) {
           if (await devServer.hasFilesystem(reqPathname)) {
             break;
           }
@@ -50,16 +50,10 @@ export default async function(
         continue;
       }
 
+      let { src, headers, methods } = routeConfig;
+
       if (Array.isArray(methods) && reqMethod && !methods.includes(reqMethod)) {
         continue;
-      }
-
-      if (!src.startsWith('^')) {
-        src = `^${src}`;
-      }
-
-      if (!src.endsWith('$')) {
-        src = `${src}$`;
       }
 
       const keys: string[] = [];

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -13,6 +13,7 @@ import serveHandler from 'serve-handler';
 import { watch, FSWatcher } from 'chokidar';
 import { parse as parseDotenv } from 'dotenv';
 import { basename, dirname, extname, join } from 'path';
+import { getTransformedRoutes } from '@now/routing-utils';
 import directoryTemplate from 'serve-handler/src/directory';
 
 import {
@@ -553,6 +554,20 @@ export default class DevServer {
 
       if (warnings && warnings.length > 0) {
         warnings.forEach(warning => this.output.warn(warning.message));
+      }
+
+      const { error, routes } = getTransformedRoutes({
+        nowConfig: config,
+        filePaths: files,
+      });
+      if (error) {
+        this.output.error(error.message);
+        await this.exit();
+      }
+
+      if (routes) {
+        config.routes = config.routes || [];
+        config.routes.push(...routes);
       }
 
       if (builders) {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -36,7 +36,15 @@ import {
   staticFiles as getFiles,
   getAllProjectFiles,
 } from '../get-files';
-import { validateNowConfigBuilds, validateNowConfigRoutes } from './validate';
+import {
+  validateNowConfigBuilds,
+  validateNowConfigRoutes,
+  validateNowConfigCleanUrls,
+  validateNowConfigHeaders,
+  validateNowConfigRedirects,
+  validateNowConfigRewrites,
+  validateNowConfigTrailingSlash,
+} from './validate';
 
 import isURL from './is-url';
 import devRouter from './router';
@@ -605,25 +613,31 @@ export default class DevServer {
     return pkg;
   }
 
+  async tryValidateOrExit(
+    config: NowConfig,
+    validate: (c: NowConfig) => string | null
+  ): Promise<void> {
+    const message = validate(config);
+
+    if (message) {
+      this.output.error(message);
+      await this.exit(1);
+    }
+  }
+
   async validateNowConfig(config: NowConfig): Promise<void> {
     if (config.version === 1) {
       this.output.error('Only `version: 2` is supported by `now dev`');
       await this.exit(1);
     }
 
-    const buildsError = validateNowConfigBuilds(config);
-
-    if (buildsError) {
-      this.output.error(buildsError);
-      await this.exit(1);
-    }
-
-    const routesError = validateNowConfigRoutes(config);
-
-    if (routesError) {
-      this.output.error(routesError);
-      await this.exit(1);
-    }
+    await this.tryValidateOrExit(config, validateNowConfigBuilds);
+    await this.tryValidateOrExit(config, validateNowConfigRoutes);
+    await this.tryValidateOrExit(config, validateNowConfigCleanUrls);
+    await this.tryValidateOrExit(config, validateNowConfigHeaders);
+    await this.tryValidateOrExit(config, validateNowConfigRedirects);
+    await this.tryValidateOrExit(config, validateNowConfigRewrites);
+    await this.tryValidateOrExit(config, validateNowConfigTrailingSlash);
   }
 
   validateEnvConfig(

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -550,10 +550,7 @@ export default class DevServer {
       this.output.error(routeError.message);
       await this.exit();
     }
-    if (maybeRoutes) {
-      config.routes = config.routes || [];
-      config.routes.push(...maybeRoutes);
-    }
+    config.routes = maybeRoutes || [];
 
     // no builds -> zero config
     if (!config.builds || config.builds.length === 0) {

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -8,7 +8,7 @@ import {
   Lambda,
   PackageJson,
 } from '@now/build-utils';
-import { NowRedirect, NowRewrite, NowHeader } from '@now/routing-utils';
+import { NowRedirect, NowRewrite, NowHeader, Route } from '@now/routing-utils';
 import { Output } from '../output';
 
 export interface DevServerOptions {
@@ -28,15 +28,7 @@ export interface BuildMatch extends BuildConfig {
   buildProcess?: ChildProcess;
 }
 
-export interface RouteConfig {
-  src: string;
-  dest: string;
-  methods?: string[];
-  headers?: HttpHeadersConfig;
-  status?: number;
-  handle?: string;
-  continue?: boolean;
-}
+export type RouteConfig = Route;
 
 export interface NowConfig {
   name?: string;

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -8,6 +8,7 @@ import {
   Lambda,
   PackageJson,
 } from '@now/build-utils';
+import { NowRedirect, NowRewrite, NowHeader } from '@now/routing-utils';
 import { Output } from '../output';
 
 export interface DevServerOptions {
@@ -47,6 +48,11 @@ export interface NowConfig {
   builds?: BuildConfig[];
   routes?: RouteConfig[];
   files?: string[];
+  cleanUrls?: boolean;
+  rewrites?: NowRewrite[];
+  redirects?: NowRedirect[];
+  headers?: NowHeader[];
+  trailingSlash?: boolean;
 }
 
 export interface HttpHandler {

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -44,34 +44,34 @@ const validateRewrites = ajv.compile(rewritesSchema);
 const validateTrailingSlash = ajv.compile(trailingSlashSchema);
 
 export function validateNowConfigBuilds(config: NowConfig) {
-  return validateNowConfig(config, 'builds', validateBuilds);
+  return validateKey(config, 'builds', validateBuilds);
 }
 
 export function validateNowConfigRoutes(config: NowConfig) {
-  return validateNowConfig(config, 'routes', validateRoutes);
+  return validateKey(config, 'routes', validateRoutes);
 }
 
 export function validateNowConfigCleanUrls(config: NowConfig) {
-  return validateNowConfig(config, 'cleanUrls', validateCleanUrls);
+  return validateKey(config, 'cleanUrls', validateCleanUrls);
 }
 
 export function validateNowConfigHeaders(config: NowConfig) {
-  return validateNowConfig(config, 'headers', validateHeaders);
+  return validateKey(config, 'headers', validateHeaders);
 }
 
 export function validateNowConfigRedirects(config: NowConfig) {
-  return validateNowConfig(config, 'redirects', validateRedirects);
+  return validateKey(config, 'redirects', validateRedirects);
 }
 
 export function validateNowConfigRewrites(config: NowConfig) {
-  return validateNowConfig(config, 'rewrites', validateRewrites);
+  return validateKey(config, 'rewrites', validateRewrites);
 }
 
 export function validateNowConfigTrailingSlash(config: NowConfig) {
-  return validateNowConfig(config, 'trailingSlash', validateTrailingSlash);
+  return validateKey(config, 'trailingSlash', validateTrailingSlash);
 }
 
-function validateNowConfig(
+function validateKey(
   config: NowConfig,
   key: keyof NowConfig,
   validate: Ajv.ValidateFunction

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -1,5 +1,12 @@
 import Ajv from 'ajv';
-import { routesSchema } from '@now/routing-utils';
+import {
+  routesSchema,
+  cleanUrlsSchema,
+  headersSchema,
+  redirectsSchema,
+  rewritesSchema,
+  trailingSlashSchema,
+} from '@now/routing-utils';
 import { NowConfig } from './types';
 
 const ajv = new Ajv();
@@ -30,38 +37,58 @@ const buildsSchema = {
 
 const validateBuilds = ajv.compile(buildsSchema);
 const validateRoutes = ajv.compile(routesSchema);
+const validateCleanUrls = ajv.compile(cleanUrlsSchema);
+const validateHeaders = ajv.compile(headersSchema);
+const validateRedirects = ajv.compile(redirectsSchema);
+const validateRewrites = ajv.compile(rewritesSchema);
+const validateTrailingSlash = ajv.compile(trailingSlashSchema);
 
-export function validateNowConfigBuilds({ builds }: NowConfig) {
-  if (!builds) {
-    return null;
-  }
-
-  if (!validateBuilds(builds)) {
-    if (!validateBuilds.errors) {
-      return null;
-    }
-
-    const error = validateBuilds.errors[0];
-
-    return `Invalid \`builds\` property: ${error.dataPath} ${error.message}`;
-  }
-
-  return null;
+export function validateNowConfigBuilds(config: NowConfig) {
+  return validateNowConfig(config, 'builds', validateBuilds);
 }
 
-export function validateNowConfigRoutes({ routes }: NowConfig) {
-  if (!routes) {
+export function validateNowConfigRoutes(config: NowConfig) {
+  return validateNowConfig(config, 'routes', validateRoutes);
+}
+
+export function validateNowConfigCleanUrls(config: NowConfig) {
+  return validateNowConfig(config, 'cleanUrls', validateCleanUrls);
+}
+
+export function validateNowConfigHeaders(config: NowConfig) {
+  return validateNowConfig(config, 'headers', validateHeaders);
+}
+
+export function validateNowConfigRedirects(config: NowConfig) {
+  return validateNowConfig(config, 'redirects', validateRedirects);
+}
+
+export function validateNowConfigRewrites(config: NowConfig) {
+  return validateNowConfig(config, 'rewrites', validateRewrites);
+}
+
+export function validateNowConfigTrailingSlash(config: NowConfig) {
+  return validateNowConfig(config, 'trailingSlash', validateTrailingSlash);
+}
+
+function validateNowConfig(
+  config: NowConfig,
+  key: keyof NowConfig,
+  validate: Ajv.ValidateFunction
+) {
+  const value = config[key];
+  if (!value) {
     return null;
   }
 
-  if (!validateRoutes(routes)) {
-    if (!validateRoutes.errors) {
+  if (!validate(value)) {
+    if (!validate.errors) {
       return null;
     }
 
-    const error = validateRoutes.errors[0];
+    const error = validate.errors[0];
 
-    return `Invalid \`routes\` property: ${error.dataPath} ${error.message}`;
+    return `Invalid \`${key}\` property: ${error.dataPath} ${error.message}`;
   }
 
   return null;

--- a/packages/now-cli/test/dev/fixtures/invalid-clean-urls/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-clean-urls/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-clean-urls/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-clean-urls/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "cleanUrls": "nope"
+}

--- a/packages/now-cli/test/dev/fixtures/invalid-headers/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-headers/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-headers/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-headers/now.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "headers": [
+    {
+      "source": "/first",
+      "headers": [
+        {
+          "key": "x-fake-header",
+          "value": 1
+        }
+      ]
+    }
+  ]
+}

--- a/packages/now-cli/test/dev/fixtures/invalid-mixed-routes-rewrites/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-mixed-routes-rewrites/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-mixed-routes-rewrites/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-mixed-routes-rewrites/now.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/new",
+      "destination": "/index.html"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/old",
+      "dest": "/index.html"
+    }
+  ]
+}

--- a/packages/now-cli/test/dev/fixtures/invalid-redirects/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-redirects/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-redirects/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-redirects/now.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "redirects": [
+    { "source": "/first", "destination": "/foo", "statusCode": "ok" }
+  ]
+}

--- a/packages/now-cli/test/dev/fixtures/invalid-rewrites/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-rewrites/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-rewrites/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-rewrites/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "rewrites": [{ "source": "/first", "destination": 1 }]
+}

--- a/packages/now-cli/test/dev/fixtures/invalid-trailing-slash/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-trailing-slash/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/packages/now-cli/test/dev/fixtures/invalid-trailing-slash/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-trailing-slash/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "trailingSlash": "nope"
+}

--- a/packages/now-cli/test/dev/fixtures/test-rewrites/index.html
+++ b/packages/now-cli/test/dev/fixtures/test-rewrites/index.html
@@ -1,0 +1,1 @@
+Hello World

--- a/packages/now-cli/test/dev/fixtures/test-rewrites/now.json
+++ b/packages/now-cli/test/dev/fixtures/test-rewrites/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@now/static",
+      "config": {
+        "zeroConfig": true
+      }
+    }
+  ],
+  "rewrites": [{ "source": "/hello", "destination": "index.html" }]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -155,6 +155,58 @@ test('[now dev] validate routes', async t => {
   );
 });
 
+test('[now dev] validate cleanUrls', async t => {
+  const directory = fixture('invalid-clean-urls');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(output.stderr, /Invalid `cleanUrls` property:\s+should be boolean/gm);
+});
+
+test('[now dev] validate trailingSlash', async t => {
+  const directory = fixture('invalid-trailing-slash');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(
+    output.stderr,
+    /Invalid `trailingSlash` property:\s+should be boolean/gm
+  );
+});
+
+test('[now dev] validate rewrites', async t => {
+  const directory = fixture('invalid-rewrites');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(
+    output.stderr,
+    /Invalid `rewrites` property: \[0\]\.destination should be string/gm
+  );
+});
+
+test('[now dev] validate redirects', async t => {
+  const directory = fixture('invalid-redirects');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(
+    output.stderr,
+    /Invalid `redirects` property: \[0\]\.statusCode should be integer/gm
+  );
+});
+
+test('[now dev] validate headers', async t => {
+  const directory = fixture('invalid-headers');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(
+    output.stderr,
+    /Invalid `headers` property: \[0\]\.headers\[0\]\.value should be string/gm
+  );
+});
+
 test('[now dev] validate env var names', async t => {
   const directory = fixture('invalid-env-var-name');
   const { dev } = await testFixture(directory, { stdio: 'pipe' });

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -206,6 +206,14 @@ test('[now dev] validate headers', async t => {
   );
 });
 
+test('[now dev] validate mixed routes and rewrites', async t => {
+  const directory = fixture('invalid-mixed-routes-rewrites');
+  const output = await exec(directory);
+
+  t.is(output.code, 1, formatOutput(output));
+  t.regex(output.stderr, /Cannot define both `routes` and `rewrites`/gm);
+});
+
 test('[now dev] validate env var names', async t => {
   const directory = fixture('invalid-env-var-name');
   const { dev } = await testFixture(directory, { stdio: 'pipe' });


### PR DESCRIPTION
This PR is a followup to #3138 so that `now dev` will validate and transform the following `now.json` config keys to routes:

- cleanUrls
- rewrites
- redirects
- headers
- trailingSlash

[PRODUCT-341] #close

[PRODUCT-341]: https://zeit.atlassian.net/browse/PRODUCT-341