### PR TITLE
[now-build-utils] Exclude `_test.go` files

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -28,7 +28,7 @@ function getApiBuilders({ tag }: Pick<Options, 'tag'> = {}): Builder[] {
   return [
     { src: 'api/**/*.js', use: `@now/node${withTag}`, config },
     { src: 'api/**/*.ts', use: `@now/node${withTag}`, config },
-    { src: 'api/**/*.go', use: `@now/go${withTag}`, config },
+    { src: 'api/**/!(*_test).go', use: `@now/go${withTag}`, config },
     { src: 'api/**/*.py', use: `@now/python${withTag}`, config },
     { src: 'api/**/*.rb', use: `@now/ruby${withTag}`, config },
   ];

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -151,6 +151,27 @@ describe('Test `detectBuilders`', () => {
     expect(builders!.length).toBe(2);
   });
 
+  it('api go with test files', async () => {
+    const files = [
+      'api/index.go',
+      'api/index_test.go',
+      'api/test.go',
+      'api/testing_another.go',
+      'api/readme.md',
+      'api/config/staging.go',
+      'api/config/staging_test.go',
+      'api/config/production.go',
+      'api/config/production_test.go',
+      'api/src/controllers/health.go',
+      'api/src/controllers/user.module.go',
+      'api/src/controllers/user.module_test.go',
+    ];
+
+    const { builders } = await detectBuilders(files);
+    expect(builders!.length).toBe(7);
+    expect(builders!.some(b => b.src.endsWith('_test.go'))).toBe(false);
+  });
+
   it('just public', async () => {
     const files = ['public/index.html', 'public/favicon.ico', 'README.md'];
 

--- a/packages/now-go/test/test.js
+++ b/packages/now-go/test/test.js
@@ -3,14 +3,24 @@ const path = require('path');
 
 const {
   packAndDeploy,
-  testDeployment
+  testDeployment,
 } = require('../../../test/lib/deployment/test-deployment.js');
 
 jest.setTimeout(4 * 60 * 1000);
-const buildUtilsUrl = '@canary';
+let buildUtilsUrl;
 let builderUrl;
 
 beforeAll(async () => {
+  if (!buildUtilsUrl) {
+    const buildUtilsPath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'now-build-utils'
+    );
+    buildUtilsUrl = await packAndDeploy(buildUtilsPath);
+    console.log('buildUtilsUrl', buildUtilsUrl);
+  }
   const builderPath = path.resolve(__dirname, '..');
   builderUrl = await packAndDeploy(builderPath);
   console.log('builderUrl', builderUrl);


### PR DESCRIPTION
Typically, Go tests are side-by-side with their source files in a `_test.go`.

The Go documentation says the following:

> To write a new test suite, create a file whose name ends _test.go that contains the TestXxx functions as described here. Put the file in the same package as the one being tested. The file will be excluded from regular package builds but will be included when the “go test” command is run. [View Docs](https://golang.org/pkg/testing/)

This PR excludes the test files from being turned into Serverless Functions.