### PR TITLE
Update `signal-exit` to v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "resolutions": {
-    "signal-exit": "TooTallNate/signal-exit#update/sighub-to-sigint-on-windows"
-  },
   "prettier": {
     "trailingComma": "es5",
     "singleQuote": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -9733,10 +9733,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@TooTallNate/signal-exit#update/sighub-to-sigint-on-windows, signal-exit@^3.0.0, signal-exit@^3.0.2:
-  version "3.0.2"
-  uid "58088fa7f715149f8411e089a4a6e3fe6ed265ec"
-  resolved "https://codeload.github.com/TooTallNate/signal-exit/tar.gz/58088fa7f715149f8411e089a4a6e3fe6ed265ec"
+signal-exit@^3.0.0, signal-exit@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 sinon@4.4.2:
   version "4.4.2"


### PR DESCRIPTION
@tootallnate's bug fix for `SIGHUB` on Windows has been merged and
published as `signal-exit@3.0.3`, so no more need for the "resolutions"
field in `package.json`.

The `yarn.lock` file has been updated accordingly.