### PR TITLE
[now-next] Fix dynamic routes and data routes order

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1224,11 +1224,12 @@ export const build = async ({
       // routes that are called after each rewrite or after routes
       // if there no rewrites
       { handle: 'rewrite' },
-      // Dynamic routes
-      ...dynamicRoutes,
 
       // /_next/data routes for getServerProps/getStaticProps pages
       ...dataRoutes,
+
+      // Dynamic routes (must come after dataRoutes as they are more specific)
+      ...dynamicRoutes,
 
       // routes to call after a file has been matched
       { handle: 'hit' },

--- a/packages/now-next/test/fixtures/22-ssg-v2-catchall/next.config.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2-catchall/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2-catchall/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2-catchall/now.json
@@ -1,0 +1,38 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@now/next" }],
+  "probes": [
+    // make sure index responds correctly
+    {
+      "path": "/",
+      "mustContain": "Create Next App"
+    },
+
+    // make sure lazy catch-all SSG page matches
+    {
+      "path": "/another",
+      "mustContain": "Loading..."
+    },
+
+    { "delay": 2000 },
+
+    // make sure lazy catch-all SSG page was cached
+    {
+      "path": "/another",
+      "mustContain": "My awesome article"
+    },
+
+    // make sure lazy catch-all SSG data route matches
+    {
+      "path": "/_next/data/testing-build-id/something.json",
+      "mustContain": "My awesome article"
+    },
+
+    // make sure lazy catch-all SSG data route doesn't have HTML
+    // make sure lazy catch-all SSG data route matches
+    {
+      "path": "/_next/data/testing-build-id/one-more.json",
+      "mustNotContain": "<html>"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2-catchall/package.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2-catchall/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "9.3.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/[...path].js
+++ b/packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/[...path].js
@@ -1,0 +1,62 @@
+import { useRouter } from 'next/router'
+import Error from 'next/error'
+
+function loadArticle() {
+  return {
+    content: [
+      {
+        type: 'header',
+        content: 'My awesome article',
+      },
+      {
+        type: 'paragraph',
+        content: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend.'
+      }
+    ]
+  }
+}
+
+const Page = ({ path, article }) => {
+  const router = useRouter()
+
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
+
+  if (!article.content) {
+    return <Error statusCode={404}/>
+  }
+
+  const [header, ...body] = article.content;
+
+  return (
+    <article>
+      <header>{header.content}</header>
+      <small>path: {path.join('/')}</small>
+      <main>
+        {body.map(({ content }) => <p>{content}</p>)}
+      </main>
+    </article>
+  )
+}
+
+export default Page
+
+export async function getStaticProps({ params }) {
+  const { path } = params;
+  const article = loadArticle(path);
+
+  return {
+    props: {
+      article,
+      path,
+    }
+  }
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}

--- a/packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/index.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/index.js
@@ -1,0 +1,203 @@
+import Head from 'next/head';
+
+const Home = () => (
+  <div className="container">
+    <Head>
+      <title>Create Next App</title>
+      <link rel="icon" href="/favicon.ico" />
+    </Head>
+
+    <main>
+      <h1 className="title">
+        Welcome to <a href="https://nextjs.org">Next.js!</a>
+      </h1>
+
+      <p className="description">
+        Get started by editing <code>pages/index.js</code>
+      </p>
+
+      <div className="grid">
+        <a href="https://nextjs.org/docs" className="card">
+          <h3>Documentation &rarr;</h3>
+          <p>Find in-depth information about Next.js features and API.</p>
+        </a>
+
+        <a href="https://nextjs.org/learn" className="card">
+          <h3>Learn &rarr;</h3>
+          <p>Learn about Next.js in an interactive course with quizzes!</p>
+        </a>
+
+        <a
+          href="https://github.com/zeit/next.js/tree/master/examples"
+          className="card"
+        >
+          <h3>Examples &rarr;</h3>
+          <p>Discover and deploy boilerplate example Next.js projects.</p>
+        </a>
+
+        <a
+          href="https://zeit.co/import?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          className="card"
+        >
+          <h3>Deploy &rarr;</h3>
+          <p>
+            Instantly deploy your Next.js site to a public URL with ZEIT Now.
+          </p>
+        </a>
+      </div>
+    </main>
+
+    <footer>
+      <a
+        href="https://zeit.co?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Powered by <img src="/zeit.svg" alt="ZEIT Logo" />
+      </a>
+    </footer>
+
+    <style jsx>{`
+      .container {
+        min-height: 100vh;
+        padding: 0 0.5rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+
+      main {
+        padding: 5rem 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+
+      footer {
+        width: 100%;
+        height: 100px;
+        border-top: 1px solid #eaeaea;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      footer img {
+        margin-left: 0.5rem;
+      }
+
+      footer a {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .title a {
+        color: #0070f3;
+        text-decoration: none;
+      }
+
+      .title a:hover,
+      .title a:focus,
+      .title a:active {
+        text-decoration: underline;
+      }
+
+      .title {
+        margin: 0;
+        line-height: 1.15;
+        font-size: 4rem;
+      }
+
+      .title,
+      .description {
+        text-align: center;
+      }
+
+      .description {
+        line-height: 1.5;
+        font-size: 1.5rem;
+      }
+
+      code {
+        background: #fafafa;
+        border-radius: 5px;
+        padding: 0.75rem;
+        font-size: 1.1rem;
+        font-family: Menlo, Monaco, Lucida Console, Liberation Mono,
+          DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
+      }
+
+      .grid {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+
+        max-width: 800px;
+        margin-top: 3rem;
+      }
+
+      .card {
+        margin: 1rem;
+        flex-basis: 45%;
+        padding: 1.5rem;
+        text-align: left;
+        color: inherit;
+        text-decoration: none;
+        border: 1px solid #eaeaea;
+        border-radius: 10px;
+        transition: color 0.15s ease, border-color 0.15s ease;
+      }
+
+      .card:hover,
+      .card:focus,
+      .card:active {
+        color: #0070f3;
+        border-color: #0070f3;
+      }
+
+      .card h3 {
+        margin: 0 0 1rem 0;
+        font-size: 1.5rem;
+      }
+
+      .card p {
+        margin: 0;
+        font-size: 1.25rem;
+        line-height: 1.5;
+      }
+
+      @media (max-width: 600px) {
+        .grid {
+          width: 100%;
+          flex-direction: column;
+        }
+      }
+    `}</style>
+
+    <style jsx global>{`
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+          Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+    `}</style>
+  </div>
+);
+
+export default Home;


### PR DESCRIPTION
When using a catch-all route at the base of the project it would cause it to be prioritized over any GS(S)P `/_next/data` routes. This fixes the order putting `/_next/data` routes first as they have higher specificity and adds tests to ensure we don't regress on this