### PR TITLE
[now-next] Make sure to 404 and clear cache header for invalid _next requests

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -459,6 +459,20 @@ export const build = async ({
         // folder
         { handle: 'filesystem' },
 
+        // This needs to come directly after handle: filesystem to make sure to
+        // 404 and clear the cache header for _next requests
+        {
+          src: path.join(
+            '/',
+            entryDirectory,
+            '_next/static/(?:[^/]+/pages|chunks|runtime|css|media)/.+'
+          ),
+          headers: {
+            'cache-control': '',
+          },
+          status: 404,
+        },
+
         ...rewrites,
         // Dynamic routes
         // TODO: do we want to do this?: ...dynamicRoutes,
@@ -1042,6 +1056,20 @@ export const build = async ({
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },
+
+      // This needs to come directly after handle: filesystem to make sure to
+      // 404 and clear the cache header for _next requests
+      {
+        src: path.join(
+          '/',
+          entryDirectory,
+          '_next/static/(?:[^/]+/pages|chunks|runtime|css|media)/.+'
+        ),
+        headers: {
+          'cache-control': '',
+        },
+        status: 404,
+      },
 
       ...rewrites,
       // Dynamic routes

--- a/packages/now-next/test/fixtures/01-cache-headers/now.json
+++ b/packages/now-next/test/fixtures/01-cache-headers/now.json
@@ -7,6 +7,16 @@
       "responseHeaders": {
         "cache-control": "public,max-age=31536000,immutable"
       }
+    },
+    {
+      "path": "/_next/static/invalid-build-id/pages/index.js",
+      "notResponseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
+    },
+    {
+      "path": "/_next/static/invalid-build-id/pages/non-existent.js",
+      "mustNotContain": "final route"
     }
   ]
 }

--- a/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/[another]/[final]/index.js
+++ b/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/[another]/[final]/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi from final route'

--- a/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/[another]/index.js
+++ b/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/[another]/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi from another route'

--- a/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/index.js
+++ b/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/[deployment]/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi from deployment route'

--- a/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/index.js
+++ b/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/[project]/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi from project route'

--- a/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/index.js
+++ b/packages/now-next/test/fixtures/01-cache-headers/pages/[team]/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi from team route'

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -163,6 +163,21 @@ async function testDeployment(
           );
         }
       });
+    } else if (probe.notResponseHeaders) {
+      Object.keys(probe.notResponseHeaders).forEach(header => {
+        const headerValue = resp.headers.get(header);
+        const expected = probe.notResponseHeaders[header];
+
+        if (headerValue === expected) {
+          const headers = Array.from(resp.headers.entries())
+            .map(([k, v]) => `  ${k}=${v}`)
+            .join('\n');
+
+          throw new Error(
+            `Page ${probeUrl} invalid page header ${header}.\n\n Did not expect: ${header}=${expected}.\nBut got ${headers}`
+          );
+        }
+      });
     } else if (!probe.status) {
       assert(false, 'probe must have a test condition');
     }


### PR DESCRIPTION
This handles an edge case where deeply nested dynamic routes were handling `_next` 404s that were cached forever since the immutable header we set isn't cleared after not matching on the filesystem.

I updated our cache-header fixture to check for this edge case also to make sure we don't regress on this