### PR TITLE
[now-static-build] Ensure outputDirectory is used when it exists

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -163,20 +163,12 @@ function getPkg(entrypoint: string, workPath: string) {
 }
 
 function getFramework(config: Config | null, pkg?: PackageJson | null) {
-  const { framework: configFramework = null, outputDirectory = null } =
-    config || {};
+  const { framework: configFramework = null } = config || {};
 
   if (configFramework) {
     const framework = frameworks.find(({ slug }) => slug === configFramework);
 
     if (framework) {
-      if (outputDirectory) {
-        return {
-          ...framework,
-          getOutputDirName: async () => outputDirectory,
-        };
-      }
-
       return framework;
     }
   }
@@ -418,7 +410,9 @@ export async function build({
       const outputDirPrefix = path.join(workPath, path.dirname(entrypoint));
 
       if (framework) {
-        const outputDirName = await framework.getOutputDirName(outputDirPrefix);
+        const outputDirName = config.outputDirectory
+          ? config.outputDirectory
+          : await framework.getOutputDirName(outputDirPrefix);
 
         distPath = path.join(outputDirPrefix, outputDirName);
       } else if (!config || !config.distDir) {

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/.gitignore
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+custom-output
+yarn.lock
+node_modules

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/.nowignore
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/.nowignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+custom-output
+yarn.lock
+node_modules

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/now.json
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/now.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "use": "@now/static-build",
+      "src": "package.json",
+      "config": {
+        "zeroConfig": true,
+        "buildCommand": "yarn generate && mv dist custom-output",
+        "outputDirectory": "custom-output"
+      }
+    }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/package.json
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "47-nuxt-with-custom-output",
+  "version": "1.0.0",
+  "main": "pages/index.js",
+  "scripts": {
+    "dev": "nuxt dev",
+    "generate": "nuxt generate"
+  },
+  "keywords": [],
+  "private": true,
+  "dependencies": {
+    "nuxt": "2.11.0"
+  }
+}

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/pages/index.js
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <h1>hello nuxt</h1>;


### PR DESCRIPTION
Ensure outputDirectory is used when it exists.