### PR TITLE
[now-python] Fix path segments in `now dev`

### DIFF
--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -35,21 +35,17 @@ export async function downloadFilesInWorkPath({
   entrypoint,
   workPath,
   files,
-  meta,
-  config,
+  meta = {},
 }: BuildOptions) {
   debug('Downloading user files...');
   let downloadedFiles = await download(files, workPath, meta);
-  if (meta && meta.isDev) {
-    let base = null;
-
-    if (config && config.zeroConfig) {
-      base = workPath;
-    } else {
-      base = dirname(downloadedFiles['now.json'].fsPath);
-    }
-
-    const destNow = join(base, '.now', 'cache', basename(entrypoint, '.py'));
+  if (meta.isDev) {
+    const destNow = join(
+      workPath,
+      '.now',
+      'cache',
+      basename(entrypoint, '.py')
+    );
     await download(downloadedFiles, destNow);
     downloadedFiles = await glob('**', destNow);
     workPath = destNow;

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -147,14 +147,15 @@ export const build = async ({
 
   const originalPyPath = join(__dirname, '..', 'now_init.py');
   const originalNowHandlerPyContents = await readFile(originalPyPath, 'utf8');
-
-  // will be used on `from $here import handler`
-  // for example, `from api.users import handler`
   debug('Entrypoint is', entrypoint);
   const moduleName = entrypoint.replace(/\//g, '.').replace(/\.py$/, '');
+  // Since `now dev` renames source files, we must reference the original
+  const suffix = meta.isDev && !entrypoint.endsWith('.py') ? '.py' : '';
+  const entrypointWithSuffix = `${entrypoint}${suffix}`;
+  debug('Entrypoint with suffix is', entrypointWithSuffix);
   const nowHandlerPyContents = originalNowHandlerPyContents
     .replace(/__NOW_HANDLER_MODULE_NAME/g, moduleName)
-    .replace(/__NOW_HANDLER_ENTRYPOINT/g, entrypoint);
+    .replace(/__NOW_HANDLER_ENTRYPOINT/g, entrypointWithSuffix);
 
   // in order to allow the user to have `server.py`, we need our `server.py` to be called
   // somethig else


### PR DESCRIPTION
The combination of file renaming and brackets doesn't work well for python imports so we need too add the file extension back before importing the python module.

I also simplified the `.now/cache/folder` logic because it should be the same whether `builds` is defined or not (aka zero config).