### PR TITLE
[now-cli] Don't throw if builder child process can not be killed

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -411,8 +411,16 @@ export async function shutdownBuilder(
   const ops: Promise<void>[] = [];
 
   if (match.buildProcess) {
-    debug(`Killing builder sub-process with PID ${match.buildProcess.pid}`);
-    ops.push(treeKill(match.buildProcess.pid));
+    const { pid } = match.buildProcess;
+    debug(`Killing builder sub-process with PID ${pid}`);
+    const killPromise = treeKill(pid)
+      .then(() => {
+        debug(`Killed builder with PID ${pid}`);
+      })
+      .catch((err: Error) => {
+        debug(`Failed to kill builder with PID ${pid}: ${err}`);
+      });
+    ops.push(killPromise);
     delete match.buildProcess;
   }
 


### PR DESCRIPTION
The Sentry error reports that the process has already been killed, so no need to throw in this case.

Fixes #3191.