### PR TITLE
[now-build-utils] Remove unused `execa`

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -35,7 +35,6 @@
     "boxen": "4.2.0",
     "cross-spawn": "6.0.5",
     "end-of-stream": "1.4.1",
-    "execa": "^1.0.0",
     "fs-extra": "7.0.0",
     "glob": "7.1.3",
     "into-stream": "5.0.0",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -35,7 +35,7 @@
     "boxen": "4.2.0",
     "cross-spawn": "6.0.5",
     "end-of-stream": "1.4.1",
-    "execa": "3.4.0",
+    "execa": "^1.0.0",
     "fs-extra": "7.0.0",
     "glob": "7.1.3",
     "into-stream": "5.0.0",

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -1,9 +1,14 @@
 const path = require('path');
 const fs = require('fs-extra');
-const execa = require('execa');
 const assert = require('assert');
 const { createZip } = require('../dist/lambda');
-const { glob, download, detectBuilders, detectRoutes } = require('../');
+const {
+  glob,
+  download,
+  detectBuilders,
+  detectRoutes,
+  spawnAsync,
+} = require('../');
 const {
   getSupportedNodeVersion,
   defaultSelection,
@@ -39,7 +44,7 @@ it('should create zip files with symlinks properly', async () => {
   await fs.mkdirp(outDir);
 
   await fs.writeFile(outFile, await createZip(files));
-  await execa('unzip', [outFile], { cwd: outDir });
+  await spawnAsync('unzip', [outFile], { cwd: outDir });
 
   const [linkStat, aStat] = await Promise.all([
     fs.lstat(path.join(outDir, 'link.txt')),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4629,22 +4629,6 @@ execa@3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
-  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    p-finally "^2.0.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"


### PR DESCRIPTION
~~Reverts the execa bump from #3422~~

Removes `execa` since it is no longer used.