### PR TITLE
[now-routing-utils] Improve error message for invalid regexes

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -112,7 +112,7 @@ function createNowError(
     errors.length > 0
       ? {
           code,
-          message: `${msg}: \n${JSON.stringify(errors, null, 2)}`,
+          message: `${msg}: \n${errors.map(error => `- ${error.message}\n`)}`,
           errors,
         }
       : null;

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -112,7 +112,7 @@ function createNowError(
     errors.length > 0
       ? {
           code,
-          message: `${msg}: \n${errors.map(error => `- ${error.message}\n`)}`,
+          message: `${msg}: \n${errors.map(item => `- ${item.message}\n`)}`,
           errors,
         }
       : null;

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -156,10 +156,8 @@ describe('normalizeRoutes', () => {
     assert.deepStrictEqual(normalized.routes, routes);
     assert.deepStrictEqual(normalized.error, {
       code: 'invalid_routes',
-      message: `One or more invalid routes were found: \n${JSON.stringify(
-        errors,
-        null,
-        2
+      message: `One or more invalid routes were found: \n${errors.map(
+        item => `- ${item.message}\n`
       )}`,
       errors,
     });


### PR DESCRIPTION
Currently, this is what you see if you enter invalid regexes with any of the new routing properties:

![image](https://user-images.githubusercontent.com/6170607/67955351-c0fd6480-fbf2-11e9-999c-b36509b5c405.png)

Instead of printing JSON, we want to print a list of all error messages.