### PR TITLE
[now-client] Change npm publish to use files key

### DIFF
--- a/packages/now-client/.npmignore
+++ b/packages/now-client/.npmignore
@@ -1,3 +1,0 @@
-src
-types
-.git

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -3,7 +3,16 @@
   "version": "5.1.1-canary.9",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
+  "homepage": "https://zeit.co",
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now.git",
+    "directory": "packages/now-client"
+  },
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",

--- a/packages/now-client/tests/common.ts
+++ b/packages/now-client/tests/common.ts
@@ -1,0 +1,30 @@
+import fetch from 'node-fetch';
+const str = 'aHR0cHM6Ly9hcGktdG9rZW4tZmFjdG9yeS56ZWl0LnNo';
+
+async function fetchTokenWithRetry(url: string, retries = 3): Promise<string> {
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.token;
+  } catch (error) {
+    console.log(`Failed to fetch token. Retries remaining: ${retries}`);
+    if (retries === 0) {
+      throw error;
+    }
+    await sleep(500);
+    return fetchTokenWithRetry(url, retries - 1);
+  }
+}
+
+export async function generateNewToken(): Promise<string> {
+  const token = await fetchTokenWithRetry(
+    Buffer.from(str, 'base64').toString()
+  );
+  return token;
+}
+
+export function sleep(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/now-client/tests/constants.ts
+++ b/packages/now-client/tests/constants.ts
@@ -1,2 +1,0 @@
-// zeit-support user
-export const TOKEN = 'HRp5EAN0TZBnSUBIleD3ZrMW'

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -1,19 +1,24 @@
 import path from 'path';
-import { TOKEN } from './constants';
+import { generateNewToken } from './common';
 import { fetch, API_DEPLOYMENTS } from '../src/utils';
 import { Deployment } from './types';
 import { createDeployment } from '../src/index';
 
 describe('create v2 deployment', () => {
   let deployment: Deployment;
+  let token = '';
+
+  beforeEach(async () => {
+    token = await generateNewToken();
+  });
 
   afterEach(async () => {
     if (deployment) {
       const response = await fetch(
         `${API_DEPLOYMENTS}/${deployment.id}`,
-        TOKEN,
+        token,
         {
-          method: 'DELETE'
+          method: 'DELETE',
         }
       );
       expect(response.status).toEqual(200);
@@ -24,8 +29,8 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       path.resolve(__dirname, 'fixtures', 'v2'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v2'
+        token,
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'warning') {
@@ -43,8 +48,8 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       path.resolve(__dirname, 'fixtures', 'v2'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v2'
+        token,
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'file_count') {
@@ -62,8 +67,8 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       path.resolve(__dirname, 'fixtures', 'v2'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v2'
+        token,
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'ready') {

--- a/packages/now-client/tests/create-legacy-deployment.test.ts
+++ b/packages/now-client/tests/create-legacy-deployment.test.ts
@@ -1,77 +1,83 @@
-import path from 'path'
-import { TOKEN } from './constants'
-import { fetch, API_DELETE_DEPLOYMENTS_LEGACY } from '../src/utils'
-import { Deployment } from './types'
-import { createLegacyDeployment } from '../src/index'
+import path from 'path';
+import { generateNewToken } from './common';
+import { fetch, API_DELETE_DEPLOYMENTS_LEGACY } from '../src/utils';
+import { Deployment } from './types';
+import { createLegacyDeployment } from '../src/index';
 
 describe('create v1 deployment', () => {
-  let deployment: Deployment | undefined
+  let deployment: Deployment | undefined;
+  let token = '';
+
+  beforeEach(async () => {
+    token = await generateNewToken();
+  });
 
   afterEach(async () => {
     if (deployment) {
       const response = await fetch(
-        `${API_DELETE_DEPLOYMENTS_LEGACY}/${deployment.deploymentId || deployment.uid}`,
-        TOKEN,
+        `${API_DELETE_DEPLOYMENTS_LEGACY}/${deployment.deploymentId ||
+          deployment.uid}`,
+        token,
         {
-          method: 'DELETE'
+          method: 'DELETE',
         }
-      )
-      expect(response.status).toEqual(200)
-      deployment = undefined
+      );
+      expect(response.status).toEqual(200);
+      deployment = undefined;
     }
-  })
+  });
 
   it('will create a v1 static deployment', async () => {
     for await (const event of createLegacyDeployment(
       path.resolve(__dirname, 'fixtures', 'v1', 'static'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v1-static'
+        token,
+        name: 'now-client-tests-v1-static',
       }
     )) {
       if (event.type === 'ready') {
-        deployment = event.payload
+        deployment = event.payload;
         if (deployment) {
-          expect(deployment.readyState || deployment.state).toEqual('READY')
-          break
+          expect(deployment.readyState || deployment.state).toEqual('READY');
+          break;
         }
       }
     }
-  })
+  });
 
   it('will create a v1 npm deployment', async () => {
     for await (const event of createLegacyDeployment(
       path.resolve(__dirname, 'fixtures', 'v1', 'npm'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v1-npm'
+        token,
+        name: 'now-client-tests-v1-npm',
       }
     )) {
       if (event.type === 'ready') {
-        deployment = event.payload
+        deployment = event.payload;
         if (deployment) {
-          expect(deployment.readyState || deployment.state).toEqual('READY')
-          break
+          expect(deployment.readyState || deployment.state).toEqual('READY');
+          break;
         }
       }
     }
-  })
+  });
 
   it('will create a v1 Docker deployment', async () => {
     for await (const event of createLegacyDeployment(
       path.resolve(__dirname, 'fixtures', 'v1', 'docker'),
       {
-        token: TOKEN,
-        name: 'now-client-tests-v1-docker'
+        token,
+        name: 'now-client-tests-v1-docker',
       }
     )) {
       if (event.type === 'ready') {
-        deployment = event.payload
+        deployment = event.payload;
         if (deployment) {
-          expect(deployment.readyState || deployment.state).toEqual('READY')
-          break
+          expect(deployment.readyState || deployment.state).toEqual('READY');
+          break;
         }
       }
     }
-  })
-})
+  });
+});

--- a/packages/now-client/tests/setup/index.ts
+++ b/packages/now-client/tests/setup/index.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(120000)
+jest.setTimeout(240000);

--- a/packages/now-client/tests/setup/index.ts
+++ b/packages/now-client/tests/setup/index.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(480000);
+jest.setTimeout(120000);

--- a/packages/now-client/tests/setup/index.ts
+++ b/packages/now-client/tests/setup/index.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(240000);
+jest.setTimeout(480000);


### PR DESCRIPTION
- remove `.npmignore`
- use [`files`](https://docs.npmjs.com/files/package.json#files) key in `package.json`
- update metadata in `package.json`
- fix test harness to generate a token for each test deployment

This PR will prevent publishing [tests](https://cdn.jsdelivr.net/npm/now-client@5.2.0/tests/) to npm and any other unused files.