### PR TITLE
[now-build-utils] Install all deps regardless of `NODE_ENV`

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -206,10 +206,10 @@ export async function runNpmInstall(
   debug(`Installing to ${destPath}`);
   const { hasPackageLockJson } = await scanParentDirs(destPath);
 
-  const opts = { cwd: destPath, ...spawnOpts } || {
-    cwd: destPath,
-    env: process.env,
-  };
+  const opts: SpawnOptions = { cwd: destPath, ...spawnOpts };
+  const env = opts.env || { ...process.env };
+  delete env.NODE_ENV;
+  opts.env = env;
 
   if (hasPackageLockJson) {
     commandArgs = args.filter(a => a !== '--prefer-offline');
@@ -239,10 +239,7 @@ export async function runBundleInstall(
   }
 
   assert(path.isAbsolute(destPath));
-  const opts = { cwd: destPath, ...spawnOpts } || {
-    cwd: destPath,
-    env: process.env,
-  };
+  const opts = { cwd: destPath, ...spawnOpts };
 
   await spawnAsync(
     'bundle',
@@ -270,10 +267,7 @@ export async function runPipInstall(
   }
 
   assert(path.isAbsolute(destPath));
-  const opts = { cwd: destPath, ...spawnOpts } || {
-    cwd: destPath,
-    env: process.env,
-  };
+  const opts = { cwd: destPath, ...spawnOpts };
 
   await spawnAsync(
     'pip3',


### PR DESCRIPTION
Some build utilities and SSG Frameworks instruct users to set `NODE_ENV=production` which typically means updating `now.json` to the following:

```json
{
  "build": {
    "env": {
      "NODE_ENV": "production"
    }
  }
}
```

The problem is that this environment variable is assigned during `npm install` or `yarn install` which is the equivalent of running install with the `--production` flag. This flag prevents `devDependencies` from installing. This is almost never what the user intends so they have to remove `now.json` and instead updating their build script to `NODE_ENV=production yarn build`.

This PR improves the experience by deleting `NODE_ENV` during the install step.