### PR TITLE
[now-cli] Do not prompt for root directory when project is linked

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -427,8 +427,10 @@ export default async function main(
 
     if (typeof projectOrNewProjectName === 'string') {
       newProjectName = projectOrNewProjectName;
+      rootDirectory = await inputRootDirectory(path, output, autoConfirm);
     } else {
       project = projectOrNewProjectName;
+      rootDirectory = project.rootDirectory;
 
       // we can already link the project
       await linkFolderToProject(
@@ -443,8 +445,6 @@ export default async function main(
       );
       status = 'linked';
     }
-
-    rootDirectory = await inputRootDirectory(path, output, autoConfirm);
   }
 
   const sourcePath = rootDirectory ? join(path, rootDirectory) : path;
@@ -455,7 +455,9 @@ export default async function main(
       output,
       path,
       sourcePath,
-      project ? `To change your project settings, go to https://zeit.co/${org.slug}/${project.name}/settings` : ''
+      project
+        ? `To change your project settings, go to https://zeit.co/${org.slug}/${project.name}/settings`
+        : ''
     )) === false
   ) {
     return 1;


### PR DESCRIPTION
We ask for the root directory after linking to an existing project:
![image](https://user-images.githubusercontent.com/6616955/73791363-6ef44e00-47a2-11ea-8d53-e6a242165b0a.png)

Instead, we should use the existing project's `rootDirectory`:
![image](https://user-images.githubusercontent.com/6616955/73791445-9ea35600-47a2-11ea-8f59-c430707a1c8a.png)
