### PR TITLE
[now-cli] Send `framework` to `api-deployments`

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -501,6 +501,14 @@ export default async function main(
       return 1;
     }
 
+    if (deployment instanceof Error) {
+      output.error(
+        `${deployment.message ||
+          'An unexpected error occurred while deploying your project'} (http://zeit.ink/P4)`
+      );
+      return 1;
+    }
+
     const deploymentResponse = await getDeploymentByIdOrHost(
       now,
       contextName,

--- a/packages/now-cli/src/util/input/edit-project-settings.ts
+++ b/packages/now-cli/src/util/input/edit-project-settings.ts
@@ -11,6 +11,10 @@ export interface ProjectSettings {
   devCommand: string | null;
 }
 
+export type ProjectSettingsWithFramework = ProjectSettings & {
+  framework: string | null;
+};
+
 const fields: { name: string; value: keyof ProjectSettings }[] = [
   { name: 'Build Command', value: 'buildCommand' },
   { name: 'Output Directory', value: 'outputDirectory' },
@@ -21,22 +25,25 @@ export default async function editProjectSettings(
   output: Output,
   projectSettings: ProjectSettings | null,
   framework: Framework | null
-) {
-  // create new settings object filled with "null" values
-  const settings: Partial<ProjectSettings> = {};
+): Promise<ProjectSettingsWithFramework | {}> {
+  const settings: Partial<ProjectSettingsWithFramework> = {};
 
   for (let field of fields) {
     settings[field.value] =
       (projectSettings && projectSettings[field.value]) || null;
   }
 
+  // skip editing project settings if no framework is detected
   if (!framework) {
+    settings.framework = null;
     return settings;
   }
 
   output.print(
     `Auto-detected project settings (${chalk.bold(framework.name)}):\n`
   );
+
+  settings.framework = framework.slug;
 
   for (let field of fields) {
     const defaults = framework.settings[field.value];

--- a/packages/now-cli/src/util/input/edit-project-settings.ts
+++ b/packages/now-cli/src/util/input/edit-project-settings.ts
@@ -11,7 +11,7 @@ export interface ProjectSettings {
   devCommand: string | null;
 }
 
-export type ProjectSettingsWithFramework = ProjectSettings & {
+export interface ProjectSettingsWithFramework extends ProjectSettings {
   framework: string | null;
 };
 


### PR DESCRIPTION
Fix a bug on current Now CLI canary. It is failing when creating a new project through the `now` command.