### PR TITLE
[now-cli] Handle `uv_cwd` error when cwd is deleted

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
+import error from './util/output/error';
+import param from './util/output/param';
+import info from './util/output/info';
 try {
+  // Test to see if cwd has been deleted before
+  // importing 3rd party packages that might need cwd.
   process.cwd();
-} catch (error) {
-  if (error && error.message && error.message.includes('uv_cwd')) {
-    console.error('The current working directory does not exist.');
+} catch (e) {
+  if (e && e.message && e.message.includes('uv_cwd')) {
+    console.error(error('The current working directory does not exist.'));
     process.exit(1);
   }
-  throw error;
 }
 import 'core-js/modules/es7.symbol.async-iterator';
 import { join } from 'path';
@@ -20,9 +24,7 @@ import checkForUpdate from 'update-check';
 import ms from 'ms';
 import { URL } from 'url';
 import * as Sentry from '@sentry/node';
-import error from './util/output/error';
-import param from './util/output/param.ts';
-import info from './util/output/info';
+
 import getNowDir from './util/config/global-path';
 import {
   getDefaultConfig,

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -24,7 +24,6 @@ import checkForUpdate from 'update-check';
 import ms from 'ms';
 import { URL } from 'url';
 import * as Sentry from '@sentry/node';
-
 import getNowDir from './util/config/global-path';
 import {
   getDefaultConfig,

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+try {
+  process.cwd();
+} catch (error) {
+  if (error && error.message && error.message.includes('uv_cwd')) {
+    console.error('The current working directory does not exist.');
+    process.exit(1);
+  }
+  throw error;
+}
 import 'core-js/modules/es7.symbol.async-iterator';
 import { join } from 'path';
 import { existsSync } from 'fs';

--- a/packages/now-cli/src/util/report-error.ts
+++ b/packages/now-cli/src/util/report-error.ts
@@ -1,11 +1,20 @@
 import Client from './client';
-import getScope from './get-scope.ts';
+import getScope from './get-scope';
 import getArgs from './get-args';
+import { Team, User } from '../types';
 
-export default async (sentry, error, apiUrl, configFiles) => {
-  let user;
-  let team;
-  let scopeError;
+export default async function reportError(
+  sentry: typeof import('@sentry/node'),
+  error: Error,
+  apiUrl: string,
+  configFiles: typeof import('./config/files')
+) {
+  if (ignoreError(error)) {
+    return;
+  }
+  let user: User | undefined;
+  let team: Team | null | undefined;
+  let scopeError: Error | undefined;
 
   try {
     const { token } = configFiles.readAuthConfigFile();
@@ -23,15 +32,9 @@ export default async (sentry, error, apiUrl, configFiles) => {
       const spec = {
         email: user.email,
         id: user.uid,
+        username: user.username,
+        name: (user as any).name,
       };
-
-      if (user.username) {
-        spec.username = user.username;
-      }
-
-      if (user.name) {
-        spec.name = user.name;
-      }
 
       scope.setUser(spec);
     }
@@ -49,8 +52,8 @@ export default async (sentry, error, apiUrl, configFiles) => {
     }
 
     // Report `process.argv` without sensitive data
-    let args;
-    let argsError;
+    let args: any | undefined;
+    let argsError: Error | undefined;
     try {
       args = getArgs(process.argv.slice(2), {});
     } catch (err) {
@@ -60,7 +63,7 @@ export default async (sentry, error, apiUrl, configFiles) => {
     if (args) {
       const flags = ['--env', '--build-env', '--token'];
       for (const flag of flags) {
-        if (args[flag]) args[flag] = 'REDACTED';
+        if (args['--env']) args[flag] = 'REDACTED';
       }
       if (
         args._.length >= 4 &&
@@ -93,4 +96,8 @@ export default async (sentry, error, apiUrl, configFiles) => {
   if (client) {
     await client.close();
   }
-};
+}
+
+function ignoreError(error: Error) {
+  return error.message.includes('uv_cwd');
+}

--- a/packages/now-cli/src/util/report-error.ts
+++ b/packages/now-cli/src/util/report-error.ts
@@ -63,7 +63,7 @@ export default async function reportError(
     if (args) {
       const flags = ['--env', '--build-env', '--token'];
       for (const flag of flags) {
-        if (args['--env']) args[flag] = 'REDACTED';
+        if (args[flag]) args[flag] = 'REDACTED';
       }
       if (
         args._.length >= 4 &&

--- a/packages/now-cli/src/util/report-error.ts
+++ b/packages/now-cli/src/util/report-error.ts
@@ -98,6 +98,6 @@ export default async function reportError(
   }
 }
 
-function ignoreError(error: Error) {
-  return error.message.includes('uv_cwd');
+function ignoreError(error: Error | undefined) {
+  return error && error.message && error.message.includes('uv_cwd');
 }


### PR DESCRIPTION
Converts `reportError()` to typescript and adds an ignore list.

In particular, `uv_cwd` comes from `process.cwd()` so we don't need to track these errors in the case the user deletes their current working directory.

This is a follow up to #3194 which handled only one scenario.