### PR TITLE
[now-cli] Prevent framework from clearing console in `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1667,6 +1667,9 @@ export default class DevServer {
     const port = await getPort();
 
     const env: EnvConfig = {
+      // Because of child process 'pipe' below, isTTY will be false.
+      // Most frameworks use `chalk`/`supports-color` so we enable it anyway.
+      FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
       ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
       ...process.env,
       ...this.buildEnv,

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1667,6 +1667,7 @@ export default class DevServer {
     const port = await getPort();
 
     const env: EnvConfig = {
+      ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
       ...process.env,
       ...this.buildEnv,
       ...(this.frameworkSlug === 'nextjs' ? this.env : {}),
@@ -1706,7 +1707,29 @@ export default class DevServer {
 
     this.output.debug(`Spawning dev command: ${command}`);
 
-    const p = spawnCommand(command, { stdio: 'inherit', cwd, env });
+    const p = spawnCommand(command, {
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      cwd,
+      env,
+    });
+
+    if (!p.stdout || !p.stderr) {
+      throw new Error('Expected child process to have stdout and stderr');
+    }
+
+    p.stdout.on('data', data => {
+      if (data) {
+        this.output.debug(`Replacing framework output with now dev address`);
+        data = data
+          .toString()
+          .replace(`http://localhost:${port}`, this.address);
+      }
+      process.stdout.write(data);
+    });
+
+    p.stderr.on('data', data => {
+      process.stderr.write(data);
+    });
 
     p.on('exit', () => {
       this.devProcessPort = undefined;


### PR DESCRIPTION
When running a framework like Create React App or Gridsome, the console gets cleared. This prevented the user from seeing the message printed from `now dev` which is typically `http://localhost:3000`. Instead the user would see the framework's URL such as `http://localhost:54684`.

See #3497 for an example.

The solution is to change the child process to pipe stdout/stderr. Since most frameworks detect [`process.stdout.isTTY`](https://github.com/facebook/create-react-app/blob/7e6d6cd05f3054723c8b015c813e13761659759e/packages/react-scripts/scripts/start.js#L141-L143) before clearing the console, this will solve the problem. I was also able to intercept stdout to replace the framework's port with the `now dev` port and I think this will also help prevent confusion.

I also had to set `FORCE_COLOR=1` to avoid losing ANSI colors.

- Related to https://github.com/facebook/create-react-app/issues/2495
- Fixes #3497 