### PR TITLE
[now-cli] Add support for `check: true` routes in `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -89,10 +89,9 @@ export default async function(
         }
 
         if (routeConfig.check && devServer) {
-          const hasFile = await devServer.hasFilesystem(
-            routeConfig.dest || routeConfig.src
-          );
-          if (!hasFile) {
+          const filePath = url.parse(destPath).pathname || '';
+          const hasDestFile = await devServer.hasFilesystem(filePath);
+          if (!hasDestFile) {
             reqPathname = destPath;
             continue;
           }

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -89,9 +89,11 @@ export default async function(
         }
 
         if (routeConfig.check && devServer) {
-          const filePath = url.parse(destPath).pathname || '';
-          const hasDestFile = await devServer.hasFilesystem(filePath);
+          const { pathname = '/' } = url.parse(destPath);
+          const hasDestFile = await devServer.hasFilesystem(pathname);
           if (!hasDestFile) {
+            // If the file is not found, `check: true` will
+            // behave the same as `continue: true`
             reqPathname = destPath;
             continue;
           }

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -88,6 +88,16 @@ export default async function(
           continue;
         }
 
+        if (routeConfig.check && devServer) {
+          const hasFile = await devServer.hasFilesystem(
+            routeConfig.dest || routeConfig.src
+          );
+          if (!hasFile) {
+            reqPathname = destPath;
+            continue;
+          }
+        }
+
         if (isURL(destPath)) {
           found = {
             found: true,

--- a/packages/now-cli/test/dev/fixtures/routes-check-true/now.json
+++ b/packages/now-cli/test/dev/fixtures/routes-check-true/now.json
@@ -1,0 +1,19 @@
+{
+  "routes": [
+    {
+      "src": "/blog/(.*)",
+      "check": true,
+      "dest": "/blog?post=$1"
+    },
+    {
+      "src": "/(.*)",
+      "check": true,
+      "dest": "/src/$1"
+    },
+    {
+      "src": "/(.*)",
+      "check": true,
+      "dest": "/fake/$1"
+    }
+  ]
+}

--- a/packages/now-cli/test/dev/fixtures/routes-check-true/src/blog
+++ b/packages/now-cli/test/dev/fixtures/routes-check-true/src/blog
@@ -1,0 +1,1 @@
+Blog Home

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -154,6 +154,22 @@ function testFixtureStdio(directory, fn) {
   };
 }
 
+test(
+  '[now dev] validate routes that use check true',
+  testFixtureStdio('routes-check-true', async (t, port) => {
+    const result = await fetchWithRetry(
+      `http://localhost:${port}/blog/post`,
+      3
+    );
+    const response = await result;
+
+    validateResponseHeaders(t, response);
+
+    const body = await response.text();
+    t.regex(body, /Blog Home/gm);
+  })
+);
+
 test('[now dev] validate builds', async t => {
   const directory = fixture('invalid-builds');
   const output = await exec(directory);

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -155,7 +155,7 @@ function testFixtureStdio(directory, fn) {
 }
 
 test(
-  '[now dev] validate routes that use check true',
+  '[now dev] validate routes that use `check: true`',
   testFixtureStdio('routes-check-true', async (t, port) => {
     const result = await fetchWithRetry(
       `http://localhost:${port}/blog/post`,


### PR DESCRIPTION
This PR adds `now dev` support for routes that define `check: true`.

The algorithm is as follows:

- If a matching `dest` file is found, then serve it
- If a matching `src` file is found, then serve it
- Otherwise, behave the same as `continue: true` and continue processing routes