### PR TITLE
[now-routing-utils] Fix html redirects for `cleanUrls`

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -15,6 +15,8 @@ import {
   convertTrailingSlash,
 } from './superstatic';
 
+export { getCleanUrls } from './superstatic';
+
 export function isHandler(route: Route): route is Handler {
   return typeof (route as Handler).handle !== 'undefined';
 }
@@ -135,9 +137,8 @@ export function getTransformedRoutes({
     }
   } else {
     routes = [];
-    if (cleanUrls) {
-      const clean = convertCleanUrls(filePaths);
-      routes.push(...clean.redirects);
+    if (typeof cleanUrls !== 'undefined') {
+      routes.push(...convertCleanUrls(cleanUrls));
     }
     if (typeof trailingSlash !== 'undefined') {
       routes.push(...convertTrailingSlash(trailingSlash));

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -6,9 +6,9 @@
 import pathToRegexp from 'path-to-regexp';
 import { Route, NowRedirect, NowRewrite, NowHeader } from './types';
 
-export function convertCleanUrls(
+export function getCleanUrls(
   filePaths: string[]
-): { redirects: Route[]; rewrites: Route[] } {
+): { html: string; clean: string }[] {
   const htmlFiles = filePaths
     .map(toRoute)
     .filter(f => f.endsWith('.html'))
@@ -17,19 +17,24 @@ export function convertCleanUrls(
       clean: f.slice(0, -5),
     }));
 
-  const redirects: Route[] = htmlFiles.map(o => ({
-    src: o.html,
-    headers: { Location: o.clean },
-    status: 301,
-  }));
+  return htmlFiles;
+}
 
-  const rewrites: Route[] = htmlFiles.map(o => ({
-    src: o.clean,
-    dest: o.html,
-    continue: true,
-  }));
-
-  return { redirects, rewrites };
+export function convertCleanUrls(enable: boolean): Route[] {
+  const routes: Route[] = [];
+  if (enable) {
+    routes.push({
+      src: '^/(?:(.+)/)?index(?:\\.html)?$',
+      headers: { Location: '/$1' },
+      status: 301,
+    });
+    routes.push({
+      src: '^/(.*)\\.html$',
+      headers: { Location: '/$1' },
+      status: 301,
+    });
+  }
+  return routes;
 }
 
 export function convertRedirects(redirects: NowRedirect[]): Route[] {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -455,13 +455,13 @@ describe('getTransformedRoutes', () => {
     const actual = getTransformedRoutes({ nowConfig, filePaths });
     const expected = [
       {
-        src: '^/index.html$',
-        headers: { Location: '/index' },
+        src: '^/(?:(.+)/)?index(?:\\.html)?$',
+        headers: { Location: '/$1' },
         status: 301,
       },
       {
-        src: '^/support.html$',
-        headers: { Location: '/support' },
+        src: '^/(.*)\\.html$',
+        headers: { Location: '/$1' },
         status: 301,
       },
       {


### PR DESCRIPTION
We used to read the output files and create a route for each redirect when `cleanUrls: true`.

Instead, this PR will add 2 redirects for `cleanUrls: true` no matter how many files are in the outputs.