### PR TITLE
[now-cli] Change `--debug` to avoid debugging builders

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -294,15 +294,11 @@ export default async function main(
     parseEnv(argv['--env'])
   );
 
-  // Enable debug mode for builders
-  const buildDebugEnv = debugEnabled ? { NOW_BUILDER_DEBUG: '1' } : {};
-
   // Merge build env out of  `build.env` from now.json, and `--build-env` args
   const deploymentBuildEnv = Object.assign(
     {},
     parseEnv(localConfig.build && localConfig.build.env),
-    parseEnv(argv['--build-env']),
-    buildDebugEnv
+    parseEnv(argv['--build-env'])
   );
 
   // If there's any undefined values, then inherit them from this process

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -83,12 +83,6 @@ async function createBuildProcess(
     NOW_REGION: 'dev1',
   };
 
-  // Builders won't show debug logs by default.
-  // The `NOW_BUILDER_DEBUG` env variable enables them.
-  if (debugEnabled) {
-    env.NOW_BUILDER_DEBUG = '1';
-  }
-
   const buildProcess = fork(modulePath, [], {
     cwd: workPath,
     env,

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -204,7 +204,7 @@ fs.writeFileSync(
   'index.js',
   fs
     .readFileSync('index.js', 'utf8')
-    .replace('BUILD_ENV_DEBUG', process.env.NOW_BUILDER_DEBUG),
+    .replace('BUILD_ENV_DEBUG', process.env.NOW_BUILDER_DEBUG ? 'on' : 'off'),
 );
       `,
       'index.js': `

--- a/packages/now-cli/test/integration-v1.js
+++ b/packages/now-cli/test/integration-v1.js
@@ -1995,7 +1995,7 @@ test('use `--debug` CLI flag', async t => {
   // get the content
   const response = await fetch(href);
   const content = await response.text();
-  t.is(content.trim(), '');
+  t.is(content.trim(), 'off');
 });
 
 test('try to deploy non-existing path', async t => {

--- a/packages/now-cli/test/integration-v1.js
+++ b/packages/now-cli/test/integration-v1.js
@@ -1995,7 +1995,7 @@ test('use `--debug` CLI flag', async t => {
   // get the content
   const response = await fetch(href);
   const content = await response.text();
-  t.is(content.trim(), '1');
+  t.is(content.trim(), '');
 });
 
 test('try to deploy non-existing path', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1456,7 +1456,7 @@ test('use `--debug` CLI flag', async t => {
   // get the content
   const response = await fetch(href);
   const content = await response.text();
-  t.is(content.trim(), '');
+  t.is(content.trim(), 'off');
 });
 
 test('try to deploy non-existing path', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1456,7 +1456,7 @@ test('use `--debug` CLI flag', async t => {
   // get the content
   const response = await fetch(href);
   const content = await response.text();
-  t.is(content.trim(), '1');
+  t.is(content.trim(), '');
 });
 
 test('try to deploy non-existing path', async t => {


### PR DESCRIPTION
Fixes [PRODUCT-683]

To print builder debug information, you will need to run `now -b NOW_BUILDER_DEBUG=1`

[PRODUCT-683]: https://zeit.atlassian.net/browse/PRODUCT-683