### PR TITLE
[now-cli] Change style for warnings

### DIFF
--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import boxen from 'boxen';
 import { format } from 'util';
 import { Console } from 'console';
 
@@ -18,10 +19,23 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   }
 
   function warn(str: string, slug: string | null = null) {
-    log(chalk`{yellow.bold WARN!} ${str}`);
-    if (slug !== null) {
-      log(`More details: https://err.sh/now/${slug}`);
-    }
+    print(
+      boxen(
+        chalk.bold.yellow('WARN! ') +
+          str +
+          (slug ? `\nMore details: https://err.sh/now/${slug}` : ''),
+        {
+          padding: {
+            top: 0,
+            bottom: 0,
+            left: 1,
+            right: 1,
+          },
+          borderColor: 'yellow',
+        }
+      )
+    );
+    print('\n');
   }
 
   function note(str: string) {
@@ -59,7 +73,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     _times: new Map(),
     log(a: string, ...args: string[]) {
       debug(format(a, ...args));
-    }
+    },
   };
 
   async function time(label: string, fn: Promise<any> | (() => Promise<any>)) {
@@ -85,6 +99,6 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     debug,
     dim,
     time,
-    note
+    note,
   };
 }

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -19,6 +19,13 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   }
 
   function warn(str: string, slug: string | null = null) {
+    const prevTerm = process.env.TERM;
+
+    if (!prevTerm) {
+      // workaround for https://github.com/sindresorhus/term-size/issues/13
+      process.env.TERM = 'xterm';
+    }
+
     print(
       boxen(
         chalk.bold.yellow('WARN! ') +
@@ -36,6 +43,8 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
       )
     );
     print('\n');
+
+    process.env.TERM = prevTerm;
   }
 
   function note(str: string) {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -915,7 +915,7 @@ test('ensure we render a warning for deployments with no files', async t => {
   // Ensure the warning is printed
   t.true(
     stderr.includes(
-      '> WARN! There are no files (or only files starting with a dot) inside your deployment.'
+      'WARN! There are no files (or only files starting with a dot) inside your deployment.'
     )
   );
 


### PR DESCRIPTION
Changes the warning style from Now CLI to make them more distinguishable.

#### Right now
![image](https://user-images.githubusercontent.com/16088670/70928077-8b8cc900-2030-11ea-8ab5-bd21fa348aca.png)

#### With change
![image](https://user-images.githubusercontent.com/16088670/70928179-be36c180-2030-11ea-92d3-4514af37b1fb.png)

[PRODUCT-775]

[PRODUCT-775]: https://zeit.atlassian.net/browse/PRODUCT-775
