### PR TITLE
[tests] Fix circle ci to xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
 
   test-integration-macos-node-8:
     macos:
-      xcode: '9.2.0'
+      xcode: '9.0.1'
     working_directory: ~/repo
     steps:
       - checkout
@@ -208,7 +208,7 @@ jobs:
 
   test-integration-macos-now-dev-node-8:
     macos:
-      xcode: '9.2.0'
+      xcode: '9.0.1'
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Fixes the issue where circle ci fails with the following:

```
Build-agent version 1.0.18109-4dd65c28 (2019-10-23T21:49:59+0000)
Creating a dedicated VM with xcode:9.2.0 image
failed to create host: Image xcode:9.2.0 is not supported

failed to create host: Image xcode:9.2.0 is not supported
```