### PR TITLE
[now-client] Fix publish output

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -141,7 +141,6 @@
     "mri": "1.1.0",
     "ms": "2.1.2",
     "node-fetch": "1.7.3",
-    "now-client": "./packages/now-client",
     "npm-package-arg": "6.1.0",
     "nyc": "13.2.0",
     "ora": "3.4.0",

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -6,7 +6,7 @@ import {
   createDeployment,
   createLegacyDeployment,
   DeploymentOptions,
-} from '../../../../now-client';
+} from 'now-client';
 import wait from '../output/wait';
 import { Output } from '../output';
 // @ts-ignore

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -6,7 +6,7 @@ import {
   createDeployment,
   createLegacyDeployment,
   DeploymentOptions,
-} from 'now-client';
+} from 'now-client/dist';
 import wait from '../output/wait';
 import { Output } from '../output';
 // @ts-ignore

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/now-client"
   },
   "scripts": {
-    "build": "tsc && rm dist/package.json",
+    "build": "tsc",
     "test-integration-once": "jest --verbose --forceExit",
     "test-lint": "eslint . --ext .js,.ts --ignore-path ../../.eslintignore"
   },

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -14,8 +14,7 @@
     "directory": "packages/now-client"
   },
   "scripts": {
-    "build": "tsc",
-    "prepare": "npm run build",
+    "build": "tsc && rm dist/package.json",
     "test-integration-once": "jest --verbose --forceExit",
     "test-lint": "eslint . --ext .js,.ts --ignore-path ../../.eslintignore"
   },

--- a/packages/now-client/src/pkg.ts
+++ b/packages/now-client/src/pkg.ts
@@ -1,0 +1,3 @@
+//eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../package.json');
+export const pkgVersion = pkg.version;

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -4,6 +4,7 @@ import fetch_ from 'node-fetch';
 import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
+import { pkgVersion } from '../pkg';
 import { Options } from '../deploy';
 import { NowJsonOptions, DeploymentOptions } from '../types';
 import { Sema } from 'async-sema';
@@ -12,9 +13,6 @@ const semaphore = new Sema(10);
 
 export const API_FILES = '/v2/now/files';
 export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
-
-//eslint-disable-next-line @typescript-eslint/no-var-requires
-const pkg = require('../../package.json');
 
 export const EVENTS = new Set([
   // File events
@@ -139,7 +137,7 @@ export const fetch = async (
     ...opts.headers,
     authorization: `Bearer ${token}`,
     accept: 'application/json',
-    'user-agent': `now-client-v${pkg.version}`,
+    'user-agent': `now-client-v${pkgVersion}`,
   };
 
   debug(`${opts.method || 'GET'} ${url}`);

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -4,7 +4,6 @@ import fetch_ from 'node-fetch';
 import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
-import pkg from '../../package.json';
 import { Options } from '../deploy';
 import { NowJsonOptions, DeploymentOptions } from '../types';
 import { Sema } from 'async-sema';
@@ -13,6 +12,9 @@ const semaphore = new Sema(10);
 
 export const API_FILES = '/v2/now/files';
 export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
+
+//eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../../package.json');
 
 export const EVENTS = new Set([
   // File events

--- a/packages/now-client/tsconfig.json
+++ b/packages/now-client/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext"],
     "module": "CommonJS",
     "moduleResolution": "node",
-    "outDir": "./dist",
+    "outDir": "dist",
     "resolveJsonModule": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
@@ -15,5 +15,5 @@
     "target": "ES2015",
     "downlevelIteration": true
   },
-  "include": ["./src", "./types"]
+  "include": ["./src"]
 }

--- a/packages/now-client/tsconfig.json
+++ b/packages/now-client/tsconfig.json
@@ -6,7 +6,6 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "dist",
-    "resolveJsonModule": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7972,20 +7972,6 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
   integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
-now-client@./packages/now-client:
-  version "5.1.1-canary.17"
-  dependencies:
-    "@zeit/fetch" "5.1.0"
-    async-retry "1.2.3"
-    async-sema "3.0.0"
-    fs-extra "8.0.1"
-    ignore "4.0.6"
-    ms "2.1.2"
-    node-fetch "2.6.0"
-    querystring "^0.2.0"
-    recursive-readdir "2.2.2"
-    sleep-promise "8.0.1"
-
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"


### PR DESCRIPTION
Fixes #3310

The root `package.json` file is copied to `dist` by tsc because of a relative import. This causes npm `files` property to be nested and therefore skip publishing most of the files.

```ts
import pkg from '../../package.json';
```

Disabling `resolveJsonModule` and using `require()` instead fixed it.

However, this change caused `now-cli` build to fail so I had to change the way `now-client` gets imported.
