### PR TITLE
[now-cli] Improve wording and styling of "--prod not available for 1.0" error

### DIFF
--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -306,9 +306,9 @@ export default async function main(
 
   if (argv.prod || argv.target) {
     error(
-      `Option ${
+      `The option ${cmd(
         argv.prod ? '--prod' : '--target'
-      } is not supported for Now 1.0 deployments. To manually alias a deployment, use ${cmd(
+      )} is not supported for Now 1.0 deployments. To manually alias a deployment, use ${cmd(
         'now alias'
       )} instead.`
     );

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2039,7 +2039,7 @@ test('try to deploy with non-existing team', async t => {
 
 testv1('try to deploy v1 deployment with --prod', async t => {
   const target = fixture('node');
-  const goal = `> Error! Option --prod is not supported for Now 1.0 deployments.`;
+  const goal = `is not supported for Now 1.0 deployments`;
 
   const { stderr, stdout, code } = await execa(binaryPath, [target, '--prod'], {
     reject: false,
@@ -2055,7 +2055,7 @@ testv1('try to deploy v1 deployment with --prod', async t => {
 
 testv1('try to deploy v1 deployment with --target production', async t => {
   const target = fixture('node');
-  const goal = `> Error! Option --target is not supported for Now 1.0 deployments.`;
+  const goal = `is not supported for Now 1.0 deployments`;
 
   const { stderr, stdout, code } = await execa(
     binaryPath,


### PR DESCRIPTION
From @leo on Slack:
> Can you quickly replace “Option” with “The option” and make --prod be wrapped in `, like the command

This PR does that.