### PR TITLE
[now-cli] Always add two spaces after emojis and update emojis

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -48,6 +48,7 @@ import getProjectName from '../../util/get-project-name';
 import selectOrg from '../../util/input/select-org';
 import inputProject from '../../util/input/input-project';
 import validatePaths from '../../util/validate-paths';
+import { prependEmoji, emoji } from '../../util/emoji';
 
 const addProcessEnv = async (log, env) => {
   let val;
@@ -141,18 +142,22 @@ const printDeploymentStatus = async (
     }
 
     output.print(
-      `✅ ${isProdDeployment ? 'Production' : 'Preview'}: ${chalk.bold(
-        previewUrl
-      )} ${deployStamp()}\n`
+      prependEmoji(
+        `${isProdDeployment ? 'Production' : 'Preview'}: ${chalk.bold(
+          previewUrl
+        )} ${deployStamp()}`,
+        emoji('success')
+      ) + `\n`
     );
   }
 
   if (indications) {
-    const emojis = { notice: 'ℹ️ ', tip: '💡', warning: '⚠️' };
     for (let indication of indications) {
-      const emoji = emojis[indication.type];
       output.print(
-        `${emoji ? `${emoji} ` : ''}${chalk.grey(indication.payload)}\n`
+        prependEmoji(
+          `${chalk.grey(indication.payload)}`,
+          emoji(indication.type)
+        ) + `\n`
       );
     }
   }

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -15,6 +15,7 @@ import { Org } from '../../types';
 import ua from '../ua';
 import processLegacyDeployment from './process-legacy-deployment';
 import { linkFolderToProject } from '../projects/link';
+import { prependEmoji, emoji } from '../emoji';
 
 function printInspectUrl(
   output: Output,
@@ -29,7 +30,12 @@ function printInspectUrl(
   const deploymentShortId = urlParts.pop();
   const projectName = urlParts.join('-');
   const inspectUrl = `https://zeit.co/${orgName}/${projectName}/${deploymentShortId}`;
-  output.print(`🔍 Inspect: ${chalk.bold(inspectUrl)} ${deployStamp()}\n`);
+  output.print(
+    prependEmoji(
+      `Inspect: ${chalk.bold(inspectUrl)} ${deployStamp()}`,
+      emoji('inspect')
+    ) + `\n`
+  );
 }
 
 export default async function processDeployment({

--- a/packages/now-cli/src/util/emoji.ts
+++ b/packages/now-cli/src/util/emoji.ts
@@ -1,13 +1,13 @@
 export function emoji(label: string): string | undefined {
   switch (label) {
     case 'notice':
-      return 'ℹ️';
+      return '📝';
     case 'tip':
       return '💡';
     case 'warning':
-      return '⚠️';
+      return '❗️';
     case 'link':
-      return '☑️';
+      return '🔗';
     case 'inspect':
       return '🔍';
     case 'success':

--- a/packages/now-cli/src/util/emoji.ts
+++ b/packages/now-cli/src/util/emoji.ts
@@ -1,0 +1,26 @@
+export function emoji(label: string): string | undefined {
+  switch (label) {
+    case 'notice':
+      return 'ℹ️';
+    case 'tip':
+      return '💡';
+    case 'warning':
+      return '⚠️';
+    case 'link':
+      return '☑️';
+    case 'inspect':
+      return '🔍';
+    case 'success':
+      return '✅';
+    default:
+      return undefined;
+  }
+}
+
+export function prependEmoji(message: string, emoji?: string): string {
+  if (emoji && process.stdout.isTTY) {
+    return `${emoji}  ${message}`;
+  }
+
+  return message;
+}

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -117,7 +117,7 @@ export async function linkFolderToProject(
     prependEmoji(
       `Linked to ${chalk.bold(
         `${orgSlug}/${projectName}`
-      )} (created .now and added it to .nowignore)`,
+      )} (created .now and added it to .gitignore)`,
       emoji('link')
     ) + '\n'
   );

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -11,6 +11,7 @@ import { Output } from '../output';
 import { Project } from '../../types';
 import { Org } from '../../types';
 import chalk from 'chalk';
+import { prependEmoji, emoji } from '../emoji';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -113,8 +114,11 @@ export async function linkFolderToProject(
   }
 
   output.print(
-    `☑️ Linked to ${chalk.bold(
-      `${orgSlug}/${projectName}`
-    )} (created .now and added it to .nowignore)\n`
+    prependEmoji(
+      `Linked to ${chalk.bold(
+        `${orgSlug}/${projectName}`
+      )} (created .now and added it to .nowignore)`,
+      emoji('link')
+    ) + '\n'
   );
 }


### PR DESCRIPTION
Updates emojis to fix "spacing issues" with previous emojis and always add 2 spaces after emojis.
- ℹ️ -> 📝
- ⚠️ -> ❗
- ☑️ -> 🔗



Also fixes a typo:
```
Linked to <project> (created .now and added it to .nowignore)
->
Linked to <project> (created .now and added it to .gitignore)
```

It looks like this:

![image](https://user-images.githubusercontent.com/6616955/72445323-d590d800-37b1-11ea-92eb-a3b503a95774.png)

![image](https://user-images.githubusercontent.com/6616955/72445618-47692180-37b2-11ea-9aed-3b3268c82ad3.png)


![image](https://user-images.githubusercontent.com/6616955/72445492-11c43880-37b2-11ea-8091-1e1e8ac8b3a0.png)





