### PR TITLE
[now-next] Add Bypass Token to Next.js Builder

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -948,12 +948,14 @@ export const build = async ({
           lambda,
           fallback: htmlFsRef,
           group: prerenderGroup,
+          bypassToken: prerenderManifest.bypassToken,
         });
         prerenders[outputPathData] = new Prerender({
           expiration: initialRevalidate,
           lambda,
           fallback: jsonFsRef,
           group: prerenderGroup,
+          bypassToken: prerenderManifest.bypassToken,
         });
 
         ++prerenderGroup;

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -614,6 +614,8 @@ export async function createLambdaFromPseudoLayers({
 }
 
 export type NextPrerenderedRoutes = {
+  bypassToken: string | null;
+
   routes: {
     [route: string]: {
       initialRevalidate: number | false;
@@ -714,7 +716,7 @@ export async function getPrerenderManifest(
     .catch(() => false);
 
   if (!hasManifest) {
-    return { routes: {}, lazyRoutes: {} };
+    return { routes: {}, lazyRoutes: {}, bypassToken: null };
   }
 
   const manifest: {
@@ -734,6 +736,9 @@ export async function getPrerenderManifest(
         dataRouteRegex: string;
       };
     };
+    preview?: {
+      previewModeId: string;
+    };
   } = JSON.parse(await fs.readFile(pathPrerenderManifest, 'utf8'));
 
   switch (manifest.version) {
@@ -741,7 +746,12 @@ export async function getPrerenderManifest(
       const routes = Object.keys(manifest.routes);
       const lazyRoutes = Object.keys(manifest.dynamicRoutes);
 
-      const ret: NextPrerenderedRoutes = { routes: {}, lazyRoutes: {} };
+      const ret: NextPrerenderedRoutes = {
+        routes: {},
+        lazyRoutes: {},
+        bypassToken:
+          (manifest.preview && manifest.preview.previewModeId) || null,
+      };
 
       routes.forEach(route => {
         const {
@@ -778,7 +788,7 @@ export async function getPrerenderManifest(
       return ret;
     }
     default: {
-      return { routes: {}, lazyRoutes: {} };
+      return { routes: {}, lazyRoutes: {}, bypassToken: null };
     }
   }
 }

--- a/packages/now-next/tsconfig.json
+++ b/packages/now-next/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "esModuleInterop": true,
     "lib": ["esnext"],
-    "target": "esnext",
+    "target": "es2018",
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": false,


### PR DESCRIPTION
This pull request adds the bypass token to returned `Prerender` output objects.

There's no tests as this doesn't exist in production yet.