### PR TITLE
Remove `now dev` suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ To quickly start a new project, run the following commands:
 ```
 now init        # Pick an example project to clone
 cd <PROJECT>    # Change directory to the newly created project
-now dev         # Run locally during development
 now             # Deploy to the cloud
 ```
 


### PR DESCRIPTION
We don't want people to use `now dev` unless it's really needed.