### PR TITLE
[now-static-build] Use NowBuildError for static build errors

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -47,11 +47,7 @@ async function checkForPort(
   }
 }
 
-function validateDistDir(
-  distDir: string,
-  isDev: boolean | undefined,
-  config: Config
-) {
+function validateDistDir(distDir: string, config: Config) {
   const distDirName = path.basename(distDir);
   const exists = () => existsSync(distDir);
   const isDirectory = () => statSync(distDir).isDirectory();
@@ -433,7 +429,7 @@ export async function build({
         }
       }
 
-      validateDistDir(distPath, meta.isDev, config);
+      validateDistDir(distPath, config);
 
       if (framework) {
         const frameworkRoutes = await getFrameworkRoutes(
@@ -460,7 +456,7 @@ export async function build({
     );
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
     await runShellScript(path.join(workPath, entrypoint), [], spawnOpts);
-    validateDistDir(distPath, meta.isDev, config);
+    validateDistDir(distPath, config);
 
     const output = await glob('**', distPath, mountpoint);
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -98,7 +98,7 @@ function validateDistDir(
 
   if (isEmpty()) {
     const err = new NowBuildError({
-      code: 'no_output_dir',
+      code: 'NOW_STATIC_BUILD_EMPTY_OUT_DIR',
       message: `Build failed because distDir is empty: "${distDirName}". ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -26,9 +26,9 @@ import {
   debug,
   PackageJson,
   PrepareCacheOptions,
+  NowBuildError,
 } from '@now/build-utils';
 import { Route, Source } from '@now/routing-utils';
-import { NowBuildError } from '@now/build-utils';
 
 const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -28,6 +28,7 @@ import {
   PrepareCacheOptions,
 } from '@now/build-utils';
 import { Route, Source } from '@now/routing-utils';
+import { NowBuildError } from '@now/build-utils';
 
 const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
 
@@ -44,22 +45,6 @@ async function checkForPort(
     }
     await sleep(100);
   }
-}
-
-class BuildError extends Error {
-  constructor(err: {
-    link?: string;
-    message: string;
-    hideStackTrace?: boolean;
-  }) {
-    super(err.message);
-    this.link = err.link;
-    this.name = 'BuildError';
-    this.hideStackTrace = err.hideStackTrace;
-  }
-
-  link?: string;
-  hideStackTrace?: boolean;
 }
 
 function validateDistDir(
@@ -80,39 +65,50 @@ function validateDistDir(
     : `https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build${hash}`;
 
   if (!exists()) {
-    throw new BuildError({
+    const err = new NowBuildError({
+      code: 'no_output_dir',
       message: `No output directory named "${distDirName}" found. ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'
           : ''
       }`,
       link,
-      hideStackTrace: true,
     });
+
+    err.hideStackTrace = true;
+
+    throw err;
   }
 
   if (!isDirectory()) {
-    throw new BuildError({
-      message: `Build failed because distDir is not a directory: "${distDirName}". ${
+    const err = new NowBuildError({
+      code: 'no_output_dir',
+      message: `Build failed because Output Directory is not a directory: "${distDirName}". ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'
           : ''
       }`,
       link,
-      hideStackTrace: true,
     });
+
+    err.hideStackTrace = true;
+
+    throw err;
   }
 
   if (isEmpty()) {
-    throw new BuildError({
+    const err = new NowBuildError({
+      code: 'no_output_dir',
       message: `Build failed because distDir is empty: "${distDirName}". ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'
           : ''
       }`,
       link,
-      hideStackTrace: true,
     });
+
+    err.hideStackTrace = true;
+    throw err;
   }
 }
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -78,7 +78,7 @@ function validateDistDir(
 
   if (!isDirectory()) {
     throw new NowBuildError({
-      code: 'no_output_dir',
+      code: 'NOW_STATIC_BUILD_NOT_A_DIR',
       message: `Build failed because Output Directory is not a directory: "${distDirName}". ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -47,13 +47,19 @@ async function checkForPort(
 }
 
 class BuildError extends Error {
-  constructor(err: { link?: string; message: string }) {
+  constructor(err: {
+    link?: string;
+    message: string;
+    hideStackTrace?: boolean;
+  }) {
     super(err.message);
     this.link = err.link;
     this.name = 'BuildError';
+    this.hideStackTrace = err.hideStackTrace;
   }
 
   link?: string;
+  hideStackTrace?: boolean;
 }
 
 function validateDistDir(
@@ -81,6 +87,7 @@ function validateDistDir(
           : ''
       }`,
       link,
+      hideStackTrace: true,
     });
   }
 
@@ -92,6 +99,7 @@ function validateDistDir(
           : ''
       }`,
       link,
+      hideStackTrace: true,
     });
   }
 
@@ -103,6 +111,7 @@ function validateDistDir(
           : ''
       }`,
       link,
+      hideStackTrace: true,
     });
   }
 }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -57,17 +57,13 @@ function validateDistDir(
   const isDirectory = () => statSync(distDir).isDirectory();
   const isEmpty = () => readdirSync(distDir).length === 0;
 
-  const hash = isDev
-    ? '#local-development'
-    : '#configuring-the-build-output-directory';
-  const link = config.zeroConfig
-    ? 'https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory'
-    : `https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build${hash}`;
+  const link =
+    'https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory';
 
   if (!exists()) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_NO_OUT_DIR',
-      message: `No output directory named "${distDirName}" found. ${
+      message: `No Output Directory named "${distDirName}" found. ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'
           : ''
@@ -91,7 +87,7 @@ function validateDistDir(
   if (isEmpty()) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_EMPTY_OUT_DIR',
-      message: `Build failed because distDir is empty: "${distDirName}". ${
+      message: `Build failed because Output Directory is empty: "${distDirName}". ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'
           : ''

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -65,7 +65,7 @@ function validateDistDir(
     : `https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build${hash}`;
 
   if (!exists()) {
-    const err = new NowBuildError({
+    throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_NO_OUT_DIR',
       message: `No output directory named "${distDirName}" found. ${
         !config.zeroConfig
@@ -74,14 +74,10 @@ function validateDistDir(
       }`,
       link,
     });
-
-    err.hideStackTrace = true;
-
-    throw err;
   }
 
   if (!isDirectory()) {
-    const err = new NowBuildError({
+    throw new NowBuildError({
       code: 'no_output_dir',
       message: `Build failed because Output Directory is not a directory: "${distDirName}". ${
         !config.zeroConfig
@@ -90,14 +86,10 @@ function validateDistDir(
       }`,
       link,
     });
-
-    err.hideStackTrace = true;
-
-    throw err;
   }
 
   if (isEmpty()) {
-    const err = new NowBuildError({
+    throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_EMPTY_OUT_DIR',
       message: `Build failed because distDir is empty: "${distDirName}". ${
         !config.zeroConfig
@@ -106,9 +98,6 @@ function validateDistDir(
       }`,
       link,
     });
-
-    err.hideStackTrace = true;
-    throw err;
   }
 }
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -46,6 +46,16 @@ async function checkForPort(
   }
 }
 
+class BuildError extends Error {
+  constructor(err: { link?: string; message: string }) {
+    super(err.message);
+    this.link = err.link;
+    this.name = 'BuildError';
+  }
+
+  link?: string;
+}
+
 function validateDistDir(
   distDir: string,
   isDev: boolean | undefined,
@@ -59,26 +69,41 @@ function validateDistDir(
   const hash = isDev
     ? '#local-development'
     : '#configuring-the-build-output-directory';
-  const docsUrl = `https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build${hash}`;
-
-  const info = config.zeroConfig
-    ? '\nMore details: https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory'
-    : `\nMake sure you configure the the correct distDir: ${docsUrl}`;
+  const link = config.zeroConfig
+    ? 'https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory'
+    : `https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build${hash}`;
 
   if (!exists()) {
-    throw new Error(`No output directory named "${distDirName}" found.${info}`);
+    throw new BuildError({
+      message: `No output directory named "${distDirName}" found. ${
+        !config.zeroConfig
+          ? '\nMake sure you configure the the correct distDir'
+          : ''
+      }`,
+      link,
+    });
   }
 
   if (!isDirectory()) {
-    throw new Error(
-      `Build failed because distDir is not a directory: "${distDirName}".${info}`
-    );
+    throw new BuildError({
+      message: `Build failed because distDir is not a directory: "${distDirName}". ${
+        !config.zeroConfig
+          ? '\nMake sure you configure the the correct distDir'
+          : ''
+      }`,
+      link,
+    });
   }
 
   if (isEmpty()) {
-    throw new Error(
-      `Build failed because distDir is empty: "${distDirName}".${info}`
-    );
+    throw new BuildError({
+      message: `Build failed because distDir is empty: "${distDirName}". ${
+        !config.zeroConfig
+          ? '\nMake sure you configure the the correct distDir'
+          : ''
+      }`,
+      link,
+    });
   }
 }
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -60,14 +60,14 @@ function validateDistDir(
   const link =
     'https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory';
 
+  const legacyMsg = !config.zeroConfig
+    ? '\nMake sure you configure the the correct `distDir`.'
+    : '';
+
   if (!exists()) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_NO_OUT_DIR',
-      message: `No Output Directory named "${distDirName}" found. ${
-        !config.zeroConfig
-          ? '\nMake sure you configure the the correct distDir'
-          : ''
-      }`,
+      message: `No Output Directory named "${distDirName}" found. ${legacyMsg}`,
       link,
     });
   }
@@ -75,11 +75,7 @@ function validateDistDir(
   if (!isDirectory()) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_NOT_A_DIR',
-      message: `Build failed because Output Directory is not a directory: "${distDirName}". ${
-        !config.zeroConfig
-          ? '\nMake sure you configure the the correct distDir'
-          : ''
-      }`,
+      message: `Build failed because Output Directory is not a directory: "${distDirName}". ${legacyMsg}`,
       link,
     });
   }
@@ -87,11 +83,7 @@ function validateDistDir(
   if (isEmpty()) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_EMPTY_OUT_DIR',
-      message: `Build failed because Output Directory is empty: "${distDirName}". ${
-        !config.zeroConfig
-          ? '\nMake sure you configure the the correct distDir'
-          : ''
-      }`,
+      message: `Build failed because Output Directory is empty: "${distDirName}". ${legacyMsg}`,
       link,
     });
   }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -66,7 +66,7 @@ function validateDistDir(
 
   if (!exists()) {
     const err = new NowBuildError({
-      code: 'no_output_dir',
+      code: 'NOW_STATIC_BUILD_NO_OUT_DIR',
       message: `No output directory named "${distDirName}" found. ${
         !config.zeroConfig
           ? '\nMake sure you configure the the correct distDir'


### PR DESCRIPTION
This PR fixes error messages and uses `NowBuildError ` for static build errors