### PR TITLE
[now-node] Fix helpers when POST json has empty body

### DIFF
--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "./build.sh",
-    "test-integration-once": "jest --env node --verbose --runInBand",
+    "test-unit": "jest --env node --verbose --runInBand test/helpers.test.js",
+    "test-integration-once": "jest --env node --verbose --runInBand test/integration.test.js",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -13,13 +13,14 @@ function getBodyParser(req: NowRequest, body: Buffer) {
     if (!req.headers['content-type']) {
       return undefined;
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { parse: parseContentType } = require('content-type');
     const { type } = parseContentType(req.headers['content-type']);
 
     if (type === 'application/json') {
       try {
-        return JSON.parse(body.toString());
+        const str = body.toString();
+        return str ? JSON.parse(str) : {};
       } catch (error) {
         throw new ApiError(400, 'Invalid JSON');
       }
@@ -30,6 +31,7 @@ function getBodyParser(req: NowRequest, body: Buffer) {
     }
 
     if (type === 'application/x-www-form-urlencoded') {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { parse: parseQS } = require('querystring');
       // note: querystring.parse does not produce an iterable object
       // https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options
@@ -46,6 +48,7 @@ function getBodyParser(req: NowRequest, body: Buffer) {
 
 function getQueryParser({ url = '/' }: NowRequest) {
   return function parseQuery(): NowRequestQuery {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { URL } = require('url');
     // we provide a placeholder base url because we only want searchParams
     const params = new URL(url, 'https://n').searchParams;
@@ -67,6 +70,7 @@ function getCookieParser(req: NowRequest) {
       return {};
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { parse } = require('cookie');
     return parse(Array.isArray(header) ? header.join(';') : header);
   };
@@ -78,6 +82,7 @@ function status(res: NowResponse, statusCode: number): NowResponse {
 }
 
 function setCharset(type: string, charset: string) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { parse, format } = require('content-type');
   const parsed = parse(type);
   parsed.parameters.charset = charset;
@@ -85,6 +90,7 @@ function setCharset(type: string, charset: string) {
 }
 
 function createETag(body: any, encoding: 'utf8' | undefined) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const etag = require('etag');
   const buf = !Buffer.isBuffer(body) ? Buffer.from(body, encoding) : body;
   return etag(buf, { weak: true });

--- a/packages/now-node/test/fixtures/15-helpers/now.json
+++ b/packages/now-node/test/fixtures/15-helpers/now.json
@@ -27,6 +27,12 @@
     },
     {
       "path": "/",
+      "method": "POST",
+      "headers": { "Content-Type": "application/json" },
+      "status": 200
+    },
+    {
+      "path": "/",
       "headers": { "cookie": "who=chris" },
       "mustContain": "hello chris:RANDOMNESS_PLACEHOLDER"
     },

--- a/packages/now-node/test/helpers.test.js
+++ b/packages/now-node/test/helpers.test.js
@@ -21,7 +21,7 @@ async function fetchWithProxyReq(_url, opts = {}) {
 
   return fetch(_url, {
     ...opts,
-    headers: { ...opts.headers, 'x-now-bridge-request-id': '2' }
+    headers: { ...opts.headers, 'x-now-bridge-request-id': '2' },
   });
 }
 
@@ -66,7 +66,7 @@ describe('all helpers', () => {
     ['body', 0],
     ['status', 1],
     ['send', 1],
-    ['json', 1]
+    ['json', 1],
   ];
 
   test('should not recalculate req properties twice', async () => {
@@ -83,7 +83,7 @@ describe('all helpers', () => {
     await fetchWithProxyReq(`${url}/?who=bill`, {
       method: 'POST',
       body: JSON.stringify({ who: 'mike' }),
-      headers: { 'content-type': 'application/json', cookie: 'who=jim' }
+      headers: { 'content-type': 'application/json', cookie: 'who=jim' },
     });
 
     // here we test that bodySpy is called twice with exactly the same arguments
@@ -137,7 +137,7 @@ describe('req.query', () => {
 
     expect(mockListener.mock.calls[0][0].query).toMatchObject({
       who: 'bill',
-      where: 'us'
+      where: 'us',
     });
   });
 
@@ -152,13 +152,13 @@ describe('req.cookies', () => {
   test('req.cookies should reflect req.cookie header', async () => {
     await fetchWithProxyReq(url, {
       headers: {
-        cookie: 'who=bill; where=us'
-      }
+        cookie: 'who=bill; where=us',
+      },
     });
 
     expect(mockListener.mock.calls[0][0].cookies).toMatchObject({
       who: 'bill',
-      where: 'us'
+      where: 'us',
     });
   });
 });
@@ -172,7 +172,7 @@ describe('req.body', () => {
   test('req.body should be undefined if content-type is not defined', async () => {
     await fetchWithProxyReq(url, {
       method: 'POST',
-      body: 'hello'
+      body: 'hello',
     });
     expect(mockListener.mock.calls[0][0].body).toBe(undefined);
   });
@@ -181,7 +181,7 @@ describe('req.body', () => {
     await fetchWithProxyReq(url, {
       method: 'POST',
       body: 'hello',
-      headers: { 'content-type': 'text/plain' }
+      headers: { 'content-type': 'text/plain' },
     });
 
     expect(mockListener.mock.calls[0][0].body).toBe('hello');
@@ -191,7 +191,7 @@ describe('req.body', () => {
     await fetchWithProxyReq(url, {
       method: 'POST',
       body: 'hello',
-      headers: { 'content-type': 'application/octet-stream' }
+      headers: { 'content-type': 'application/octet-stream' },
     });
 
     const [{ body }] = mockListener.mock.calls[0];
@@ -208,7 +208,7 @@ describe('req.body', () => {
     await fetchWithProxyReq(url, {
       method: 'POST',
       body: qs.encode(obj),
-      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
     });
 
     expect(mockListener.mock.calls[0][0].body).toMatchObject(obj);
@@ -217,19 +217,19 @@ describe('req.body', () => {
   test('req.body should be an object when content-type is `application/json`', async () => {
     const json = {
       who: 'bill',
-      where: 'us'
+      where: 'us',
     };
 
     await fetchWithProxyReq(url, {
       method: 'POST',
       body: JSON.stringify(json),
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/json' },
     });
 
     expect(mockListener.mock.calls[0][0].body).toMatchObject(json);
   });
 
-  test('should throw error when body is empty and content-type is `application/json`', async () => {
+  test('should work when body is empty and content-type is `application/json`', async () => {
     mockListener.mockImplementation((req, res) => {
       console.log(req.body);
       res.end();
@@ -238,10 +238,11 @@ describe('req.body', () => {
     const res = await fetchWithProxyReq(url, {
       method: 'POST',
       body: '',
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/json' },
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({});
   });
 
   test('should be able to try/catch parse errors', async () => {
@@ -260,7 +261,7 @@ describe('req.body', () => {
     await fetchWithProxyReq(url, {
       method: 'POST',
       body: '{"wrong":"json"',
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/json' },
     });
 
     expect(bodySpy).toHaveBeenCalled();

--- a/packages/now-node/test/integration.test.js
+++ b/packages/now-node/test/integration.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const {
   packAndDeploy,
-  testDeployment
+  testDeployment,
 } = require('../../../test/lib/deployment/test-deployment.js');
 
 jest.setTimeout(4 * 60 * 1000);


### PR DESCRIPTION
The `@now/node` helpers json parsing is too strict and doesn't match the behavior of Express when an incoming request has `{ method: 'POST', Content-Type: 'application/json', body: '' }`.

Instead of returning 400, this PR will continue with `body = {}` to match Express.

Fixes https://spectrum.chat/zeit/now/klarna-with-zeit-now~60852003-4db6-4ec4-a611-83b2349ece08