### PR TITLE
[now-routing-utils] Add mergeRoutes function

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from './superstatic';
 
 export { getCleanUrls } from './superstatic';
+export { mergeRoutes } from './merge';
 
 export function isHandler(route: Route): route is Handler {
   return typeof (route as Handler).handle !== 'undefined';

--- a/packages/now-routing-utils/src/merge.ts
+++ b/packages/now-routing-utils/src/merge.ts
@@ -1,0 +1,78 @@
+import { Route, MergeRoutesProps } from './types';
+import { isHandler } from './index';
+
+interface BuilderToRoute {
+  [use: string]: Route[];
+}
+
+interface BuilderRoutes {
+  [entrypoint: string]: BuilderToRoute;
+}
+
+export function mergeRoutes({ userRoutes, builds }: MergeRoutesProps): Route[] {
+  const outputRoutes = (userRoutes || []).slice(0); // shallow clone
+  const builderRoutes: BuilderRoutes = {};
+  const sortedBuilderRoutes: Route[] = [];
+  const afterFilesystemBuilderRoutes: Route[] = [];
+  let handleFilesystem = false;
+
+  for (const build of builds) {
+    if (build.routes) {
+      if (!builderRoutes[build.entrypoint]) {
+        builderRoutes[build.entrypoint] = {};
+      }
+
+      builderRoutes[build.entrypoint][build.use] = build.routes.map(route => {
+        //route.built = true; // TODO: is this necessary?
+        return route;
+      });
+    }
+  }
+
+  const sortedPaths = Object.keys(builderRoutes).sort();
+  sortedPaths.forEach(path => {
+    const br = builderRoutes[path];
+    const sortedBuilders = Object.keys(br).sort();
+    sortedBuilders.forEach(use => {
+      let normalRoute = true;
+      br[use].forEach(route => {
+        if (normalRoute) {
+          if (isHandler(route) && route.handle === 'filesystem') {
+            normalRoute = false;
+          } else {
+            sortedBuilderRoutes.push(route);
+          }
+        } else {
+          afterFilesystemBuilderRoutes.push(route);
+        }
+      });
+    });
+  });
+
+  // If the user routes specify a handle: 'filesystem', inject
+  // the sortedBuilderRoutes right before it.
+  // FYI: outputRoutes already contains all user routes
+  outputRoutes.some((r, i) => {
+    if (!handleFilesystem && isHandler(r) && r.handle === 'filesystem') {
+      handleFilesystem = true;
+      outputRoutes.splice(i, 0, ...sortedBuilderRoutes);
+    }
+    return handleFilesystem;
+  });
+
+  // If the user's routes did not specify handle: 'filesystem',
+  // push the sortedBuilderRoutes to the end of the user routes.
+  if (!handleFilesystem) {
+    outputRoutes.push(...sortedBuilderRoutes);
+
+    // We only want to inject { handle: 'filesystem' } if it
+    // was defined by builder routes.
+    if (afterFilesystemBuilderRoutes.length > 0) {
+      outputRoutes.push({ handle: 'filesystem' });
+    }
+  }
+  // Finally, push the routes that should appear after handle:
+  // 'filesystem' -- these will be after all user defined routes.
+  outputRoutes.push(...afterFilesystemBuilderRoutes);
+  return outputRoutes;
+}

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -36,6 +36,17 @@ export interface GetRoutesProps {
   nowConfig: NowConfig;
 }
 
+export interface MergeRoutesProps {
+  userRoutes?: Route[];
+  builds: Build[];
+}
+
+export interface Build {
+  use: string;
+  entrypoint: string;
+  routes?: Route[];
+}
+
 export interface NowConfig {
   name?: string;
   version?: number;

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -37,7 +37,7 @@ export interface GetRoutesProps {
 }
 
 export interface MergeRoutesProps {
-  userRoutes?: Route[];
+  userRoutes?: Route[] | null | undefined;
   builds: Build[];
 }
 

--- a/packages/now-routing-utils/test/merge.spec.js
+++ b/packages/now-routing-utils/test/merge.spec.js
@@ -1,0 +1,180 @@
+const { deepEqual } = require('assert');
+const { mergeRoutes } = require('../dist/merge');
+
+test('mergeRoutes simple', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { src: '/user2', dest: '/u2' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [{ src: '/node1', dest: '/n1' }, { src: '/node2', dest: '/n2' }],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { src: '/python2', dest: '/py2' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { dest: '/u1', src: '/user1' },
+    { dest: '/u2', src: '/user2' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/n2', src: '/node2' },
+    { dest: '/py1', src: '/python1' },
+    { dest: '/py2', src: '/python2' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes continue', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1', continue: true },
+    { src: '/user2', dest: '/u2' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1', continue: true },
+        { src: '/node2', dest: '/n2' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1', continue: true },
+        { src: '/python2', dest: '/py2' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { continue: true, dest: '/u1', src: '/user1' },
+    { dest: '/u2', src: '/user2' },
+    { continue: true, dest: '/n1', src: '/node1' },
+    { dest: '/n2', src: '/node2' },
+    { continue: true, dest: '/py1', src: '/python1' },
+    { dest: '/py2', src: '/python2' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes handle filesystem user routes', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { handle: 'filesystem' },
+    { src: '/user2', dest: '/u2' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [{ src: '/node1', dest: '/n1' }, { src: '/node2', dest: '/n2' }],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { src: '/python2', dest: '/py2' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { dest: '/u1', src: '/user1' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/n2', src: '/node2' },
+    { dest: '/py1', src: '/python1' },
+    { dest: '/py2', src: '/python2' },
+    { handle: 'filesystem' },
+    { dest: '/u2', src: '/user2' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes handle filesystem build routes', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { src: '/user2', dest: '/u2' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1' },
+        { handle: 'filesystem' },
+        { src: '/node2', dest: '/n2' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { handle: 'filesystem' },
+        { src: '/python2', dest: '/py2' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { dest: '/u1', src: '/user1' },
+    { dest: '/u2', src: '/user2' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/py1', src: '/python1' },
+    { handle: 'filesystem' },
+    { dest: '/n2', src: '/node2' },
+    { dest: '/py2', src: '/python2' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes handle filesystem both user and builds', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { handle: 'filesystem' },
+    { src: '/user2', dest: '/u2' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1' },
+        { handle: 'filesystem' },
+        { src: '/node2', dest: '/n2' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { handle: 'filesystem' },
+        { src: '/python2', dest: '/py2' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { dest: '/u1', src: '/user1' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/py1', src: '/python1' },
+    { handle: 'filesystem' },
+    { dest: '/u2', src: '/user2' },
+    { dest: '/n2', src: '/node2' },
+    { dest: '/py2', src: '/python2' },
+  ];
+  deepEqual(actual, expected);
+});

--- a/packages/now-routing-utils/test/merge.spec.js
+++ b/packages/now-routing-utils/test/merge.spec.js
@@ -58,11 +58,11 @@ test('mergeRoutes continue', () => {
   ];
   const actual = mergeRoutes({ userRoutes, builds });
   const expected = [
+    { continue: true, dest: '/n1', src: '/node1' },
+    { continue: true, dest: '/py1', src: '/python1' },
     { continue: true, dest: '/u1', src: '/user1' },
     { dest: '/u2', src: '/user2' },
-    { continue: true, dest: '/n1', src: '/node1' },
     { dest: '/n2', src: '/node2' },
-    { continue: true, dest: '/py1', src: '/python1' },
     { dest: '/py2', src: '/python2' },
   ];
   deepEqual(actual, expected);

--- a/packages/now-routing-utils/test/merge.spec.js
+++ b/packages/now-routing-utils/test/merge.spec.js
@@ -226,7 +226,7 @@ test('mergeRoutes check true', () => {
   deepEqual(actual, expected);
 });
 
-test('mergeRoutes check true, continue true, handle filesystem', () => {
+test('mergeRoutes check true, continue true, handle filesystem middle', () => {
   const userRoutes = [
     { src: '/user1', dest: '/u1', continue: true },
     { src: '/user2', dest: '/u2' },
@@ -267,6 +267,44 @@ test('mergeRoutes check true, continue true, handle filesystem', () => {
     { dest: '/u3', src: '/user3' },
     { dest: '/n3', src: '/node3' },
     { dest: '/py3', src: '/python3' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes check true, continue true, handle filesystem top', () => {
+  const userRoutes = [{ handle: 'filesystem' }, { src: '/user1', dest: '/u1' }];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { handle: 'filesystem' },
+        { src: '/node1', dest: '/n1' },
+        { src: '/node2', dest: '/n2', continue: true },
+        { src: '/node3', dest: '/n3', check: true },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { handle: 'filesystem' },
+        { src: '/python1', dest: '/py1' },
+        { src: '/python2', dest: '/py2', check: true },
+        { src: '/python3', dest: '/py3', continue: true },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { handle: 'filesystem' },
+    { continue: true, dest: '/n2', src: '/node2' },
+    { continue: true, dest: '/py3', src: '/python3' },
+    { dest: '/u1', src: '/user1' },
+    { check: true, dest: '/n3', src: '/node3' },
+    { check: true, dest: '/py2', src: '/python2' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/py1', src: '/python1' },
   ];
   deepEqual(actual, expected);
 });

--- a/packages/now-routing-utils/test/merge.spec.js
+++ b/packages/now-routing-utils/test/merge.spec.js
@@ -33,41 +33,6 @@ test('mergeRoutes simple', () => {
   deepEqual(actual, expected);
 });
 
-test('mergeRoutes continue', () => {
-  const userRoutes = [
-    { src: '/user1', dest: '/u1', continue: true },
-    { src: '/user2', dest: '/u2' },
-  ];
-  const builds = [
-    {
-      use: '@now/node',
-      entrypoint: 'api/home.js',
-      routes: [
-        { src: '/node1', dest: '/n1', continue: true },
-        { src: '/node2', dest: '/n2' },
-      ],
-    },
-    {
-      use: '@now/python',
-      entrypoint: 'api/users.py',
-      routes: [
-        { src: '/python1', dest: '/py1', continue: true },
-        { src: '/python2', dest: '/py2' },
-      ],
-    },
-  ];
-  const actual = mergeRoutes({ userRoutes, builds });
-  const expected = [
-    { continue: true, dest: '/n1', src: '/node1' },
-    { continue: true, dest: '/py1', src: '/python1' },
-    { continue: true, dest: '/u1', src: '/user1' },
-    { dest: '/u2', src: '/user2' },
-    { dest: '/n2', src: '/node2' },
-    { dest: '/py2', src: '/python2' },
-  ];
-  deepEqual(actual, expected);
-});
-
 test('mergeRoutes handle filesystem user routes', () => {
   const userRoutes = [
     { src: '/user1', dest: '/u1' },
@@ -175,6 +140,133 @@ test('mergeRoutes handle filesystem both user and builds', () => {
     { dest: '/u2', src: '/user2' },
     { dest: '/n2', src: '/node2' },
     { dest: '/py2', src: '/python2' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes continue true', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { src: '/user2', dest: '/u2', continue: true },
+    { src: '/user3', dest: '/u3' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1' },
+        { src: '/node3', dest: '/n2', continue: true },
+        { src: '/node3', dest: '/n3' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { src: '/python2', dest: '/py2', continue: true },
+        { src: '/python3', dest: '/py3' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { continue: true, dest: '/n2', src: '/node3' },
+    { continue: true, dest: '/py2', src: '/python2' },
+    { dest: '/u1', src: '/user1' },
+    { continue: true, dest: '/u2', src: '/user2' },
+    { dest: '/u3', src: '/user3' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/n3', src: '/node3' },
+    { dest: '/py1', src: '/python1' },
+    { dest: '/py3', src: '/python3' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes check true', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1' },
+    { src: '/user2', dest: '/u2' },
+    { src: '/user3', dest: '/u3' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1' },
+        { src: '/node3', dest: '/n2', check: true },
+        { src: '/node3', dest: '/n3' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1' },
+        { src: '/python2', dest: '/py2', check: true },
+        { src: '/python3', dest: '/py3' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { dest: '/u1', src: '/user1' },
+    { dest: '/u2', src: '/user2' },
+    { dest: '/u3', src: '/user3' },
+    { check: true, dest: '/n2', src: '/node3' },
+    { check: true, dest: '/py2', src: '/python2' },
+    { dest: '/n1', src: '/node1' },
+    { dest: '/n3', src: '/node3' },
+    { dest: '/py1', src: '/python1' },
+    { dest: '/py3', src: '/python3' },
+  ];
+  deepEqual(actual, expected);
+});
+
+test('mergeRoutes check true, continue true, handle filesystem', () => {
+  const userRoutes = [
+    { src: '/user1', dest: '/u1', continue: true },
+    { src: '/user2', dest: '/u2' },
+    { handle: 'filesystem' },
+    { src: '/user3', dest: '/u3' },
+  ];
+  const builds = [
+    {
+      use: '@now/node',
+      entrypoint: 'api/home.js',
+      routes: [
+        { src: '/node1', dest: '/n1', continue: true },
+        { src: '/node3', dest: '/n2', check: true },
+        { handle: 'filesystem' },
+        { src: '/node3', dest: '/n3' },
+      ],
+    },
+    {
+      use: '@now/python',
+      entrypoint: 'api/users.py',
+      routes: [
+        { src: '/python1', dest: '/py1', check: true },
+        { src: '/python2', dest: '/py2', continue: true },
+        { handle: 'filesystem' },
+        { src: '/python3', dest: '/py3' },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { continue: true, dest: '/n1', src: '/node1' },
+    { continue: true, dest: '/py2', src: '/python2' },
+    { continue: true, dest: '/u1', src: '/user1' },
+    { dest: '/u2', src: '/user2' },
+    { check: true, dest: '/n2', src: '/node3' },
+    { check: true, dest: '/py1', src: '/python1' },
+    { handle: 'filesystem' },
+    { dest: '/u3', src: '/user3' },
+    { dest: '/n3', src: '/node3' },
+    { dest: '/py3', src: '/python3' },
   ];
   deepEqual(actual, expected);
 });


### PR DESCRIPTION
This moves the merging logic to `@now/routing-utils` and adds support for `check: true`.

- Builder before filesystem, continue: true
- User before filesystem
- Builder before filesystem, check: true
- Builder before filesystem, continue: false
- Handle filesystem
- Builder after filesystem, continue: true
- User after filesystem
- Builder after filesystem, check: true
- Builder after filesystem, continue: false
