### PR TITLE
[now-next] Consider `buildCommand` from `config`

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -337,6 +337,7 @@ export const build = async ({
   env.NODE_OPTIONS = `--max_old_space_size=${memoryToConsume}`;
 
   if (config.buildCommand) {
+    console.log(`Running "${config.buildCommand}"`);
     await execCommand(config.buildCommand, {
       ...spawnOpts,
       cwd: entryPath,

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -17,6 +17,7 @@ import {
   Prerender,
   runNpmInstall,
   runPackageJsonScript,
+  execCommand,
 } from '@now/build-utils';
 import { Route } from '@now/routing-utils';
 import {
@@ -334,7 +335,19 @@ export const build = async ({
   const memoryToConsume = Math.floor(os.totalmem() / 1024 ** 2) - 128;
   const env: { [key: string]: string | undefined } = { ...spawnOpts.env };
   env.NODE_OPTIONS = `--max_old_space_size=${memoryToConsume}`;
-  await runPackageJsonScript(entryPath, shouldRunScript, { ...spawnOpts, env });
+
+  if (config.buildCommand) {
+    await execCommand(config.buildCommand, {
+      ...spawnOpts,
+      cwd: entryPath,
+      env,
+    });
+  } else {
+    await runPackageJsonScript(entryPath, shouldRunScript, {
+      ...spawnOpts,
+      env,
+    });
+  }
 
   const appMountPrefixNoTrailingSlash = path.posix
     .join('/', entryDirectory)


### PR DESCRIPTION
Consider `buildCommand` from `config`

[PRODUCT-1380]

[PRODUCT-1380]: https://zeit.atlassian.net/browse/PRODUCT-1380