### PR TITLE
[now-build-utils] Add `.ru` api detection for Ruby Rack

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -31,6 +31,7 @@ function getApiBuilders({ tag }: Pick<Options, 'tag'> = {}): Builder[] {
     { src: 'api/**/*.go', use: `@now/go${withTag}`, config },
     { src: 'api/**/*.py', use: `@now/python${withTag}`, config },
     { src: 'api/**/*.rb', use: `@now/ruby${withTag}`, config },
+    { src: 'api/**/*.ru', use: `@now/ruby${withTag}`, config },
   ];
 }
 


### PR DESCRIPTION
Currently this instruction
https://zeit.co/docs/runtimes#advanced-usage/advanced-ruby-usage/rack-interface
does not work unless manually specify the runtime.