### PR TITLE
[now-build-utils] Add function detectApiExtensions()

### DIFF
--- a/packages/now-build-utils/src/detect-routes.ts
+++ b/packages/now-build-utils/src/detect-routes.ts
@@ -1,4 +1,4 @@
-import { parse as parsePath } from 'path';
+import { parse as parsePath, extname } from 'path';
 import { Route, Source } from '@now/routing-utils';
 import { Builder } from './types';
 import { getIgnoreApiFilter, sortFiles } from './detect-builders';
@@ -337,6 +337,18 @@ export function detectApiDirectory(builders: Builder[]): string | null {
   return found ? 'api' : null;
 }
 
+export function detectApiExtensions(builders: Builder[]): Set<string> {
+  return new Set<string>(
+    builders
+      .filter(
+        b =>
+          b.config && b.config.zeroConfig && b.src && b.src.startsWith('api/')
+      )
+      .map(b => extname(b.src))
+      .filter(Boolean)
+  );
+}
+
 export async function detectRoutes(
   files: string[],
   builders: Builder[],
@@ -363,12 +375,7 @@ export async function detectRoutes(
     );
     if (featHandleMiss) {
       defaultRoutes.push({ handle: 'miss' });
-      const extSet = new Set(
-        builders
-          .filter(b => b.src && b.src.startsWith('api/'))
-          .map(b => parsePath(b.src).ext)
-          .filter(Boolean)
-      );
+      const extSet = detectApiExtensions(builders);
       if (extSet.size > 0) {
         const exts = Array.from(extSet)
           .map(ext => ext.slice(1))

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -66,6 +66,7 @@ export {
   detectRoutes,
   detectOutputDirectory,
   detectApiDirectory,
+  detectApiExtensions,
 } from './detect-routes';
 export { detectBuilders } from './detect-builders';
 export { detectFramework } from './detect-framework';

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1896,7 +1896,7 @@ describe('Test `detectApiDirectory`', () => {
 });
 
 describe('Test `detectApiExtensions`', () => {
-  it('should be `null` with no config', async () => {
+  it('should have correct extensions', async () => {
     const builders = [
       {
         use: '@now/node',
@@ -1928,8 +1928,24 @@ describe('Test `detectApiExtensions`', () => {
       },
       {
         use: 'now-bash',
-        src: 'api/index.sh',
+        src: 'api/**/*.sh',
         // No zero config so it should not be added
+      },
+      {
+        use: 'now-no-extension',
+        src: 'api/executable',
+        // No extension should not be added
+        config: {
+          zeroConfig: true,
+        },
+      },
+      {
+        use: '@now/next',
+        src: 'package.json',
+        // No api directory should not be added
+        config: {
+          zeroConfig: true,
+        },
       },
       {
         use: 'now-rust@1.0.1',

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1,6 +1,10 @@
 import { Source, Route } from '@now/routing-utils';
 import { detectBuilders, detectRoutes } from '../src';
-import { detectOutputDirectory, detectApiDirectory } from '../';
+import {
+  detectOutputDirectory,
+  detectApiDirectory,
+  detectApiExtensions,
+} from '../';
 
 describe('Test `detectBuilders`', () => {
   it('package.json + no build', async () => {
@@ -1888,6 +1892,65 @@ describe('Test `detectApiDirectory`', () => {
     ];
     const result = detectApiDirectory(builders);
     expect(result).toBe(null);
+  });
+});
+
+describe('Test `detectApiExtensions`', () => {
+  it('should be `null` with no config', async () => {
+    const builders = [
+      {
+        use: '@now/node',
+        src: 'api/**/*.js',
+        config: {
+          zeroConfig: true,
+        },
+      },
+      {
+        use: '@now/python',
+        src: 'api/**/*.py',
+        config: {
+          zeroConfig: true,
+        },
+      },
+      {
+        use: '@now/go',
+        src: 'api/**/*.go',
+        config: {
+          zeroConfig: true,
+        },
+      },
+      {
+        use: '@now/ruby',
+        src: 'api/**/*.rb',
+        config: {
+          zeroConfig: true,
+        },
+      },
+      {
+        use: 'now-bash',
+        src: 'api/index.sh',
+        // No zero config so it should not be added
+      },
+      {
+        use: 'now-rust@1.0.1',
+        src: 'api/user.rs',
+        config: {
+          zeroConfig: true,
+          functions: {
+            'api/**/*.rs': {
+              runtime: 'now-rust@1.0.1',
+            },
+          },
+        },
+      },
+    ];
+    const result = detectApiExtensions(builders);
+    expect(result.size).toBe(5);
+    expect(result.has('.js')).toBe(true);
+    expect(result.has('.py')).toBe(true);
+    expect(result.has('.go')).toBe(true);
+    expect(result.has('.rb')).toBe(true);
+    expect(result.has('.rs')).toBe(true);
   });
 });
 

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -116,10 +116,7 @@ it('should throw for discontinued versions', async () => {
   const realDateNow = Date.now.bind(global.Date);
   global.Date.now = () => new Date('2020-02-14').getTime();
 
-  expect(getSupportedNodeVersion('', false)).rejects.toThrow();
   expect(getSupportedNodeVersion('8.10.x', false)).rejects.toThrow();
-
-  expect(getSupportedNodeVersion('', true)).rejects.toThrow();
   expect(getSupportedNodeVersion('8.10.x', true)).rejects.toThrow();
 
   expect(getDiscontinuedNodeVersions().length).toBe(1);

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -13,6 +13,7 @@ import {
   FileBlob,
   FileFsRef,
   detectApiDirectory,
+  detectApiExtensions,
 } from '@now/build-utils';
 import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
@@ -419,6 +420,7 @@ export async function getBuildMatches(
   const noMatches: Builder[] = [];
   const builds = nowConfig.builds || [{ src: '**', use: '@now/static' }];
   const apiDir = detectApiDirectory(builds || []);
+  const apiExtensions = detectApiExtensions(builds || []);
   const apiMatch = apiDir + '/';
 
   for (const buildConfig of builds) {
@@ -438,13 +440,10 @@ export async function getBuildMatches(
     // We need to escape brackets since `glob` will
     // try to find a group otherwise
     src = src.replace(/(\[|\])/g, '[$1]');
-
-    if (apiDir && src.startsWith(apiMatch)) {
+    const ext = extname(src);
+    if (apiDir && src.startsWith(apiMatch) && apiExtensions.has(ext)) {
       // lambda function files are trimmed of their file extension
-      const ext = extname(src);
-      if (ext) {
-        src = src.slice(0, -ext.length);
-      }
+      src = src.slice(0, -ext.length);
     }
 
     const files = fileList

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -27,6 +27,7 @@ import {
   detectBuilders,
   detectRoutes,
   detectApiDirectory,
+  detectApiExtensions,
 } from '@now/build-utils';
 
 import { once } from '../once';
@@ -733,16 +734,15 @@ export default class DevServer {
     const files = await getFiles(this.cwd, nowConfig, opts);
     const results: { [filePath: string]: FileFsRef } = {};
     const apiDir = detectApiDirectory(nowConfig.builds || []);
+    const apiExtensions = detectApiExtensions(nowConfig.builds || []);
     const apiMatch = apiDir + '/';
     for (const fsPath of files) {
       let path = relative(this.cwd, fsPath);
       const { mode } = await fs.stat(fsPath);
-      if (apiDir && path.startsWith(apiMatch)) {
+      const ext = extname(path);
+      if (apiDir && path.startsWith(apiMatch) && apiExtensions.has(ext)) {
         // lambda function files are trimmed of their file extension
-        const ext = extname(path);
-        if (ext) {
-          path = path.slice(0, -ext.length);
-        }
+        path = path.slice(0, -ext.length);
       }
       results[path] = new FileFsRef({ mode, fsPath });
     }


### PR DESCRIPTION
We are adding routes with redirects, only if we detect extensions.

This PR makes sure that file renaming uses the same pattern.