### PR TITLE
[now-cli] Fix ambiguous argument error

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -369,13 +369,15 @@ const main = async argv_ => {
   // we check if we are deploying something
   if (targetOrSubcommand) {
     const targetPath = join(process.cwd(), targetOrSubcommand);
-    const targetPathExists =
-      existsSync(targetPath) && lstatSync(targetPath).isDirectory();
+    const targetPathExists = existsSync(targetPath);
     const subcommandExists =
       GLOBAL_COMMANDS.has(targetOrSubcommand) ||
       commands.has(targetOrSubcommand);
 
     if (targetPathExists && subcommandExists) {
+      const fileType = lstatSync(targetPath).isDirectory()
+        ? 'subdirectory'
+        : 'file';
       const plural = targetOrSubcommand + 's';
       const singular = targetOrSubcommand.endsWith('s')
         ? targetOrSubcommand.slice(0, -1)
@@ -389,7 +391,7 @@ const main = async argv_ => {
       console.error(
         error(
           `The supplied argument ${param(targetOrSubcommand)} is ambiguous.` +
-            `\nIf you wish to deploy the subdirectory ${param(
+            `\nIf you wish to deploy the ${fileType} ${param(
               targetOrSubcommand
             )}, first run "cd ${targetOrSubcommand}". ` +
             (alternative

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -319,6 +319,10 @@ CMD ["node", "index.js"]`,
         name: 'nested-level',
       }),
     },
+    'subdirectory-secret': {
+      'index.html': 'Home page',
+      'secret/file.txt': 'my secret',
+    },
     'alias-rules': {
       'rules.json': JSON.stringify({
         rules: [

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -366,6 +366,30 @@ test('output the version', async t => {
   t.is(version, pkg.version);
 });
 
+test('should error with suggestion for secrets subcommand', async t => {
+  const target = fixture('subdirectory-secret');
+
+  const { exitCode, stderr, stdout } = await execa(
+    binaryPath,
+    ['secret', 'add', 'key', 'value', ...defaultArgs],
+    {
+      cwd: target,
+      reject: false,
+    }
+  );
+
+  console.log(stderr);
+  console.log(stdout);
+  console.log(exitCode);
+
+  t.is(exitCode, 1);
+  t.regex(
+    stderr,
+    /secrets/gm,
+    `Expected "secrets" suggestion but received "${stderr}"`
+  );
+});
+
 test('login with unregistered user', async t => {
   const { stdout, stderr, exitCode } = await execa(
     binaryPath,


### PR DESCRIPTION
This updates the error message to offer action items when an ambiguous argument is provided.

## Before

```
Error! The supplied argument "secrets" is ambiguous. Both a directory and a subcommand are known 
```

## After

```
Error! The supplied argument "secrets" is ambiguous.
If you wish to deploy the subdirectory "secrets", first run "cd secrets".
If you wish to use the subcommand "secrets", use "secret" instead.
```