### PR TITLE
[now-build-utils][now-cli] Move builds schema and functions schema to `build-utils`

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -57,4 +57,5 @@ export {
 };
 
 export { detectDefaults } from './detectors';
+export * from './schemas';
 export * from './types';

--- a/packages/now-build-utils/src/schemas.ts
+++ b/packages/now-build-utils/src/schemas.ts
@@ -16,9 +16,10 @@ export const functionsSchema = {
           maxLength: 256,
         },
         memory: {
-          type: 'number',
-          minimum: 128,
-          maximum: 3008,
+          // Number between 128 and 3008 in steps of 64
+          enum: Object.keys(Array.from({ length: 50 }))
+            .slice(2, 48)
+            .map(x => Number(x) * 64),
         },
         maxDuration: {
           type: 'number',

--- a/packages/now-build-utils/src/schemas.ts
+++ b/packages/now-build-utils/src/schemas.ts
@@ -1,6 +1,3 @@
-/**
- * Ajv schema for the functions property
- */
 export const functionsSchema = {
   type: 'object',
   minProperties: 1,
@@ -35,6 +32,30 @@ export const functionsSchema = {
           maxLength: 256,
         },
       },
+    },
+  },
+};
+
+export const buildsSchema = {
+  type: 'array',
+  minItems: 0,
+  maxItems: 128,
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['use'],
+    properties: {
+      src: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 4096,
+      },
+      use: {
+        type: 'string',
+        minLength: 3,
+        maxLength: 256,
+      },
+      config: { type: 'object' },
     },
   },
 };

--- a/packages/now-build-utils/src/schemas.ts
+++ b/packages/now-build-utils/src/schemas.ts
@@ -1,0 +1,39 @@
+/**
+ * Ajv schema for the functions property
+ */
+export const functionsSchema = {
+  type: 'object',
+  minProperties: 1,
+  maxProperties: 50,
+  additionalProperties: false,
+  patternProperties: {
+    '^.{1,256}$': {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        runtime: {
+          type: 'string',
+          maxLength: 256,
+        },
+        memory: {
+          type: 'number',
+          minimum: 128,
+          maximum: 3008,
+        },
+        maxDuration: {
+          type: 'number',
+          minimum: 1,
+          maximum: 900,
+        },
+        includeFiles: {
+          type: 'string',
+          maxLength: 256,
+        },
+        excludeFiles: {
+          type: 'string',
+          maxLength: 256,
+        },
+      },
+    },
+  },
+};

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -8,6 +8,7 @@ import {
   trailingSlashSchema,
 } from '@now/routing-utils';
 import { NowConfig } from './types';
+import { functionsSchema } from '@now/build-utils';
 
 const ajv = new Ajv();
 
@@ -31,35 +32,6 @@ const buildsSchema = {
         maxLength: 256,
       },
       config: { type: 'object' },
-    },
-  },
-};
-
-const functionsSchema = {
-  type: 'object',
-  minProperties: 1,
-  maxProperties: 50,
-  additionalProperties: false,
-  patternProperties: {
-    '^.{1,256}$': {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        runtime: {
-          type: 'string',
-          maxLength: 256,
-        },
-        memory: {
-          enum: Object.keys(Array.from({ length: 50 }))
-            .slice(2, 48)
-            .map(x => Number(x) * 64),
-        },
-        maxDuration: {
-          type: 'number',
-          minimum: 1,
-          maximum: 900,
-        },
-      },
     },
   },
 };

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -8,33 +8,9 @@ import {
   trailingSlashSchema,
 } from '@now/routing-utils';
 import { NowConfig } from './types';
-import { functionsSchema } from '@now/build-utils';
+import { functionsSchema, buildsSchema } from '@now/build-utils';
 
 const ajv = new Ajv();
-
-const buildsSchema = {
-  type: 'array',
-  minItems: 0,
-  maxItems: 128,
-  items: {
-    type: 'object',
-    additionalProperties: false,
-    required: ['use'],
-    properties: {
-      src: {
-        type: 'string',
-        minLength: 1,
-        maxLength: 4096,
-      },
-      use: {
-        type: 'string',
-        minLength: 3,
-        maxLength: 256,
-      },
-      config: { type: 'object' },
-    },
-  },
-};
 
 const validateBuilds = ajv.compile(buildsSchema);
 const validateRoutes = ajv.compile(routesSchema);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -770,7 +770,7 @@ test('create wildcard alias for deployment', async t => {
   // Retries to make sure we consider the time it takes to update
   const response = await retry(
     async () => {
-      const response = fetch(`https://test.${contextName}.now.sh`);
+      const response = await fetch(`https://test.${contextName}.now.sh`);
 
       if (response.ok) {
         return response;

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -767,7 +767,19 @@ test('create wildcard alias for deployment', async t => {
   t.true(stdout.startsWith(goal));
 
   // Send a test request to the alias
-  const response = await fetch(`https://test.${contextName}.now.sh`);
+  // Retries to make sure we consider the time it takes to update
+  const response = await retry(
+    async () => {
+      const response = fetch(`https://test.${contextName}.now.sh`);
+
+      if (response.ok) {
+        return response;
+      }
+
+      throw new Error(`Error: Returned code ${response.status}`);
+    },
+    { retries: 3 }
+  );
   const content = await response.text();
 
   t.true(response.ok);


### PR DESCRIPTION
Move builds schema and functions schema to `build-utils`.

Also adds retries to the `create wildcard alias for deployment` test, since it fails from time to time even though the alias was created.