### PR TITLE
[now-ruby] update bundler on ruby rack examples

### DIFF
--- a/packages/now-ruby/test/fixtures/07-rack/Gemfile.lock
+++ b/packages/now-ruby/test/fixtures/07-rack/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.1.1)
+    rack (2.2.2)
 
 PLATFORMS
   ruby
@@ -10,4 +10,4 @@ DEPENDENCIES
   rack (~> 2.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/packages/now-ruby/test/fixtures/08-rack-proc/Gemfile.lock
+++ b/packages/now-ruby/test/fixtures/08-rack-proc/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.1.1)
+    rack (2.2.2)
 
 PLATFORMS
   ruby
@@ -10,4 +10,4 @@ DEPENDENCIES
   rack (~> 2.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
* update bundler on ruby rack examples
  * bundle with latest bundler `v2.1.4`
  * update rack to `v2.2.2`
  :link: https://github.com/zeit/now/pull/3626