### PR TITLE
[tests] Fix builder debug flag

### DIFF
--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -61,9 +61,7 @@ async function testDeployment(
     if (!nowJson.build.env) {
       nowJson.build.env = {};
     }
-    nowJson.build.env = {
-      NOW_BUILDER_DEBUG: process.env.NOW_BUILDER_DEBUG,
-    };
+    nowJson.build.env.NOW_BUILDER_DEBUG = process.env.NOW_BUILDER_DEBUG;
   }
 
   for (const build of nowJson.builds) {


### PR DESCRIPTION
When testing, you can set `NOW_BUILDER_DEBUG=1` to print verbose logs from builders.

However, this was causing some tests to fail that depended on a build environment variable.

This PR fixes the assignment so that it preserves the environment variables from the tests by adding `NOW_BUILDER_DEBUG` instead of replacing.