### PR TITLE
[now-cli] Remove dead link to max lambda size

### DIFF
--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1097,7 +1097,7 @@ export class LambdaSizeExceededError extends NowError<
         size
       ).toLowerCase()}) exceeds the maximum size limit (${bytes(
         maxLambdaSize
-      ).toLowerCase()}). Learn more: https://zeit.co/docs/v2/deployments/concepts/lambdas/#maximum-bundle-size`,
+      ).toLowerCase()}).`,
       meta: { size, maxLambdaSize },
     });
   }


### PR DESCRIPTION
We used to have a default `maxLambdaSize` and allow the user to increase to 50 MB.

However, this is no longer true. Today, the `maxLambdaSize` for every function is 50 MB and is not configurable, it's a hard limit.

This PR removes the dead link to avoid confusion like in Issue #3416. 