### PR TITLE
[now-build-utils] Fix now dev to use system node

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -7,7 +7,7 @@ import { SpawnOptions } from 'child_process';
 import { deprecate } from 'util';
 import { cpus } from 'os';
 import { Meta, PackageJson, NodeVersion, Config } from '../types';
-import { getSupportedNodeVersion } from './node-version';
+import { getSupportedNodeVersion, getLatestNodeVersion } from './node-version';
 
 export function spawnAsync(
   command: string,
@@ -140,8 +140,15 @@ export function getSpawnOptions(
 export async function getNodeVersion(
   destPath: string,
   minNodeVersion?: string,
-  config?: Config
+  config?: Config,
+  meta?: Meta
 ): Promise<NodeVersion> {
+  if (meta && meta.isDev) {
+    // Use the system-installed version of `node` when running via `now dev`
+    const latest = getLatestNodeVersion();
+    const runtime = 'nodejs';
+    return { ...latest, runtime };
+  }
   const { packageJson } = await scanParentDirs(destPath, true);
   let range: string | undefined;
   let isAuto = false;

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -144,10 +144,9 @@ export async function getNodeVersion(
   meta?: Meta
 ): Promise<NodeVersion> {
   if (meta && meta.isDev) {
-    // Use the system-installed version of `node` when running via `now dev`
+    // Use the system-installed version of `node` in PATH for `now dev`
     const latest = getLatestNodeVersion();
-    const runtime = 'nodejs';
-    return { ...latest, runtime };
+    return { ...latest, runtime: 'nodejs' };
   }
   const { packageJson } = await scanParentDirs(destPath, true);
   let range: string | undefined;

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -104,6 +104,17 @@ it('should select correct node version in getNodeVersion()', async () => {
   ).toHaveProperty('major', 10);
 });
 
+it('should ignore node version in now dev getNodeVersion()', async () => {
+  expect(
+    await getNodeVersion(
+      '/tmp',
+      undefined,
+      { nodeVersion: '1' },
+      { isDev: true }
+    )
+  ).toHaveProperty('runtime', 'nodejs');
+});
+
 it('should get latest node version', async () => {
   expect(await getLatestNodeVersion()).toHaveProperty('major', 12);
 });

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -202,7 +202,7 @@ export const build = async ({
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);
 
-  const nodeVersion = await getNodeVersion(entryPath, undefined, config);
+  const nodeVersion = await getNodeVersion(entryPath, undefined, config, meta);
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
   if (!nextVersion) {

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -71,7 +71,8 @@ async function downloadInstallAndBundle({
   const nodeVersion = await getNodeVersion(
     entrypointFsDirname,
     undefined,
-    config
+    config,
+    meta
   );
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
   await runNpmInstall(
@@ -369,16 +370,13 @@ export async function build({
     });
   }
 
-  // Use the system-installed version of `node` when running via `now dev`
-  const runtime = meta.isDev ? 'nodejs' : nodeVersion.runtime;
-
   const lambda = await createLambda({
     files: {
       ...preparedFiles,
       ...launcherFiles,
     },
     handler: `${LAUNCHER_FILENAME}.launcher`,
-    runtime,
+    runtime: nodeVersion.runtime,
   });
 
   return { output: lambda, watch };

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -454,7 +454,12 @@ export async function build({
 
   if (!config.zeroConfig && entrypoint.endsWith('.sh')) {
     debug(`Running build script "${entrypoint}"`);
-    const nodeVersion = await getNodeVersion(entrypointDir, undefined, config);
+    const nodeVersion = await getNodeVersion(
+      entrypointDir,
+      undefined,
+      config,
+      meta
+    );
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
     await runShellScript(path.join(workPath, entrypoint), [], spawnOpts);
     validateDistDir(distPath, meta.isDev, config);

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -300,7 +300,8 @@ export async function build({
     const nodeVersion = await getNodeVersion(
       entrypointDir,
       minNodeRange,
-      config
+      config,
+      meta
     );
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
 

--- a/test/lib/run-build-lambda.js
+++ b/test/lib/run-build-lambda.js
@@ -16,6 +16,10 @@ async function runBuildLambda(inputPath) {
   const nowJson = require(nowJsonRef.fsPath);
   expect(nowJson.builds.length).toBe(1);
   const build = nowJson.builds[0];
+  if (!build.config.nodeVersion) {
+    // Mimic api-deployments when a new project is created
+    build.config.nodeVersion = 12;
+  }
   expect(build.src.includes('*')).toBeFalsy();
   const entrypoint = build.src.replace(/^\//, ''); // strip leftmost slash
   expect(inputFiles[entrypoint]).toBeDefined();
@@ -26,7 +30,7 @@ async function runBuildLambda(inputPath) {
   const analyzeResult = runAnalyze(wrapper, {
     files: inputFiles,
     entrypoint,
-    config: build.config
+    config: build.config,
   });
 
   const workPath = await getWritableDirectory();
@@ -34,7 +38,7 @@ async function runBuildLambda(inputPath) {
     files: inputFiles,
     entrypoint,
     config: build.config,
-    workPath
+    workPath,
   });
   const { output } = buildResult;
 
@@ -43,7 +47,7 @@ async function runBuildLambda(inputPath) {
     buildResult.output = Object.keys(output).reduce(
       (result, path) => ({
         ...result,
-        [path.replace(/\\/g, '/')]: output[path]
+        [path.replace(/\\/g, '/')]: output[path],
       }),
       {}
     );
@@ -52,7 +56,7 @@ async function runBuildLambda(inputPath) {
   return {
     analyzeResult,
     buildResult,
-    workPath
+    workPath,
   };
 }
 


### PR DESCRIPTION
This PR will use the system installed version of Node.js and avoid printing a warning or error if a discontinued version is selected.

This optimization was already in `@now/node` but for some reason it was never add to `@now/next`.

The reason why its relevant today is because the warnings turned into errors due to Node 8 deprecation and we don't have the "Project" in `now dev` so we don't know which version of node to select.

So instead of determining the version, `now dev` will always use `node` in the PATH and avoid printing warnings or errors. This also results in less FS reads since we no longer need to read package.json.