### PR TITLE
Cache `public` directory for Gatsby deployments

### DIFF
--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -62,7 +62,7 @@ const frameworkList: Framework[] = [
         return [];
       }
     },
-    cachePattern: '.cache/**',
+    cachePattern: '{.cache,public}/**',
   },
   {
     name: 'Hexo',


### PR DESCRIPTION
This pull request ensures we'll cache `public` for Gatsby deployments.