### PR TITLE
[now-routing-utils] Add validation for `handle:hit` and `handle:miss`

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -19,10 +19,16 @@ import {
 export { getCleanUrls } from './superstatic';
 export { mergeRoutes } from './merge';
 
-export const validHandlers = new Set<string>(['filesystem', 'hit', 'miss']);
+const VALID_HANDLE_VALUES = ['filesystem', 'hit', 'miss'] as const;
+const validHandleValues = new Set<string>(VALID_HANDLE_VALUES);
+export type HandleValue = typeof VALID_HANDLE_VALUES[number];
 
 export function isHandler(route: Route): route is Handler {
   return typeof (route as Handler).handle !== 'undefined';
+}
+
+export function isValidHandleValue(handle: string): handle is HandleValue {
+  return validHandleValues.has(handle);
 }
 
 export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
@@ -31,8 +37,8 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
   }
 
   const routes: Route[] = [];
-  const handling: string[] = [];
-  const errors = [];
+  const handling: HandleValue[] = [];
+  const errors: NowErrorNested[] = [];
 
   // We don't want to treat the input routes as references
   inputRoutes.forEach(r => routes.push(Object.assign({}, r)));
@@ -45,19 +51,21 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
           handle: route.handle,
         });
       }
-      if (!validHandlers.has(route.handle)) {
+      const { handle } = route;
+      if (!isValidHandleValue(handle)) {
         errors.push({
-          message: `This is not a valid handler (handle: ${route.handle})`,
-          handle: route.handle,
+          message: `This is not a valid handler (handle: ${handle})`,
+          handle: handle,
         });
+        continue;
       }
-      if (handling.includes(route.handle)) {
+      if (handling.includes(handle)) {
         errors.push({
-          message: `You can only handle something once (handle: ${route.handle})`,
-          handle: route.handle,
+          message: `You can only handle something once (handle: ${handle})`,
+          handle: handle,
         });
       } else {
-        handling.push(route.handle);
+        handling.push(handle);
       }
     } else if (route.src) {
       // Route src should always start with a '^'
@@ -76,6 +84,35 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
       const regError = checkRegexSyntax(route.src);
       if (regError) {
         errors.push(regError);
+      }
+
+      // The last seen handling is the current handler
+      const handleValue = handling[handling.length - 1];
+      if (handleValue === 'hit') {
+        if (route.dest) {
+          errors.push({
+            message: `You cannot assign "dest" after "handle: hit"`,
+            src: route.src,
+          });
+        }
+        if (!route.continue) {
+          errors.push({
+            message: `You must assign "continue: true" after "handle: hit"`,
+            src: route.src,
+          });
+        }
+      } else if (handleValue === 'miss') {
+        if (route.dest && !route.check) {
+          errors.push({
+            message: `You must assign "check: true" after "handle: miss"`,
+            src: route.src,
+          });
+        } else if (!route.dest && !route.continue) {
+          errors.push({
+            message: `You must assign "continue: true" after "handle: miss"`,
+            src: route.src,
+          });
+        }
       }
     } else {
       errors.push({

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -19,6 +19,8 @@ import {
 export { getCleanUrls } from './superstatic';
 export { mergeRoutes } from './merge';
 
+export const validHandlers = new Set<string>(['filesystem', 'hit', 'miss']);
+
 export function isHandler(route: Route): route is Handler {
   return typeof (route as Handler).handle !== 'undefined';
 }
@@ -37,14 +39,13 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
 
   for (const route of routes) {
     if (isHandler(route)) {
-      // typeof { handle: string }
       if (Object.keys(route).length !== 1) {
         errors.push({
           message: `Cannot have any other keys when handle is used (handle: ${route.handle})`,
           handle: route.handle,
         });
       }
-      if (!['filesystem'].includes(route.handle)) {
+      if (!validHandlers.has(route.handle)) {
         errors.push({
           message: `This is not a valid handler (handle: ${route.handle})`,
           handle: route.handle,

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -54,6 +54,10 @@ describe('normalizeRoutes', () => {
       },
       { handle: 'filesystem' },
       { src: '^/(?<slug>[^/]+)$', dest: 'blog?slug=$slug' },
+      { handle: 'hit' },
+      { src: '^/hit-me$', dest: '/api/hit-miss' },
+      { handle: 'miss' },
+      { src: '^/missed-me$', dest: '/api/missed-me' },
     ];
 
     assertValid(routes);

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -455,6 +455,82 @@ describe('normalizeRoutes', () => {
       ]
     );
   });
+
+  test('fails if routes after `handle: hit` use `dest`', () => {
+    const input = [
+      {
+        handle: 'hit',
+      },
+      {
+        src: '^/user$',
+        dest: '^/api/user$',
+      },
+    ];
+    const { error } = normalizeRoutes(input);
+
+    assert.deepEqual(error.code, 'invalid_routes');
+    assert.deepEqual(
+      error.errors[0].message,
+      'You cannot assign "dest" after "handle: hit"'
+    );
+  });
+
+  test('fails if routes after `handle: hit` do not use `continue: true`', () => {
+    const input = [
+      {
+        handle: 'hit',
+      },
+      {
+        src: '^/user$',
+        headers: { 'Cache-Control': 'no-cache' },
+      },
+    ];
+    const { error } = normalizeRoutes(input);
+
+    assert.deepEqual(error.code, 'invalid_routes');
+    assert.deepEqual(
+      error.errors[0].message,
+      'You must assign "continue: true" after "handle: hit"'
+    );
+  });
+
+  test('fails if routes after `handle: miss` do not use `check: true`', () => {
+    const input = [
+      {
+        handle: 'miss',
+      },
+      {
+        src: '^/user$',
+        dest: '^/api/user$',
+      },
+    ];
+    const { error } = normalizeRoutes(input);
+
+    assert.deepEqual(error.code, 'invalid_routes');
+    assert.deepEqual(
+      error.errors[0].message,
+      'You must assign "check: true" after "handle: miss"'
+    );
+  });
+
+  test('fails if routes after `handle: miss` do not use `continue: true`', () => {
+    const input = [
+      {
+        handle: 'miss',
+      },
+      {
+        src: '^/user$',
+        headers: { 'Cache-Control': 'no-cache' },
+      },
+    ];
+    const { error } = normalizeRoutes(input);
+
+    assert.deepEqual(error.code, 'invalid_routes');
+    assert.deepEqual(
+      error.errors[0].message,
+      'You must assign "continue: true" after "handle: miss"'
+    );
+  });
 });
 
 describe('getTransformedRoutes', () => {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -55,9 +55,18 @@ describe('normalizeRoutes', () => {
       { handle: 'filesystem' },
       { src: '^/(?<slug>[^/]+)$', dest: 'blog?slug=$slug' },
       { handle: 'hit' },
-      { src: '^/hit-me$', dest: '/api/hit-miss' },
+      {
+        src: '^/hit-me$',
+        headers: { 'Cache-Control': 'max-age=20' },
+        continue: true,
+      },
       { handle: 'miss' },
-      { src: '^/missed-me$', dest: '/api/missed-me' },
+      { src: '^/missed-me$', dest: '/api/missed-me', check: true },
+      {
+        src: '^/missed-me$',
+        headers: { 'Cache-Control': 'max-age=10' },
+        continue: true,
+      },
     ];
 
     assertValid(routes);


### PR DESCRIPTION
This PR adds initial support for `handle: hit` and `handle: miss` routes.