### PR TITLE
[now-client] Fix root directory with trailing slash

### DIFF
--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -2,7 +2,7 @@ import { DeploymentFile } from './hashes';
 import { parse as parseUrl } from 'url';
 import { FetchOptions } from '@zeit/fetch';
 import { nodeFetch, zeitFetch } from './fetch';
-import { join, sep } from 'path';
+import { join, sep, relative } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
 import { pkgVersion } from '../pkg';
@@ -191,9 +191,10 @@ export const prepareFiles = (
 
         if (clientOptions.isDirectory) {
           // Directory
-          fileName = clientOptions.path
-            ? name.substring(clientOptions.path.length + 1)
-            : name;
+          fileName =
+            typeof clientOptions.path === 'string'
+              ? relative(clientOptions.path, name)
+              : name;
         } else {
           // Array of files or single file
           const segments = name.split(sep);

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -92,6 +92,7 @@ describe('create v2 deployment', () => {
       {
         token,
         path: path.resolve(__dirname, 'fixtures', 'v2-file-permissions'),
+        skipAutoDetectionConfirmation: true,
       },
       {
         name: 'now-client-tests-v2',
@@ -129,6 +130,7 @@ describe('create v2 deployment', () => {
       {
         token,
         path: path.resolve(__dirname, 'fixtures', 'nowignore'),
+        skipAutoDetectionConfirmation: true,
       },
       {
         name: 'now-client-tests-v2',

--- a/packages/now-client/tests/create-deployment.test.ts
+++ b/packages/now-client/tests/create-deployment.test.ts
@@ -87,6 +87,7 @@ describe('create v2 deployment', () => {
   });
 
   it('will create a v2 deployment with correct file permissions', async () => {
+    let error = null;
     for await (const event of createDeployment(
       {
         token,
@@ -104,8 +105,15 @@ describe('create v2 deployment', () => {
       if (event.type === 'ready') {
         deployment = event.payload;
         break;
+      } else if (event.type === 'error') {
+        error = event.payload;
+        console.error(error.message);
+        break;
       }
     }
+
+    expect(error).toBe(null);
+    expect(deployment.readyState).toEqual('READY');
 
     const url = `https://${deployment.url}/api/index.js`;
     console.log('testing url ' + url);
@@ -116,6 +124,7 @@ describe('create v2 deployment', () => {
   });
 
   it('will create a v2 deployment and ignore files specified in .nowignore', async () => {
+    let error = null;
     for await (const event of createDeployment(
       {
         token,
@@ -132,10 +141,16 @@ describe('create v2 deployment', () => {
     )) {
       if (event.type === 'ready') {
         deployment = event.payload;
-        expect(deployment.readyState).toEqual('READY');
+        break;
+      } else if (event.type === 'error') {
+        error = event.payload;
+        console.error(error.message);
         break;
       }
     }
+
+    expect(error).toBe(null);
+    expect(deployment.readyState).toEqual('READY');
 
     const index = await fetch_(`https://${deployment.url}`);
     expect(index.status).toBe(200);


### PR DESCRIPTION
There was a bug in `now-client` when deploying a directory that ends with a slash, for example `/Users/styfle/Code/myapp/` instead of the usual `/Users/styfle/Code/myapp`.

This never affected `now-cli` until we added support for defining the `rootDirectory` which allows the user to type whatever they wish in the Project Settings.

The fix is to use `path.relative()` instead of substring.