### PR TITLE
[now-cli] Remove `github` property from payload before sending it

### DIFF
--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -134,6 +134,7 @@ export default class Now extends EventEmitter {
 
     // Ignore specific items from Now.json
     delete requestBody.scope;
+    delete requestBody.github;
 
     if (isLegacy) {
       // Read `registry.npmjs.org` authToken from .npmrc

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -463,6 +463,15 @@ CMD ["node", "index.js"]`,
         },
       }),
     },
+    'github-and-scope-config': {
+      'index.txt': 'I Am a Website!',
+      'now.json': JSON.stringify({
+        scope: 'i-do-not-exist',
+        github: {
+          name: 'github-repo'
+        }
+      })
+    }
   };
 
   for (const typeName of Object.keys(spec)) {

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -122,11 +122,6 @@ module.exports = async session => {
     'single-dotfile': {
       '.testing': 'i am a dotfile',
     },
-    'config-alias-property': {
-      'now.json':
-        '{ "alias": "test.now.sh", "builds": [ { "src": "*.html", "use": "@now/static" } ] }',
-      'index.html': '<span>test alias</span',
-    },
     'config-scope-property-email': {
       'now.json': `{ "scope": "${session}@zeit.pub", "builds": [ { "src": "*.html", "use": "@now/static" } ], "version": 2 }`,
       'index.html': '<span>test scope email</span',

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -463,7 +463,10 @@ CMD ["node", "index.js"]`,
       'now.json': JSON.stringify({
         scope: 'i-do-not-exist',
         github: {
-          name: 'github-repo'
+          autoAlias: true,
+          autoJobCancelation: true,
+          enabled: true,
+          silent: true
         }
       })
     }

--- a/packages/now-cli/test/integration-v1.js
+++ b/packages/now-cli/test/integration-v1.js
@@ -1427,35 +1427,6 @@ test('ensure we render a prompt when deploying home directory', async t => {
   t.true(stderr.includes('> Aborted'));
 });
 
-test('ensure the `alias` property is not sent to the API', async t => {
-  const directory = fixture('config-alias-property');
-
-  const { stdout, stderr, exitCode } = await execa(
-    binaryPath,
-    [directory, '--public', '--name', session, ...defaultArgs, '--force'],
-    {
-      reject: false,
-    }
-  );
-
-  console.log(stderr);
-  console.log(stdout);
-  console.log(exitCode);
-
-  // Ensure the exit code is right
-  t.is(exitCode, 0);
-
-  // Test if the output is really a URL
-  const { href, host } = new URL(stdout);
-  t.is(host.split('-')[0], session);
-
-  // Send a test request to the deployment
-  const response = await fetch(href);
-  const contentType = response.headers.get('content-type');
-
-  t.is(contentType, 'text/html; charset=utf-8');
-});
-
 test('ensure the `scope` property works with email', async t => {
   const directory = fixture('config-scope-property-email');
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2039,7 +2039,7 @@ test('fail to deploy a Lambda with a specific runtime but without a locked versi
   );
 });
 
-test.only('ensure `github` and `scope` are not sent to the API', async t => {
+test('ensure `github` and `scope` are not sent to the API', async t => {
     const directory = fixture('github-and-scope-config');
     const output = await execute([directory]);
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -919,35 +919,6 @@ test('ensure we render a prompt when deploying home directory', async t => {
   t.true(stderr.includes('> Aborted'));
 });
 
-test('ensure the `alias` property is not sent to the API', async t => {
-  const directory = fixture('config-alias-property');
-
-  const { stdout, stderr, exitCode } = await execa(
-    binaryPath,
-    [directory, '--public', '--name', session, ...defaultArgs, '--force'],
-    {
-      reject: false,
-    }
-  );
-
-  console.log(stderr);
-  console.log(stdout);
-  console.log(exitCode);
-
-  // Ensure the exit code is right
-  t.is(exitCode, 0);
-
-  // Test if the output is really a URL
-  const { href, host } = new URL(stdout);
-  t.is(host.split('-')[0], session);
-
-  // Send a test request to the deployment
-  const response = await fetch(href);
-  const contentType = response.headers.get('content-type');
-
-  t.is(contentType, 'text/html; charset=utf-8');
-});
-
 test('ensure the `scope` property works with email', async t => {
   const directory = fixture('config-scope-property-email');
 
@@ -2056,7 +2027,6 @@ test('deploy a Lambda with a specific runtime', async t => {
   t.is(build.use, 'now-php@0.0.7', JSON.stringify(build, null, 2));
 });
 
-// We need to skip this test until `now-php` supports Runtime version 3
 test('fail to deploy a Lambda with a specific runtime but without a locked version', async t => {
   const directory = fixture('lambda-with-invalid-runtime');
   const output = await execute([directory]);
@@ -2067,6 +2037,13 @@ test('fail to deploy a Lambda with a specific runtime but without a locked versi
     /Function Runtimes must have a valid version/gim,
     formatOutput(output)
   );
+});
+
+test.only('ensure `github` and `scope` are not sent to the API', async t => {
+    const directory = fixture('github-and-scope-config');
+    const output = await execute([directory]);
+
+    t.is(output.exitCode, 0, formatOutput(output));
 });
 
 test.after.always(async () => {


### PR DESCRIPTION
This makes sure the `github` property is removed from the payload before sending it.

This will make it like it was before https://github.com/zeit/now/pull/3382/: 

https://github.com/zeit/now/blob/0ecdb35d506f363a180f5637ab056a80647b3e97/packages/now-client/src/deploy.ts#L118-L119