### PR TITLE
[now-build-utils] Restore previous detectors

### DIFF
--- a/packages/now-build-utils/src/detect-builders-legacy.ts
+++ b/packages/now-build-utils/src/detect-builders-legacy.ts
@@ -1,0 +1,432 @@
+import minimatch from 'minimatch';
+import { valid as validSemver } from 'semver';
+import { PackageJson, Builder, Config, BuilderFunctions } from './types';
+
+interface ErrorResponse {
+  code: string;
+  message: string;
+}
+
+interface Options {
+  tag?: 'canary' | 'latest' | string;
+  functions?: BuilderFunctions;
+}
+
+const src = 'package.json';
+const config: Config = { zeroConfig: true };
+
+const MISSING_BUILD_SCRIPT_ERROR: ErrorResponse = {
+  code: 'missing_build_script',
+  message:
+    'Your `package.json` file is missing a `build` property inside the `scripts` property.' +
+    '\nMore details: https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-build-script',
+};
+
+// Static builders are special cased in `@now/static-build`
+function getBuilders({ tag }: Options = {}): Map<string, Builder> {
+  const withTag = tag ? `@${tag}` : '';
+  const config = { zeroConfig: true };
+
+  return new Map<string, Builder>([
+    ['next', { src, use: `@now/next${withTag}`, config }],
+  ]);
+}
+
+// Must be a function to ensure that the returned
+// object won't be a reference
+function getApiBuilders({ tag }: Pick<Options, 'tag'> = {}): Builder[] {
+  const withTag = tag ? `@${tag}` : '';
+  const config = { zeroConfig: true };
+
+  return [
+    { src: 'api/**/*.js', use: `@now/node${withTag}`, config },
+    { src: 'api/**/*.ts', use: `@now/node${withTag}`, config },
+    { src: 'api/**/*.go', use: `@now/go${withTag}`, config },
+    { src: 'api/**/*.py', use: `@now/python${withTag}`, config },
+    { src: 'api/**/*.rb', use: `@now/ruby${withTag}`, config },
+  ];
+}
+
+function hasPublicDirectory(files: string[]) {
+  return files.some(name => name.startsWith('public/'));
+}
+
+function hasBuildScript(pkg: PackageJson | undefined) {
+  const { scripts = {} } = pkg || {};
+  return Boolean(scripts && scripts['build']);
+}
+
+function getApiFunctionBuilder(
+  file: string,
+  prevBuilder: Builder | undefined,
+  { functions = {} }: Pick<Options, 'functions'>
+) {
+  const key = Object.keys(functions).find(
+    k => file === k || minimatch(file, k)
+  );
+  const fn = key ? functions[key] : undefined;
+
+  if (!fn || (!fn.runtime && !prevBuilder)) {
+    return prevBuilder;
+  }
+
+  const src = (prevBuilder && prevBuilder.src) || file;
+  const use = fn.runtime || (prevBuilder && prevBuilder.use);
+
+  const config: Config = { zeroConfig: true };
+
+  if (key) {
+    Object.assign(config, {
+      functions: {
+        [key]: fn,
+      },
+    });
+  }
+
+  const { includeFiles, excludeFiles } = fn;
+
+  if (includeFiles) Object.assign(config, { includeFiles });
+  if (excludeFiles) Object.assign(config, { excludeFiles });
+
+  return use ? { use, src, config } : prevBuilder;
+}
+
+async function detectFrontBuilder(
+  pkg: PackageJson,
+  builders: Builder[],
+  options: Options
+): Promise<Builder> {
+  const { tag } = options;
+  const withTag = tag ? `@${tag}` : '';
+  for (const [dependency, builder] of getBuilders(options)) {
+    const deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+
+    // Return the builder when a dependency matches
+    if (deps[dependency]) {
+      if (options.functions) {
+        Object.entries(options.functions).forEach(([key, func]) => {
+          // When the builder is not used yet we'll use it for the frontend
+          if (
+            builders.every(
+              b => !(b.config && b.config.functions && b.config.functions[key])
+            )
+          ) {
+            if (!builder.config) builder.config = {};
+            if (!builder.config.functions) builder.config.functions = {};
+            builder.config.functions[key] = { ...func };
+          }
+        });
+      }
+
+      return builder;
+    }
+  }
+
+  // By default we'll choose the `static-build` builder
+  return { src, use: `@now/static-build${withTag}`, config };
+}
+
+// Files that match a specific pattern will get ignored
+export function getIgnoreApiFilter(optionsOrBuilders: Options | Builder[]) {
+  const possiblePatterns: string[] = getApiBuilders().map(b => b.src);
+
+  if (Array.isArray(optionsOrBuilders)) {
+    optionsOrBuilders.forEach(({ src }) => possiblePatterns.push(src));
+  } else if (optionsOrBuilders.functions) {
+    Object.keys(optionsOrBuilders.functions).forEach(p =>
+      possiblePatterns.push(p)
+    );
+  }
+
+  return (file: string) => {
+    if (!file.startsWith('api/')) {
+      return false;
+    }
+
+    if (file.includes('/.')) {
+      return false;
+    }
+
+    if (file.includes('/_')) {
+      return false;
+    }
+
+    if (file.endsWith('.d.ts')) {
+      return false;
+    }
+
+    if (possiblePatterns.every(p => !(file === p || minimatch(file, p)))) {
+      return false;
+    }
+
+    return true;
+  };
+}
+
+// We need to sort the file paths by alphabet to make
+// sure the routes stay in the same order e.g. for deduping
+export function sortFiles(fileA: string, fileB: string) {
+  return fileA.localeCompare(fileB);
+}
+
+async function detectApiBuilders(
+  files: string[],
+  options: Options
+): Promise<Builder[]> {
+  const builds = files
+    .sort(sortFiles)
+    .filter(getIgnoreApiFilter(options))
+    .map(file => {
+      const apiBuilders = getApiBuilders(options);
+      const apiBuilder = apiBuilders.find(b => minimatch(file, b.src));
+      const fnBuilder = getApiFunctionBuilder(file, apiBuilder, options);
+      return fnBuilder ? { ...fnBuilder, src: file } : null;
+    });
+
+  return builds.filter(Boolean) as Builder[];
+}
+
+// When a package has files that conflict with `/api` routes
+// e.g. Next.js pages/api we'll check it here and return an error.
+async function checkConflictingFiles(
+  files: string[],
+  builders: Builder[]
+): Promise<ErrorResponse | null> {
+  // For Next.js
+  if (builders.some(b => b.use.startsWith('@now/next'))) {
+    const hasApiPages = files.some(file => file.startsWith('pages/api/'));
+    const hasApiBuilders = builders.some(b => b.src.startsWith('api/'));
+
+    if (hasApiPages && hasApiBuilders) {
+      return {
+        code: 'conflicting_files',
+        message:
+          'It is not possible to use `api` and `pages/api` at the same time, please only use one option',
+      };
+    }
+  }
+
+  return null;
+}
+
+// When e.g. Next.js receives a `functions` property it has to make sure,
+// that it can handle those files, otherwise there are unused functions.
+async function checkUnusedFunctionsOnFrontendBuilder(
+  files: string[],
+  builder: Builder
+): Promise<ErrorResponse | null> {
+  const { config: { functions = undefined } = {} } = builder;
+
+  if (!functions) return null;
+
+  if (builder.use.startsWith('@now/next')) {
+    const matchingFiles = files.filter(file =>
+      Object.keys(functions).some(key => file === key || minimatch(file, key))
+    );
+
+    for (const matchedFile of matchingFiles) {
+      if (
+        !matchedFile.startsWith('src/pages/') &&
+        !matchedFile.startsWith('pages/')
+      ) {
+        return {
+          code: 'unused_function',
+          message: `The function for ${matchedFile} can't be handled by any builder`,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function validateFunctions(files: string[], { functions = {} }: Options) {
+  const apiBuilders = getApiBuilders();
+
+  for (const [path, func] of Object.entries(functions)) {
+    if (path.length > 256) {
+      return {
+        code: 'invalid_function_glob',
+        message: 'Function globs must be less than 256 characters long.',
+      };
+    }
+
+    if (!func || typeof func !== 'object') {
+      return {
+        code: 'invalid_function',
+        message: 'Function must be an object.',
+      };
+    }
+
+    if (Object.keys(func).length === 0) {
+      return {
+        code: 'invalid_function',
+        message: 'Function must contain at least one property.',
+      };
+    }
+
+    if (
+      func.maxDuration !== undefined &&
+      (func.maxDuration < 1 ||
+        func.maxDuration > 900 ||
+        !Number.isInteger(func.maxDuration))
+    ) {
+      return {
+        code: 'invalid_function_duration',
+        message: 'Functions must have a duration between 1 and 900.',
+      };
+    }
+
+    if (
+      func.memory !== undefined &&
+      (func.memory < 128 || func.memory > 3008 || func.memory % 64 !== 0)
+    ) {
+      return {
+        code: 'invalid_function_memory',
+        message:
+          'Functions must have a memory value between 128 and 3008 in steps of 64.',
+      };
+    }
+
+    if (path.startsWith('/')) {
+      return {
+        code: 'invalid_function_source',
+        message: `The function path "${path}" is invalid. The path must be relative to your project root and therefore cannot start with a slash.`,
+      };
+    }
+
+    if (files.some(f => f === path || minimatch(f, path)) === false) {
+      return {
+        code: 'invalid_function_source',
+        message: `No source file matched the function for ${path}.`,
+      };
+    }
+
+    if (func.runtime !== undefined) {
+      const tag = `${func.runtime}`.split('@').pop();
+
+      if (!tag || !validSemver(tag)) {
+        return {
+          code: 'invalid_function_runtime',
+          message:
+            'Function Runtimes must have a valid version, for example `now-php@1.0.0`.',
+        };
+      }
+
+      if (
+        apiBuilders.some(b => func.runtime && func.runtime.startsWith(b.use))
+      ) {
+        return {
+          code: 'invalid_function_runtime',
+          message: `The function Runtime ${func.runtime} is not a Community Runtime and must not be specified.`,
+        };
+      }
+    }
+
+    if (func.includeFiles !== undefined) {
+      if (typeof func.includeFiles !== 'string') {
+        return {
+          code: 'invalid_function_property',
+          message: `The property \`includeFiles\` must be a string.`,
+        };
+      }
+    }
+
+    if (func.excludeFiles !== undefined) {
+      if (typeof func.excludeFiles !== 'string') {
+        return {
+          code: 'invalid_function_property',
+          message: `The property \`excludeFiles\` must be a string.`,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+// When zero config is used we can call this function
+// to determine what builders to use
+export async function detectBuildersLegacy(
+  files: string[],
+  pkg?: PackageJson | undefined | null,
+  options: Options = {}
+): Promise<{
+  builders: Builder[] | null;
+  errors: ErrorResponse[] | null;
+  warnings: ErrorResponse[];
+}> {
+  const errors: ErrorResponse[] = [];
+  const warnings: ErrorResponse[] = [];
+
+  const functionError = validateFunctions(files, options);
+
+  if (functionError) {
+    return {
+      builders: null,
+      errors: [functionError],
+      warnings,
+    };
+  }
+
+  // Detect all builders for the `api` directory before anything else
+  const builders = await detectApiBuilders(files, options);
+
+  if (pkg && hasBuildScript(pkg)) {
+    const frontendBuilder = await detectFrontBuilder(pkg, builders, options);
+    builders.push(frontendBuilder);
+
+    const conflictError = await checkConflictingFiles(files, builders);
+
+    if (conflictError) {
+      warnings.push(conflictError);
+    }
+
+    const unusedFunctionError = await checkUnusedFunctionsOnFrontendBuilder(
+      files,
+      frontendBuilder
+    );
+
+    if (unusedFunctionError) {
+      return {
+        builders: null,
+        errors: [unusedFunctionError],
+        warnings,
+      };
+    }
+  } else {
+    if (pkg && builders.length === 0) {
+      // We only show this error when there are no api builders
+      // since the dependencies of the pkg could be used for those
+      errors.push(MISSING_BUILD_SCRIPT_ERROR);
+      return { errors, warnings, builders: null };
+    }
+
+    // We allow a `public` directory
+    // when there are no build steps
+    if (hasPublicDirectory(files)) {
+      builders.push({
+        use: '@now/static',
+        src: 'public/**/*',
+        config,
+      });
+    } else if (
+      builders.length > 0 &&
+      files.some(f => !f.startsWith('api/') && f !== 'package.json')
+    ) {
+      // Everything besides the api directory
+      // and package.json can be served as static files
+      builders.push({
+        use: '@now/static',
+        src: '!{api/**,package.json}',
+        config,
+      });
+    }
+  }
+
+  return {
+    builders: builders.length ? builders : null,
+    errors: errors.length ? errors : null,
+    warnings,
+  };
+}

--- a/packages/now-build-utils/src/detect-routes-legacy.ts
+++ b/packages/now-build-utils/src/detect-routes-legacy.ts
@@ -1,0 +1,298 @@
+import { parse as parsePath } from 'path';
+import { Route, Builder } from './types';
+import { getIgnoreApiFilter, sortFiles } from './detect-builders-legacy';
+
+function escapeName(name: string) {
+  const special = '[]^$.|?*+()'.split('');
+
+  for (const char of special) {
+    name = name.replace(new RegExp(`\\${char}`, 'g'), `\\${char}`);
+  }
+
+  return name;
+}
+
+function joinPath(...segments: string[]) {
+  const joinedPath = segments.join('/');
+  return joinedPath.replace(/\/{2,}/g, '/');
+}
+
+function concatArrayOfText(texts: string[]): string {
+  if (texts.length <= 2) {
+    return texts.join(' and ');
+  }
+
+  const last = texts.pop();
+  return `${texts.join(', ')}, and ${last}`;
+}
+
+// Takes a filename or foldername, strips the extension
+// gets the part between the "[]" brackets.
+// It will return `null` if there are no brackets
+// and therefore no segment.
+function getSegmentName(segment: string): string | null {
+  const { name } = parsePath(segment);
+
+  if (name.startsWith('[') && name.endsWith(']')) {
+    return name.slice(1, -1);
+  }
+
+  return null;
+}
+
+function createRouteFromPath(filePath: string): Route {
+  const parts = filePath.split('/');
+
+  let counter = 1;
+  const query: string[] = [];
+
+  const srcParts = parts.map((segment, index): string => {
+    const name = getSegmentName(segment);
+    const isLast = index === parts.length - 1;
+
+    if (name !== null) {
+      // We can't use `URLSearchParams` because `$` would get escaped
+      query.push(`${name}=$${counter++}`);
+      return `([^\\/]+)`;
+    } else if (isLast) {
+      const { name: fileName, ext } = parsePath(segment);
+      const isIndex = fileName === 'index';
+      const prefix = isIndex ? '\\/' : '';
+
+      const names = [
+        isIndex ? prefix : `${fileName}\\/`,
+        prefix + escapeName(fileName),
+        prefix + escapeName(fileName) + escapeName(ext),
+      ].filter(Boolean);
+
+      // Either filename with extension, filename without extension
+      // or nothing when the filename is `index`
+      return `(${names.join('|')})${isIndex ? '?' : ''}`;
+    }
+
+    return segment;
+  });
+
+  const { name: fileName } = parsePath(filePath);
+  const isIndex = fileName === 'index';
+
+  const src = isIndex
+    ? `^/${srcParts.slice(0, -1).join('/')}${srcParts.slice(-1)[0]}$`
+    : `^/${srcParts.join('/')}$`;
+
+  const dest = `/${filePath}${query.length ? '?' : ''}${query.join('&')}`;
+
+  return { src, dest };
+}
+
+// Check if the path partially matches and has the same
+// name for the path segment at the same position
+function partiallyMatches(pathA: string, pathB: string): boolean {
+  const partsA = pathA.split('/');
+  const partsB = pathB.split('/');
+
+  const long = partsA.length > partsB.length ? partsA : partsB;
+  const short = long === partsA ? partsB : partsA;
+
+  let index = 0;
+
+  for (const segmentShort of short) {
+    const segmentLong = long[index];
+
+    const nameLong = getSegmentName(segmentLong);
+    const nameShort = getSegmentName(segmentShort);
+
+    // If there are no segments or the paths differ we
+    // return as they are not matching
+    if (segmentShort !== segmentLong && (!nameLong || !nameShort)) {
+      return false;
+    }
+
+    if (nameLong !== nameShort) {
+      return true;
+    }
+
+    index += 1;
+  }
+
+  return false;
+}
+
+// Counts how often a path occurs when all placeholders
+// got resolved, so we can check if they have conflicts
+function pathOccurrences(filePath: string, files: string[]): string[] {
+  const getAbsolutePath = (unresolvedPath: string): string => {
+    const { dir, name } = parsePath(unresolvedPath);
+    const parts = joinPath(dir, name).split('/');
+    return parts.map(part => part.replace(/\[.*\]/, '1')).join('/');
+  };
+
+  const currentAbsolutePath = getAbsolutePath(filePath);
+
+  return files.reduce((prev: string[], file: string): string[] => {
+    const absolutePath = getAbsolutePath(file);
+
+    if (absolutePath === currentAbsolutePath) {
+      prev.push(file);
+    } else if (partiallyMatches(filePath, file)) {
+      prev.push(file);
+    }
+
+    return prev;
+  }, []);
+}
+
+// Checks if a placeholder with the same name is used
+// multiple times inside the same path
+function getConflictingSegment(filePath: string): string | null {
+  const segments = new Set<string>();
+
+  for (const segment of filePath.split('/')) {
+    const name = getSegmentName(segment);
+
+    if (name !== null && segments.has(name)) {
+      return name;
+    }
+
+    if (name) {
+      segments.add(name);
+    }
+  }
+
+  return null;
+}
+
+function sortFilesBySegmentCount(fileA: string, fileB: string): number {
+  const lengthA = fileA.split('/').length;
+  const lengthB = fileB.split('/').length;
+
+  if (lengthA > lengthB) {
+    return -1;
+  }
+
+  if (lengthA < lengthB) {
+    return 1;
+  }
+
+  // Paths that have the same segment length but
+  // less placeholders are preferred
+  const countSegments = (prev: number, segment: string) =>
+    getSegmentName(segment) ? prev + 1 : 0;
+  const segmentLengthA = fileA.split('/').reduce(countSegments, 0);
+  const segmentLengthB = fileB.split('/').reduce(countSegments, 0);
+
+  if (segmentLengthA > segmentLengthB) {
+    return 1;
+  }
+
+  if (segmentLengthA < segmentLengthB) {
+    return -1;
+  }
+
+  return 0;
+}
+
+interface RoutesResult {
+  defaultRoutes: Route[] | null;
+  error: { [key: string]: string } | null;
+}
+
+async function detectApiRoutes(
+  files: string[],
+  builders: Builder[]
+): Promise<RoutesResult> {
+  if (!files || files.length === 0) {
+    return { defaultRoutes: null, error: null };
+  }
+
+  // The deepest routes need to be
+  // the first ones to get handled
+  const sortedFiles = files
+    .filter(getIgnoreApiFilter(builders))
+    .sort(sortFiles)
+    .sort(sortFilesBySegmentCount);
+
+  const defaultRoutes: Route[] = [];
+
+  for (const file of sortedFiles) {
+    // We only consider every file in the api directory
+    // as we will strip extensions as well as resolving "[segments]"
+    if (!file.startsWith('api/')) {
+      continue;
+    }
+
+    const conflictingSegment = getConflictingSegment(file);
+
+    if (conflictingSegment) {
+      return {
+        defaultRoutes: null,
+        error: {
+          code: 'conflicting_path_segment',
+          message:
+            `The segment "${conflictingSegment}" occurs more than ` +
+            `one time in your path "${file}". Please make sure that ` +
+            `every segment in a path is unique`,
+        },
+      };
+    }
+
+    const occurrences = pathOccurrences(file, sortedFiles).filter(
+      name => name !== file
+    );
+
+    if (occurrences.length > 0) {
+      const messagePaths = concatArrayOfText(
+        occurrences.map(name => `"${name}"`)
+      );
+
+      return {
+        defaultRoutes: null,
+        error: {
+          code: 'conflicting_file_path',
+          message:
+            `Two or more files have conflicting paths or names. ` +
+            `Please make sure path segments and filenames, without their extension, are unique. ` +
+            `The path "${file}" has conflicts with ${messagePaths}`,
+        },
+      };
+    }
+
+    defaultRoutes.push(createRouteFromPath(file));
+  }
+
+  // 404 Route to disable directory listing
+  if (defaultRoutes.length) {
+    defaultRoutes.push({
+      status: 404,
+      src: '/api(\\/.*)?$',
+    });
+  }
+
+  return { defaultRoutes, error: null };
+}
+
+function hasPublicBuilder(builders: Builder[]): boolean {
+  return builders.some(
+    builder =>
+      builder.use === '@now/static' &&
+      builder.src === 'public/**/*' &&
+      builder.config &&
+      builder.config.zeroConfig === true
+  );
+}
+
+export async function detectRoutesLegacy(
+  files: string[],
+  builders: Builder[]
+): Promise<RoutesResult> {
+  const routesResult = await detectApiRoutes(files, builders);
+
+  if (routesResult.defaultRoutes && hasPublicBuilder(builders)) {
+    routesResult.defaultRoutes.push({
+      src: '/(.*)',
+      dest: '/public/$1',
+    });
+  }
+
+  return routesResult;
+}

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -56,6 +56,9 @@ export {
   getLambdaOptionsFromFunction,
 };
 
+export { detectBuildersLegacy } from './detect-builders-legacy';
+export { detectRoutesLegacy } from './detect-routes-legacy';
+
 export { detectDefaults } from './detectors';
 export * from './schemas';
 export * from './types';


### PR DESCRIPTION
As discussed with @leo, we need those functions to not change how the API currently works, we only want to update `now dev` and a new API version. Everything else will stay.

This restores the functions from before #3402

Part of [PRODUCT-783]

[PRODUCT-783]: https://zeit.atlassian.net/browse/PRODUCT-783