### PR TITLE
[now-cli][now-routing-utils] Add support for v4 builders

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -272,7 +272,7 @@ export async function executeBuild(
     if (builder.version === 4) {
       const { error, routes: buildRoutes } = getTransformedRoutes({
         nowConfig: rest,
-        filePaths: [],
+        builderVersion: builder.version,
       });
       if (error) {
         throw new Error(error.message);

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -29,9 +29,11 @@ import {
   BuilderInputs,
   BuilderOutput,
   BuildResultV3,
+  BuildResultV4,
   BuilderOutputs,
+  RouteConfig,
 } from './types';
-import { normalizeRoutes } from '@now/routing-utils';
+import { normalizeRoutes, getTransformedRoutes } from '@now/routing-utils';
 
 interface BuildMessage {
   type: string;
@@ -174,7 +176,11 @@ export async function executeBuild(
     },
   };
 
-  let buildResultOrOutputs: BuilderOutputs | BuildResult | BuildResultV3;
+  let buildResultOrOutputs:
+    | BuilderOutputs
+    | BuildResult
+    | BuildResultV3
+    | BuildResultV4;
   if (buildProcess) {
     buildProcess.send({
       type: 'build',
@@ -227,8 +233,10 @@ export async function executeBuild(
     };
   } else if (builder.version === 2) {
     result = buildResultOrOutputs as BuildResult;
-  } else if (builder.version === 3) {
-    const { output, ...rest } = buildResultOrOutputs as BuildResultV3;
+  } else if (builder.version === 3 || builder.version === 4) {
+    const { output, ...rest } = buildResultOrOutputs as (
+      | BuildResultV3
+      | BuildResultV4);
 
     if (!output || (output as BuilderOutput).type !== 'Lambda') {
       throw new Error('The result of "builder.build()" must be a `Lambda`');
@@ -260,8 +268,21 @@ export async function executeBuild(
       }
     }
 
+    let routes: RouteConfig[] = [];
+    if (builder.version === 4) {
+      const { error, routes: buildRoutes } = getTransformedRoutes({
+        nowConfig: rest,
+        filePaths: [],
+      });
+      if (error) {
+        throw new Error(error.message);
+      }
+      routes = buildRoutes || [];
+    }
+
     result = {
       ...rest,
+      routes,
       output: {
         [entrypoint]: output,
       },

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -517,7 +517,6 @@ export default class DevServer {
     await this.validateNowConfig(config);
     const { error: routeError, routes: maybeRoutes } = getTransformedRoutes({
       nowConfig: config,
-      filePaths: files,
     });
     if (routeError) {
       this.output.error(routeError.message);

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -100,7 +100,7 @@ export interface BuilderConfigAttr {
 }
 
 export interface Builder {
-  version?: 1 | 2 | 3;
+  version?: 1 | 2 | 3 | 4;
   config?: BuilderConfigAttr;
   build(
     params: BuilderParams
@@ -127,6 +127,17 @@ export interface BuildResultV3 {
   routes: RouteConfig[];
   watch: string[];
   distPath?: string;
+}
+
+export interface BuildResultV4 {
+  output: Lambda;
+  watch: string[];
+  distPath?: string;
+  cleanUrls?: boolean;
+  rewrites?: NowRewrite[];
+  redirects?: NowRedirect[];
+  headers?: NowHeader[];
+  trailingSlash?: boolean;
 }
 
 export interface ShouldServeParams {

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -127,11 +127,25 @@ function notEmpty<T>(value: T | null | undefined): value is T {
 
 export function getTransformedRoutes({
   nowConfig,
+  builderVersion,
 }: GetRoutesProps): NormalizedRoutes {
   const { cleanUrls, rewrites, redirects, headers, trailingSlash } = nowConfig;
   let { routes = null } = nowConfig;
   const errors: NowErrorNested[] = [];
   if (routes) {
+    if (typeof builderVersion === 'number' && builderVersion >= 4) {
+      const error = createNowError(
+        'invalid_builder_result',
+        'Invalid builder result',
+        [
+          {
+            message:
+              'Cannot define `routes` when builder.version is 4 or newer',
+          },
+        ]
+      );
+      return { routes, error };
+    }
     if (typeof cleanUrls !== 'undefined') {
       errors.push({
         message: 'Cannot define both `routes` and `cleanUrls`',

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -33,7 +33,7 @@ export type NormalizedRoutes = {
 
 export interface GetRoutesProps {
   nowConfig: NowConfig;
-  filePaths: string[];
+  builderVersion?: number;
 }
 
 export interface NowConfig {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -425,8 +425,7 @@ describe('normalizeRoutes', () => {
 describe('getTransformedRoutes', () => {
   test('should normalize nowConfig.routes', () => {
     const nowConfig = { routes: [{ src: '/page', dest: '/page.html' }] };
-    const filePaths = [];
-    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    const actual = getTransformedRoutes({ nowConfig });
     const expected = normalizeRoutes(nowConfig.routes);
     assert.deepEqual(actual, expected);
     assertValid(actual.routes);
@@ -434,8 +433,7 @@ describe('getTransformedRoutes', () => {
 
   test('should not error when routes is null and cleanUrls is true', () => {
     const nowConfig = { cleanUrls: true, routes: null };
-    const filePaths = ['file.html'];
-    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    const actual = getTransformedRoutes({ nowConfig });
     assert.equal(actual.error, null);
     assertValid(actual.routes);
   });
@@ -445,8 +443,7 @@ describe('getTransformedRoutes', () => {
       cleanUrls: true,
       routes: [{ src: '/page', dest: '/file.html' }],
     };
-    const filePaths = ['file.html'];
-    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    const actual = getTransformedRoutes({ nowConfig });
     assert.notEqual(actual.error, null);
     assert.equal(actual.error.code, 'invalid_keys');
   });
@@ -477,8 +474,7 @@ describe('getTransformedRoutes', () => {
         { source: '/help', destination: '/support', statusCode: 302 },
       ],
     };
-    const filePaths = ['/index.html', '/support.html', '/v2/api.py'];
-    const actual = getTransformedRoutes({ nowConfig, filePaths });
+    const actual = getTransformedRoutes({ nowConfig });
     const expected = [
       {
         src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
@@ -551,5 +547,22 @@ describe('getTransformedRoutes', () => {
     const nowConfig = { routes: null };
     const actual = getTransformedRoutes({ nowConfig });
     assert.equal(actual.routes, null);
+  });
+
+  test('should error when builder version 4 uses routes', () => {
+    const nowConfig = { routes: [{ src: '/page', dest: '/another' }] };
+    const actual = getTransformedRoutes({ nowConfig, builderVersion: 4 });
+    assert.notEqual(actual.error, null);
+    assert.equal(actual.error.code, 'invalid_builder_result');
+  });
+
+  test('should not error when builder version 4 uses rewrites', () => {
+    const nowConfig = {
+      rewrites: [{ source: '/page', destination: '/another' }],
+    };
+    const actual = getTransformedRoutes({ nowConfig, builderVersion: 4 });
+    assert.equal(actual.error, null);
+    assert.notEqual(actual.routes, null);
+    assertValid(actual.routes);
   });
 });


### PR DESCRIPTION
- Add now dev `BuildResultV4` type similar to V3 but no routes, only superstatic keys
- Add validation to `@now/routing-utils` to ensure V4 Builders do not return `routes`

Note, no builders have been changed yet because this needs to be shipped first so we can bump build-utils and then builders will work in production. Then in a separate PR, we can update builders to V4.