### PR TITLE
[now-next] Add testing for export handling

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -379,9 +379,15 @@ export const build = async ({
     }
 
     const resultingExport = await getExportStatus(entryPath);
-    if (!resultingExport || resultingExport.success !== true) {
+    if (!resultingExport) {
       throw new Error(
         'Exporting Next.js app failed. Please check your build logs and contact us if this continues.'
+      );
+    }
+
+    if (resultingExport.success !== true) {
+      throw new Error(
+        'Export of Next.js app failed. Please check your build logs.'
       );
     }
 

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -355,10 +355,11 @@ export const build = async ({
   }
 
   const exportIntent = await getExportIntent(entryPath);
-  if (exportIntent) {
-    const { trailingSlash } = exportIntent;
+  const userExport = await getExportStatus(entryPath);
 
-    const userExport = await getExportStatus(entryPath);
+  if (exportIntent || userExport) {
+    const { trailingSlash = true } = exportIntent || {};
+
     if (!userExport) {
       await writePackageJson(entryPath, {
         ...pkg,
@@ -378,15 +379,9 @@ export const build = async ({
     }
 
     const resultingExport = await getExportStatus(entryPath);
-    if (!resultingExport) {
+    if (!resultingExport || resultingExport.success !== true) {
       throw new Error(
         'Exporting Next.js app failed. Please check your build logs and contact us if this continues.'
-      );
-    }
-
-    if (resultingExport.success !== true) {
-      throw new Error(
-        'Export of Next.js app failed. Please check your build logs.'
       );
     }
 

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -358,7 +358,7 @@ export const build = async ({
   const userExport = await getExportStatus(entryPath);
 
   if (exportIntent || userExport) {
-    const { trailingSlash = true } = exportIntent || {};
+    const { trailingSlash = false } = exportIntent || {};
 
     if (!userExport) {
       await writePackageJson(entryPath, {

--- a/packages/now-next/test/fixtures/10-export-cache-headers/now.json
+++ b/packages/now-next/test/fixtures/10-export-cache-headers/now.json
@@ -7,6 +7,10 @@
       "responseHeaders": {
         "cache-control": "public,max-age=31536000,immutable"
       }
+    },
+    {
+      "path": "/",
+      "mustContain": "nextExport\":true"
     }
   ]
 }

--- a/packages/now-next/test/fixtures/10-export-cache-headers/pages/index.js
+++ b/packages/now-next/test/fixtures/10-export-cache-headers/pages/index.js
@@ -1,1 +1,5 @@
-export default () => 'Hi';
+const Page = () => 'Hi';
+
+Page.getInitialProps = () => ({ hello: 'world' });
+
+export default Page;

--- a/packages/now-next/test/fixtures/11-export-clean-urls/now.json
+++ b/packages/now-next/test/fixtures/11-export-clean-urls/now.json
@@ -9,6 +9,10 @@
     {
       "path": "/about",
       "mustContain": "Hi on About"
+    },
+    {
+      "path": "/",
+      "mustContain": "nextExport\":true"
     }
   ]
 }

--- a/packages/now-next/test/fixtures/12-export-auto/now.json
+++ b/packages/now-next/test/fixtures/12-export-auto/now.json
@@ -9,6 +9,10 @@
     {
       "path": "/about",
       "mustContain": "Hi on About"
+    },
+    {
+      "path": "/",
+      "mustContain": "nextExport\":true"
     }
   ]
 }

--- a/packages/now-next/test/fixtures/13-export-custom-routes/next.config.js
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/next.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  exportPathMap: d => d,
+  experimental: {
+    async rewrites() {
+      return [
+        {
+          source: '/first',
+          destination: '/',
+        },
+      ];
+    },
+    async redirects() {
+      return [
+        {
+          source: '/second',
+          destination: '/about',
+        },
+      ];
+    },
+  },
+};

--- a/packages/now-next/test/fixtures/13-export-custom-routes/now.json
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/now.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@now/next" }],
+  "probes": [
+    {
+      "path": "/first",
+      "mustContain": "Hi There"
+    },
+    {
+      "path": "/second",
+      "mustContain": "Hi on About"
+    },
+    {
+      "path": "/",
+      "mustContain": "nextExport\":true"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/13-export-custom-routes/package.json
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/13-export-custom-routes/pages/about.js
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/pages/about.js
@@ -1,0 +1,7 @@
+function About() {
+  return <div>Hi on About</div>;
+}
+
+About.getInitialProps = () => ({});
+
+export default About;

--- a/packages/now-next/test/fixtures/13-export-custom-routes/pages/index.js
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/pages/index.js
@@ -1,0 +1,7 @@
+function Home() {
+  return <div>Hi There</div>;
+}
+
+Home.getInitialProps = () => ({});
+
+export default Home;

--- a/packages/now-next/test/test.js
+++ b/packages/now-next/test/test.js
@@ -20,7 +20,7 @@ beforeAll(async () => {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
-for (const fixture of ['10-export-cache-headers']) {
+for (const fixture of fs.readdirSync(fixturesPath)) {
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(

--- a/packages/now-next/test/test.js
+++ b/packages/now-next/test/test.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const {
   packAndDeploy,
-  testDeployment
+  testDeployment,
 } = require('../../../test/lib/deployment/test-deployment.js');
 
 jest.setTimeout(4 * 60 * 1000);
@@ -20,7 +20,7 @@ beforeAll(async () => {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
-for (const fixture of fs.readdirSync(fixturesPath)) {
+for (const fixture of ['10-export-cache-headers']) {
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(


### PR DESCRIPTION
Follow up to #3431 adding tests for this behavior

Tests to add:
- [x] custom routes: redirects
- [x] custom routes: rewrites
- [x] confirming each test is actually a `next export` deploy somehow