### PR TITLE
[now-cli] Update ZEIT Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![now](https://assets.zeit.co/image/upload/v1542240976/repositories/now-cli/now-cli-repo-banner-v3.png)
+![now](https://assets.zeit.co/image/upload/v1581518533/repositories/now-cli/v4.png)
 
 [![CI Status](https://badgen.net/github/checks/zeit/now?label=CI)](https://github.com/zeit/now/actions?workflow=CI)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)

--- a/packages/now-cli/README.md
+++ b/packages/now-cli/README.md
@@ -1,4 +1,4 @@
-![now](https://assets.zeit.co/image/upload/v1542240976/repositories/now-cli/now-cli-repo-banner-v3.png)
+![now](https://assets.zeit.co/image/upload/v1581518533/repositories/now-cli/v4.png)
 
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)
 


### PR DESCRIPTION
This PR updates the logo to match https://zeit.co/home