### PR TITLE
[now-next] Add handling for new routes-manifest version

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -339,7 +339,8 @@ export const build = async ({
 
   if (routesManifest) {
     switch (routesManifest.version) {
-      case 1: {
+      case 1:
+      case 2: {
         redirects.push(...convertRedirects(routesManifest.redirects));
         rewrites.push(...convertRewrites(routesManifest.rewrites));
         break;

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -360,7 +360,8 @@ export async function getDynamicRoutes(
 
   if (routesManifest) {
     switch (routesManifest.version) {
-      case 1: {
+      case 1:
+      case 2: {
         return routesManifest.dynamicRoutes.map(
           ({ page, regex }: { page: string; regex: string }) => {
             return {


### PR DESCRIPTION
This handles the new `routes-manifest` version in the latest canary of Next.js since we throw an error if the version isn't handled by `@now/next`

unblocks: https://github.com/zeit/now/pull/3481