### PR TITLE
[@now/frameworks] Improve `Framework` type

### DIFF
--- a/packages/frameworks/index.d.ts
+++ b/packages/frameworks/index.d.ts
@@ -3,10 +3,7 @@ export interface FrameworkDetectionItem {
   matchContent?: string;
 }
 
-interface Setting {
-  value?: string;
-  placeholder?: string;
-}
+type Setting = { value: string } | { placeholder: string }
 
 export interface Framework {
   name: string;
@@ -18,9 +15,9 @@ export interface Framework {
     every?: FrameworkDetectionItem[];
     some?: FrameworkDetectionItem[];
   };
-  settings?: {
-    buildCommand?: Setting;
-    devCommand?: Setting;
-    outputDirectory?: Setting;
+  settings: {
+    buildCommand: Setting;
+    devCommand: Setting;
+    outputDirectory: Setting;
   };
 }

--- a/packages/frameworks/index.d.ts
+++ b/packages/frameworks/index.d.ts
@@ -3,7 +3,9 @@ export interface FrameworkDetectionItem {
   matchContent?: string;
 }
 
-type Setting = { value: string } | { placeholder: string }
+type Setting =
+  | { value: string; placeholder?: string }
+  | { value?: string; placeholder: string }
 
 export interface Framework {
   name: string;

--- a/packages/frameworks/index.d.ts
+++ b/packages/frameworks/index.d.ts
@@ -3,9 +3,7 @@ export interface FrameworkDetectionItem {
   matchContent?: string;
 }
 
-type Setting =
-  | { value: string; placeholder?: string }
-  | { value?: string; placeholder: string }
+type Setting = { value: string } | { placeholder: string }
 
 export interface Framework {
   name: string;


### PR DESCRIPTION
Makes types more specific: we want to avoid missing project settings placeholder/value in the UIs that consume frameworks (cli, front-end, ...).