### PR TITLE
[api] Silence github comments

### DIFF
--- a/now.json
+++ b/now.json
@@ -10,6 +10,10 @@
     "GITHUB_ACCESS_TOKEN": "@now-api-examples-github-token",
     "SENTRY_DSN": "@sentry-product-dsn"
   },
+  "github": {
+    "silent": true,
+    "autoJobCancelation": true
+  },
   "headers": [
     {
       "source": "/api/frameworks",


### PR DESCRIPTION
Most PRs don't touch the examples api so let's silence the comments and cancel in-progress builds if we push again.

This should reduce the noise in this repository.

Documentation: https://zeit.co/docs/configuration#introduction/configuration-reference