### PR TITLE
[now-next][now-static-build][now-build-utils] Use util to get node .bin in path

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -99,6 +99,14 @@ export async function execCommand(command: string, options: SpawnOptions = {}) {
   return true;
 }
 
+export async function getNodeBinPath(entrypointDir: string) {
+  const { stdout } = await execAsync('yarn', ['bin'], {
+    cwd: entrypointDir,
+  });
+
+  return stdout.trim();
+}
+
 async function chmodPlusX(fsPath: string) {
   const s = await fs.stat(fsPath);
   const newMode = s.mode | 64 | 8 | 1; // eslint-disable-line no-bitwise

--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -99,11 +99,8 @@ export async function execCommand(command: string, options: SpawnOptions = {}) {
   return true;
 }
 
-export async function getNodeBinPath(entrypointDir: string) {
-  const { stdout } = await execAsync('yarn', ['bin'], {
-    cwd: entrypointDir,
-  });
-
+export async function getNodeBinPath({ cwd }: { cwd: string }) {
+  const { stdout } = await execAsync('npm', ['bin'], { cwd });
   return stdout.trim();
 }
 

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -20,6 +20,7 @@ import {
   runShellScript,
   getNodeVersion,
   getSpawnOptions,
+  getNodeBinPath,
 } from './fs/run-user-scripts';
 import {
   getLatestNodeVersion,
@@ -48,6 +49,7 @@ export {
   runPackageJsonScript,
   execCommand,
   spawnCommand,
+  getNodeBinPath,
   runNpmInstall,
   runBundleInstall,
   runPipInstall,

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -18,6 +18,7 @@ import {
   runNpmInstall,
   runPackageJsonScript,
   execCommand,
+  getNodeBinPath,
 } from '@now/build-utils';
 import { Route, Handler } from '@now/routing-utils';
 import {
@@ -338,6 +339,14 @@ export const build = async ({
   env.NODE_OPTIONS = `--max_old_space_size=${memoryToConsume}`;
 
   if (config.buildCommand) {
+    // Add `node_modules/.bin` to PATH
+    const nodeBinPath = await getNodeBinPath(entryPath);
+    env.PATH = `${nodeBinPath}${path.delimiter}${env.PATH}`;
+
+    debug(
+      `Added "${nodeBinPath}" to PATH env because a build command was used.`
+    );
+
     console.log(`Running "${config.buildCommand}"`);
     await execCommand(config.buildCommand, {
       ...spawnOpts,

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -340,7 +340,7 @@ export const build = async ({
 
   if (config.buildCommand) {
     // Add `node_modules/.bin` to PATH
-    const nodeBinPath = await getNodeBinPath(entryPath);
+    const nodeBinPath = await getNodeBinPath({ cwd: entryPath });
     env.PATH = `${nodeBinPath}${path.delimiter}${env.PATH}`;
 
     debug(

--- a/packages/now-next/test/fixtures/24-custom-output-dir/now.json
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/now.json
@@ -4,7 +4,7 @@
       "src": "package.json",
       "use": "@now/next",
       "config": {
-        "buildCommand": "npm run build",
+        "buildCommand": "next build",
         "outputDirectory": "the-output-directory"
       }
     }

--- a/packages/now-next/test/test.js
+++ b/packages/now-next/test/test.js
@@ -7,10 +7,21 @@ const {
 } = require('../../../test/lib/deployment/test-deployment.js');
 
 jest.setTimeout(4 * 60 * 1000);
-const buildUtilsUrl = '@canary';
+let buildUtilsUrl;
 let builderUrl;
 
 beforeAll(async () => {
+  if (!buildUtilsUrl) {
+    const buildUtilsPath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'now-build-utils'
+    );
+    buildUtilsUrl = await packAndDeploy(buildUtilsPath);
+    console.log('buildUtilsUrl', buildUtilsUrl);
+  }
+
   process.env.NEXT_TELEMETRY_DISABLED = '1';
   const builderPath = path.resolve(__dirname, '..');
   builderUrl = await packAndDeploy(builderPath);

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -9,11 +9,11 @@ import { frameworks, Framework } from './frameworks';
 import {
   glob,
   download,
-  execAsync,
   spawnAsync,
   execCommand,
   spawnCommand,
   runNpmInstall,
+  getNodeBinPath,
   runBundleInstall,
   runPipInstall,
   runPackageJsonScript,
@@ -341,19 +341,17 @@ export async function build({
 
     if (pkg && (buildCommand || devCommand)) {
       // We want to add `node_modules/.bin` after `npm install`
-      const { stdout } = await execAsync('yarn', ['bin'], {
-        cwd: entrypointDir,
-      });
+      const nodeBinPath = await getNodeBinPath(entrypointDir);
 
       spawnOpts.env = {
         ...spawnOpts.env,
-        PATH: `${stdout.trim()}${path.delimiter}${
+        PATH: `${nodeBinPath}${path.delimiter}${
           spawnOpts.env ? spawnOpts.env.PATH : ''
         }`,
       };
 
       debug(
-        `Added "${stdout.trim()}" to PATH env because a package.json file was found.`
+        `Added "${nodeBinPath}" to PATH env because a package.json file was found.`
       );
     }
 

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -341,7 +341,7 @@ export async function build({
 
     if (pkg && (buildCommand || devCommand)) {
       // We want to add `node_modules/.bin` after `npm install`
-      const nodeBinPath = await getNodeBinPath(entrypointDir);
+      const nodeBinPath = await getNodeBinPath({ cwd: entrypointDir });
 
       spawnOpts.env = {
         ...spawnOpts.env,


### PR DESCRIPTION
https://zeit.atlassian.net/browse/PRODUCT-1380

This makes `now-next` consider the `node_modules/.bin` path if a custom build command was specified, which makes it work like `now-static-build`. 