### PR TITLE
Revert "[now-client] ignores is missing ignores added from .nowignore"

### DIFF
--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -95,7 +95,8 @@ export async function getNowIgnore(path: string | string[]): Promise<any> {
     : await maybeRead(join(path, '.nowignore'), '');
 
   const ig = ignore().add(`${ignores.join('\n')}\n${nowIgnore}`);
-  return { ig, ignores: ignores.concat(nowIgnore.split('\n')) };
+
+  return { ig, ignores };
 }
 
 export const fetch = async (


### PR DESCRIPTION
Reverts zeit/now#3186

Now CLI tests fail because of it.