### PR TITLE
[tests] Cancel previous workflows on push

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,7 +1,7 @@
 name: Cancel
 on:
   push:
-    branches:    
+    branches:
     - '*'
     - '!master'
 
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.2.0
+      - uses: styfle/cancel-workflow-action@0.3.1
         with:
-          workflow_id: 435869
+          workflow_id: 849295, 849296, 849297, 849298
           access_token: ${{ secrets.GITHUB_WORKFLOW_TOKEN }}
 


### PR DESCRIPTION
Follow up to #3961

Workflow IDs are found here: from https://api.github.com/repos/zeit/now/actions/workflows