### PR TITLE
[now-cli] Fix preinstall script on windows when `LOCALAPPDATA` is missing

### DIFF
--- a/packages/now-cli/scripts/preinstall.js
+++ b/packages/now-cli/scripts/preinstall.js
@@ -39,6 +39,9 @@ function isGlobal() {
 // See: https://git.io/fj4jD
 function getNowPath() {
   if (process.platform === 'win32') {
+    if (!process.env.LOCALAPPDATA) {
+      return null;
+    }
     const path = join(process.env.LOCALAPPDATA, 'now-cli', 'now.exe');
     return fs.existsSync(path) ? path : null;
   }
@@ -48,7 +51,7 @@ function getNowPath() {
   const paths = [
     join(process.env.HOME || '/', 'bin'),
     '/usr/local/bin',
-    '/usr/bin'
+    '/usr/bin',
   ];
 
   for (const basePath of paths) {

--- a/packages/now-cli/scripts/preinstall.js
+++ b/packages/now-cli/scripts/preinstall.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const { promisify } = require('util');
 const { join, delimiter } = require('path');
+const { homedir } = require('os');
 
 const stat = promisify(fs.stat);
 const unlink = promisify(fs.unlink);
@@ -39,10 +40,16 @@ function isGlobal() {
 // See: https://git.io/fj4jD
 function getNowPath() {
   if (process.platform === 'win32') {
-    if (!process.env.LOCALAPPDATA) {
-      return null;
+    const { LOCALAPPDATA, USERPROFILE, HOMEPATH } = process.env;
+    const home = homedir() || USERPROFILE || HOMEPATH;
+    let path;
+    if (LOCALAPPDATA) {
+      path = join(LOCALAPPDATA, 'now-cli', 'now.exe');
+    } else if (home) {
+      path = join(home, 'AppData', 'Local', 'now-cli', 'now.exe');
+    } else {
+      path = '';
     }
-    const path = join(process.env.LOCALAPPDATA, 'now-cli', 'now.exe');
     return fs.existsSync(path) ? path : null;
   }
 


### PR DESCRIPTION
Usually `LOCALAPPDATA` is set to `C:\Users\{username}\AppData\Local` but occasionally, it is unassigned and causes installation failures. Looks like this could be due to the [registry](https://liquidwarelabs.zendesk.com/hc/en-us/articles/210634163-How-To-Make-APPDATA-and-LOCALAPPDATA-Environment-Variables-Follow-The-Registry-Keys).

If `LOCALAPPDATA` is missing, we can assume that now.exe was not installed before and can skip the deletion step that happens in the preinstall script.