### PR TITLE
[now-build-utils] Fix NODE_ENV assignment

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -207,7 +207,7 @@ export async function runNpmInstall(
   const { hasPackageLockJson } = await scanParentDirs(destPath);
 
   const opts: SpawnOptions = { cwd: destPath, ...spawnOpts };
-  const env = opts.env || { ...process.env };
+  const env = opts.env ? { ...opts.env } : { ...process.env };
   delete env.NODE_ENV;
   opts.env = env;
 

--- a/packages/now-build-utils/test/fixtures/17-node-env-build/now.json
+++ b/packages/now-build-utils/test/fixtures/17-node-env-build/now.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@now/static-build" }],
+  "build": { "env": { "NODE_ENV": "custom-value:RANDOMNESS_PLACEHOLDER" } },
+  "probes": [
+    { "path": "/", "mustContain": "custom-value:RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-build-utils/test/fixtures/17-node-env-build/package.json
+++ b/packages/now-build-utils/test/fixtures/17-node-env-build/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir public && echo $NODE_ENV > public/index.html"
+  }
+}


### PR DESCRIPTION
Fixes a regression in #3847 which was preventing the user from assigning `NODE_ENV`.

The root cause was that the spread operator (`...`) performs a shallow clone, not a deep clone. So we must perform another spread to clone the user-provided `env` object before deleting `NODE_ENV` during `npm install`.