### PR TITLE
[now-node] Disable default node timeout

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -141,6 +141,7 @@ export default class DevServer {
 
     this.cachedNowConfig = null;
     this.server = http.createServer(this.devServerHandler);
+    this.server.timeout = 0; // Disable timeout
     this.serverUrlPrinted = false;
     this.stopping = false;
     this.buildMatches = new Map();

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2020,7 +2020,7 @@ test('fail to deploy a Lambda with a specific runtime but without a locked versi
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Function runtimes must have a valid version/gm,
+    /Function Runtimes must have a valid version/gim,
     formatOutput(output)
   );
 });

--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -5,7 +5,7 @@ import {
   Server,
   IncomingHttpHeaders,
   OutgoingHttpHeaders,
-  request
+  request,
 } from 'http';
 
 interface NowProxyEvent {
@@ -29,6 +29,7 @@ export interface NowProxyResponse {
 }
 
 interface ServerLike {
+  timeout: number;
   listen: (
     opts: {
       host?: string;
@@ -138,10 +139,16 @@ export class Bridge {
 
     const resolveListening = this.resolveListening;
 
+    if (this.server.timeout > 0) {
+      // Disable timeout (usually 2 minutes) until Node 13.x.
+      // Instead, user should assign function `maxDuration`.
+      this.server.timeout = 0;
+    }
+
     return this.server.listen(
       {
         host: '127.0.0.1',
-        port: 0
+        port: 0,
       },
       function listeningCallback() {
         if (!this || typeof this.address !== 'function') {
@@ -206,7 +213,7 @@ export class Bridge {
             statusCode: response.statusCode || 200,
             headers: response.headers,
             body: bodyBuffer.toString('base64'),
-            encoding: 'base64'
+            encoding: 'base64',
           });
         });
       });

--- a/packages/now-node-bridge/src/bridge.ts
+++ b/packages/now-node-bridge/src/bridge.ts
@@ -29,7 +29,7 @@ export interface NowProxyResponse {
 }
 
 interface ServerLike {
-  timeout: number;
+  timeout?: number;
   listen: (
     opts: {
       host?: string;
@@ -133,19 +133,18 @@ export class Bridge {
   }
 
   listen() {
-    if (!this.server) {
+    const { server, resolveListening } = this;
+    if (!server) {
       throw new Error('Server has not been set!');
     }
 
-    const resolveListening = this.resolveListening;
-
-    if (this.server.timeout > 0) {
-      // Disable timeout (usually 2 minutes) until Node 13.x.
+    if (typeof server.timeout === 'number' && server.timeout > 0) {
+      // Disable timeout (usually 2 minutes until Node 13).
       // Instead, user should assign function `maxDuration`.
-      this.server.timeout = 0;
+      server.timeout = 0;
     }
 
-    return this.server.listen(
+    return server.listen(
       {
         host: '127.0.0.1',
         port: 0,

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -279,5 +279,9 @@ export function createServerWithHelpers(
     }
   });
 
+  // Disable timeout (usually 2 minutes) until Node 13.x.
+  // Instead, user should assign function `maxDuration`.
+  server.timeout = 0;
+
   return server;
 }

--- a/packages/now-node/src/helpers.ts
+++ b/packages/now-node/src/helpers.ts
@@ -279,9 +279,5 @@ export function createServerWithHelpers(
     }
   });
 
-  // Disable timeout (usually 2 minutes) until Node 13.x.
-  // Instead, user should assign function `maxDuration`.
-  server.timeout = 0;
-
   return server;
 }


### PR DESCRIPTION
Node had a default [timeout](https://nodejs.org/api/http.html#http_server_timeout) of 2 minutes until Node 13.x so we'll need to manually disable the timeout so that the `maxDuration` config works properly.