### PR TITLE
[now-cli] Fix `now dev` env vars in Next.js APIs

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -56,6 +56,7 @@ export default async function dev(
   }
 
   let devCommand: undefined | string;
+  let frameworkSlug: null | string = null;
   if (link.status === 'linked') {
     const { project } = link;
 
@@ -65,6 +66,7 @@ export default async function dev(
       const framework = frameworks.find(f => f.slug === project.framework);
 
       if (framework) {
+        frameworkSlug = framework.slug;
         const defaults = framework.settings.devCommand;
 
         if (isSettingValue(defaults)) {
@@ -78,7 +80,12 @@ export default async function dev(
     }
   }
 
-  const devServer = new DevServer(cwd, { output, debug, devCommand });
+  const devServer = new DevServer(cwd, {
+    output,
+    debug,
+    devCommand,
+    frameworkSlug,
+  });
 
   process.once('SIGINT', () => devServer.stop());
 

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -107,6 +107,7 @@ export default class DevServer {
   public output: Output;
   public env: EnvConfig;
   public buildEnv: EnvConfig;
+  public frameworkSlug: string | null;
   public files: BuilderInputs;
   public yarnPath: string;
   public address: string;
@@ -142,6 +143,7 @@ export default class DevServer {
     this.files = {};
     this.address = '';
     this.devCommand = options.devCommand;
+    this.frameworkSlug = options.frameworkSlug;
 
     // This gets updated when `start()` is invoked
     this.yarnPath = '/';
@@ -1677,6 +1679,7 @@ export default class DevServer {
     const env: EnvConfig = {
       ...process.env,
       ...this.buildEnv,
+      ...(this.frameworkSlug === 'nextjs' ? this.env : {}),
       NOW_REGION: 'dev1',
       PORT: `${port}`,
     };

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -18,7 +18,8 @@ export { NowConfig };
 export interface DevServerOptions {
   output: Output;
   debug: boolean;
-  devCommand?: string;
+  devCommand: string | undefined;
+  frameworkSlug: string | null;
 }
 
 export interface EnvConfig {

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.env
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.env
@@ -1,0 +1,1 @@
+ANOTHER_SECRET=runtime

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.env.build
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.env.build
@@ -1,0 +1,1 @@
+SECRET=buildtime

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.gitignore
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/.gitignore
@@ -1,0 +1,6 @@
+.now
+.next
+.idea
+node_modules
+!.env
+!.env.build

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/next.config.js
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/next.config.js
@@ -1,0 +1,10 @@
+console.log({
+  SECRET: process.env.SECRET,
+  ANOTHER_SECRET: process.env.ANOTHER_SECRET,
+});
+
+module.exports = {
+  env: {
+    SECRET: process.env.SECRET,
+  },
+};

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/now.json
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/now.json
@@ -1,0 +1,10 @@
+{
+  "build": {
+    "env": {
+      "SECRET": "@buildtime"
+    }
+  },
+  "env": {
+    "ANOTHER_SECRET": "@runtime"
+  }
+}

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/package.json
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/package.json
@@ -1,15 +1,13 @@
 {
-  "name": "with-now-env",
-  "version": "2.0.0",
-  "license": "ISC",
+  "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "next": "9.2.2",
+    "react": "16.13.0",
+    "react-dom": "16.13.0"
   }
 }

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/package.json
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-now-env",
+  "version": "2.0.0",
+  "license": "ISC",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/pages/api/user.js
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/pages/api/user.js
@@ -1,0 +1,3 @@
+export default async (_req, res) => {
+  return res.end(process.env.ANOTHER_SECRET);
+};

--- a/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/pages/index.js
+++ b/packages/now-cli/test/dev/fixtures/26-nextjs-secrets/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <p>{process.env.SECRET}</p>;

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1376,6 +1376,20 @@ test('[now dev] 25-nextjs-src-dir', async t => {
 });
 
 test(
+  '[now dev] 26-nextjs-secrets',
+  testFixtureStdio('26-nextjs-secrets', async (t, port) => {
+    const user = await fetchWithRetry(`http://localhost:${port}/api/user`);
+    const index = await fetchWithRetry(`http://localhost:${port}`);
+
+    validateResponseHeaders(t, user);
+    validateResponseHeaders(t, index);
+
+    t.regex(await user.text(), new RegExp('runtime'));
+    t.regex(await index.text(), new RegExp('buildtime'));
+  })
+);
+
+test(
   '[now dev] Use `@now/python` with Flask requirements.txt',
   testFixtureStdio('python-flask', async (t, port) => {
     const name = 'Alice';


### PR DESCRIPTION
In Now CLI 17 when Next.js is detected, the `next dev` command is proxied from `now dev`.

This brings Next.js into alignment as other other frameworks such as Gatsby and CRA. But those other frameworks are building static websites, so we were only passing build time env vars. However, Next.js needs runtime env vars for APIs in `/pages/api`.

So the solution is to special case until Next.js can read these files directly. See https://github.com/zeit/next.js/pull/10525

Fixes #3758 