### PR TITLE
[now dev] Fix validate functions config failed in now json

### DIFF
--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -61,11 +61,11 @@ const functionsSchema = {
         },
         includeFiles: {
           type: 'string',
-          maxLength: 4096,
+          maxLength: 256,
         },
         excludeFiles: {
           type: 'string',
-          maxLength: 4096,
+          maxLength: 256,
         },
       },
     },

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -59,6 +59,14 @@ const functionsSchema = {
           minimum: 1,
           maximum: 900,
         },
+        includeFiles: {
+          type: 'string',
+          maxLength: 4096,
+        },
+        excludeFiles: {
+          type: 'string',
+          maxLength: 4096,
+        },
       },
     },
   },


### PR DESCRIPTION
Follow up to #3408 .

```
> Error! Checking for updates failed
> Now CLI 16.6.3 dev (beta) — https://zeit.co/feedback/dev
> Error! Invalid `functions` property: ['api/test.js'] should NOT have additional properties
```