### PR TITLE
[now-routing-utils] Update `path-to-regexp` to v6.1.0

### DIFF
--- a/packages/now-routing-utils/package.json
+++ b/packages/now-routing-utils/package.json
@@ -20,7 +20,7 @@
     "test-unit": "jest --env node --verbose --runInBand"
   },
   "dependencies": {
-    "path-to-regexp": "3.1.0"
+    "path-to-regexp": "6.1.0"
   },
   "devDependencies": {
     "ajv": "^6.0.0",

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -3,7 +3,7 @@
  * See https://github.com/firebase/superstatic#configuration
  */
 
-import pathToRegexp from 'path-to-regexp';
+import { pathToRegexp, Key } from 'path-to-regexp';
 import { Route, NowRedirect, NowRewrite, NowHeader } from './types';
 
 export function getCleanUrls(
@@ -97,7 +97,7 @@ export function convertTrailingSlash(enable: boolean): Route[] {
 }
 
 function sourceToRegex(source: string): { src: string; segments: string[] } {
-  const keys: pathToRegexp.Key[] = [];
+  const keys: Key[] = [];
   const r = pathToRegexp(source, keys, { strict: true });
   const segments = keys.map(k => k.name).filter(isString);
   return { src: r.source, segments };

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -148,6 +148,7 @@ test('convertCleanUrls false', () => {
 test('convertRedirects', () => {
   const actual = convertRedirects([
     { source: '/some/old/path', destination: '/some/new/path' },
+    { source: '/next(\\.js)?', destination: 'https://nextjs.org' },
     {
       source: '/firebase/(.*)',
       destination: 'https://www.firebase.com',
@@ -164,6 +165,11 @@ test('convertRedirects', () => {
     {
       src: '^\\/some\\/old\\/path$',
       headers: { Location: '/some/new/path' },
+      status: 307,
+    },
+    {
+      src: '^\\/next(\\.js)?$',
+      headers: { Location: 'https://nextjs.org' },
       status: 307,
     },
     {
@@ -187,6 +193,7 @@ test('convertRedirects', () => {
 
   const mustMatch = [
     ['/some/old/path'],
+    ['/next', '/next.js'],
     ['/firebase/one', '/firebase/2', '/firebase/-', '/firebase/dir/sub'],
     ['/projects/one/edit', '/projects/two/edit'],
     ['/old/one/path', '/old/two/path'],
@@ -194,6 +201,7 @@ test('convertRedirects', () => {
 
   const mustNotMatch = [
     ['/nope'],
+    ['/nextAjs', '/nextjs'],
     ['/fire', '/firebasejumper/two'],
     ['/projects/edit', '/projects/two/three/delete', '/projects'],
     ['/old/path', '/old/two/foo', '/old'],

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -167,17 +167,17 @@ test('convertRedirects', () => {
       status: 307,
     },
     {
-      src: '^\\/firebase\\/(.*)$',
+      src: '^\\/firebase(?:\\/(.*))$',
       headers: { Location: 'https://www.firebase.com' },
       status: 302,
     },
     {
-      src: '^\\/projects\\/([^\\/]+?)\\/([^\\/]+?)$',
+      src: '^\\/projects(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))$',
       headers: { Location: '/projects.html?id=$1&action=$2' },
       status: 307,
     },
     {
-      src: '^\\/old\\/([^\\/]+?)\\/path$',
+      src: '^\\/old(?:\\/([^\\/#\\?]+?))\\/path$',
       headers: { Location: '/new/path/$1' },
       status: 307,
     },
@@ -212,12 +212,12 @@ test('convertRewrites', () => {
   const expected = [
     { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', check: true },
     {
-      src: '^\\/firebase\\/(.*)$',
+      src: '^\\/firebase(?:\\/(.*))$',
       dest: 'https://www.firebase.com',
       check: true,
     },
     {
-      src: '^\\/projects\\/([^\\/]+?)\\/edit$',
+      src: '^\\/projects(?:\\/([^\\/#\\?]+?))\\/edit$',
       dest: '/projects.html?id=$1',
       check: true,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9695,7 +9695,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8610,10 +8610,10 @@ path-to-regexp@2.2.1:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
   integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
-path-to-regexp@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.1.0.tgz#f45a9cc4dc6331ae8f131e0ce4fde8607f802367"
-  integrity sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==
+path-to-regexp@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
 
 path-to-regexp@^1.0.0, path-to-regexp@^1.7.0:
   version "1.7.0"
@@ -9695,7 +9695,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 


### PR DESCRIPTION
This bumps `path-to-regexp` to the latest version 6.1.0 which fixes optional capture groups like the test I added for `/next.js`.