### PR TITLE
[now-ruby] Add minimal HTTP handler examples

### DIFF
--- a/packages/now-ruby/test/fixtures/10-handler-proc/index.rb
+++ b/packages/now-ruby/test/fixtures/10-handler-proc/index.rb
@@ -1,0 +1,3 @@
+Handler = Proc.new do |request, response|
+  response.body = "RANDOMNESS_PLACEHOLDER"
+end

--- a/packages/now-ruby/test/fixtures/10-handler-proc/now.json
+++ b/packages/now-ruby/test/fixtures/10-handler-proc/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.rb", "use": "@now/ruby" }],
+  "probes": [{ "path": "/", "mustContain": "RANDOMNESS_PLACEHOLDER" }]
+}

--- a/packages/now-ruby/test/fixtures/11-handler-class/index.rb
+++ b/packages/now-ruby/test/fixtures/11-handler-class/index.rb
@@ -1,0 +1,5 @@
+class Handler < WEBrick::HTTPServlet::AbstractServlet
+  def do_GET(request, response)
+    response.body = "RANDOMNESS_PLACEHOLDER"
+  end
+end

--- a/packages/now-ruby/test/fixtures/11-handler-class/now.json
+++ b/packages/now-ruby/test/fixtures/11-handler-class/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.rb", "use": "@now/ruby" }],
+  "probes": [{ "path": "/", "mustContain": "RANDOMNESS_PLACEHOLDER" }]
+}


### PR DESCRIPTION
* add minimal possible HTTP handler examples
* avoid `Gemfile` / `Gemfile.lock` setup