### PR TITLE
[now-routing-utils] Add support for new handle types

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -28,7 +28,6 @@ const VALID_HANDLE_VALUES = [
   'rewrite',
   'error',
 ] as const;
-const VALID_HANDLE_ERROR_KEYS = ['handle', 'src', 'dest', 'status'];
 const validHandleValues = new Set<string>(VALID_HANDLE_VALUES);
 export type HandleValue = typeof VALID_HANDLE_VALUES[number];
 
@@ -54,23 +53,9 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
 
   for (const route of routes) {
     if (isHandler(route)) {
-      if (route.handle === 'error') {
-        const invalidKeys = Object.keys(route).filter(key => {
-          return !VALID_HANDLE_ERROR_KEYS.includes(key);
-        });
-
-        if (invalidKeys.length > 0) {
-          errors.push({
-            message: `Cannot have keys other than ${VALID_HANDLE_ERROR_KEYS.join(
-              ', '
-            )} when handle: ${
-              route.handle
-            } is used. Invalid keys: ${invalidKeys.join(',')}`,
-          });
-        }
-      } else if (Object.keys(route).length !== 1) {
+      if (Object.keys(route).length !== 1) {
         errors.push({
-          message: `Cannot have any other keys when handle: ${route.handle} is used`,
+          message: `Cannot have any other keys when handle is used (handle: ${route.handle})`,
           handle: route.handle,
         });
       }

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -27,6 +27,7 @@ const VALID_HANDLE_VALUES = [
   'miss',
   'rewrite',
   'error',
+  'resource',
 ] as const;
 const validHandleValues = new Set<string>(VALID_HANDLE_VALUES);
 export type HandleValue = typeof VALID_HANDLE_VALUES[number];

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -21,7 +21,14 @@ export { getCleanUrls } from './superstatic';
 export { mergeRoutes } from './merge';
 export { appendRoutesToPhase } from './append';
 
-const VALID_HANDLE_VALUES = ['filesystem', 'hit', 'miss'] as const;
+const VALID_HANDLE_VALUES = [
+  'filesystem',
+  'hit',
+  'miss',
+  'rewrite',
+  'error',
+] as const;
+const VALID_HANDLE_ERROR_KEYS = ['handle', 'src', 'dest', 'status'];
 const validHandleValues = new Set<string>(VALID_HANDLE_VALUES);
 export type HandleValue = typeof VALID_HANDLE_VALUES[number];
 
@@ -47,9 +54,23 @@ export function normalizeRoutes(inputRoutes: Route[] | null): NormalizedRoutes {
 
   for (const route of routes) {
     if (isHandler(route)) {
-      if (Object.keys(route).length !== 1) {
+      if (route.handle === 'error') {
+        const invalidKeys = Object.keys(route).filter(key => {
+          return !VALID_HANDLE_ERROR_KEYS.includes(key);
+        });
+
+        if (invalidKeys.length > 0) {
+          errors.push({
+            message: `Cannot have keys other than ${VALID_HANDLE_ERROR_KEYS.join(
+              ', '
+            )} when handle: ${
+              route.handle
+            } is used. Invalid keys: ${invalidKeys.join(',')}`,
+          });
+        }
+      } else if (Object.keys(route).length !== 1) {
         errors.push({
-          message: `Cannot have any other keys when handle is used (handle: ${route.handle})`,
+          message: `Cannot have any other keys when handle: ${route.handle} is used`,
           handle: route.handle,
         });
       }

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -25,6 +25,9 @@ export type Source = {
 
 export type Handler = {
   handle: HandleValue;
+  src?: string;
+  dest?: string;
+  status?: number;
 };
 
 export type Route = Source | Handler;

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -25,9 +25,6 @@ export type Source = {
 
 export type Handler = {
   handle: HandleValue;
-  src?: string;
-  dest?: string;
-  status?: number;
 };
 
 export type Route = Source | Handler;

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -60,9 +60,9 @@ describe('normalizeRoutes', () => {
       },
       { handle: 'rewrite' },
       { src: '^.*$', dest: '/somewhere' },
+      { handle: 'error' },
       {
-        handle: 'error',
-        src: '.*',
+        src: '^.*$',
         dest: '/404',
         status: 404,
       },
@@ -73,32 +73,6 @@ describe('normalizeRoutes', () => {
     const normalized = normalizeRoutes(routes);
     assert.equal(normalized.error, null);
     assert.deepStrictEqual(normalized.routes, routes);
-  });
-
-  test('should show proper error for invalid handle: error', () => {
-    const routes = [
-      {
-        handle: 'error',
-        status: 404,
-        invalid: 'value',
-        dest: '/404',
-        src: '^.*$',
-      },
-    ];
-    const normalized = normalizeRoutes(routes);
-
-    assert.deepStrictEqual(normalized.error.code, 'invalid_routes');
-    assert.deepStrictEqual(normalized.error.errors, [
-      {
-        message:
-          'Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid',
-      },
-    ]);
-    assert.deepStrictEqual(
-      normalized.error.message,
-      `One or more invalid routes were found:
-- Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid`
-    );
   });
 
   test('normalizes src', () => {
@@ -142,14 +116,6 @@ describe('normalizeRoutes', () => {
     assert.strictEqual(routes, input);
   });
 
-  test('returns if empty', () => {
-    const input = [];
-    const { error, routes } = normalizeRoutes(input);
-
-    assert.strictEqual(error, null);
-    assert.strictEqual(routes, input);
-  });
-
   test('fails with abnormal routes', () => {
     const errors = [];
     const routes = [];
@@ -163,7 +129,8 @@ describe('normalizeRoutes', () => {
     // @ts-ignore
     routes.push({ handle: 'filesystem', illegal: true });
     errors.push({
-      message: 'Cannot have any other keys when handle: filesystem is used',
+      message:
+        'Cannot have any other keys when handle is used (handle: filesystem)',
       handle: 'filesystem',
     });
 
@@ -197,7 +164,7 @@ describe('normalizeRoutes', () => {
       normalized.error.message,
       `One or more invalid routes were found:
 - This is not a valid handler (handle: doesnotexist)
-- Cannot have any other keys when handle: filesystem is used
+- Cannot have any other keys when handle is used (handle: filesystem)
 - You can only handle something once (handle: filesystem)
 - Invalid regular expression: "^/(broken]$"
 - A route must set either handle or src`

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -87,18 +87,18 @@ describe('normalizeRoutes', () => {
     ];
     const normalized = normalizeRoutes(routes);
 
-    expect(normalized.error).toMatchInlineSnapshot(`
-      Object {
-        "code": "invalid_routes",
-        "errors": Array [
-          Object {
-            "message": "Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid",
-          },
-        ],
-        "message": "One or more invalid routes were found:
-      - Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid",
-      }
-    `);
+    assert.deepStrictEqual(normalized.error.code, 'invalid_routes');
+    assert.deepStrictEqual(normalized.error.errors, [
+      {
+        message:
+          'Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid',
+      },
+    ]);
+    assert.deepStrictEqual(
+      normalized.error.message,
+      `One or more invalid routes were found:
+- Cannot have keys other than handle, src, dest, status when handle: error is used. Invalid keys: invalid`
+    );
   });
 
   test('normalizes src', () => {

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -108,6 +108,14 @@ describe('normalizeRoutes', () => {
     }
   });
 
+  test('returns if empty', () => {
+    const input = [];
+    const { error, routes } = normalizeRoutes(input);
+
+    assert.strictEqual(error, null);
+    assert.strictEqual(routes, input);
+  });
+
   test('returns if null', () => {
     const input = null;
     const { error, routes } = normalizeRoutes(input);

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -108,16 +108,16 @@ describe('normalizeRoutes', () => {
     }
   });
 
-  test('returns if empty', () => {
-    const input = [];
+  test('returns if null', () => {
+    const input = null;
     const { error, routes } = normalizeRoutes(input);
 
     assert.strictEqual(error, null);
     assert.strictEqual(routes, input);
   });
 
-  test('returns if null', () => {
-    const input = null;
+  test('returns if empty', () => {
+    const input = [];
     const { error, routes } = normalizeRoutes(input);
 
     assert.strictEqual(error, null);


### PR DESCRIPTION
This adds support for the new internal `handle` types `error` and `rewrite` and also updates the error messages to be more verbose since additional keys are allowed when using `handle: 'error'`. 

This is needed so that we can implement utilize the new handles in `@now/next` for the new custom-routes support