### PR TITLE
[now-build-utils] Add getDiscontinuedNodeVersions() function

### DIFF
--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -33,6 +33,10 @@ export function getLatestNodeVersion(): NodeVersion {
   return allOptions[0];
 }
 
+export function getDiscontinuedNodeVersions(): NodeVersion[] {
+  return allOptions.filter(isDiscontinued);
+}
+
 export async function getSupportedNodeVersion(
   engineRange?: string,
   isAuto?: boolean

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -21,7 +21,10 @@ import {
   getNodeVersion,
   getSpawnOptions,
 } from './fs/run-user-scripts';
-import { getLatestNodeVersion } from './fs/node-version';
+import {
+  getLatestNodeVersion,
+  getDiscontinuedNodeVersions,
+} from './fs/node-version';
 import streamToBuffer from './fs/stream-to-buffer';
 import shouldServe from './should-serve';
 import debug from './debug';
@@ -50,6 +53,7 @@ export {
   runShellScript,
   getNodeVersion,
   getLatestNodeVersion,
+  getDiscontinuedNodeVersions,
   getSpawnOptions,
   streamToBuffer,
   shouldServe,

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -4,7 +4,11 @@ const assert = require('assert');
 const { createZip } = require('../dist/lambda');
 const { glob, spawnAsync, download } = require('../');
 const { getSupportedNodeVersion } = require('../dist/fs/node-version');
-const { getNodeVersion, getLatestNodeVersion } = require('../dist');
+const {
+  getNodeVersion,
+  getLatestNodeVersion,
+  getDiscontinuedNodeVersions,
+} = require('../dist');
 
 it('should re-create symlinks properly', async () => {
   const files = await glob('**', path.join(__dirname, 'symlinks'));
@@ -129,6 +133,9 @@ it('should throw for discontinued versions', async () => {
 
   expect(getSupportedNodeVersion('', true)).rejects.toThrow();
   expect(getSupportedNodeVersion('8.10.x', true)).rejects.toThrow();
+
+  expect(getDiscontinuedNodeVersions().length).toBe(1);
+  expect(getDiscontinuedNodeVersions()[0]).toHaveProperty('range', '8.10.x');
 
   global.Date.now = realDateNow;
 });


### PR DESCRIPTION
Add an exported function `getDiscontinuedNodeVersions()` so we can gracefully handle discontinued versions of Node in other parts of the system.