### PR TITLE
[script] Cleanup changelog script

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -12,7 +12,12 @@ if (!commit) {
   throw new Error('Unable to find last publish commit');
 }
 
-const log = execSync(`git log --pretty=format:"- %s [%an]" ${commit}...HEAD`).toString().trim();
+const log = execSync(`git log --pretty=format:"- %s [%an]" ${commit}...HEAD`)
+  .toString()
+  .trim()
+  .split('\n')
+  .filter(line => !line.startsWith('- Publish Canary '))
+  .join('\n');
 
-console.log(`Changes since the last publish commit ${commit}:`);
+console.log(`Changes since the last Stable release (${commit.slice(0, 7)}):`);
 console.log(`\n${log}\n`);


### PR DESCRIPTION
This script is only used for stable releases so we should filter out canary publish commits.