### PR TITLE
[now dev] skip installing already installed versioned runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 package-lock.json
 dist
+.vscode
 npm-debug.log
 yarn-error.log
 .nyc_output

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -158,6 +158,14 @@ export function getBuildUtils(packages: string[]): string {
   return `@now/build-utils@${version}`;
 }
 
+function parseVersionSafe(rawSpec: string) {
+  try {
+    return semver.parse(rawSpec);
+  } catch (e) {
+    return null;
+  }
+}
+
 export function filterPackage(
   builderSpec: string,
   distTag: string,
@@ -165,7 +173,7 @@ export function filterPackage(
 ) {
   if (builderSpec in localBuilders) return false;
   const parsed = npa(builderSpec);
-  const parsedVersion = semver.parse(parsed.rawSpec);
+  const parsedVersion = parseVersionSafe(parsed.rawSpec);
   // skip install of already installed runtime
   if (
     parsed.name &&

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -165,6 +165,17 @@ export function filterPackage(
 ) {
   if (builderSpec in localBuilders) return false;
   const parsed = npa(builderSpec);
+  const parsedVersion = semver.parse(parsed.rawSpec);
+  // skip install of already installed runtime
+  if (
+    parsed.name &&
+    parsed.type === 'version' &&
+    parsedVersion &&
+    buildersPkg.dependencies &&
+    parsedVersion.version == buildersPkg.dependencies[parsed.name]
+  ) {
+    return false;
+  }
   if (
     parsed.name &&
     parsed.type === 'tag' &&

--- a/packages/now-cli/test/dev-builder.unit.js
+++ b/packages/now-cli/test/dev-builder.unit.js
@@ -4,8 +4,8 @@ import { filterPackage } from '../src/util/dev/builder-cache';
 test('[dev-builder] filter install "latest", cached canary', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1-canary.0'
-    }
+      '@now/build-utils': '0.0.1-canary.0',
+    },
   };
   const result = filterPackage('@now/build-utils', 'canary', buildersPkg);
   t.is(result, true);
@@ -14,8 +14,8 @@ test('[dev-builder] filter install "latest", cached canary', async t => {
 test('[dev-builder] filter install "canary", cached stable', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1'
-    }
+      '@now/build-utils': '0.0.1',
+    },
   };
   const result = filterPackage(
     '@now/build-utils@canary',
@@ -28,8 +28,8 @@ test('[dev-builder] filter install "canary", cached stable', async t => {
 test('[dev-builder] filter install "latest", cached stable', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1'
-    }
+      '@now/build-utils': '0.0.1',
+    },
   };
   const result = filterPackage('@now/build-utils', 'latest', buildersPkg);
   t.is(result, false);
@@ -38,8 +38,8 @@ test('[dev-builder] filter install "latest", cached stable', async t => {
 test('[dev-builder] filter install "canary", cached canary', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1-canary.0'
-    }
+      '@now/build-utils': '0.0.1-canary.0',
+    },
   };
   const result = filterPackage(
     '@now/build-utils@canary',
@@ -52,8 +52,8 @@ test('[dev-builder] filter install "canary", cached canary', async t => {
 test('[dev-builder] filter install URL, cached stable', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1'
-    }
+      '@now/build-utils': '0.0.1',
+    },
   };
   const result = filterPackage('https://tarball.now.sh', 'latest', buildersPkg);
   t.is(result, true);
@@ -62,8 +62,8 @@ test('[dev-builder] filter install URL, cached stable', async t => {
 test('[dev-builder] filter install URL, cached canary', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': '0.0.1-canary.0'
-    }
+      '@now/build-utils': '0.0.1-canary.0',
+    },
   };
   const result = filterPackage('https://tarball.now.sh', 'canary', buildersPkg);
   t.is(result, true);
@@ -72,8 +72,8 @@ test('[dev-builder] filter install URL, cached canary', async t => {
 test('[dev-builder] filter install "latest", cached URL - stable', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': 'https://tarball.now.sh'
-    }
+      '@now/build-utils': 'https://tarball.now.sh',
+    },
   };
   const result = filterPackage('@now/build-utils', 'latest', buildersPkg);
   t.is(result, true);
@@ -82,9 +82,39 @@ test('[dev-builder] filter install "latest", cached URL - stable', async t => {
 test('[dev-builder] filter install "latest", cached URL - canary', async t => {
   const buildersPkg = {
     dependencies: {
-      '@now/build-utils': 'https://tarball.now.sh'
-    }
+      '@now/build-utils': 'https://tarball.now.sh',
+    },
   };
   const result = filterPackage('@now/build-utils', 'canary', buildersPkg);
+  t.is(result, true);
+});
+
+test('[dev-builder] filter install not bundled version, cached same version', async t => {
+  const buildersPkg = {
+    dependencies: {
+      'not-bundled-package': '0.0.1',
+    },
+  };
+  const result = filterPackage('not-bundled-package@0.0.1', '_', buildersPkg);
+  t.is(result, false);
+});
+
+test('[dev-builder] filter install not bundled version, cached different version', async t => {
+  const buildersPkg = {
+    dependencies: {
+      'not-bundled-package': '0.0.9',
+    },
+  };
+  const result = filterPackage('not-bundled-package@0.0.1', '_', buildersPkg);
+  t.is(result, true);
+});
+
+test('[dev-builder] filter install not bundled stable, cached version', async t => {
+  const buildersPkg = {
+    dependencies: {
+      'not-bundled-package': '0.0.1',
+    },
+  };
+  const result = filterPackage('not-bundled-package', '_', buildersPkg);
   t.is(result, true);
 });

--- a/packages/now-cli/test/dev-builder.unit.js
+++ b/packages/now-cli/test/dev-builder.unit.js
@@ -118,3 +118,13 @@ test('[dev-builder] filter install not bundled stable, cached version', async t 
   const result = filterPackage('not-bundled-package', '_', buildersPkg);
   t.is(result, true);
 });
+
+test('[dev-builder] filter install not bundled tagged, cached tagged', async t => {
+  const buildersPkg = {
+    dependencies: {
+      'not-bundled-package': '16.9.0-alpha.0',
+    },
+  };
+  const result = filterPackage('not-bundled-package@alpha', '_', buildersPkg);
+  t.is(result, true);
+});


### PR DESCRIPTION
Fixes #3353
The current solution might break if a user interrupts `now dev` while yarn wrote the package in the cache package.json but has not yet added to node_modules.
This happens in like 20 ms but is possible, so we could execute `yarn` every time to be sure.
Tell me if the above is a problem or not