### PR TITLE
feat: Read default dev port from .env

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import 'dotenv/config';
 
 import pkg from '../../../package.json';
 import DevServer from '../../util/dev/server';
@@ -21,7 +22,7 @@ export default async function dev(
 
   const [dir = '.'] = args;
   const cwd = path.resolve(dir);
-  const listen = parseListen(opts['--listen'] || '3000');
+  const listen = parseListen(opts['--listen'] || process.env.PORT || '3000');
   const debug = opts['--debug'] || false;
   const devServer = new DevServer(cwd, { output, debug });
 


### PR DESCRIPTION
Adds support for specifying the default port via environment variable `PORT`.

`dotenv` is used to read that variable from `.env` files.
The default port remains 3000.

Helps to solve #2613

What tests are required, where do I hook them in at best?