### PR TITLE
[tests] Add timeout to test jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-unit:
     name: Unit Tests
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +30,7 @@ jobs:
 
   test-integration:
     name: Integration Tests
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,6 +41,7 @@ jobs:
 
   test-now-cli:
     name: Now CLI Tests
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +61,7 @@ jobs:
 
   test-now-dev:
     name: "`now dev` Tests"
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +81,7 @@ jobs:
 
   coverage:
     name: Coverage
+    timeout-minutes: 10
     needs: [test-unit, test-now-cli, test-now-dev, test-integration]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Circle CI used to have a max timeout of 10 minutes.

This adds a timeout to each job so that hanging tests are noticed earlier.

For example, these have been "in progress" for 4 hours: 

![image](https://user-images.githubusercontent.com/229881/73222438-3a90ea00-4131-11ea-97a7-76651a2cce45.png)
