### PR TITLE
Rename zeit.co/new → zeit.co/import

### DIFF
--- a/.github/EXAMPLE_README_TEMPLATE.md
+++ b/.github/EXAMPLE_README_TEMPLATE.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Name](site-link) site that can be deploy
 
 Deploy your own [Name] project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now-examples/tree/master/example-directory)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now-examples/tree/master/example-directory)
 
 ### How We Created This Example
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ now             # Deploy to the cloud
 
 ## Documentation
 
-For details on how to use Now CLI, check out our [documentation](https://zeit.co/docs).
+For details on how to use Now CLI, check out our [documentation](https://zeit.co/docs/now-cli).
 
 ## Caught a Bug?
 

--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of an [AMP](https://amp.dev/) site that can be
 
 Deploy your own AMP project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/amp)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/amp)
 
 _Live Example: https://amp.now-examples.now.sh_
 

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of an [Angular](https://angular.io/) app that 
 
 Deploy your own Angular project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/angular)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/angular)
 
 _Live Example: https://angular.now-examples.now.sh_
 

--- a/examples/assemble/README.md
+++ b/examples/assemble/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Assemble](http://assemble.io/) app that 
 
 Deploy your own Assemble project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/assemble)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/assemble)
 
 _Live Example: https://assemble.now-examples.now.sh_
 

--- a/examples/aurelia/README.md
+++ b/examples/aurelia/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of an [Aurelia](https://aurelia.io/) app that 
 
 Deploy your own Aurelia project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/aurelia)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/aurelia)
 
 _Live Example: https://aurelia.now-examples.now.sh_
 

--- a/examples/brunch/README.md
+++ b/examples/brunch/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Brunch](https://brunch.io/) site that ca
 
 Deploy your own Brunch project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/brunch)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/brunch)
 
 _Live Example: https://brunch.now-examples.now.sh_
 

--- a/examples/charge/README.md
+++ b/examples/charge/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Charge.js](https://charge.js.org/) site 
 
 Deploy your own Charge.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/charge)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/charge)
 
 _Live Example: https://charge.now-examples.now.sh_
 

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [React](https://reactjs.org/) app with [S
 
 Deploy your own React project, along with Serverless Functions, with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/create-react-app-functions)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/create-react-app-functions)
 
 _Live Example: https://create-react-app.now-examples.now.sh/_
 

--- a/examples/custom-build/README.md
+++ b/examples/custom-build/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of using a Custom Build script that can be dep
 
 Deploy your own Custom Built project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/custom-build)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/custom-build)
 
 _Live Example: https://custom-build.now-examples.now.sh_
 

--- a/examples/docusaurus/README.md
+++ b/examples/docusaurus/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Docusaurus](https://docusaurus.io/) site
 
 Deploy your own Docusaurus project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/docusaurus)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/docusaurus)
 
 _Live Example: https://docusaurus.now-examples.now.sh_
 

--- a/examples/docz/README.md
+++ b/examples/docz/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Docz](https://www.docz.site/) site that 
 
 Deploy your own Docz project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/docz)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/docz)
 
 _Live Example: https://docz.now-examples.now.sh_
 

--- a/examples/eleventy/README.md
+++ b/examples/eleventy/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Eleventy](https://www.11ty.io/) site tha
 
 Deploy your own Eleventy project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/eleventy)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/eleventy)
 
 _Live Example: https://eleventy.now-examples.now.sh_
 

--- a/examples/ember/README.md
+++ b/examples/ember/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of an [Ember](https://emberjs.com/) app that c
 
 Deploy your own Ember project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/ember)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/ember)
 
 _Live Example: https://ember.now-examples.now.sh_
 

--- a/examples/foundation/README.md
+++ b/examples/foundation/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Foundation](https://foundation.zurb.com/
 
 Deploy your own Foundation project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/foundation)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/foundation)
 
 _Live Example: https://foundation.now-examples.now.sh_
 

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Gatsby](https://www.gatsbyjs.org/) app w
 
 Deploy your own Gatsby project, along with Serverless Functions, with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/gatsby)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/gatsby)
 
 _Live Example: https://gatsby.now-examples.now.sh_
 

--- a/examples/gridsome/README.md
+++ b/examples/gridsome/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Gridsome](https://gridsome.org/) app tha
 
 Deploy your own Gridsome project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/gridsome)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/gridsome)
 
 _Live Example: https://gridsome.now-examples.now.sh_
 

