### PR TITLE
Stop running Circle CI on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: master
       - build:
           requires:
             - install


### PR DESCRIPTION
In order to decrease our Circle CI usage, we'll disable unnecessary `master` builds.

The important piece (running tests on the PRs) will remain.