### PR TITLE
[now-routing-utils] Fix redirects when cleanUrls and trailingSlash

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -167,7 +167,9 @@ export function getTransformedRoutes({
   }
 
   if (typeof cleanUrls !== 'undefined') {
-    const normalized = normalizeRoutes(convertCleanUrls(cleanUrls));
+    const normalized = normalizeRoutes(
+      convertCleanUrls(cleanUrls, trailingSlash)
+    );
     if (normalized.error) {
       normalized.error.code = 'invalid_clean_urls';
       return { routes, error: normalized.error };

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -20,17 +20,21 @@ export function getCleanUrls(
   return htmlFiles;
 }
 
-export function convertCleanUrls(enable: boolean): Route[] {
+export function convertCleanUrls(
+  cleanUrls: boolean,
+  trailingSlash: boolean | undefined
+): Route[] {
   const routes: Route[] = [];
-  if (enable) {
+  if (cleanUrls) {
+    const loc = trailingSlash ? '/$1/' : '/$1';
     routes.push({
-      src: '^/(?:(.+)/)?index(?:\\.html)?$',
-      headers: { Location: '/$1' },
+      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
+      headers: { Location: loc },
       status: 301,
     });
     routes.push({
-      src: '^/(.*)\\.html$',
-      headers: { Location: '/$1' },
+      src: '^/(.*)\\.html/?$',
+      headers: { Location: loc },
       status: 301,
     });
   }

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -479,12 +479,12 @@ describe('getTransformedRoutes', () => {
     const actual = getTransformedRoutes({ nowConfig, filePaths });
     const expected = [
       {
-        src: '^/(?:(.+)/)?index(?:\\.html)?$',
+        src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
         headers: { Location: '/$1' },
         status: 301,
       },
       {
-        src: '^/(.*)\\.html$',
+        src: '^/(.*)\\.html/?$',
         headers: { Location: '/$1' },
         status: 301,
       },

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -56,12 +56,12 @@ test('convertCleanUrls true', () => {
   const actual = convertCleanUrls(true);
   const expected = [
     {
-      src: '^/(?:(.+)/)?index(?:\\.html)?$',
+      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
       headers: { Location: '/$1' },
       status: 301,
     },
     {
-      src: '^/(.*)\\.html$',
+      src: '^/(.*)\\.html/?$',
       headers: { Location: '/$1' },
       status: 301,
     },
@@ -83,6 +83,42 @@ test('convertCleanUrls true', () => {
       '/sub/indexAhtml',
     ],
     ['/filehtml', '/sub/filehtml'],
+  ];
+
+  assertRegexMatches(actual, mustMatch, mustNotMatch);
+});
+
+test('convertCleanUrls true, trailingSlash true', () => {
+  const actual = convertCleanUrls(true, true);
+  const expected = [
+    {
+      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
+      headers: { Location: '/$1/' },
+      status: 301,
+    },
+    {
+      src: '^/(.*)\\.html/?$',
+      headers: { Location: '/$1/' },
+      status: 301,
+    },
+  ];
+  deepEqual(actual, expected);
+
+  const mustMatch = [
+    ['/index/', '/index.html/', '/sub/index/', '/sub/index.html/'],
+    ['/file.html/', '/sub/file.html/'],
+  ];
+
+  const mustNotMatch = [
+    [
+      '/someindex/',
+      '/someindex.html/',
+      '/indexAhtml/',
+      '/sub/someindex/',
+      '/sub/someindex.html/',
+      '/sub/indexAhtml/',
+    ],
+    ['/filehtml/', '/sub/filehtml/'],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -105,12 +105,27 @@ test('convertCleanUrls true, trailingSlash true', () => {
   deepEqual(actual, expected);
 
   const mustMatch = [
-    ['/index/', '/index.html/', '/sub/index/', '/sub/index.html/'],
-    ['/file.html/', '/sub/file.html/'],
+    [
+      '/index',
+      '/index.html',
+      '/sub/index',
+      '/sub/index.html',
+      '/index/',
+      '/index.html/',
+      '/sub/index/',
+      '/sub/index.html/',
+    ],
+    ['/file.html', '/sub/file.html', '/file.html/', '/sub/file.html/'],
   ];
 
   const mustNotMatch = [
     [
+      '/someindex',
+      '/someindex.html',
+      '/indexAhtml',
+      '/sub/someindex',
+      '/sub/someindex.html',
+      '/sub/indexAhtml',
       '/someindex/',
       '/someindex.html/',
       '/indexAhtml/',
@@ -118,7 +133,7 @@ test('convertCleanUrls true, trailingSlash true', () => {
       '/sub/someindex.html/',
       '/sub/indexAhtml/',
     ],
-    ['/filehtml/', '/sub/filehtml/'],
+    ['/filehtml', '/sub/filehtml', '/filehtml/', '/sub/filehtml/'],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);


### PR DESCRIPTION
This fixes the scenario when both `{ cleanUrls: true, and trailingSlash: true }` so that only one redirect occurs when visiting `/file.html`.

Previously, this would have redirected twice from `/file.html` => `/file` => `/file/`.

Now it will redirect once from `/file.html` => `/file/`.