### PR TITLE
[api] Fix build script

### DIFF
--- a/utils/run.js
+++ b/utils/run.js
@@ -76,7 +76,7 @@ async function main() {
   }
 
   execSync(
-    `mkdir public && echo '<a href="https://zeit.co/new">https://zeit.co/new</a>' >> public/index.html`
+    `rm -rf public && mkdir public && echo '<a href="https://zeit.co/new">https://zeit.co/new</a>' > public/index.html`
   );
 }
 


### PR DESCRIPTION
I was getting errors when running `yarn build` locally because the public directory already exists.

This will make sure the public directory is deleted before generating it again.