### PR TITLE
[tests] Revert NOW_TOKEN env for health checks

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -135,9 +135,14 @@ async function fetchWithAuth (url, opts = {}) {
     currentCount += 1;
     if (!token || currentCount === MAX_COUNT) {
       currentCount = 0;
-      token = await fetchTokenWithRetry(
-        Buffer.from(str, 'base64').toString()
-      );
+      if (process.env.NOW_TOKEN) {
+        // used for health checks
+        token = process.env.NOW_TOKEN;
+      } else {
+        token = await fetchTokenWithRetry(
+          Buffer.from(str, 'base64').toString()
+        );
+      }
     }
 
     opts.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
As we discussed, the health checks need to assign `NOW_TOKEN` env var.