--- a/examples/hexo/README.md
+++ b/examples/hexo/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Hexo](https://hexo.io/) site that can be
 
 Deploy your own Hexo project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/hexo)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/hexo)
 
 _Live Example: https://hexo.now-examples.now.sh_
 

--- a/examples/hugo/README.md
+++ b/examples/hugo/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Hugo](https://gohugo.io/) app that can b
 
 Deploy your own Hugo project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/hugo)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/hugo)
 
 _Live Example: https://hugo.now-examples.now.sh_
 

--- a/examples/hyperapp/README.md
+++ b/examples/hyperapp/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [HyperApp](https://github.com/jorgebucara
 
 Deploy your own HyperApp project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/hyperapp)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/hyperapp)
 
 _Live Example: https://hyperapp.now-examples.now.sh_
 

--- a/examples/ionic-react/readme.md
+++ b/examples/ionic-react/readme.md
@@ -6,7 +6,7 @@ This directory is a brief example of an [Ionic React](https://ionicframework.com
 
 Deploy your own Ionic React project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/ionic-react)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/ionic-react)
 
 _Live Example: https://ionic-react.now-examples.now.sh_
 

--- a/examples/jekyll/README.md
+++ b/examples/jekyll/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Jekyll](https://jekyllrb.com/) site that
 
 Deploy your own Jekyll project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/jekyll)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/jekyll)
 
 _Live Example: https://jekyll.now-examples.now.sh_
 

--- a/examples/marko/README.md
+++ b/examples/marko/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Marko.js](https://markojs.com/) app that
 
 Deploy your own Marko.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/marko)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/marko)
 
 _Live Example: https://marko.now-examples.now.sh_
 

--- a/examples/mdx-deck/README.md
+++ b/examples/mdx-deck/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [mdx-deck](https://github.com/jxnblk/mdx-
 
 Deploy your own mdx-deck project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/mdx-deck)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/mdx-deck)
 
 _Live Example: https://mdx-deck.now-examples.now.sh_
 

--- a/examples/metalsmith/README.md
+++ b/examples/metalsmith/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Metalsmith](https://metalsmith.io/) app 
 
 Deploy your own Metalsmith project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/metalsmith)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/metalsmith)
 
 _Live Example: https://metalsmith.now-examples.now.sh_
 

--- a/examples/middleman/README.md
+++ b/examples/middleman/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Middleman](https://middlemanapp.com/) si
 
 Deploy your own Middleman project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/middleman)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/middleman)
 
 _Live Example: https://middleman.now-examples.now.sh_
 

--- a/examples/mithril/README.md
+++ b/examples/mithril/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Mithril](https://mithril.js.org/) app th
 
 Deploy your own Mithril project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/mithril)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/mithril)
 
 _Live Example: https://mithril.now-examples.now.sh_
 

--- a/examples/mkdocs/README.md
+++ b/examples/mkdocs/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [MkDocs](https://www.mkdocs.org/) site th
 
 Deploy your own MkDocs project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/mkdocs)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/mkdocs)
 
 _Live Example: https://mkdocs.now-examples.now.sh_
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Next.js](https://nextjs.org) app that ca
 
 Deploy your own Next.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/nextjs)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/nextjs)
 
 _Live Example: https://nextjs.now-examples.now.sh_
 

--- a/examples/nuxtjs/README.md
+++ b/examples/nuxtjs/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Nuxt.js](https://nuxtjs.org) app that ca
 
 Deploy your own Nuxt.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/nuxtjs)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/nuxtjs)
 
 _Live Example: https://nuxtjs.now-examples.now.sh_
 

--- a/examples/pelican/README.md
+++ b/examples/pelican/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Pelican](https://docs.getpelican.com/en/
 
 Deploy your own Pelican project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/pelican)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/pelican)
 
 _Live Example: https://pelican.now-examples.now.sh_
 

--- a/examples/polymer/README.md
+++ b/examples/polymer/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Polymer](https://www.polymer-project.org
 
 Deploy your own Polymer project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/polymer)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/polymer)
 
 _Live Example: https://polymer.now-examples.now.sh_
 

--- a/examples/preact/README.md
+++ b/examples/preact/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Preact](https://preactjs.com/) app that 
 
 Deploy your own Preact project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/preact)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/preact)
 
 _Live Example: https://preact.now-examples.now.sh_
 

