### PR TITLE
[now-static-build] Fix `distDir` when zero config framework is detected

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -162,7 +162,13 @@ function getPkg(entrypoint: string, workPath: string) {
   return pkg;
 }
 
-function getFramework(config: Config | null, pkg?: PackageJson | null) {
+function getFramework(
+  config: Config | null,
+  pkg?: PackageJson | null
+): Framework | undefined {
+  if (!config || !config.zeroConfig) {
+    return;
+  }
   const { framework: configFramework = null } = config || {};
 
   if (configFramework) {

--- a/packages/now-static-build/test/fixtures/04a-correct-dist-dir/now.json
+++ b/packages/now-static-build/test/fixtures/04a-correct-dist-dir/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "out" }
+    }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/04a-correct-dist-dir/now.json
+++ b/packages/now-static-build/test/fixtures/04a-correct-dist-dir/now.json
@@ -6,5 +6,6 @@
       "use": "@now/static-build",
       "config": { "distDir": "out" }
     }
-  ]
+  ],
+  "probes": [{ "path": "/", "mustContain": "output:RANDOMNESS_PLACEHOLDER" }]
 }

--- a/packages/now-static-build/test/fixtures/04a-correct-dist-dir/package.json
+++ b/packages/now-static-build/test/fixtures/04a-correct-dist-dir/package.json
@@ -2,5 +2,8 @@
   "private": true,
   "scripts": {
     "now-build": "mkdir out && echo 'output:RANDOMNESS_PLACEHOLDER' > out/index.txt"
+  },
+  "dependencies": {
+    "@vue/cli-service": "3.11.0"
   }
 }

--- a/packages/now-static-build/test/fixtures/04a-correct-dist-dir/package.json
+++ b/packages/now-static-build/test/fixtures/04a-correct-dist-dir/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "now-build": "mkdir out && echo 'output:RANDOMNESS_PLACEHOLDER' > out/index.txt"
+  }
+}

--- a/packages/now-static-build/test/fixtures/04a-correct-dist-dir/public/index.txt
+++ b/packages/now-static-build/test/fixtures/04a-correct-dist-dir/public/index.txt
@@ -1,0 +1,1 @@
+Should not use this file

--- a/packages/now-static-build/test/unit.test.js
+++ b/packages/now-static-build/test/unit.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 describe('prepareCache', () => {
   test('should cache node_modules', async () => {
     const files = await prepareCache({
+      config: { zeroConfig: true },
       workPath: path.resolve(__dirname, './cache-fixtures/default'),
       entrypoint: 'index.js',
     });
@@ -14,6 +15,7 @@ describe('prepareCache', () => {
 
   test('should cache node_modules and `.cache` folder for gatsby deployments', async () => {
     const files = await prepareCache({
+      config: { zeroConfig: true },
       workPath: path.resolve(__dirname, './cache-fixtures/gatsby'),
       entrypoint: 'package.json',
     });


### PR DESCRIPTION
There was a regression with framework detection that was preferring the frameworks output directory instead of the `distDir` defined in the `@now/static-build`.

The fix is to only run framework detection when `builds` is not defined (ie zero config).

Related to https://github.com/Ebury/chameleon/pull/63