### PR TITLE
[all] Fix test fixture pkg names and increase retry

### DIFF
--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "gatsby-starter-default",
+  "name": "gatsby",
   "version": "1.0.0",
   "dependencies": {
     "gatsby": "^2.18.14",

--- a/examples/gridsome/package.json
+++ b/examples/gridsome/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gridsomee",
+  "name": "gridsome",
   "private": true,
   "scripts": {
     "build": "gridsome build",

--- a/packages/now-build-utils/test/fixtures/05-zero-config-gatsby/gatsby-config.js
+++ b/packages/now-build-utils/test/fixtures/05-zero-config-gatsby/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
+        name: `05-zero-config-gatsby`,
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,

--- a/packages/now-build-utils/test/fixtures/05-zero-config-gatsby/package.json
+++ b/packages/now-build-utils/test/fixtures/05-zero-config-gatsby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "05-zero-config-gatsby",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/now-cli/test/dev/fixtures/05-gatsby/gatsby-config.js
+++ b/packages/now-cli/test/dev/fixtures/05-gatsby/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
+        name: `05-gatsby`,
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,

--- a/packages/now-cli/test/dev/fixtures/05-gatsby/package.json
+++ b/packages/now-cli/test/dev/fixtures/05-gatsby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "05-gatsby",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/now-cli/test/dev/fixtures/08-hugo/themes/ananke/package.json
+++ b/packages/now-cli/test/dev/fixtures/08-hugo/themes/ananke/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "gohugo-default-theme",
+  "name": "08-gohugo-default-theme",
   "version": "1.0.0",
   "description": "Base Theme to start Hugo Sites",
-  "main": "index.js",  
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/theNewDynamic/thenewdynamic.com.git"

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -20,6 +20,7 @@ import logo from '../src/util/output/logo';
 import sleep from '../src/util/sleep';
 import pkg from '../package';
 import prepareFixtures from './helpers/prepare';
+import { fetchTokenWithRetry } from '../../../test/lib/deployment/now-deploy';
 
 // log command when running `execa`
 function execa(file, args, options) {
@@ -69,25 +70,6 @@ const waitForDeployment = async href => {
     await sleep(2000);
   }
 };
-
-function fetchTokenWithRetry(url, retries = 3) {
-  return retry(
-    async () => {
-      const res = await fetch(url);
-
-      if (!res.ok) {
-        throw new Error(
-          `Failed to fetch ${url}, received status ${res.status}`
-        );
-      }
-
-      const data = await res.json();
-
-      return data.token;
-    },
-    { retries, factor: 1 }
-  );
-}
 
 function fetchTokenInformation(token, retries = 3) {
   const url = `https://api.zeit.co/www/user`;

--- a/packages/now-static-build/test/fixtures/10-gatsby-without-build-script/gatsby-config.js
+++ b/packages/now-static-build/test/fixtures/10-gatsby-without-build-script/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
+        name: `10-gatsby-without-build-script`,
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,

--- a/packages/now-static-build/test/fixtures/10-gatsby-without-build-script/package.json
+++ b/packages/now-static-build/test/fixtures/10-gatsby-without-build-script/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "10-gatsby-without-build-script",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/now-static-build/test/fixtures/10-gatsby/gatsby-config.js
+++ b/packages/now-static-build/test/fixtures/10-gatsby/gatsby-config.js
@@ -18,7 +18,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
+        name: `10-gatsby`,
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,

--- a/packages/now-static-build/test/fixtures/10-gatsby/package.json
+++ b/packages/now-static-build/test/fixtures/10-gatsby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "10-gatsby",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/now-static-build/test/fixtures/26-ejected-cra/package.json
+++ b/packages/now-static-build/test/fixtures/26-ejected-cra/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "12-create-react-app",
+  "name": "26-ejected-cra",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/packages/now-static-build/test/fixtures/31-hugo/themes/ananke/package.json
+++ b/packages/now-static-build/test/fixtures/31-hugo/themes/ananke/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "gohugo-default-theme",
+  "name": "31-gohugo-default-theme",
   "version": "1.0.0",
   "description": "Base Theme to start Hugo Sites",
-  "main": "index.js",  
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/theNewDynamic/thenewdynamic.com.git"

--- a/packages/now-static-build/test/fixtures/46-hugo-with-framework/themes/ananke/package.json
+++ b/packages/now-static-build/test/fixtures/46-hugo-with-framework/themes/ananke/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gohugo-default-theme",
+  "name": "46-gohugo-default-theme",
   "version": "2.5.5",
   "description": "Base Theme to start Hugo Sites",
   "main": "index.js",

--- a/packages/now-static-build/test/fixtures/48-nuxt-without-framework/package.json
+++ b/packages/now-static-build/test/fixtures/48-nuxt-without-framework/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "47-nuxt-with-custom-output",
+  "name": "48-nuxt-without-framework",
   "version": "1.0.0",
   "main": "pages/index.js",
   "scripts": {

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -166,12 +166,16 @@ async function fetchWithAuth (url, opts = {}) {
   return await fetchApi(url, opts);
 }
 
-function fetchTokenWithRetry (url, retries = 3) {
+function fetchTokenWithRetry (url, retries = 4) {
   return new Promise(async (resolve, reject) => {
     try {
       const res = await fetch(url);
       const data = await res.json();
-      resolve(data.token);
+      if (res.status === 200 && data && data.token) {
+        resolve(data.token);
+      } else {
+        throw new Error('Unexpected response from token factory');
+      }
     } catch (error) {
       console.log(`Failed to fetch token. Retries remaining: ${retries}`);
       if (retries === 0) {

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -170,12 +170,21 @@ function fetchTokenWithRetry (url, retries = 4) {
   return new Promise(async (resolve, reject) => {
     try {
       const res = await fetch(url);
-      const data = await res.json();
-      if (res.status === 200 && data && data.token) {
-        resolve(data.token);
-      } else {
-        throw new Error('Unexpected response from token factory');
+      if (!res.ok) {
+        throw new Error(
+          `Unexpected response from token factory: status ${res.status}`
+        );
       }
+      const data = await res.json();
+      if (!data) {
+        throw new Error(`Unexpected response from token factory: no body`);
+      }
+      if (!data.token) {
+        throw new Error(
+          `Unexpected response from token factory: ${JSON.stringify(data)}`
+        );
+      }
+      resolve(data.token);
     } catch (error) {
       console.log(`Failed to fetch token. Retries remaining: ${retries}`);
       if (retries === 0) {

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -7,10 +7,10 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const str = 'aHR0cHM6Ly9hcGktdG9rZW4tZmFjdG9yeS56ZWl0LnNo';
 
-async function nowDeploy (bodies, randomness) {
+async function nowDeploy(bodies, randomness) {
   const files = Object.keys(bodies)
-    .filter((n) => n !== 'now.json')
-    .map((n) => ({
+    .filter(n => n !== 'now.json')
+    .map(n => ({
       sha: digestOfFile(bodies[n]),
       size: bodies[n].length,
       file: n,
@@ -37,7 +37,7 @@ async function nowDeploy (bodies, randomness) {
   };
 
   if (process.env.FORCE_BUILD_IN_REGION) {
-    const { builds=[] } = nowDeployPayload;
+    const { builds = [] } = nowDeployPayload;
     builds.forEach(b => {
       if (!b.config) {
         b.config = {};
@@ -57,7 +57,8 @@ async function nowDeploy (bodies, randomness) {
 
   {
     const json = await deploymentPost(nowDeployPayload);
-    if (json.error && json.error.code === 'missing_files') throw new Error('Missing files');
+    if (json.error && json.error.code === 'missing_files')
+      throw new Error('Missing files');
     deploymentId = json.id;
     deploymentUrl = json.url;
   }
@@ -67,21 +68,22 @@ async function nowDeploy (bodies, randomness) {
 
   for (let i = 0; i < 750; i += 1) {
     const { state } = await deploymentGet(deploymentId);
-    if (state === 'ERROR') throw new Error(`State of ${deploymentUrl} is ${state}`);
+    if (state === 'ERROR')
+      throw new Error(`State of ${deploymentUrl} is ${state}`);
     if (state === 'READY') break;
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, 1000));
   }
 
   return { deploymentId, deploymentUrl };
 }
 
-function digestOfFile (body) {
+function digestOfFile(body) {
   return createHash('sha1')
     .update(body)
     .digest('hex');
 }
 
-async function filePost (body, digest) {
+async function filePost(body, digest) {
   assert(Buffer.isBuffer(body));
 
   const headers = {
@@ -104,13 +106,13 @@ async function filePost (body, digest) {
   if (json.error) {
     const { status, statusText, headers } = resp;
     const { message } = json.error;
-    console.log('Fetch Error', { url , status, statusText, headers, digest });
+    console.log('Fetch Error', { url, status, statusText, headers, digest });
     throw new Error(message);
   }
   return json;
 }
 
-async function deploymentPost (payload) {
+async function deploymentPost(payload) {
   const url = '/v6/now/deployments?forceNew=1';
   const resp = await fetchWithAuth(url, {
     method: 'POST',
@@ -122,30 +124,30 @@ async function deploymentPost (payload) {
   if (json.error) {
     const { status, statusText, headers } = resp;
     const { message } = json.error;
-    console.log('Fetch Error', { url , status, statusText, headers });
+    console.log('Fetch Error', { url, status, statusText, headers });
     throw new Error(message);
   }
   return json;
 }
 
-async function deploymentGet (deploymentId) {
+async function deploymentGet(deploymentId) {
   const url = `/v3/now/deployments/${deploymentId}`;
   const resp = await fetchWithAuth(url);
   const json = await resp.json();
   if (json.error) {
     const { status, statusText, headers } = resp;
     const { message } = json.error;
-    console.log('Fetch Error', { url , status, statusText, headers });
+    console.log('Fetch Error', { url, status, statusText, headers });
     throw new Error(message);
   }
-  return json
+  return json;
 }
 
 let token;
 let currentCount = 0;
 const MAX_COUNT = 10;
 
-async function fetchWithAuth (url, opts = {}) {
+async function fetchWithAuth(url, opts = {}) {
   if (!opts.headers) opts.headers = {};
 
   if (!opts.headers.Authorization) {
@@ -168,7 +170,7 @@ async function fetchWithAuth (url, opts = {}) {
   return await fetchApi(url, opts);
 }
 
-async function fetchTokenWithRetry (url, retries = 4) {
+async function fetchTokenWithRetry(url, retries = 5) {
   try {
     const res = await _fetch(url);
     if (!res.ok) {
@@ -179,7 +181,7 @@ async function fetchTokenWithRetry (url, retries = 4) {
       throw new Error(`Unexpected response from token factory: no body`);
     }
     if (!data.token) {
-      const text = JSON.stringify(data)
+      const text = JSON.stringify(data);
       throw new Error(`Unexpected response from token factory: ${text}`);
     }
     return data.token;
@@ -194,7 +196,7 @@ async function fetchTokenWithRetry (url, retries = 4) {
   }
 }
 
-async function fetchApi (url, opts = {}) {
+async function fetchApi(url, opts = {}) {
   const apiHost = process.env.API_HOST || 'api.zeit.co';
   const urlWithHost = `https://${apiHost}${url}`;
   const { method = 'GET', body } = opts;


### PR DESCRIPTION
Fixes test warnings from `jest-hast-map`:

```
[now-static-build] Running yarn test-integration-once
$ jest --env node --verbose --runInBand test/integration.test.js
jest-haste-map: Haste module naming collision: 12-create-react-app
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/test/fixtures/12-create-react-app/package.json
    * <rootDir>/test/fixtures/26-ejected-cra/package.json

jest-haste-map: Haste module naming collision: gatsby-starter-default
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/test/fixtures/10-gatsby/package.json
    * <rootDir>/test/fixtures/10-gatsby-without-build-script/package.json

jest-haste-map: Haste module naming collision: gohugo-default-theme
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/test/fixtures/31-hugo/themes/ananke/package.json
    * <rootDir>/test/fixtures/46-hugo-with-framework/themes/ananke/package.json

jest-haste-map: Haste module naming collision: gohugo-default-styles
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/test/fixtures/31-hugo/themes/ananke/src/package.json
    * <rootDir>/test/fixtures/46-hugo-with-framework/themes/ananke/src/package.json

jest-haste-map: Haste module naming collision: 47-nuxt-with-custom-output
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/test/fixtures/47-nuxt-with-custom-output/package.json
    * <rootDir>/test/fixtures/48-nuxt-without-framework/package.json
```

Also increased test retry to 5.