### PR TITLE
[tests] Change warn to error on unsed vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
       "@typescript-eslint/camelcase": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-unused-vars": 2,
       "@typescript-eslint/no-use-before-define": 0
     },
     "overrides": [


### PR DESCRIPTION
Follow up to #3714 that turns the warning into an error.

![image](https://user-images.githubusercontent.com/229881/73582375-ea7c9500-445a-11ea-9d20-2a17073a068a.png)
