### PR TITLE
[now-routing-utils] Update to not pass used segments in redirect query

### DIFF
--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -49,7 +49,7 @@ export function convertRedirects(
 ): Route[] {
   return redirects.map(r => {
     const { src, segments } = sourceToRegex(r.source);
-    const loc = replaceSegments(segments, r.destination);
+    const loc = replaceSegments(segments, r.destination, true);
     const route: Route = {
       src,
       headers: { Location: loc },
@@ -137,7 +137,11 @@ export function sourceToRegex(
   return { src: r.source, segments };
 }
 
-function replaceSegments(segments: string[], destination: string): string {
+function replaceSegments(
+  segments: string[],
+  destination: string,
+  isRedirect?: boolean
+): string {
   const parsedDestination = parseUrl(destination, true);
   delete parsedDestination.href;
   delete parsedDestination.path;
@@ -169,6 +173,14 @@ function replaceSegments(segments: string[], destination: string): string {
     }
 
     for (const [name, value] of Object.entries(indexes)) {
+      const segmentRegex = new RegExp(`\\${value}(?!\\d)`);
+      if (isRedirect && segmentRegex.test(pathname + (hash || ''))) {
+        // Don't add segment to query if used in destination
+        // and it's a redirect so that we don't pollute the query
+        // with unwanted values
+        continue;
+      }
+
       if (!(name in query)) {
         query[name] = value;
       }

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -174,7 +174,7 @@ function replaceSegments(
 
     for (const [name, value] of Object.entries(indexes)) {
       const segmentRegex = new RegExp(`\\${value}(?!\\d)`);
-      if (isRedirect && segmentRegex.test(pathname + (hash || ''))) {
+      if (isRedirect && new RegExp(`\\${value}(?!\\d)`).test(pathname + (hash || ''))) {
         // Don't add segment to query if used in destination
         // and it's a redirect so that we don't pollute the query
         // with unwanted values

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -173,8 +173,10 @@ function replaceSegments(
     }
 
     for (const [name, value] of Object.entries(indexes)) {
-      const segmentRegex = new RegExp(`\\${value}(?!\\d)`);
-      if (isRedirect && new RegExp(`\\${value}(?!\\d)`).test(pathname + (hash || ''))) {
+      if (
+        isRedirect &&
+        new RegExp(`\\${value}(?!\\d)`).test(pathname + (hash || ''))
+      ) {
         // Don't add segment to query if used in destination
         // and it's a redirect so that we don't pollute the query
         // with unwanted values

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -216,17 +216,17 @@ test('convertRedirects', () => {
     },
     {
       src: '^\\/old(?:\\/([^\\/]+?))\\/path$',
-      headers: { Location: '/new/path/$1?segment=$1' },
+      headers: { Location: '/new/path/$1' },
       status: 308,
     },
     {
       src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
-      headers: { Location: '/catchall/$1/?hello=$1' },
+      headers: { Location: '/catchall/$1/' },
       status: 308,
     },
     {
       src: '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))$',
-      headers: { Location: '/another-catch/$1/?hello=$1' },
+      headers: { Location: '/another-catch/$1/' },
       status: 308,
     },
     {
@@ -241,7 +241,7 @@ test('convertRedirects', () => {
     },
     {
       src: '^\\/hello(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
-      headers: { Location: '/something?world=$1#$1' },
+      headers: { Location: '/something#$1' },
       status: 308,
     },
   ];


### PR DESCRIPTION
This updates to not pass segments already used in a redirect's destination query since these values are most likely unwanted and can still be manually added if desired. This change does not affect rewrites and we still pass through all segments in the query