### PR TITLE
Use correct frameworks endpoint

### DIFF
--- a/packages/now-cli/src/util/get-frameworks.ts
+++ b/packages/now-cli/src/util/get-frameworks.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { Framework } from '@now/frameworks';
 
 export async function getFrameworks(): Promise<Framework[]> {
-  const res = await fetch('https://api-frameworks.zeit.sh/api/frameworks');
+  const res = await fetch('https://api.zeit.co/v1/frameworks');
 
   if (!res.ok) {
     throw new Error('Could not retrieve frameworks');


### PR DESCRIPTION
This ensures we're using the correct endpoint to retrieve frameworks.