### PR TITLE
[all] Bump npm version to match export version

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/build-utils",
-  "version": "1.0.1-canary.0",
+  "version": "3.0.0-canary.0",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",

--- a/packages/now-cgi/package.json
+++ b/packages/now-cgi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/cgi",
-  "version": "1.0.1-canary.0",
+  "version": "3.0.0-canary.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/go",
-  "version": "1.0.1-canary.0",
+  "version": "3.0.0-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/runtimes#official-runtimes/go",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/node",
-  "version": "1.1.3-canary.0",
+  "version": "3.0.0-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/runtimes#official-runtimes/node-js",

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/python",
-  "version": "1.0.1-canary.0",
+  "version": "3.0.0-canary.0",
   "main": "./dist/index.js",
   "license": "MIT",
   "homepage": "https://zeit.co/docs/runtimes#official-runtimes/python",

--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@now/ruby",
   "author": "Nathan Cahill <nathan@nathancahill.com>",
-  "version": "1.0.1-canary.0",
+  "version": "3.0.0-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/runtimes#official-runtimes/ruby",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@now/static-build",
-  "version": "0.12.3-canary.0",
+  "version": "2.0.0-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://zeit.co/docs/runtimes#official-runtimes/static-builds",


### PR DESCRIPTION
This bumps the versions of each npm package to match the exported version.

After we publish these changes, a follow up PR will be used to "lock" builder versions in now deployments as well as `now dev`.

- Related to #3298 
- Related to #3254 