### PR TITLE
[now-cli][now-client] Drop support for Node 8

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",

--- a/packages/now-cli/scripts/start.js
+++ b/packages/now-cli/scripts/start.js
@@ -1,25 +1,3 @@
 #!/usr/bin/env node
 
-// This should only be used for the integration tests
-
-const { join } = require('path');
-const { spawnSync } = require('child_process');
-
-const match = process.version.match(/^v(\d+)\.(\d+)/);
-const major = match && parseInt(match[1], 10);
-
-// Must be above or equal to 10.10.0
-// const isVersion = major > 10 || (major === 10 && minor >= 10);
-
-if (major === 8 && process.platform === 'darwin') {
-  const [node, _, ...args] = process.argv; // eslint-disable-line @typescript-eslint/no-unused-vars
-  const script = join(__dirname, '../dist/index.js');
-
-  const { status } = spawnSync(node, ['--no-warnings', script, ...args], {
-    stdio: 'inherit'
-  });
-
-  process.exit(status);
-} else {
-  require('../dist/index.js');
-}
+require('../dist/index.js');

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -780,9 +780,9 @@ test('[now dev] 03-aurelia', async t => {
 // );
 
 test('[now dev] 05-gatsby', async t => {
-  const tester = testFixtureStdio('05-gatsby', async (t, port) => {
-    if (shouldSkip(t, '05-gatsby', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
+  if (shouldSkip(t, '05-gatsby', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
 
+  const tester = testFixtureStdio('05-gatsby', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
     validateResponseHeaders(t, response);

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -114,10 +114,6 @@ async function exec(directory, args = []) {
 
 async function runNpmInstall(fixturePath) {
   if (await fs.exists(path.join(fixturePath, 'package.json'))) {
-    if (process.platform === 'darwin' && satisfies(process.version, '8.x')) {
-      await execa('yarn', ['cache', 'clean']);
-    }
-
     return execa('yarn', ['install'], { cwd: fixturePath });
   }
 }
@@ -720,10 +716,7 @@ test('[now dev] 01-node', async t => {
   await tester(t);
 });
 
-// Angular has `engines: { node: "10.x" }` in its `package.json`
 test('[now dev] 02-angular-node', async t => {
-  if (shouldSkip(t, '02-angular-node', '10.x')) return;
-
   const directory = fixture('02-angular-node');
   const { dev, port } = await testFixture(directory, { stdio: 'pipe' }, [
     '--debug',
@@ -759,8 +752,6 @@ test('[now dev] 02-angular-node', async t => {
 });
 
 test('[now dev] 03-aurelia', async t => {
-  if (shouldSkip(t, '03-aurelia', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
-
   const tester = testFixtureStdio('03-aurelia', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -786,8 +777,6 @@ test('[now dev] 03-aurelia', async t => {
 // );
 
 test('[now dev] 05-gatsby', async t => {
-  if (shouldSkip(t, '05-gatsby', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
-
   const tester = testFixtureStdio('05-gatsby', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -801,8 +790,6 @@ test('[now dev] 05-gatsby', async t => {
 });
 
 test('[now dev] 06-gridsome', async t => {
-  if (shouldSkip(t, '06-gridsome', '>= 6.9.0 <7.0.0 || >= 8.9.0')) return;
-
   const tester = testFixtureStdio('06-gridsome', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -949,8 +936,6 @@ test('[now dev] 14-svelte-node', async t => {
 // });
 
 test('[now dev] 16-vue-node', async t => {
-  if (shouldSkip(t, '16-vue-node', '^8.12.0 || >=9.7.0')) return;
-
   const directory = fixture('16-vue-node');
   const { dev, port } = await testFixture(directory);
 
@@ -970,8 +955,6 @@ test('[now dev] 16-vue-node', async t => {
 });
 
 test('[now dev] 17-vuepress-node', async t => {
-  if (shouldSkip(t, '17-vuepress-node', '^8.12.0 || >=9.7.0')) return;
-
   const directory = fixture('17-vuepress-node');
   const { dev, port } = await testFixture(directory);
 
@@ -1045,8 +1028,6 @@ test('[now dev] double slashes redirect', async t => {
 });
 
 test('[now dev] 18-marko', async t => {
-  if (shouldSkip(t, '18-marko', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
-
   const tester = testFixtureStdio('18-marko', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -1084,8 +1065,6 @@ test(
 );
 
 test('[now dev] 21-charge', async t => {
-  if (shouldSkip(t, '21-charge', '>= 8.10.0')) return;
-
   const tester = testFixtureStdio('21-charge', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -1111,8 +1090,6 @@ test(
 );
 
 test('[now dev] 23-docusaurus', async t => {
-  if (shouldSkip(t, '23-docusaurus', '>= 8.10')) return;
-
   const tester = testFixtureStdio('23-docusaurus', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -1126,8 +1103,6 @@ test('[now dev] 23-docusaurus', async t => {
 });
 
 test('[now dev] 24-ember', async t => {
-  if (shouldSkip(t, '24-ember', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
-
   const tester = await testFixtureStdio('24-ember', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 
@@ -1245,15 +1220,6 @@ test('[now dev] no build matches warning', async t => {
 });
 
 test('[now dev] do not recursivly check the path', async t => {
-  if (
-    shouldSkip(
-      t,
-      'do not recursivly check the path',
-      '^8.10.0 || ^10.13.0 || >=11.10.1'
-    )
-  )
-    return;
-
   const directory = fixture('handle-filesystem-missing');
   const { dev, port } = await testFixture(directory);
 
@@ -1370,8 +1336,6 @@ test('[now dev] do not rebuild for changes in the output directory', async t => 
 });
 
 test('[now dev] 25-nextjs-src-dir', async t => {
-  if (shouldSkip(t, '25-nextjs-src-dir', '>= 8.9.0')) return;
-
   const directory = fixture('25-nextjs-src-dir');
   const { dev, port } = await testFixture(directory);
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1108,6 +1108,8 @@ test('[now dev] 23-docusaurus', async t => {
 });
 
 test('[now dev] 24-ember', async t => {
+  if (shouldSkip(t, '24-ember', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
+
   const tester = await testFixtureStdio('24-ember', async (t, port) => {
     const response = await fetch(`http://localhost:${port}`);
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -716,7 +716,10 @@ test('[now dev] 01-node', async t => {
   await tester(t);
 });
 
+// Angular has `engines: { node: "10.x" }` in its `package.json`
 test('[now dev] 02-angular-node', async t => {
+  if (shouldSkip(t, '02-angular-node', '10.x')) return;
+
   const directory = fixture('02-angular-node');
   const { dev, port } = await testFixture(directory, { stdio: 'pipe' }, [
     '--debug',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -781,6 +781,8 @@ test('[now dev] 03-aurelia', async t => {
 
 test('[now dev] 05-gatsby', async t => {
   const tester = testFixtureStdio('05-gatsby', async (t, port) => {
+    if (shouldSkip(t, '05-gatsby', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
+
     const response = await fetch(`http://localhost:${port}`);
 
     validateResponseHeaders(t, response);

--- a/packages/now-cli/test/integration-v1.js
+++ b/packages/now-cli/test/integration-v1.js
@@ -331,12 +331,6 @@ test('detect update command', async t => {
     t.regex(stderr, /yarn add now@/gm, `Received: "${stderr}"`);
   }
 
-  if (process.version.startsWith('v8.')) {
-    // Don't do further checks for node 8 here
-    // since `npm i -g <tarball>` seems to fail
-    return;
-  }
-
   {
     const pkg = require('../package.json');
 

--- a/packages/now-cli/tsconfig.json
+++ b/packages/now-cli/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "CommonJS",
     "target": "ES2018",
     "esModuleInterop": true,
-    "lib": ["esnext"],
+    "lib": ["ES2018"],
     "resolveJsonModule": true,
     "sourceMap": true,
     "typeRoots": ["./@types", "./node_modules/@types"]

--- a/packages/now-cli/tsconfig.json
+++ b/packages/now-cli/tsconfig.json
@@ -3,15 +3,12 @@
     "strict": true,
     "moduleResolution": "node",
     "module": "CommonJS",
-    "target": "es2015",
+    "target": "ES2018",
     "esModuleInterop": true,
     "lib": ["esnext"],
     "resolveJsonModule": true,
     "sourceMap": true,
-    "typeRoots": [
-      "./@types",
-      "./node_modules/@types"
-    ]
+    "typeRoots": ["./@types", "./node_modules/@types"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/now-client/src/index.ts
+++ b/packages/now-client/src/index.ts
@@ -1,9 +1,3 @@
-// Polyfill Node 8 and below
-// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#the-for-await-of-statement
-if (!Symbol.asyncIterator) {
-  (Symbol as any).asyncIterator = Symbol.for('Symbol.asyncIterator');
-}
-
 import buildCreateDeployment from './create-deployment';
 
 export const createDeployment = buildCreateDeployment(2);

--- a/packages/now-client/tsconfig.json
+++ b/packages/now-client/tsconfig.json
@@ -11,8 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "target": "ES2015",
-    "downlevelIteration": true
+    "target": "ES2018"
   },
   "include": ["./src"]
 }

--- a/packages/now-client/tsconfig.json
+++ b/packages/now-client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["esnext"],
+    "lib": ["ES2018"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "dist",

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -35,15 +35,6 @@ describe('normalizeRoutes', () => {
   });
 
   test('accepts valid routes', () => {
-    if (Number(process.versions.node.split('.')[0]) < 10) {
-      // Skip this test for any Node version less than Node 10
-      // which introduced ES2018 RegExp Named Capture Groups.
-      // TODO: When now dev integrates this package, we should
-      // look at including `pcre-to-regexp`.
-      console.log('WARNING: skipping test for Node 8');
-      assert.equal(1, 1);
-      return;
-    }
     const routes = [
       { src: '^/about$' },
       {


### PR DESCRIPTION
Deployments no longer support Node 8 since reaching EOL so we can also drop all of the special casing used to support Node 8 in Now CLI and Now Client.

The `tsconfig.json` has been updated to ES2018 per [Node-Target-Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping).