### PR TITLE
[now-next] Leverage routes-manifest if available for dynamic routes

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -240,7 +240,7 @@ export const build = async ({
 
     return {
       output: {},
-      routes: getRoutes(
+      routes: await getRoutes(
         entryPath,
         entryDirectory,
         pathsInside,

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -825,19 +825,21 @@ export const build = async ({
   let dynamicPrefix = path.join('/', entryDirectory);
   dynamicPrefix = dynamicPrefix === '/' ? '' : dynamicPrefix;
 
-  const dynamicRoutes = getDynamicRoutes(
+  const dynamicRoutes = await getDynamicRoutes(
     entryPath,
     entryDirectory,
     dynamicPages
-  ).map(route => {
-    // make sure .html is added to dest for now until
-    // outputting static files to clean routes is available
-    if (staticPages[`${route.dest}.html`.substr(1)]) {
-      route.dest = `${route.dest}.html`;
-    }
-    route.src = route.src.replace('^', `^${dynamicPrefix}`);
-    return route;
-  });
+  ).then(arr =>
+    arr.map(route => {
+      // make sure .html is added to dest for now until
+      // outputting static files to clean routes is available
+      if (staticPages[`${route.dest}.html`.substr(1)]) {
+        route.dest = `${route.dest}.html`;
+      }
+      route.src = route.src.replace('^', `^${dynamicPrefix}`);
+      return route;
+    })
+  );
 
   return {
     output: {

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -315,7 +315,8 @@ export async function getDynamicRoutes(
     const routesManifest = await fs.readJSON(pathRoutesManifest);
 
     switch (routesManifest.version) {
-      case 0: {
+      case 0:
+      case 1: {
         return routesManifest.dynamicRoutes.map(
           ({ page, regex }: { page: string; regex: string }) => {
             return {

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -169,13 +169,13 @@ function normalizePage(page: string): string {
   return page;
 }
 
-function getRoutes(
+async function getRoutes(
   entryPath: string,
   entryDirectory: string,
   pathsInside: string[],
   files: Files,
   url: string
-): Route[] {
+): Promise<Route[]> {
   let pagesDir = '';
   const filesInside: Files = {};
   const prefix = entryDirectory === `.` ? `/` : `/${entryDirectory}/`;
@@ -255,17 +255,18 @@ function getRoutes(
   }
 
   routes.push(
-    ...getDynamicRoutes(entryPath, entryDirectory, dynamicPages).map(
-      (route: { src: string; dest: string }) => {
-        // convert to make entire RegExp match as one group
-        route.src = route.src
-          .replace('^', `^${prefix}(`)
-          .replace('(\\/', '(')
-          .replace('$', ')$');
-        route.dest = `${url}/$1`;
-        return route;
-      }
-    )
+    ...(await getDynamicRoutes(entryPath, entryDirectory, dynamicPages).then(
+      arr =>
+        arr.map((route: { src: string; dest: string }) => {
+          // convert to make entire RegExp match as one group
+          route.src = route.src
+            .replace('^', `^${prefix}(`)
+            .replace('(\\/', '(')
+            .replace('$', ')$');
+          route.dest = `${url}/$1`;
+          return route;
+        })
+    ))
   );
 
   // Add public folder routes


### PR DESCRIPTION
This allows us to start de-coupling the builder from relying on inner utils of Next.js to generate dynamic routes for Now by leveraging a `routes-manifest` output during the build

Relies on: https://github.com/zeit/next.js/pull/9347