### PR TITLE
[CircleCI] Remove `rsync` apt-get install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: Installing apt dependencies
-          command: sudo apt install -y rsync
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
Used to be used in the now-cli build script when it was a bash script.
Now it's a TypeScript file and the `cpy` module is used instead.