### PR TITLE
[tests] Fix publish job environment variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,3 +27,5 @@ jobs:
       run: yarn publish-from-github
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
The env vars were included on the build step but not the publish step.