### PR TITLE
[now-next] Only log serverless times if there are lambdas

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -465,8 +465,7 @@ export const build = async ({
     const pages = await glob('**/*.js', pagesDir);
     const staticPageFiles = await glob('**/*.html', pagesDir);
     const prerenderManifest = await getPrerenderManifest(entryPath);
-    // The app is static if it only has a single lambda (_error.js)
-    const hasLambdas = Object.keys(pages).length > 1;
+    const hasLambdas = Object.keys(pages).length > 0;
 
     Object.keys(staticPageFiles).forEach((page: string) => {
       const pathname = page.replace(/\.html$/, '');

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -3,10 +3,16 @@ const fs = require('fs-extra');
 const runBuildLambda = require('../../../../test/lib/run-build-lambda');
 
 const FOUR_MINUTES = 240000;
+const time = console.time;
+const timeEnd = console.timeEnd;
 
 beforeAll(() => {
   process.env.NEXT_TELEMETRY_DISABLED = '1';
-})
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 it(
   'Should build the standard example',
@@ -111,9 +117,11 @@ it(
 it(
   'Should build the static-files test',
   async () => {
+    console.time = jest.fn(time);
     const {
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'static-files'));
+    expect(console.time).toHaveBeenCalledTimes(0);
     expect(output['static/test.txt']).toBeDefined();
   },
   FOUR_MINUTES
@@ -303,11 +311,15 @@ it(
 it(
   'Should build the serverless-no-config example',
   async () => {
+    console.timeEnd = jest.fn(timeEnd);
     const {
       workPath,
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-no-config'));
 
+    expect(console.timeEnd).toHaveBeenCalledWith(
+      'All serverless functions created in'
+    );
     expect(output['index.html']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);

--- a/packages/now-next/test/integration/static-files/package.json
+++ b/packages/now-next/test/integration/static-files/package.json
@@ -3,8 +3,8 @@
     "now-build": "next build"
   },
   "dependencies": {
-    "next": "8",
-    "react": "16",
-    "react-dom": "16"
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
   }
 }


### PR DESCRIPTION
This PR hides serverless logs when only the lambda for `_error.js` is detected