### PR TITLE
[now-dev] Fix route normalization

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -30,6 +30,7 @@ import {
   BuilderOutput,
   BuilderOutputs,
 } from './types';
+import { normalizeRoutes } from '@now/routing-utils';
 
 interface BuildMessage {
   type: string;
@@ -225,6 +226,14 @@ export async function executeBuild(
     };
   } else {
     result = buildResultOrOutputs as BuildResult;
+  }
+
+  // Normalize Builder Routes
+  const normalized = normalizeRoutes(result.routes);
+  if (normalized.error) {
+    throw new Error(normalized.error.message);
+  } else {
+    result.routes = normalized.routes || [];
   }
 
   // Convert the JSON-ified output map back into their corresponding `File`

--- a/packages/now-cli/test/dev/fixtures/invalid-builder-routes/index.html
+++ b/packages/now-cli/test/dev/fixtures/invalid-builder-routes/index.html
@@ -1,0 +1,1 @@
+Home Page

--- a/packages/now-cli/test/dev/fixtures/invalid-builder-routes/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-builder-routes/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "https://files-dx8orl9ax.static-host.site"
+    }
+  ]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -266,6 +266,15 @@ test(
 );
 
 test(
+  '[now dev] throw when invalid builder routes detected',
+  testFixtureStdio('invalid-builder-routes', async (t, port) => {
+    const response = await fetch(`http://localhost:${port}`);
+    const body = await response.text();
+    t.regex(body, /Invalid regular expression/gm);
+  })
+);
+
+test(
   '[now dev] 00-list-directory',
   testFixtureStdio('00-list-directory', async (t, port) => {
     const result = await fetchWithRetry(`http://localhost:${port}`, 60);


### PR DESCRIPTION
This PR fixes a regression introduced in #3174 when removing the `^` and `$` normalization.

The previous PR was normalizing user-defined routes but forgot to normalize builder routes.

This PR normalizes builder routes 👍 