### PR TITLE
[now-routing-utils] Fix validation for routes/cleanUrls

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -107,7 +107,7 @@ export function getTransformedRoutes({
   const { cleanUrls, rewrites, redirects, headers, trailingSlash } = nowConfig;
   let { routes } = nowConfig;
   const errors: { message: string }[] = [];
-  if (typeof routes !== 'undefined') {
+  if (routes) {
     if (typeof cleanUrls !== 'undefined') {
       errors.push({
         message: 'Cannot define both `routes` and `cleanUrls`',

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -425,6 +425,24 @@ describe('getTransformedRoutes', () => {
     assertValid(actual.routes);
   });
 
+  test('should not error when routes is null and cleanUrls is true', () => {
+    const nowConfig = { cleanUrls: true, routes: null };
+    const filePaths = ['file.html'];
+    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    assert.equal(actual.error, null);
+    assertValid(actual.routes);
+  });
+
+  test('should error when routes is defined and cleanUrls is true', () => {
+    const nowConfig = {
+      cleanUrls: true,
+      routes: [{ src: '/page', dest: '/file.html' }],
+    };
+    const filePaths = ['file.html'];
+    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    assert.notEqual(actual.error, null);
+  });
+
   test('should normalize all redirects before rewrites', () => {
     const nowConfig = {
       cleanUrls: true,


### PR DESCRIPTION
This fixes an issue when routes is normalized to `null` which should be treated the same as `undefined`.