### PR TITLE
[now-node] Fix TS version selection

### DIFF
--- a/packages/now-node/src/typescript.ts
+++ b/packages/now-node/src/typescript.ts
@@ -152,7 +152,7 @@ export function register(opts: Options = {}): Register {
   let compiler: string;
   try {
     compiler = require.resolve(options.compiler || 'typescript', {
-      paths: [cwd, nowNodeBase],
+      paths: [options.project || cwd, nowNodeBase],
     });
   } catch (e) {
     compiler = require.resolve(eval('"./typescript"'));

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/index.ts
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/index.ts
@@ -1,0 +1,7 @@
+const ts = require('typescript');
+
+export default function handler(req: any, res: any) {
+  if (req) {
+    res.end(`RANDOMNESS_PLACEHOLDER:backend ts version ${ts.version}`);
+  }
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/package.json
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "nested-backend",
+  "devDependencies": {
+    "@types/node": "*",
+    "typescript": "3.0.3"
+  }
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/tsconfig.json
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "lib": ["esnext"],
+    "target": "esnext",
+    "module": "commonjs"
+  },
+  "include": ["index.ts"]
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/index.ts
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/index.ts
@@ -1,0 +1,7 @@
+const ts = require('typescript');
+
+export default function handler(req: any, res: any) {
+  if (req) {
+    res.end(`RANDOMNESS_PLACEHOLDER:frontend ts version ${ts.version}`);
+  }
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/package.json
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "nested-frontend",
+  "devDependencies": {
+    "@types/node": "*",
+    "typescript": "3.0.1"
+  }
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/tsconfig.json
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "lib": ["esnext"],
+    "target": "esnext",
+    "module": "commonjs"
+  },
+  "include": ["index.ts"]
+}

--- a/packages/now-node/test/fixtures/18.1-nested-packagejson/now.json
+++ b/packages/now-node/test/fixtures/18.1-nested-packagejson/now.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "builds": [{ "src": "**/*.ts", "use": "@now/node" }],
+  "probes": [
+    {
+      "path": "/backend",
+      "mustContain": "backend ts version 3.0.3"
+    },
+    {
+      "path": "/frontend",
+      "mustContain": "frontend ts version 3.0.1"
+    }
+  ]
+}


### PR DESCRIPTION
Previously, the `typescript` dependency resolution was using the package.json beside the `now.json` base directory.

This PR changes the behavior to start looking for package.json in the entrypoint directory.

Fixes #3258