### PR TITLE
Add note for Windows environment variable syntax

### DIFF
--- a/errors/now-static-build-failed-to-detect-a-server.md
+++ b/errors/now-static-build-failed-to-detect-a-server.md
@@ -19,6 +19,8 @@ the provided `$PORT` that the builder expects the server to bind to.
 For example, if you are using Gatsby, your `now-dev` script must use the `-p`
 (port) option to bind to the `$PORT` specified from the builder:
 
+> *In Windows environments, reference the `PORT` environment variable with `%PORT%`*
+
 ```
 {
   ...


### PR DESCRIPTION
After a good while searching around, I finally realized that this was the cause of my local development woes. 
The CLI would continually tell me that it was trying to run on `port NaN`.
Thought I would add this as a note for anyone else who may need it.