### PR TITLE
[now-build-utils] fix non npm registry builder imports

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -322,14 +322,32 @@ function validateFunctions(files: string[], { functions = {} }: Options) {
     }
 
     if (func.runtime !== undefined) {
-      const tag = `${func.runtime}`.split('@').pop();
+      const { runtime } = func;
 
-      if (!tag || !validSemver(tag)) {
-        return {
-          code: 'invalid_function_runtime',
-          message:
-            'Function Runtimes must have a valid version, for example `now-php@1.0.0`.',
-        };
+      // Only check for tag if none of these other possible options are used: https://docs.npmjs.com/cli/install
+      if (
+        !runtime.startsWith('https://') &&
+        !runtime.startsWith('http://') &&
+        !runtime.startsWith('git://') &&
+        !runtime.startsWith('git+ssh://') &&
+        !runtime.startsWith('git+http://') &&
+        !runtime.startsWith('git+https://') &&
+        !runtime.startsWith('git+file://') &&
+        !(runtime.includes('/') && !runtime.startsWith('@')) &&
+        !runtime.startsWith('github:') &&
+        !runtime.startsWith('gist:') &&
+        !runtime.startsWith('bitbucket:') &&
+        !runtime.startsWith('gitlab:')
+      ) {
+        const tag = `${runtime}`.split('@').pop();
+
+        if (!tag || !validSemver(tag)) {
+          return {
+            code: 'invalid_function_runtime',
+            message:
+              'Function Runtimes must have a valid version, for example `now-php@1.0.0`.',
+          };
+        }
       }
     }
 

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -452,6 +452,18 @@ describe('Test `detectBuilders`', () => {
     expect(errors![0].code).toBe('invalid_function_runtime');
   });
 
+  it('no missing version on special npm import', async () => {
+    const functions = { 'api/index.pc': { runtime: 'https://haha' } };
+    const files = ['api/index.pc'];
+    const { builders, errors } = await detectBuilders(files, null, {
+      functions,
+    });
+
+    expect(errors).toBe(null);
+    expect(builders!.length).toBe(1);
+    expect(builders![0].use).toBe('https://haha');
+  });
+
   it('use a custom runtime', async () => {
     const functions = { 'api/user.php': { runtime: 'now-php@0.0.5' } };
     const files = ['api/user.php'];


### PR DESCRIPTION
According to https://github.com/zeit/now/blob/master/DEVELOPING_A_RUNTIME.md the builder `use` property will work with any npm install argument (https://docs.npmjs.com/cli/install). Currently this is not the case because `Function Runtimes must have a valid version`. Pretty much every npm import type except for the imports from the npm registry don't have a version tag. This adds exceptions for all npm import types except for the types that have a version tag.