### PR TITLE
[now-build-utils] Fix canary selection for static build

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -96,6 +96,8 @@ async function detectFrontBuilder(
   builders: Builder[],
   options: Options
 ): Promise<Builder> {
+  const { tag } = options;
+  const withTag = tag ? `@${tag}` : '';
   for (const [dependency, builder] of getBuilders(options)) {
     const deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
 
@@ -121,7 +123,7 @@ async function detectFrontBuilder(
   }
 
   // By default we'll choose the `static-build` builder
-  return { src, use: '@now/static-build', config };
+  return { src, use: `@now/static-build${withTag}`, config };
 }
 
 // Files that match a specific pattern will get ignored
@@ -289,8 +291,7 @@ function validateFunctions(files: string[], { functions = {} }: Options) {
     if (path.startsWith('/')) {
       return {
         code: 'invalid_function_source',
-        message:
-          `The function path "${path}" is invalid. The path must be relative to your project root and therefore cannot start with a slash.`,
+        message: `The function path "${path}" is invalid. The path must be relative to your project root and therefore cannot start with a slash.`,
       };
     }
 

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -288,6 +288,19 @@ describe('Test `detectBuilders`', () => {
     expect(builders.length).toBe(1);
   });
 
+  it('nuxt + tag canary', async () => {
+    const pkg = {
+      scripts: { build: 'nuxt build' },
+      dependencies: { nuxt: '2.8.1' },
+    };
+    const files = ['package.json', 'pages/index.js'];
+
+    const { builders } = await detectBuilders(files, pkg, { tag: 'canary' });
+    expect(builders[0].use).toBe('@now/static-build@canary');
+    expect(builders[0].src).toBe('package.json');
+    expect(builders.length).toBe(1);
+  });
+
   it('package.json with no build + api', async () => {
     const pkg = { dependencies: { next: '9.0.0' } };
     const files = ['package.json', 'api/[endpoint].js'];


### PR DESCRIPTION
We expect `now@canary` to use canary builders. This PR fixes a bug where a zero config deployment was selecting `@now/static-build` instead of `@now/static-build@canary`.