### PR TITLE
[now-next] Bump now-next for new routing-utils

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -75,6 +75,7 @@ interface BuildParamsType extends BuildOptions {
   meta: BuildParamsMeta;
 }
 
+// bump for now/routing-utils
 export const version = 2;
 const htmlContentType = 'text/html; charset=utf-8';
 const nowDevChildProcesses = new Set<ChildProcess>();


### PR DESCRIPTION
Follow-up to https://github.com/zeit/now/pull/3446 since we use ncc to bundle this dependency we need to trigger a re-build before we can release a new canary of `@now/next` with the changes to `@now/routing-utils`