### PR TITLE
Prevent removing ongoing deployments while using safe flag

### DIFF
--- a/packages/now-cli/src/commands/remove.js
+++ b/packages/now-cli/src/commands/remove.js
@@ -38,7 +38,7 @@ const help = () => {
     'TOKEN'
   )}        Login token
     -y, --yes                      Skip confirmation
-    -s, --safe                     Skip deployments with an active alias
+    -s, --safe                     Skip finished deployments with an active alias
     -S, --scope                    Set a custom scope
 
   ${chalk.dim('Examples:')}
@@ -196,6 +196,10 @@ export default async function main(ctx) {
   }
 
   deployments = deployments.filter((match, i) => {
+    if (argv.safe && match.state !== 'READY' || match.state !== 'ERROR') {
+      return false;
+    }
+
     if (argv.safe && aliases[i].length > 0) {
       return false;
     }


### PR DESCRIPTION
The background behind this proposal is described in #1919

TL;DR; I think it's not safe to remove ongoing deployments, and in many cases, it's just a very frustrating behavior.

Re-submitted after closing #2274