### PR TITLE
[now-cli] Disable `--prod` and `--target` for Now 1.0 deployments

### DIFF
--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -144,6 +144,7 @@ export const legacyArgsMri = {
     'no-scale',
     'no-verify',
     'dotenv',
+    'prod',
   ],
   default: {
     C: false,

--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -127,6 +127,7 @@ export const legacyArgsMri = {
     'session-affinity',
     'regions',
     'dotenv',
+    'target',
   ],
   boolean: [
     'help',

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -304,7 +304,7 @@ export default async function main(
     `You are using an old version of the Now Platform. More: ${link(infoUrl)}`
   );
 
-  if (argv['--prod']) {
+  if (argv.prod) {
     error(
       `Now 1.0 does not support Production Deployments. Please use Now 2.0 to take advantage this feature: ${link(
         'https://zeit.co/upgrade'

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -304,6 +304,16 @@ export default async function main(
     `You are using an old version of the Now Platform. More: ${link(infoUrl)}`
   );
 
+  if (argv['--prod']) {
+    error(
+      `Now 1.0 does not support Production Deployments. Please use Now 2.0 to take advantage this feature: ${link(
+        'https://zeit.co/upgrade'
+      )}`
+    );
+    await exit(1);
+    return 1;
+  }
+
   const {
     authConfig: { token },
     config,

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -308,13 +308,9 @@ export default async function main(
     error(
       `Option ${
         argv.prod ? '--prod' : '--target'
-      } is not supported for Now 1.0 deployments. ${
-        argv.prod
-          ? `Please use Now 2.0 to take advantage this feature: ${link(
-              'https://zeit.co/upgrade'
-            )}`
-          : ''
-      }`
+      } is not supported for Now 1.0 deployments. To manually alias a deployment, use ${cmd(
+        'now alias'
+      )} instead.`
     );
     await exit(1);
     return 1;

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -308,9 +308,13 @@ export default async function main(
     error(
       `Option ${
         argv.prod ? '--prod' : '--target'
-      } is not supported for Now 1.0 deployments. Please use Now 2.0 to take advantage this feature: ${link(
-        'https://zeit.co/upgrade'
-      )}`
+      } is not supported for Now 1.0 deployments. ${
+        argv.prod
+          ? `Please use Now 2.0 to take advantage this feature: ${link(
+              'https://zeit.co/upgrade'
+            )}`
+          : ''
+      }`
     );
     await exit(1);
     return 1;

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -304,9 +304,11 @@ export default async function main(
     `You are using an old version of the Now Platform. More: ${link(infoUrl)}`
   );
 
-  if (argv.prod) {
+  if (argv.prod || argv.target !== undefined) {
     error(
-      `Now 1.0 does not support Production Deployments. Please use Now 2.0 to take advantage this feature: ${link(
+      `Option ${
+        argv.prod ? '--prod' : '--target'
+      } is not supported by Now 1.0 deployments. Please use Now 2.0 to take advantage this feature: ${link(
         'https://zeit.co/upgrade'
       )}`
     );

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -308,7 +308,7 @@ export default async function main(
     error(
       `Option ${
         argv.prod ? '--prod' : '--target'
-      } is not supported by Now 1.0 deployments. Please use Now 2.0 to take advantage this feature: ${link(
+      } is not supported for Now 1.0 deployments. Please use Now 2.0 to take advantage this feature: ${link(
         'https://zeit.co/upgrade'
       )}`
     );

--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -304,7 +304,7 @@ export default async function main(
     `You are using an old version of the Now Platform. More: ${link(infoUrl)}`
   );
 
-  if (argv.prod || argv.target !== undefined) {
+  if (argv.prod || argv.target) {
     error(
       `Option ${
         argv.prod ? '--prod' : '--target'

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2037,6 +2037,40 @@ test('try to deploy with non-existing team', async t => {
   t.true(stderr.includes(goal));
 });
 
+test('try to deploy v1 deployment with --prod', async t => {
+  const target = fixture('node');
+  const goal = `> Error! Option --prod is not supported for Now 1.0 deployments.`;
+
+  const { stderr, stdout, code } = await execa(binaryPath, [target, '--prod'], {
+    reject: false,
+  });
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  t.is(code, 1);
+  t.true(stderr.includes(goal));
+});
+
+test('try to deploy v1 deployment with --target production', async t => {
+  const target = fixture('node');
+  const goal = `> Error! Option --target is not supported for Now 1.0 deployments.`;
+
+  const { stderr, stdout, code } = await execa(
+    binaryPath,
+    [target, '--target', 'production'],
+    { reject: false }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(code);
+
+  t.is(code, 1);
+  t.true(stderr.includes(goal));
+});
+
 const verifyExampleAngular = (cwd, dir) =>
   fs.existsSync(path.join(cwd, dir, 'package.json')) &&
   fs.existsSync(path.join(cwd, dir, 'tsconfig.json')) &&

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2037,7 +2037,7 @@ test('try to deploy with non-existing team', async t => {
   t.true(stderr.includes(goal));
 });
 
-test('try to deploy v1 deployment with --prod', async t => {
+testv1('try to deploy v1 deployment with --prod', async t => {
   const target = fixture('node');
   const goal = `> Error! Option --prod is not supported for Now 1.0 deployments.`;
 
@@ -2053,7 +2053,7 @@ test('try to deploy v1 deployment with --prod', async t => {
   t.true(stderr.includes(goal));
 });
 
-test('try to deploy v1 deployment with --target production', async t => {
+testv1('try to deploy v1 deployment with --target production', async t => {
   const target = fixture('node');
   const goal = `> Error! Option --target is not supported for Now 1.0 deployments.`;
 


### PR DESCRIPTION
This PR disables Now 1.0 production deployments with the following error message:

> Option --prod is not supported for Now 1.0 deployments. To manually alias a deployment, use `now alias` instead.

It looks like this:
<img width="835" alt="Capture d’écran 2019-10-23 à 19 42 09" src="https://user-images.githubusercontent.com/6616955/67419574-3e125380-f5cd-11e9-81ff-63bde292539b.png">

Also disables `--target` for Now 1.0 deployments.
