### PR TITLE
[examples][now-static-build] Bump `ionic-react` to latest typescript

### DIFF
--- a/examples/ionic-react/package.json
+++ b/examples/ionic-react/package.json
@@ -20,7 +20,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
-    "typescript": "3.7.4"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/now-static-build/test/fixtures/50-ionic-react/package.json
+++ b/packages/now-static-build/test/fixtures/50-ionic-react/package.json
@@ -20,7 +20,7 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
-    "typescript": "3.7.4"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Fixes an issue with a dependency that was bumped but typescript was pinned in `ionic-react`.


```
$ react-scripts build
Creating an optimized production build...
Failed to compile.
/zeit/333ecfab/node_modules/@types/testing-library__react/node_modules/pretty-format/build/index.d.ts
TypeScript error in /zeit/333ecfab/node_modules/@types/testing-library__react/node_modules/pretty-format/build/index.d.ts(7,13):
'=' expected.  TS1005
     5 |  * LICENSE file in the root directory of this source tree.
     6 |  */
  >  7 | import type * as PrettyFormat from './types';
       |             ^
     8 | /**
     9 |  * Returns a presentation string of your `val` object
    10 |  * @param val any potential JavaScript object
error Command failed with exit code 1.
```