### PR TITLE
[now-go] Fix `/api/go.sum` detection

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -182,6 +182,12 @@ Learn more: https://zeit.co/docs/v2/advanced/builders/#go
         const newFsPath = pathParts.join(sep);
         debug(`Moving api/go.mod to root: ${fsPath} to ${newFsPath}`);
         await move(fsPath, newFsPath, { overwrite: forceMove });
+        const oldSumPath = join(dirname(fsPath), 'go.sum');
+        const newSumPath = join(dirname(newFsPath), 'go.sum');
+        if (await pathExists(oldSumPath)) {
+          debug(`Moving api/go.sum to root: ${oldSumPath} to ${newSumPath}`);
+          await move(oldSumPath, newSumPath, { overwrite: forceMove });
+        }
         break;
       }
     }

--- a/packages/now-go/test/fixtures/17-go-mod-api/api/go.mod
+++ b/packages/now-go/test/fixtures/17-go-mod-api/api/go.mod
@@ -1,3 +1,5 @@
 module github.com/zeit/does-not-exist
 
 go 1.13
+
+require github.com/dhruvbird/go-cowsay v0.0.0-20131019225157-6fd7bd0281c0 // indirect

--- a/packages/now-go/test/fixtures/17-go-mod-api/api/go.sum
+++ b/packages/now-go/test/fixtures/17-go-mod-api/api/go.sum
@@ -1,0 +1,2 @@
+github.com/dhruvbird/go-cowsay v0.0.0-20131019225157-6fd7bd0281c0 h1:t/CyPFyQ/Y5zHoxCd7hZ+15fOYIwKPsTxyqTmBlA2A8=
+github.com/dhruvbird/go-cowsay v0.0.0-20131019225157-6fd7bd0281c0/go.mod h1:Pj0EWCBFS61kh+c6d7rUu6496j3XEAL/QnDQ3D0V8Js=


### PR DESCRIPTION
Follow up to #3793 

The `go.mod` and `go.sum` file must both be moved.