### PR TITLE
[now-cli] Purge require cache after packages install in `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -30,14 +30,7 @@ import * as staticBuilder from './static-builder';
 import { BuilderWithPackage } from './types';
 import { getBundledBuilders } from './get-bundled-builders';
 
-interface NodeRequire {
-  (id: string): any;
-  cache: {
-    [name: string]: any;
-  };
-}
-
-declare const __non_webpack_require__: NodeRequire;
+declare const __non_webpack_require__: typeof require;
 
 const registryTypes = new Set(['version', 'tag', 'range']);
 

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -30,6 +30,15 @@ import * as staticBuilder from './static-builder';
 import { BuilderWithPackage } from './types';
 import { getBundledBuilders } from './get-bundled-builders';
 
+interface NodeRequire {
+  (id: string): any;
+  cache: {
+    [name: string]: any;
+  };
+}
+
+declare const __non_webpack_require__: NodeRequire;
+
 const registryTypes = new Set(['version', 'tag', 'range']);
 
 const localBuilders: { [key: string]: BuilderWithPackage } = {
@@ -213,13 +222,13 @@ export async function installBuilders(
   }
   const yarnPath = join(yarnDir, 'yarn');
   const buildersPkgPath = join(builderDir, 'package.json');
-  const buildersPkg = await readJSON(buildersPkgPath);
+  const buildersPkgBefore = await readJSON(buildersPkgPath);
 
   packages.push(getBuildUtils(packages));
 
   // Filter out any packages that come packaged with `now-cli`
   const packagesToInstall = packages.filter(p =>
-    filterPackage(p, distTag, buildersPkg)
+    filterPackage(p, distTag, buildersPkgBefore)
   );
 
   if (packagesToInstall.length === 0) {
@@ -230,6 +239,7 @@ export async function installBuilders(
   const stopSpinner = wait(
     `Installing builders: ${packagesToInstall.sort().join(', ')}`
   );
+
   try {
     await retry(
       () =>
@@ -252,6 +262,17 @@ export async function installBuilders(
   } finally {
     stopSpinner();
   }
+
+  const updatedPackages: string[] = [];
+  const buildersPkgAfter = await readJSON(buildersPkgPath);
+  for (const [name, version] of Object.entries(buildersPkgAfter.dependencies)) {
+    if (version !== buildersPkgBefore.dependencies[name]) {
+      output.debug(`Builder "${name}" updated to version \`${version}\``);
+      updatedPackages.push(name);
+    }
+  }
+
+  purgeRequireCache(updatedPackages, builderDir, output);
 }
 
 export async function updateBuilders(
@@ -297,6 +318,8 @@ export async function updateBuilders(
       updatedPackages.push(name);
     }
   }
+
+  purgeRequireCache(updatedPackages, builderDir, output);
 
   return updatedPackages;
 }
@@ -372,4 +395,26 @@ function hasBundledBuilders(dependencies: { [name: string]: string }): boolean {
     }
   }
   return true;
+}
+
+function purgeRequireCache(
+  packages: string[],
+  builderDir: string,
+  output: Output
+) {
+  const _require =
+    typeof __non_webpack_require__ === 'function'
+      ? __non_webpack_require__
+      : require;
+
+  // The `require()` cache for the builder's assets must be purged
+  const packagesPaths = packages.map(b => join(builderDir, 'node_modules', b));
+  for (const id of Object.keys(_require.cache)) {
+    for (const path of packagesPaths) {
+      if (id.startsWith(path)) {
+        output.debug(`Purging require cache for "${id}"`);
+        delete _require.cache[id];
+      }
+    }
+  }
 }

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -214,7 +214,7 @@ export async function executeBuild(
   }
 
   // Sort out build result to builder v2 shape
-  if (builder.version === undefined) {
+  if (!builder.version || builder.version === 1) {
     // `BuilderOutputs` map was returned (Now Builder v1 behavior)
     result = {
       output: buildResultOrOutputs as BuilderOutputs,
@@ -225,20 +225,24 @@ export async function executeBuild(
           ? buildResultOrOutputs.distPath
           : undefined,
     };
+  } else if (builder.version === 2) {
+    result = buildResultOrOutputs as BuildResult;
   } else if (builder.version === 3) {
     const { output, ...rest } = buildResultOrOutputs as BuildResultV3;
 
     if (!output || (output as BuilderOutput).type !== 'Lambda') {
-      throw new Error(`The result of "builder.build" must be a Lambda'`);
+      throw new Error('The result of "builder.build()" must be a `Lambda`');
     }
 
     if (output.maxDuration) {
-      throw new Error('The result of "builder.build" cannot contain `memory`');
+      throw new Error(
+        'The result of "builder.build()" must not contain `memory`'
+      );
     }
 
     if (output.memory) {
       throw new Error(
-        'The result of "builder.build" cannot contain `maxDuration`'
+        'The result of "builder.build()" must not contain `maxDuration`'
       );
     }
 

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -88,15 +88,6 @@ interface FSEvent {
   path: string;
 }
 
-interface NodeRequire {
-  (id: string): any;
-  cache: {
-    [name: string]: any;
-  };
-}
-
-declare const __non_webpack_require__: NodeRequire;
-
 function sortBuilders(buildA: Builder, buildB: Builder) {
   if (buildA && buildA.use && buildA.use.startsWith('@now/static-build')) {
     return 1;
@@ -415,25 +406,6 @@ export default class DevServer {
     if (updatedBuilders.length === 0) {
       this.output.debug('No builders were updated');
       return;
-    }
-
-    const _require =
-      typeof __non_webpack_require__ === 'function'
-        ? __non_webpack_require__
-        : require;
-
-    // The `require()` cache for the builder's assets must be purged
-    const builderDir = await builderDirPromise;
-    const updatedBuilderPaths = updatedBuilders.map(b =>
-      join(builderDir, 'node_modules', b)
-    );
-    for (const id of Object.keys(_require.cache)) {
-      for (const path of updatedBuilderPaths) {
-        if (id.startsWith(path)) {
-          this.output.debug(`Purging require cache for "${id}"`);
-          delete _require.cache[id];
-        }
-      }
     }
 
     // Delete any build matches that have the old builder required already

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -100,7 +100,7 @@ export interface BuilderConfigAttr {
 }
 
 export interface Builder {
-  version?: 2 | 3;
+  version?: 1 | 2 | 3;
   config?: BuilderConfigAttr;
   build(
     params: BuilderParams


### PR DESCRIPTION
This is really only relevant for the unit tests, where multiple `DevServer` instances are created in the same process. But this avoids the parent `now dev` process from having stale builder information after a different version of the same builder is installed.

Fixes builder 2 vs. 3 discrepancies that are causing unit tests to fail.