--- a/examples/riot/README.md
+++ b/examples/riot/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Riot.js](https://riot.js.org/) app that 
 
 Deploy your own Riot.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/riot)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/riot)
 
 _Live Example: https://riot.now-examples.now.sh_
 

--- a/examples/saber/README.md
+++ b/examples/saber/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Saber](https://saber.land) site that can
 
 Deploy your own Saber project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/saber)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/saber)
 
 _Live Example: https://saber.now-examples.now.sh_
 

--- a/examples/sapper/README.md
+++ b/examples/sapper/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Sapper](https://sapper.svelte.dev/) app 
 
 Deploy your own Sapper project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/sapper)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/sapper)
 
 _Live Example: https://sapper.now-examples.now.sh_
 

--- a/examples/stencil/readme.md
+++ b/examples/stencil/readme.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Stencil](https://stenciljs.com/) app tha
 
 Deploy your own Stencil project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/stencil)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/stencil)
 
 _Live Example: https://stencil.now-examples.now.sh_
 

--- a/examples/storybook/README.md
+++ b/examples/storybook/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Storybook](https://storybook.js.org/) ap
 
 Deploy your own Storybook project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/storybook)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/storybook)
 
 _Live Example: https://storybook.now-examples.now.sh_
 

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Svelte](https://svelte.dev/) app with [S
 
 Deploy your own Svelte project, along with Serverless Functions, with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/svelte)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/svelte)
 
 _Live Example: https://svelte.now-examples.now.sh_
 

--- a/examples/umijs/README.md
+++ b/examples/umijs/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [UmiJS](https://umijs.org/) app that can 
 
 Deploy your own UmiJS project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/umijs)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/umijs)
 
 _Live Example: https://umijs.now-examples.now.sh_
 

--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a vanilla site that can be deployed with ZE
 
 Deploy your own vanilla website, along with Serverless Functions, with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/vanilla)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/vanilla)
 
 _Live Example: https://vanilla.now-examples.now.sh_
 

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Vue.js](https://vuejs.org/) app that can
 
 Deploy your own Vue.js project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/vue)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/vue)
 
 _Live Example: https://vue.now-examples.now.sh_
 

--- a/examples/vuepress/README.md
+++ b/examples/vuepress/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [VuePress](https://vuepress.vuejs.org/) a
 
 Deploy your own VuePress project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/vuepress)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/vuepress)
 
 _Live Example: https://vuepress.now-examples.now.sh_
 

--- a/examples/zola/README.md
+++ b/examples/zola/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Zola](https://www.getzola.org/) site tha
 
 Deploy your own Zola project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/zola)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/zola)
 
 _Live Example: https://zola.now-examples.now.sh_
 

--- a/packages/now-static-build/test/fixtures/21-docusaurus-with-framework/README.md
+++ b/packages/now-static-build/test/fixtures/21-docusaurus-with-framework/README.md
@@ -8,7 +8,7 @@ This directory is a brief example of a [Docusaurus](https://docusaurus.io/) site
 
 Deploy your own Docusaurus project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/docusaurus)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/docusaurus)
 
 _Live Example: https://docusaurus.now-examples.now.sh_
 

--- a/packages/now-static-build/test/fixtures/50-ionic-react/readme.md
+++ b/packages/now-static-build/test/fixtures/50-ionic-react/readme.md
@@ -6,7 +6,7 @@ This directory is a brief example of an [Ionic React](https://ionicframework.com
 
 Deploy your own Ionic React project with ZEIT Now.
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now/tree/master/examples/ionic-react)
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/zeit/now/tree/master/examples/ionic-react)
 
 _Live Example: https://ionic-react.now-examples.now.sh_
 

--- a/utils/run.js
+++ b/utils/run.js
@@ -85,7 +85,7 @@ async function main() {
 
   if (process.env.NOW_GITHUB_DEPLOYMENT) {
     execSync(
-      `rm -rf public && mkdir public && echo '<a href="https://zeit.co/new">https://zeit.co/new</a>' > public/output.html`
+      `rm -rf public && mkdir public && echo '<a href="https://zeit.co/import">https://zeit.co/import</a>' > public/output.html`
     );
   }
 }


### PR DESCRIPTION
We're replacing https://zei.co/new to https://zei.co/import - I did VSCode search and replace.

[PRODUCT-1248](https://zeit.atlassian.net/browse/PRODUCT-1248)