### PR TITLE
[now-cli] Deprecate `--name` and now.json `name` property

### DIFF
--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -96,7 +96,6 @@ export const latestHelp = () => `
 `;
 
 export const latestArgs = {
-  '--name': String,
   '--force': Boolean,
   '--public': Boolean,
   '--no-clipboard': Boolean,
@@ -107,10 +106,8 @@ export const latestArgs = {
   // This is not an array in favor of matching
   // the config property name.
   '--regions': String,
-  '--target': String,
   '--prod': Boolean,
   '--confirm': Boolean,
-  '-n': '--name',
   '-f': '--force',
   '-p': '--public',
   '-e': '--env',
@@ -118,6 +115,11 @@ export const latestArgs = {
   '-C': '--no-clipboard',
   '-m': '--meta',
   '-c': '--confirm',
+
+  // deprecated
+  '--name': String,
+  '-n': '--name',
+  '--target': String,
 };
 
 export const legacyArgsMri = {

--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -38,7 +38,6 @@ export const latestHelp = () => `
     -h, --help                     Output usage information
     -v, --version                  Output the version number
     -V, --platform-version         Set the platform version to deploy to
-    -n, --name                     Set the project name of the deployment
     -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
   'FILE'
 )}   Path to the local ${'`now.json`'} file

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -269,6 +269,17 @@ export default async function main(
     );
   }
 
+  if (localConfig && localConfig.name) {
+    output.print(
+      `${prependEmoji(
+        `The ${code('name')} property in ${highlight(
+          'now.json'
+        )} is deprecated (https://zeit.ink/5F)`,
+        emoji('warning')
+      )}\n`
+    );
+  }
+
   // build `env`
   const isObject = item =>
     Object.prototype.toString.call(item) === '[object Object]';

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -259,6 +259,16 @@ export default async function main(
     warn(`The option --no-scale is only supported on Now 1.0 deployments`);
   }
 
+  // deprecate --name
+  if (argv['--name']) {
+    output.print(
+      `${prependEmoji(
+        `The ${param('--name')} flag is deprecated (https://zeit.ink/1B)`,
+        emoji('warning')
+      )}\n`
+    );
+  }
+
   // build `env`
   const isObject = item =>
     Object.prototype.toString.call(item) === '[object Object]';

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2384,7 +2384,7 @@ test('should prefill "project name" prompt with folder name', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 });
 
-test('should prefill "project name" prompt with --name', async t => {
+test.only('should prefill "project name" prompt with --name', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
     Math.random()
@@ -2402,8 +2402,18 @@ test('should prefill "project name" prompt with --name', async t => {
     ...defaultArgs,
   ]);
 
-  await waitForPrompt(now, chunk => /Set up and deploy [^?]+\?/.test(chunk));
+  let isDeprecated = false;
+
+  await waitForPrompt(now, chunk => {
+    if (chunk.includes('The "--name" flag is deprecated')) {
+      isDeprecated = true;
+    }
+
+    return /Set up and deploy [^?]+\?/.test(chunk);
+  });
   now.stdin.write('yes\n');
+
+  t.is(isDeprecated, true);
 
   await waitForPrompt(now, chunk =>
     chunk.includes('Which scope do you want to deploy to?')
@@ -2424,7 +2434,7 @@ test('should prefill "project name" prompt with --name', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 });
 
-test('should prefill "project name" prompt with now.json `name`', async t => {
+test.only('should prefill "project name" prompt with now.json `name`', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
     Math.random()
@@ -2443,8 +2453,18 @@ test('should prefill "project name" prompt with now.json `name`', async t => {
 
   const now = execa(binaryPath, [directory, ...defaultArgs]);
 
-  await waitForPrompt(now, chunk => /Set up and deploy [^?]+\?/.test(chunk));
+  let isDeprecated = false;
+
+  await waitForPrompt(now, chunk => {
+    if (chunk.includes('The `name` property in now.json is deprecated')) {
+      isDeprecated = true;
+    }
+
+    return /Set up and deploy [^?]+\?/.test(chunk);
+  });
   now.stdin.write('yes\n');
+
+  t.is(isDeprecated, true);
 
   await waitForPrompt(now, chunk =>
     chunk.includes('Which scope do you want to deploy to?')

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2384,7 +2384,7 @@ test('should prefill "project name" prompt with folder name', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 });
 
-test.only('should prefill "project name" prompt with --name', async t => {
+test('should prefill "project name" prompt with --name', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
     Math.random()
@@ -2434,7 +2434,7 @@ test.only('should prefill "project name" prompt with --name', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 });
 
-test.only('should prefill "project name" prompt with now.json `name`', async t => {
+test('should prefill "project name" prompt with now.json `name`', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
     Math.random()


### PR DESCRIPTION
`--name` is replaced by either:
- linking the folder to a project
- `NOW_ORG_ID` and `NOW_PROJECT_ID` environment variables

![image](https://user-images.githubusercontent.com/6616955/73393717-6f8d7000-42dc-11ea-9369-a45e70cd6c58.png)
