### PR TITLE
[tests] Fix coverage checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,19 +2,7 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
+  status:
+    project: off
+    patch: off
 
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
-
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: no


### PR DESCRIPTION
The CodeCov GitHub integration is confused about the monorepo and started reporting failures recently.

<img src="https://user-images.githubusercontent.com/229881/77462927-2983f280-6ddb-11ea-9ee2-38b660b2fd2f.png" height=120 />

We run `codecov` from the CLI so we can disable the integration. 

## References

- https://docs.codecov.io/docs/codecovyml-reference
- https://docs.codecov.io/docs/commit-status#section-disabling-a-status