### PR TITLE
[now-cli] Loosen "engines" requirement to Node `>= 8`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Update Node.js
-          command: curl -sfLS install-node.now.sh/8.11 | sh -s -- --yes
-      - run:
           name: Output version
           command: node --version
       - run:
@@ -214,9 +211,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Update Node.js
-          command: curl -sfLS install-node.now.sh/8.11 | sh -s -- --yes
       - run:
           name: Output version
           command: node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Update Node.js
+          command: curl -sfLS install-node.now.sh/8.10 | sh -s -- --yes
+      - run:
           name: Output version
           command: node --version
       - run:
@@ -211,6 +214,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Update Node.js
+          command: curl -sfLS install-node.now.sh/8.10 | sh -s -- --yes
       - run:
           name: Output version
           command: node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Update Node.js
-          command: curl -sfLS install-node.now.sh/8.10 | sh -s -- --yes
-      - run:
           name: Output version
           command: node --version
       - run:
@@ -214,9 +211,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Update Node.js
-          command: curl -sfLS install-node.now.sh/8.10 | sh -s -- --yes
       - run:
           name: Output version
           command: node --version

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8.11"
+    "node": ">= 8"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8.10"
+    "node": ">= 8"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.10"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -725,18 +725,23 @@ test(
   })
 );
 
-test(
-  '[now dev] 23-docusaurus',
-  testFixtureStdio('23-docusaurus', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// react-dev-utils has `engines: { node: ">= 8.10" }` in its `package.json`
+if (satisfies(process.version, '>= 8.10')) {
+  test(
+    '[now dev] 23-docusaurus',
+    testFixtureStdio('23-docusaurus', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Test Site · A website for testing/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Test Site · A website for testing/gm);
+    })
+  );
+} else {
+  console.log('Skipping `23-docusaurus` test since it requires Node >= 8.10');
+}
 
 test(
   '[now dev] 24-ember',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -694,18 +694,23 @@ test(
   })
 );
 
-test(
-  '[now dev] 21-charge',
-  testFixtureStdio('21-charge', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// @static/charge has `engines: { node: ">= 8.10.0" }` in its `package.json`
+if (satisfies(process.version, '>= 8.10.0')) {
+  test(
+    '[now dev] 21-charge',
+    testFixtureStdio('21-charge', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Welcome to my new Charge site/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Welcome to my new Charge site/gm);
+    })
+  );
+} else {
+  console.log('Skipping `21-charge` test since it requires Node >= 8.10.0');
+}
 
 test(
   '[now dev] 22-brunch',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -388,18 +388,25 @@ if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
   );
 }
 
-test(
-  '[now dev] 06-gridsome',
-  testFixtureStdio('06-gridsome', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// mini-css-extract-plugin has `engines: { node: ">= 6.9.0 <7.0.0 || >= 8.9.0" }` in its `package.json`
+if (satisfies(process.version, '>= 6.9.0 <7.0.0 || >= 8.9.0')) {
+  test(
+    '[now dev] 06-gridsome',
+    testFixtureStdio('06-gridsome', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Hello, world!/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Hello, world!/gm);
+    })
+  );
+} else {
+  console.log(
+    'Skipping `06-gridsome` test since it requires Node >= 6.9.0 <7.0.0 || >= 8.9.0'
+  );
+}
 
 test(
   '[now dev] 07-hexo-node',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -335,18 +335,23 @@ if (satisfies(process.version, '10.x')) {
   console.log('Skipping `02-angular-node` test since it requires Node >= 10.9');
 }
 
-test(
-  '[now dev] 03-aurelia',
-  testFixtureStdio('03-aurelia', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// Aurelia has `engines: { node: ">8.9.0" }` in its `package.json`
+if (satisfies(process.version, '>= 8.9.0')) {
+  test(
+    '[now dev] 03-aurelia',
+    testFixtureStdio('03-aurelia', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Aurelia Navigation Skeleton/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Aurelia Navigation Skeleton/gm);
+    })
+  );
+} else {
+  console.log('Skipping `03-aurelia` test since it requires Node >= 8.9.0');
+}
 
 // test(
 //   '[now dev] 04-create-react-app-node',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -335,7 +335,7 @@ if (satisfies(process.version, '10.x')) {
   console.log('Skipping `02-angular-node` test since it requires Node >= 10.9');
 }
 
