### PR TITLE
[script] Fix stable publish script

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -12,12 +12,31 @@ if (!commit) {
   throw new Error('Unable to find last publish commit');
 }
 
-const log = execSync(`git log --pretty=format:"- %s [%an]" ${commit}...HEAD`)
-  .toString()
-  .trim()
-  .split('\n')
-  .filter(line => !line.startsWith('- Publish Canary '))
-  .join('\n');
+const log =
+  execSync(`git log --pretty=format:"- %s [%an]" ${commit}...HEAD`)
+    .toString()
+    .trim()
+    .split('\n')
+    .filter(line => !line.startsWith('- Publish Canary '))
+    .join('\n') || 'NO CHANGES DETECTED';
 
 console.log(`Changes since the last Stable release (${commit.slice(0, 7)}):`);
 console.log(`\n${log}\n`);
+
+const pkgs =
+  Array.from(
+    new Set(
+      execSync(`git diff --name-only ${commit}...HEAD`)
+        .toString()
+        .trim()
+        .split('\n')
+        .filter(line => line.startsWith('packages/'))
+        .map(line => line.split('/')[1])
+        .map(pkgName => require(`./packages/${pkgName}/package.json`).name)
+    )
+  ).join(',') || 'now';
+
+console.log('To publish a stable release, execute the following:');
+console.log(
+  `\ngit pull && lerna version --message 'Publish Stable' --exact --force-publish=${pkgs}\n`
+);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap",
-    "publish-stable": "git pull && lerna version --message 'Publish Stable' --exact",
+    "publish-stable": "echo 'Run `yarn changelog` for instructions'",
     "publish-canary": "git pull && lerna version prerelease --preid canary --message 'Publish Canary' --exact",
     "publish-from-github": "./.circleci/publish.sh",
     "changelog": "node changelog.js",


### PR DESCRIPTION
Since we switched to a single branch (instead of master/canary), lerna gets confused about which packages to publish because stable and canary releases are in the same branch.

This PR fixes the confusion by looking at the git history and using [--force-publish](https://github.com/lerna/lerna/tree/master/commands/version#--force-publish) on the changed packages.

In order to avoid confusion for the person publishing, I removed the `yarn publish-stable` script in favor of `yarn changelog` which will print the change log and emit a script that can be used to publish stable.

<details><summary>View Example Output</summary>
<p>

```
$ yarn changelog
yarn run v1.19.1
$ node changelog.js
Changes since the last Stable release (21fe0a2):

- [now-cli] Change `--debug` to avoid debugging builders (#3386) [Steven]
- [now-next] Update routes for new check: true behavior (#3383) [JJ Kasper]
- [now-build-utils] Update Detectors API (#3384) [Nathan Rajlich]
- [now-client] Bump version (#3385) [Andy]
- [now-client] (Major) Split `now-client` options (#3382) [Andy]
- [now-cli][now-client] Fix user agent (#3381) [Steven]
- [now-client] Fix `main` in package.json (#3344) [Max]
- [now-build-utils] Change `script` to `scripts` in error message (#3376) [Andy]
- [now-cli] Add support for `check: true` routes in `now dev` (#3364) [Steven]
- [now-cli] Fix preinstall script on windows when `LOCALAPPDATA` is missing (#3365) [Steven]
- [now dev] skip installing already installed versioned runtimes (#3354) [Tommaso De Rossi]
- [now-routing-utils] Update `path-to-regexp` to v6.1.0 (#3361) [Steven]
- [now-routing-utils] Add mergeRoutes function (#3358) [Steven]
- [docs] Remove deprecated LambdaRuntimes (#3346) [Steven]
- [now-routing-utils] Add support for `check: true` (#3343) [Steven]
- [now-static-build] Cache `.cache` folder for gatsby deployments (#3260) (#3342) [Luc]

To publish a stable release, execute the following:

git pull && lerna version --message 'Publish Stable' --exact --force-publish=@now/build-utils,now,now-client,@now/next,@now/routing-utils,@now/static-build
```

</p>
</details>