### PR TITLE
[now-cli] Disable sentry during local development

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       run: yarn install --check-files --frozen-lockfile
     - name: Build
       run: yarn build
+      env:
+        GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     - name: Publish
       run: yarn publish-from-github
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 packages/now-cli/.builders
 packages/now-cli/assets
 packages/now-cli/src/util/dev/templates/*.ts
+packages/now-cli/src/util/constants.ts
 packages/now-cli/test/**/yarn.lock
 !packages/now-cli/test/dev/**/yarn.lock
 packages/now-cli/test/**/node_modules

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -66,7 +66,11 @@ export const SENTRY_DSN: string | undefined =  ${envToString('SENTRY_DSN')};
 }
 
 function envToString(key: string) {
-  return JSON.stringify(process.env[key]);
+  const value = process.env[key];
+  if (!value) {
+    console.log(`- Constant ${key} is not assigned`);
+  }
+  return JSON.stringify(value);
 }
 
 async function main() {

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -57,10 +57,16 @@ async function createConstants() {
   console.log('Creating constants.ts');
   const filename = join(dirRoot, 'src/util/constants.ts');
   const contents = `// This file is auto-generated
-export const GA_TRACKING_ID: string | undefined = '${process.env.GA_TRACKING_ID}';
-export const SENTRY_DSN: string | undefined = '${process.env.SENTRY_DSN}';
+export const GA_TRACKING_ID: string | undefined = ${envToString(
+    'GA_TRACKING_ID'
+  )};
+export const SENTRY_DSN: string | undefined =  ${envToString('SENTRY_DSN')};
 `;
   await writeFile(filename, contents, 'utf8');
+}
+
+function envToString(key: string) {
+  return JSON.stringify(process.env[key]);
 }
 
 async function main() {

--- a/packages/now-cli/src/util/constants.ts
+++ b/packages/now-cli/src/util/constants.ts
@@ -1,2 +1,0 @@
-export const GA_TRACKING_ID = 'UA-117491914-3';
-export const SENTRY_DSN = 'https://26a24e59ba954011919a524b341b6ab5@sentry.io/1323225';

--- a/packages/now-cli/src/util/metrics.ts
+++ b/packages/now-cli/src/util/metrics.ts
@@ -10,12 +10,10 @@ const config: any = configFiles.getConfigFilePath();
 
 export const shouldCollectMetrics =
   (config.collectMetrics === undefined || config.collectMetrics === true) &&
-  process.env.NOW_CLI_COLLECT_METRICS !== '0';
+  process.env.NOW_CLI_COLLECT_METRICS !== '0' &&
+  GA_TRACKING_ID;
 
-export const metrics = () => {
-  if (!GA_TRACKING_ID) {
-    return function noop() {};
-  }
+export const metrics = (): ua.Visitor => {
   const token =
     typeof config.token === 'string' ? config.token : platform() + release();
   const salt = userInfo().username;
@@ -24,7 +22,7 @@ export const metrics = () => {
     .toString('hex')
     .substring(0, 24);
 
-  return ua(GA_TRACKING_ID, {
+  return ua(GA_TRACKING_ID || '', {
     cid: hash,
     strictCidFormat: false,
     uid: hash,

--- a/packages/now-cli/src/util/metrics.ts
+++ b/packages/now-cli/src/util/metrics.ts
@@ -8,22 +8,28 @@ import * as configFiles from './config/files';
 
 const config: any = configFiles.getConfigFilePath();
 
-export const shouldCollectMetrics = (
-  config.collectMetrics === undefined
-  || config.collectMetrics === true)
-  && process.env.NOW_CLI_COLLECT_METRICS !== '0';
+export const shouldCollectMetrics =
+  (config.collectMetrics === undefined || config.collectMetrics === true) &&
+  process.env.NOW_CLI_COLLECT_METRICS !== '0';
 
 export const metrics = () => {
-  const token = typeof config.token === 'string' ? config.token : platform() + release();
+  if (!GA_TRACKING_ID) {
+    return function noop() {};
+  }
+  const token =
+    typeof config.token === 'string' ? config.token : platform() + release();
   const salt = userInfo().username;
-  const hash = crypto.pbkdf2Sync(token, salt, 1000, 64, 'sha512').toString('hex').substring(0, 24);
+  const hash = crypto
+    .pbkdf2Sync(token, salt, 1000, 64, 'sha512')
+    .toString('hex')
+    .substring(0, 24);
 
   return ua(GA_TRACKING_ID, {
     cid: hash,
     strictCidFormat: false,
     uid: hash,
     headers: {
-      'User-Agent': userAgent
-    }
+      'User-Agent': userAgent,
+    },
   });
-}
+};


### PR DESCRIPTION
This PR changes the behavior of error reporting and metrics so that developers who build and run Now CLI locally won't accidentally report any metrics. It also prevents errors during CI tests from being reported.

The env vars are only assigned during the publishing step so that the official Now CLI hosted on npm is the only way to report metrics.