### PR TITLE
[tests] Fix now cli breaking tests

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2189,6 +2189,11 @@ test('should prefill "project name" prompt with folder name', async t => {
   );
   now.stdin.write('\n');
 
+  await waitForPrompt(now, chunk =>
+    chunk.includes('Want to override the settings?')
+  );
+  now.stdin.write('no\n');
+
   const output = await now;
   t.is(output.exitCode, 0, formatOutput(output));
 });
@@ -2243,6 +2248,11 @@ test('should prefill "project name" prompt with --name', async t => {
     chunk.includes('In which directory is your code located?')
   );
   now.stdin.write('\n');
+
+  await waitForPrompt(now, chunk =>
+    chunk.includes('Want to override the settings?')
+  );
+  now.stdin.write('no\n');
 
   const output = await now;
   t.is(output.exitCode, 0, formatOutput(output));
@@ -2299,6 +2309,11 @@ test('should prefill "project name" prompt with now.json `name`', async t => {
     chunk.includes('In which directory is your code located?')
   );
   now.stdin.write('\n');
+
+  await waitForPrompt(now, chunk =>
+    chunk.includes('Want to override the settings?')
+  );
+  now.stdin.write('no\n');
 
   const output = await now;
   t.is(output.exitCode, 0, formatOutput(output));


### PR DESCRIPTION
Fix tests that are currently breaking on `master`.

They were broken in https://github.com/zeit/now/pull/3738 and caused the `Now CLI Tests` to hang and cancel after ~30 minutes.