### PR TITLE
[now-cli] Fix broken message when a deployment is canceled

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -576,7 +576,7 @@ export default async function main(
     }
 
     if (deployment.readyState === 'CANCELED') {
-      output.log('The deployment has been canceled.');
+      output.print('The deployment has been canceled.');
       return 1;
     }
 

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -576,7 +576,7 @@ export default async function main(
     }
 
     if (deployment.readyState === 'CANCELED') {
-      output.print('The deployment has been canceled.');
+      output.print('The deployment has been canceled.\n');
       return 1;
     }
 

--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -205,6 +205,9 @@ export default async function processDeployment({
     }
 
     if (event.type === 'canceled') {
+      if (queuedSpinner) {
+        queuedSpinner();
+      }
       if (buildSpinner) {
         buildSpinner();
       }


### PR DESCRIPTION
This PR fixes an issue with displaying the message when a deployment is canceled, either when it is canceled from the UI, or when a deployment is automatically canceled if no change has been made in the project.