### PR TITLE
[now-routing-utils] Disallow "status" in hit phase

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -96,15 +96,15 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
             src: route.src,
           });
         }
-        if (!route.continue) {
+        if (route.status) {
           errors.push({
-            message: `You must assign "continue: true" after "handle: hit"`,
+            message: `You cannot assign "status" after "handle: hit"`,
             src: route.src,
           });
         }
-        if (route.status) {
+        if (!route.continue) {
           errors.push({
-            message: `You must not assign "status" after "handle: hit"`,
+            message: `You must assign "continue: true" after "handle: hit"`,
             src: route.src,
           });
         }

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -102,6 +102,12 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
             src: route.src,
           });
         }
+        if (route.status) {
+          errors.push({
+            message: `You must not assign "status" after "handle: hit"`,
+            src: route.src,
+          });
+        }
       } else if (handleValue === 'miss') {
         if (route.dest && !route.check) {
           errors.push({

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -494,6 +494,26 @@ describe('normalizeRoutes', () => {
     );
   });
 
+  test('fails if routes after `handle: hit` use `status', () => {
+    const input = [
+      {
+        handle: 'hit',
+      },
+      {
+        src: '^/(.*)$',
+        status: 404,
+        continue: true,
+      },
+    ];
+    const { error } = normalizeRoutes(input);
+
+    assert.deepEqual(error.code, 'invalid_routes');
+    assert.deepEqual(
+      error.errors[0].message,
+      'You must not assign "status" after "handle: hit"'
+    );
+  });
+
   test('fails if routes after `handle: miss` do not use `check: true`', () => {
     const input = [
       {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -510,7 +510,7 @@ describe('normalizeRoutes', () => {
     assert.deepEqual(error.code, 'invalid_routes');
     assert.deepEqual(
       error.errors[0].message,
-      'You must not assign "status" after "handle: hit"'
+      'You cannot assign "status" after "handle: hit"'
     );
   });
 


### PR DESCRIPTION
This will prevent any strange behavior since production already ignores status code in the hit phase.