### PR TITLE
[now-client] Fix single file deploy with new routing properties

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -311,6 +311,13 @@ CMD ["node", "index.js"]`,
         files: ['.gitignore', 'folder', 'index.js', 'test.html'],
       }),
     },
+    'redirects-v2': {
+      'now.json': JSON.stringify({
+        version: 2,
+        name: 'redirects-v2',
+        redirects: [{ source: `/(.*)`, destination: 'https://example.com/$1' }],
+      }),
+    },
     'local-config-v2': {
       [`main-${session}.html`]: '<h1>hello main</h1>',
       [`test-${session}.html`]: '<h1>hello test</h1>',

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -211,6 +211,26 @@ test('login', async t => {
   t.is(typeof token, 'string');
 });
 
+test('deploy using only now.json with `redirects` defined', async t => {
+  const target = fixture('redirects-v2');
+
+  const { exitCode, stderr, stdout } = await execa(
+    binaryPath,
+    [target, ...defaultArgs],
+    {
+      reject: false,
+    }
+  );
+
+  t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+
+  const i = stdout.lastIndexOf('https://');
+  const url = stdout.slice(i);
+  const res = await fetch(`${url}/foo/bar`, { redirect: 'manual' });
+  const location = res.headers.get('location');
+  t.is(location, 'https://example.com/foo/bar');
+});
+
 test('deploy using --local-config flag v2', async t => {
   const target = fixture('local-config-v2');
   const configPath = path.join(target, 'now-test.json');

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -114,13 +114,13 @@ export async function* deploy(
 
   if (
     files.size === 1 &&
-    typeof deploymentOptions.builds === 'undefined' &&
-    typeof deploymentOptions.routes === 'undefined' &&
-    typeof deploymentOptions.cleanUrls === 'undefined' &&
-    typeof deploymentOptions.rewrites === 'undefined' &&
-    typeof deploymentOptions.redirects === 'undefined' &&
-    typeof deploymentOptions.headers === 'undefined' &&
-    typeof deploymentOptions.trailingSlash === 'undefined'
+    deploymentOptions.builds === undefined &&
+    deploymentOptions.routes === undefined &&
+    deploymentOptions.cleanUrls === undefined &&
+    deploymentOptions.rewrites === undefined &&
+    deploymentOptions.redirects === undefined &&
+    deploymentOptions.headers === undefined &&
+    deploymentOptions.trailingSlash === undefined
   ) {
     debug(`Assigning '/' route for single file deployment`);
     const filePath = Array.from(files.values())[0].names[0];

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -37,7 +37,7 @@ async function* createDeployment(
       headers: {
         'Content-Type': 'application/json',
       },
-      body: body,
+      body,
       apiUrl: clientOptions.apiUrl,
       userAgent: clientOptions.userAgent,
     });

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -23,25 +23,24 @@ async function* createDeployment(
   const debug = createDebug(clientOptions.debug);
   const preparedFiles = prepareFiles(files, clientOptions);
   const apiDeployments = getApiDeploymentsUrl(deploymentOptions);
+  const url = `${apiDeployments}${generateQueryString(clientOptions)}`;
+  const body = JSON.stringify({
+    ...deploymentOptions,
+    files: preparedFiles,
+  });
 
-  debug('Sending deployment creation API request');
+  debug('Sending deployment creation API request to ' + url);
+
   try {
-    const dpl = await fetch(
-      `${apiDeployments}${generateQueryString(clientOptions)}`,
-      clientOptions.token,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...deploymentOptions,
-          files: preparedFiles,
-        }),
-        apiUrl: clientOptions.apiUrl,
-        userAgent: clientOptions.userAgent,
-      }
-    );
+    const dpl = await fetch(url, clientOptions.token, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: body,
+      apiUrl: clientOptions.apiUrl,
+      userAgent: clientOptions.userAgent,
+    });
 
     const json = await dpl.json();
 
@@ -115,8 +114,13 @@ export async function* deploy(
 
   if (
     files.size === 1 &&
-    !deploymentOptions.builds &&
-    !deploymentOptions.routes
+    typeof deploymentOptions.builds === 'undefined' &&
+    typeof deploymentOptions.routes === 'undefined' &&
+    typeof deploymentOptions.cleanUrls === 'undefined' &&
+    typeof deploymentOptions.rewrites === 'undefined' &&
+    typeof deploymentOptions.redirects === 'undefined' &&
+    typeof deploymentOptions.headers === 'undefined' &&
+    typeof deploymentOptions.trailingSlash === 'undefined'
   ) {
     debug(`Assigning '/' route for single file deployment`);
     const filePath = Array.from(files.values())[0].names[0];

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -23,24 +23,25 @@ async function* createDeployment(
   const debug = createDebug(clientOptions.debug);
   const preparedFiles = prepareFiles(files, clientOptions);
   const apiDeployments = getApiDeploymentsUrl(deploymentOptions);
-  const url = `${apiDeployments}${generateQueryString(clientOptions)}`;
-  const body = JSON.stringify({
-    ...deploymentOptions,
-    files: preparedFiles,
-  });
 
-  debug('Sending deployment creation API request to ' + url);
-
+  debug('Sending deployment creation API request');
   try {
-    const dpl = await fetch(url, clientOptions.token, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body,
-      apiUrl: clientOptions.apiUrl,
-      userAgent: clientOptions.userAgent,
-    });
+    const dpl = await fetch(
+      `${apiDeployments}${generateQueryString(clientOptions)}`,
+      clientOptions.token,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...deploymentOptions,
+          files: preparedFiles,
+        }),
+        apiUrl: clientOptions.apiUrl,
+        userAgent: clientOptions.userAgent,
+      }
+    );
 
     const json = await dpl.json();
 

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -153,6 +153,11 @@ export interface DeploymentOptions extends LegacyDeploymentOptions {
   version?: number;
   regions?: string[];
   routes?: Route[];
+  cleanUrls?: boolean;
+  rewrites?: NowRewrite[];
+  redirects?: NowRedirect[];
+  headers?: NowHeader[];
+  trailingSlash?: boolean;
   builds?: Builder[];
   functions?: BuilderFunctions;
   env?: Dictionary<string>;


### PR DESCRIPTION
There is an undocumented feature that adds a route when a single file is deployed, for example a single image or a zip file. This was causing the legacy routes to be added even when `rewrites` or `redirects` was defined. This PR fixes that case when the user has a single file, `now.json`, with redirects defined.