### PR TITLE
Add zeit.ink URL for output directory error

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -54,8 +54,7 @@ function validateDistDir(distDir: string) {
   const isDirectory = () => statSync(distDir).isDirectory();
   const isEmpty = () => readdirSync(distDir).length === 0;
 
-  const link =
-    'https://zeit.co/docs/v2/platform/frequently-asked-questions#missing-public-directory';
+  const link = 'https://zeit.ink/OD';
 
   if (!exists()) {
     throw new NowBuildError({


### PR DESCRIPTION
Related to: https://github.com/zeit/docs/pull/1661

Uses `zeit.ink` url for the output error, which points to: https://docs-git-project-settings-docs.zeit.now.sh/docs/v2/platform/frequently-asked-questions#errors-related-to-output-directory - this documentation is rewritten to match new project settings.