### PR TITLE
[now-go] Fix path segments in `now dev`

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -41,7 +41,8 @@ async function initPrivateGit(credentials: string) {
  * Since `go build` does not support files that begin with a square bracket,
  * we must rename to something temporary to support Path Segments.
  * The output file is not renamed because v3 builders can't rename outputs
- * which works great for this feature.
+ * which works great for this feature. We also need to add a suffix during `now dev`
+ * since the entrypoint is already stripped of its suffix before build() is called.
  */
 async function getRenamedEntrypoint(
   entrypoint: string,
@@ -50,7 +51,6 @@ async function getRenamedEntrypoint(
 ) {
   const filename = basename(entrypoint);
   if (filename.startsWith('[')) {
-    // Suffix is necessary since `now dev` renames source files, we must reference the original
     const suffix = meta.isDev && !entrypoint.endsWith('.go') ? '.go' : '';
     const newEntrypoint = entrypoint.replace('/[', '/now-bracket[') + suffix;
     const file = files[entrypoint];

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -132,7 +132,7 @@ Learn more: https://zeit.co/docs/v2/advanced/builders/#go
   const parsedAnalyzed = JSON.parse(analyzed) as Analyzed;
 
   if (meta.isDev) {
-    // Create cache so Go rebuilds fast with `now dev
+    // Create cache so Go rebuilds fast with `now dev`
     goPath = join(
       workPath,
       '.now',

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -50,6 +50,7 @@ async function getRenamedEntrypoint(
 ) {
   const filename = basename(entrypoint);
   if (filename.startsWith('[')) {
+    // Suffix is necessary since `now dev` renames source files, we must reference the original
     const suffix = meta.isDev && !entrypoint.endsWith('.go') ? '.go' : '';
     const newEntrypoint = entrypoint.replace('/[', '/now-bracket[') + suffix;
     const file = files[entrypoint];

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -126,26 +126,16 @@ Learn more: https://zeit.co/docs/v2/advanced/builders/#go
   const parsedAnalyzed = JSON.parse(analyzed) as Analyzed;
 
   if (meta.isDev) {
-    let base = null;
-
-    if (config && config.zeroConfig) {
-      base = workPath;
-    } else {
-      base = dirname(downloadedFiles['now.json'].fsPath);
-    }
-
-    const destNow = join(
-      base,
+    // Create cache so Go rebuilds fast with `now dev
+    goPath = join(
+      workPath,
       '.now',
       'cache',
-      basename(entrypoint, '.go'),
-      'src',
-      'lambda'
+      'now-go',
+      basename(entrypoint, '.go')
     );
-    // this will ensure Go rebuilt fast
-    goPath = join(base, '.now', 'cache', basename(entrypoint, '.go'));
+    const destNow = join(goPath, 'src', 'lambda');
     await download(downloadedFiles, destNow);
-
     downloadedFiles = await glob('**', destNow);
     downloadPath = destNow;
   }

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -12,6 +12,7 @@ import {
   shouldServe,
   Files,
   debug,
+  Meta,
 } from '@now/build-utils';
 
 import { createGo, getAnalyzedEntrypoint, OUT_EXTENSION } from './go-helpers';
@@ -42,10 +43,15 @@ async function initPrivateGit(credentials: string) {
  * The output file is not renamed because v3 builders can't rename outputs
  * which works great for this feature.
  */
-async function getRenamedEntrypoint(entrypoint: string, files: Files) {
+async function getRenamedEntrypoint(
+  entrypoint: string,
+  files: Files,
+  meta: Meta
+) {
   const filename = basename(entrypoint);
   if (filename.startsWith('[')) {
-    const newEntrypoint = entrypoint.replace('/[', '/now-bracket[');
+    const suffix = meta.isDev && !entrypoint.endsWith('.go') ? '.go' : '';
+    const newEntrypoint = entrypoint.replace('/[', '/now-bracket[') + suffix;
     const file = files[entrypoint];
     delete files[entrypoint];
     files[newEntrypoint] = file;
@@ -81,7 +87,7 @@ We highly recommend you leverage Go Modules in your project.
 Learn more: https://github.com/golang/go/wiki/Modules
 `);
   }
-  entrypoint = await getRenamedEntrypoint(entrypoint, files);
+  entrypoint = await getRenamedEntrypoint(entrypoint, files, meta);
   const entrypointArr = entrypoint.split(sep);
 
   // eslint-disable-next-line prefer-const


### PR DESCRIPTION
The combination of file renaming and brackets doesn't work well for go build so we need to add the file extension back before building.

I also simplified the `.now/cache/folder` logic because it should be the same whether `builds` is defined or not (aka zero config).