### PR TITLE
[now-build-utils] Handle empty `buildCommand` and `outputDirectory`

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -423,7 +423,10 @@ export async function detectBuilders(
 
   let frontendBuilder: Builder | null = null;
 
-  if (hasBuildScript(pkg) || buildCommand || framework) {
+  // Everything will be static if either is an empty string
+  const ignoreBuild = buildCommand === '' || outputDirectory === '';
+
+  if (!ignoreBuild && (hasBuildScript(pkg) || buildCommand || framework)) {
     frontendBuilder = detectFrontBuilder(pkg, builders, files, options);
   } else {
     if (!options.ignoreBuildScript && pkg && builders.length === 0) {
@@ -442,7 +445,9 @@ export async function detectBuilders(
     // when there are no build steps
     const outDir = outputDirectory || 'public';
 
-    if (hasDirectory(outDir, files)) {
+    // If `outputDirectory` is an empty string we'll default
+    // to the root directory if possible.
+    if (hasDirectory(outDir, files) && outputDirectory !== '') {
       frontendBuilder = {
         use: '@now/static',
         src: `${outDir}/**/*`,

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -445,8 +445,8 @@ export async function detectBuilders(
     // when there are no build steps
     const outDir = outputDirectory || 'public';
 
-    // If `outputDirectory` is an empty string we'll default
-    // to the root directory if possible.
+    // If `outputDirectory` is an empty string,
+    // we'll default to the root directory.
     if (hasDirectory(outDir, files) && outputDirectory !== '') {
       frontendBuilder = {
         use: '@now/static',

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -766,6 +766,37 @@ describe('Test `detectBuilders`', () => {
       },
     ]);
   });
+
+  it('All static if `buildCommand` is an empty string', async () => {
+    const files = ['index.html'];
+    const projectSettings = { buildCommand: '' };
+    const { builders, errors } = await detectBuilders(files, null, {
+      projectSettings,
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBe(null);
+  });
+
+  it('All static if `outputDirectory` is an empty string', async () => {
+    const files = ['index.html'];
+    const projectSettings = { outputDirectory: '' };
+    const { builders, errors } = await detectBuilders(files, null, {
+      projectSettings,
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBe(null);
+  });
+
+  it('All static if `buildCommand` is an empty string with an `outputDirectory`', async () => {
+    const files = ['out/index.html'];
+    const projectSettings = { buildCommand: '', outputDirectory: 'out' };
+    const { builders, errors } = await detectBuilders(files, null, {
+      projectSettings,
+    });
+    expect(errors).toBe(null);
+    expect(builders![0]!.use).toBe('@now/static');
+    expect(builders![0]!.src).toBe('out/**/*');
+  });
 });
 
 it('Test `detectRoutes`', async () => {


### PR DESCRIPTION
Handle empty `buildCommand` and `outputDirectory`