### PR TITLE
[now-static-build] Add defaultRoutes for docusaurus v2

### DIFF
--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -95,6 +95,21 @@ const frameworkList: Framework[] = [
 
       return base;
     },
+    defaultRoutes: [
+      {
+        src: '^/[^./]+\\.[0-9a-f]{8}\\.(css|js)',
+        headers: { 'cache-control': 'max-age=31536000, immutable' },
+        continue: true,
+      },
+      {
+        handle: 'filesystem',
+      },
+      {
+        src: '.*',
+        status: 404,
+        dest: '404.html',
+      },
+    ],
   },
   {
     name: 'Preact',
@@ -365,7 +380,7 @@ const frameworkList: Framework[] = [
     buildCommand: 'stencil build',
     getOutputDirName: async () => 'www',
     defaultRoutes: [
-      { 
+      {
         src: '/assets/(.*)',
         headers: { 'cache-control': 'max-age=2592000' },
         continue: true,


### PR DESCRIPTION
Add a default router for Docusaurus v2 to add strong asset caching and 404 page fallback.