### PR TITLE
[now-cgi][now-next][now-ruby] Unify logging about downloading user files

### DIFF
--- a/packages/now-cgi/index.js
+++ b/packages/now-cgi/index.js
@@ -3,6 +3,7 @@ const { mkdirp, copyFile } = require('fs-extra');
 
 const {
   glob,
+  debug,
   download,
   shouldServe,
   createLambda,
@@ -14,7 +15,7 @@ exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 exports.version = 3;
 
 exports.build = async ({ workPath, files, entrypoint, meta, config }) => {
-  console.log('downloading files...');
+  debug('Downloading user files...');
   const outDir = await getWritableDirectory();
 
   await download(files, workPath, meta);

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -201,7 +201,7 @@ export const build = async ({
   const entryPath = path.join(workPath, entryDirectory);
   const dotNextStatic = path.join(entryPath, '.next/static');
 
-  debug(`${name} Downloading user files...`);
+  debug('Downloading user files...');
   await download(files, workPath, meta);
 
   const pkg = await readPackageJson(entryPath);

--- a/packages/now-next/test/fixtures/05-spr-support/package.json
+++ b/packages/now-next/test/fixtures/05-spr-support/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "^9.1.2-canary.8",
+    "next": "^9.1.6-canary.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/05-spr-support/pages/blog/[post]/[comment].js
+++ b/packages/now-next/test/fixtures/05-spr-support/pages/blog/[post]/[comment].js
@@ -1,16 +1,16 @@
 import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticParams() {
+export async function unstable_getStaticPaths () {
   return [
     '/blog/post-1/comment-1',
-    { post: 'post-2', comment: 'comment-2' },
+    { params: { post: 'post-2', comment: 'comment-2' } },
     '/blog/post-1337/comment-1337',
   ];
 }
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticProps({ params }) {
+export async function unstable_getStaticProps ({ params }) {
   return {
     props: {
       post: params.post,

--- a/packages/now-next/test/fixtures/05-spr-support/pages/blog/[post]/index.js
+++ b/packages/now-next/test/fixtures/05-spr-support/pages/blog/[post]/index.js
@@ -1,12 +1,13 @@
 import React from 'react'
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticParams () {
+export async function unstable_getStaticPaths () {
   return [
     '/blog/post-1',
-    { post: 'post-2' },
+    { params: { post: 'post-2' } },
   ]
 }
+
 
 // eslint-disable-next-line camelcase
 export async function unstable_getStaticProps ({ params }) {

--- a/packages/now-ruby/index.ts
+++ b/packages/now-ruby/index.ts
@@ -84,7 +84,7 @@ export const build = async ({
   entrypoint,
   config,
 }: BuildOptions) => {
-  debug('downloading files...');
+  debug('Downloading user files...');
 
   await download(files, workPath);
 


### PR DESCRIPTION
This makes sure we don't show the runtime name for `@now/next` and show the same text everywhere.

[PRODUCT-778]

[PRODUCT-778]: https://zeit.atlassian.net/browse/PRODUCT-778