### PR TITLE
[now-static-build] Add `public` folder to Gatsby cache

### DIFF
--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -62,7 +62,7 @@ const frameworkList: Framework[] = [
         return [];
       }
     },
-    cachePattern: '.cache/**',
+    cachePattern: '{.cache,public}/**',
   },
   {
     name: 'Hexo',

--- a/packages/now-static-build/test/unit.test.js
+++ b/packages/now-static-build/test/unit.test.js
@@ -13,7 +13,7 @@ describe('prepareCache', () => {
     expect(files['index.js']).toBeUndefined();
   });
 
-  test('should cache node_modules and `.cache` folder for gatsby deployments', async () => {
+  test('should cache node_modules, .cache and public folders for gatsby deployments', async () => {
     const files = await prepareCache({
       config: { zeroConfig: true },
       workPath: path.resolve(__dirname, './cache-fixtures/gatsby'),
@@ -22,6 +22,7 @@ describe('prepareCache', () => {
 
     expect(files['node_modules/file2']).toBeDefined();
     expect(files['.cache/file']).toBeDefined();
+    expect(files['public/file3']).toBeDefined();
     expect(files['package.json']).toBeUndefined();
   });
 });


### PR DESCRIPTION
This PR caches `public` as recommended here: https://www.gatsbyjs.org/docs/build-caching/

- cache `public`
- add test