### PR TITLE
[now-cli] Bump dot to 1.1.3

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -114,7 +114,7 @@
     "debug": "3.1.0",
     "deployment-type": "1.0.1",
     "docker-file-parser": "1.0.2",
-    "dot": "1.1.2",
+    "dot": "1.1.3",
     "dotenv": "4.0.0",
     "download": "6.2.5",
     "email-prompt": "0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4223,10 +4223,10 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-dot@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/dot/-/dot-1.1.2.tgz#c7377019fc4e550798928b2b9afeb66abfa1f2f9"
-  integrity sha1-xzdwGfxOVQeYkosrmv62ar+h8vk=
+dot@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dot/-/dot-1.1.3.tgz#351360e00a748bce9a1f8f27c00c394a7e4e1e9f"
+  integrity sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==
 
 dotenv@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Bumps `dot` to the latest version [1.1.3](https://github.com/olado/doT/releases/tag/v1.1.3).