-// Aurelia has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
+// eslint has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
 if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
   test(
     '[now dev] 03-aurelia',
@@ -368,18 +368,25 @@ if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
 //   })
 // );
 
-test(
-  '[now dev] 05-gatsby',
-  testFixtureStdio('05-gatsby', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// eslint has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
+if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
+  test(
+    '[now dev] 05-gatsby',
+    testFixtureStdio('05-gatsby', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Gatsby Default Starter/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Gatsby Default Starter/gm);
+    })
+  );
+} else {
+  console.log(
+    'Skipping `05-gatsby` test since it requires Node >= ^6.14.0 || ^8.10.0 || >=9.10.0'
+  );
+}
 
 test(
   '[now dev] 06-gridsome',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -750,18 +750,25 @@ if (satisfies(process.version, '>= 8.10')) {
   console.log('Skipping `23-docusaurus` test since it requires Node >= 8.10');
 }
 
-test(
-  '[now dev] 24-ember',
-  testFixtureStdio('24-ember', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// eslint has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
+if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
+  test(
+    '[now dev] 24-ember',
+    testFixtureStdio('24-ember', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /HelloWorld/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /HelloWorld/gm);
+    })
+  );
+} else {
+  console.log(
+    'Skipping `24-ember` test since it requires Node >= ^6.14.0 || ^8.10.0 || >=9.10.0'
+  );
+}
 
 test('[now dev] temporary directory listing', async t => {
   const directory = fixture('temporary-directory-listing');

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -335,8 +335,8 @@ if (satisfies(process.version, '10.x')) {
   console.log('Skipping `02-angular-node` test since it requires Node >= 10.9');
 }
 
-// Aurelia has `engines: { node: ">8.9.0" }` in its `package.json`
-if (satisfies(process.version, '>= 8.9.0')) {
+// Aurelia has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
+if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
   test(
     '[now dev] 03-aurelia',
     testFixtureStdio('03-aurelia', async (t, port) => {
@@ -350,7 +350,9 @@ if (satisfies(process.version, '>= 8.9.0')) {
     })
   );
 } else {
-  console.log('Skipping `03-aurelia` test since it requires Node >= 8.9.0');
+  console.log(
+    'Skipping `03-aurelia` test since it requires Node >= ^6.14.0 || ^8.10.0 || >=9.10.0'
+  );
 }
 
 // test(

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -648,18 +648,25 @@ test('[now dev] double slashes redirect', async t => {
   }
 });
 
-test(
-  '[now dev] 18-marko',
-  testFixtureStdio('18-marko', async (t, port) => {
-    const result = fetch(`http://localhost:${port}`);
-    const response = await result;
+// eslint has `engines: { node: ">^6.14.0 || ^8.10.0 || >=9.10.0" }` in its `package.json`
+if (satisfies(process.version, '>^6.14.0 || ^8.10.0 || >=9.10.0')) {
+  test(
+    '[now dev] 18-marko',
+    testFixtureStdio('18-marko', async (t, port) => {
+      const result = fetch(`http://localhost:${port}`);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Marko Starter/gm);
-  })
-);
+      const body = await response.text();
+      t.regex(body, /Marko Starter/gm);
+    })
+  );
+} else {
+  console.log(
+    'Skipping `18-marko` test since it requires Node >= ^6.14.0 || ^8.10.0 || >=9.10.0'
+  );
+}
 
 test(
   '[now dev] 19-mithril',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -987,22 +987,28 @@ test('[now dev] do not rebuild for changes in the output directory', async t => 
   }
 });
 
-test('[now dev] 25-nextjs-src-dir', async t => {
-  const directory = fixture('25-nextjs-src-dir');
-  const { dev, port } = await testFixture(directory);
+if (satisfies(process.version, '>= 8.9.0')) {
+  test('[now dev] 25-nextjs-src-dir', async t => {
+    const directory = fixture('25-nextjs-src-dir');
+    const { dev, port } = await testFixture(directory);
 
-  try {
-    // start `now dev` detached in child_process
-    dev.unref();
+    try {
+      // start `now dev` detached in child_process
+      dev.unref();
 
-    const result = await fetchWithRetry(`http://localhost:${port}`, 80);
-    const response = await result;
+      const result = await fetchWithRetry(`http://localhost:${port}`, 80);
+      const response = await result;
 
-    validateResponseHeaders(t, response);
+      validateResponseHeaders(t, response);
 
-    const body = await response.text();
-    t.regex(body, /Next.js \+ Node.js API/gm);
-  } finally {
-    dev.kill('SIGTERM');
-  }
-});
+      const body = await response.text();
+      t.regex(body, /Next.js \+ Node.js API/gm);
+    } finally {
+      dev.kill('SIGTERM');
+    }
+  });
+} else {
+  console.log(
+    'Skipping `25-nextjs-src-dir` test since it requires Node >= 8.9.0'
+  );
+}


### PR DESCRIPTION
Now that `now-client` does not use `fetch-h2`, any version of Node 8 or newer should work with `now-cli`.

Related to #2711.