### PR TITLE
[examples] Update jekyll and middleman to use bundler 2.1.4

### DIFF
--- a/examples/jekyll/Gemfile.lock
+++ b/examples/jekyll/Gemfile.lock
@@ -79,4 +79,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/examples/jekyll/Gemfile.lock
+++ b/examples/jekyll/Gemfile.lock
@@ -79,4 +79,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.17.2
+   2.0.2

--- a/examples/middleman/Gemfile.lock
+++ b/examples/middleman/Gemfile.lock
@@ -105,4 +105,4 @@ DEPENDENCIES
   wdm (~> 0.1)
 
 BUNDLED WITH
-   1.17.2
+   2.0.2

--- a/examples/middleman/Gemfile.lock
+++ b/examples/middleman/Gemfile.lock
@@ -105,4 +105,4 @@ DEPENDENCIES
   wdm (~> 0.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
These examples were using an old version of Bundler which didn't match our tests and would fail with:

```
/ruby27/lib/ruby/2.7.0/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by your /zeit/6f4b9e46/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.2`
	from /ruby27/lib/ruby/2.7.0/rubygems.rb:294:in `activate_bin_path'
	from /ruby27/bin/bundle:23:in `<main>'
```

I ran `bundle update --bundler` in each of these directories and it only updated the version in `Gemfile.lock` because 2.x is mostly backwards compatible.