### PR TITLE
[now-dev] Improved feedback link

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -18,7 +18,7 @@ export default async function dev(
   output: Output
 ) {
   output.dim(
-    `Now CLI ${pkg.version} dev (beta) — https://zeit.co/feedback/dev`
+    `Now CLI ${pkg.version} dev (beta) — https://zeit.co/feedback`
   );
 
   const [dir = '.'] = args;


### PR DESCRIPTION
We've shut down our Typeform for feedback, so we can simply the feedback link. The old one will continue working, but we should start using the new one.

Pending on https://github.com/zeit/front/pull/5874.

Fixes #3377 