### PR TITLE
[now-routing-utils] Return null routes when provided null

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -127,7 +127,7 @@ export function getTransformedRoutes({
   nowConfig,
 }: GetRoutesProps): NormalizedRoutes {
   const { cleanUrls, rewrites, redirects, headers, trailingSlash } = nowConfig;
-  let { routes } = nowConfig;
+  let { routes = null } = nowConfig;
   const errors: NowErrorNested[] = [];
   if (routes) {
     if (typeof cleanUrls !== 'undefined') {
@@ -166,14 +166,13 @@ export function getTransformedRoutes({
     return normalizeRoutes(routes);
   }
 
-  routes = [];
-
   if (typeof cleanUrls !== 'undefined') {
     const normalized = normalizeRoutes(convertCleanUrls(cleanUrls));
     if (normalized.error) {
       normalized.error.code = 'invalid_clean_urls';
       return { routes, error: normalized.error };
     }
+    routes = routes || [];
     routes.push(...(normalized.routes || []));
   }
 
@@ -183,6 +182,7 @@ export function getTransformedRoutes({
       normalized.error.code = 'invalid_trailing_slash';
       return { routes, error: normalized.error };
     }
+    routes = routes || [];
     routes.push(...(normalized.routes || []));
   }
 
@@ -206,6 +206,7 @@ export function getTransformedRoutes({
       normalized.error.code = code;
       return { routes, error: normalized.error };
     }
+    routes = routes || [];
     routes.push(...(normalized.routes || []));
   }
 
@@ -215,6 +216,7 @@ export function getTransformedRoutes({
       normalized.error.code = 'invalid_headers';
       return { routes, error: normalized.error };
     }
+    routes = routes || [];
     routes.push(...(normalized.routes || []));
   }
 
@@ -238,6 +240,7 @@ export function getTransformedRoutes({
       normalized.error.code = code;
       return { routes, error: normalized.error };
     }
+    routes = routes || [];
     routes.push({ handle: 'filesystem' });
     routes.push(...(normalized.routes || []));
   }

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -29,6 +29,11 @@ const assertError = (data, errors, schema = routesSchema) => {
 };
 
 describe('normalizeRoutes', () => {
+  test('should return routes null if provided routes is null', () => {
+    const actual = normalizeRoutes(null);
+    assert.equal(actual.routes, null);
+  });
+
   test('accepts valid routes', () => {
     if (Number(process.versions.node.split('.')[0]) < 10) {
       // Skip this test for any Node version less than Node 10
@@ -538,5 +543,11 @@ describe('getTransformedRoutes', () => {
     assertValid(nowConfig.redirects, redirectsSchema);
     assertValid(nowConfig.headers, headersSchema);
     assertValid(nowConfig.trailingSlashSchema, trailingSlashSchema);
+  });
+
+  test('should return null routes if no transformations are performed', () => {
+    const nowConfig = { routes: null };
+    const actual = getTransformedRoutes({ nowConfig });
+    assert.equal(actual.routes, null);
   });
 });


### PR DESCRIPTION
This PR ensures that null routes are returned as null instead of the empty array.