### PR TITLE
Add support for `/api/v1/frameworks` to the framework API

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/",
+      "source": "/(api/v1/frameworks)?",
       "destination": "/api/frameworks"
     }
   ],

--- a/now.json
+++ b/now.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/(api/v1/frameworks)?",
+      "source": "^/(api/v1/frameworks)?$",
       "destination": "/api/frameworks"
     }
   ],

--- a/now.json
+++ b/now.json
@@ -1,7 +1,11 @@
 {
   "rewrites": [
     {
-      "source": "^/(api/v1/frameworks)?$",
+      "source": "/",
+      "destination": "/api/frameworks"
+    },
+    {
+      "source": "/api/v1/frameworks",
       "destination": "/api/frameworks"
     }
   ],


### PR DESCRIPTION
This change ensures `/api/v1/frameworks` is supported by the frameworks API.