### PR TITLE
[now-cli] Enable Runtime tests

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -432,12 +432,12 @@ CMD ["node", "index.js"]`,
         },
       }),
     },
-    'lambda-with-node-runtime': {
+    'lambda-with-php-runtime': {
       'api/test.php': `<?php echo 'Hello from PHP'; ?>`,
       'now.json': JSON.stringify({
         functions: {
           'api/**/*.php': {
-            runtime: 'now-php@0.0.6',
+            runtime: 'now-php@0.0.7',
           },
         },
       }),

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1999,8 +1999,8 @@ test('fail to deploy a Lambda with an incorrect value for maxDuration', async t 
 });
 
 // We need to skip those tests until `now-php` supports Runtime version 3
-test.skip('deploy a Lambda with a specific runtime', async t => {
-  const directory = fixture('lambda-with-node-runtime');
+test('deploy a Lambda with a specific runtime', async t => {
+  const directory = fixture('lambda-with-php-runtime');
   const output = await execute([directory, '--public']);
 
   t.is(output.code, 0, formatOutput(output));
@@ -2008,11 +2008,11 @@ test.skip('deploy a Lambda with a specific runtime', async t => {
   const { host: url } = new URL(output.stdout);
 
   const [build] = await getDeploymentBuildsByUrl(url);
-  t.is(build.use, '@now/node@1.0.0-canary.10', JSON.stringify(build, null, 2));
+  t.is(build.use, 'now-php@0.0.7', JSON.stringify(build, null, 2));
 });
 
 // We need to skip those tests until `now-php` supports Runtime version 3
-test.skip('fail to deploy a Lambda with a specific runtime but without a locked version', async t => {
+test('fail to deploy a Lambda with a specific runtime but without a locked version', async t => {
   const directory = fixture('lambda-with-invalid-runtime');
   const output = await execute([directory]);
 


### PR DESCRIPTION
Enable Runtime tests, since a new version of the `now-php` package was released.