### PR TITLE
[now-python] Fix path segments with square brackets

### DIFF
--- a/packages/now-python/now_init.py
+++ b/packages/now-python/now_init.py
@@ -5,7 +5,7 @@ import json
 import inspect
 from importlib import util
 
-
+# Import relative path https://stackoverflow.com/a/67692/266535
 __now_spec = util.spec_from_file_location("__NOW_HANDLER_MODULE_NAME", "./__NOW_HANDLER_ENTRYPOINT")
 __now_module = util.module_from_spec(__now_spec)
 __now_spec.loader.exec_module(__now_module)
@@ -28,7 +28,7 @@ if 'handler' in __now_variables or 'Handler' in __now_variables:
     base = __now_module.handler if ('handler' in __now_variables) else  __now_module.Handler
     if not issubclass(base, BaseHTTPRequestHandler):
         print('Handler must inherit from BaseHTTPRequestHandler')
-        print('See the docs https://zeit.co/docs/v2/deployments/official-builders/python-now-python')
+        print('See the docs https://zeit.co/docs/runtimes#advanced-usage/advanced-python-usage')
         exit(1)
 
     print('using HTTP Handler')
@@ -279,6 +279,6 @@ elif 'app' in __now_variables:
             return response
 
 else:
-    print('Missing variable `handler` or `app` in file __now_module.py')
-    print('See the docs https://zeit.co/docs/v2/deployments/official-builders/python-now-python')
+    print('Missing variable `handler` or `app` in file "__NOW_HANDLER_ENTRYPOINT".')
+    print('See the docs https://zeit.co/docs/runtimes#advanced-usage/advanced-python-usage')
     exit(1)

--- a/packages/now-python/now_init.py
+++ b/packages/now-python/now_init.py
@@ -3,9 +3,13 @@ from http.server import BaseHTTPRequestHandler
 import base64
 import json
 import inspect
+from importlib import util
 
-import __NOW_HANDLER_FILENAME
-__now_variables = dir(__NOW_HANDLER_FILENAME)
+
+__now_spec = util.spec_from_file_location("__NOW_HANDLER_MODULE_NAME", "./__NOW_HANDLER_ENTRYPOINT")
+__now_module = util.module_from_spec(__now_spec)
+__now_spec.loader.exec_module(__now_module)
+__now_variables = dir(__now_module)
 
 
 def format_headers(headers, decode=False):
@@ -21,7 +25,7 @@ def format_headers(headers, decode=False):
 
 
 if 'handler' in __now_variables or 'Handler' in __now_variables:
-    base = __NOW_HANDLER_FILENAME.handler if ('handler' in __now_variables) else  __NOW_HANDLER_FILENAME.Handler
+    base = __now_module.handler if ('handler' in __now_variables) else  __now_module.Handler
     if not issubclass(base, BaseHTTPRequestHandler):
         print('Handler must inherit from BaseHTTPRequestHandler')
         print('See the docs https://zeit.co/docs/v2/deployments/official-builders/python-now-python')
@@ -74,8 +78,8 @@ if 'handler' in __now_variables or 'Handler' in __now_variables:
 
 elif 'app' in __now_variables:
     if (
-        not inspect.iscoroutinefunction(__NOW_HANDLER_FILENAME.app) and
-        not inspect.iscoroutinefunction(__NOW_HANDLER_FILENAME.app.__call__)
+        not inspect.iscoroutinefunction(__now_module.app) and
+        not inspect.iscoroutinefunction(__now_module.app.__call__)
     ):
         print('using Web Server Gateway Interface (WSGI)')
         import sys
@@ -136,7 +140,7 @@ elif 'app' in __now_variables:
                 if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
                     environ[key] = value
 
-            response = Response.from_app(__NOW_HANDLER_FILENAME.app, environ)
+            response = Response.from_app(__now_module.app, environ)
 
             return_dict = {
                 'statusCode': response.status_code,
@@ -271,10 +275,10 @@ elif 'app' in __now_variables:
             }
 
             asgi_cycle = ASGICycle(scope)
-            response = asgi_cycle(__NOW_HANDLER_FILENAME.app, body)
+            response = asgi_cycle(__now_module.app, body)
             return response
 
 else:
-    print('Missing variable `handler` or `app` in file __NOW_HANDLER_FILENAME.py')
+    print('Missing variable `handler` or `app` in file __now_module.py')
     print('See the docs https://zeit.co/docs/v2/deployments/official-builders/python-now-python')
     exit(1)

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -155,13 +155,10 @@ export const build = async ({
   // will be used on `from $here import handler`
   // for example, `from api.users import handler`
   debug('Entrypoint is', entrypoint);
-  const userHandlerFilePath = entrypoint
-    .replace(/\//g, '.')
-    .replace(/\.py$/, '');
-  const nowHandlerPyContents = originalNowHandlerPyContents.replace(
-    /__NOW_HANDLER_FILENAME/g,
-    userHandlerFilePath
-  );
+  const moduleName = entrypoint.replace(/\//g, '.').replace(/\.py$/, '');
+  const nowHandlerPyContents = originalNowHandlerPyContents
+    .replace(/__NOW_HANDLER_MODULE_NAME/g, moduleName)
+    .replace(/__NOW_HANDLER_ENTRYPOINT/g, entrypoint);
 
   // in order to allow the user to have `server.py`, we need our `server.py` to be called
   // somethig else

--- a/packages/now-python/test/fixtures/27-square-brackets/api/[hello].py
+++ b/packages/now-python/test/fixtures/27-square-brackets/api/[hello].py
@@ -1,0 +1,11 @@
+from http.server import BaseHTTPRequestHandler
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write('hello:RANDOMNESS_PLACEHOLDER'.encode())
+        return

--- a/packages/now-python/test/fixtures/27-square-brackets/now.json
+++ b/packages/now-python/test/fixtures/27-square-brackets/now.json
@@ -2,6 +2,6 @@
   "version": 2,
   "builds": [{ "src": "api/[hello].py", "use": "@now/python" }],
   "probes": [
-    { "path": "/[hello].py", "mustContain": "hello:RANDOMNESS_PLACEHOLDER" }
+    { "path": "/api/[hello].py", "mustContain": "hello:RANDOMNESS_PLACEHOLDER" }
   ]
 }

--- a/packages/now-python/test/fixtures/27-square-brackets/now.json
+++ b/packages/now-python/test/fixtures/27-square-brackets/now.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/[hello].py", "use": "@now/python" }],
+  "probes": [
+    { "path": "/[hello].py", "mustContain": "hello:RANDOMNESS_PLACEHOLDER" }
+  ]
+}


### PR DESCRIPTION
Previously, python would fail when using [Path Segments](https://zeit.co/docs/v2/serverless-functions/introduction#path-segments) as seen in #3729.

This PR changes the import logic so that the entrypoint file is [imported as a relative file path](https://stackoverflow.com/a/67692/266535) instead of by module name. 
