### PR TITLE
[now-cli] Add tests for project linking and framework detection

### DIFF
--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -64,7 +64,7 @@ export default async function inputProject(
       const answers = await inquirer.prompt({
         type: 'input',
         name: 'existingProjectName',
-        message: `What's the name of your existing project?`,
+        message: `What’s the name of your existing project?`,
       });
       const projectName = answers.existingProjectName as string;
 

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -479,7 +479,7 @@ CMD ["node", "index.js"]`,
     },
     'project-link': {
       'pages/index.js':
-        'export default () => <div><h1>Now CLI test</h1><p>Zero-config + Next.js</p></div>',
+        'export default () => <div><h1>Now CLI test</h1></div>',
       'package.json': JSON.stringify({
         dependencies: {
           gatsby: 'latest',

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -477,6 +477,15 @@ CMD ["node", "index.js"]`,
         },
       }),
     },
+    'project-link': {
+      'pages/index.js':
+        'export default () => <div><h1>Now CLI test</h1><p>Zero-config + Next.js</p></div>',
+      'package.json': JSON.stringify({
+        dependencies: {
+          gatsby: 'latest',
+        },
+      }),
+    },
   };
 
   for (const typeName of Object.keys(spec)) {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -167,7 +167,7 @@ const waitForPrompt = (cp, assertion) =>
     cp.stdout.on('data', listener);
     cp.stderr.on('data', listener);
 
-    cp.on('exit', () => resolve());
+    cp.on('exit', () => reject());
   });
 
 const getDeploymentBuildsByUrl = async url => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2264,7 +2264,6 @@ test('should show prompts to set up project', async t => {
   const now = execa(binaryPath, [directory, ...defaultArgs]);
 
   await waitForPrompt(now, chunk => /Set up and deploy [^?]+\?/.test(chunk));
-  console.log('setup and deploy passedddd');
   now.stdin.write('yes\n');
 
   await waitForPrompt(now, chunk =>

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -157,6 +157,7 @@ const waitForPrompt = (cp, assertion) =>
         if (a) {
           cp.stdout.off('data', listener);
           cp.stderr.off('data', listener);
+          cp.off('exit', exitListener);
           resolve();
         }
       } catch (error) {
@@ -164,10 +165,12 @@ const waitForPrompt = (cp, assertion) =>
       }
     };
 
+    const exitListener = () => reject();
+
     cp.stdout.on('data', listener);
     cp.stderr.on('data', listener);
 
-    cp.on('exit', () => reject());
+    cp.on('exit', exitListener);
   });
 
 const getDeploymentBuildsByUrl = async url => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -152,8 +152,8 @@ const waitForPrompt = (cp, assertion) =>
   new Promise(resolve => {
     const listener = chunk => {
       if (assertion(chunk)) {
-        cp.stdout.off('data', listener);
-        cp.stderr.off('data', listener);
+        cp.stdout.off && cp.stdout.off('data', listener);
+        cp.stderr.off && cp.stderr.off('data', listener);
         resolve();
       }
     };


### PR DESCRIPTION
Adds two test cases:
- linking a project and overwriting build settings
- "overwrite settings" prompt should not appear when no framework is detected