### PR TITLE
[now-build-utils] Add monorepo packages to "dependencies"

### DIFF
--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -17,8 +17,8 @@
     "prepublishOnly": "./build.sh"
   },
   "dependencies": {
-    "@now/frameworks": "^0.0.7",
-    "@now/routing-utils": "^1.5.2-canary.2"
+    "@now/frameworks": "0.0.7-canary.0",
+    "@now/routing-utils": "1.5.2-canary.3"
   },
   "devDependencies": {
     "@iarna/toml": "2.2.3",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -16,6 +16,10 @@
     "test-integration-once": "jest --env node --verbose --runInBand test/integration.test.js",
     "prepublishOnly": "./build.sh"
   },
+  "dependencies": {
+    "@now/frameworks": "^0.0.7",
+    "@now/routing-utils": "^1.5.2-canary.2"
+  },
   "devDependencies": {
     "@iarna/toml": "2.2.3",
     "@types/async-retry": "^1.2.1",


### PR DESCRIPTION
When writing a community Runtime, you need to bring in
`@now/build-utils` as a dependency in order to have TypeScript
access to the types. When trying to compile, `@now/frameworks` and
`@now/routing-utils` are not present because they are not listed
as dependencies of this project, causing the build to fail:

```
$ tsc
node_modules/@now/build-utils/dist/detect-framework.d.ts:1:27 - error TS2307: Cannot find module '@now/frameworks'.

1 import { Framework } from '@now/frameworks';
                            ~~~~~~~~~~~~~~~~~

node_modules/@now/build-utils/dist/detect-routes.d.ts:1:23 - error TS2307: Cannot find module '@now/routing-utils'.

1 import { Route } from '@now/routing-utils';
                        ~~~~~~~~~~~~~~~~~~~~

Found 2 errors.
```

The versions listed are a result of invoking `lerna add …`.