### PR TITLE
[now-cli] Fix test invalid-builder-routes

### DIFF
--- a/packages/now-cli/test/dev/fixtures/invalid-builder-routes/now.json
+++ b/packages/now-cli/test/dev/fixtures/invalid-builder-routes/now.json
@@ -3,7 +3,7 @@
   "builds": [
     {
       "src": "index.html",
-      "use": "https://files-dx8orl9ax.static-host.site"
+      "use": "https://files-1bsmqkkol.now.sh"
     }
   ]
 }


### PR DESCRIPTION
This fixes the test that was failing with "402 Payment Required" by deploying to the `testuser` account instead.

https://circleci.com/gh/zeit/now/26106