### PR TITLE
[examples] Fix Go build if Windows Git is configured to checkout CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Ignore test fixtures in GitHub Languages
 # See https://github.com/github/linguist#vendored-code
 packages/*/test/* linguist-vendored
+
+# Go build fails with Windows line endings.
+*.go text eol=lf
+go.mod text eol=lf


### PR DESCRIPTION
Fixes #3820 