### PR TITLE
[now-client] Fix lint error: forbidden non-null assertion

### DIFF
--- a/packages/now-client/src/create-deployment.ts
+++ b/packages/now-client/src/create-deployment.ts
@@ -1,7 +1,7 @@
 import { readdir as readRootFolder, lstatSync } from 'fs-extra';
 
 import readdir from 'recursive-readdir';
-import { relative, join, isAbsolute } from 'path';
+import { relative, join, isAbsolute, basename } from 'path';
 import hashes, { mapToObject } from './utils/hashes';
 import { upload } from './upload';
 import { getNowIgnore, createDebug, parseNowJSON } from './utils';
@@ -156,14 +156,7 @@ export default function buildCreateDeployment(version: number) {
     // from getting confused about a deployment that renders 404.
     if (
       fileList.length === 0 ||
-      fileList.every(item =>
-        item
-          ? item
-              .split('/')
-              .pop()!
-              .startsWith('.')
-          : true
-      )
+      fileList.every(f => (f ? basename(f).startsWith('.') : true))
     ) {
       debug(
         `Deployment path has no files (or only dotfiles). Yielding a warning event`


### PR DESCRIPTION
Fixes the following lint error: `Forbidden non-null assertion`.

<img src="https://user-images.githubusercontent.com/229881/77072131-98b8ab80-69c3-11ea-84f5-e45be43951f9.png" height=200 />

I realized this logic was somewhat brittle because it relied on `/` path separators so I switched it to use the native file name function `basename()` to determine if a file begins with a dot.
