### PR TITLE
[now-cli] Print link to more details on error

### DIFF
--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -13,6 +13,7 @@ import code from './output/code';
 export class APIError extends Error {
   status: number;
   serverMessage: string;
+  link?: string;
   retryAfter: number | null | 'never';
   [key: string]: any;
 

--- a/packages/now-cli/src/util/handle-error.ts
+++ b/packages/now-cli/src/util/handle-error.ts
@@ -12,37 +12,36 @@ export default function handleError(
     error = new Error(error);
   }
 
+  const apiError = error as APIError;
+  const { message, stack, status, code, sizeLimit } = apiError;
+
   if (debug) {
-    console.log(`> [debug] handling error: ${error.stack}`);
+    console.log(`> [debug] handling error: ${stack}`);
   }
 
-  if ((<APIError>error).status === 403) {
+  if (status === 403) {
     console.error(
       errorOutput(
-        error.message ||
-          'Authentication error. Run `now login` to log-in again.'
+        message || 'Authentication error. Run `now login` to log-in again.'
       )
     );
-  } else if ((<APIError>error).status === 429) {
+  } else if (status === 429) {
     // Rate limited: display the message from the server-side,
     // which contains more details
-    console.error(errorOutput(error.message));
-  } else if ((<APIError>error).code === 'size_limit_exceeded') {
-    const { sizeLimit = 0 } = <APIError>error;
+    console.error(errorOutput(message));
+  } else if (code === 'size_limit_exceeded') {
     console.error(
       errorOutput(`File size limit exceeded (${bytes(sizeLimit)})`)
     );
-  } else if (error.message) {
-    console.error(errorOutput(error.message));
-  } else if ((<APIError>error).status === 500) {
+  } else if (message) {
+    console.error(errorOutput(apiError));
+  } else if (status === 500) {
     console.error(errorOutput('Unexpected server error. Please retry.'));
-  } else if ((<APIError>error).code === 'USER_ABORT') {
+  } else if (code === 'USER_ABORT') {
     info('Aborted');
   } else {
     console.error(
-      errorOutput(
-        `Unexpected error. Please try again later. (${error.message})`
-      )
+      errorOutput(`Unexpected error. Please try again later. (${message})`)
     );
   }
 }

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -19,7 +19,11 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     print(`${color(`> ${str}`)}\n`);
   }
 
-  function warn(str: string, slug: string | null = null) {
+  function warn(
+    str: string,
+    slug: string | null = null,
+    link: string | null = null
+  ) {
     const prevTerm = process.env.TERM;
 
     if (!prevTerm) {
@@ -27,11 +31,13 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
       process.env.TERM = 'xterm';
     }
 
+    const details = slug ? `https://err.sh/now/${slug}` : link;
+
     print(
       boxen(
         chalk.bold.yellow('WARN! ') +
           str +
-          (slug ? `\nMore details: https://err.sh/now/${slug}` : ''),
+          (details ? `\nMore details: ${details}` : ''),
         {
           padding: {
             top: 0,
@@ -52,10 +58,15 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     log(chalk`{yellow.bold NOTE:} ${str}`);
   }
 
-  function error(str: string, slug: string | null = null) {
+  function error(
+    str: string,
+    slug: string | null = null,
+    link: string | null = null
+  ) {
     print(`${chalk.red(`Error!`)} ${str}\n`);
-    if (slug !== null) {
-      print(`More details: https://err.sh/now/${slug}\n`);
+    const details = slug ? `https://err.sh/now/${slug}` : link;
+    if (details) {
+      print(`More details: ${details}\n`);
     }
   }
 

--- a/packages/now-cli/src/util/output/error.ts
+++ b/packages/now-cli/src/util/output/error.ts
@@ -1,17 +1,23 @@
 import chalk from 'chalk';
 import { metrics, shouldCollectMetrics } from '../metrics';
 
+interface ApiError {
+  message: string;
+  slug?: string;
+  link?: string;
+}
+
 const metric = metrics();
 
-export default function error(
-  ...input: string[] | [{ slug: string; message: string }]
-) {
+export default function error(...input: string[] | [ApiError]) {
   let messages = input;
   if (typeof input[0] === 'object') {
-    const { slug, message } = input[0];
+    const { slug, message, link } = input[0];
     messages = [message];
     if (slug) {
       messages.push(`> More details: https://err.sh/now/${slug}`);
+    } else if (link) {
+      messages.push(`> More details: ${link}`);
     }
   }
 

--- a/packages/now-cli/src/util/output/error.ts
+++ b/packages/now-cli/src/util/output/error.ts
@@ -1,15 +1,10 @@
 import chalk from 'chalk';
 import { metrics, shouldCollectMetrics } from '../metrics';
-
-interface ApiError {
-  message: string;
-  slug?: string;
-  link?: string;
-}
+import { APIError } from '../errors-ts';
 
 const metric = metrics();
 
-export default function error(...input: string[] | [ApiError]) {
+export default function error(...input: string[] | [APIError]) {
   let messages = input;
   if (typeof input[0] === 'object') {
     const { slug, message, link } = input[0];

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1862,11 +1862,7 @@ test('fail to deploy a Lambda with an incorrect value for of memory', async t =>
   const output = await execute([directory, '--confirm']);
 
   t.is(output.exitCode, 1, formatOutput(output));
-  t.regex(
-    output.stderr,
-    /Functions must have a memory value between 128 and 3008 in steps of 64\./gm,
-    formatOutput(output)
-  );
+  t.regex(output.stderr, /in steps of 64\./gm, formatOutput(output));
 });
 
 test('deploy a Lambda with 3 seconds of maxDuration', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1862,7 +1862,7 @@ test('fail to deploy a Lambda with an incorrect value for of memory', async t =>
   const output = await execute([directory, '--confirm']);
 
   t.is(output.exitCode, 1, formatOutput(output));
-  t.regex(output.stderr, /in steps of 64\./gm, formatOutput(output));
+  t.regex(output.stderr, /in steps of 64/gm, formatOutput(output));
 });
 
 test('deploy a Lambda with 3 seconds of maxDuration', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1862,7 +1862,8 @@ test('fail to deploy a Lambda with an incorrect value for of memory', async t =>
   const output = await execute([directory, '--confirm']);
 
   t.is(output.exitCode, 1, formatOutput(output));
-  t.regex(output.stderr, /in steps of 64/gm, formatOutput(output));
+  t.regex(output.stderr, /steps of 64/gm, formatOutput(output));
+  t.regex(output.stderr, /More details/gm, formatOutput(output));
 });
 
 test('deploy a Lambda with 3 seconds of maxDuration', async t => {


### PR DESCRIPTION
This PR updates API Errors to support the `error.link` property.

Unlike `error.slug` which is only a path to an error message, `error.link` contains the full URL.


### Example Output

```
$ now
Error! Serverless Functions.........etc
> More details: https://zeit.ink/...etc
```