### PR TITLE
[now-cli] Improve formatting of new deploy command prompts

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -155,7 +155,7 @@ const printDeploymentStatus = async (
     for (let indication of indications) {
       output.print(
         prependEmoji(
-          `${chalk.grey(indication.payload)}`,
+          `${chalk.dim(indication.payload)}`,
           emoji(indication.type)
         ) + `\n`
       );

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -211,7 +211,7 @@ export default async function processDeployment({
         buildSpinner();
       }
 
-      deploySpinner = wait('Finalizing', 0);
+      deploySpinner = wait('Completing', 0);
     }
 
     // Handle error events

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -37,7 +37,7 @@ function printInspectUrl(
 
   const inspectUrl = `https://zeit.co/${orgSlug}/${projectName}/${deploymentShortId}${
     apex !== 'now.sh' ? `/${apex}` : ''
-  }}`;
+  }`;
 
   output.print(
     prependEmoji(

--- a/packages/now-cli/src/util/input/edit-project-settings.ts
+++ b/packages/now-cli/src/util/input/edit-project-settings.ts
@@ -45,7 +45,7 @@ export default async function editProjectSettings(
     const defaults = framework.settings[field.value];
 
     output.print(
-      chalk.whiteBright(
+      chalk.dim(
         `- ${chalk.bold(`${field.name}:`)} ${`${
           isSettingValue(defaults)
             ? defaults.value

--- a/packages/now-cli/src/util/input/edit-project-settings.ts
+++ b/packages/now-cli/src/util/input/edit-project-settings.ts
@@ -45,7 +45,7 @@ export default async function editProjectSettings(
     const defaults = framework.settings[field.value];
 
     output.print(
-      chalk.gray(
+      chalk.whiteBright(
         `- ${chalk.bold(`${field.name}:`)} ${`${
           isSettingValue(defaults)
             ? defaults.value

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -70,7 +70,7 @@ export default async function inputProject(
       const projectName = answers.existingProjectName as string;
 
       if (!projectName) {
-        output.print(`${chalk.red('Error!')} Project name can not be empty\n`);
+        output.print(`${chalk.red('Error!')} Project name cannot be empty\n`);
         continue;
       }
 

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -74,9 +74,10 @@ export default async function inputProject(
         continue;
       }
 
-      const loader = wait('Verifying project name…', 1000);
-      project = await getProjectByIdOrName(client, projectName, org.id);
-      loader();
+      const spinner = wait('Verifying project name…', 1000);
+      project = await getProjectByIdOrName(client, projectName, org.id).finally(
+        () => spinner()
+      );
 
       if (project instanceof ProjectNotFound) {
         output.print(`${chalk.red('Error!')} Project not found\n`);
@@ -108,8 +109,7 @@ export default async function inputProject(
       client,
       newProjectName,
       org.id
-    );
-    spinner();
+    ).finally(() => spinner());
 
     if (existingProject && !(existingProject instanceof ProjectNotFound)) {
       output.print(`${chalk.red('Error!')} Project already exists\n`);

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -69,6 +69,11 @@ export default async function inputProject(
       });
       const projectName = answers.existingProjectName as string;
 
+      if (!projectName) {
+        output.print(`${chalk.red('Error!')} Project name can not be empty\n`);
+        continue;
+      }
+
       const loader = wait('Verifying project name…', 1000);
       project = await getProjectByIdOrName(client, projectName, org.id);
       loader();
@@ -92,6 +97,11 @@ export default async function inputProject(
       default: !detectedProject ? detectedProjectName : undefined,
     });
     newProjectName = answers.newProjectName as string;
+
+    if (!newProjectName) {
+      output.print(`${chalk.red('Error!')} Project name can not be empty\n`);
+      continue;
+    }
 
     const spinner = wait('Verifying project name…', 1000);
     const existingProject = await getProjectByIdOrName(

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -70,7 +70,7 @@ export default async function inputProject(
       const projectName = answers.existingProjectName as string;
 
       if (!projectName) {
-        output.print(`${chalk.red('Error!')} Project name cannot be empty\n`);
+        output.error(`Project name cannot be empty`);
         continue;
       }
 
@@ -102,7 +102,7 @@ export default async function inputProject(
     newProjectName = answers.newProjectName as string;
 
     if (!newProjectName) {
-      output.print(`${chalk.red('Error!')} Project name cannot be empty\n`);
+      output.error(`Project name cannot be empty`);
       continue;
     }
 

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -102,7 +102,7 @@ export default async function inputProject(
     newProjectName = answers.newProjectName as string;
 
     if (!newProjectName) {
-      output.print(`${chalk.red('Error!')} Project name can not be empty\n`);
+      output.print(`${chalk.red('Error!')} Project name cannot be empty\n`);
       continue;
     }
 

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -75,9 +75,11 @@ export default async function inputProject(
       }
 
       const spinner = wait('Verifying project name…', 1000);
-      project = await getProjectByIdOrName(client, projectName, org.id).finally(
-        () => spinner()
-      );
+      try {
+        project = await getProjectByIdOrName(client, projectName, org.id);
+      } finally {
+        spinner();
+      }
 
       if (project instanceof ProjectNotFound) {
         output.print(`${chalk.red('Error!')} Project not found\n`);
@@ -105,11 +107,16 @@ export default async function inputProject(
     }
 
     const spinner = wait('Verifying project name…', 1000);
-    const existingProject = await getProjectByIdOrName(
-      client,
-      newProjectName,
-      org.id
-    ).finally(() => spinner());
+    let existingProject: Project | ProjectNotFound;
+    try {
+      existingProject = await getProjectByIdOrName(
+        client,
+        newProjectName,
+        org.id
+      );
+    } finally {
+      spinner();
+    }
 
     if (existingProject && !(existingProject instanceof ProjectNotFound)) {
       output.print(`${chalk.red('Error!')} Project already exists\n`);

--- a/packages/now-cli/src/util/input/select-org.ts
+++ b/packages/now-cli/src/util/input/select-org.ts
@@ -2,7 +2,7 @@ import Client from '../client';
 import inquirer from 'inquirer';
 import getUser from '../get-user';
 import getTeams from '../get-teams';
-import { Org } from '../../types';
+import { User, Team, Org } from '../../types';
 import wait from '../output/wait';
 
 type Choice = { name: string; value: Org };
@@ -16,10 +16,13 @@ export default async function selectProject(
   require('./patch-inquirer');
 
   const spinner = wait('Loading scopes…', 1000);
-  const [user, teams] = await Promise.all([
-    getUser(client),
-    getTeams(client),
-  ]).finally(() => spinner());
+  let user: User;
+  let teams: Team[];
+  try {
+    [user, teams] = await Promise.all([getUser(client), getTeams(client)]);
+  } finally {
+    spinner();
+  }
 
   const choices: Choice[] = [
     {

--- a/packages/now-cli/src/util/input/select-org.ts
+++ b/packages/now-cli/src/util/input/select-org.ts
@@ -16,8 +16,10 @@ export default async function selectProject(
   require('./patch-inquirer');
 
   const spinner = wait('Loading scopes…', 1000);
-  const [user, teams] = await Promise.all([getUser(client), getTeams(client)]);
-  spinner();
+  const [user, teams] = await Promise.all([
+    getUser(client),
+    getTeams(client),
+  ]).finally(() => spinner());
 
   const choices: Choice[] = [
     {

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -52,9 +52,9 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   }
 
   function error(str: string, slug: string | null = null) {
-    log(chalk`{red.bold Error!} ${str}`, chalk.red);
+    print(`${chalk.red(`Error!`)} ${str}\n`);
     if (slug !== null) {
-      log(`More details: https://err.sh/now/${slug}`);
+      print(`More details: https://err.sh/now/${slug}\n`);
     }
   }
 

--- a/packages/now-cli/src/util/output/error.ts
+++ b/packages/now-cli/src/util/output/error.ts
@@ -19,5 +19,5 @@ export default function error(
     metric.exception(messages.join('\n')).send();
   }
 
-  return `${chalk.red('> Error!')} ${messages.join('\n')}`;
+  return `${chalk.red('Error!')} ${messages.join('\n')}`;
 }

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -12,6 +12,7 @@ import { Project } from '../../types';
 import { Org } from '../../types';
 import chalk from 'chalk';
 import { prependEmoji, emoji } from '../emoji';
+import wait from '../output/wait';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -49,10 +50,12 @@ export async function getLinkedProject(
 
     const link: ProjectFolderLink = JSON.parse(json);
 
+    const spinner = wait('Retrieving project…', 1000);
     const [org, project] = await Promise.all([
       getOrg(client, link.orgId),
       getProjectByIdOrName(client, link.projectId, link.orgId),
     ]);
+    spinner();
 
     if (project instanceof ProjectNotFound || org === null) {
       return [null, null];

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -51,10 +51,16 @@ export async function getLinkedProject(
     const link: ProjectFolderLink = JSON.parse(json);
 
     const spinner = wait('Retrieving project…', 1000);
-    const [org, project] = await Promise.all([
-      getOrg(client, link.orgId),
-      getProjectByIdOrName(client, link.projectId, link.orgId),
-    ]).finally(() => spinner());
+    let org: Org | null;
+    let project: Project | ProjectNotFound | null;
+    try {
+      [org, project] = await Promise.all([
+        getOrg(client, link.orgId),
+        getProjectByIdOrName(client, link.projectId, link.orgId),
+      ]);
+    } finally {
+      spinner();
+    }
 
     if (project instanceof ProjectNotFound || org === null) {
       return [null, null];

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -54,8 +54,7 @@ export async function getLinkedProject(
     const [org, project] = await Promise.all([
       getOrg(client, link.orgId),
       getProjectByIdOrName(client, link.projectId, link.orgId),
-    ]);
-    spinner();
+    ]).finally(() => spinner());
 
     if (project instanceof ProjectNotFound || org === null) {
       return [null, null];

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -427,7 +427,7 @@ test('login with unregistered user', async t => {
   console.log(stdout);
   console.log(exitCode);
 
-  const goal = `> Error! Please sign up: https://zeit.co/signup`;
+  const goal = `Error! Please sign up: https://zeit.co/signup`;
   const lines = stdout.trim().split('\n');
   const last = lines[lines.length - 1];
 
@@ -606,7 +606,7 @@ test('try to purchase a domain', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      `> Error! Could not purchase domain. Please add a payment method using \`now billing add\`.`
+      `Error! Could not purchase domain. Please add a payment method using \`now billing add\`.`
     )
   );
 });
@@ -633,7 +633,7 @@ test('try to transfer-in a domain with "--code" option', async t => {
 
   t.true(
     stderr.includes(
-      `> Error! The domain "${session}-test.org" is not transferable.`
+      `Error! The domain "${session}-test.org" is not transferable.`
     )
   );
   t.is(exitCode, 1);
@@ -658,7 +658,7 @@ test('try to move an invalid domain', async t => {
   console.log(stdout);
   console.log(exitCode);
 
-  t.true(stderr.includes(`> Error! Domain not found under `));
+  t.true(stderr.includes(`Error! Domain not found under `));
   t.is(exitCode, 1);
 });
 
@@ -703,7 +703,7 @@ test('try to remove a non-existing payment method', async t => {
 test('set platform version using `-V` to invalid number', async t => {
   const directory = fixture('builds');
   const goal =
-    '> Error! The "--platform-version" option must be either `1` or `2`.';
+    'Error! The "--platform-version" option must be either `1` or `2`.';
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -727,7 +727,7 @@ test('set platform version using `-V` to invalid number', async t => {
 test('set platform version using `--platform-version` to invalid number', async t => {
   const directory = fixture('builds');
   const goal =
-    '> Error! The "--platform-version" option must be either `1` or `2`.';
+    'Error! The "--platform-version" option must be either `1` or `2`.';
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -1144,7 +1144,7 @@ test('try to create a builds deployments with wrong config', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      '> Error! The property `builder` is not allowed in now.json when using Now 2.0 – please remove it.'
+      'Error! The property `builder` is not allowed in now.json when using Now 2.0 – please remove it.'
     )
   );
 });
@@ -1624,7 +1624,7 @@ test('use `--debug` CLI flag', async t => {
 });
 
 test('try to deploy non-existing path', async t => {
-  const goal = `> Error! The specified file or directory "${session}" does not exist.`;
+  const goal = `Error! The specified file or directory "${session}" does not exist.`;
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -1644,7 +1644,7 @@ test('try to deploy non-existing path', async t => {
 
 test('try to deploy with non-existing team', async t => {
   const target = fixture('node');
-  const goal = `> Error! The specified scope does not exist`;
+  const goal = `Error! The specified scope does not exist`;
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -1760,7 +1760,7 @@ test('try to initialize example to existing directory', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    '> Error! Destination path "angular" already exists and is not an empty directory. You may use `--force` or `--f` to override it.';
+    'Error! Destination path "angular" already exists and is not an empty directory. You may use `--force` or `--f` to override it.';
 
   createDirectory(path.join(cwd, 'angular'));
   createFile(path.join(cwd, 'angular', '.gitignore'));
@@ -1781,7 +1781,7 @@ test('try to initialize misspelled example (noce) in non-tty', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    '> Error! No example found for noce, run `now init` to see the list of available examples.';
+    'Error! No example found for noce, run `now init` to see the list of available examples.';
 
   const { stdout, stderr, exitCode } = await execute(['init', 'noce'], { cwd });
 
@@ -1797,7 +1797,7 @@ test('try to initialize example "example-404"', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    '> Error! No example found for example-404, run `now init` to see the list of available examples.';
+    'Error! No example found for example-404, run `now init` to see the list of available examples.';
 
   const { stdout, stderr, exitCode } = await execute(['init', 'example-404'], {
     cwd,


### PR DESCRIPTION
- Adjust error prompt
- Add spinner while loading org and project
- Use lighter gray for infos
- Remove `{` in inspector url (was mistakenly added in https://github.com/zeit/now/pull/3599)
- Show error when entering a project name
- Fix bug with spinner not cleared when error is displayed
- "Finalizing" -> "Completing"

![image](https://user-images.githubusercontent.com/6616955/72535453-da6c8f00-3878-11ea-838d-dcb4367e5120.png)
