### PR TITLE
[now-cli] Add error message when running now dev on an unlinked folder

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -443,7 +443,6 @@ export default async function main(
       [path],
       createArgs,
       org,
-      status === 'not_linked',
       !project && !isFile
     );
 
@@ -471,7 +470,6 @@ export default async function main(
         [path],
         createArgs,
         org,
-        status === 'not_linked',
         false
       );
     }

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -444,7 +444,7 @@ export default async function main(
       createArgs,
       org,
       status === 'not_linked',
-      !project
+      !project && !isFile
     );
 
     if (

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -90,7 +90,8 @@ const printDeploymentStatus = async (
   },
   deployStamp,
   isClipboardEnabled,
-  quiet
+  quiet,
+  isFile
 ) => {
   const isProdDeployment = target === 'production';
 
@@ -113,7 +114,7 @@ const printDeploymentStatus = async (
     // print preview/production url
     let previewUrl;
     let isWildcard;
-    if (Array.isArray(aliasList) && aliasList.length > 0) {
+    if (!isFile && Array.isArray(aliasList) && aliasList.length > 0) {
       // search for a non now.sh/non wildcard domain
       // but fallback to the first alias in the list
       const mainAlias =
@@ -594,7 +595,8 @@ export default async function main(
     deployment,
     deployStamp,
     !argv['--no-clipboard'],
-    quiet
+    quiet,
+    isFile
   );
 }
 

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -44,7 +44,7 @@ export default async function dev(
     return link.exitCode;
   }
 
-  if (link.status === 'not_linked') {
+  if (link.status === 'not_linked' && !process.env.__NOW_SKIP_DEV_COMMAND) {
     output.print(
       `${chalk.red(
         'Error!'

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -50,7 +50,7 @@ export default async function dev(
         'Error!'
       )} Your codebase isn’t linked to a project on ZEIT Now. Run ${cmd(
         'now'
-      )} to link it.`
+      )} to link it.\n`
     );
     return 1;
   }

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import chalk from 'chalk';
 
 import DevServer from '../../util/dev/server';
 import parseListen from '../../util/dev/parse-listen';
@@ -8,6 +9,7 @@ import Client from '../../util/client';
 import { getLinkedProject } from '../../util/projects/link';
 import { getFrameworks } from '../../util/get-frameworks';
 import { isSettingValue } from '../../util/is-setting-value';
+import cmd from '../../util/output/cmd';
 
 type Options = {
   '--debug'?: boolean;
@@ -33,13 +35,30 @@ export default async function dev(
   });
 
   // retrieve dev command
-  const [[, project], frameworks] = await Promise.all([
+  const [link, frameworks] = await Promise.all([
     getLinkedProject(output, client, cwd),
     getFrameworks(),
   ]);
 
+  if (link.status === 'error') {
+    return link.exitCode;
+  }
+
+  if (link.status === 'not_linked') {
+    output.print(
+      `${chalk.red(
+        'Error!'
+      )} Your codebase isn’t linked to a project on ZEIT Now. Run ${cmd(
+        'now'
+      )} to link it.`
+    );
+    return 1;
+  }
+
   let devCommand: undefined | string;
-  if (project) {
+  if (link.status === 'linked') {
+    const { project } = link;
+
     if (project.devCommand) {
       devCommand = project.devCommand;
     } else if (project.framework) {

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -519,29 +519,17 @@ const main = async argv_ => {
 
   let scope = argv['--scope'] || argv['--team'] || localConfig.scope;
 
-  // overwrite scope with `NOW_ORG_ID` if defined
-  const { NOW_ORG_ID } = process.env;
-  if (NOW_ORG_ID) {
+  if (process.env.NOW_ORG_ID || !scope) {
     const client = new Client({ apiUrl, token });
-    const org = await getLinkedOrg(client);
+    const link = await getLinkedOrg(client, output);
 
-    if (!org) {
-      output.print(
-        `${chalk.red('Error!')} Organization not found (${JSON.stringify({
-          NOW_ORG_ID,
-        })})\n`
-      );
-      return 1;
+    if (link.status === 'error') {
+      return link.exitCode;
     }
 
-    scope = org.slug;
-  }
-
-  // use local `.now` scope if not explicitly specified
-  if (!scope) {
-    const client = new Client({ apiUrl, token });
-    const org = await getLinkedOrg(client);
-    scope = org ? org.slug : undefined;
+    if (process.status === 'linked') {
+      scope = link.org.slug;
+    }
   }
 
   const targetCommand = commands.get(subcommand);

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -527,7 +527,7 @@ const main = async argv_ => {
       return link.exitCode;
     }
 
-    if (process.status === 'linked') {
+    if (link.status === 'linked') {
       scope = link.org.slug;
     }
   }

--- a/packages/now-cli/src/util/deploy/create-deploy.js
+++ b/packages/now-cli/src/util/deploy/create-deploy.js
@@ -11,17 +11,10 @@ export default async function createDeploy(
   paths,
   createArgs,
   org,
-  shouldLinkFolder,
   isSettingUpProject
 ) {
   try {
-    return await now.create(
-      paths,
-      createArgs,
-      org,
-      shouldLinkFolder,
-      isSettingUpProject
-    );
+    return await now.create(paths, createArgs, org, isSettingUpProject);
   } catch (error) {
     if (error.code === 'rate_limited') {
       throw new ERRORS_TS.DeploymentsRateLimited(error.message);
@@ -104,7 +97,6 @@ export default async function createDeploy(
         paths,
         createArgs,
         org,
-        shouldLinkFolder,
         isSettingUpProject
       );
     }

--- a/packages/now-cli/src/util/deploy/create-deploy.js
+++ b/packages/now-cli/src/util/deploy/create-deploy.js
@@ -12,7 +12,7 @@ export default async function createDeploy(
   createArgs,
   org,
   shouldLinkFolder,
-  isDetectingFramework
+  isSettingUpProject
 ) {
   try {
     return await now.create(
@@ -20,7 +20,7 @@ export default async function createDeploy(
       createArgs,
       org,
       shouldLinkFolder,
-      isDetectingFramework
+      isSettingUpProject
     );
   } catch (error) {
     if (error.code === 'rate_limited') {
@@ -105,7 +105,7 @@ export default async function createDeploy(
         createArgs,
         org,
         shouldLinkFolder,
-        isDetectingFramework
+        isSettingUpProject
       );
     }
 

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -52,7 +52,7 @@ export default async function processDeployment({
   org,
   projectName,
   shouldLinkFolder,
-  isDetectingFramework,
+  isSettingUpProject,
   skipAutoDetectionConfirmation,
   ...args
 }: {
@@ -70,7 +70,7 @@ export default async function processDeployment({
   org: Org;
   projectName: string;
   shouldLinkFolder: boolean;
-  isDetectingFramework: boolean;
+  isSettingUpProject: boolean;
   skipAutoDetectionConfirmation?: boolean;
 }) {
   if (isLegacy) return processLegacyDeployment(args);
@@ -107,7 +107,7 @@ export default async function processDeployment({
   let deploySpinner = null;
 
   let deployingSpinner = wait(
-    isDetectingFramework
+    isSettingUpProject
       ? `Setting up project`
       : `Deploying ${chalk.bold(`${org.slug}/${projectName}`)}`,
     0

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -51,7 +51,6 @@ export default async function processDeployment({
   isLegacy,
   org,
   projectName,
-  shouldLinkFolder,
   isSettingUpProject,
   skipAutoDetectionConfirmation,
   ...args
@@ -69,7 +68,6 @@ export default async function processDeployment({
   force?: boolean;
   org: Org;
   projectName: string;
-  shouldLinkFolder: boolean;
   isSettingUpProject: boolean;
   skipAutoDetectionConfirmation?: boolean;
 }) {
@@ -167,18 +165,16 @@ export default async function processDeployment({
 
       now._host = event.payload.url;
 
-      if (shouldLinkFolder) {
-        await linkFolderToProject(
-          output,
-          paths[0],
-          {
-            orgId: org.id,
-            projectId: event.payload.projectId,
-          },
-          projectName,
-          org.slug
-        );
-      }
+      await linkFolderToProject(
+        output,
+        paths[0],
+        {
+          orgId: org.id,
+          projectId: event.payload.projectId,
+        },
+        projectName,
+        org.slug
+      );
 
       printInspectUrl(output, event.payload.url, deployStamp, org.slug);
 

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -71,7 +71,7 @@ export default class Now extends EventEmitter {
     },
     org,
     shouldLinkFolder,
-    isDetectingFramework
+    isSettingUpProject
   ) {
     const opts = { output: this._output, hasNowJson };
     const { log, warn } = this._output;
@@ -183,7 +183,7 @@ export default class Now extends EventEmitter {
       org,
       projectName: name,
       shouldLinkFolder,
-      isDetectingFramework,
+      isSettingUpProject,
       skipAutoDetectionConfirmation,
     });
 

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -70,7 +70,6 @@ export default class Now extends EventEmitter {
       skipAutoDetectionConfirmation,
     },
     org,
-    shouldLinkFolder,
     isSettingUpProject
   ) {
     const opts = { output: this._output, hasNowJson };
@@ -182,7 +181,6 @@ export default class Now extends EventEmitter {
       force: forceNew,
       org,
       projectName: name,
-      shouldLinkFolder,
       isSettingUpProject,
       skipAutoDetectionConfirmation,
     });

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -121,7 +121,7 @@ export async function getLinkedProject(
   const { NOW_ORG_ID, NOW_PROJECT_ID } = process.env;
   const shouldUseEnv = Boolean(NOW_ORG_ID && NOW_PROJECT_ID);
 
-  if ((NOW_ORG_ID || NOW_ORG_ID) && !shouldUseEnv) {
+  if ((NOW_ORG_ID || NOW_PROJECT_ID) && !shouldUseEnv) {
     output.print(
       `${chalk.red('Error!')} You specified ${
         NOW_ORG_ID ? '`NOW_ORG_ID`' : '`NOW_PROJECT_ID`'

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -184,6 +184,22 @@ export async function linkFolderToProject(
   projectName: string,
   orgSlug: string
 ) {
+  // if NOW_ORG_ID or NOW_PROJECT_ID are used, we skip linking
+  const { NOW_ORG_ID, NOW_PROJECT_ID } = process.env;
+  if (NOW_ORG_ID || NOW_PROJECT_ID) {
+    return;
+  }
+
+  // if the project is already linked, we skip linking
+  const link = await getLink(path);
+  if (
+    link &&
+    link.orgId === projectLink.orgId &&
+    link.projectId === projectLink.projectId
+  ) {
+    return;
+  }
+
   try {
     await ensureDir(join(path, NOW_FOLDER));
   } catch (error) {

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -109,6 +109,7 @@ function validateResponseHeaders(t, res) {
 async function exec(directory, args = []) {
   return execa(binaryPath, ['dev', directory, ...args], {
     reject: false,
+    env: { __NOW_SKIP_DEV_COMMAND: 1 },
   });
 }
 
@@ -161,6 +162,7 @@ async function testFixture(directory, opts = {}, args = []) {
       detached: true,
       stdio: 'pipe',
       ...opts,
+      env: { ...opts.env, __NOW_SKIP_DEV_COMMAND: 1 },
     }
   );
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -223,7 +223,9 @@ function testFixtureStdio(directory, fn) {
       let stderr = '';
       let printedOutput = false;
 
-      dev = execa(binaryPath, ['dev', dir, '-l', port]);
+      dev = execa(binaryPath, ['dev', dir, '-l', port], {
+        env: { __NOW_SKIP_DEV_COMMAND: 1 },
+      });
 
       dev.stdout.on('data', data => {
         stdoutList.push(data);


### PR DESCRIPTION
Add error message when `now dev` is run on an unlinked folder:
![image](https://user-images.githubusercontent.com/6616955/73319750-9ea0d480-423d-11ea-8cf5-54cd9ccfa548.png)

Also:
- Refactor `getLinkedProject`
- Fixes folder not being linked when deploying a project with `builds` in `now.json`