### PR TITLE
[now-build-utils] Fix zero config trailing slash

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -60,9 +60,9 @@ function createRouteFromPath(filePath: string): Route {
       const prefix = isIndex ? '\\/' : '';
 
       const names = [
-        prefix,
+        isIndex ? prefix : `${fileName}\\/`,
         prefix + escapeName(fileName),
-        prefix + escapeName(fileName) + escapeName(ext)
+        prefix + escapeName(fileName) + escapeName(ext),
       ].filter(Boolean);
 
       // Either filename with extension, filename without extension
@@ -228,8 +228,8 @@ async function detectApiRoutes(files: string[]): Promise<RoutesResult> {
           message:
             `The segment "${conflictingSegment}" occurs more than ` +
             `one time in your path "${file}". Please make sure that ` +
-            `every segment in a path is unique`
-        }
+            `every segment in a path is unique`,
+        },
       };
     }
 
@@ -249,8 +249,8 @@ async function detectApiRoutes(files: string[]): Promise<RoutesResult> {
           message:
             `Two or more files have conflicting paths or names. ` +
             `Please make sure path segments and filenames, without their extension, are unique. ` +
-            `The path "${file}" has conflicts with ${messagePaths}`
-        }
+            `The path "${file}" has conflicts with ${messagePaths}`,
+        },
       };
     }
 
@@ -261,7 +261,7 @@ async function detectApiRoutes(files: string[]): Promise<RoutesResult> {
   if (defaultRoutes.length) {
     defaultRoutes.push({
       status: 404,
-      src: '/api(\\/.*)?$'
+      src: '/api(\\/.*)?$',
     });
   }
 
@@ -287,7 +287,7 @@ export async function detectRoutes(
   if (routesResult.defaultRoutes && hasPublicBuilder(builders)) {
     routesResult.defaultRoutes.push({
       src: '/(.*)',
-      dest: '/public/$1'
+      dest: '/public/$1',
     });
   }
 

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -646,7 +646,7 @@ it('Test `detectRoutes`', async () => {
       '^/api/date(\\/|\\/index|\\/index\\.js)?$'
     );
     expect(defaultRoutes[0].dest).toBe('/api/date/index.js');
-    expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
+    expect(defaultRoutes[1].src).toBe('^/api/(date\\/|date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
   }
 
@@ -661,7 +661,7 @@ it('Test `detectRoutes`', async () => {
       '^/api/([^\\/]+)(\\/|\\/index|\\/index\\.js)?$'
     );
     expect(defaultRoutes[0].dest).toBe('/api/[date]/index.js?date=$1');
-    expect(defaultRoutes[1].src).toBe('^/api/(date|date\\.js)$');
+    expect(defaultRoutes[1].src).toBe('^/api/(date\\/|date|date\\.js)$');
     expect(defaultRoutes[1].dest).toBe('/api/date.js');
   }
 


### PR DESCRIPTION
This fixes the scenario where the user defines `trailingSlash: true` and creates a file `/api/users.js`. They would expect to be able to visit `/api/users/` and it should run that function.