### PR TITLE
[now-next] Add Support for Prerender v2

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -366,11 +366,13 @@ export const build = async ({
           // Load the /_next/data routes for both dynamic SSG and SSP pages.
           // These must be combined and sorted to prevent conflicts
           for (const dataRoute of routesManifest.dataRoutes) {
-            const ssgDataRoute = prerenderManifest.lazyRoutes[dataRoute.page];
+            const ssgDataRoute =
+              prerenderManifest.fallbackRoutes[dataRoute.page] ||
+              prerenderManifest.legacyBlockingRoutes[dataRoute.page];
 
             // we don't need to add routes for non-lazy SSG routes since
             // they have outputs which would override the routes anyways
-            if (prerenderManifest.routes[dataRoute.page]) {
+            if (prerenderManifest.staticRoutes[dataRoute.page]) {
               continue;
             }
 
@@ -669,9 +671,8 @@ export const build = async ({
       // Lazily prerendered routes have a fallback `.html` file on newer
       // Next.js versions so we need to also not treat it as a static page here.
       if (
-        prerenderManifest.routes[routeName] ||
-        (prerenderManifest.lazyRoutes[routeName] &&
-          prerenderManifest.lazyRoutes[routeName].fallback)
+        prerenderManifest.staticRoutes[routeName] ||
+        prerenderManifest.fallbackRoutes[routeName]
       ) {
         return;
       }
@@ -913,33 +914,49 @@ export const build = async ({
     }
 
     let prerenderGroup = 1;
-    const onPrerenderRoute = (routeKey: string, isLazy: boolean) => {
+    const onPrerenderRoute = (
+      routeKey: string,
+      { isBlocking, isFallback }: { isBlocking: boolean; isFallback: boolean }
+    ) => {
+      if (isBlocking && isFallback) {
+        throw new Error(
+          'invariant: isBlocking and isFallback cannot both be true'
+        );
+      }
+
       // Get the route file as it'd be mounted in the builder output
       const routeFileNoExt = routeKey === '/' ? '/index' : routeKey;
-      const lazyHtmlFallback =
-        isLazy && prerenderManifest.lazyRoutes[routeKey].fallback;
 
-      const htmlFsRef =
-        isLazy && !lazyHtmlFallback
+      const htmlFsRef = isBlocking
+        ? // Blocking pages do not have an HTML fallback
+          null
+        : new FileFsRef({
+            fsPath: path.join(
+              pagesDir,
+              isFallback
+                ? // Fallback pages have a special file.
+                  prerenderManifest.fallbackRoutes[routeKey].fallback
+                : // Otherwise, the route itself should exist as a static HTML
+                  // file.
+                  `${routeFileNoExt}.html`
+            ),
+          });
+      const jsonFsRef =
+        // JSON data does not exist for fallback or blocking pages
+        isFallback || isBlocking
           ? null
           : new FileFsRef({
-              fsPath: path.join(
-                pagesDir,
-                `${lazyHtmlFallback || routeFileNoExt + '.html'}`
-              ),
+              fsPath: path.join(pagesDir, `${routeFileNoExt}.json`),
             });
-      const jsonFsRef = isLazy
-        ? null
-        : new FileFsRef({
-            fsPath: path.join(pagesDir, `${routeFileNoExt}.json`),
-          });
 
       let initialRevalidate: false | number;
       let srcRoute: string | null;
       let dataRoute: string;
 
-      if (isLazy) {
-        const pr = prerenderManifest.lazyRoutes[routeKey];
+      if (isFallback || isBlocking) {
+        const pr = isFallback
+          ? prerenderManifest.fallbackRoutes[routeKey]
+          : prerenderManifest.legacyBlockingRoutes[routeKey];
         initialRevalidate = 1; // TODO: should Next.js provide this default?
         // @ts-ignore
         if (initialRevalidate === false) {
@@ -949,7 +966,7 @@ export const build = async ({
         srcRoute = null;
         dataRoute = pr.dataRoute;
       } else {
-        const pr = prerenderManifest.routes[routeKey];
+        const pr = prerenderManifest.staticRoutes[routeKey];
         ({ initialRevalidate, srcRoute, dataRoute } = pr);
       }
 
@@ -998,21 +1015,24 @@ export const build = async ({
       ++prerenderGroup;
     };
 
-    Object.keys(prerenderManifest.routes).forEach(route =>
-      onPrerenderRoute(route, false)
+    Object.keys(prerenderManifest.staticRoutes).forEach(route =>
+      onPrerenderRoute(route, { isBlocking: false, isFallback: false })
     );
-    Object.keys(prerenderManifest.lazyRoutes).forEach(route =>
-      onPrerenderRoute(route, true)
+    Object.keys(prerenderManifest.fallbackRoutes).forEach(route =>
+      onPrerenderRoute(route, { isBlocking: false, isFallback: true })
+    );
+    Object.keys(prerenderManifest.legacyBlockingRoutes).forEach(route =>
+      onPrerenderRoute(route, { isBlocking: true, isFallback: false })
     );
 
     // We still need to use lazyRoutes if the dataRoutes field
     // isn't available for backwards compatibility
     if (!(routesManifest && routesManifest.dataRoutes)) {
       // Dynamic pages for lazy routes should be handled by the lambda flow.
-      Object.keys(prerenderManifest.lazyRoutes).forEach(lazyRoute => {
-        const { dataRouteRegex, dataRoute } = prerenderManifest.lazyRoutes[
-          lazyRoute
-        ];
+      [
+        ...Object.entries(prerenderManifest.fallbackRoutes),
+        ...Object.entries(prerenderManifest.legacyBlockingRoutes),
+      ].forEach(([, { dataRouteRegex, dataRoute }]) => {
         dataRoutes.push({
           // Next.js provided data route regex
           src: dataRouteRegex.replace(

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -617,7 +617,7 @@ export async function createLambdaFromPseudoLayers({
 export type NextPrerenderedRoutes = {
   bypassToken: string | null;
 
-  routes: {
+  staticRoutes: {
     [route: string]: {
       initialRevalidate: number | false;
       dataRoute: string;
@@ -625,9 +625,17 @@ export type NextPrerenderedRoutes = {
     };
   };
 
-  lazyRoutes: {
+  legacyBlockingRoutes: {
     [route: string]: {
-      fallback?: string;
+      routeRegex: string;
+      dataRoute: string;
+      dataRouteRegex: string;
+    };
+  };
+
+  fallbackRoutes: {
+    [route: string]: {
+      fallback: string;
       routeRegex: string;
       dataRoute: string;
       dataRouteRegex: string;
@@ -717,30 +725,57 @@ export async function getPrerenderManifest(
     .catch(() => false);
 
   if (!hasManifest) {
-    return { routes: {}, lazyRoutes: {}, bypassToken: null };
+    return {
+      staticRoutes: {},
+      legacyBlockingRoutes: {},
+      fallbackRoutes: {},
+      bypassToken: null,
+    };
   }
 
-  const manifest: {
-    version: 1;
-    routes: {
-      [key: string]: {
-        initialRevalidateSeconds: number | false;
-        dataRoute: string;
-        srcRoute: string | null;
-      };
-    };
-    dynamicRoutes: {
-      [key: string]: {
-        fallback?: string;
-        routeRegex: string;
-        dataRoute: string;
-        dataRouteRegex: string;
-      };
-    };
-    preview?: {
-      previewModeId: string;
-    };
-  } = JSON.parse(await fs.readFile(pathPrerenderManifest, 'utf8'));
+  const manifest:
+    | {
+        version: 1;
+        routes: {
+          [key: string]: {
+            initialRevalidateSeconds: number | false;
+            dataRoute: string;
+            srcRoute: string | null;
+          };
+        };
+        dynamicRoutes: {
+          [key: string]: {
+            fallback?: string;
+            routeRegex: string;
+            dataRoute: string;
+            dataRouteRegex: string;
+          };
+        };
+        preview?: {
+          previewModeId: string;
+        };
+      }
+    | {
+        version: 2;
+        routes: {
+          [route: string]: {
+            initialRevalidateSeconds: number | false;
+            srcRoute: string | null;
+            dataRoute: string;
+          };
+        };
+        dynamicRoutes: {
+          [route: string]: {
+            routeRegex: string;
+            fallback: string | false;
+            dataRoute: string;
+            dataRouteRegex: string;
+          };
+        };
+        preview: {
+          previewModeId: string;
+        };
+      } = JSON.parse(await fs.readFile(pathPrerenderManifest, 'utf8'));
 
   switch (manifest.version) {
     case 1: {
@@ -748,8 +783,9 @@ export async function getPrerenderManifest(
       const lazyRoutes = Object.keys(manifest.dynamicRoutes);
 
       const ret: NextPrerenderedRoutes = {
-        routes: {},
-        lazyRoutes: {},
+        staticRoutes: {},
+        legacyBlockingRoutes: {},
+        fallbackRoutes: {},
         bypassToken:
           (manifest.preview && manifest.preview.previewModeId) || null,
       };
@@ -760,7 +796,7 @@ export async function getPrerenderManifest(
           dataRoute,
           srcRoute,
         } = manifest.routes[route];
-        ret.routes[route] = {
+        ret.staticRoutes[route] = {
           initialRevalidate:
             initialRevalidateSeconds === false
               ? false
@@ -778,7 +814,66 @@ export async function getPrerenderManifest(
           dataRouteRegex,
         } = manifest.dynamicRoutes[lazyRoute];
 
-        ret.lazyRoutes[lazyRoute] = {
+        if (fallback) {
+          ret.fallbackRoutes[lazyRoute] = {
+            routeRegex,
+            fallback,
+            dataRoute,
+            dataRouteRegex,
+          };
+        } else {
+          ret.legacyBlockingRoutes[lazyRoute] = {
+            routeRegex,
+            dataRoute,
+            dataRouteRegex,
+          };
+        }
+      });
+
+      return ret;
+    }
+    case 2: {
+      const routes = Object.keys(manifest.routes);
+      const lazyRoutes = Object.keys(manifest.dynamicRoutes);
+
+      const ret: NextPrerenderedRoutes = {
+        staticRoutes: {},
+        legacyBlockingRoutes: {},
+        fallbackRoutes: {},
+        bypassToken: manifest.preview.previewModeId,
+      };
+
+      routes.forEach(route => {
+        const {
+          initialRevalidateSeconds,
+          dataRoute,
+          srcRoute,
+        } = manifest.routes[route];
+        ret.staticRoutes[route] = {
+          initialRevalidate:
+            initialRevalidateSeconds === false
+              ? false
+              : Math.max(1, initialRevalidateSeconds),
+          dataRoute,
+          srcRoute,
+        };
+      });
+
+      lazyRoutes.forEach(lazyRoute => {
+        const {
+          routeRegex,
+          fallback,
+          dataRoute,
+          dataRouteRegex,
+        } = manifest.dynamicRoutes[lazyRoute];
+
+        if (!fallback) {
+          // Fallback behavior is disabled, all routes would've been provided
+          // in the top-level `routes` key (`staticRoutes`).
+          return;
+        }
+
+        ret.fallbackRoutes[lazyRoute] = {
           routeRegex,
           fallback,
           dataRoute,
@@ -789,7 +884,12 @@ export async function getPrerenderManifest(
       return ret;
     }
     default: {
-      return { routes: {}, lazyRoutes: {}, bypassToken: null };
+      return {
+        staticRoutes: {},
+        legacyBlockingRoutes: {},
+        fallbackRoutes: {},
+        bypassToken: null,
+      };
     }
   }
 }

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -641,6 +641,8 @@ export type NextPrerenderedRoutes = {
       dataRouteRegex: string;
     };
   };
+
+  omittedLambdas: string[];
 };
 
 export async function getExportIntent(
@@ -730,6 +732,7 @@ export async function getPrerenderManifest(
       legacyBlockingRoutes: {},
       fallbackRoutes: {},
       bypassToken: null,
+      omittedLambdas: [],
     };
   }
 
@@ -788,6 +791,7 @@ export async function getPrerenderManifest(
         fallbackRoutes: {},
         bypassToken:
           (manifest.preview && manifest.preview.previewModeId) || null,
+        omittedLambdas: [],
       };
 
       routes.forEach(route => {
@@ -841,6 +845,7 @@ export async function getPrerenderManifest(
         legacyBlockingRoutes: {},
         fallbackRoutes: {},
         bypassToken: manifest.preview.previewModeId,
+        omittedLambdas: [],
       };
 
       routes.forEach(route => {
@@ -870,6 +875,7 @@ export async function getPrerenderManifest(
         if (!fallback) {
           // Fallback behavior is disabled, all routes would've been provided
           // in the top-level `routes` key (`staticRoutes`).
+          ret.omittedLambdas.push(lazyRoute);
           return;
         }
 
@@ -889,6 +895,7 @@ export async function getPrerenderManifest(
         legacyBlockingRoutes: {},
         fallbackRoutes: {},
         bypassToken: null,
+        omittedLambdas: [],
       };
     }
   }

--- a/packages/now-next/test/fixtures/22-ssg-v2/next.config.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/now.json
@@ -1,0 +1,185 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@now/next" }],
+  "probes": [
+    {
+      "path": "/lambda",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "MISS"
+      }
+    },
+    {
+      "path": "/forever",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/forever",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/another",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/another",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/blog/post-1",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/blog/post-1",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/blog/post-2",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/blog/post-2",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/blog/post-3",
+      "status": 200,
+      "mustContain": "loading..."
+    },
+    { "delay": 2000 },
+    {
+      "path": "/blog/post-3",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/blog/post-4.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "MISS"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/_next/data/testing-build-id/blog/post-4.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE/"
+      }
+    },
+    {
+      "path": "/blog/post-3",
+      "status": 200,
+      "mustContain": "post-3"
+    },
+    {
+      "path": "/blog/post-1/comment-1",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    {
+      "path": "/blog/post-2/comment-2",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    {
+      "path": "/blog/post-3/comment-3",
+      "status": 200,
+      "mustContain": "loading..."
+    },
+    {
+      "path": "/_next/data/testing-build-id/lambda.json",
+      "status": 404
+    },
+    {
+      "path": "/_next/data/testing-build-id/forever.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/PRERENDER|HIT/"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/blog/post-3/comment-3",
+      "status": 200,
+      "mustContain": "comment-3"
+    },
+    {
+      "path": "/_next/data/testing-build-id/forever.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/another.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/another2.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    },
+    { "delay": 2000 },
+    {
+      "path": "/_next/data/testing-build-id/another2.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "HIT"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/blog/post-1.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE|PRERENDER/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/blog/post-1337/comment-1337.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "PRERENDER"
+      }
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/now.json
@@ -180,6 +180,38 @@
       "responseHeaders": {
         "x-now-cache": "PRERENDER"
       }
+    },
+    {
+      "path": "/nofallback/one",
+      "status": 200,
+      "mustContain": "one"
+    },
+    {
+      "path": "/nofallback/two",
+      "status": 200,
+      "mustContain": "two"
+    },
+    {
+      "path": "/nofallback/nope",
+      "status": 404
+    },
+    {
+      "path": "/_next/data/testing-build-id/nofallback/one.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE|PRERENDER/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/nofallback/two.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-now-cache": "/HIT|STALE|PRERENDER/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/nofallback/nope.json",
+      "status": 404
     }
   ]
 }

--- a/packages/now-next/test/fixtures/22-ssg-v2/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/now.json
@@ -193,7 +193,8 @@
     },
     {
       "path": "/nofallback/nope",
-      "status": 404
+      "status": 404,
+      "mustContain": "This page could not be found"
     },
     {
       "path": "/_next/data/testing-build-id/nofallback/one.json",

--- a/packages/now-next/test/fixtures/22-ssg-v2/package.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "9.2.3-canary.14",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/another.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/another.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps() {
+  return {
+    props: {
+      world: 'world',
+      time: new Date().getTime(),
+    },
+    revalidate: 5,
+  };
+}
+
+export default ({ world, time }) => {
+  return (
+    <>
+      <p>hello: {world}</p>
+      <span>time: {time}</span>
+    </>
+  );
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/another2.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/another2.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps() {
+  return {
+    props: {
+      world: 'world',
+      time: new Date().getTime(),
+    },
+    revalidate: 5,
+  };
+}
+
+export default ({ world, time }) => {
+  return (
+    <>
+      <p>hello: {world}</p>
+      <span>time: {time}</span>
+    </>
+  );
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/blog/[post]/[comment].js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/blog/[post]/[comment].js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticPaths() {
+  return {
+    paths: [
+      '/blog/post-1/comment-1',
+      { params: { post: 'post-2', comment: 'comment-2' } },
+      '/blog/post-1337/comment-1337',
+    ],
+    fallback: true,
+  };
+}
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps({ params }) {
+  return {
+    props: {
+      post: params.post,
+      comment: params.comment,
+      time: new Date().getTime(),
+    },
+    revalidate: 2,
+  };
+}
+
+export default ({ post, comment, time }) => {
+  if (!post) return <p>loading...</p>;
+
+  return (
+    <>
+      <p>Post: {post}</p>
+      <p>Comment: {comment}</p>
+      <span>time: {time}</span>
+    </>
+  );
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/blog/[post]/index.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/blog/[post]/index.js
@@ -1,0 +1,40 @@
+import React from 'react'
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticPaths () {
+  return {
+    paths: [
+      '/blog/post-1',
+      { params: { post: 'post-2' } },
+    ]
+  }
+}
+
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps ({ params }) {
+  if (params.post === 'post-10') {
+    await new Promise(resolve => {
+      setTimeout(() => resolve(), 1000)
+    })
+  }
+
+  return {
+    props: {
+      post: params.post,
+      time: (await import('perf_hooks')).performance.now()
+    },
+    revalidate: 10
+  }
+}
+
+export default ({ post, time }) => {
+  if (!post) return <p>loading...</p>
+
+  return (
+    <>
+      <p>Post: {post}</p>
+      <span>time: {time}</span>
+    </>
+  )
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/forever.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/forever.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps() {
+  return {
+    props: {
+      world: 'world',
+      time: new Date().getTime(),
+    },
+    revalidate: false,
+  };
+}
+
+export default ({ world, time }) => {
+  return (
+    <>
+      <p>hello: {world}</p>
+      <span>time: {time}</span>
+    </>
+  );
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/index.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Hi';

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/lambda.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/lambda.js
@@ -1,0 +1,5 @@
+const Page = ({ data }) => <p>{data} world</p>;
+
+Page.getInitialProps = () => ({ data: 'hello' });
+
+export default Page;

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/nofallback/[slug].js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/nofallback/[slug].js
@@ -3,34 +3,28 @@ import React from 'react';
 // eslint-disable-next-line camelcase
 export async function unstable_getStaticPaths() {
   return {
-    paths: ['/blog/post-1', { params: { post: 'post-2' } }],
-    fallback: true,
+    paths: ['/nofallback/one', { params: { slug: 'two' } }],
+    fallback: false,
   };
 }
 
 // eslint-disable-next-line camelcase
 export async function unstable_getStaticProps({ params }) {
-  if (params.post === 'post-10') {
-    await new Promise(resolve => {
-      setTimeout(() => resolve(), 1000);
-    });
-  }
-
   return {
     props: {
-      post: params.post,
+      slug: params.slug,
       time: (await import('perf_hooks')).performance.now(),
     },
     revalidate: 10,
   };
 }
 
-export default ({ post, time }) => {
-  if (!post) return <p>loading...</p>;
-
+export default ({ slug, time }) => {
   return (
     <>
-      <p>Post: {post}</p>
+      <p>
+        Slug ({slug.length}): {slug}
+      </p>
       <span>time: {time}</span>
     </>
   );


### PR DESCRIPTION
This adds support for the v2 Prerender Manifest in Next.js `^9.2.3-canary.14`.