### PR TITLE
[now-cli] Check for cert before printing url

### DIFF
--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -16,6 +16,7 @@ import { isValidName } from '../../util/is-valid-name';
 import handleCertError from '../../util/certs/handle-cert-error';
 import isWildcardAlias from '../../util/alias/is-wildcard-alias';
 import link from '../../util/output/link';
+import hasCertForDomain from '../../util/certs/has-cert-for-domain';
 
 type Options = {
   '--debug': boolean;
@@ -147,7 +148,8 @@ export default async function set(
     return 1;
   }
 
-  const prefix = isWildcard ? '' : 'https://';
+  const hasCert = await hasCertForDomain(output, client, deployment.url);
+  const prefix = isWildcard ? '' : hasCert ? 'https://' : 'http://';
 
   console.log(
     `${chalk.cyan('> Success!')} ${chalk.bold(

--- a/packages/now-cli/src/util/certs/has-cert-for-domain.ts
+++ b/packages/now-cli/src/util/certs/has-cert-for-domain.ts
@@ -1,0 +1,40 @@
+import { stringify } from 'querystring';
+import { Cert } from '../../types';
+import { Output } from '../output';
+import Client from '../client';
+import isWildcardAlias from '../alias/is-wildcard-alias';
+
+type Response = {
+  certs: Cert[];
+};
+
+export default async function hasCertForDomain(
+  output: Output,
+  client: Client,
+  domain: string
+) {
+  try {
+    if (domain.endsWith('.now.sh')) {
+      return true;
+    }
+    const { certs } = await client.fetch<Response>(
+      `/v3/now/certs?${stringify({ domain })}`
+    );
+    const wildcardCn = isWildcardAlias(domain)
+      ? domain
+      : `*.${stripSubdomain(domain)}`;
+    return certs.some(cert => {
+      return cert.cns.some(cn => cn === domain || cn === wildcardCn);
+    });
+  } catch (error) {
+    output.debug(`Error fetching certs for ${domain}: ${error.message}`);
+    return false;
+  }
+}
+
+function stripSubdomain(domain: string) {
+  return domain
+    .split('.')
+    .slice(1)
+    .join('.');
+}


### PR DESCRIPTION
Check for cert before printing alias url. A cert may not exist yet, so we show http in these cases.