### PR TITLE
[now-build-utils] Only add 404 route when there are no api routes

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,5 @@
 import { parse as parsePath } from 'path';
-import { Route } from '@now/routing-utils';
+import { Route, Source } from '@now/routing-utils';
 import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
 
@@ -281,7 +281,12 @@ async function detectApiRoutes(
           continue: true,
         },
       ];
-    } else {
+    } else if (
+      defaultRoutes.some(
+        route =>
+          (route as Source).dest && (route as Source).dest!.startsWith('/api')
+      )
+    ) {
       defaultRoutes.push({
         status: 404,
         src: '/api(/.*)?$',

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -284,7 +284,7 @@ async function detectApiRoutes(
     } else if (
       defaultRoutes.some(
         route =>
-          (route as Source).dest && (route as Source).dest!.startsWith('/api')
+          (route as Source).dest && (route as Source).dest!.startsWith('/api/')
       )
     ) {
       defaultRoutes.push({

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,5 +1,5 @@
 import { parse as parsePath } from 'path';
-import { Route, Source } from '@now/routing-utils';
+import { Route, isHandler } from '@now/routing-utils';
 import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
 

--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -284,7 +284,7 @@ async function detectApiRoutes(
     } else if (
       defaultRoutes.some(
         route =>
-          (route as Source).dest && (route as Source).dest!.startsWith('/api/')
+          !isHandler(route) && route.dest && route.dest.startsWith('/api/')
       )
     ) {
       defaultRoutes.push({

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -700,7 +700,7 @@ describe('Test `detectBuilders`', () => {
 
     const { defaultRoutes } = await detectRoutes(files, builders!);
 
-    expect(defaultRoutes!.length).toBe(3);
+    expect(defaultRoutes!.length).toBe(2);
     expect((defaultRoutes![0] as any).dest).toBe('/server/team.ts');
     expect((defaultRoutes![0] as any).src).toBe(
       '^/server/(team\\/|team|team\\.ts)$'
@@ -709,7 +709,6 @@ describe('Test `detectBuilders`', () => {
     expect((defaultRoutes![1] as any).src).toBe(
       '^/server/(user\\/|user|user\\.ts)$'
     );
-    expect((defaultRoutes![2] as any).status).toBe(404);
   });
 
   it('Custom directory for Serverless Functions + Next.js', async () => {
@@ -755,12 +754,11 @@ describe('Test `detectBuilders`', () => {
 
     const { defaultRoutes } = await detectRoutes(files, builders!);
 
-    expect(defaultRoutes!.length).toBe(2);
+    expect(defaultRoutes!.length).toBe(1);
     expect((defaultRoutes![0] as any).dest).toBe('/server/user.ts');
     expect((defaultRoutes![0] as any).src).toBe(
       '^/server/(user\\/|user|user\\.ts)$'
     );
-    expect((defaultRoutes![1] as any).status).toBe(404);
   });
 
   it('Framework with non-package.json entrypoint', async () => {


### PR DESCRIPTION
Only add 404 route when there are no api routes.