### PR TITLE
[now-cli] Handle Now v1 to v2 upgrade

### DIFF
--- a/packages/now-cli/src/commands/deploy/legacy.ts
+++ b/packages/now-cli/src/commands/deploy/legacy.ts
@@ -890,29 +890,25 @@ async function sync({
     const { url } = now;
     const dcs =
       deploymentType !== 'static' && deployment.scale
-        ? ` (${chalk.bold(Object.keys(deployment.scale).join(', '))})`
+        ? chalk` ({bold ${Object.keys(deployment.scale).join(', ')})`
         : '';
 
     if (isTTY) {
+      let inClipboard = '';
+      const platformVersion = deployment.version || 1;
+
       if (clipboard) {
         try {
           await copy(url);
-          log(
-            `${chalk.bold(chalk.cyan(url))} ${chalk.gray('[v1]')} ${chalk.gray(
-              '[in clipboard]'
-            )}${dcs} ${deployStamp()}`
-          );
+          inClipboard = chalk.gray(' [in clipboard]');
         } catch (err) {
           debug(`Error copying to clipboard: ${err}`);
-          log(
-            `${chalk.bold(chalk.cyan(url))} ${chalk.gray(
-              '[v1]'
-            )} ${dcs} ${deployStamp()}`
-          );
         }
-      } else {
-        log(`${chalk.bold(chalk.cyan(url))}${dcs} ${deployStamp()}`);
       }
+
+      log(
+        chalk`{bold.cyan ${url}} {gray [v${platformVersion}]}${inClipboard}${dcs} ${deployStamp()}`
+      );
     }
 
     if (deploymentType === 'static') {
@@ -921,7 +917,7 @@ async function sync({
         noVerify = true;
       } else {
         if (!quiet) {
-          output.log(chalk`{cyan Deployment complete!}`);
+          log(chalk`{cyan Deployment complete!}`);
         }
         await exit(0);
         return;
@@ -935,7 +931,7 @@ async function sync({
       const eventsStream = await maybeGetEventsStream(now, deployment);
 
       if (!noVerify) {
-        output.log(
+        log(
           `Verifying instantiation in ${joinWords(
             Object.keys(deployment.scale).map(dc => chalk.bold(dc))
           )}`
@@ -954,13 +950,11 @@ async function sync({
             output.error(
               `Instance verification timed out (${ms(dcOrEvent.meta.timeout)})`
             );
-            output.log(
-              'Read more: https://err.sh/now-cli/verification-timeout'
-            );
+            log('Read more: https://err.sh/now-cli/verification-timeout');
             await exit(1);
           } else if (Array.isArray(dcOrEvent)) {
             const [dc, instances] = dcOrEvent;
-            output.log(
+            log(
               `${chalk.cyan(chars.tick)} Scaled ${plural(
                 'instance',
                 instances,
@@ -975,7 +969,7 @@ async function sync({
               `[${instanceIndex(dcOrEvent.payload.instanceId)}] `
             );
             formatLogOutput(dcOrEvent.payload.text, prefix).forEach(
-              (msg: string) => output.log(msg)
+              (msg: string) => log(msg)
             );
           }
         }

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -19,7 +19,7 @@ import { linkFolderToProject } from '../projects/link';
 function printInspectUrl(
   output: Output,
   deploymentUrl: string,
-  deployStamp: () => number,
+  deployStamp: () => string,
   orgName: string
 ) {
   const urlParts = deploymentUrl
@@ -46,8 +46,8 @@ export default async function processDeployment({
   hashes: { [key: string]: any };
   paths: string[];
   requestBody: DeploymentOptions;
-  uploadStamp: () => number;
-  deployStamp: () => number;
+  uploadStamp: () => string;
+  deployStamp: () => string;
   isLegacy: boolean;
   quiet: boolean;
   nowConfig?: NowConfig;
@@ -226,7 +226,7 @@ export default async function processDeployment({
       throw error;
     }
 
-    // Handle ready event
+    // Handle alias-assigned event
     if (event.type === 'alias-assigned') {
       if (queuedSpinner) {
         queuedSpinner();

--- a/packages/now-cli/src/util/output/elapsed.ts
+++ b/packages/now-cli/src/util/output/elapsed.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
  * @param time Number of ms
  * @param ago  Boolean to indicate if we should append `ago`
  */
-export default function elapsed(time: number, ago: boolean = false) {
+export default function elapsed(time: number, ago: boolean = false): string {
   return chalk.gray(
     `[${time < 1000 ? `${time}ms` : ms(time)}${ago ? ' ago' : ''}]`
   );

--- a/packages/now-cli/src/util/output/stamp.ts
+++ b/packages/now-cli/src/util/output/stamp.ts
@@ -5,5 +5,5 @@ import elapsed from './elapsed';
  * with the ellapsed time formatted.
  */
 export default (start: number = Date.now()) => {
-  return () => elapsed(Date.now() - start);
+  return (): string => elapsed(Date.now() - start);
 };


### PR DESCRIPTION
* Print warnings / notices from the API
* Print `v2` instead of `v1` when upgraded to v2
* Wait for "alias-assigned" event in v1 pipeline when upgraded to v2