### PR TITLE
[now-cli] Pre-fill "project name" prompt

### DIFF
--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -23,17 +23,18 @@ export default async function inputProject(
   let detectedProject = null;
   const existingProjectSpinner = wait('Searching for existing projects…', 1000);
   try {
-    detectedProject = await getProjectByIdOrName(
+    const project = await getProjectByIdOrName(
       client,
       detectedProjectName,
       org.id
     );
+    detectedProject = project instanceof ProjectNotFound ? null : project;
   } catch (error) {}
   existingProjectSpinner();
 
   let shouldLinkProject;
 
-  if (!detectedProject || detectedProject instanceof ProjectNotFound) {
+  if (!detectedProject) {
     // did not auto-detect a project to link
     shouldLinkProject = await confirm(`Link to existing project?`, false);
   } else {
@@ -88,6 +89,7 @@ export default async function inputProject(
       type: 'input',
       name: 'newProjectName',
       message: `What’s your project’s name?`,
+      default: !detectedProject ? detectedProjectName : undefined,
     });
     newProjectName = answers.newProjectName as string;
 

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -478,8 +478,7 @@ CMD ["node", "index.js"]`,
       }),
     },
     'project-link': {
-      'pages/index.js':
-        'export default () => <div><h1>Now CLI test</h1></div>',
+      'pages/index.js': 'export default () => <div><h1>Now CLI test</h1></div>',
       'package.json': JSON.stringify({
         dependencies: {
           gatsby: 'latest',

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -151,6 +151,7 @@ const apiFetch = (url, { headers, ...options } = {}) => {
 const waitForPrompt = (cp, assertion) =>
   new Promise(resolve => {
     const listener = chunk => {
+      console.log('chunk ' + chunk);
       if (assertion(chunk)) {
         cp.stdout.off && cp.stdout.off('data', listener);
         cp.stderr.off && cp.stderr.off('data', listener);
@@ -2324,7 +2325,7 @@ test('should show prompts to set up project', async t => {
 
 test('should not prompt "project settings overwrite" for undetected projects', async t => {
   const directory = fixture('static-deployment');
-  const projectName = `project-link-${
+  const projectName = `static-deployment-${
     Math.random()
       .toString(36)
       .split('.')[1]
@@ -2360,6 +2361,46 @@ test('should not prompt "project settings overwrite" for undetected projects', a
     );
     return chunk.includes('Linked to');
   });
+
+  const output = await now;
+  t.is(output.exitCode, 0, formatOutput(output));
+});
+
+test('should prefill "project name" prompt with detected project name', async t => {
+  const directory = fixture('static-deployment');
+  const projectName = `static-deployment-${
+    Math.random()
+      .toString(36)
+      .split('.')[1]
+  }`;
+
+  // remove previously linked project if it exists
+  await remove(path.join(directory, '.now'));
+
+  const now = execa(binaryPath, [
+    directory,
+    '--name',
+    projectName,
+    ...defaultArgs,
+  ]);
+
+  await waitForPrompt(now, chunk => /Set up and deploy [^?]+\?/.test(chunk));
+  now.stdin.write('yes\n');
+
+  await waitForPrompt(now, chunk =>
+    chunk.includes('Which scope do you want to deploy to?')
+  );
+  now.stdin.write('\n');
+
+  await waitForPrompt(now, chunk =>
+    chunk.includes('Link to existing project?')
+  );
+  now.stdin.write('no\n');
+
+  await waitForPrompt(now, chunk =>
+    chunk.includes(`What’s your project’s name? (${projectName})`)
+  );
+  now.stdin.write(`\n`);
 
   const output = await now;
   t.is(output.exitCode, 0, formatOutput(output));


### PR DESCRIPTION
It looks like this:
![image](https://user-images.githubusercontent.com/6616955/72454716-aa15e980-37c1-11ea-858d-33799b3496f1.png)

We don't pre-fill if we detect an existing project with the same name:
![image](https://user-images.githubusercontent.com/6616955/72454792-d7629780-37c1-11ea-863f-496537ec92a4.png)
