### PR TITLE
[now-client] Add `apiUrl` debug log

### DIFF
--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -191,6 +191,10 @@ export default function buildCreateDeployment(
       ...metadata
     } = options;
 
+    if (apiUrl) {
+      debug(`Using provided API URL: ${apiUrl}`);
+    }
+
     debug(`Setting platform version to ${version}`);
     metadata.version = version;
 

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -110,6 +110,7 @@ export const fetch = async (
   let time: number;
 
   url = `${opts.apiUrl || 'https://api.zeit.co'}${url}`;
+  delete opts.apiUrl;
 
   if (opts.teamId) {
     const parsedUrl = parseUrl(url, true);
@@ -118,7 +119,6 @@ export const fetch = async (
     query.teamId = opts.teamId;
     url = `${parsedUrl.href}?${qs.encode(query)}`;
     delete opts.teamId;
-    delete opts.apiUrl;
   }
 
   opts.headers = opts.headers || {};


### PR DESCRIPTION
This adds `now-client` debug log when custom `apiUrl` is provided