### PR TITLE
[now-cli] Remove unnecessary `console.log()`

### DIFF
--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -653,7 +653,6 @@ function hasNpmStart(pkg) {
 
 function hasFile(base, files, name) {
   const relative = files.map(file => toRelative(file, base));
-  console.log(731, relative);
   return relative.indexOf(name) !== -1;
 }
 


### PR DESCRIPTION
Seems to be a leftover from dd1d9d856.