### PR TITLE
[now-go] Fix import for go-bridge

### DIFF
--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"net/http"
-	now "github.com/zeit/now/utils/go/bridge"
+	now "github.com/zeit/now/utils/go/bridge@3ae83172eccea727118baed5c0250bfe45cea385"
 )
 
 func main() {

--- a/packages/now-go/main.go
+++ b/packages/now-go/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"net/http"
-	now "github.com/zeit/now/utils/go/bridge@3ae83172eccea727118baed5c0250bfe45cea385"
+	now "github.com/zeit/now-go-bridge/go/bridge"
 )
 
 func main() {

--- a/packages/now-go/main__mod__.go
+++ b/packages/now-go/main__mod__.go
@@ -4,7 +4,7 @@ import (
   "net/http"
   "__NOW_HANDLER_PACKAGE_NAME"
 
-  now "github.com/zeit/now/utils/go/bridge@3ae83172eccea727118baed5c0250bfe45cea385"
+  now "github.com/zeit/now-go-bridge/go/bridge"
 )
 
 func main() {

--- a/packages/now-go/main__mod__.go
+++ b/packages/now-go/main__mod__.go
@@ -4,7 +4,7 @@ import (
   "net/http"
   "__NOW_HANDLER_PACKAGE_NAME"
 
-  now "github.com/zeit/now/utils/go/bridge"
+  now "github.com/zeit/now/utils/go/bridge@3ae83172eccea727118baed5c0250bfe45cea385"
 )
 
 func main() {


### PR DESCRIPTION
Somehow, PR #3973 broke Go since the bridge is imported from this repo's master branch.

Go has very strict file name constraints and the file `[...path].js` is not compatible.


Here's what a `@now/go` deployment error message looks like:

```
Error: Command failed: go mod tidy
go: finding github.com/zeit/now latest
go: downloading github.com/zeit/now v0.0.0-20200326223129-c91495338d5e
go: extracting github.com/zeit/now v0.0.0-20200326223129-c91495338d5e
-> unzip /tmp/5a0676f5/pkg/mod/cache/download/github.com/zeit/now/@v/v0.0.0-20200326223129-c91495338d5e.zip: malformed file path "packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/[...path].js": double dot
handler imports
github.com/zeit/now/utils/go/bridge: unzip /tmp/5a0676f5/pkg/mod/cache/download/github.com/zeit/now/@v/v0.0.0-20200326223129-c91495338d5e.zip: malformed file path "packages/now-next/test/fixtures/22-ssg-v2-catchall/pages/[...path].js": double dot
```

The solution is to move Go Bridge into a separate repository: https://github.com/zeit/now-go-bridge

This will also have the side effect of speeding up Go imports because the repo will be much smaller.