### PR TITLE
[now-cli] Gracefully exit when the `cwd` does not exist

### DIFF
--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -784,6 +784,19 @@ export class CantFindConfig extends NowError<
   }
 }
 
+export class WorkingDirectoryDoesNotExist extends NowError<
+  'CWD_DOES_NOT_EXIST',
+  {}
+> {
+  constructor() {
+    super({
+      code: 'CWD_DOES_NOT_EXIST',
+      meta: {},
+      message: 'The current working directory does not exist.',
+    });
+  }
+}
+
 export class FileNotFound extends NowError<'FILE_NOT_FOUND', { file: string }> {
   constructor(file: string) {
     super({


### PR DESCRIPTION
There have been Sentry errors where `process.cwd()` fails and throws an error. This patch handles that scenario gracefully by printing a more clear error message to the user and avoids sending a report to Sentry.

Fixes #3193.