### PR TITLE
[examples] Remove outdated jekyll build section from README

### DIFF
--- a/examples/jekyll/README.md
+++ b/examples/jekyll/README.md
@@ -25,18 +25,3 @@ You can deploy your new Jekyll project with a single command from your terminal 
 ```shell
 $ now
 ```
-
-### Build Command
-
-The default build command is `jekyll build`.
-
-If you wish to change the build command, add a `package.json` file with the following:
-
-```json
-{
-  "private": true,
-  "scripts": {
-    "build": "jekyll build"
-  }
-}
-```


### PR DESCRIPTION
We used to require a `package.json` but we have since introduced [Advanced Project Settings](https://zeit.co/blog/advanced-project-settings) which will ask the user for a build command during the first deploy.