### PR TITLE
[now-routing-utils] Add support for `check: true`

### DIFF
--- a/packages/now-routing-utils/src/schemas.ts
+++ b/packages/now-routing-utils/src/schemas.ts
@@ -43,6 +43,9 @@ export const routesSchema = {
       continue: {
         type: 'boolean',
       },
+      check: {
+        type: 'boolean',
+      },
       status: {
         type: 'integer',
         minimum: 100,

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -45,21 +45,22 @@ export function convertRedirects(redirects: NowRedirect[]): Route[] {
   return redirects.map(r => {
     const { src, segments } = sourceToRegex(r.source);
     const loc = replaceSegments(segments, r.destination);
-    return {
+    const route: Route = {
       src,
       headers: { Location: loc },
       status: r.statusCode || 307,
     };
+    return route;
   });
 }
 
 export function convertRewrites(rewrites: NowRewrite[]): Route[] {
-  const routes: Route[] = rewrites.map(r => {
+  return rewrites.map(r => {
     const { src, segments } = sourceToRegex(r.source);
     const dest = replaceSegments(segments, r.destination);
-    return { src, dest, continue: true };
+    const route: Route = { src, dest, check: true };
+    return route;
   });
-  return routes;
 }
 
 export function convertHeaders(headers: NowHeader[]): Route[] {
@@ -68,11 +69,12 @@ export function convertHeaders(headers: NowHeader[]): Route[] {
     h.headers.forEach(kv => {
       obj[kv.key] = kv.value;
     });
-    return {
+    const route: Route = {
       src: h.source,
       headers: obj,
       continue: true,
     };
+    return route;
   });
 }
 

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -17,6 +17,7 @@ export type Source = {
   headers?: { [name: string]: string };
   methods?: string[];
   continue?: boolean;
+  check?: boolean;
   status?: number;
 };
 

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -377,6 +377,28 @@ describe('normalizeRoutes', () => {
     );
   });
 
+  test('fails if check is not boolean', () => {
+    assertError(
+      [
+        // @ts-ignore
+        {
+          check: 'false',
+        },
+      ],
+      [
+        {
+          dataPath: '[0].check',
+          keyword: 'type',
+          message: 'should be boolean',
+          params: {
+            type: 'boolean',
+          },
+          schemaPath: '#/items/properties/check/type',
+        },
+      ]
+    );
+  });
+
   test('fails if status is not number', () => {
     assertError(
       [
@@ -492,7 +514,7 @@ describe('getTransformedRoutes', () => {
         status: 302,
       },
       { handle: 'filesystem' },
-      { src: '^/v1$', dest: '/v2/api.py', continue: true },
+      { src: '^/v1$', dest: '/v2/api.py', check: true },
     ];
     assert.deepEqual(actual.error, null);
     assert.deepEqual(actual.routes, expected);

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -210,16 +210,16 @@ test('convertRewrites', () => {
   ]);
 
   const expected = [
-    { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', continue: true },
+    { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', check: true },
     {
       src: '^\\/firebase\\/(.*)$',
       dest: 'https://www.firebase.com',
-      continue: true,
+      check: true,
     },
     {
       src: '^\\/projects\\/([^\\/]+?)\\/edit$',
       dest: '/projects.html?id=$1',
-      continue: true,
+      check: true,
     },
   ];
 


### PR DESCRIPTION
This PR adds support for `check: true` for a route object. It is basically a way to add a rewrite and still check the filesystem.