### PR TITLE
[now-build-utils] Fix api directory detection

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -331,8 +331,10 @@ export function detectOutputDirectory(builders: Builder[]): string | null {
 export function detectApiDirectory(builders: Builder[]): string | null {
   // TODO: We eventually want to save the api directory to
   // builder.config.apiDirectory so it is only detected once
-  const isZeroConfig = builders.some(b => b.config && b.config.zeroConfig);
-  return isZeroConfig ? 'api' : null;
+  const found = builders.some(
+    b => b.config && b.config.zeroConfig && b.src.startsWith('api/')
+  );
+  return found ? 'api' : null;
 }
 
 export async function detectRoutes(

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1877,6 +1877,18 @@ describe('Test `detectApiDirectory`', () => {
     const result = detectApiDirectory(builders);
     expect(result).toBe('api');
   });
+
+  it('should be `null` with zero config but without api directory', async () => {
+    const builders = [
+      {
+        use: '@now/next',
+        src: 'package.json',
+        config: { zeroConfig: true },
+      },
+    ];
+    const result = detectApiDirectory(builders);
+    expect(result).toBe(null);
+  });
 });
 
 /**


### PR DESCRIPTION
There was an issue where `@now/next` was emitting an api directory with serverless functions but the functions should not be renamed.