### PR TITLE
[now-cli] Fix certs error message and handling

### DIFF
--- a/packages/now-cli/src/util/certs/create-cert-from-file.ts
+++ b/packages/now-cli/src/util/certs/create-cert-from-file.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { DomainPermissionDenied, InvalidCert } from '../errors-ts';
 import wait from '../output/wait';
 import Client from '../client';
 import { Cert } from '../../types';
@@ -13,29 +12,32 @@ export default async function createCertFromFile(
   context: string
 ) {
   const cancelWait = wait('Adding your custom certificate');
-  const cert = readFileSync(resolve(certPath), 'utf8');
-  const key = readFileSync(resolve(keyPath), 'utf8');
-  const ca = readFileSync(resolve(caPath), 'utf8');
 
   try {
+    const cert = readFileSync(resolve(certPath), 'utf8');
+    const key = readFileSync(resolve(keyPath), 'utf8');
+    const ca = readFileSync(resolve(caPath), 'utf8');
+
     const certificate = await client.fetch<Cert>('/v3/now/certs', {
       method: 'PUT',
       body: {
         ca,
         cert,
-        key
-      }
+        key,
+      },
     });
-    cancelWait();
     return certificate;
   } catch (error) {
-    cancelWait();
-    if (error.code === 'invalid_cert') {
-      return new InvalidCert();
+    if (error.code === 'ENOENT') {
+      return new Error(`The specified file "${error.path}" doesn't exist.`);
     }
-    if (error.code === 'forbidden') {
-      return new DomainPermissionDenied(error.domain, context);
+
+    if (error.status < 500) {
+      return error;
     }
+
     throw error;
+  } finally {
+    cancelWait();
   }
 }


### PR DESCRIPTION
Makes sure to show the error message from the API instead of trying to generate its own.

[PRODUCT-1000]

[PRODUCT-1000]: https://zeit.atlassian.net/browse/PRODUCT-1000