### PR TITLE
[now-next] Add initial support for static 404

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -453,7 +453,7 @@ export const build = async ({
         // TODO: do we want to do this?: ...dynamicRoutes,
 
         // 404
-        ...(output['/404']
+        ...(output['404']
           ? [
               {
                 src: path.join('/', entryDirectory, '.*'),

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -623,6 +623,7 @@ export const build = async ({
     });
 
     const pageKeys = Object.keys(pages);
+    // > 1 because _error is a lambda but isn't used if a static 404 is available
     const hasLambdas = !staticPages['_errors/404'] || pageKeys.length > 1;
 
     if (pageKeys.length === 0) {
@@ -757,7 +758,10 @@ export const build = async ({
     const launcherPath = path.join(__dirname, 'templated-launcher.js');
     const launcherData = await readFile(launcherPath, 'utf8');
     const allLambdasLabel = `All serverless functions created in`;
-    console.time(allLambdasLabel);
+
+    if (hasLambdas) {
+      console.time(allLambdasLabel);
+    }
 
     await Promise.all(
       pageKeys.map(async page => {

--- a/packages/now-next/test/fixtures/17-static-404/next.config.js
+++ b/packages/now-next/test/fixtures/17-static-404/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  experimental: {
+    static404: true,
+  },
+};

--- a/packages/now-next/test/fixtures/17-static-404/now.json
+++ b/packages/now-next/test/fixtures/17-static-404/now.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@now/next" }],
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "Hi"
+    },
+    {
+      "path": "/",
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/non-existent",
+      "mustContain": "page could not be found"
+    },
+    {
+      "path": "/non-existent",
+      "mustContain": "__next"
+    },
+    {
+      "path": "/_errors/404",
+      "mustContain": "__next"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/17-static-404/package.json
+++ b/packages/now-next/test/fixtures/17-static-404/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "9.2.1-canary.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/17-static-404/pages/index.js
+++ b/packages/now-next/test/fixtures/17-static-404/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Hi';


### PR DESCRIPTION
This adds initial support for static 404 pages when enabled for Next.js applications > `9.2.1-canary.3` it also disables tracing/logging related to lambdas when there aren't any lambdas besides the `_error` when a static 404 is being used 

Closes: #3368