### PR TITLE
[now-static-build] Add missing frameworks

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2010,7 +2010,7 @@ test('fail to deploy a Lambda with an incorrect value for of memory', async t =>
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Functions must have a memory value between 128 and 3008 in steps of 64\./gm,
+    /memory should be equal to one of the allowed values/gm,
     formatOutput(output)
   );
 });

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2010,7 +2010,7 @@ test('fail to deploy a Lambda with an incorrect value for of memory', async t =>
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /memory should be equal to one of the allowed values/gm,
+    /Functions must have a memory value between 128 and 3008 in steps of 64\./gm,
     formatOutput(output)
   );
 });

--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -328,7 +328,8 @@ export const frameworks: Framework[] = [
     name: 'Nuxt.js',
     slug: 'nuxtjs',
     dependency: 'nuxt',
-    getOutputDirName: async () => 'public',
+    buildCommand: 'nuxt generate',
+    getOutputDirName: async () => 'dist',
   },
   {
     name: 'Hugo',
@@ -342,9 +343,6 @@ export const frameworks: Framework[] = [
         })
       );
 
-      console.log(`trying to read file at ${dirPrefix}`);
-      console.log('got config', config);
-
       return (config && config.publishDir) || 'public';
     },
   },
@@ -357,6 +355,18 @@ export const frameworks: Framework[] = [
       const config = await readConfigFile(join(dirPrefix, '_config.yml'));
       return (config && config.destination) || '_site';
     },
+  },
+  {
+    name: 'Brunch',
+    slug: 'brunch',
+    getOutputDirName: async () => 'public',
+  },
+  {
+    name: 'Middleman',
+    slug: 'middleman',
+    buildCommand: 'bundle exec middleman build',
+    devCommand: 'bundle exec middleman server -p $PORT',
+    getOutputDirName: async () => 'build',
   },
 ];
 


### PR DESCRIPTION
Add missing frameworks to keep up with `@now/frameworks`.