### PR TITLE
Don't render `Synced X files` when everything got deduped

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -113,7 +113,11 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          log(`Synced ${pluralize('file', fileCount, true)} ${uploadStamp()}`);
+          if (fileCount) {
+            log(
+              `Synced ${pluralize('file', fileCount, true)} ${uploadStamp()}`
+            );
+          }
           const version = isLegacy ? `${chalk.grey('[v1]')} ` : '';
           log(`https://${event.payload.url} ${version}${deployStamp()}`);
         } else {
@@ -228,7 +232,11 @@ export default async function processDeployment({
         now._host = event.payload.url;
 
         if (!quiet) {
-          log(`Synced ${pluralize('file', fileCount, true)} ${uploadStamp()}`);
+          if (fileCount) {
+            log(
+              `Synced ${pluralize('file', fileCount, true)} ${uploadStamp()}`
+            );
+          }
           const version = isLegacy ? `${chalk.grey('[v1]')} ` : '';
           log(`${event.payload.url} ${version}${deployStamp()}`);
         } else {


### PR DESCRIPTION
This removes `Synced XX files` message if the entire deployment got deduped