### PR TITLE
[now-build-utils] Update Detectors API

### DIFF
--- a/packages/now-build-utils/src/detectors/angular.ts
+++ b/packages/now-build-utils/src/detectors/angular.ts
@@ -6,9 +6,9 @@ export default async function detectAngular({
   const hasAngular = await hasDependency('@angular/cli');
   if (!hasAngular) return false;
   return {
-    buildCommand: ['ng', 'build'],
+    buildCommand: 'ng build',
     buildDirectory: 'dist',
-    devCommand: ['ng', 'serve', '--port', '$PORT'],
+    devCommand: 'ng serve --port $PORT',
     minNodeRange: '10.x',
     routes: [
       {

--- a/packages/now-build-utils/src/detectors/brunch.ts
+++ b/packages/now-build-utils/src/detectors/brunch.ts
@@ -10,8 +10,8 @@ export default async function detectBrunch({
   if (!hasConfig) return false;
 
   return {
-    buildCommand: ['brunch', 'build', '--production'],
+    buildCommand: 'brunch build --production',
     buildDirectory: 'public',
-    devCommand: ['brunch', 'watch', '--server', '--port', '$PORT'],
+    devCommand: 'brunch watch --server --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/create-react-app-ejected.ts
+++ b/packages/now-build-utils/src/detectors/create-react-app-ejected.ts
@@ -8,10 +8,10 @@ export default async function detectCreateReactAppEjected({
     return false;
   }
   return {
-    buildCommand: ['node', 'scripts/build.js'],
+    buildCommand: 'node scripts/build.js',
     buildDirectory: 'build',
-    devCommand: ['node', 'scripts/start.js'],
-    devEnv: { BROWSER: 'none' },
+    devCommand: 'node scripts/start.js',
+    devVariables: { BROWSER: 'none' },
     routes: [
       {
         src: '/static/(.*)',

--- a/packages/now-build-utils/src/detectors/create-react-app.ts
+++ b/packages/now-build-utils/src/detectors/create-react-app.ts
@@ -8,10 +8,10 @@ export default async function detectCreateReactApp({
     return false;
   }
   return {
-    buildCommand: ['react-scripts', 'build'],
+    buildCommand: 'react-scripts build',
     buildDirectory: 'build',
-    devCommand: ['react-scripts', 'start'],
-    devEnv: { BROWSER: 'none' },
+    devCommand: 'react-scripts start',
+    devVariables: { BROWSER: 'none' },
     routes: [
       {
         src: '/static/(.*)',

--- a/packages/now-build-utils/src/detectors/docusaurus.ts
+++ b/packages/now-build-utils/src/detectors/docusaurus.ts
@@ -6,8 +6,8 @@ export default async function detectDocusaurus({
   const hasDocusaurus = await hasDependency('docusaurus');
   if (!hasDocusaurus) return false;
   return {
-    buildCommand: ['docusaurus-build'],
+    buildCommand: 'docusaurus-build',
     buildDirectory: 'build',
-    devCommand: ['docusaurus-start', '--port', '$PORT'],
+    devCommand: 'docusaurus-start --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/eleventy.ts
+++ b/packages/now-build-utils/src/detectors/eleventy.ts
@@ -6,15 +6,8 @@ export default async function detectEleventy({
   const hasEleventy = await hasDependency('@11ty/eleventy');
   if (!hasEleventy) return false;
   return {
-    buildCommand: ['npx', '@11ty/eleventy'],
+    buildCommand: 'npx @11ty/eleventy',
     buildDirectory: '_site',
-    devCommand: [
-      'npx',
-      '@11ty/eleventy',
-      '--serve',
-      '--watch',
-      '--port',
-      '$PORT',
-    ],
+    devCommand: 'npx @11ty/eleventy --serve --watch --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/ember.ts
+++ b/packages/now-build-utils/src/detectors/ember.ts
@@ -6,9 +6,9 @@ export default async function detectEmber({
   const hasEmber = await hasDependency('ember-cli');
   if (!hasEmber) return false;
   return {
-    buildCommand: ['ember', 'build'],
+    buildCommand: 'ember build',
     buildDirectory: 'dist',
-    devCommand: ['ember', 'serve', '--port', '$PORT'],
+    devCommand: 'ember serve --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/gatsby.ts
+++ b/packages/now-build-utils/src/detectors/gatsby.ts
@@ -8,9 +8,9 @@ export default async function detectGatsby({
     return false;
   }
   return {
-    buildCommand: ['gatsby', 'build'],
+    buildCommand: 'gatsby build',
     buildDirectory: 'public',
-    devCommand: ['gatsby', 'develop', '-p', '$PORT'],
+    devCommand: 'gatsby develop -p $PORT',
     cachePattern: '.cache/**',
   };
 }

--- a/packages/now-build-utils/src/detectors/gridsome.ts
+++ b/packages/now-build-utils/src/detectors/gridsome.ts
@@ -8,8 +8,8 @@ export default async function detectGridsome({
     return false;
   }
   return {
-    buildCommand: ['gridsome', 'build'],
+    buildCommand: 'gridsome build',
     buildDirectory: 'dist',
-    devCommand: ['gridsome', 'develop', '-p', '$PORT'],
+    devCommand: 'gridsome develop -p $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/hexo.ts
+++ b/packages/now-build-utils/src/detectors/hexo.ts
@@ -6,8 +6,8 @@ export default async function detectHexo({
   const hasHexo = await hasDependency('hexo');
   if (!hasHexo) return false;
   return {
-    buildCommand: ['hexo', 'generate'],
+    buildCommand: 'hexo generate',
     buildDirectory: 'public',
-    devCommand: ['hexo', 'server', '--port', '$PORT'],
+    devCommand: 'hexo server --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/hugo.ts
+++ b/packages/now-build-utils/src/detectors/hugo.ts
@@ -19,8 +19,8 @@ export default async function detectHugo({
     return false;
   }
   return {
-    buildCommand: ['hugo'],
+    buildCommand: 'hugo',
     buildDirectory: config.publishDir || 'public',
-    devCommand: ['hugo', 'server', '-D', '-w', '-p', '$PORT'],
+    devCommand: 'hugo server -D -w -p $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/jekyll.ts
+++ b/packages/now-build-utils/src/detectors/jekyll.ts
@@ -15,16 +15,8 @@ export default async function detectJekyll({
     return false;
   }
   return {
-    buildCommand: ['jekyll', 'build'],
+    buildCommand: 'jekyll build',
     buildDirectory: config.destination || '_site',
-    devCommand: [
-      'bundle',
-      'exec',
-      'jekyll',
-      'serve',
-      '--watch',
-      '--port',
-      '$PORT',
-    ],
+    devCommand: 'bundle exec jekyll serve --watch --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/middleman.ts
+++ b/packages/now-build-utils/src/detectors/middleman.ts
@@ -7,8 +7,8 @@ export default async function detectMiddleman({
   if (!hasConfig) return false;
 
   return {
-    buildCommand: ['bundle', 'exec', 'middleman', 'build'],
+    buildCommand: 'bundle exec middleman build',
     buildDirectory: 'build',
-    devCommand: ['bundle', 'exec', 'middleman', 'server', '-p', '$PORT'],
+    devCommand: 'bundle exec middleman server -p $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/next.ts
+++ b/packages/now-build-utils/src/detectors/next.ts
@@ -6,8 +6,8 @@ export default async function detectNext({
   const hasNext = await hasDependency('next');
   if (!hasNext) return false;
   return {
-    buildCommand: ['next', 'build'],
+    buildCommand: 'next build',
     buildDirectory: 'build',
-    devCommand: ['next', '-p', '$PORT'],
+    devCommand: 'next -p $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/polymer.ts
+++ b/packages/now-build-utils/src/detectors/polymer.ts
@@ -6,9 +6,9 @@ export default async function detectPolymer({
   const hasPolymer = await hasDependency('polymer-cli');
   if (!hasPolymer) return false;
   return {
-    buildCommand: ['polymer', 'build'],
+    buildCommand: 'polymer build',
     buildDirectory: 'build',
-    devCommand: ['polymer', 'serve', '--port', '$PORT'],
+    devCommand: 'polymer serve --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/preact.ts
+++ b/packages/now-build-utils/src/detectors/preact.ts
@@ -6,9 +6,9 @@ export default async function detectPreact({
   const hasPreact = await hasDependency('preact-cli');
   if (!hasPreact) return false;
   return {
-    buildCommand: ['preact', 'build'],
+    buildCommand: 'preact build',
     buildDirectory: 'build',
-    devCommand: ['preact', 'watch', '--port', '$PORT'],
+    devCommand: 'preact watch --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/saber.ts
+++ b/packages/now-build-utils/src/detectors/saber.ts
@@ -6,9 +6,9 @@ export default async function detectSaber({
   const hasSaber = await hasDependency('saber');
   if (!hasSaber) return false;
   return {
-    buildCommand: ['saber', 'build'],
+    buildCommand: 'saber build',
     buildDirectory: 'public',
-    devCommand: ['saber', '--port', '$PORT'],
+    devCommand: 'saber --port $PORT',
     routes: [
       {
         src: '/_saber/.*',

--- a/packages/now-build-utils/src/detectors/sapper.ts
+++ b/packages/now-build-utils/src/detectors/sapper.ts
@@ -6,8 +6,8 @@ export default async function detectSapper({
   const hasSapper = await hasDependency('sapper');
   if (!hasSapper) return false;
   return {
-    buildCommand: ['sapper', 'export'],
+    buildCommand: 'sapper export',
     buildDirectory: '__sapper__/export',
-    devCommand: ['sapper', 'dev', '--port', '$PORT'],
+    devCommand: 'sapper dev --port $PORT',
   };
 }

--- a/packages/now-build-utils/src/detectors/stencil.ts
+++ b/packages/now-build-utils/src/detectors/stencil.ts
@@ -6,17 +6,9 @@ export default async function detectStencil({
   const hasStencil = await hasDependency('@stencil/core');
   if (!hasStencil) return false;
   return {
-    buildCommand: ['stencil', 'build'],
+    buildCommand: 'stencil build',
     buildDirectory: 'www',
-    devCommand: [
-      'stencil',
-      'build',
-      '--dev',
-      '--watch',
-      '--serve',
-      '--port',
-      '$PORT',
-    ],
+    devCommand: 'stencil build --dev --watch --serve --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/svelte.ts
+++ b/packages/now-build-utils/src/detectors/svelte.ts
@@ -6,9 +6,9 @@ export default async function detectSvelte({
   const hasSvelte = await hasDependency('sirv-cli');
   if (!hasSvelte) return false;
   return {
-    buildCommand: ['rollup', '-c'],
+    buildCommand: 'rollup -c',
     buildDirectory: 'public',
-    devCommand: ['sirv', 'public', '--single', '--dev', ' --port', '$PORT'],
+    devCommand: 'sirv public --single --dev --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/umi.ts
+++ b/packages/now-build-utils/src/detectors/umi.ts
@@ -6,9 +6,9 @@ export default async function detectUmiJS({
   const hasUmi = await hasDependency('umi');
   if (!hasUmi) return false;
   return {
-    buildCommand: ['umi', 'build'],
+    buildCommand: 'umi build',
     buildDirectory: 'dist',
-    devCommand: ['umi', 'dev', '--port', '$PORT'],
+    devCommand: 'umi dev --port $PORT',
     routes: [
       {
         handle: 'filesystem',

--- a/packages/now-build-utils/src/detectors/vue.ts
+++ b/packages/now-build-utils/src/detectors/vue.ts
@@ -6,9 +6,9 @@ export default async function detectVue({
   const hasVue = await hasDependency('@vue/cli-service');
   if (!hasVue) return false;
   return {
-    buildCommand: ['vue-cli-service', 'build'],
+    buildCommand: 'vue-cli-service build',
     buildDirectory: 'dist',
-    devCommand: ['vue-cli-service', 'serve', '--port', '$PORT'],
+    devCommand: 'vue-cli-service serve --port $PORT',
     routes: [
       {
         src: '^/[^/]*\\.(js|txt|ico|json)',

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -352,11 +352,11 @@ export interface DetectorParameters {
 }
 
 export interface DetectorOutput {
-  buildCommand: string[];
+  buildCommand: string;
   buildDirectory: string;
-  buildEnv?: Env;
-  devCommand?: string[];
-  devEnv?: Env;
+  buildVariables?: Env;
+  devCommand?: string;
+  devVariables?: Env;
   minNodeRange?: string;
   cachePattern?: string;
   routes?: Route[];

--- a/packages/now-build-utils/test/unit.detectors.test.ts
+++ b/packages/now-build-utils/test/unit.detectors.test.ts
@@ -68,7 +68,7 @@ test('detectDefaults() - angular', async () => {
   const result = await detectDefaults({ fs });
   if (!result) throw new Error('Expected result');
   assert.equal(result.buildDirectory, 'dist');
-  assert.deepEqual(result.buildCommand, ['ng', 'build']);
+  assert.deepEqual(result.buildCommand, 'ng build');
 });
 
 test('detectDefaults() - brunch', async () => {
@@ -77,7 +77,7 @@ test('detectDefaults() - brunch', async () => {
   const result = await detectDefaults({ fs });
   if (!result) throw new Error('Expected result');
   assert.equal(result.buildDirectory, 'public');
-  assert.deepEqual(result.buildCommand, ['brunch', 'build', '--production']);
+  assert.deepEqual(result.buildCommand, 'brunch build --production');
 });
 
 test('detectDefaults() - hugo', async () => {
@@ -86,7 +86,7 @@ test('detectDefaults() - hugo', async () => {
   const result = await detectDefaults({ fs });
   if (!result) throw new Error('Expected result');
   assert.equal(result.buildDirectory, 'public');
-  assert.deepEqual(result.buildCommand, ['hugo']);
+  assert.deepEqual(result.buildCommand, 'hugo');
 });
 
 test('detectDefaults() - jekyll', async () => {
@@ -95,7 +95,7 @@ test('detectDefaults() - jekyll', async () => {
   const result = await detectDefaults({ fs });
   if (!result) throw new Error('Expected result');
   assert.equal(result.buildDirectory, '_site');
-  assert.deepEqual(result.buildCommand, ['jekyll', 'build']);
+  assert.deepEqual(result.buildCommand, 'jekyll build');
 });
 
 test('detectDefaults() - middleman', async () => {
@@ -104,10 +104,5 @@ test('detectDefaults() - middleman', async () => {
   const result = await detectDefaults({ fs });
   if (!result) throw new Error('Expected result');
   assert.equal(result.buildDirectory, 'build');
-  assert.deepEqual(result.buildCommand, [
-    'bundle',
-    'exec',
-    'middleman',
-    'build',
-  ]);
+  assert.deepEqual(result.buildCommand, 'bundle exec middleman build');
 });


### PR DESCRIPTION
* Changes the `buildCommand` and `devCommand` from `string[]` to `string`
 * Renames `buildEnv` to `buildVariables` and `devEnv` to `devVariables`