### PR TITLE
[now-next] Update routes for new check: true behavior

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -633,7 +633,7 @@ export const build = async ({
           return;
         }
 
-        const pathname = page.replace(/\.js$/, '');
+        const pathname = normalizePage(page.replace(/\.js$/, ''));
 
         if (isDynamicRoute(pathname)) {
           dynamicPages.push(normalizePage(pathname));
@@ -723,7 +723,9 @@ export const build = async ({
         ({ initialRevalidate, srcRoute, dataRoute } = pr);
       }
 
-      const outputPathPage = path.posix.join(entryDirectory, routeFileNoExt);
+      const outputPathPage = normalizePage(
+        path.posix.join(entryDirectory, routeFileNoExt)
+      );
       const outputSrcPathPage =
         srcRoute == null
           ? outputPathPage

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -737,11 +737,9 @@ export const build = async ({
         if (htmlFsRef == null || jsonFsRef == null) {
           throw new Error('invariant: htmlFsRef != null && jsonFsRef != null');
         }
-
+        htmlFsRef.contentType = htmlContentType
         prerenders[outputPathPage] = htmlFsRef;
         prerenders[outputPathData] = jsonFsRef;
-        // we need to set the contentType since we removed the extension
-        (prerenders[outputPathPage] as FileFsRef).contentType = htmlContentType
       } else {
         const lambda = lambdas[outputSrcPathPage];
         if (lambda == null) {

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -633,7 +633,7 @@ export const build = async ({
           return;
         }
 
-        const pathname = normalizePage(page.replace(/\.js$/, ''));
+        const pathname = page.replace(/\.js$/, '');
 
         if (isDynamicRoute(pathname)) {
           dynamicPages.push(normalizePage(pathname));
@@ -723,9 +723,7 @@ export const build = async ({
         ({ initialRevalidate, srcRoute, dataRoute } = pr);
       }
 
-      const outputPathPage = normalizePage(
-        path.posix.join(entryDirectory, routeFileNoExt)
-      );
+      const outputPathPage = path.posix.join(entryDirectory, routeFileNoExt)
       const outputSrcPathPage =
         srcRoute == null
           ? outputPathPage

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -59,8 +59,8 @@ import {
 
 import {
   convertRedirects,
-  convertRewrites
-} from '@now/routing-utils/dist/superstatic'
+  convertRewrites,
+} from '@now/routing-utils/dist/superstatic';
 
 interface BuildParamsMeta {
   isDev: boolean | undefined;
@@ -76,7 +76,7 @@ interface BuildParamsType extends BuildOptions {
 }
 
 export const version = 2;
-const htmlContentType = 'text/html; charset=utf-8'
+const htmlContentType = 'text/html; charset=utf-8';
 const nowDevChildProcesses = new Set<ChildProcess>();
 
 ['SIGINT', 'SIGTERM'].forEach(signal => {
@@ -484,7 +484,7 @@ export const build = async ({
 
       const staticRoute = path.join(entryDirectory, pathname);
       staticPages[staticRoute] = staticPageFiles[page];
-      staticPages[staticRoute].contentType = htmlContentType
+      staticPages[staticRoute].contentType = htmlContentType;
 
       if (isDynamicRoute(pathname)) {
         dynamicPages.push(routeName);
@@ -723,7 +723,7 @@ export const build = async ({
         ({ initialRevalidate, srcRoute, dataRoute } = pr);
       }
 
-      const outputPathPage = path.posix.join(entryDirectory, routeFileNoExt)
+      const outputPathPage = path.posix.join(entryDirectory, routeFileNoExt);
       const outputSrcPathPage =
         srcRoute == null
           ? outputPathPage
@@ -737,7 +737,7 @@ export const build = async ({
         if (htmlFsRef == null || jsonFsRef == null) {
           throw new Error('invariant: htmlFsRef != null && jsonFsRef != null');
         }
-        htmlFsRef.contentType = htmlContentType
+        htmlFsRef.contentType = htmlContentType;
         prerenders[outputPathPage] = htmlFsRef;
         prerenders[outputPathData] = jsonFsRef;
       } else {
@@ -821,7 +821,7 @@ export const build = async ({
   let dynamicPrefix = path.join('/', entryDirectory);
   dynamicPrefix = dynamicPrefix === '/' ? '' : dynamicPrefix;
 
-  const routesManifest = await getRoutesManifest(entryPath, realNextVersion)
+  const routesManifest = await getRoutesManifest(entryPath, realNextVersion);
 
   const dynamicRoutes = await getDynamicRoutes(
     entryPath,
@@ -836,15 +836,15 @@ export const build = async ({
     })
   );
 
-  const rewrites: Route[] = []
-  const redirects: Route[] = []
+  const rewrites: Route[] = [];
+  const redirects: Route[] = [];
 
   if (routesManifest) {
-    switch(routesManifest.version) {
+    switch (routesManifest.version) {
       case 1: {
-        redirects.push(...convertRedirects(routesManifest.redirects))
-        rewrites.push(...convertRewrites(routesManifest.rewrites))
-        break
+        redirects.push(...convertRedirects(routesManifest.redirects));
+        rewrites.push(...convertRewrites(routesManifest.rewrites));
+        break;
       }
       default: {
         // update MIN_ROUTES_MANIFEST_VERSION in ./utils.ts

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -902,13 +902,13 @@ export const build = async ({
         continue: true,
       },
       { src: path.join('/', entryDirectory, '_next(?!/data(?:/|$))(?:/.*)?') },
+      // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
+      // folder
       { handle: 'filesystem' },
       ...redirects,
       ...rewrites,
       // Static exported pages (.html rewrites)
       ...exportedPageRoutes,
-      // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
-      // folder
       // Dynamic routes
       ...dynamicRoutes,
       ...dynamicDataRoutes,

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -293,37 +293,36 @@ async function getRoutes(
 }
 
 export type Rewrite = {
-  source: string,
-  destination: string,
-}
+  source: string;
+  destination: string;
+};
 
 export type Redirect = Rewrite & {
-  statusCode?: number
-}
+  statusCode?: number;
+};
 
 type RoutesManifestRegex = {
-  regex: string,
-  regexKeys: string[]
-}
+  regex: string;
+  regexKeys: string[];
+};
 
 export type RoutesManifest = {
-  redirects: (Redirect & RoutesManifestRegex)[],
-  rewrites: (Rewrite & RoutesManifestRegex)[],
+  redirects: (Redirect & RoutesManifestRegex)[];
+  rewrites: (Rewrite & RoutesManifestRegex)[];
   dynamicRoutes: {
-    page: string,
-    regex: string,
-  }[],
-  version: number
-}
+    page: string;
+    regex: string;
+  }[];
+  version: number;
+};
 
 export async function getRoutesManifest(
   entryPath: string,
-  nextVersion?: string,
-): Promise< RoutesManifest | undefined> {
-  const shouldHaveManifest = (
-    nextVersion && semver.gte(nextVersion, '9.1.4-canary.0')
-  )
-  if (!shouldHaveManifest) return
+  nextVersion?: string
+): Promise<RoutesManifest | undefined> {
+  const shouldHaveManifest =
+    nextVersion && semver.gte(nextVersion, '9.1.4-canary.0');
+  if (!shouldHaveManifest) return;
 
   const pathRoutesManifest = path.join(
     entryPath,
@@ -338,12 +337,12 @@ export async function getRoutesManifest(
   if (shouldHaveManifest && !hasRoutesManifest) {
     throw new Error(
       `A routes-manifest.json couldn't be found. This could be due to a failure during the build`
-    )
+    );
   }
 
-  const routesManifest: RoutesManifest = require(pathRoutesManifest)
+  const routesManifest: RoutesManifest = require(pathRoutesManifest);
 
-  return routesManifest
+  return routesManifest;
 }
 
 export async function getDynamicRoutes(

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -14,7 +14,7 @@ it(
     const {
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'standard'));
-    expect(output['index.html']).toBeDefined();
+    expect(output['/']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -274,7 +274,7 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-config-object'));
 
-    expect(output['index.html']).toBeDefined();
+    expect(output['/']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -308,7 +308,7 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-no-config'));
 
-    expect(output['index.html']).toBeDefined();
+    expect(output['/']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -344,7 +344,7 @@ it(
       path.join(__dirname, 'serverless-no-config-build')
     );
 
-    expect(output['index.html']).toBeDefined();
+    expect(output['/']).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -14,7 +14,7 @@ it(
     const {
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'standard'));
-    expect(output['/']).toBeDefined();
+    expect(output['index']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -274,7 +274,7 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-config-object'));
 
-    expect(output['/']).toBeDefined();
+    expect(output['index']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -308,7 +308,7 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-no-config'));
 
-    expect(output['/']).toBeDefined();
+    expect(output['index']).toBeDefined();
     expect(output.goodbye).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
@@ -344,7 +344,7 @@ it(
       path.join(__dirname, 'serverless-no-config-build')
     );
 
-    expect(output['/']).toBeDefined();
+    expect(output['index']).toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)


### PR DESCRIPTION
As discussed this moves the `handle: filesystem` usage to the right location now that we have `check: true` for the `rewrites`