### PR TITLE
[now-cli] Fix error on `now ls`

### DIFF
--- a/packages/now-cli/src/commands/list.js
+++ b/packages/now-cli/src/commands/list.js
@@ -327,7 +327,7 @@ export default async function main(ctx) {
     ).replace(/^/gm, '  ')}\n\n`
   );
 
-  if (deployments.length === 20) {
+  if (pagination && deployments.length === 20) {
     log(`To display the next page use the flag --next ${pagination.next}`);
   }
 }


### PR DESCRIPTION
This PR fixes the issue `TypeError: Cannot read property 'next' of undefined` when running the command `now ls`.