### PR TITLE
[now-cli] Always output deployment url in stdout

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -94,7 +94,6 @@ const printDeploymentStatus = async (
   },
   deployStamp,
   isClipboardEnabled,
-  quiet,
   isFile
 ) => {
   const isProdDeployment = target === 'production';
@@ -142,11 +141,6 @@ const printDeploymentStatus = async (
           isCopiedToClipboard = true;
         })
         .catch(error => output.debug(`Error copying to clipboard: ${error}`));
-    }
-
-    // write to stdout
-    if (quiet) {
-      process.stdout.write(`https://${deploymentUrl}`);
     }
 
     output.print(
@@ -659,7 +653,6 @@ export default async function main(
     deployment,
     deployStamp,
     !argv['--no-clipboard'],
-    quiet,
     isFile
   );
 }

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -83,6 +83,7 @@ export default async function processDeployment({
     deployStamp,
     force,
     nowConfig,
+    quiet,
   } = args;
 
   const { debug } = output;
@@ -178,6 +179,10 @@ export default async function processDeployment({
       );
 
       printInspectUrl(output, event.payload.url, deployStamp, org.slug);
+
+      if (quiet) {
+        process.stdout.write(`https://${event.payload.url}`);
+      }
 
       if (queuedSpinner === null) {
         queuedSpinner =


### PR DESCRIPTION
Switch back to outputting deployment url in `stdout`.