### PR TITLE
[now-cli] Create `.gitignore` if it doesn't exist

### DIFF
--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -102,12 +102,18 @@ export async function linkFolderToProject(
     }
   );
 
-  // update .nowignore
+  // update .gitignore
+  let isGitIgnoreUpdated = false;
   try {
     const gitIgnorePath = join(path, '.gitignore');
-    const gitIgnore = (await readFile(gitIgnorePath)).toString();
-    if (gitIgnore.split('\n').indexOf('.now') < 0) {
-      await writeFile(gitIgnorePath, gitIgnore + '\n.now');
+
+    const gitIgnore = await readFile(gitIgnorePath)
+      .then(buf => buf.toString())
+      .catch(() => null);
+
+    if (!gitIgnore || !gitIgnore.split('\n').includes('.now')) {
+      await writeFile(gitIgnorePath, gitIgnore ? `${gitIgnore}\n.now` : '.now');
+      isGitIgnoreUpdated = true;
     }
   } catch (error) {
     // ignore errors since this is non-critical
@@ -115,9 +121,9 @@ export async function linkFolderToProject(
 
   output.print(
     prependEmoji(
-      `Linked to ${chalk.bold(
-        `${orgSlug}/${projectName}`
-      )} (created .now and added it to .gitignore)`,
+      `Linked to ${chalk.bold(`${orgSlug}/${projectName}`)} (created .now${
+        isGitIgnoreUpdated ? ' and added it to .gitignore' : ''
+      })`,
       emoji('link')
     ) + '\n'
   );

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2317,7 +2317,7 @@ test('should show prompts to set up project', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 
   // Ensure .gitignore is created
-  t.is(await readFile(path.join(directory, '.gitignore')), '.now');
+  t.is((await readFile(path.join(directory, '.gitignore'))).toString(), '.now');
 
   // Send a test request to the deployment
   const response = await fetch(new URL(output.stdout).href);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2316,6 +2316,9 @@ test('should show prompts to set up project', async t => {
   // Ensure the exit code is right
   t.is(output.exitCode, 0, formatOutput(output));
 
+  // Ensure .gitignore is created
+  t.is(await readFile(path.join(directory, '.gitignore')), '.now');
+
   // Send a test request to the deployment
   const response = await fetch(new URL(output.stdout).href);
   const text = await response.text();


### PR DESCRIPTION
When linking a new project, create `.gitignore` with `.now` if it doesn't exist yet. If it exists, adds `.now` to it.

Also adds a test for that.