### PR TITLE
[now-next] Always Emit Prerenders

### DIFF
--- a/packages/now-next/test/fixtures/05-spr-support/now.json
+++ b/packages/now-next/test/fixtures/05-spr-support/now.json
@@ -13,7 +13,7 @@
       "path": "/forever",
       "status": 200,
       "responseHeaders": {
-        "x-now-cache": "MISS"
+        "x-now-cache": "PRERENDER"
       }
     },
     { "delay": 2000 },
@@ -113,7 +113,7 @@
       "path": "/_next/data/testing-build-id/forever.json",
       "status": 200,
       "responseHeaders": {
-        "x-now-cache": "MISS"
+        "x-now-cache": "/PRERENDER|HIT/"
       }
     },
     { "delay": 2000 },

--- a/packages/now-next/test/fixtures/18-ssg-fallback-support/now.json
+++ b/packages/now-next/test/fixtures/18-ssg-fallback-support/now.json
@@ -13,7 +13,7 @@
       "path": "/forever",
       "status": 200,
       "responseHeaders": {
-        "x-now-cache": "MISS"
+        "x-now-cache": "PRERENDER"
       }
     },
     { "delay": 2000 },
@@ -114,7 +114,7 @@
       "path": "/_next/data/testing-build-id/forever.json",
       "status": 200,
       "responseHeaders": {
-        "x-now-cache": "MISS"
+        "x-now-cache": "/PRERENDER|HIT/"
       }
     },
     { "delay": 2000 },


### PR DESCRIPTION
This ensures we always emit Prerender objects for bypass tokens.