### PR TITLE
[now-cli] Add link to "deploying files is deprecated"

### DIFF
--- a/packages/now-cli/src/util/validate-paths.ts
+++ b/packages/now-cli/src/util/validate-paths.ts
@@ -43,7 +43,7 @@ export default async function validatePaths(
   if (isFile) {
     output.print(
       `${prependEmoji(
-        'Deploying files with ZEIT Now is deprecated',
+        'Deploying files with ZEIT Now is deprecated (https://zeit.ink/3Z)',
         emoji('warning')
       )}\n`
     );


### PR DESCRIPTION
Adds a link to "Deploying files with ZEIT Now is deprecated" warning.

At the moment, the link points zeit.co/docs. We'll update the redirection to point to a dedicated page.

![image](https://user-images.githubusercontent.com/6616955/73258138-61006500-41c5-11ea-91a6-c277f95aba93.png)
