### PR TITLE
[now-cli] Change suggestion for `rootDirectory` to `./`

### DIFF
--- a/packages/now-cli/src/util/input/input-root-directory.ts
+++ b/packages/now-cli/src/util/input/input-root-directory.ts
@@ -13,8 +13,6 @@ export async function inputRootDirectory(
     return null;
   }
 
-  const basename = path.basename(cwd);
-
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const { rootDirectory } = await inquirer.prompt({
@@ -22,7 +20,7 @@ export async function inputRootDirectory(
       name: 'rootDirectory',
       message: `In which directory is your code located?`,
       transformer: (input: string) => {
-        return `${chalk.dim(`${basename}/`)}${input}`;
+        return `${chalk.dim(`./`)}${input}`;
       },
     });
 


### PR DESCRIPTION
When we ask the question "In which directory is your code located?" we were displaying a prefix  of `cwd/` which is confusing because it seems like you are supposed to type in the current directory. It also doesn't match what is displayed in the Project Settings after it is deployed.

This changes the prefix to `./` so that `rootDirectory` is set to the current directory and the user can type in a subdirectory if they wish such as `./packages/web` for example.

### Before

```
? Set up and deploy “~/Code/app”? [Y/n] y
? Which scope do you want to deploy to? Testing
? Link to existing project? [y/N] n
? What’s your project’s name? app
? In which directory is your code located? app/
```

### After

```
? Set up and deploy “~/Code/app”? [Y/n] y
? Which scope do you want to deploy to? Testing
? Link to existing project? [y/N] n
? What’s your project’s name? app
? In which directory is your code located? ./
```