### PR TITLE
[now-cli] Remove unused `fs` import

### DIFF
--- a/packages/now-cli/src/util/input/input-root-directory.ts
+++ b/packages/now-cli/src/util/input/input-root-directory.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs-extra';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { Output } from '../output';


### PR DESCRIPTION
Fixes GH pull request auto-lint:

> #### Check warning on line 2 in `packages/now-cli/src/util/input/input-root-directory.ts`:
>
> ## GitHub Actions / Unit Tests (ubuntu-latest, 12)
>
> `packages/now-cli/src/util/input/input-root-directory.ts#L2`
>
> ```
> 'fs' is defined but never used
> ```