### PR TITLE
[all] Move "Downloading deployment source files" message to `download()`

### DIFF
--- a/packages/now-build-utils/src/fs/download.ts
+++ b/packages/now-build-utils/src/fs/download.ts
@@ -80,7 +80,7 @@ export default async function download(
   );
 
   const duration = Date.now() - start;
-  debug(`Downloaded ${filenames.length} source files [${duration}ms]`);
+  debug(`Downloaded ${filenames.length} source files: ${duration}ms`);
 
   return files2;
 }

--- a/packages/now-build-utils/src/fs/download.ts
+++ b/packages/now-build-utils/src/fs/download.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import debug from '../debug';
 import FileFsRef from '../file-fs-ref';
 import { File, Files, Meta } from '../types';
 import { remove, mkdirp, readlink, symlink } from 'fs-extra';
@@ -39,8 +40,12 @@ export default async function download(
   basePath: string,
   meta?: Meta
 ): Promise<DownloadedFiles> {
-  const { isDev = false, skipDownload = false, filesChanged = null, filesRemoved = null } =
-    meta || {};
+  const {
+    isDev = false,
+    skipDownload = false,
+    filesChanged = null,
+    filesRemoved = null,
+  } = meta || {};
 
   if (isDev || skipDownload) {
     // In `now dev`, the `download()` function is a no-op because
@@ -48,11 +53,14 @@ export default async function download(
     // source files are already available.
     return files as DownloadedFiles;
   }
+  debug('Downloading deployment source files...');
 
+  const start = Date.now();
   const files2: DownloadedFiles = {};
+  const filenames = Object.keys(files);
 
   await Promise.all(
-    Object.keys(files).map(async name => {
+    filenames.map(async name => {
       // If the file does not exist anymore, remove it.
       if (Array.isArray(filesRemoved) && filesRemoved.includes(name)) {
         await removeFile(basePath, name);
@@ -70,6 +78,9 @@ export default async function download(
       files2[name] = await downloadFile(file, fsPath);
     })
   );
+
+  const duration = Date.now() - start;
+  debug(`Downloaded ${filenames.length} source files [${duration}ms]`);
 
   return files2;
 }

--- a/packages/now-cgi/index.js
+++ b/packages/now-cgi/index.js
@@ -15,7 +15,6 @@ exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 exports.version = 3;
 
 exports.build = async ({ workPath, files, entrypoint, meta, config }) => {
-  debug('Downloading user files...');
   const outDir = await getWritableDirectory();
 
   await download(files, workPath, meta);

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -70,7 +70,6 @@ Learn more: https://github.com/golang/go/wiki/Modules
 `);
   }
 
-  debug('Downloading user files...');
   const entrypointArr = entrypoint.split(sep);
 
   // eslint-disable-next-line prefer-const

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -202,7 +202,6 @@ export const build = async ({
   const entryPath = path.join(workPath, entryDirectory);
   const dotNextStatic = path.join(entryPath, '.next/static');
 
-  debug('Downloading user files...');
   await download(files, workPath, meta);
 
   const pkg = await readPackageJson(entryPath);

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -63,10 +63,7 @@ async function downloadInstallAndBundle({
   config,
   meta,
 }: DownloadOptions) {
-  debug('Downloading user files...');
-  const downloadTime = Date.now();
   const downloadedFiles = await download(files, workPath, meta);
-  debug(`download complete [${Date.now() - downloadTime}ms]`);
 
   console.log('Installing dependencies...');
   const installTime = Date.now();

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -77,7 +77,6 @@ export const build = async ({
   meta = {},
   config,
 }: BuildOptions) => {
-  debug('Downloading user files...');
   let downloadedFiles = await download(originalFiles, workPath, meta);
 
   if (meta.isDev) {

--- a/packages/now-ruby/index.ts
+++ b/packages/now-ruby/index.ts
@@ -84,8 +84,6 @@ export const build = async ({
   entrypoint,
   config,
 }: BuildOptions) => {
-  debug('Downloading user files...');
-
   await download(files, workPath);
 
   const { gemHome, bundlerPath } = await installBundler();

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -175,7 +175,6 @@ export async function build({
   config,
   meta = {},
 }: BuildOptions) {
-  debug('Downloading user files...');
   await download(files, workPath, meta);
 
   const mountpoint = path.dirname(entrypoint);


### PR DESCRIPTION
Before, the debug log message "Downloading user files..." was copy+pasted to all the builders.

This change centralizes that log message to be inside the `download()` function for consistency and DRY purposes.

Additionally, the wording has changed as per [INFRA-289], and a resulting timestamp message is also printed.

[INFRA-289]: https://zeit.atlassian.net/browse/INFRA-289