### PR TITLE
[now-cli][now-client] Fix user agent

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -12,6 +12,7 @@ import { Output } from '../output';
 // @ts-ignore
 import Now from '../../util';
 import { NowConfig } from '../dev/types';
+import ua from '../ua';
 
 export default async function processDeployment({
   now,
@@ -46,6 +47,7 @@ export default async function processDeployment({
     ...requestBody,
     debug: now._debug,
     apiUrl: now._apiUrl,
+    userAgent: ua,
   };
 
   if (!legacy) {

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -11,6 +11,7 @@ import {
   DeploymentOptions,
   NowJsonOptions,
 } from './types';
+import { Options } from './deploy';
 
 export { EVENTS } from './utils';
 
@@ -188,6 +189,7 @@ export default function buildCreateDeployment(
       defaultName,
       debug: debug_,
       apiUrl,
+      userAgent,
       ...metadata
     } = options;
 
@@ -195,10 +197,14 @@ export default function buildCreateDeployment(
       debug(`Using provided API URL: ${apiUrl}`);
     }
 
+    if (userAgent) {
+      debug(`Using provided user agent: ${userAgent}`);
+    }
+
     debug(`Setting platform version to ${version}`);
     metadata.version = version;
 
-    const deploymentOpts = {
+    const deploymentOpts: Options = {
       debug: debug_,
       totalFiles: files.size,
       nowConfig,
@@ -210,6 +216,7 @@ export default function buildCreateDeployment(
       defaultName,
       metadata,
       apiUrl,
+      userAgent,
     };
 
     debug(`Creating the deployment and starting upload...`);

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -23,6 +23,7 @@ export interface Options {
   debug?: boolean;
   nowConfig?: NowJsonOptions;
   apiUrl?: string;
+  userAgent?: string;
 }
 
 async function* createDeployment(
@@ -50,6 +51,7 @@ async function* createDeployment(
           files: preparedFiles,
         }),
         apiUrl: options.apiUrl,
+        userAgent: options.userAgent,
       }
     );
 
@@ -207,7 +209,8 @@ export default async function* deploy(
         metadata.version,
         options.teamId,
         debug,
-        options.apiUrl
+        options.apiUrl,
+        options.userAgent
       )) {
         yield event;
       }

--- a/packages/now-client/src/deployment-status.ts
+++ b/packages/now-client/src/deployment-status.ts
@@ -22,7 +22,8 @@ export default async function* checkDeploymentStatus(
   version: number | undefined,
   teamId: string | undefined,
   debug: Function,
-  apiUrl?: string
+  apiUrl?: string,
+  userAgent?: string
 ): AsyncIterableIterator<DeploymentStatus> {
   let deploymentState = deployment;
   let allBuildsCompleted = false;
@@ -31,7 +32,7 @@ export default async function* checkDeploymentStatus(
   const apiDeployments = getApiDeploymentsUrl({
     version,
     builds: deployment.builds,
-    functions: deployment.functions
+    functions: deployment.functions,
   });
 
   debug(`Using ${version ? `${version}.0` : '2.0'} API for status checks`);
@@ -54,7 +55,7 @@ export default async function* checkDeploymentStatus(
           teamId ? `?teamId=${teamId}` : ''
         }`,
         token,
-        { apiUrl }
+        { apiUrl, userAgent }
       );
 
       const data = await buildsData.json();
@@ -91,7 +92,8 @@ export default async function* checkDeploymentStatus(
         `${apiDeployments}/${deployment.id || deployment.deploymentId}${
           teamId ? `?teamId=${teamId}` : ''
         }`,
-        token
+        token,
+        { apiUrl, userAgent }
       );
       const deploymentUpdate = await deploymentData.json();
 

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -124,6 +124,7 @@ export interface DeploymentOptions {
   config?: { [key: string]: any };
   debug?: boolean;
   apiUrl?: string;
+  userAgent?: string;
 }
 
 export interface NowJsonOptions {

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -28,7 +28,7 @@ export default async function* upload(
   files: Map<string, DeploymentFile>,
   options: Options
 ): AsyncIterableIterator<any> {
-  const { token, teamId, debug: isDebug, apiUrl } = options;
+  const { token, teamId, debug: isDebug, apiUrl, userAgent } = options;
   const debug = createDebug(isDebug);
 
   if (!files && !token && !teamId) {
@@ -105,6 +105,7 @@ export default async function* upload(
               body: stream,
               teamId,
               apiUrl,
+              userAgent,
             },
             isDebug
           );

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -1,6 +1,6 @@
 import { DeploymentFile } from './hashes';
 import { parse as parseUrl } from 'url';
-import fetch_ from 'node-fetch';
+import fetch_, { RequestInit } from 'node-fetch';
 import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
@@ -111,10 +111,18 @@ export async function getNowIgnore(path: string | string[]): Promise<any> {
   return { ig, ignores };
 }
 
+interface FetchOpts extends RequestInit {
+  apiUrl?: string;
+  method?: string;
+  teamId?: string;
+  headers?: { [key: string]: any };
+  userAgent?: string;
+}
+
 export const fetch = async (
   url: string,
   token: string,
-  opts: any = {},
+  opts: FetchOpts = {},
   debugEnabled?: boolean
 ): Promise<any> => {
   semaphore.acquire();
@@ -133,11 +141,14 @@ export const fetch = async (
     delete opts.teamId;
   }
 
+  const userAgent = opts.userAgent || `now-client-v${pkgVersion}`;
+  delete opts.userAgent;
+
   opts.headers = {
     ...opts.headers,
     authorization: `Bearer ${token}`,
     accept: 'application/json',
-    'user-agent': `now-client-v${pkgVersion}`,
+    'user-agent': userAgent,
   };
 
   debug(`${opts.method || 'GET'} ${url}`);


### PR DESCRIPTION
Since switching to a single branch, each package in the monorepo can be independently versioned so that some packages are using a canary version and others using a stable version.

This PR fixes an issue where a canary version of `now-cli` is bundling a stable version of `now-client` and thus does does not deploy zero config using canary builders.

The solution is to pass the User Agent from `now-cli` to `now-client` in a new option.

A nice side-effect of this PR is that we will switch the User Agent back to what it used to be pre-now-client days. It will look something like `now 16.6.1-canary.0 node-v10.17.0 darwin (x64)`.