### PR TITLE
[examples] Add ZEIT logo to Next.js example

### DIFF
--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+!public/
 
 # production
 /build

--- a/examples/nextjs/public/zeit.svg
+++ b/examples/nextjs/public/zeit.svg
@@ -1,0 +1,10 @@
+<svg width="82" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill="url(#prefix__paint0_linear)" d="M9.018 0l9.019 16H0L9.018 0z"/>
+    <path fill="#333" fill-rule="evenodd" d="M51.634 12.028h-6.492V2.052h6.492v1.256H46.61v3.007h4.37V7.57h-4.37v3.202h5.024v1.255zm-14.063 0h-7.235v-1.096l5.342-7.624h-5.253V2.052h7.058v1.097l-5.342 7.623h5.43v1.256zm21.88 0h6.333v-1.256h-2.423V3.308h2.423V2.052h-6.332v1.256h2.441v7.465h-2.441v1.255zm18.22 0h-1.468v-8.72h-3.36V2.052h8.225v1.256H77.67v8.72z" clip-rule="evenodd"/>
+    <defs>
+        <linearGradient id="prefix__paint0_linear" x1="28.022" x2="16.189" y1="22.991" y2="8.569" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#fff"/>
+            <stop offset="1"/>
+        </linearGradient>
+    </defs>
+</svg>


### PR DESCRIPTION
The SVG was missing from #3881.

Example of broken image link here: https://nextjs-o64nyfk49.now.sh/