### PR TITLE
[now-next] Make lambda memory test more reliable

### DIFF
--- a/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
@@ -16,7 +16,7 @@
     {
       "path": "/api/memory",
       "status": 200,
-      "mustContain": "true"
+      "mustContain": "128"
     }
   ]
 }

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/memory.js
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/memory.js
@@ -1,5 +1,3 @@
-import os from 'os';
-
 export default function(req, res) {
-  res.end(`${4.5e8 > os.memtotal()}`);
+  res.end(`${process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE}`);
 }


### PR DESCRIPTION
Make lambda memory test more reliable, like it works in Now CLI.