### PR TITLE
[now-routing-utils] Change cleanUrls to redirect only

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -150,8 +150,6 @@ export function getTransformedRoutes({
     }
     if (typeof rewrites !== 'undefined') {
       routes.push({ handle: 'filesystem' });
-    }
-    if (typeof rewrites !== 'undefined') {
       routes.push(...convertRewrites(rewrites));
     }
   }

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -135,11 +135,9 @@ export function getTransformedRoutes({
     }
   } else {
     routes = [];
-    let cleanUrlsRewrites: Route[] | undefined;
-    if (typeof cleanUrls !== 'undefined') {
-      const cleanUrls = convertCleanUrls(filePaths);
-      cleanUrlsRewrites = cleanUrls.rewrites;
-      routes.push(...cleanUrls.redirects);
+    if (cleanUrls) {
+      const clean = convertCleanUrls(filePaths);
+      routes.push(...clean.redirects);
     }
     if (typeof trailingSlash !== 'undefined') {
       routes.push(...convertTrailingSlash(trailingSlash));
@@ -150,13 +148,7 @@ export function getTransformedRoutes({
     if (typeof headers !== 'undefined') {
       routes.push(...convertHeaders(headers));
     }
-    if (typeof cleanUrlsRewrites !== 'undefined') {
-      routes.push(...cleanUrlsRewrites);
-    }
-    if (
-      typeof cleanUrlsRewrites !== 'undefined' ||
-      typeof rewrites !== 'undefined'
-    ) {
+    if (typeof rewrites !== 'undefined') {
       routes.push({ handle: 'filesystem' });
     }
     if (typeof rewrites !== 'undefined') {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -451,8 +451,6 @@ describe('getTransformedRoutes', () => {
         headers: { Location: '/support' },
         status: 302,
       },
-      { src: '^/index$', dest: '/index.html', continue: true },
-      { src: '^/support$', dest: '/support.html', continue: true },
       { handle: 'filesystem' },
       { src: '^/v1$', dest: '/v2/api.py', continue: true },
     ];


### PR DESCRIPTION
When `cleanUrls` is true, the redirects will be applied to the routes however there are no longer any rewrites. Instead (through a different PR to fmeta-util) we will rename the file output to remove the `.html` extension.