### PR TITLE
[now-build-utils] Add `--no-audit` flag to npm install

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -155,7 +155,7 @@ export async function runNpmInstall(
     commandArgs = args.filter(a => a !== '--prefer-offline');
     await spawnAsync(
       'npm',
-      commandArgs.concat(['install', '--unsafe-perm']),
+      commandArgs.concat(['install', '--no-audit', '--unsafe-perm']),
       opts
     );
   } else {


### PR DESCRIPTION
This PR will reduce deployment time when a `package-lock.json` file is found by avoiding the audit step which usually [sends audit reports](https://docs.npmjs.com/cli/audit#description) to the registry.

The [--no-audit](https://docs.npmjs.com/cli/install) flag was introduced in [npm@6](
https://medium.com/npm-inc/announcing-npm-6-5d0b1799a905) which shipped with Node 10. However, using the flag with npm@5 does not do anything which is great because npm@5 doesn't audit. So this PR is backwards compatible.

### Performance

I tried `npm install` and `npm install --no-audit` with a large project, [StateOfJS](https://github.com/StateOfJS/StateOfJS/tree/a9fa6d47f9d0d19387e0db1bda2d1590d58ff2d7/homepages/stateofjs), which has 2206 packages (audited 21778 packages).

I made sure to `rm -rf node_modules` each time and ran both commands 5 times to make sure it was always faster with `--no-audit`.

- Before: 61 seconds
- After: 49 seconds