### PR TITLE
[now-ruby] Add test fixture for ActiveSupport gem

### DIFF
--- a/packages/now-ruby/test/fixtures/09-activesupport/Gemfile
+++ b/packages/now-ruby/test/fixtures/09-activesupport/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'activesupport', '~> 6.0'
+gem "activesupport", "~> 6.0"

--- a/packages/now-ruby/test/fixtures/09-activesupport/Gemfile
+++ b/packages/now-ruby/test/fixtures/09-activesupport/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'activesupport', '~> 6.0'

--- a/packages/now-ruby/test/fixtures/09-activesupport/Gemfile.lock
+++ b/packages/now-ruby/test/fixtures/09-activesupport/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   activesupport (~> 6.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/packages/now-ruby/test/fixtures/09-activesupport/Gemfile.lock
+++ b/packages/now-ruby/test/fixtures/09-activesupport/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 6.0)
+
+BUNDLED WITH
+   1.17.3

--- a/packages/now-ruby/test/fixtures/09-activesupport/index.rb
+++ b/packages/now-ruby/test/fixtures/09-activesupport/index.rb
@@ -1,0 +1,14 @@
+require 'active_support'
+require 'active_support/core_ext'
+
+Handler = Proc.new do |request, response|
+  response.status = 200
+  response["Content-Type"] = "text/plain"
+  response.body = <<-BODY
+    10y+ future:
+    #{Date.current + 10.years}
+
+    test:
+    gem:RANDOMNESS_PLACEHOLDER
+  BODY
+end

--- a/packages/now-ruby/test/fixtures/09-activesupport/now.json
+++ b/packages/now-ruby/test/fixtures/09-activesupport/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.rb", "use": "@now/ruby" }],
+  "probes": [{ "path": "/", "mustContain": "gem:RANDOMNESS_PLACEHOLDER" }]
+}


### PR DESCRIPTION
* add ruby ActiveSupport test fixture
  > ActiveSupport is a Ruby module & a stand-alone component of Rails that includes additional functionality to core Ruby classes, like Array, String & Numeric.
  :link: https://guides.rubyonrails.org/active_support_core_extensions.html

* add `Date.current + 10.years` calculation example