### PR TITLE
[now-ruby] Fix rails test

### DIFF
--- a/packages/now-ruby/test/test.js
+++ b/packages/now-ruby/test/test.js
@@ -20,11 +20,6 @@ const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
-  if (['06-rails'].includes(fixture)) {
-    console.log(`Skipping ${fixture}`);
-    continue;
-  }
-
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(


### PR DESCRIPTION
This test was failing for the last week.

The issue was fixed in the build environment. The root cause was [ruby-build](https://github.com/rbenv/ruby-build) which is used to install the version of Ruby used in `@now/ruby`. It started using an older (possible broken) version of `bundler`. I pinned `ruby-build` to a previous version so that deployments continue working.

So now we can enable the Rails test again (which uses nokogiri).

Fixes #3246