### PR TITLE
[now-next] Update custom-routes tests

### DIFF
--- a/packages/now-next/test/fixtures/07-custom-routes/next.config.js
+++ b/packages/now-next/test/fixtures/07-custom-routes/next.config.js
@@ -5,38 +5,39 @@ module.exports = {
         {
           source: '/redir1',
           destination: '/redir2',
-          statusCode: 301
+          permanent: true,
         },
         {
           source: '/redir2',
           destination: '/hello',
-          statusCode: 307
+          permanent: false,
         },
         {
           source: '/redir/:path',
-          destination: '/:path'
-        }
-      ]
+          destination: '/:path',
+          permanent: false,
+        },
+      ];
     },
     async rewrites() {
       return [
         {
           source: '/rewrite1',
-          destination: '/rewrite2'
+          destination: '/rewrite2',
         },
         {
           source: '/rewrite2',
-          destination: '/hello'
+          destination: '/hello',
         },
         {
           source: '/rewrite/:first/:second',
-          destination: '/rewrite-2/hello/:second'
+          destination: '/rewrite-2/hello/:second',
         },
         {
           source: '/rewrite-2/:first/:second',
-          destination: '/params'
-        }
-      ]
-    }
-  }
-}
+          destination: '/params',
+        },
+      ];
+    },
+  },
+};

--- a/packages/now-next/test/fixtures/07-custom-routes/now.json
+++ b/packages/now-next/test/fixtures/07-custom-routes/now.json
@@ -7,7 +7,7 @@
       "fetchOptions": {
         "redirect": "manual"
       },
-      "status": 301,
+      "status": 308,
       "responseHeaders": {
         "location": "/redir2/"
       }

--- a/packages/now-next/test/fixtures/13-export-custom-routes/next.config.js
+++ b/packages/now-next/test/fixtures/13-export-custom-routes/next.config.js
@@ -17,6 +17,7 @@ module.exports = {
         {
           source: '/second',
           destination: '/about',
+          permanent: false,
         },
       ];
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9730,7 +9730,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 


### PR DESCRIPTION
This adds `permanent: boolean` to the redirects in the custom-routes tests for `@now/next` since this field is required for redirects in Next.js in the latest version 

unblocks: https://github.com/zeit/now/pull/3613