### PR TITLE
[all] Fix types for Route vs Source

### DIFF
--- a/packages/now-build-utils/src/detect-routes-legacy.ts
+++ b/packages/now-build-utils/src/detect-routes-legacy.ts
@@ -1,5 +1,6 @@
 import { parse as parsePath } from 'path';
-import { Route, Builder } from './types';
+import { Route } from '@now/routing-utils';
+import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders-legacy';
 
 function escapeName(name: string) {

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,6 @@
 import { parse as parsePath } from 'path';
-import { Route, Builder } from './types';
+import { Route } from '@now/routing-utils';
+import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
 
 function escapeName(name: string) {

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -1,6 +1,7 @@
 import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 import DetectorFilesystem from './detectors/filesystem';
+import { Route } from '@now/routing-utils';
 
 export interface Env {
   [name: string]: string | undefined;
@@ -19,18 +20,6 @@ export interface File {
 
 export interface Files {
   [filePath: string]: File;
-}
-
-export interface Route {
-  src?: string;
-  dest?: string;
-  handle?: string;
-  type?: string;
-  headers?: {
-    [key: string]: string;
-  };
-  continue?: boolean;
-  status?: number;
 }
 
 export interface Config {

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -15,10 +15,10 @@ import {
   PackageJson,
   PrepareCacheOptions,
   Prerender,
-  Route,
   runNpmInstall,
   runPackageJsonScript,
 } from '@now/build-utils';
+import { Route } from '@now/routing-utils';
 import {
   convertRedirects,
   convertRewrites,

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -11,9 +11,9 @@ import {
   FileFsRef,
   streamToBuffer,
   Lambda,
-  Route,
   isSymbolicLink,
 } from '@now/build-utils';
+import { Route, Source } from '@now/routing-utils';
 
 type stringMap = { [key: string]: string };
 
@@ -279,13 +279,13 @@ async function getRoutes(
     if (!isPublic) continue;
 
     const fileName = path.relative('public', relativePath);
-    const route = {
+    const route: Source = {
       src: `${prefix}${fileName}`,
       dest: `${url}/${fileName}`,
     };
 
     // Only add the route if a page is not already using it
-    if (!routes.some(r => r.src === route.src)) {
+    if (!routes.some(r => (r as Source).src === route.src)) {
       routes.push(route);
     }
   }

--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -1,7 +1,7 @@
 import { readdir, stat, readFile, unlink } from 'fs';
 import { promisify } from 'util';
 import { join } from 'path';
-import { Route } from '@now/build-utils';
+import { Route } from '@now/routing-utils';
 
 const readirPromise = promisify(readdir);
 const readFilePromise = promisify(readFile);

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -21,13 +21,13 @@ import {
   getSpawnOptions,
   Files,
   FileFsRef,
-  Route,
   BuildOptions,
   Config,
   debug,
   PackageJson,
   PrepareCacheOptions,
 } from '@now/build-utils';
+import { Route, Source } from '@now/routing-utils';
 
 const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
 
@@ -120,8 +120,8 @@ const nowDevChildProcesses = new Set<ChildProcess>();
   });
 });
 
-const getDevRoute = (srcBase: string, devPort: number, route: Route) => {
-  const basic: Route = {
+const getDevRoute = (srcBase: string, devPort: number, route: Source) => {
+  const basic: Source = {
     src: `${srcBase}${route.src}`,
     dest: `http://localhost:${devPort}${route.dest}`,
   };

--- a/run.js
+++ b/run.js
@@ -42,8 +42,8 @@ async function main() {
   }
 
   // Sort the matches such that `utils` modules are compiled first,
-  // because other packages may rely on them.
-  // We also need to ensure that `now-client` is built last.
+  // because other packages (such as builders) depend on them.
+  // We also need to ensure that `now-cli` is built last.
 
   matches.sort((a, b) => {
     if (a === 'now-routing-utils' && b !== 'now-routing-utils') {

--- a/run.js
+++ b/run.js
@@ -42,14 +42,20 @@ async function main() {
   }
 
   // Sort the matches such that `utils` modules are compiled first,
-  // because other packages may rely on them
-  // We also need to ensure that `now-client` is built before the CLI
+  // because other packages may rely on them.
+  // We also need to ensure that `now-client` is built last.
 
   matches.sort((a, b) => {
-    if (a.endsWith('-utils') && !b.endsWith('-utils')) {
+    if (a === 'now-routing-utils' && b !== 'now-routing-utils') {
       return -1;
     }
-    if (b.endsWith('-utils') && !a.endsWith('-utils')) {
+    if (b === 'now-routing-utils' && a !== 'now-routing-utils') {
+      return 1;
+    }
+    if (a === 'now-build-utils' && b !== 'now-build-utils') {
+      return -1;
+    }
+    if (b === 'now-build-utils' && a !== 'now-build-utils') {
       return 1;
     }
     if (a === 'now-cli' && b !== 'now-cli') {


### PR DESCRIPTION
This PR deletes the incorrect `Route` type defined in `@now/build-utils` and instead relies on the correct type defined in `@now/routing-utils`. There is no change to runtime code since this is strictly a change to the typescript types. The one exception to this is I had to change the sort order for our build script so that `@now/routing-utils` is built first.

This is necessary for PR #3403