### PR TITLE
[now-cli] Bump @zeit/fun to 0.11.2

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -93,7 +93,7 @@
     "@types/which": "1.3.1",
     "@types/write-json-file": "2.2.1",
     "@zeit/dockerignore": "0.0.5",
-    "@zeit/fun": "0.11.0",
+    "@zeit/fun": "0.11.2",
     "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,10 +2050,10 @@
     agentkeepalive "3.4.1"
     debug "3.1.0"
 
-"@zeit/fun@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.11.0.tgz#e226af0a2b63020a0e233dd37a2ceb2ac2e68fe3"
-  integrity sha512-w9IqoMV6SIKVmQbocKKvllgL27im7YQfTFV/0hjIgASfi8yQgPIj7mo76VFosRS0HQA5MEIzYz+oigdelOTIOQ==
+"@zeit/fun@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@zeit/fun/-/fun-0.11.2.tgz#a9ac34c8db09f8de40f7e727bdfde808c1be6505"
+  integrity sha512-1LoKTF2jq7YT3eATD/iTRuaTmvVtX3pWi3SVZPAgDTb70OLklpDkvVA/Z7dqP/WMB3gVGBdQNIhWfPTlBwrHEA==
   dependencies:
     async-listen "1.0.0"
     debug "4.1.1"


### PR DESCRIPTION
Updates `@zeit/fun` to [0.11.2](https://github.com/zeit/fun/releases/tag/0.11.2).

- https://github.com/zeit/fun/pull/49
- https://github.com/zeit/fun/pull/50