### PR TITLE
[now-build-utils] Add contentType prop to File

### DIFF
--- a/packages/now-build-utils/src/file-blob.ts
+++ b/packages/now-build-utils/src/file-blob.ts
@@ -4,11 +4,13 @@ import { File } from './types';
 
 interface FileBlobOptions {
   mode?: number;
+  contentType?: string;
   data: string | Buffer;
 }
 
 interface FromStreamOptions {
   mode?: number;
+  contentType?: string;
   stream: NodeJS.ReadableStream;
 }
 
@@ -16,16 +18,22 @@ export default class FileBlob implements File {
   public type: 'FileBlob';
   public mode: number;
   public data: string | Buffer;
+  public contentType: string | undefined;
 
-  constructor({ mode = 0o100644, data }: FileBlobOptions) {
+  constructor({ mode = 0o100644, contentType, data }: FileBlobOptions) {
     assert(typeof mode === 'number');
     assert(typeof data === 'string' || Buffer.isBuffer(data));
     this.type = 'FileBlob';
     this.mode = mode;
+    this.contentType = contentType;
     this.data = data;
   }
 
-  static async fromStream({ mode = 0o100644, stream }: FromStreamOptions) {
+  static async fromStream({
+    mode = 0o100644,
+    contentType,
+    stream,
+  }: FromStreamOptions) {
     assert(typeof mode === 'number');
     assert(typeof stream.pipe === 'function'); // is-stream
     const chunks: Buffer[] = [];
@@ -37,7 +45,7 @@ export default class FileBlob implements File {
     });
 
     const data = Buffer.concat(chunks);
-    return new FileBlob({ mode, data });
+    return new FileBlob({ mode, contentType, data });
   }
 
   toStream(): NodeJS.ReadableStream {

--- a/packages/now-build-utils/src/file-fs-ref.ts
+++ b/packages/now-build-utils/src/file-fs-ref.ts
@@ -9,11 +9,13 @@ const semaToPreventEMFILE = new Sema(20);
 
 interface FileFsRefOptions {
   mode?: number;
+  contentType?: string;
   fsPath: string;
 }
 
 interface FromStreamOptions {
   mode: number;
+  contentType?: string;
   stream: NodeJS.ReadableStream;
   fsPath: string;
 }
@@ -22,17 +24,20 @@ class FileFsRef implements File {
   public type: 'FileFsRef';
   public mode: number;
   public fsPath: string;
+  public contentType: string | undefined;
 
-  constructor({ mode = 0o100644, fsPath }: FileFsRefOptions) {
+  constructor({ mode = 0o100644, contentType, fsPath }: FileFsRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof fsPath === 'string');
     this.type = 'FileFsRef';
     this.mode = mode;
+    this.contentType = contentType;
     this.fsPath = fsPath;
   }
 
   static async fromFsPath({
     mode,
+    contentType,
     fsPath,
   }: FileFsRefOptions): Promise<FileFsRef> {
     let m = mode;
@@ -40,11 +45,12 @@ class FileFsRef implements File {
       const stat = await fs.lstat(fsPath);
       m = stat.mode;
     }
-    return new FileFsRef({ mode: m, fsPath });
+    return new FileFsRef({ mode: m, contentType, fsPath });
   }
 
   static async fromStream({
     mode = 0o100644,
+    contentType,
     stream,
     fsPath,
   }: FromStreamOptions): Promise<FileFsRef> {
@@ -63,7 +69,7 @@ class FileFsRef implements File {
       dest.on('error', reject);
     });
 
-    return new FileFsRef({ mode, fsPath });
+    return new FileFsRef({ mode, contentType, fsPath });
   }
 
   async toStreamAsync(): Promise<NodeJS.ReadableStream> {

--- a/packages/now-build-utils/src/file-ref.ts
+++ b/packages/now-build-utils/src/file-ref.ts
@@ -8,6 +8,7 @@ import { File } from './types';
 interface FileRefOptions {
   mode?: number;
   digest: string;
+  contentType?: string;
   mutable?: boolean;
 }
 
@@ -26,14 +27,21 @@ export default class FileRef implements File {
   public type: 'FileRef';
   public mode: number;
   public digest: string;
+  public contentType: string | undefined;
   private mutable: boolean;
 
-  constructor({ mode = 0o100644, digest, mutable = false }: FileRefOptions) {
+  constructor({
+    mode = 0o100644,
+    digest,
+    contentType,
+    mutable = false,
+  }: FileRefOptions) {
     assert(typeof mode === 'number');
     assert(typeof digest === 'string');
     this.type = 'FileRef';
     this.mode = mode;
     this.digest = digest;
+    this.contentType = contentType;
     this.mutable = mutable;
   }
 

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -8,6 +8,7 @@ export interface Env {
 export interface File {
   type: string;
   mode: number;
+  contentType?: string;
   toStream: () => NodeJS.ReadableStream;
   /**
    * The absolute path to the file in the filesystem


### PR DESCRIPTION
This PR adds a `contentType` to the File interface.

This is necessary for [PRODUCT-341] to work properly with `cleanUrls` which will strip the file name but we will still need specify `contentType: 'text/html'`.

This is required for @dav-is `api-builds` PR 633 to work properly.

[PRODUCT-341]: https://zeit.atlassian.net/browse/PRODUCT-341