### PR TITLE
[now-cli] Do not show spinners with `--debug`

### DIFF
--- a/packages/now-cli/src/commands/alias/ls.js
+++ b/packages/now-cli/src/commands/alias/ls.js
@@ -8,12 +8,11 @@ import getAliases from '../../util/alias/get-aliases';
 import getScope from '../../util/get-scope.ts';
 import stamp from '../../util/output/stamp.ts';
 import strlen from '../../util/strlen.ts';
-import wait from '../../util/output/wait';
 
 export default async function ls(ctx, opts, args, output) {
   const {
     authConfig: { token },
-    config
+    config,
   } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
@@ -22,7 +21,7 @@ export default async function ls(ctx, opts, args, output) {
     apiUrl,
     token,
     currentTeam,
-    debug: debugEnabled
+    debug: debugEnabled,
   });
   let contextName = null;
 
@@ -51,7 +50,7 @@ export default async function ls(ctx, opts, args, output) {
     return 1;
   }
 
-  cancelWait = wait(
+  cancelWait = output.spinner(
     args[0]
       ? `Fetching alias details for "${args[0]}" under ${chalk.bold(
           contextName
@@ -112,13 +111,13 @@ function printAliasTable(aliases) {
           ? a.deployment.url
           : chalk.gray('–'),
         a.alias,
-        ms(Date.now() - new Date(a.created))
-      ])
+        ms(Date.now() - new Date(a.created)),
+      ]),
     ],
     {
       align: ['l', 'l', 'r'],
       hsep: ' '.repeat(4),
-      stringLength: strlen
+      stringLength: strlen,
     }
   ).replace(/^/gm, '  ')}\n\n`;
 }
@@ -130,13 +129,13 @@ function printPathAliasTable(rules) {
       rules.map(rule => [
         rule.pathname ? rule.pathname : chalk.cyan('[fallthrough]'),
         rule.method ? rule.method : '*',
-        rule.dest
+        rule.dest,
       ])
     ),
     {
       align: ['l', 'l', 'l', 'l'],
       hsep: ' '.repeat(6),
-      stringLength: strlen
+      stringLength: strlen,
     }
   ).replace(/^(.*)/gm, '  $1')}\n`;
 }

--- a/packages/now-cli/src/commands/billing/add.js
+++ b/packages/now-cli/src/commands/billing/add.js
@@ -21,7 +21,7 @@ export default async function({ creditCards, clear = false, contextName }) {
     name: {
       label: rightPad('Full Name', 12),
       placeholder: 'John Appleseed',
-      validateValue: data => data.trim().length > 0
+      validateValue: data => data.trim().length > 0,
     },
 
     cardNumber: {
@@ -36,7 +36,7 @@ export default async function({ creditCards, clear = false, contextName }) {
           return false;
         }
         return ccValidator.isValidCardNumber(data, type);
-      }
+      },
     },
 
     ccv: {
@@ -46,7 +46,7 @@ export default async function({ creditCards, clear = false, contextName }) {
       validateValue: data => {
         const brand = state.cardNumber.brand.toLowerCase();
         return ccValidator.doesCvvMatchType(data, brand);
-      }
+      },
     },
 
     expDate: {
@@ -54,8 +54,8 @@ export default async function({ creditCards, clear = false, contextName }) {
       mask: 'expDate',
       placeholder: 'mm / yyyy',
       middleware: expDateMiddleware,
-      validateValue: data => !ccValidator.isExpired(...data.split(' / '))
-    }
+      validateValue: data => !ccValidator.isExpired(...data.split(' / ')),
+    },
   };
 
   async function render() {
@@ -80,7 +80,7 @@ export default async function({ creditCards, clear = false, contextName }) {
             mask: piece.mask,
             validateKeypress: piece.validateKeypress,
             validateValue: piece.validateValue,
-            autoComplete: piece.autoComplete
+            autoComplete: piece.autoComplete,
           });
 
           piece.value = result;
@@ -135,7 +135,7 @@ export default async function({ creditCards, clear = false, contextName }) {
         name: state.name.value,
         cardNumber: state.cardNumber.value,
         ccv: state.ccv.value,
-        expDate: state.expDate.value
+        expDate: state.expDate.value,
       });
 
       stopSpinner();
@@ -156,9 +156,9 @@ export default async function({ creditCards, clear = false, contextName }) {
       stopSpinner();
       const linesToClear = state.error ? 15 : 14;
       process.stdout.write(ansiEscapes.eraseLines(linesToClear));
-      state.error = `${chalk.red(
-        '> Error!'
-      )} ${err.message} Please make sure the info is correct`;
+      state.error = `${chalk.red('> Error!')} ${
+        err.message
+      } Please make sure the info is correct`;
       await render();
     }
   }

--- a/packages/now-cli/src/commands/certs/add.ts
+++ b/packages/now-cli/src/commands/certs/add.ts
@@ -5,7 +5,6 @@ import Now from '../../util';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
-import wait from '../../util/output/wait';
 import createCertFromFile from '../../util/certs/create-cert-from-file';
 import createCertForCns from '../../util/certs/create-cert-for-cns';
 import { NowContext } from '../../types';
@@ -110,7 +109,7 @@ async function add(
       (res, item) => res.concat(item.split(',')),
       []
     );
-    const cancelWait = wait(
+    const cancelWait = output.spinner(
       `Generating a certificate for ${chalk.bold(cns.join(', '))}`
     );
 

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -404,6 +404,7 @@ export default async function main(
     }
 
     org = await selectOrg(
+      output,
       'Which scope do you want to deploy to?',
       client,
       ctx.config.currentTeam,
@@ -455,7 +456,9 @@ export default async function main(
       output,
       path,
       sourcePath,
-      project ? `To change your project settings, go to https://zeit.co/${org.slug}/${project.name}/settings` : ''
+      project
+        ? `To change your project settings, go to https://zeit.co/${org.slug}/${project.name}/settings`
+        : ''
     )) === false
   ) {
     return 1;

--- a/packages/now-cli/src/commands/domains/buy.ts
+++ b/packages/now-cli/src/commands/domains/buy.ts
@@ -13,7 +13,6 @@ import param from '../../util/output/param';
 import promptBool from '../../util/input/prompt-bool';
 import purchaseDomain from '../../util/domains/purchase-domain';
 import stamp from '../../util/output/stamp';
-import wait from '../../util/output/wait';
 
 type Options = {
   '--debug': boolean;
@@ -27,7 +26,7 @@ export default async function buy(
 ) {
   const {
     authConfig: { token },
-    config
+    config,
   } = ctx;
   const { currentTeam } = config;
   const { apiUrl } = ctx;
@@ -100,7 +99,7 @@ export default async function buy(
 
   let buyResult;
   const purchaseStamp = stamp();
-  const stopPurchaseSpinner = wait('Purchasing');
+  const stopPurchaseSpinner = output.spinner('Purchasing');
 
   try {
     buyResult = await purchaseDomain(client, domainName, price);

--- a/packages/now-cli/src/commands/init/init.ts
+++ b/packages/now-cli/src/commands/init/init.ts
@@ -9,7 +9,6 @@ import listInput from '../../util/input/list';
 import listItem from '../../util/output/list-item';
 import promptBool from '../../util/input/prompt-bool';
 import toHumanPath from '../../util/humanize-path';
-import wait from '../../util/output/wait';
 import { Output } from '../../util/output';
 import { NowContext } from '../../types';
 import success from '../../util/output/success';
@@ -24,10 +23,10 @@ type Options = {
 };
 
 type Example = {
-  name: string,
-  visible: boolean,
-  suggestions: string[]
-}
+  name: string;
+  visible: boolean;
+  suggestions: string[];
+};
 
 const EXAMPLE_API = 'https://now-example-files.zeit.sh';
 
@@ -40,7 +39,7 @@ export default async function init(
   const [name, dir] = args;
   const force = opts['-f'] || opts['--force'];
 
-  const examples = await fetchExampleList();
+  const examples = await fetchExampleList(output);
 
   if (!examples) {
     throw new Error(`Could not fetch example list.`);
@@ -56,22 +55,22 @@ export default async function init(
       return 0;
     }
 
-    return extractExample(chosen, dir, force);
+    return extractExample(output, chosen, dir, force);
   }
 
   if (exampleList.includes(name)) {
-    return extractExample(name, dir, force);
+    return extractExample(output, name, dir, force);
   }
 
   const oldExample = examples.find(x => !x.visible && x.name === name);
   if (oldExample) {
-    return extractExample(name, dir, force, 'v1');
+    return extractExample(output, name, dir, force, 'v1');
   }
 
   const found = await guess(exampleList, name);
 
   if (typeof found === 'string') {
-    return extractExample(found, dir, force);
+    return extractExample(output, found, dir, force);
   }
 
   console.log(info('No changes made.'));
@@ -81,8 +80,8 @@ export default async function init(
 /**
  * Fetch example list json
  */
-async function fetchExampleList() {
-  const stopSpinner = wait('Fetching examples');
+async function fetchExampleList(output: Output) {
+  const stopSpinner = output.spinner('Fetching examples');
   const url = `${EXAMPLE_API}/v2/list.json`;
 
   try {
@@ -93,7 +92,7 @@ async function fetchExampleList() {
       throw new Error(`Failed fetching list.json (${resp.statusText}).`);
     }
 
-    return await resp.json() as Example[];
+    return (await resp.json()) as Example[];
   } catch (e) {
     stopSpinner();
   }
@@ -106,22 +105,28 @@ async function chooseFromDropdown(message: string, exampleList: string[]) {
   const choices = exampleList.map(name => ({
     name,
     value: name,
-    short: name
+    short: name,
   }));
 
   return listInput({
     message,
     separator: false,
-    choices
+    choices,
   });
 }
 
 /**
  * Extract example to directory
  */
-async function extractExample(name: string, dir: string, force?: boolean, ver: string = 'v2') {
+async function extractExample(
+  output: Output,
+  name: string,
+  dir: string,
+  force?: boolean,
+  ver: string = 'v2'
+) {
   const folder = prepareFolder(process.cwd(), dir || name, force);
-  const stopSpinner = wait(`Fetching ${name}`);
+  const stopSpinner = output.spinner(`Fetching ${name}`);
 
   const url = `${EXAMPLE_API}/${ver}/download/${name}.tar.gz`;
 

--- a/packages/now-cli/src/commands/inspect.js
+++ b/packages/now-cli/src/commands/inspect.js
@@ -9,7 +9,6 @@ import createOutput from '../util/output';
 import Now from '../util';
 import logo from '../util/output/logo';
 import elapsed from '../util/output/elapsed.ts';
-import wait from '../util/output/wait';
 import { handleError } from '../util/error';
 import strlen from '../util/strlen.ts';
 import Client from '../util/client.ts';
@@ -79,13 +78,16 @@ export default async function main(ctx) {
     return 1;
   }
 
-  const { authConfig: { token }, config } = ctx;
+  const {
+    authConfig: { token },
+    config,
+  } = ctx;
   const { currentTeam } = config;
   const client = new Client({
     apiUrl,
     token,
     currentTeam,
-    debug: debugEnabled
+    debug: debugEnabled,
   });
   let contextName = null;
 
@@ -104,7 +106,7 @@ export default async function main(ctx) {
 
   // resolve the deployment, since we might have been given an alias
   const depFetchStart = Date.now();
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Fetching deployment "${id}" in ${chalk.bold(contextName)}`
   );
 
@@ -140,7 +142,7 @@ export default async function main(ctx) {
     limits,
     version,
     routes,
-    readyState
+    readyState,
   } = deployment;
 
   const isBuilds = version === 2;
@@ -159,7 +161,7 @@ export default async function main(ctx) {
             )}/events?types=event`
           )
         ),
-    isBuilds ? now.fetch(buildsUrl) : { builds: [] }
+    isBuilds ? now.fetch(buildsUrl) : { builds: [] },
   ]);
 
   cancelWait();
@@ -174,7 +176,9 @@ export default async function main(ctx) {
   print(`    ${chalk.cyan('version')}\t${version}\n`);
   print(`    ${chalk.cyan('id')}\t\t${finalId}\n`);
   print(`    ${chalk.cyan('name')}\t${name}\n`);
-  print(`    ${chalk.cyan('readyState')}\t${stateString(state || readyState)}\n`);
+  print(
+    `    ${chalk.cyan('readyState')}\t${stateString(state || readyState)}\n`
+  );
   if (!isBuilds) {
     print(`    ${chalk.cyan('type')}\t${type}\n`);
   }
@@ -255,7 +259,7 @@ export default async function main(ctx) {
       `${table(t, {
         align: ['l', 'c', 'c', 'c'],
         hsep: ' '.repeat(8),
-        stringLength: strlen
+        stringLength: strlen,
       }).replace(/^(.*)/gm, '    $1')}\n`
     );
     print('\n');
@@ -269,9 +273,9 @@ export default async function main(ctx) {
     events.forEach(data => {
       if (!data.event) return; // keepalive
       print(
-        `    ${chalk.gray(
-          new Date(data.created).toISOString()
-        )} ${data.event} ${getEventMetadata(data)}\n`
+        `    ${chalk.gray(new Date(data.created).toISOString())} ${
+          data.event
+        } ${getEventMetadata(data)}\n`
       );
     });
     print('\n');

--- a/packages/now-cli/src/commands/login.js
+++ b/packages/now-cli/src/commands/login.js
@@ -8,7 +8,6 @@ import chalk from 'chalk';
 import ua from '../util/ua.ts';
 import getArgs from '../util/get-args';
 import error from '../util/output/error';
-import wait from '../util/output/wait';
 import highlight from '../util/output/highlight';
 import ok from '../util/output/ok';
 import cmd from '../util/output/cmd.ts';
@@ -191,7 +190,7 @@ const login = async ctx => {
   let verificationToken;
   let securityCode;
 
-  stopSpinner = wait('Sending you an email');
+  stopSpinner = output.spinner('Sending you an email');
 
   try {
     const data = await executeLogin(apiUrl, email);
@@ -216,7 +215,7 @@ const login = async ctx => {
     )}.\n`
   );
 
-  stopSpinner = wait('Waiting for your confirmation');
+  stopSpinner = output.spinner('Waiting for your confirmation');
 
   let token;
 

--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -6,7 +6,6 @@ import logo from '../util/output/logo';
 import elapsed from '../util/output/elapsed.ts';
 import { maybeURL, normalizeURL, parseInstanceURL } from '../util/url';
 import printEvents from '../util/events';
-import wait from '../util/output/wait';
 import Client from '../util/client.ts';
 import getScope from '../util/get-scope.ts';
 
@@ -165,7 +164,7 @@ export default async function main(ctx) {
   const id = deploymentIdOrURL;
 
   const depFetchStart = Date.now();
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Fetching deployment "${id}" in ${chalk.bold(contextName)}`
   );
 
@@ -287,12 +286,12 @@ function printLogShort(log) {
     data = JSON.stringify(obj, null, 2);
   } else {
     data = (log.text || '')
-          .replace(/\n$/, '')
-          .replace(/^\n/, '')
-          // eslint-disable-next-line no-control-regex
-          .replace(/\x1b\[1000D/g, '')
-          .replace(/\x1b\[0K/g, '')
-          .replace(/\x1b\[1A/g, '');
+      .replace(/\n$/, '')
+      .replace(/^\n/, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\[1000D/g, '')
+      .replace(/\x1b\[0K/g, '')
+      .replace(/\x1b\[1A/g, '');
     if (/warning/i.test(data)) {
       data = chalk.yellow(data);
     } else if (log.type === 'stderr') {

--- a/packages/now-cli/src/commands/remove.js
+++ b/packages/now-cli/src/commands/remove.js
@@ -6,7 +6,6 @@ import table from 'text-table';
 import Now from '../util';
 import getAliases from '../util/alias/get-aliases';
 import createOutput from '../util/output';
-import wait from '../util/output/wait';
 import logo from '../util/output/logo';
 import cmd from '../util/output/cmd.ts';
 import elapsed from '../util/output/elapsed.ts';
@@ -132,7 +131,7 @@ export default async function main(ctx) {
     throw err;
   }
 
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Fetching deployment(s) ${ids
       .map(id => `"${id}"`)
       .join(' ')} in ${chalk.bold(contextName)}`

--- a/packages/now-cli/src/commands/teams/add.js
+++ b/packages/now-cli/src/commands/teams/add.js
@@ -57,7 +57,7 @@ export default async function({ apiUrl, token, teams, config }) {
         validateKeypress: validateSlugKeypress,
         initialValue: slug,
         valid: team,
-        forceLowerCase: true
+        forceLowerCase: true,
       });
     } catch (err) {
       if (err.message === 'USER_ABORT') {
@@ -95,7 +95,7 @@ export default async function({ apiUrl, token, teams, config }) {
   try {
     name = await textInput({
       label: `- ${teamNamePrefix}`,
-      validateKeypress: validateNameKeypress
+      validateKeypress: validateNameKeypress,
     });
   } catch (err) {
     if (err.message === 'USER_ABORT') {
@@ -153,7 +153,7 @@ export default async function({ apiUrl, token, teams, config }) {
     introMsg: 'Invite your teammates! When done, press enter on an empty field',
     noopMsg: `You can invite teammates later by running ${cmd(
       'now teams invite'
-    )}`
+    )}`,
   });
 
   gracefulExit();

--- a/packages/now-cli/src/commands/teams/invite.js
+++ b/packages/now-cli/src/commands/teams/invite.js
@@ -30,7 +30,7 @@ const domains = Array.from(
     'inbox.com',
     'mail.com',
     'gmx.com',
-    'icloud.com'
+    'icloud.com',
   ])
 );
 
@@ -56,17 +56,15 @@ const emailAutoComplete = (value, teamSlug) => {
   return false;
 };
 
-export default async function(
-  {
-    teams,
-    args,
-    config,
-    introMsg,
-    noopMsg = 'No changes made',
-    apiUrl,
-    token
-  } = {}
-) {
+export default async function({
+  teams,
+  args,
+  config,
+  introMsg,
+  noopMsg = 'No changes made',
+  apiUrl,
+  token,
+} = {}) {
   const { currentTeam: currentTeamId } = config;
 
   const stopSpinner = wait('Fetching teams');
@@ -86,7 +84,11 @@ export default async function(
 
   if (!currentTeam) {
     // We specifically need a team scope here
-    let err = `You can't run this command under ${param(user.username || user.email)}.\nPlease select a team scope using ${cmd('now switch')} or use ${cmd('--scope')}`;
+    let err = `You can't run this command under ${param(
+      user.username || user.email
+    )}.\nPlease select a team scope using ${cmd('now switch')} or use ${cmd(
+      '--scope'
+    )}`;
     return fatalError(err);
   }
 
@@ -107,7 +109,9 @@ export default async function(
           userInfo = res.name || res.username;
         } catch (err) {
           if (err.code === 'user_not_found') {
-            console.error(error(`No user exists with the email address "${email}".`));
+            console.error(
+              error(`No user exists with the email address "${email}".`)
+            );
             return 1;
           }
 
@@ -115,7 +119,11 @@ export default async function(
         }
 
         stopSpinner();
-        console.log(`${chalk.cyan(chars.tick)} ${email}${userInfo ? ` (${userInfo})` : ''} ${elapsed()}`);
+        console.log(
+          `${chalk.cyan(chars.tick)} ${email}${
+            userInfo ? ` (${userInfo})` : ''
+          } ${elapsed()}`
+        );
       } else {
         console.log(`${chalk.red(`✖ ${email}`)} ${chalk.gray('[invalid]')}`);
       }
@@ -135,7 +143,7 @@ export default async function(
       email = await textInput({
         label: `- ${inviteUserPrefix}`,
         validateValue: validateEmail,
-        autoComplete: value => emailAutoComplete(value, currentTeam.slug)
+        autoComplete: value => emailAutoComplete(value, currentTeam.slug),
       });
     } catch (err) {
       if (err.message !== 'USER_ABORT') {
@@ -149,7 +157,10 @@ export default async function(
       stopSpinner = wait(inviteUserPrefix + email);
       try {
         // eslint-disable-next-line no-await-in-loop
-        const { name, username } = await teams.inviteUser({ teamId: currentTeam.id, email });
+        const { name, username } = await teams.inviteUser({
+          teamId: currentTeam.id,
+          email,
+        });
         stopSpinner();
         const userInfo = name || username;
         email = `${email}${userInfo ? ` (${userInfo})` : ''} ${elapsed()}`;

--- a/packages/now-cli/src/commands/teams/list.js
+++ b/packages/now-cli/src/commands/teams/list.js
@@ -27,20 +27,20 @@ export default async function({ teams, config, apiUrl, token }) {
 
   if (accountIsCurrent) {
     currentTeam = {
-      slug: user.username || user.email
+      slug: user.username || user.email,
     };
   }
 
   const teamList = list.map(({ slug, name }) => ({
     name,
     value: slug,
-    current: slug === currentTeam.slug ? chars.tick : ''
+    current: slug === currentTeam.slug ? chars.tick : '',
   }));
 
   teamList.unshift({
     name: user.email,
     value: user.username || user.email,
-    current: (accountIsCurrent && chars.tick) || ''
+    current: (accountIsCurrent && chars.tick) || '',
   });
 
   // Let's bring the current team to the beginning of the list

--- a/packages/now-cli/src/util/alias/create-alias.ts
+++ b/packages/now-cli/src/util/alias/create-alias.ts
@@ -3,7 +3,6 @@ import { Output } from '../output';
 import * as ERRORS from '../errors-ts';
 import Client from '../client';
 import createCertForAlias from '../certs/create-cert-for-alias';
-import wait from '../output/wait';
 
 export type AliasRecord = {
   uid: string;
@@ -20,7 +19,7 @@ export default async function createAlias(
   alias: string,
   externalDomain: boolean
 ) {
-  let cancelMessage = wait(`Creating alias`);
+  let cancelMessage = output.spinner(`Creating alias`);
   const result = await performCreateAlias(
     client,
     contextName,
@@ -41,7 +40,7 @@ export default async function createAlias(
       return cert;
     }
 
-    let cancelMessage = wait(`Creating alias`);
+    let cancelMessage = output.spinner(`Creating alias`);
     const secondTry = await performCreateAlias(
       client,
       contextName,
@@ -66,7 +65,7 @@ async function performCreateAlias(
       `/now/deployments/${deployment.uid}/aliases`,
       {
         method: 'POST',
-        body: { alias }
+        body: { alias },
       }
     );
   } catch (error) {
@@ -77,7 +76,10 @@ async function performCreateAlias(
       return { uid: error.uid, alias: error.alias } as AliasRecord;
     }
     if (error.code === 'deployment_not_found') {
-      return new ERRORS.DeploymentNotFound({ context: contextName, id: deployment.uid });
+      return new ERRORS.DeploymentNotFound({
+        context: contextName,
+        id: deployment.uid,
+      });
     }
     if (error.code === 'gone') {
       return new ERRORS.DeploymentFailedAliasImpossible();
@@ -94,7 +96,7 @@ async function performCreateAlias(
       }
     }
     if (error.status === 400) {
-      return new ERRORS.DeploymentNotReady({url: deployment.url })
+      return new ERRORS.DeploymentNotReady({ url: deployment.url });
     }
 
     throw error;

--- a/packages/now-cli/src/util/alias/get-deployment-for-alias.ts
+++ b/packages/now-cli/src/util/alias/get-deployment-for-alias.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import getAppLastDeployment from '../deploy/get-app-last-deployment';
 import getAppName from '../deploy/get-app-name';
 import fetchDeploymentByIdOrHost from '../deploy/get-deployment-by-id-or-host';
-import wait from '../output/wait';
 import Client from '../client';
 import { Output } from '../output';
 import { User, Config } from '../../types';
@@ -17,7 +16,7 @@ export default async function getDeploymentForAlias(
   contextName: string,
   localConfig: Config
 ) {
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Fetching deployment to alias in ${chalk.bold(contextName)}`
   );
 

--- a/packages/now-cli/src/util/alias/upsert-path-alias.ts
+++ b/packages/now-cli/src/util/alias/upsert-path-alias.ts
@@ -4,7 +4,6 @@ import * as ERRORS from '../errors-ts';
 import Client from '../client';
 import createCertForAlias from '../certs/create-cert-for-alias';
 import setupDomain from '../domains/setup-domain';
-import wait from '../output/wait';
 
 const NOW_SH_REGEX = /\.now\.sh$/;
 
@@ -34,6 +33,7 @@ export default async function upsertPathAlias(
   }
 
   const result = await performUpsertPathAlias(
+    output,
     client,
     alias,
     rules,
@@ -51,23 +51,26 @@ export default async function upsertPathAlias(
       return cert;
     }
 
-    return performUpsertPathAlias(client, alias, rules, contextName);
+    return performUpsertPathAlias(output, client, alias, rules, contextName);
   }
 
   return result;
 }
 
 async function performUpsertPathAlias(
+  output: Output,
   client: Client,
   alias: string,
   rules: PathRule[],
   contextName: string
 ) {
-  const cancelMessage = wait(`Updating path alias rules for ${alias}`);
+  const cancelMessage = output.spinner(
+    `Updating path alias rules for ${alias}`
+  );
   try {
     const record = await client.fetch<AliasRecord>(`/now/aliases`, {
       body: { alias, rules },
-      method: 'POST'
+      method: 'POST',
     });
     cancelMessage();
     return record;

--- a/packages/now-cli/src/util/certs/create-cert-for-alias.ts
+++ b/packages/now-cli/src/util/certs/create-cert-for-alias.ts
@@ -5,7 +5,6 @@ import createCertForCns from './create-cert-for-cns';
 import getWildcardCnsForAlias from './get-wildcard-cns-for-alias';
 import joinWords from '../output/join-words';
 import stamp from '../output/stamp';
-import wait from '../output/wait';
 
 export default async function createCertificateForAlias(
   output: Output,
@@ -15,7 +14,7 @@ export default async function createCertificateForAlias(
   shouldBeWildcard: boolean
 ) {
   const cns = shouldBeWildcard ? getWildcardCnsForAlias(alias) : [alias];
-  const cancelMessage = wait(`Generating a certificate...`);
+  const cancelMessage = output.spinner(`Generating a certificate...`);
   const certStamp = stamp();
   const cert = await createCertForCns(client, cns, context);
   if (cert instanceof NowError) {
@@ -25,9 +24,9 @@ export default async function createCertificateForAlias(
 
   cancelMessage();
   output.log(
-    `Certificate for ${joinWords(
-      cert.cns
-    )} (${cert.uid}) created ${certStamp()}`
+    `Certificate for ${joinWords(cert.cns)} (${
+      cert.uid
+    }) created ${certStamp()}`
   );
   return cert;
 }

--- a/packages/now-cli/src/util/deploy/generate-cert-for-deploy.ts
+++ b/packages/now-cli/src/util/deploy/generate-cert-for-deploy.ts
@@ -4,7 +4,6 @@ import { Output } from '../output';
 import Client from '../client';
 import createCertForCns from '../certs/create-cert-for-cns';
 import setupDomain from '../domains/setup-domain';
-import wait from '../output/wait';
 import { InvalidDomain } from '../errors-ts';
 
 export default async function generateCertForDeploy(
@@ -23,7 +22,9 @@ export default async function generateCertForDeploy(
     return new InvalidDomain(deployURL);
   }
 
-  const cancelSetupWait = wait(`Setting custom suffix domain ${domain}`);
+  const cancelSetupWait = output.spinner(
+    `Setting custom suffix domain ${domain}`
+  );
   const result = await setupDomain(output, client, domain, contextName);
   cancelSetupWait();
   if (result instanceof NowError) {
@@ -31,7 +32,7 @@ export default async function generateCertForDeploy(
   }
 
   // Generate the certificate with the given parameters
-  const cancelCertWait = wait(
+  const cancelCertWait = output.spinner(
     `Generating a wildcard certificate for ${domain}`
   );
   const cert = await createCertForCns(

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -6,7 +6,6 @@ import {
   DeploymentOptions,
   NowClientOptions,
 } from 'now-client';
-import wait from '../output/wait';
 import { Output } from '../output';
 // @ts-ignore
 import Now from '../../util';
@@ -106,7 +105,7 @@ export default async function processDeployment({
   let buildSpinner = null;
   let deploySpinner = null;
 
-  let deployingSpinner = wait(
+  let deployingSpinner = output.spinner(
     isSettingUpProject
       ? `Setting up project`
       : `Deploying ${chalk.bold(`${org.slug}/${projectName}`)}`,
@@ -183,8 +182,8 @@ export default async function processDeployment({
       if (queuedSpinner === null) {
         queuedSpinner =
           event.payload.readyState === 'QUEUED'
-            ? wait('Queued', 0)
-            : wait('Building', 0);
+            ? output.spinner('Queued', 0)
+            : output.spinner('Building', 0);
       }
     }
 
@@ -194,7 +193,7 @@ export default async function processDeployment({
       }
 
       if (buildSpinner === null) {
-        buildSpinner = wait('Building', 0);
+        buildSpinner = output.spinner('Building', 0);
       }
     }
 
@@ -206,7 +205,7 @@ export default async function processDeployment({
         buildSpinner();
       }
 
-      deploySpinner = wait('Completing', 0);
+      deploySpinner = output.spinner('Completing', 0);
     }
 
     // Handle error events

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -20,7 +20,6 @@ import {
 import pkg from '../../../package.json';
 
 import { NoBuilderCacheError } from '../errors-ts';
-import wait from '../output/wait';
 import { Output } from '../output';
 import { getDistTag } from '../get-dist-tag';
 
@@ -246,7 +245,7 @@ export async function installBuilders(
     return;
   }
 
-  const stopSpinner = wait(
+  const stopSpinner = output.spinner(
     `Installing ${pluralize(
       'Runtime',
       packagesToInstall.length

--- a/packages/now-cli/src/util/domains/purchase-domain-if-available.ts
+++ b/packages/now-cli/src/util/domains/purchase-domain-if-available.ts
@@ -9,7 +9,6 @@ import getDomainStatus from './get-domain-status';
 import promptBool from '../input/prompt-bool';
 import purchaseDomain from './purchase-domain';
 import stamp from '../output/stamp';
-import wait from '../output/wait';
 import * as ERRORS from '../errors-ts';
 
 const isTTY = process.stdout.isTTY;
@@ -20,7 +19,7 @@ export default async function purchaseDomainIfAvailable(
   domain: string,
   contextName: string
 ) {
-  const cancelWait = wait(`Checking status of ${chalk.bold(domain)}`);
+  const cancelWait = output.spinner(`Checking status of ${chalk.bold(domain)}`);
   const buyDomainStamp = stamp();
   const { available } = await getDomainStatus(client, domain);
 

--- a/packages/now-cli/src/util/input/input-project.ts
+++ b/packages/now-cli/src/util/input/input-project.ts
@@ -6,7 +6,6 @@ import chalk from 'chalk';
 import { ProjectNotFound } from '../../util/errors-ts';
 import { Output } from '../output';
 import { Project, Org } from '../../types';
-import wait from '../output/wait';
 
 export default async function inputProject(
   output: Output,
@@ -21,7 +20,10 @@ export default async function inputProject(
 
   // attempt to auto-detect a project to link
   let detectedProject = null;
-  const existingProjectSpinner = wait('Searching for existing projects…', 1000);
+  const existingProjectSpinner = output.spinner(
+    'Searching for existing projects…',
+    1000
+  );
   try {
     const project = await getProjectByIdOrName(
       client,
@@ -74,7 +76,7 @@ export default async function inputProject(
         continue;
       }
 
-      const spinner = wait('Verifying project name…', 1000);
+      const spinner = output.spinner('Verifying project name…', 1000);
       try {
         project = await getProjectByIdOrName(client, projectName, org.id);
       } finally {
@@ -106,7 +108,7 @@ export default async function inputProject(
       continue;
     }
 
-    const spinner = wait('Verifying project name…', 1000);
+    const spinner = output.spinner('Verifying project name…', 1000);
     let existingProject: Project | ProjectNotFound;
     try {
       existingProject = await getProjectByIdOrName(

--- a/packages/now-cli/src/util/input/select-org.ts
+++ b/packages/now-cli/src/util/input/select-org.ts
@@ -3,11 +3,12 @@ import inquirer from 'inquirer';
 import getUser from '../get-user';
 import getTeams from '../get-teams';
 import { User, Team, Org } from '../../types';
-import wait from '../output/wait';
+import { Output } from '../output';
 
 type Choice = { name: string; value: Org };
 
-export default async function selectProject(
+export default async function selectOrg(
+  output: Output,
   question: string,
   client: Client,
   currentTeam?: string,
@@ -15,7 +16,7 @@ export default async function selectProject(
 ): Promise<Org> {
   require('./patch-inquirer');
 
-  const spinner = wait('Loading scopes…', 1000);
+  const spinner = output.spinner('Loading scopes…', 1000);
   let user: User;
   let teams: Team[];
   try {

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -80,7 +80,12 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   function spinner(message: string, timeout: number = 300) {
     if (debugEnabled) {
       debug(`Spinner invoked (${message})`);
-      return () => debug(`Spinner ended (${message})`);
+      let isEnded = false;
+      return () => {
+        if (isEnded) return;
+        isEnded = true;
+        debug(`Spinner ended (${message})`);
+      };
     }
 
     return wait(message, timeout);

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -77,9 +77,9 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
-  function spinner(message: string, timeout: number = 300) {
+  function spinner(message: string, delay: number = 300) {
     if (debugEnabled) {
-      debug(`Spinner invoked (${message})`);
+      debug(`Spinner invoked (${message}) with a ${delay}ms delay`);
       let isEnded = false;
       return () => {
         if (isEnded) return;
@@ -88,7 +88,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
       };
     }
 
-    return wait(message, timeout);
+    return wait(message, delay);
   }
 
   // This is pretty hacky, but since we control the version of Node.js

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { format } from 'util';
 import { Console } from 'console';
+import wait from './wait';
 
 export type Output = ReturnType<typeof createOutput>;
 
@@ -76,6 +77,15 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
+  function spinner(message: string, timeout: number = 300) {
+    if (debugEnabled) {
+      debug(`Spinner invoked (${message})`);
+      return () => debug(`Spinner ended (${message})`);
+    }
+
+    return wait(message, timeout);
+  }
+
   // This is pretty hacky, but since we control the version of Node.js
   // being used because of `pkg` it's safe to do in this case.
   const c = {
@@ -109,5 +119,6 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     dim,
     time,
     note,
+    spinner,
   };
 }

--- a/packages/now-cli/src/util/output/wait.ts
+++ b/packages/now-cli/src/util/output/wait.ts
@@ -2,7 +2,7 @@ import ora from 'ora';
 import chalk from 'chalk';
 import eraseLines from './erase-lines';
 
-export default function wait(msg: string, timeout: number = 300, _ora = ora) {
+export default function wait(msg: string, delay: number = 300, _ora = ora) {
   let spinner: ReturnType<typeof _ora>;
   let running = false;
 
@@ -11,7 +11,7 @@ export default function wait(msg: string, timeout: number = 300, _ora = ora) {
     spinner.color = 'gray';
     spinner.start();
     running = true;
-  }, timeout);
+  }, delay);
 
   const cancel = () => {
     clearTimeout(planned);

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -12,7 +12,6 @@ import { Project } from '../../types';
 import { Org, ProjectLink } from '../../types';
 import chalk from 'chalk';
 import { prependEmoji, emoji } from '../emoji';
-import wait from '../output/wait';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -86,7 +85,7 @@ export async function getLinkedOrg(
     return { status: 'not_linked', org: null };
   }
 
-  const spinner = wait('Retrieving scope…', 1000);
+  const spinner = output.spinner('Retrieving scope…', 1000);
   try {
     const org = await getOrgById(client, orgId);
 
@@ -141,7 +140,7 @@ export async function getLinkedProject(
     return { status: 'not_linked', org: null, project: null };
   }
 
-  const spinner = wait('Retrieving project…', 1000);
+  const spinner = output.spinner('Retrieving project…', 1000);
   let org: Org | null;
   let project: Project | ProjectNotFound | null;
   try {

--- a/packages/now-cli/src/util/scale/patch-deployment-scale.ts
+++ b/packages/now-cli/src/util/scale/patch-deployment-scale.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import wait from '../output/wait';
 import joinWords from '../output/join-words';
 import * as Errors from '../errors-ts';
 import { Output } from '../output';
@@ -17,7 +16,7 @@ export default async function patchDeploymentScale(
   scaleArgs: ScaleArgs,
   url: string
 ) {
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Setting scale rules for ${joinWords(
       Object.keys(scaleArgs).map(dc => `${chalk.bold(dc)}`)
     )}`
@@ -28,7 +27,7 @@ export default async function patchDeploymentScale(
       `/v3/now/deployments/${encodeURIComponent(deploymentId)}/instances`,
       {
         method: 'PATCH',
-        body: scaleArgs
+        body: scaleArgs,
       }
     );
     cancelWait();

--- a/packages/now-cli/src/util/scale/set-deployment-scale.ts
+++ b/packages/now-cli/src/util/scale/set-deployment-scale.ts
@@ -4,7 +4,6 @@ import { Output } from '../output';
 import * as ERRORS from '../errors-ts';
 import Client from '../client';
 import joinWords from '../output/join-words';
-import wait from '../output/wait';
 
 type ScaleArgs = {
   min: number;
@@ -18,7 +17,7 @@ export default async function setScale(
   scaleArgs: ScaleArgs | DeploymentScale,
   url: string
 ) {
-  const cancelWait = wait(
+  const cancelWait = output.spinner(
     `Setting scale rules for ${joinWords(
       Object.keys(scaleArgs).map(dc => `${chalk.bold(dc)}`)
     )}`
@@ -29,7 +28,7 @@ export default async function setScale(
       `/v3/now/deployments/${encodeURIComponent(deploymentId)}/instances`,
       {
         method: 'PUT',
-        body: scaleArgs
+        body: scaleArgs,
       }
     );
     cancelWait();

--- a/packages/now-cli/src/util/scale/wait-verify-deployment-scale.ts
+++ b/packages/now-cli/src/util/scale/wait-verify-deployment-scale.ts
@@ -9,7 +9,6 @@ import Client from '../client';
 import joinWords from '../output/join-words';
 import stamp from '../output/stamp';
 import verifyDeploymentScale from './verify-deployment-scale';
-import wait from '../output/wait';
 
 export default async function waitForScale(
   output: Output,
@@ -19,7 +18,7 @@ export default async function waitForScale(
 ) {
   const remainingDCs = new Set(Object.keys(scale));
   const scaleStamp = stamp();
-  let cancelWait = renderWaitDcs(Array.from(remainingDCs.keys()));
+  let cancelWait = renderWaitDcs(output, Array.from(remainingDCs.keys()));
 
   for await (const dcReady of verifyDeploymentScale(
     output,
@@ -43,13 +42,13 @@ export default async function waitForScale(
     }
 
     if (remainingDCs.size > 0) {
-      cancelWait = renderWaitDcs(Array.from(remainingDCs.keys()));
+      cancelWait = renderWaitDcs(output, Array.from(remainingDCs.keys()));
     }
   }
 }
 
-function renderWaitDcs(dcs: string[]) {
-  return wait(
+function renderWaitDcs(output: Output, dcs: string[]) {
+  return output.spinner(
     `Waiting for instances in ${joinWords(
       dcs.map(dc => chalk.bold(dc))
     )} to be ready`


### PR DESCRIPTION
When `--debug` is activated, do not show spinners but show instead:
- `Spinner invoked (spinner message)`
- `Spinner ended (spinner message)`

Here's how it looks now:
![image](https://user-images.githubusercontent.com/6616955/73736475-1b9de380-4741-11ea-9629-a371f3e938ed.png)

After this PR:
![image](https://user-images.githubusercontent.com/6616955/73786241-2d12da00-4799-11ea-86dc-d25a3d2bb0c9.png)


- Creates `output.spinner`
- Use `output.spinner` for the deploy command
