### PR TITLE
[now-build-utils] Add `handle: miss` route to zero config

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,5 @@
 import { parse as parsePath } from 'path';
-import { Route } from '@now/routing-utils';
+import { Route, Source } from '@now/routing-utils';
 import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
 
@@ -315,10 +315,14 @@ export async function detectRoutes(
   if (routesResult.defaultRoutes && publicBuilder) {
     const directory = publicBuilder.src.replace('/**/*', '');
 
-    routesResult.defaultRoutes.push({
+    const route: Source = {
       src: '/(.*)',
       dest: `/${directory}/$1`,
-    });
+    };
+    if (featHandleMiss) {
+      route.check = true;
+    }
+    routesResult.defaultRoutes.push(route);
   }
 
   return routesResult;

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,5 @@
 import { parse as parsePath } from 'path';
-import { Route, Source } from '@now/routing-utils';
+import { Route } from '@now/routing-utils';
 import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
 
@@ -314,17 +314,16 @@ export function detectOutputDirectory(builders: Builder[]): string | null {
 export async function detectRoutes(
   files: string[],
   builders: Builder[],
-  featHandleMiss: boolean
+  featHandleMiss = false
 ): Promise<RoutesResult> {
   const routesResult = await detectApiRoutes(files, builders, featHandleMiss);
   const directory = detectOutputDirectory(builders);
 
   if (routesResult.defaultRoutes && directory && !featHandleMiss) {
-    const route: Source = {
+    routesResult.defaultRoutes.push({
       src: '/(.*)',
       dest: `/${directory}/$1`,
-    };
-    routesResult.defaultRoutes.push(route);
+    });
   }
 
   return routesResult;

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -304,24 +304,26 @@ function getPublicBuilder(builders: Builder[]): Builder | null {
   return builder || null;
 }
 
+export function detectOutputDirectory(builders: Builder[]): string | null {
+  // TODO: We eventually want to save the output directory to
+  // builder.config.outputDirectory so it is only detected once
+  const publicBuilder = getPublicBuilder(builders);
+  return publicBuilder ? publicBuilder.src.replace('/**/*', '') : null;
+}
+
 export async function detectRoutes(
   files: string[],
   builders: Builder[],
   featHandleMiss: boolean
 ): Promise<RoutesResult> {
   const routesResult = await detectApiRoutes(files, builders, featHandleMiss);
-  const publicBuilder = getPublicBuilder(builders);
+  const directory = detectOutputDirectory(builders);
 
-  if (routesResult.defaultRoutes && publicBuilder) {
-    const directory = publicBuilder.src.replace('/**/*', '');
-
+  if (routesResult.defaultRoutes && directory && !featHandleMiss) {
     const route: Source = {
       src: '/(.*)',
       dest: `/${directory}/$1`,
     };
-    if (featHandleMiss) {
-      route.check = true;
-    }
     routesResult.defaultRoutes.push(route);
   }
 

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -277,14 +277,14 @@ async function detectApiRoutes(
         },
         {
           status: 404,
-          src: '/api(\\/.*)?$',
+          src: '/api(/.*)?$',
           continue: true,
         },
       ];
     } else {
       defaultRoutes.push({
         status: 404,
-        src: '/api(\\/.*)?$',
+        src: '/api(/.*)?$',
       });
     }
   }

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -24,7 +24,7 @@ import {
 import streamToBuffer from './fs/stream-to-buffer';
 import shouldServe from './should-serve';
 import { detectBuilders } from './detect-builders';
-import { detectRoutes } from './detect-routes';
+import { detectRoutes, detectOutputDirectory } from './detect-routes';
 import DetectorFilesystem from './detectors/filesystem';
 import debug from './debug';
 
@@ -57,6 +57,7 @@ export {
   shouldServe,
   detectBuilders,
   detectRoutes,
+  detectOutputDirectory,
   debug,
   isSymbolicLink,
   getLambdaOptionsFromFunction,

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -1000,7 +1000,7 @@ it('Test `detectRoutes`', async () => {
     const { builders } = await detectBuilders(files);
     const { defaultRoutes } = await detectRoutes(files, builders);
     expect(defaultRoutes[2].status).toBe(404);
-    expect(defaultRoutes[2].src).toBe('/api(\\/.*)?$');
+    expect(defaultRoutes[2].src).toBe('/api(/.*)?$');
     expect(defaultRoutes[3].src).toBe('/(.*)');
     expect(defaultRoutes[3].dest).toBe('/public/$1');
     expect(defaultRoutes.length).toBe(4);
@@ -1020,7 +1020,7 @@ it('Test `detectRoutes`', async () => {
     const { builders } = await detectBuilders(files, detected);
     const { defaultRoutes } = await detectRoutes(files, builders);
     expect(defaultRoutes[1].status).toBe(404);
-    expect(defaultRoutes[1].src).toBe('/api(\\/.*)?$');
+    expect(defaultRoutes[1].src).toBe('/api(/.*)?$');
     expect(defaultRoutes.length).toBe(2);
   }
 

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -936,6 +936,189 @@ describe('Test `detectBuilders`', () => {
   });
 });
 
+it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
+  const featHandleMiss = true;
+
+  const expectedRoutes = [
+    { handle: 'miss' },
+    {
+      src: '/api/(.+)\\.\\w+',
+      dest: '/api/$1',
+      check: true,
+    },
+    {
+      status: 404,
+      src: '/api(/.*)?$',
+      continue: true,
+    },
+  ];
+
+  {
+    const files = ['api/user.go', 'api/team.js', 'api/package.json'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const files = ['api/user.go', 'api/user.js'];
+
+    const { builders } = await detectBuilders(files);
+    const { error } = await detectRoutes(files, builders, featHandleMiss);
+    expect(error.code).toBe('conflicting_file_path');
+  }
+
+  {
+    const files = ['api/[user].go', 'api/[team]/[id].js'];
+
+    const { builders } = await detectBuilders(files);
+    const { error } = await detectRoutes(files, builders, featHandleMiss);
+    expect(error.code).toBe('conflicting_file_path');
+  }
+
+  {
+    const files = ['api/[team]/[team].js'];
+
+    const { builders } = await detectBuilders(files);
+    const { error } = await detectRoutes(files, builders, featHandleMiss);
+    expect(error.code).toBe('conflicting_path_segment');
+  }
+
+  {
+    const files = ['api/date/index.js', 'api/date/index.go'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes, error } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toBe(null);
+    expect(error.code).toBe('conflicting_file_path');
+  }
+
+  {
+    const files = ['api/[endpoint].js', 'api/[endpoint]/[id].js'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const files = [
+      'public/index.html',
+      'api/[endpoint].js',
+      'api/[endpoint]/[id].js',
+    ];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const detected = {
+      buildCommand: 'yarn build',
+      framework: {
+        slug: 'next',
+        version: '9.0.0',
+      },
+    };
+
+    const files = ['public/index.html', 'api/[endpoint].js'];
+
+    const { builders } = await detectBuilders(files, detected);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const files = ['public/index.html'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual([]);
+  }
+
+  {
+    const files = ['api/date/index.js', 'api/date.js'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const files = ['api/date.js', 'api/[date]/index.js'];
+
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    const files = [
+      'api/index.ts',
+      'api/index.d.ts',
+      'api/users/index.ts',
+      'api/users/index.d.ts',
+      'api/food.ts',
+      'api/ts/gold.ts',
+    ];
+    const { builders } = await detectBuilders(files);
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+
+  {
+    // use a custom runtime
+    const functions = { 'api/user.php': { runtime: 'now-php@0.0.5' } };
+    const files = ['api/user.php'];
+
+    const { builders } = await detectBuilders(files, null, { functions });
+    const { defaultRoutes } = await detectRoutes(
+      files,
+      builders,
+      featHandleMiss
+    );
+    expect(defaultRoutes).toStrictEqual(expectedRoutes);
+  }
+});
+
 it('Test `detectRoutes`', async () => {
   {
     const files = ['api/user.go', 'api/team.js', 'api/package.json'];

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -570,7 +570,8 @@ export default class DevServer {
       if (builders) {
         const { defaultRoutes, error: routesError } = await detectRoutes(
           files,
-          builders
+          builders,
+          false // TODO: enable after implementing `handle: miss`
         );
 
         config.builds = config.builds || [];

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -570,8 +570,7 @@ export default class DevServer {
       if (builders) {
         const { defaultRoutes, error: routesError } = await detectRoutes(
           files,
-          builders,
-          false // TODO: enable after implementing `handle: miss`
+          builders
         );
 
         config.builds = config.builds || [];


### PR DESCRIPTION
This PR adds the route `handle: miss` and a catch-all route for the api directory.

The plan is to rename files in `/api` and `/public` (in a future PR) to be extension-less and then the route is only used to rewrite the extension to the extension-less file (for example, `/api/user.go` => `/api/user`)

This reduces the routes needed for zero config (previously N routes for N files down to 1 route for N files). 