### PR TITLE
[tests] Fix unit test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,10 @@ jobs:
       - run:
           name: Running Unit Tests
           command: yarn test-unit --clean false
+      - persist_to_workspace:
+          root: .
+          paths:
+            - packages/now-cli/.nyc_output
 
   coverage:
     docker:
@@ -349,12 +353,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Compiling `now dev` HTML error templates
-          command: node packages/now-cli/scripts/compile-templates.js
-      - run:
-          name: Run unit tests
-          command: yarn workspace now run test-unit
       - run:
           name: Run coverage report
           command: yarn workspace now run coverage


### PR DESCRIPTION
This PR reduces the time running Circle CI tests.

Since creating the monorepo in #2812, the coverage broke and then was fixed in #2876 with a workaround which would run unit tests twice.

More recently, we enabled Now CLI to always run tests in #3305 so that means coverage data is always generated.

This PR is a final proper fix so that unit tests run once which saves approximately 2 minutes per push (CI workflow).