### PR TITLE
[now-cli] Adjust `name` error messages

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -665,6 +665,10 @@ function handleCreateDeployError(output, error) {
       return 1;
     }
 
+    if (dataPath === '.name') {
+      output.error(message);
+    }
+
     if (keyword === 'type') {
       const prop = dataPath.substr(1, dataPath.length);
 

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -667,6 +667,7 @@ function handleCreateDeployError(output, error) {
 
     if (dataPath === '.name') {
       output.error(message);
+      return 1;
     }
 
     if (keyword === 'type') {


### PR DESCRIPTION
Should be merged after https://github.com/zeit/api/pull/2508.

We return nicer errors for `name` validation errors, so we can simply display the error message.