### PR TITLE
[now-static-build][now-client] Ignore known static outputs

### DIFF
--- a/packages/now-client/src/index.ts
+++ b/packages/now-client/src/index.ts
@@ -1,5 +1,6 @@
 import buildCreateDeployment from './create-deployment';
 
+export { getNowIgnore } from './utils/index';
 export const createDeployment = buildCreateDeployment(2);
 export const createLegacyDeployment = buildCreateDeployment(1);
 export * from './errors';

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -5,6 +5,7 @@ import { nodeFetch, zeitFetch } from './fetch';
 import { join, sep, relative } from 'path';
 import qs from 'querystring';
 import ignore from 'ignore';
+type Ignore = ReturnType<typeof ignore>;
 import { pkgVersion } from '../pkg';
 import { NowClientOptions, DeploymentOptions, NowConfig } from '../types';
 import { Sema } from 'async-sema';
@@ -74,15 +75,17 @@ const maybeRead = async function<T>(path: string, default_: T) {
   }
 };
 
-export async function getNowIgnore(path: string | string[]): Promise<any> {
-  let ignores: string[] = [
-    '.hg',
-    '.git',
+export async function getNowIgnore(
+  path: string | string[]
+): Promise<{ ig: Ignore; ignores: string[] }> {
+  const ignores: string[] = [
+    '.hg/',
+    '.git/',
     '.gitmodules',
-    '.svn',
+    '.svn/',
     '.cache',
-    '.next',
-    '.now',
+    '.next/',
+    '.now/',
     '.npmignore',
     '.dockerignore',
     '.gitignore',
@@ -95,7 +98,7 @@ export async function getNowIgnore(path: string | string[]): Promise<any> {
     '.venv',
     'npm-debug.log',
     'config.gypi',
-    'node_modules',
+    'node_modules/',
     '__pycache__/',
     'venv/',
     'CVS',

--- a/packages/now-static-build/test/fixtures/55-ignore-output/example.html
+++ b/packages/now-static-build/test/fixtures/55-ignore-output/example.html
@@ -1,0 +1,1 @@
+<h1>Example Page</h1>

--- a/packages/now-static-build/test/fixtures/55-ignore-output/now.json
+++ b/packages/now-static-build/test/fixtures/55-ignore-output/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "zeroConfig": true, "outputDirectory": "." }
+    }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/55-ignore-output/package.json
+++ b/packages/now-static-build/test/fixtures/55-ignore-output/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "dependencies": {
+    "copee": "1.0.6"
+  },
+  "scripts": {
+    "build": "echo 'Output Page' > output.html && echo 'foo' > .env && git init && ls -lA"
+  }
+}

--- a/packages/now-static-build/test/fixtures/55-ignore-output/probe.js
+++ b/packages/now-static-build/test/fixtures/55-ignore-output/probe.js
@@ -1,0 +1,28 @@
+const assert = require('assert').strict;
+
+async function tryTest({ path, status, deploymentUrl, fetch }) {
+  const res = await fetch(`https://${deploymentUrl}${path}`);
+  assert.equal(res.status, status);
+  console.log(`Finished testing "${path}" probe.`);
+}
+
+module.exports = async ({ deploymentUrl, fetch }) => {
+  await tryTest({ path: '/example.html', status: 200, deploymentUrl, fetch });
+  await tryTest({ path: '/output.html', status: 200, deploymentUrl, fetch });
+  await tryTest({
+    path: '/node_modules/copee/package.json',
+    status: 404,
+    deploymentUrl,
+    fetch,
+  });
+  await tryTest({ path: '/.git/HEAD', status: 404, deploymentUrl, fetch });
+  await tryTest({ path: '/.env', status: 404, deploymentUrl, fetch });
+  await tryTest({ path: '/yarn.lock', status: 404, deploymentUrl, fetch });
+  await tryTest({
+    path: '/package-lock.json',
+    status: 404,
+    deploymentUrl,
+    fetch,
+  });
+  await tryTest({ path: '/package.json', status: 404, deploymentUrl, fetch });
+};


### PR DESCRIPTION
We already ignore specific files such as `node_modules` and `.env` during the upload phase so these never make it to the build. However, if those files are generated during the build, that are still emitted.

This PR will ignore these specific files even if they end up in the output directory (for example, when the user assigns `outputDirectory='.'` in project settings)