### PR TITLE
[now-client] (Major) Remove builds check from now-client and change events

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -190,10 +190,7 @@ export default async function processDeployment({
       }
     }
 
-    if (
-      event.type === 'build-state-changed' &&
-      event.payload.readyState === 'BUILDING'
-    ) {
+    if (event.type === 'building' && event.payload.readyState === 'BUILDING') {
       if (queuedSpinner) {
         queuedSpinner();
       }
@@ -203,7 +200,7 @@ export default async function processDeployment({
       }
     }
 
-    if (event.type === 'all-builds-completed') {
+    if (event.type === 'ready') {
       if (queuedSpinner) {
         queuedSpinner();
       }

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -190,7 +190,7 @@ export default async function processDeployment({
       }
     }
 
-    if (event.type === 'building' && event.payload.readyState === 'BUILDING') {
+    if (event.type === 'building') {
       if (queuedSpinner) {
         queuedSpinner();
       }

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -130,7 +130,7 @@ export default async function processDeployment({
       indications.push(event);
     }
 
-    if (event.type === 'file_count') {
+    if (event.type === 'file-count') {
       debug(
         `Total files ${event.payload.total.size}, ${event.payload.missing.length} changed`
       );

--- a/packages/now-cli/src/util/deploy/process-legacy-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-legacy-deployment.ts
@@ -71,7 +71,7 @@ export default async function processLegacyDeployment({
       hashes = event.payload;
     }
 
-    if (event.type === 'file_count') {
+    if (event.type === 'file-count') {
       debug(
         `Total files ${event.payload.total.size}, ${event.payload.missing.length} changed`
       );

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1213,7 +1213,7 @@ export class BuildError extends NowError<'BUILD_ERROR', {}> {
     meta,
   }: {
     message: string;
-    meta: { entrypoint: string };
+    meta: { entrypoint?: string };
   }) {
     super({
       code: 'BUILD_ERROR',

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -319,6 +319,10 @@ export default class Now extends EventEmitter {
       });
     }
 
+    if (error.errorCode && error.errorCode === 'BUILD_FAILED') {
+      return new BuildError();
+    }
+
     return new Error(error.message);
   }
 

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -320,7 +320,10 @@ export default class Now extends EventEmitter {
     }
 
     if (error.errorCode && error.errorCode === 'BUILD_FAILED') {
-      return new BuildError();
+      return new BuildError({
+        message: error.errorMessage,
+        meta: {},
+      });
     }
 
     return new Error(error.message);

--- a/packages/now-client/README.md
+++ b/packages/now-client/README.md
@@ -32,10 +32,10 @@ Then call inside a `for...of` loop to follow the progress with the following arg
 async function deploy() {
   let deployment;
 
-  for await (const event of createDeployment(
-    '/Users/zeit-user/projects/front',
-    { token: process.env.TOKEN }
-  )) {
+  for await (const event of createDeployment({
+    token: process.env.TOKEN,
+    path: '/Users/zeit-user/projects/front',
+  })) {
     if (event.type === 'ready') {
       deployment = event.payload;
       break;
@@ -50,16 +50,18 @@ Full list of events:
 
 ```js
 [
-  // File events (receive relevant data as payload)
+  // File events
   'hashes-calculated',
+  'file-count',
   'file-uploaded',
   'all-files-uploaded',
-  // Deployment events (receive deployment object as payload)
+  // Deployment events
   'created',
+  'building',
   'ready',
+  'alias-assigned',
+  'warning',
   'error',
-  // Build events (receive build object as payload)
-  'build-state-changed'
 ];
 ```
 

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "now-client",
-  "version": "6.0.2-canary.2",
+  "version": "7.0.0-canary.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "homepage": "https://zeit.co",

--- a/packages/now-client/src/check-deployment-status.ts
+++ b/packages/now-client/src/check-deployment-status.ts
@@ -9,12 +9,7 @@ import {
   isAliasError,
 } from './utils/ready-state';
 import { createDebug } from './utils';
-import {
-  Dictionary,
-  Deployment,
-  NowClientOptions,
-  DeploymentBuild,
-} from './types';
+import { Deployment, NowClientOptions, DeploymentBuild } from './types';
 
 interface DeploymentStatus {
   type: string;
@@ -31,8 +26,6 @@ export async function* checkDeploymentStatus(
   const debug = createDebug(clientOptions.debug);
 
   let deploymentState = deployment;
-  let allBuildsCompleted = false;
-  const buildsState: Dictionary<DeploymentBuild> = {};
 
   const apiDeployments = getApiDeploymentsUrl({
     version,
@@ -52,87 +45,58 @@ export async function* checkDeploymentStatus(
 
   // Build polling
   debug('Waiting for builds and the deployment to complete...');
-  let readyEventFired = false;
+  const finishedEvents = new Set();
+
   while (true) {
-    if (!allBuildsCompleted) {
-      const buildsData = await fetch(
-        `${apiDeployments}/${deployment.id}/builds${
-          teamId ? `?teamId=${teamId}` : ''
-        }`,
-        token,
-        { apiUrl, userAgent }
+    // Deployment polling
+    const deploymentData = await fetch(
+      `${apiDeployments}/${deployment.id || deployment.deploymentId}${
+        teamId ? `?teamId=${teamId}` : ''
+      }`,
+      token,
+      { apiUrl, userAgent }
+    );
+    const deploymentUpdate = await deploymentData.json();
+
+    if (deploymentUpdate.error) {
+      debug('Deployment status check has errorred');
+      return yield { type: 'error', payload: deploymentUpdate.error };
+    }
+
+    if (
+      deploymentUpdate.readyState === 'BUILDING' &&
+      !finishedEvents.has('building')
+    ) {
+      debug('Deployment state changed to BUILDING');
+      finishedEvents.add('building');
+      yield { type: 'building', payload: deploymentUpdate };
+    }
+
+    if (isReady(deploymentUpdate) && !finishedEvents.has('ready')) {
+      debug('Deployment state changed to READY 2');
+      finishedEvents.add('ready');
+      yield { type: 'ready', payload: deploymentUpdate };
+    }
+
+    if (isAliasAssigned(deploymentUpdate)) {
+      debug('Deployment alias assigned');
+      return yield { type: 'alias-assigned', payload: deploymentUpdate };
+    }
+
+    const aliasError = isAliasError(deploymentUpdate);
+
+    if (isFailed(deploymentUpdate) || aliasError) {
+      debug(
+        aliasError
+          ? 'Alias assignment error has occurred'
+          : 'Deployment has failed'
       );
-
-      const data = await buildsData.json();
-      const { builds = [] } = data;
-
-      for (const build of builds) {
-        const prevState = buildsState[build.id];
-
-        if (!prevState || prevState.readyState !== build.readyState) {
-          debug(
-            `Build state for '${build.entrypoint}' changed to ${build.readyState}`
-          );
-          yield { type: 'build-state-changed', payload: build };
-        }
-
-        if (build.readyState.includes('ERROR')) {
-          debug(`Build '${build.entrypoint}' has errorred`);
-          return yield { type: 'error', payload: build };
-        }
-
-        buildsState[build.id] = build;
-      }
-
-      const readyBuilds = builds.filter((b: DeploymentBuild) => isDone(b));
-
-      if (readyBuilds.length === builds.length) {
-        debug('All builds completed');
-        allBuildsCompleted = true;
-        yield { type: 'all-builds-completed', payload: readyBuilds };
-      }
-    } else {
-      // Deployment polling
-      const deploymentData = await fetch(
-        `${apiDeployments}/${deployment.id || deployment.deploymentId}${
-          teamId ? `?teamId=${teamId}` : ''
-        }`,
-        token,
-        { apiUrl, userAgent }
-      );
-      const deploymentUpdate = await deploymentData.json();
-
-      if (deploymentUpdate.error) {
-        debug('Deployment status check has errorred');
-        return yield { type: 'error', payload: deploymentUpdate.error };
-      }
-
-      if (isReady(deploymentUpdate) && !readyEventFired) {
-        debug('Deployment state changed to READY 2');
-        readyEventFired = true;
-        yield { type: 'ready', payload: deploymentUpdate };
-      }
-
-      if (isAliasAssigned(deploymentUpdate)) {
-        debug('Deployment alias assigned');
-        return yield { type: 'alias-assigned', payload: deploymentUpdate };
-      }
-
-      const aliasError = isAliasError(deploymentUpdate);
-
-      if (isFailed(deploymentUpdate) || aliasError) {
-        debug(
-          aliasError
-            ? 'Alias assignment error has occurred'
-            : 'Deployment has failed'
-        );
-        return yield {
-          type: 'error',
-          payload: aliasError
-            ? deploymentUpdate.aliasError
-            : deploymentUpdate.error || deploymentUpdate,
-        };
-      }
+      return yield {
+        type: 'error',
+        payload: aliasError
+          ? deploymentUpdate.aliasError
+          : deploymentUpdate.error || deploymentUpdate,
+      };
     }
 
     await sleep(ms('1.5s'));

--- a/packages/now-client/src/check-deployment-status.ts
+++ b/packages/now-client/src/check-deployment-status.ts
@@ -9,10 +9,15 @@ import {
   isAliasError,
 } from './utils/ready-state';
 import { createDebug } from './utils';
-import { Deployment, NowClientOptions, DeploymentBuild } from './types';
+import {
+  Deployment,
+  NowClientOptions,
+  DeploymentBuild,
+  DeploymentEventType,
+} from './types';
 
 interface DeploymentStatus {
-  type: string;
+  type: DeploymentEventType;
   payload: Deployment | DeploymentBuild[];
 }
 

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -6,16 +6,19 @@ import hashes, { mapToObject } from './utils/hashes';
 import { upload } from './upload';
 import { getNowIgnore, createDebug, parseNowJSON } from './utils';
 import { DeploymentError } from './errors';
-import { NowConfig, NowClientOptions, DeploymentOptions } from './types';
-
-export { EVENTS } from './utils';
+import {
+  NowConfig,
+  NowClientOptions,
+  DeploymentOptions,
+  DeploymentEventType,
+} from './types';
 
 export default function buildCreateDeployment(version: number) {
   return async function* createDeployment(
     clientOptions: NowClientOptions,
     deploymentOptions: DeploymentOptions = {},
     nowConfig: NowConfig = {}
-  ): AsyncIterableIterator<any> {
+  ): AsyncIterableIterator<{ type: DeploymentEventType; payload: any }> {
     const { path } = clientOptions;
 
     const debug = createDebug(clientOptions.debug);

--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -13,7 +13,7 @@ export { EVENTS } from './utils';
 export default function buildCreateDeployment(version: number) {
   return async function* createDeployment(
     clientOptions: NowClientOptions,
-    deploymentOptions: DeploymentOptions,
+    deploymentOptions: DeploymentOptions = {},
     nowConfig: NowConfig = {}
   ): AsyncIterableIterator<any> {
     const { path } = clientOptions;

--- a/packages/now-client/src/deploy.ts
+++ b/packages/now-client/src/deploy.ts
@@ -13,9 +13,8 @@ import {
   DeploymentOptions,
   NowConfig,
   NowClientOptions,
+  DeploymentEventType,
 } from './types';
-
-type DeploymentEventType = 'warning' | 'tip' | 'error' | 'notice' | 'created';
 
 async function* createDeployment(
   files: Map<string, DeploymentFile>,

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -5,6 +5,20 @@ export interface Dictionary<T> {
   [key: string]: T;
 }
 
+export type DeploymentEventType =
+  | 'hashes-calculated'
+  | 'file-count'
+  | 'file-uploaded'
+  | 'all-files-uploaded'
+  | 'created'
+  | 'building'
+  | 'ready'
+  | 'alias-assigned'
+  | 'warning'
+  | 'error'
+  | 'notice'
+  | 'tip';
+
 /**
  * Options for `now-client` or
  * properties that should not

--- a/packages/now-client/src/types.ts
+++ b/packages/now-client/src/types.ts
@@ -1,23 +1,11 @@
 import { Builder, BuilderFunctions } from '@now/build-utils';
 import { NowHeader, Route, NowRedirect, NowRewrite } from '@now/routing-utils';
 
+export { DeploymentEventType } from './utils';
+
 export interface Dictionary<T> {
   [key: string]: T;
 }
-
-export type DeploymentEventType =
-  | 'hashes-calculated'
-  | 'file-count'
-  | 'file-uploaded'
-  | 'all-files-uploaded'
-  | 'created'
-  | 'building'
-  | 'ready'
-  | 'alias-assigned'
-  | 'warning'
-  | 'error'
-  | 'notice'
-  | 'tip';
 
 /**
  * Options for `now-client` or

--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -71,7 +71,7 @@ export async function* upload(
 
   const shas = missingFiles;
 
-  yield { type: 'file_count', payload: { total: files, missing: shas } };
+  yield { type: 'file-count', payload: { total: files, missing: shas } };
 
   const uploadList: { [key: string]: Promise<any> } = {};
   debug('Building an upload list...');

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -6,12 +6,7 @@ import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
 import { pkgVersion } from '../pkg';
-import {
-  NowClientOptions,
-  DeploymentOptions,
-  NowConfig,
-  DeploymentEventType,
-} from '../types';
+import { NowClientOptions, DeploymentOptions, NowConfig } from '../types';
 import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
 const semaphore = new Sema(10);
@@ -19,7 +14,7 @@ const semaphore = new Sema(10);
 export const API_FILES = '/v2/now/files';
 export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
 
-export const EVENTS = new Set<DeploymentEventType>([
+const EVENTS_ARRAY = [
   // File events
   'hashes-calculated',
   'file-count',
@@ -34,7 +29,10 @@ export const EVENTS = new Set<DeploymentEventType>([
   'error',
   'notice',
   'tip',
-]);
+] as const;
+
+export type DeploymentEventType = (typeof EVENTS_ARRAY)[number];
+export const EVENTS = new Set(EVENTS_ARRAY);
 
 export function getApiDeploymentsUrl(
   metadata?: Pick<DeploymentOptions, 'version' | 'builds' | 'functions'>

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -6,7 +6,12 @@ import { join, sep } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
 import { pkgVersion } from '../pkg';
-import { NowClientOptions, DeploymentOptions, NowConfig } from '../types';
+import {
+  NowClientOptions,
+  DeploymentOptions,
+  NowConfig,
+  DeploymentEventType,
+} from '../types';
 import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
 const semaphore = new Sema(10);
@@ -14,7 +19,7 @@ const semaphore = new Sema(10);
 export const API_FILES = '/v2/now/files';
 export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
 
-export const EVENTS = new Set([
+export const EVENTS = new Set<DeploymentEventType>([
   // File events
   'hashes-calculated',
   'file-count',
@@ -27,6 +32,8 @@ export const EVENTS = new Set([
   'alias-assigned',
   'warning',
   'error',
+  'notice',
+  'tip',
 ]);
 
 export function getApiDeploymentsUrl(

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -17,17 +17,16 @@ export const API_DELETE_DEPLOYMENTS_LEGACY = '/v2/now/deployments';
 export const EVENTS = new Set([
   // File events
   'hashes-calculated',
-  'file_count',
+  'file-count',
   'file-uploaded',
   'all-files-uploaded',
   // Deployment events
   'created',
+  'building',
   'ready',
   'alias-assigned',
   'warning',
   'error',
-  // Build events
-  'build-state-changed',
 ]);
 
 export function getApiDeploymentsUrl(

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -57,7 +57,7 @@ describe('create v2 deployment', () => {
         name: 'now-client-tests-v2',
       }
     )) {
-      if (event.type === 'file_count') {
+      if (event.type === 'file-count') {
         expect(event.payload.total).toEqual(0);
       }
 


### PR DESCRIPTION
This removes the `/builds` endpoint check from `now-client`, it will instead just check the `readyState` of the deployment.

#### Major changes
* Renames the `file_count` event to `file-count` to make event names more consistent
* Removes the `build-state-changed` event
* Removes the `all-builds-completed` event

[PRODUCT-1031]

[PRODUCT-1031]: https://zeit.atlassian.net/browse/PRODUCT-1031