### PR TITLE
[now-static-build] Fix error when `HUGO_VERSION` not found

### DIFF
--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -21,10 +21,12 @@
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",
     "@types/ms": "0.7.31",
+    "@types/node-fetch": "2.5.4",
     "@types/promise-timeout": "1.3.0",
     "get-port": "5.0.0",
     "is-port-reachable": "2.0.1",
     "ms": "2.1.2",
+    "node-fetch": "2.6.0",
     "typescript": "3.5.2"
   }
 }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -229,7 +229,7 @@ async function fetchBinary(url: string, framework: string, version: string) {
   if (res.status === 404) {
     throw new NowBuildError({
       code: 'NOW_STATIC_BUILD_BINARY_NOT_FOUND',
-      message: `${framework} version ${version} was not found.`,
+      message: `Version ${version} of ${framework} does not exist. Please specify a different one.`,
       link: 'https://zeit.co/docs/v2/build-step#framework-versioning',
     });
   }

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -1,5 +1,6 @@
 import ms from 'ms';
 import path from 'path';
+import fetch from 'node-fetch';
 import getPort from 'get-port';
 import isPortReachable from 'is-port-reachable';
 import { ChildProcess, SpawnOptions } from 'child_process';
@@ -223,6 +224,20 @@ function getFramework(
   return framework;
 }
 
+async function fetchBinary(url: string, framework: string, version: string) {
+  const res = await fetch(url);
+  if (res.status === 404) {
+    throw new NowBuildError({
+      code: 'NOW_STATIC_BUILD_BINARY_NOT_FOUND',
+      message: `${framework} version ${version} was not found.`,
+      link: 'https://zeit.co/docs/v2/build-step#framework-versioning',
+    });
+  }
+  await spawnAsync(`curl -sSL ${url} | tar -zx -C /usr/local/bin`, [], {
+    shell: true,
+  });
+}
+
 export async function build({
   files,
   entrypoint,
@@ -284,25 +299,19 @@ export async function build({
         const isOldVersion = major === 0 && minor < 43;
         const prefix = isOldVersion ? `hugo_` : `hugo_extended_`;
         const url = `https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${prefix}${HUGO_VERSION}_Linux-64bit.tar.gz`;
-        await spawnAsync(`curl -sSL ${url} | tar -zx -C /usr/local/bin`, [], {
-          shell: true,
-        });
+        await fetchBinary(url, 'Hugo', HUGO_VERSION);
       }
 
       if (ZOLA_VERSION && !meta.isDev) {
         console.log('Installing Zola version ' + ZOLA_VERSION);
         const url = `https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
-        await spawnAsync(`curl -sSL ${url} | tar -zx -C /usr/local/bin`, [], {
-          shell: true,
-        });
+        await fetchBinary(url, 'Zola', ZOLA_VERSION);
       }
 
       if (GUTENBERG_VERSION && !meta.isDev) {
         console.log('Installing Gutenberg version ' + GUTENBERG_VERSION);
         const url = `https://github.com/getzola/zola/releases/download/v${GUTENBERG_VERSION}/gutenberg-v${GUTENBERG_VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
-        await spawnAsync(`curl -sSL ${url} | tar -zx -C /usr/local/bin`, [], {
-          shell: true,
-        });
+        await fetchBinary(url, 'Gutenberg', GUTENBERG_VERSION);
       }
 
       // `public` is the default for zero config

--- a/packages/now-static-build/test/fixtures/36-hugo-version-not-found/now.json
+++ b/packages/now-static-build/test/fixtures/36-hugo-version-not-found/now.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "zeroConfig": true }
+    }
+  ],
+  "build": {
+    "env": {
+      "HUGO_VERSION": "0.0.0"
+    }
+  }
+}

--- a/packages/now-static-build/test/fixtures/36-hugo-version-not-found/package.json
+++ b/packages/now-static-build/test/fixtures/36-hugo-version-not-found/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir public && hugo version > public/index.txt"
+  }
+}

--- a/packages/now-static-build/test/integration.test.js
+++ b/packages/now-static-build/test/integration.test.js
@@ -32,6 +32,7 @@ const testsThatFailToBuild = new Set([
   '05-empty-dist-dir',
   '06-missing-script',
   '07-nonzero-sh',
+  '36-hugo-version-not-found',
 ]);
 
 // eslint-disable-next-line no-restricted-syntax

--- a/yarn.lock
+++ b/yarn.lock
@@ -9725,7 +9725,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@3.0.2, signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
 


### PR DESCRIPTION
This PR improves the error message when the user specifies a version but that version does not exist.

- HUGO_VERSION
- ZOLA_VERSION
- GUTENBERG_VERSION

Typically this means there is no tag for that particular version. It could also mean there is a tag but no binary is attached to the tag/release.

![image](https://user-images.githubusercontent.com/229881/73673953-900f4e80-467d-11ea-90ed-3317cf83c74e.png)

![image](https://user-images.githubusercontent.com/229881/73673985-9d2c3d80-467d-11ea-8ee4-cc6ecabaac20.png)

Related to [zeit/docs#1624](https://github.com/zeit/docs/pull/1624)