### PR TITLE
[now-cli] Deprecate `now alias`

### DIFF
--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -71,6 +71,12 @@ export default async function set(
     throw err;
   }
 
+  output.warn(
+    `The ${cmd('now alias')} command was deprecated in favor of ${cmd(
+      'now --prod'
+    )}.`
+  );
+
   // If there are more than two args we have to error
   if (args.length > 2) {
     output.error(

--- a/packages/now-cli/src/util/alias/get-inferred-targets.ts
+++ b/packages/now-cli/src/util/alias/get-inferred-targets.ts
@@ -7,12 +7,6 @@ export default async function getInferredTargets(
   output: Output,
   config: Config
 ) {
-  output.warn(
-    `The ${cmd(
-      'now alias'
-    )} command (no arguments) was deprecated in favor of ${cmd('now --prod')}.`
-  );
-
   // This field is deprecated, warn about it
   if (config.aliases) {
     output.warn('The `aliases` field has been deprecated in favor of `alias`');


### PR DESCRIPTION
The `now alias` command will be deprecate in favor of `now --prod`.

[PRODUCT-556]

[PRODUCT-556]: https://zeit.atlassian.net/browse/PRODUCT-556