### PR TITLE
[now-client] (Major) Split `now-client` options

### DIFF
--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -2,7 +2,7 @@ import { NowConfig } from './util/dev/types';
 
 export type ThenArg<T> = T extends Promise<infer U> ? U : T;
 
-export interface Config extends NowConfig {};
+export type Config = NowConfig;
 
 export interface NowContext {
   argv: string[];

--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -2,13 +2,7 @@ import { NowConfig } from './util/dev/types';
 
 export type ThenArg<T> = T extends Promise<infer U> ? U : T;
 
-export interface Config extends NowConfig {
-  alias?: string[] | string;
-  aliases?: string[] | string;
-  name?: string;
-  type?: string;
-  scope?: string;
-}
+export interface Config extends NowConfig {};
 
 export interface NowContext {
   argv: string[];

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -46,7 +46,7 @@ export default async function processDeployment({
   const { env = {} } = requestBody;
 
   const nowClientOptions: NowClientOptions = {
-    teamId: now._currentTeam,
+    teamId: now.currentTeam,
     apiUrl: now._apiUrl,
     token: now._token,
     debug: now._debug,

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -6,7 +6,8 @@ import {
   createDeployment,
   createLegacyDeployment,
   DeploymentOptions,
-} from 'now-client/dist';
+  NowClientOptions
+} from 'now-client';
 import wait from '../output/wait';
 import { Output } from '../output';
 // @ts-ignore
@@ -22,9 +23,9 @@ export default async function processDeployment({
   requestBody,
   uploadStamp,
   deployStamp,
-  legacy,
-  env,
+  isLegacy,
   quiet,
+  force,
   nowConfig,
 }: {
   now: Now;
@@ -34,28 +35,32 @@ export default async function processDeployment({
   requestBody: DeploymentOptions;
   uploadStamp: () => number;
   deployStamp: () => number;
-  legacy: boolean;
-  env: any;
+  isLegacy: boolean;
   quiet: boolean;
   nowConfig?: NowConfig;
+  force?: boolean;
 }) {
   const { warn, log, debug, note } = output;
   let bar: Progress | null = null;
 
-  const path0 = paths[0];
-  const opts: DeploymentOptions = {
-    ...requestBody,
-    debug: now._debug,
+  const { env = {} } = requestBody;
+
+  const nowClientOptions: NowClientOptions = {
+    teamId: now._currentTeam,
     apiUrl: now._apiUrl,
+    token: now._token,
+    debug: now._debug,
     userAgent: ua,
+    path: paths[0],
+    force
   };
 
-  if (!legacy) {
+  if (!isLegacy) {
     let queuedSpinner = null;
     let buildSpinner = null;
     let deploySpinner = null;
 
-    for await (const event of createDeployment(path0, opts, nowConfig)) {
+    for await (const event of createDeployment(nowClientOptions, requestBody, nowConfig)) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }
@@ -112,7 +117,7 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          const version = legacy ? `${chalk.grey('[v1]')} ` : '';
+          const version = isLegacy ? `${chalk.grey('[v1]')} ` : '';
           log(`https://${event.payload.url} ${version}${deployStamp()}`);
         } else {
           process.stdout.write(`https://${event.payload.url}`);
@@ -178,7 +183,7 @@ export default async function processDeployment({
       }
     }
   } else {
-    for await (const event of createLegacyDeployment(path0, opts, nowConfig)) {
+    for await (const event of createLegacyDeployment(nowClientOptions, requestBody, nowConfig)) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }
@@ -226,7 +231,7 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          const version = legacy ? `${chalk.grey('[v1]')} ` : '';
+          const version = isLegacy ? `${chalk.grey('[v1]')} ` : '';
           log(`${event.payload.url} ${version}${deployStamp()}`);
         } else {
           process.stdout.write(`https://${event.payload.url}`);

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -6,7 +6,7 @@ import {
   createDeployment,
   createLegacyDeployment,
   DeploymentOptions,
-  NowClientOptions
+  NowClientOptions,
 } from 'now-client';
 import wait from '../output/wait';
 import { Output } from '../output';
@@ -52,7 +52,7 @@ export default async function processDeployment({
     debug: now._debug,
     userAgent: ua,
     path: paths[0],
-    force
+    force,
   };
 
   if (!isLegacy) {
@@ -60,7 +60,11 @@ export default async function processDeployment({
     let buildSpinner = null;
     let deploySpinner = null;
 
-    for await (const event of createDeployment(nowClientOptions, requestBody, nowConfig)) {
+    for await (const event of createDeployment(
+      nowClientOptions,
+      requestBody,
+      nowConfig
+    )) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }
@@ -183,7 +187,11 @@ export default async function processDeployment({
       }
     }
   } else {
-    for await (const event of createLegacyDeployment(nowClientOptions, requestBody, nowConfig)) {
+    for await (const event of createLegacyDeployment(
+      nowClientOptions,
+      requestBody,
+      nowConfig
+    )) {
       if (event.type === 'hashes-calculated') {
         hashes = event.payload;
       }

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -9,8 +9,11 @@ import {
   PackageJson,
   BuilderFunctions,
 } from '@now/build-utils';
+import { NowConfig, EnvConfig } from 'now-client';
 import { NowRedirect, NowRewrite, NowHeader, Route } from '@now/routing-utils';
 import { Output } from '../output';
+
+export { NowConfig, EnvConfig };
 
 export interface DevServerOptions {
   output: Output;
@@ -30,24 +33,6 @@ export interface BuildMatch extends BuildConfig {
 }
 
 export type RouteConfig = Route;
-
-export interface NowConfig {
-  name?: string;
-  version?: number;
-  env?: EnvConfig;
-  build?: {
-    env?: EnvConfig;
-  };
-  builds?: BuildConfig[];
-  routes?: RouteConfig[];
-  files?: string[];
-  cleanUrls?: boolean;
-  rewrites?: NowRewrite[];
-  redirects?: NowRedirect[];
-  headers?: NowHeader[];
-  trailingSlash?: boolean;
-  functions?: BuilderFunctions;
-}
 
 export interface HttpHandler {
   (req: http.IncomingMessage, res: http.ServerResponse): void;

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -9,11 +9,11 @@ import {
   PackageJson,
   BuilderFunctions,
 } from '@now/build-utils';
-import { NowConfig, EnvConfig } from 'now-client';
+import { NowConfig } from 'now-client';
 import { NowRedirect, NowRewrite, NowHeader, Route } from '@now/routing-utils';
 import { Output } from '../output';
 
-export { NowConfig, EnvConfig };
+export { NowConfig };
 
 export interface DevServerOptions {
   output: Output;

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -70,7 +70,7 @@ export default class Now extends EventEmitter {
   ) {
     const opts = { output: this._output, hasNowJson };
     const { log, warn, debug } = this._output;
-    const isLegacy = type === null;
+    const isLegacy = type !== null;
 
     let files = [];
     let hashes = {};
@@ -129,7 +129,7 @@ export default class Now extends EventEmitter {
         project,
         meta,
         regions,
-        target
+        target: target || undefined
     };
 
     if (isLegacy) {

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -121,15 +121,15 @@ export default class Now extends EventEmitter {
     const uploadStamp = stamp();
 
     let requestBody = {
-        ...nowConfig,
-        env,
-        build,
-        public: wantsPublic || nowConfig.public,
-        name,
-        project,
-        meta,
-        regions,
-        target: target || undefined
+      ...nowConfig,
+      env,
+      build,
+      public: wantsPublic || nowConfig.public,
+      name,
+      project,
+      meta,
+      regions,
+      target: target || undefined,
     };
 
     // Ignore specific items from Now.json
@@ -137,9 +137,10 @@ export default class Now extends EventEmitter {
 
     if (isLegacy) {
       // Read `registry.npmjs.org` authToken from .npmrc
-      const registryAuthToken = type === 'npm' && forwardNpm
-        ? await readAuthToken(paths[0]) || await readAuthToken(homedir())
-        : undefined;
+      const registryAuthToken =
+        type === 'npm' && forwardNpm
+          ? (await readAuthToken(paths[0])) || (await readAuthToken(homedir()))
+          : undefined;
 
       requestBody = {
         env,
@@ -171,7 +172,7 @@ export default class Now extends EventEmitter {
       deployStamp,
       quiet,
       nowConfig,
-      force: forceNew
+      force: forceNew,
     });
 
     // We report about files whose sizes are too big

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -132,6 +132,9 @@ export default class Now extends EventEmitter {
         target: target || undefined
     };
 
+    // Ignore specific items from Now.json
+    delete requestBody.scope;
+
     if (isLegacy) {
       // Read `registry.npmjs.org` authToken from .npmrc
       const registryAuthToken = type === 'npm' && forwardNpm

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -53,7 +53,6 @@ export default class Now extends EventEmitter {
       nowConfig = {},
       hasNowJson = false,
       sessionAffinity = 'random',
-      atlas = false,
 
       // Latest
       name,
@@ -71,39 +70,21 @@ export default class Now extends EventEmitter {
   ) {
     const opts = { output: this._output, hasNowJson };
     const { log, warn, debug } = this._output;
-    const isBuilds = type === null;
+    const isLegacy = type === null;
 
     let files = [];
     let hashes = {};
     const relatives = {};
     let engines;
     let deployment;
-    let requestBody = {};
 
-    if (isBuilds) {
-      requestBody = {
-        token: this._token,
-        teamId: this.currentTeam,
-        env,
-        build,
-        public: wantsPublic || nowConfig.public,
-        name,
-        project,
-        meta,
-        regions,
-        force: forceNew,
-      };
-
-      if (target) {
-        requestBody.target = target;
-      }
-    } else if (type === 'npm') {
+    if (type === 'npm') {
       files = await getNpmFiles(paths[0], pkg, nowConfig, opts);
 
       // A `start` or `now-start` npm script, or a `server.js` file
       // in the root directory of the deployment are required
       if (
-        !isBuilds &&
+        isLegacy &&
         !hasNpmStart(pkg) &&
         !hasFile(paths[0], files, 'server.js')
       ) {
@@ -139,30 +120,25 @@ export default class Now extends EventEmitter {
 
     const uploadStamp = stamp();
 
-    if (isBuilds) {
-      deployment = await processDeployment({
-        now: this,
-        output: this._output,
-        hashes,
-        paths,
-        requestBody,
-        uploadStamp,
-        deployStamp,
-        quiet,
-        nowConfig,
-      });
-    } else {
-      // Read `registry.npmjs.org` authToken from .npmrc
-      let authToken;
+    let requestBody = {
+        ...nowConfig,
+        env,
+        build,
+        public: wantsPublic || nowConfig.public,
+        name,
+        project,
+        meta,
+        regions,
+        target
+    };
 
-      if (type === 'npm' && forwardNpm) {
-        authToken =
-          (await readAuthToken(paths[0])) || (await readAuthToken(homedir()));
-      }
+    if (isLegacy) {
+      // Read `registry.npmjs.org` authToken from .npmrc
+      const registryAuthToken = type === 'npm' && forwardNpm
+        ? await readAuthToken(paths[0]) || await readAuthToken(homedir())
+        : undefined;
 
       requestBody = {
-        token: this._token,
-        teamId: this.currentTeam,
         env,
         build,
         meta,
@@ -172,30 +148,28 @@ export default class Now extends EventEmitter {
         project,
         description,
         deploymentType: type,
-        registryAuthToken: authToken,
+        registryAuthToken,
         engines,
         scale,
         sessionAffinity,
         limits: nowConfig.limits,
-        atlas,
         config: nowConfig,
-        functions: nowConfig.functions,
       };
-
-      deployment = await processDeployment({
-        legacy: true,
-        now: this,
-        output: this._output,
-        hashes,
-        paths,
-        requestBody,
-        uploadStamp,
-        deployStamp,
-        quiet,
-        env,
-        nowConfig,
-      });
     }
+
+    deployment = await processDeployment({
+      isLegacy,
+      now: this,
+      output: this._output,
+      hashes,
+      paths,
+      requestBody,
+      uploadStamp,
+      deployStamp,
+      quiet,
+      nowConfig,
+      force: forceNew
+    });
 
     // We report about files whose sizes are too big
     let missingVersion = false;
@@ -228,7 +202,7 @@ export default class Now extends EventEmitter {
       }
     }
 
-    if (!isBuilds && !quiet && type === 'npm' && deployment.nodeVersion) {
+    if (isLegacy && !quiet && type === 'npm' && deployment.nodeVersion) {
       if (engines && engines.node && !missingVersion) {
         log(
           chalk`Using Node.js {bold ${deployment.nodeVersion}} (requested: {dim \`${engines.node}\`})`

--- a/packages/now-client/src/check-deployment-status.ts
+++ b/packages/now-client/src/check-deployment-status.ts
@@ -8,7 +8,8 @@ import {
   isAliasAssigned,
   isAliasError,
 } from './utils/ready-state';
-import { Deployment, DeploymentBuild } from './types';
+import { createDebug } from './utils';
+import { Dictionary, Deployment, NowClientOptions, DeploymentBuild } from './types';
 
 interface DeploymentStatus {
   type: string;
@@ -16,18 +17,17 @@ interface DeploymentStatus {
 }
 
 /* eslint-disable */
-export default async function* checkDeploymentStatus(
+export async function* checkDeploymentStatus(
   deployment: Deployment,
-  token: string,
-  version: number | undefined,
-  teamId: string | undefined,
-  debug: Function,
-  apiUrl?: string,
-  userAgent?: string
+  clientOptions: NowClientOptions
 ): AsyncIterableIterator<DeploymentStatus> {
+  const { version } = deployment;
+  const { token, teamId, apiUrl, userAgent } = clientOptions;
+  const debug = createDebug(clientOptions.debug);
+
   let deploymentState = deployment;
   let allBuildsCompleted = false;
-  const buildsState: { [key: string]: DeploymentBuild } = {};
+  const buildsState: Dictionary<DeploymentBuild> = {};
 
   const apiDeployments = getApiDeploymentsUrl({
     version,

--- a/packages/now-client/src/check-deployment-status.ts
+++ b/packages/now-client/src/check-deployment-status.ts
@@ -9,7 +9,12 @@ import {
   isAliasError,
 } from './utils/ready-state';
 import { createDebug } from './utils';
-import { Dictionary, Deployment, NowClientOptions, DeploymentBuild } from './types';
+import {
+  Dictionary,
+  Deployment,
+  NowClientOptions,
+  DeploymentBuild,
+} from './types';
 
 interface DeploymentStatus {
   type: string;

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -45,7 +45,7 @@ export default function buildCreateDeployment(version: number) {
       });
     }
 
-    const isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory();
+    clientOptions.isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory();
 
     let rootFiles: string[];
 
@@ -65,7 +65,7 @@ export default function buildCreateDeployment(version: number) {
       });
     }
 
-    if (isDirectory && !Array.isArray(path)) {
+    if (clientOptions.isDirectory && !Array.isArray(path)) {
       debug(`Provided 'path' is a directory. Reading subpaths... `);
       rootFiles = await readRootFolder(path);
       debug(`Read ${rootFiles.length} subpaths`);
@@ -86,7 +86,7 @@ export default function buildCreateDeployment(version: number) {
 
     debug('Building file tree...');
 
-    if (isDirectory && !Array.isArray(path)) {
+    if (clientOptions.isDirectory && !Array.isArray(path)) {
       // Directory path
       const dirContents = await readdir(path, ignores);
       const relativeFileList = dirContents.map(filePath =>

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -14,7 +14,7 @@ export default function buildCreateDeployment(version: number) {
   return async function* createDeployment(
     clientOptions: NowClientOptions,
     deploymentOptions: DeploymentOptions,
-    nowConfig: NowConfig = {},
+    nowConfig: NowConfig = {}
   ): AsyncIterableIterator<any> {
     const { path } = clientOptions;
 
@@ -45,7 +45,8 @@ export default function buildCreateDeployment(version: number) {
       });
     }
 
-    clientOptions.isDirectory = !Array.isArray(path) && lstatSync(path).isDirectory();
+    clientOptions.isDirectory =
+      !Array.isArray(path) && lstatSync(path).isDirectory();
 
     let rootFiles: string[];
 
@@ -152,7 +153,14 @@ export default function buildCreateDeployment(version: number) {
     // from getting confused about a deployment that renders 404.
     if (
       fileList.length === 0 ||
-      fileList.every(item => item ? item.split('/').pop()!.startsWith('.') : true)
+      fileList.every(item =>
+        item
+          ? item
+              .split('/')
+              .pop()!
+              .startsWith('.')
+          : true
+      )
     ) {
       debug(
         `Deployment path has no files (or only dotfiles). Yielding a warning event`
@@ -181,7 +189,12 @@ export default function buildCreateDeployment(version: number) {
     deploymentOptions.version = version;
 
     debug(`Creating the deployment and starting upload...`);
-    for await (const event of upload(files, nowConfig, clientOptions, deploymentOptions)) {
+    for await (const event of upload(
+      files,
+      nowConfig,
+      clientOptions,
+      deploymentOptions
+    )) {
       debug(`Yielding a '${event.type}' event`);
       yield event;
     }

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -6,23 +6,18 @@ import hashes, { mapToObject } from './utils/hashes';
 import uploadAndDeploy from './upload';
 import { getNowIgnore, createDebug, parseNowJSON } from './utils';
 import { DeploymentError } from './errors';
-import {
-  CreateDeploymentFunction,
-  DeploymentOptions,
-  NowJsonOptions,
-} from './types';
+import { NowConfig, NowClientOptions, DeploymentOptions } from './types';
 
 export { EVENTS } from './utils';
 
-export default function buildCreateDeployment(
-  version: number
-): CreateDeploymentFunction {
+export default function buildCreateDeployment(version: number) {
   return async function* createDeployment(
     path: string | string[],
-    options: DeploymentOptions = {},
-    nowConfig?: NowJsonOptions
+    nowConfig: NowConfig,
+    clientOptions: NowClientOptions,
+    deploymentOptions: DeploymentOptions
   ): AsyncIterableIterator<any> {
-    const debug = createDebug(options.debug);
+    const debug = createDebug(clientOptions.debug);
     const cwd = process.cwd();
 
     debug('Creating deployment...');
@@ -38,9 +33,9 @@ export default function buildCreateDeployment(
       });
     }
 
-    if (typeof options.token !== 'string') {
+    if (typeof clientOptions.token !== 'string') {
       debug(
-        `Error: 'token' is expected to be a string. Received ${typeof options.token}`
+        `Error: 'token' is expected to be a string. Received ${typeof clientOptions.token}`
       );
 
       throw new DeploymentError({
@@ -189,7 +184,7 @@ export default function buildCreateDeployment(
       debug: debug_,
       apiUrl,
       ...metadata
-    } = options;
+    } = clientOptions;
 
     if (apiUrl) {
       debug(`Using provided API URL: ${apiUrl}`);

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -8,7 +8,12 @@ import {
 import { checkDeploymentStatus } from './check-deployment-status';
 import { generateQueryString } from './utils/query-string';
 import { isReady, isAliasAssigned } from './utils/ready-state';
-import { Deployment, DeploymentOptions, NowConfig, NowClientOptions } from './types';
+import {
+  Deployment,
+  DeploymentOptions,
+  NowConfig,
+  NowClientOptions,
+} from './types';
 
 async function* createDeployment(
   files: Map<string, DeploymentFile>,
@@ -108,7 +113,11 @@ export async function* deploy(
     }
   }
 
-  if (files.size === 1 && !deploymentOptions.builds && !deploymentOptions.routes) {
+  if (
+    files.size === 1 &&
+    !deploymentOptions.builds &&
+    !deploymentOptions.routes
+  ) {
     debug(`Assigning '/' route for single file deployment`);
     const filePath = Array.from(files.values())[0].names[0];
 
@@ -126,7 +135,11 @@ export async function* deploy(
     debug('No name provided. Defaulting to', deploymentOptions.name);
   }
 
-  if (deploymentOptions.version === 1 && !deploymentOptions.deploymentType && nowConfig.type) {
+  if (
+    deploymentOptions.version === 1 &&
+    !deploymentOptions.deploymentType &&
+    nowConfig.type
+  ) {
     debug(`Setting 'type' for 1.0 deployment to '${nowConfig.type}'`);
     deploymentOptions.deploymentType = nowConfig.type.toUpperCase() as DeploymentOptions['deploymentType'];
   }
@@ -137,7 +150,11 @@ export async function* deploy(
     delete deploymentOptions.config.version;
   }
 
-  if (deploymentOptions.version === 1 && !deploymentOptions.forceNew && clientOptions.force) {
+  if (
+    deploymentOptions.version === 1 &&
+    !deploymentOptions.forceNew &&
+    clientOptions.force
+  ) {
     debug(`Setting 'forceNew' for 1.0 deployment`);
     deploymentOptions.forceNew = clientOptions.force;
   }
@@ -174,7 +191,10 @@ export async function* deploy(
 
     try {
       debug('Waiting for deployment to be ready...');
-      for await (const event of checkDeploymentStatus(deployment, clientOptions)) {
+      for await (const event of checkDeploymentStatus(
+        deployment,
+        clientOptions
+      )) {
         yield event;
       }
     } catch (e) {

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -111,12 +111,11 @@ export async function* deploy(
   if (files.size === 1 && !deploymentOptions.builds && !deploymentOptions.routes) {
     debug(`Assigning '/' route for single file deployment`);
     const filePath = Array.from(files.values())[0].names[0];
-    const segments = filePath.split('/');
 
     deploymentOptions.routes = [
       {
         src: '/',
-        dest: `/${segments[segments.length - 1]}`,
+        dest: `/${filePath.split('/').pop()}`,
       },
     ];
   }

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -5,53 +5,36 @@ import {
   createDebug,
   getApiDeploymentsUrl,
 } from './utils';
-import checkDeploymentStatus from './deployment-status';
+import { checkDeploymentStatus } from './check-deployment-status';
 import { generateQueryString } from './utils/query-string';
-import { Deployment, DeploymentOptions, NowJsonOptions } from './types';
 import { isReady, isAliasAssigned } from './utils/ready-state';
-
-export interface Options {
-  metadata: DeploymentOptions;
-  totalFiles: number;
-  path: string | string[];
-  token: string;
-  teamId?: string;
-  force?: boolean;
-  isDirectory?: boolean;
-  defaultName?: string;
-  preflight?: boolean;
-  debug?: boolean;
-  nowConfig?: NowJsonOptions;
-  apiUrl?: string;
-  userAgent?: string;
-}
+import { Deployment, DeploymentOptions, NowConfig, NowClientOptions } from './types';
 
 async function* createDeployment(
-  metadata: DeploymentOptions,
   files: Map<string, DeploymentFile>,
-  options: Options,
-  debug: Function
+  clientOptions: NowClientOptions,
+  deploymentOptions: DeploymentOptions
 ): AsyncIterableIterator<{ type: string; payload: any }> {
-  const preparedFiles = prepareFiles(files, options);
-
-  const apiDeployments = getApiDeploymentsUrl(metadata);
+  const debug = createDebug(clientOptions.debug);
+  const preparedFiles = prepareFiles(files, clientOptions);
+  const apiDeployments = getApiDeploymentsUrl(deploymentOptions);
 
   debug('Sending deployment creation API request');
   try {
     const dpl = await fetch(
-      `${apiDeployments}${generateQueryString(options)}`,
-      options.token,
+      `${apiDeployments}${generateQueryString(clientOptions)}`,
+      clientOptions.token,
       {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          ...metadata,
+          ...deploymentOptions,
           files: preparedFiles,
         }),
-        apiUrl: options.apiUrl,
-        userAgent: options.userAgent,
+        apiUrl: clientOptions.apiUrl,
+        userAgent: clientOptions.userAgent,
       }
     );
 
@@ -87,59 +70,50 @@ async function* createDeployment(
   }
 }
 
-const getDefaultName = (
-  path: string | string[] | undefined,
-  isDirectory: boolean | undefined,
+function getDefaultName(
   files: Map<string, DeploymentFile>,
-  debug: Function
-): string => {
+  clientOptions: NowClientOptions
+): string {
+  const debug = createDebug(clientOptions.debug);
+  const { isDirectory, path } = clientOptions;
+
   if (isDirectory && typeof path === 'string') {
     debug('Provided path is a directory. Using last segment as default name');
-    const segments = path.split('/');
-
-    return segments[segments.length - 1];
+    return path.split('/').pop()!;
   } else {
     debug(
       'Provided path is not a directory. Using last segment of the first file as default name'
     );
     const filePath = Array.from(files.values())[0].names[0];
-    const segments = filePath.split('/');
-
-    return segments[segments.length - 1];
+    return filePath.split('/').pop()!;
   }
-};
+}
 
-export default async function* deploy(
+export async function* deploy(
   files: Map<string, DeploymentFile>,
-  options: Options
+  nowConfig: NowConfig,
+  clientOptions: NowClientOptions,
+  deploymentOptions: DeploymentOptions
 ): AsyncIterableIterator<{ type: string; payload: any }> {
-  const debug = createDebug(options.debug);
-  const nowJsonMetadata = options.nowConfig || {};
-  delete nowJsonMetadata.github;
-  delete nowJsonMetadata.scope;
-
-  const meta = options.metadata || {};
-  const metadata = { ...nowJsonMetadata, ...meta };
+  const debug = createDebug(clientOptions.debug);
 
   // Check if we should default to a static deployment
-  if (!metadata.version && !metadata.name) {
-    metadata.version = 2;
-    metadata.name =
-      options.totalFiles === 1
-        ? 'file'
-        : getDefaultName(options.path, options.isDirectory, files, debug);
+  if (!deploymentOptions.version && !deploymentOptions.name) {
+    deploymentOptions.version = 2;
+    deploymentOptions.name =
+      files.size === 1 ? 'file' : getDefaultName(files, clientOptions);
 
-    if (metadata.name === 'file') {
+    if (deploymentOptions.name === 'file') {
       debug('Setting deployment name to "file" for single-file deployment');
     }
   }
 
-  if (options.totalFiles === 1 && !metadata.builds && !metadata.routes) {
+  if (files.size === 1 && !deploymentOptions.builds && !deploymentOptions.routes) {
     debug(`Assigning '/' route for single file deployment`);
     const filePath = Array.from(files.values())[0].names[0];
     const segments = filePath.split('/');
 
-    metadata.routes = [
+    deploymentOptions.routes = [
       {
         src: '/',
         dest: `/${segments[segments.length - 1]}`,
@@ -147,27 +121,26 @@ export default async function* deploy(
     ];
   }
 
-  if (!metadata.name) {
-    metadata.name =
-      options.defaultName ||
-      getDefaultName(options.path, options.isDirectory, files, debug);
-    debug('No name provided. Defaulting to', metadata.name);
+  if (!deploymentOptions.name) {
+    deploymentOptions.name =
+      clientOptions.defaultName || getDefaultName(files, clientOptions);
+    debug('No name provided. Defaulting to', deploymentOptions.name);
   }
 
-  if (metadata.version === 1 && !metadata.deploymentType) {
-    debug(`Setting 'type' for 1.0 deployment to '${nowJsonMetadata.type}'`);
-    metadata.deploymentType = nowJsonMetadata.type;
+  if (deploymentOptions.version === 1 && !deploymentOptions.deploymentType && nowConfig.type) {
+    debug(`Setting 'type' for 1.0 deployment to '${nowConfig.type}'`);
+    deploymentOptions.deploymentType = nowConfig.type.toUpperCase() as DeploymentOptions['deploymentType'];
   }
 
-  if (metadata.version === 1) {
+  if (deploymentOptions.version === 1 && !deploymentOptions.config) {
     debug(`Writing 'config' values for 1.0 deployment`);
-    const nowConfig = { ...nowJsonMetadata };
-    delete nowConfig.version;
+    deploymentOptions.config = { ...nowConfig };
+    delete deploymentOptions.config.version;
+  }
 
-    metadata.config = {
-      ...nowConfig,
-      ...metadata.config,
-    };
+  if (deploymentOptions.version === 1 && !deploymentOptions.forceNew && clientOptions.force) {
+    debug(`Setting 'forceNew' for 1.0 deployment`);
+    deploymentOptions.forceNew = clientOptions.force;
   }
 
   let deployment: Deployment | undefined;
@@ -175,10 +148,9 @@ export default async function* deploy(
   try {
     debug('Creating deployment');
     for await (const event of createDeployment(
-      metadata,
       files,
-      options,
-      debug
+      clientOptions,
+      deploymentOptions
     )) {
       if (event.type === 'created') {
         debug('Deployment created');
@@ -203,15 +175,7 @@ export default async function* deploy(
 
     try {
       debug('Waiting for deployment to be ready...');
-      for await (const event of checkDeploymentStatus(
-        deployment,
-        options.token,
-        metadata.version,
-        options.teamId,
-        debug,
-        options.apiUrl,
-        options.userAgent
-      )) {
+      for await (const event of checkDeploymentStatus(deployment, clientOptions)) {
         yield event;
       }
     } catch (e) {

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -5,12 +5,21 @@ export interface Dictionary<T> {
   [key: string]: T;
 }
 
+/**
+ * Options for `now-client` or
+ * properties that should not
+ * be part of the payload.
+ */
 export interface NowClientOptions {
   token: string;
+  path: string | string[];
   debug?: boolean;
   teamId?: string;
   apiUrl?: string;
+  force?: boolean;
   userAgent?: string;
+  defaultName?: string;
+  isDirectory?: boolean;
 }
 
 export interface Deployment {
@@ -84,7 +93,7 @@ export interface DeploymentGithubData {
 }
 
 interface LegacyNowConfig {
-  type?: 'NPM' | 'STATIC' | 'DOCKER';
+  type?: string;
   aliases?: string | string[];
 }
 
@@ -109,7 +118,32 @@ export interface NowConfig extends LegacyNowConfig {
   alias?: string | string[];
 }
 
-export interface DeploymentOptions {
+interface LegacyDeploymentOptions {
+  project?: string;
+  forceNew?: boolean;
+  description?: string;
+  registryAuthToken?: string;
+  engines?: Dictionary<string>;
+  sessionAffinity?: 'ip' | 'key' | 'random';
+  deploymentType?: 'NPM' | 'STATIC' | 'DOCKER';
+  scale?: Dictionary<{
+    min?: number;
+    max?: number | 'auto';
+  }>;
+  limits?: {
+    duration?: number;
+    maxConcurrentReqs?: number;
+    timeout?: number;
+  };
+  // Can't be NowConfig, since we don't
+  // include all legacy types here
+  config?: Dictionary<any>;
+}
+
+/**
+ * Options that will be sent to the API.
+ */
+export interface DeploymentOptions extends LegacyDeploymentOptions {
   version?: number;
   regions?: string[];
   routes?: Route[];
@@ -120,20 +154,7 @@ export interface DeploymentOptions {
     env: Dictionary<string>;
   };
   target?: string;
-  token?: string | null;
-  teamId?: string;
-  force?: boolean;
   name?: string;
-  defaultName?: string;
-  isDirectory?: boolean;
-  path?: string | string[];
-  github?: DeploymentGithubData;
-  scope?: string;
   public?: boolean;
-  forceNew?: boolean;
-  deploymentType?: 'NPM' | 'STATIC' | 'DOCKER';
-  registryAuthToken?: string;
-  engines?: Dictionary<string>;
-  sessionAffinity?: 'ip' | 'random';
-  config?: Dictionary<any>;
+  meta?: Dictionary<string>;
 }

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -1,18 +1,16 @@
-import { BuilderFunctions } from '@now/build-utils';
+import { Builder, BuilderFunctions } from '@now/build-utils';
+import { NowHeader, Route, NowRedirect, NowRewrite } from '@now/routing-utils';
 
-export interface Route {
-  src: string;
-  dest: string;
-  headers?: {
-    [key: string]: string;
-  };
-  status?: number;
-  methods?: string[];
+export interface Dictionary<T> {
+  [key: string]: T;
 }
 
-export interface Build {
-  src: string;
-  use: string;
+export interface NowClientOptions {
+  token: string;
+  debug?: boolean;
+  teamId?: string;
+  apiUrl?: string;
+  userAgent?: string;
 }
 
 export interface Deployment {
@@ -20,13 +18,11 @@ export interface Deployment {
   deploymentId?: string;
   url: string;
   name: string;
-  meta: {
-    [key: string]: string | number | boolean;
-  };
+  meta: Dictionary<string | number | boolean>;
   version: number;
   regions: string[];
   routes: Route[];
-  builds?: Build[];
+  builds?: Builder[];
   functions?: BuilderFunctions;
   plan: string;
   public: boolean;
@@ -47,13 +43,9 @@ export interface Deployment {
     | 'ERROR';
   createdAt: string;
   createdIn: string;
-  env: {
-    [key: string]: string;
-  };
+  env: Dictionary<string>;
   build: {
-    env: {
-      [key: string]: string;
-    };
+    env: Dictionary<string>;
   };
   target: string;
   alias: string[];
@@ -91,19 +83,41 @@ export interface DeploymentGithubData {
   autoJobCancelation: boolean;
 }
 
+interface LegacyNowConfig {
+  type?: 'NPM' | 'STATIC' | 'DOCKER';
+  aliases?: string | string[];
+}
+
+export interface NowConfig extends LegacyNowConfig {
+  name?: string;
+  version?: number;
+  env?: Dictionary<string>;
+  build?: {
+    env?: Dictionary<string>;
+  };
+  builds?: Builder[];
+  routes?: Route[];
+  files?: string[];
+  cleanUrls?: boolean;
+  rewrites?: NowRewrite[];
+  redirects?: NowRedirect[];
+  headers?: NowHeader[];
+  trailingSlash?: boolean;
+  functions?: BuilderFunctions;
+  github?: DeploymentGithubData;
+  scope?: string;
+  alias?: string | string[];
+}
+
 export interface DeploymentOptions {
   version?: number;
   regions?: string[];
   routes?: Route[];
-  builds?: Build[];
+  builds?: Builder[];
   functions?: BuilderFunctions;
-  env?: {
-    [key: string]: string;
-  };
+  env?: Dictionary<string>;
   build?: {
-    env: {
-      [key: string]: string;
-    };
+    env: Dictionary<string>;
   };
   target?: string;
   token?: string | null;
@@ -119,23 +133,7 @@ export interface DeploymentOptions {
   forceNew?: boolean;
   deploymentType?: 'NPM' | 'STATIC' | 'DOCKER';
   registryAuthToken?: string;
-  engines?: { [key: string]: string };
+  engines?: Dictionary<string>;
   sessionAffinity?: 'ip' | 'random';
-  config?: { [key: string]: any };
-  debug?: boolean;
-  apiUrl?: string;
+  config?: Dictionary<any>;
 }
-
-export interface NowJsonOptions {
-  github?: DeploymentGithubData;
-  scope?: string;
-  type?: 'NPM' | 'STATIC' | 'DOCKER';
-  version?: number;
-  files?: string[];
-}
-
-export type CreateDeploymentFunction = (
-  path: string | string[],
-  options?: DeploymentOptions,
-  nowConfig?: NowJsonOptions
-) => AsyncIterableIterator<any>;

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -4,8 +4,9 @@ import retry from 'async-retry';
 import { Sema } from 'async-sema';
 import { DeploymentFile } from './utils/hashes';
 import { fetch, API_FILES, createDebug } from './utils';
-import { DeploymentError } from '.';
-import deploy, { Options } from './deploy';
+import { DeploymentError } from './errors';
+import { deploy } from './deploy';
+import { NowConfig, NowClientOptions, DeploymentOptions } from './types';
 
 const isClientNetworkError = (err: Error | DeploymentError) => {
   if (err.message) {
@@ -24,12 +25,14 @@ const isClientNetworkError = (err: Error | DeploymentError) => {
   return false;
 };
 
-export default async function* upload(
+export async function* upload(
   files: Map<string, DeploymentFile>,
-  options: Options
+  nowConfig: NowConfig,
+  clientOptions: NowClientOptions,
+  deploymentOptions: DeploymentOptions
 ): AsyncIterableIterator<any> {
-  const { token, teamId, debug: isDebug, apiUrl, userAgent } = options;
-  const debug = createDebug(isDebug);
+  const { token, teamId, apiUrl, userAgent } = clientOptions;
+  const debug = createDebug(clientOptions.debug);
 
   if (!files && !token && !teamId) {
     debug(`Neither 'files', 'token' nor 'teamId are present. Exiting`);
@@ -40,7 +43,7 @@ export default async function* upload(
 
   debug('Determining necessary files for upload...');
 
-  for await (const event of deploy(files, options)) {
+  for await (const event of deploy(files, nowConfig, clientOptions, deploymentOptions)) {
     if (event.type === 'error') {
       if (event.payload.code === 'missing_files') {
         missingFiles = event.payload.missing;
@@ -107,7 +110,7 @@ export default async function* upload(
               apiUrl,
               userAgent,
             },
-            isDebug
+            clientOptions.debug
           );
 
           if (res.status === 200) {
@@ -186,7 +189,7 @@ export default async function* upload(
 
   try {
     debug('Starting deployment creation');
-    for await (const event of deploy(files, options)) {
+    for await (const event of deploy(files, nowConfig, clientOptions, deploymentOptions)) {
       if (event.type === 'alias-assigned') {
         debug('Deployment is ready');
         return yield event;

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -43,7 +43,12 @@ export async function* upload(
 
   debug('Determining necessary files for upload...');
 
-  for await (const event of deploy(files, nowConfig, clientOptions, deploymentOptions)) {
+  for await (const event of deploy(
+    files,
+    nowConfig,
+    clientOptions,
+    deploymentOptions
+  )) {
     if (event.type === 'error') {
       if (event.payload.code === 'missing_files') {
         missingFiles = event.payload.missing;
@@ -189,7 +194,12 @@ export async function* upload(
 
   try {
     debug('Starting deployment creation');
-    for await (const event of deploy(files, nowConfig, clientOptions, deploymentOptions)) {
+    for await (const event of deploy(
+      files,
+      nowConfig,
+      clientOptions,
+      deploymentOptions
+    )) {
       if (event.type === 'alias-assigned') {
         debug('Deployment is ready');
         return yield event;

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -5,8 +5,7 @@ import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
 import { pkgVersion } from '../pkg';
-import { Options } from '../deploy';
-import { NowJsonOptions, DeploymentOptions } from '../types';
+import { NowClientOptions, DeploymentOptions, NowConfig } from '../types';
 import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
 const semaphore = new Sema(10);
@@ -44,7 +43,7 @@ export function getApiDeploymentsUrl(
   return '/v11/now/deployments';
 }
 
-export async function parseNowJSON(filePath?: string): Promise<NowJsonOptions> {
+export async function parseNowJSON(filePath?: string): Promise<NowConfig> {
   if (!filePath) {
     return {};
   }
@@ -171,7 +170,7 @@ const isWin = process.platform.includes('win');
 
 export const prepareFiles = (
   files: Map<string, DeploymentFile>,
-  options: Options
+  clientOptions: NowClientOptions
 ): PreparedFile[] => {
   const preparedFiles = [...files.keys()].reduce(
     (acc: PreparedFile[], sha: string): PreparedFile[] => {
@@ -182,10 +181,10 @@ export const prepareFiles = (
       for (const name of file.names) {
         let fileName: string;
 
-        if (options.isDirectory) {
+        if (clientOptions.isDirectory) {
           // Directory
-          fileName = options.path
-            ? name.substring(options.path.length + 1)
+          fileName = clientOptions.path
+            ? name.substring(clientOptions.path.length + 1)
             : name;
         } else {
           // Array of files or single file

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -128,6 +128,7 @@ export const fetch = async (
   const debug = createDebug(debugEnabled);
   let time: number;
 
+
   url = `${opts.apiUrl || 'https://api.zeit.co'}${url}`;
   delete opts.apiUrl;
 

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -128,7 +128,6 @@ export const fetch = async (
   const debug = createDebug(debugEnabled);
   let time: number;
 
-
   url = `${opts.apiUrl || 'https://api.zeit.co'}${url}`;
   delete opts.apiUrl;
 

--- a/packages/now-client/src/utils/query-string.ts
+++ b/packages/now-client/src/utils/query-string.ts
@@ -1,13 +1,16 @@
-import { Options } from '../deploy';
+import { URLSearchParams } from 'url';
+import { NowClientOptions } from '../types';
 
-export const generateQueryString = (options: Options): string => {
-  if (options.force && options.teamId) {
-    return `?teamId=${options.teamId}&forceNew=1`;
-  } else if (options.teamId) {
-    return `?teamId=${options.teamId}`;
-  } else if (options.force) {
-    return `?forceNew=1`;
+export function generateQueryString(clientOptions: NowClientOptions): string {
+  const options = new URLSearchParams();
+
+  if (clientOptions.force) {
+    options.set('forceNew', '1');
   }
 
-  return '';
-};
+  if (clientOptions.teamId) {
+    options.set('teamId', clientOptions.teamId);
+  }
+
+  return options.toString();
+}

--- a/packages/now-client/src/utils/query-string.ts
+++ b/packages/now-client/src/utils/query-string.ts
@@ -4,13 +4,13 @@ import { NowClientOptions } from '../types';
 export function generateQueryString(clientOptions: NowClientOptions): string {
   const options = new URLSearchParams();
 
-  if (clientOptions.force) {
-    options.set('forceNew', '1');
-  }
-
   if (clientOptions.teamId) {
     options.set('teamId', clientOptions.teamId);
   }
 
-  return options.toString();
+  if (clientOptions.force) {
+    options.set('forceNew', '1');
+  }
+
+  return Array.from(options.entries()).length ? `?${options.toString()}` : '';
 }

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -90,7 +90,7 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v2')
+        path: path.resolve(__dirname, 'fixtures', 'v2-file-permissions')
       },
       {
         name: 'now-client-tests-v2'

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -28,10 +28,12 @@ describe('create v2 deployment', () => {
 
   it('will display an empty deployment warning', async () => {
     for await (const event of createDeployment(
-      path.resolve(__dirname, 'fixtures', 'v2'),
       {
         token,
-        name: 'now-client-tests-v2',
+        path: path.resolve(__dirname, 'fixtures', 'v2')
+      },
+      {
+        name: 'now-clien-tests-v2'
       }
     )) {
       if (event.type === 'warning') {
@@ -47,10 +49,12 @@ describe('create v2 deployment', () => {
 
   it('will report correct file count event', async () => {
     for await (const event of createDeployment(
-      path.resolve(__dirname, 'fixtures', 'v2'),
       {
         token,
-        name: 'now-client-tests-v2',
+        path: path.resolve(__dirname, 'fixtures', 'v2')
+      },
+      {
+        name: 'now-client-tests-v2'
       }
     )) {
       if (event.type === 'file_count') {
@@ -66,10 +70,12 @@ describe('create v2 deployment', () => {
 
   it('will create a v2 deployment', async () => {
     for await (const event of createDeployment(
-      path.resolve(__dirname, 'fixtures', 'v2'),
       {
         token,
-        name: 'now-client-tests-v2',
+        path: path.resolve(__dirname, 'fixtures', 'v2')
+      },
+      {
+        name: 'now-client-tests-v2'
       }
     )) {
       if (event.type === 'ready') {
@@ -82,10 +88,12 @@ describe('create v2 deployment', () => {
 
   it('will create a v2 deployment with correct file permissions', async () => {
     for await (const event of createDeployment(
-      path.resolve(__dirname, 'fixtures', 'v2-file-permissions'),
       {
         token,
-        name: 'now-client-tests-v2',
+        path: path.resolve(__dirname, 'fixtures', 'v2')
+      },
+      {
+        name: 'now-client-tests-v2'
       }
     )) {
       if (event.type === 'ready') {
@@ -104,10 +112,12 @@ describe('create v2 deployment', () => {
 
   it('will create a v2 deployment and ignore files specified in .nowignore', async () => {
     for await (const event of createDeployment(
-      path.resolve(__dirname, 'fixtures', 'nowignore'),
       {
         token,
-        name: 'now-client-tests-v2-ignore',
+        path: path.resolve(__dirname, 'fixtures', 'nowignore')
+      },
+      {
+        name: 'now-client-tests-v2'
       }
     )) {
       if (event.type === 'ready') {

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -30,10 +30,10 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v2')
+        path: path.resolve(__dirname, 'fixtures', 'v2'),
       },
       {
-        name: 'now-clien-tests-v2'
+        name: 'now-clien-tests-v2',
       }
     )) {
       if (event.type === 'warning') {
@@ -51,10 +51,10 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v2')
+        path: path.resolve(__dirname, 'fixtures', 'v2'),
       },
       {
-        name: 'now-client-tests-v2'
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'file_count') {
@@ -72,10 +72,10 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v2')
+        path: path.resolve(__dirname, 'fixtures', 'v2'),
       },
       {
-        name: 'now-client-tests-v2'
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'ready') {
@@ -90,10 +90,10 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v2-file-permissions')
+        path: path.resolve(__dirname, 'fixtures', 'v2-file-permissions'),
       },
       {
-        name: 'now-client-tests-v2'
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'ready') {
@@ -114,10 +114,10 @@ describe('create v2 deployment', () => {
     for await (const event of createDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'nowignore')
+        path: path.resolve(__dirname, 'fixtures', 'nowignore'),
       },
       {
-        name: 'now-client-tests-v2'
+        name: 'now-client-tests-v2',
       }
     )) {
       if (event.type === 'ready') {

--- a/packages/now-client/tests/create-legacy-deployment.test.ts
+++ b/packages/now-client/tests/create-legacy-deployment.test.ts
@@ -29,9 +29,11 @@ describe('create v1 deployment', () => {
 
   it('will create a v1 static deployment', async () => {
     for await (const event of createLegacyDeployment(
-      path.resolve(__dirname, 'fixtures', 'v1', 'static'),
       {
         token,
+        path: path.resolve(__dirname, 'fixtures', 'v1', 'static')
+      },
+      {
         name: 'now-client-tests-v1-static',
       }
     )) {
@@ -47,9 +49,11 @@ describe('create v1 deployment', () => {
 
   it('will create a v1 npm deployment', async () => {
     for await (const event of createLegacyDeployment(
-      path.resolve(__dirname, 'fixtures', 'v1', 'npm'),
       {
         token,
+        path: path.resolve(__dirname, 'fixtures', 'v1', 'npm')
+      },
+      {
         name: 'now-client-tests-v1-npm',
       }
     )) {
@@ -65,10 +69,12 @@ describe('create v1 deployment', () => {
 
   it('will create a v1 Docker deployment', async () => {
     for await (const event of createLegacyDeployment(
-      path.resolve(__dirname, 'fixtures', 'v1', 'docker'),
       {
         token,
-        name: 'now-client-tests-v1-docker',
+        path: path.resolve(__dirname, 'fixtures', 'v1', 'docker'),
+      },
+      {
+        name: 'now-client-tests-v1-docker'
       }
     )) {
       if (event.type === 'ready') {

--- a/packages/now-client/tests/create-legacy-deployment.test.ts
+++ b/packages/now-client/tests/create-legacy-deployment.test.ts
@@ -31,7 +31,7 @@ describe('create v1 deployment', () => {
     for await (const event of createLegacyDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v1', 'static')
+        path: path.resolve(__dirname, 'fixtures', 'v1', 'static'),
       },
       {
         name: 'now-client-tests-v1-static',
@@ -51,7 +51,7 @@ describe('create v1 deployment', () => {
     for await (const event of createLegacyDeployment(
       {
         token,
-        path: path.resolve(__dirname, 'fixtures', 'v1', 'npm')
+        path: path.resolve(__dirname, 'fixtures', 'v1', 'npm'),
       },
       {
         name: 'now-client-tests-v1-npm',
@@ -74,7 +74,7 @@ describe('create v1 deployment', () => {
         path: path.resolve(__dirname, 'fixtures', 'v1', 'docker'),
       },
       {
-        name: 'now-client-tests-v1-docker'
+        name: 'now-client-tests-v1-docker',
       }
     )) {
       if (event.type === 'ready') {

--- a/packages/now-client/tests/paths.test.ts
+++ b/packages/now-client/tests/paths.test.ts
@@ -13,10 +13,10 @@ describe('path handling', () => {
       await createDeployment(
         {
           token,
-          path: './fixtures/v2/now.json'
+          path: './fixtures/v2/now.json',
         },
         {
-          name: 'now-client-tests-v2'
+          name: 'now-client-tests-v2',
         }
       );
     } catch (e) {
@@ -29,7 +29,7 @@ describe('path handling', () => {
       await createDeployment(
         {
           token,
-          path: ['./fixtures/v2/now.json']
+          path: ['./fixtures/v2/now.json'],
         },
         {
           name: 'now-client-tests-v2',

--- a/packages/now-client/tests/paths.test.ts
+++ b/packages/now-client/tests/paths.test.ts
@@ -10,10 +10,15 @@ describe('path handling', () => {
 
   it('will fali with a relative path', async () => {
     try {
-      await createDeployment('./fixtures/v2/now.json', {
-        token,
-        name: 'now-client-tests-v2',
-      });
+      await createDeployment(
+        {
+          token,
+          path: './fixtures/v2/now.json'
+        },
+        {
+          name: 'now-client-tests-v2'
+        }
+      );
     } catch (e) {
       expect(e.code).toEqual('invalid_path');
     }
@@ -21,10 +26,15 @@ describe('path handling', () => {
 
   it('will fali with an array of relative paths', async () => {
     try {
-      await createDeployment(['./fixtures/v2/now.json'], {
-        token,
-        name: 'now-client-tests-v2',
-      });
+      await createDeployment(
+        {
+          token,
+          path: ['./fixtures/v2/now.json']
+        },
+        {
+          name: 'now-client-tests-v2',
+        }
+      );
     } catch (e) {
       expect(e.code).toEqual('invalid_path');
     }


### PR DESCRIPTION
This splits the deployment options for `now-client` to make it easier to understand what is used for which step and makes sure Now CLI applies all options from `now.json` by default. We'll only filter out those that are not supported on the API, like `scope`.

[PRODUCT-611]

[PRODUCT-611]: https://zeit.atlassian.net/browse/PRODUCT-611