### PR TITLE
[now-client] Fix `main` in package.json

### DIFF
--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "now-client",
   "version": "5.2.4",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "typings": "dist/src/index.d.ts",
   "homepage": "https://zeit.co",
   "license": "MIT",

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -2,7 +2,7 @@
   "name": "now-client",
   "version": "5.2.4",
   "main": "dist/index.js",
-  "typings": "dist/src/index.d.ts",
+  "typings": "dist/index.d.ts",
   "homepage": "https://zeit.co",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
This sets `main` in `now-client` to a proper path

Follow up to #3315 

Fixes #3373