### PR TITLE
[now-static-build] Improve Gatsby default routes

### DIFF
--- a/packages/gatsby-plugin-now/gatsby-node.js
+++ b/packages/gatsby-plugin-now/gatsby-node.js
@@ -26,8 +26,23 @@ exports.onPostBuild = async ({ store }) => {
     }
   }
 
+  const finalRoutes = [
+    {
+      src: '/static/(.*)',
+      headers: { 'cache-control': 'public,max-age=31536000,immutable' },
+      continue: true,
+    },
+    {
+      src: '/.*\\.(js|json|css)$',
+      headers: { 'cache-control': 'public,max-age=31536000,immutable' },
+      continue: true,
+    },
+    ...routes,
+    { src: '/.*', status: 404, dest: '/404' },
+  ];
+
   await writeFile(
     path.join(program.directory, 'public', REDIRECT_FILE_NAME),
-    JSON.stringify(routes)
+    JSON.stringify(finalRoutes)
   );
 };

--- a/packages/gatsby-plugin-now/gatsby-node.js
+++ b/packages/gatsby-plugin-now/gatsby-node.js
@@ -22,29 +22,26 @@ exports.onPostBuild = async ({ store }) => {
     }
   }
 
+  // we implement gatsby's recommendations
+  // https://www.gatsbyjs.org/docs/caching/
   const finalRoutes = [
     {
-      src: '/(static|icons)/(.*)',
+      src: '^/static/(.*)$',
       headers: { 'cache-control': 'public,max-age=31536000,immutable' },
       continue: true,
     },
     {
-      src: '/.*\\.(js|json|css)$',
+      src: '^/.*\\.(js|css)$',
       headers: { 'cache-control': 'public,max-age=31536000,immutable' },
       continue: true,
     },
     {
-      src: '/.*\\.html',
-      headers: { 'cache-control': 'public,max-age=0,must-revalidate' },
-      continue: true,
-    },
-    {
-      src: '/page-data/.*',
+      src: '^/(sw\\.js|app-data\\.json|.*\\.html|page-data/.*)$',
       headers: { 'cache-control': 'public,max-age=0,must-revalidate' },
       continue: true,
     },
     ...routes,
-    { src: '/.*', status: 404, dest: '/404' },
+    { src: '.*', status: 404, dest: '/404.html' },
   ];
 
   await writeFile(

--- a/packages/gatsby-plugin-now/gatsby-node.js
+++ b/packages/gatsby-plugin-now/gatsby-node.js
@@ -28,13 +28,23 @@ exports.onPostBuild = async ({ store }) => {
 
   const finalRoutes = [
     {
-      src: '/static/(.*)',
+      src: '/(static|icons)/(.*)',
       headers: { 'cache-control': 'public,max-age=31536000,immutable' },
       continue: true,
     },
     {
       src: '/.*\\.(js|json|css)$',
       headers: { 'cache-control': 'public,max-age=31536000,immutable' },
+      continue: true,
+    },
+    {
+      src: '/.*\\.html',
+      headers: { 'cache-control': 'public,max-age=0,must-revalidate' },
+      continue: true,
+    },
+    {
+      src: '/page-data/.*',
+      headers: { 'cache-control': 'public,max-age=0,must-revalidate' },
       continue: true,
     },
     ...routes,

--- a/packages/gatsby-plugin-now/gatsby-node.js
+++ b/packages/gatsby-plugin-now/gatsby-node.js
@@ -6,10 +6,6 @@ const REDIRECT_FILE_NAME = '__now_routes_g4t5bY.json';
 exports.onPostBuild = async ({ store }) => {
   const { redirects, program } = store.getState();
 
-  if (redirects.length === 0) {
-    return;
-  }
-
   const routes = [{ handle: 'filesystem' }];
 
   for (const redirect of redirects) {

--- a/packages/gatsby-plugin-now/readme.md
+++ b/packages/gatsby-plugin-now/readme.md
@@ -1,24 +1,7 @@
 # gatsby-plugin-now
 
+⚠️ The use of this plugin is deprecated. ZEIT Now supports Gatsby Redirects out-of-the-box and does not require the use a plugin.
+
+---
+
 This plugin generates [Now Routes](https://zeit.co/docs/v2/advanced/routes) for [redirects](https://www.gatsbyjs.org/docs/actions/#createRedirect) you configured for to your Gatsby project.
-
-### Usage
-
-1. Install the plugin:
-
-```
-npm install gatsby-plugin-now --save-dev
-```
-
-2. Add it to the configuration file:
-
-```
-// gatsby-config.js
-module.exports = {
-  plugins: [
-    'gatsby-plugin-now'
-  ]
-}
-```
-
-3. [Deploy your project to ZEIT Now](https://www.gatsbyjs.org/docs/deploying-to-zeit-now/)

--- a/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
+++ b/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
@@ -3,6 +3,20 @@
 exports[`test generated now routes 1`] = `
 Array [
   Object {
+    "continue": true,
+    "headers": Object {
+      "cache-control": "public,max-age=31536000,immutable",
+    },
+    "src": "/static/(.*)",
+  },
+  Object {
+    "continue": true,
+    "headers": Object {
+      "cache-control": "public,max-age=31536000,immutable",
+    },
+    "src": "/.*\\\\.(js|json|css)$",
+  },
+  Object {
     "headers": Object {
       "Location": "/",
     },
@@ -81,6 +95,11 @@ Array [
     },
     "src": "/randorect",
     "status": 302,
+  },
+  Object {
+    "dest": "/404",
+    "src": "/.*",
+    "status": 404,
   },
 ]
 `;

--- a/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
+++ b/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ Array [
     "headers": Object {
       "cache-control": "public,max-age=31536000,immutable",
     },
-    "src": "/static/(.*)",
+    "src": "/(static|icons)/(.*)",
   },
   Object {
     "continue": true,
@@ -15,6 +15,20 @@ Array [
       "cache-control": "public,max-age=31536000,immutable",
     },
     "src": "/.*\\\\.(js|json|css)$",
+  },
+  Object {
+    "continue": true,
+    "headers": Object {
+      "cache-control": "public,max-age=0,must-revalidate",
+    },
+    "src": "/.*\\\\.html",
+  },
+  Object {
+    "continue": true,
+    "headers": Object {
+      "cache-control": "public,max-age=0,must-revalidate",
+    },
+    "src": "/page-data/.*",
   },
   Object {
     "headers": Object {

--- a/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
+++ b/packages/gatsby-plugin-now/test/__snapshots__/index.test.js.snap
@@ -7,28 +7,21 @@ Array [
     "headers": Object {
       "cache-control": "public,max-age=31536000,immutable",
     },
-    "src": "/(static|icons)/(.*)",
+    "src": "^/static/(.*)$",
   },
   Object {
     "continue": true,
     "headers": Object {
       "cache-control": "public,max-age=31536000,immutable",
     },
-    "src": "/.*\\\\.(js|json|css)$",
+    "src": "^/.*\\\\.(js|css)$",
   },
   Object {
     "continue": true,
     "headers": Object {
       "cache-control": "public,max-age=0,must-revalidate",
     },
-    "src": "/.*\\\\.html",
-  },
-  Object {
-    "continue": true,
-    "headers": Object {
-      "cache-control": "public,max-age=0,must-revalidate",
-    },
-    "src": "/page-data/.*",
+    "src": "^/(sw\\\\.js|app-data\\\\.json|.*\\\\.html|page-data/.*)$",
   },
   Object {
     "headers": Object {
@@ -111,8 +104,8 @@ Array [
     "status": 302,
   },
   Object {
-    "dest": "/404",
-    "src": "/.*",
+    "dest": "/404.html",
+    "src": ".*",
     "status": 404,
   },
 ]

--- a/packages/now-static-build/test/fixtures/10-gatsby/now.json
+++ b/packages/now-static-build/test/fixtures/10-gatsby/now.json
@@ -1,9 +1,37 @@
 {
   "version": 2,
   "builds": [
-    { "src": "package.json", "use": "@now/static-build", "config": { "zeroConfig": true } }
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "zeroConfig": true }
+    }
   ],
   "probes": [
-    { "path": "/", "mustContain": "Welcome to your new Gatsby site" }
+    { "path": "/", "mustContain": "Welcome to your new Gatsby site" },
+    {
+      "path": "/static/d/856328897.json",
+      "headers": { "cache-control": "public,max-age=31536000,immutable" }
+    },
+    {
+      "path": "/app-08a9fb9626777db1bf33.js",
+      "headers": { "cache-control": "public,max-age=31536000,immutable" }
+    },
+    {
+      "path": "/index.html",
+      "headers": { "cache-control": "public,max-age=0,must-revalidate" }
+    },
+    {
+      "path": "/page-data/404/page-data.json",
+      "headers": { "cache-control": "public,max-age=0,must-revalidate" }
+    },
+    {
+      "path": "/path-that-does-not-exist",
+      "mustContain": "You just hit a route that doesn&#x27;t exist..."
+    },
+    {
+      "path": "/path-that-does-not-exist",
+      "status": 404
+    }
   ]
 }

--- a/packages/now-static-build/test/fixtures/10-gatsby/now.json
+++ b/packages/now-static-build/test/fixtures/10-gatsby/now.json
@@ -11,19 +11,23 @@
     { "path": "/", "mustContain": "Welcome to your new Gatsby site" },
     {
       "path": "/static/d/856328897.json",
-      "headers": { "cache-control": "public,max-age=31536000,immutable" }
+      "responseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
     },
     {
       "path": "/app-08a9fb9626777db1bf33.js",
-      "headers": { "cache-control": "public,max-age=31536000,immutable" }
+      "responseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
     },
     {
       "path": "/index.html",
-      "headers": { "cache-control": "public,max-age=0,must-revalidate" }
+      "responseHeaders": { "cache-control": "public,max-age=0,must-revalidate" }
     },
     {
       "path": "/page-data/404/page-data.json",
-      "headers": { "cache-control": "public,max-age=0,must-revalidate" }
+      "responseHeaders": { "cache-control": "public,max-age=0,must-revalidate" }
     },
     {
       "path": "/path-that-does-not-exist",

--- a/packages/now-static-build/test/fixtures/10-gatsby/now.json
+++ b/packages/now-static-build/test/fixtures/10-gatsby/now.json
@@ -22,6 +22,20 @@
       }
     },
     {
+      "path": "/styles.fc4fa5e094d218207796.css",
+      "responseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
+    },
+    {
+      "path": "/sw.js",
+      "responseHeaders": { "cache-control": "public,max-age=0,must-revalidate" }
+    },
+    {
+      "path": "/app-data.json",
+      "responseHeaders": { "cache-control": "public,max-age=0,must-revalidate" }
+    },
+    {
       "path": "/index.html",
       "responseHeaders": { "cache-control": "public,max-age=0,must-revalidate" }
     },


### PR DESCRIPTION
This PR does 3 things:
- add default caching headers 
- redirect all missed requests to Gatsby's own 404.html page
- add deprecation message to `gatsby-plugin-now` since we're auto injecting it and it's not needed anymore

Fixes #2859