### PR TITLE
[all] Exclude `@now/build-utils` in bundled builder to fix tests

### DIFF
--- a/packages/now-go/build.sh
+++ b/packages/now-go/build.sh
@@ -1,4 +1,4 @@
-ncc build index.ts -o dist
-ncc build install.ts -o dist/install
+ncc build index.ts -e @now/build-utils -o dist
+ncc build install.ts -e @now/build-utils -o dist/install
 mv dist/install/index.js dist/install.js
 rm -rf dist/install

--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -7,10 +7,10 @@ cp -v "$bridge_defs" src/now__bridge.ts
 
 tsc
 
-ncc build src/dev-server.ts -o dist/dev
+ncc build src/dev-server.ts -e @now/build-utils -o dist/dev
 mv dist/dev/index.js dist/dev-server.js
 rm -rf dist/dev
 
-ncc build src/index.ts -o dist/main
+ncc build src/index.ts -e @now/build-utils -o dist/main
 mv dist/main/index.js dist/index.js
 rm -rf dist/main

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -21,23 +21,23 @@ mv dist/types dist/index.d.ts
 
 # bundle helpers.ts with ncc
 rm dist/helpers.js
-ncc build src/helpers.ts -o dist/helpers
+ncc build src/helpers.ts -e @now/build-utils -o dist/helpers
 mv dist/helpers/index.js dist/helpers.js
 rm -rf dist/helpers
 
 # build source-map-support/register for source maps
-ncc build ../../node_modules/source-map-support/register -o dist/source-map-support
+ncc build ../../node_modules/source-map-support/register -e @now/build-utils -o dist/source-map-support
 mv dist/source-map-support/index.js dist/source-map-support.js
 rm -rf dist/source-map-support
 
 # build typescript
-ncc build ../../node_modules/typescript/lib/typescript -o dist/typescript
+ncc build ../../node_modules/typescript/lib/typescript -e @now/build-utils -o dist/typescript
 mv dist/typescript/index.js dist/typescript.js
 mkdir -p dist/typescript/lib
 mv dist/typescript/typescript/lib/*.js dist/typescript/lib/
 mv dist/typescript/typescript/lib/*.d.ts dist/typescript/lib/
 rm -r dist/typescript/typescript
 
-ncc build src/index.ts -o dist/main
+ncc build src/index.ts -e @now/build-utils -o dist/main
 mv dist/main/index.js dist/index.js
 rm -rf dist/main

--- a/packages/now-node/test/fixtures/35-puppeteer/now.json
+++ b/packages/now-node/test/fixtures/35-puppeteer/now.json
@@ -12,15 +12,5 @@
         }
       }
     }
-  ],
-  "probes": [
-    {
-      "path": "/lighthouse",
-      "mustContain": "lighthouse:RANDOMNESS_PLACEHOLDER"
-    },
-    {
-      "path": "/screenshot",
-      "mustContain": "screenshot:RANDOMNESS_PLACEHOLDER"
-    }
   ]
 }

--- a/packages/now-node/test/fixtures/35-puppeteer/probe.js
+++ b/packages/now-node/test/fixtures/35-puppeteer/probe.js
@@ -13,6 +13,7 @@ async function tryTest({
     assert.equal(res.status, 200);
     const text = await res.text();
     assert.equal(text.trim(), `${testName}:${randomness}`);
+    console.log(`Finished testing "${testName}" probe.`);
   } catch (e) {
     if (retries === 0) {
       console.error(e);
@@ -28,7 +29,6 @@ async function tryTest({
       retries: retries - 1,
     });
   }
-  console.log(`Finished testing "${testName}" probe.`);
 }
 
 module.exports = async ({ deploymentUrl, fetch, randomness }) => {

--- a/packages/now-node/test/fixtures/35-puppeteer/probe.js
+++ b/packages/now-node/test/fixtures/35-puppeteer/probe.js
@@ -1,0 +1,37 @@
+const assert = require('assert').strict;
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function tryTest({
+  testName,
+  deploymentUrl,
+  fetch,
+  randomness,
+  retries = 4,
+}) {
+  try {
+    const res = await fetch(`https://${deploymentUrl}/${testName}`);
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.equal(text.trim(), `${testName}:${randomness}`);
+  } catch (e) {
+    if (retries === 0) {
+      console.error(e);
+      throw e;
+    }
+    console.log(`Failed "${testName}" probe. Retries remaining: ${retries}`);
+    await sleep(1000);
+    await tryTest({
+      testName,
+      deploymentUrl,
+      fetch,
+      randomness,
+      retries: retries - 1,
+    });
+  }
+  console.log(`Finished testing "${testName}" probe.`);
+}
+
+module.exports = async ({ deploymentUrl, fetch, randomness }) => {
+  await tryTest({ testName: 'lighthouse', deploymentUrl, fetch, randomness });
+  await tryTest({ testName: 'screenshot', deploymentUrl, fetch, randomness });
+};

--- a/packages/now-python/build.sh
+++ b/packages/now-python/build.sh
@@ -1,1 +1,1 @@
-ncc build src/index.ts -o dist
+ncc build src/index.ts -e @now/build-utils -o dist

--- a/packages/now-ruby/build.sh
+++ b/packages/now-ruby/build.sh
@@ -1,1 +1,1 @@
-ncc build index.ts -o dist
+ncc build index.ts -e @now/build-utils -o dist

--- a/packages/now-static-build/build.sh
+++ b/packages/now-static-build/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-ncc build src/index.ts -o dist
+ncc build src/index.ts -e @now/build-utils -o dist

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -91,7 +91,6 @@ async function testDeployment(
   bodies['now.json'] = Buffer.from(JSON.stringify(nowJson));
   delete bodies['probe.js'];
   const { deploymentId, deploymentUrl } = await nowDeploy(bodies, randomness);
-  console.log('deploymentUrl', `https://${deploymentUrl}`);
 
   for (const probe of nowJson.probes || []) {
     console.log('testing', JSON.stringify(probe));


### PR DESCRIPTION
This fixes a bug in our `@now/build-utils` tests that pair the current build-utils with a stable builder. Since ncc was bundling `@now/build-utils`, we weren't able to configure a different version and these tests were not actually testing the correct version of build-utils.

A nice side-effect is that each builder will be about 50% smaller (compared by measuring `dist`).