### PR TITLE
[examples] Add rewrite for MDX-DECK example

### DIFF
--- a/examples/mdx-deck/now.json
+++ b/examples/mdx-deck/now.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "index.html" }
+  ]
+}


### PR DESCRIPTION
We need to ensure a reload goes to the right page. MDX-DECK is a SPA and therefore it needs a catch-all route.