### PR TITLE
[now-cli] Update `now-cli` readme

### DIFF
--- a/packages/now-cli/README.md
+++ b/packages/now-cli/README.md
@@ -6,7 +6,7 @@
 
 To install the latest version of Now CLI, visit [zeit.co/download](https://zeit.co/download) or run this command:
 
-```
+```bash
 npm i -g now
 ```
 


### PR DESCRIPTION
This PR update readme to be able to release canary of `now-cli` included latest change from `now-client`