### PR TITLE
[gatsby-plugin-now] Fix logic error for redirect check

### DIFF
--- a/packages/gatsby-plugin-now/gatsby-node.js
+++ b/packages/gatsby-plugin-now/gatsby-node.js
@@ -6,7 +6,7 @@ const REDIRECT_FILE_NAME = '__now_routes_g4t5bY.json';
 exports.onPostBuild = async ({ store }) => {
   const { redirects, program } = store.getState();
 
-  if (!redirects.length === 0) {
+  if (redirects.length === 0) {
     return;
   }
 
@@ -16,7 +16,7 @@ exports.onPostBuild = async ({ store }) => {
     const route = {
       src: redirect.fromPath,
       status: redirect.statusCode || (redirect.isPermanent ? 301 : 302),
-      headers: { Location: redirect.toPath }
+      headers: { Location: redirect.toPath },
     };
 
     if (redirect.force) {


### PR DESCRIPTION
Currently `__now_routes_g4t5bY.json` always gets created, regardless of existing redirects in Gatsby.

This PR fixes that.

PS. According to https://github.com/zeit/now/blob/canary/CONTRIBUTING.md I should run `yarn lint` and `yarn test` but both fail on a clean clone. Not sure how to handle that.

gist for errors:
- [yarn lint](https://gist.github.com/michaellopez/ae187969b64da017de295967cb0d7539)
- [yarn test](https://gist.github.com/michaellopez/024c484bedca8018e933d61b3a2c13ee)