### PR TITLE
[now-build-utils][now-node] Throw new NowBuildError()

### DIFF
--- a/packages/now-build-utils/src/errors.ts
+++ b/packages/now-build-utils/src/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * This error should be thrown from a Builder in
+ * order to stop the build and print a message.
+ * This is necessary to avoid printing a stack trace.
+ */
+export class NowBuildError extends Error {
+  public code: string;
+
+  constructor({ message, code }: Props) {
+    super(message);
+    this.code = code;
+  }
+}
+
+interface Props {
+  message: string;
+  code: string;
+}

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -89,11 +89,6 @@ export async function getSupportedNodeVersion(
     const validRanges = supportedOptions
       .filter(o => !o.discontinueDate)
       .map(o => o.range);
-    const prevTerm = process.env.TERM;
-    if (!prevTerm) {
-      // workaround for https://github.com/sindresorhus/term-size/issues/13
-      process.env.TERM = 'xterm';
-    }
     console.warn(
       boxen(
         'NOTICE' +
@@ -108,7 +103,6 @@ export async function getSupportedNodeVersion(
         { padding: 1 }
       )
     );
-    process.env.TERM = prevTerm;
   }
 
   return selection;

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -1,6 +1,7 @@
 import { intersects } from 'semver';
 import boxen from 'boxen';
 import { NodeVersion } from '../types';
+import { NowBuildError } from '../errors';
 import debug from '../debug';
 
 const allOptions: NodeVersion[] = [
@@ -15,6 +16,11 @@ const allOptions: NodeVersion[] = [
 ];
 
 const supportedOptions = allOptions.filter(o => !isDiscontinued(o));
+const pleaseUse =
+  'Please use one of the following supported ranges in your `package.json`: ';
+const upstreamProvider =
+  'This change is the result of a decision made by an upstream infrastructure provider (AWS).' +
+  '\nRead more: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html';
 
 export function getOldestNodeVersion(): NodeVersion {
   return allOptions[allOptions.length - 1];
@@ -26,49 +32,60 @@ export function getLatestNodeVersion(): NodeVersion {
 
 export async function getSupportedNodeVersion(
   engineRange?: string,
-  silent?: boolean
+  isAuto?: boolean
 ): Promise<NodeVersion> {
   let selection = getOldestNodeVersion();
 
-  if (!engineRange) {
-    if (!silent) {
-      debug(
-        'Missing `engines` in `package.json`, using default range: ' +
-          selection.range
-      );
-    }
-  } else {
+  if (engineRange) {
     const found = allOptions.some(o => {
       // the array is already in order so return the first
       // match which will be the newest version of node
       selection = o;
       return intersects(o.range, engineRange);
     });
-    const discontinued = isDiscontinued(selection);
-    if (found && !discontinued) {
-      if (!silent) {
-        debug(
-          'Found `engines` in `package.json`, selecting range: ' +
-            selection.range
-        );
-      }
-    } else {
-      throw new Error(
-        'Found `engines` in `package.json` with an unsupported Node.js version range: ' +
-          engineRange +
-          '\nPlease use one of the following supported ranges: ' +
-          JSON.stringify(supportedOptions.map(o => o.range)) +
-          (discontinued
-            ? '\nThis change is the result of a decision made by an upstream infrastructure provider (AWS).' +
-              '\nRead more: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
-            : '')
-      );
+    if (!found) {
+      const intro = isAuto
+        ? 'This project is using an invalid version of Node.js and must be changed.'
+        : 'Found `engines` in `package.json` with an invalid Node.js version range: ' +
+          engineRange;
+      throw new NowBuildError({
+        code: 'NOW_BUILD_UTILS_NODE_VERSION_INVALID',
+        message:
+          intro +
+          '\n' +
+          pleaseUse +
+          JSON.stringify(supportedOptions.map(o => o.range)),
+      });
     }
   }
 
-  const { range, discontinueDate } = selection;
-  if (discontinueDate && !isDiscontinued(selection)) {
-    const d = discontinueDate.toISOString().split('T')[0];
+  if (isDiscontinued(selection)) {
+    const intro = isAuto
+      ? 'This project is using a discontinued version of Node.js and must be upgraded.'
+      : 'Found `engines` in `package.json` with a discontinued Node.js version range: ' +
+        engineRange;
+    throw new NowBuildError({
+      code: 'NOW_BUILD_UTILS_NODE_VERSION_DISCONTINUED',
+      message:
+        intro +
+        '\n' +
+        pleaseUse +
+        JSON.stringify(supportedOptions.map(o => o.range)) +
+        '\n' +
+        upstreamProvider,
+    });
+  }
+
+  debug(
+    isAuto
+      ? 'Using default Node.js range: ' + selection.range
+      : (engineRange ? 'Found' : 'Missing') +
+          ' `engines` in `package.json`, selecting range: ' +
+          selection.range
+  );
+
+  if (selection.discontinueDate) {
+    const d = selection.discontinueDate.toISOString().split('T')[0];
     const validRanges = supportedOptions
       .filter(o => !o.discontinueDate)
       .map(o => o.range);
@@ -81,12 +98,13 @@ export async function getSupportedNodeVersion(
       boxen(
         'NOTICE' +
           '\n' +
-          `\nNode.js version ${range} has reached end-of-life.` +
+          `\nNode.js version ${selection.range} has reached end-of-life.` +
           `\nAs a result, deployments created on or after ${d} will fail to build.` +
-          '\nPlease use one of the following supported `engines` in `package.json`: ' +
+          '\n' +
+          pleaseUse +
           JSON.stringify(validRanges) +
-          '\nThis change is the result of a decision made by an upstream infrastructure provider (AWS).' +
-          '\nRead more: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html',
+          '\n' +
+          upstreamProvider,
         { padding: 1 }
       )
     );

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -109,6 +109,6 @@ export async function getSupportedNodeVersion(
 }
 
 function isDiscontinued({ discontinueDate }: NodeVersion): boolean {
-  const today = new Date();
-  return discontinueDate !== undefined && discontinueDate <= today;
+  const today = Date.now();
+  return discontinueDate !== undefined && discontinueDate.getTime() <= today;
 }

--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -44,10 +44,11 @@ export async function getSupportedNodeVersion(
       return intersects(o.range, engineRange);
     });
     if (!found) {
-      const intro = isAuto
-        ? 'This project is using an invalid version of Node.js and must be changed.'
-        : 'Found `engines` in `package.json` with an invalid Node.js version range: ' +
-          engineRange;
+      const intro =
+        isAuto || !engineRange
+          ? 'This project is using an invalid version of Node.js and must be changed.'
+          : 'Found `engines` in `package.json` with an invalid Node.js version range: ' +
+            engineRange;
       throw new NowBuildError({
         code: 'NOW_BUILD_UTILS_NODE_VERSION_INVALID',
         message:
@@ -60,10 +61,11 @@ export async function getSupportedNodeVersion(
   }
 
   if (isDiscontinued(selection)) {
-    const intro = isAuto
-      ? 'This project is using a discontinued version of Node.js and must be upgraded.'
-      : 'Found `engines` in `package.json` with a discontinued Node.js version range: ' +
-        engineRange;
+    const intro =
+      isAuto || !engineRange
+        ? 'This project is using a discontinued version of Node.js and must be upgraded.'
+        : 'Found `engines` in `package.json` with a discontinued Node.js version range: ' +
+          engineRange;
     throw new NowBuildError({
       code: 'NOW_BUILD_UTILS_NODE_VERSION_DISCONTINUED',
       message:
@@ -77,7 +79,7 @@ export async function getSupportedNodeVersion(
   }
 
   debug(
-    isAuto
+    isAuto || !engineRange
       ? 'Using default Node.js range: ' + selection.range
       : (engineRange ? 'Found' : 'Missing') +
           ' `engines` in `package.json`, selecting range: ' +

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -144,20 +144,20 @@ export async function getNodeVersion(
 ): Promise<NodeVersion> {
   const { packageJson } = await scanParentDirs(destPath, true);
   let range: string | undefined;
-  let silent = false;
+  let isAuto = false;
   if (packageJson && packageJson.engines && packageJson.engines.node) {
     range = packageJson.engines.node;
   } else if (minNodeVersion) {
     range = minNodeVersion;
-    silent = true;
+    isAuto = true;
   } else if (config && config.nodeVersion) {
     range = config.nodeVersion;
-    silent = true;
+    isAuto = true;
   } else if (config && config.zeroConfig) {
     range = '10.x';
-    silent = true;
+    isAuto = true;
   }
-  return getSupportedNodeVersion(range, silent);
+  return getSupportedNodeVersion(range, isAuto);
 }
 
 async function scanParentDirs(destPath: string, readPackageJson = false) {

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -66,3 +66,4 @@ export { readConfigFile } from './fs/read-config-file';
 
 export * from './schemas';
 export * from './types';
+export * from './errors';

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -47,12 +47,31 @@ it('should create zip files with symlinks properly', async () => {
 });
 
 it('should only match supported node versions', async () => {
-  expect(await getSupportedNodeVersion('10.x')).toHaveProperty('major', 10);
-  expect(await getSupportedNodeVersion('12.x')).toHaveProperty('major', 12);
-  expect(getSupportedNodeVersion('8.11.x')).rejects.toThrow();
-  expect(getSupportedNodeVersion('6.x')).rejects.toThrow();
-  expect(getSupportedNodeVersion('999.x')).rejects.toThrow();
-  expect(getSupportedNodeVersion('foo')).rejects.toThrow();
+  expect(await getSupportedNodeVersion('10.x', false)).toHaveProperty(
+    'major',
+    10
+  );
+  expect(await getSupportedNodeVersion('12.x', false)).toHaveProperty(
+    'major',
+    12
+  );
+  expect(getSupportedNodeVersion('8.11.x', false)).rejects.toThrow();
+  expect(getSupportedNodeVersion('6.x', false)).rejects.toThrow();
+  expect(getSupportedNodeVersion('999.x', false)).rejects.toThrow();
+  expect(getSupportedNodeVersion('foo', false)).rejects.toThrow();
+
+  expect(await getSupportedNodeVersion('10.x', true)).toHaveProperty(
+    'major',
+    10
+  );
+  expect(await getSupportedNodeVersion('12.x', true)).toHaveProperty(
+    'major',
+    12
+  );
+  expect(getSupportedNodeVersion('8.11.x', true)).rejects.toThrow();
+  expect(getSupportedNodeVersion('6.x', true)).rejects.toThrow();
+  expect(getSupportedNodeVersion('999.x', true)).rejects.toThrow();
+  expect(getSupportedNodeVersion('foo', true)).rejects.toThrow();
 });
 
 it('should match all semver ranges', async () => {
@@ -87,6 +106,20 @@ it('should select correct node version in getNodeVersion()', async () => {
 
 it('should get latest node version', async () => {
   expect(await getLatestNodeVersion()).toHaveProperty('major', 12);
+});
+
+it('should throw for discontinued versions', async () => {
+  // Mock a future date so that Node 8 becomes discontinued
+  const realDateNow = Date.now.bind(global.Date);
+  global.Date.now = () => new Date('2020-02-14').getTime();
+
+  expect(getSupportedNodeVersion('', false)).rejects.toThrow();
+  expect(getSupportedNodeVersion('8.10.x', false)).rejects.toThrow();
+
+  expect(getSupportedNodeVersion('', true)).rejects.toThrow();
+  expect(getSupportedNodeVersion('8.10.x', true)).rejects.toThrow();
+
+  global.Date.now = realDateNow;
 });
 
 it('should support require by path for legacy builders', () => {

--- a/packages/now-node/src/typescript.ts
+++ b/packages/now-node/src/typescript.ts
@@ -1,5 +1,6 @@
 import { relative, basename, resolve, dirname } from 'path';
 import _ts from 'typescript';
+import { NowBuildError } from '@now/build-utils';
 
 /*
  * Fork of TS-Node - https://github.com/TypeStrong/ts-node
@@ -180,8 +181,8 @@ export function register(opts: Options = {}): Register {
   };
 
   function createTSError(diagnostics: ReadonlyArray<_ts.Diagnostic>) {
-    const diagnosticText = formatDiagnostics(diagnostics, diagnosticHost);
-    return new Error(diagnosticText);
+    const message = formatDiagnostics(diagnostics, diagnosticHost);
+    return new NowBuildError({ code: 'NOW_NODE_TYPESCRIPT_ERROR', message });
   }
 
   function reportTSError(

--- a/packages/now-node/test/fixtures/10-node-engines/now.json
+++ b/packages/now-node/test/fixtures/10-node-engines/now.json
@@ -7,7 +7,7 @@
     }
   ],
   "probes": [
-    { "path": "/empty", "mustContain": "RANDOMNESS_PLACEHOLDER:8" },
+    { "path": "/empty", "mustContain": "RANDOMNESS_PLACEHOLDER:12" },
     { "path": "/exact", "mustContain": "RANDOMNESS_PLACEHOLDER:10" },
     { "path": "/greater", "mustContain": "RANDOMNESS_PLACEHOLDER:12" },
     { "path": "/major", "mustContain": "RANDOMNESS_PLACEHOLDER:10" },

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 const { createHash } = require('crypto');
-const { homedir } = require('os');
 const path = require('path');
 const fetch = require('./fetch-retry.js');
 
@@ -28,7 +27,7 @@ async function nowDeploy (bodies, randomness) {
         RANDOMNESS_BUILD_ENV_VAR: randomness,
       },
     },
-    name: 'test',
+    name: 'test2020',
     files,
     builds: nowJson.builds,
     routes: nowJson.routes || [],
@@ -133,20 +132,12 @@ async function fetchWithAuth (url, opts = {}) {
   if (!opts.headers) opts.headers = {};
 
   if (!opts.headers.Authorization) {
-    const { NOW_TOKEN, CIRCLECI } = process.env;
     currentCount += 1;
     if (!token || currentCount === MAX_COUNT) {
       currentCount = 0;
-      if (NOW_TOKEN) {
-        token = NOW_TOKEN;
-      } else if (CIRCLECI) {
-        token = await fetchTokenWithRetry(
-          Buffer.from(str, 'base64').toString()
-        );
-      } else {
-        const authJsonPath = path.join(homedir(), '.now/auth.json');
-        token = require(authJsonPath).token;
-      }
+      token = await fetchTokenWithRetry(
+        Buffer.from(str, 'base64').toString()
+      );
     }
 
     opts.headers.Authorization = `Bearer ${token}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,9 +2341,9 @@ ansi-styles@^4.0.0:
     color-convert "^2.0.1"
 
 ansi-styles@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
-  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
@@ -9731,7 +9731,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 
@@ -10411,9 +10411,9 @@ term-size@^1.2.0:
     execa "^0.7.0"
 
 term-size@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.0.tgz#3aec444c07a7cf936e157c1dc224b590c3c7eef2"
-  integrity sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.1.tgz#f81ec25854af91a480d2f9d0c77ffcb26594ed1a"
+  integrity sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==
 
 test-exclude@^5.1.0, test-exclude@^5.2.3:
   version "5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9731,7 +9731,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 


### PR DESCRIPTION
This PR does the following

- Add and export class, `NowBuildError`, that can be thrown to stop the build and print an error but it will not print a stack trace.
- Improve logic for discontinued node versions and add more tests
- Remove hack (#3425) for undefined TERM, fixed by updating dependencies
- Rename `silent` variable to `isAuto` which means the node version was automatically selected, not defined in `package.json`
- Rename `test` deployments to `test2020` so that a fresh project is created with latest Node.js 12.x