### PR TITLE
[now-routing-utils] Update to not add path segments to redirect query automatically

### DIFF
--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -172,19 +172,13 @@ function replaceSegments(
       }
     }
 
-    for (const [name, value] of Object.entries(indexes)) {
-      if (
-        isRedirect &&
-        new RegExp(`\\${value}(?!\\d)`).test(pathname + (hash || ''))
-      ) {
-        // Don't add segment to query if used in destination
-        // and it's a redirect so that we don't pollute the query
-        // with unwanted values
-        continue;
-      }
-
-      if (!(name in query)) {
-        query[name] = value;
+    // We only add path segments to redirect queries if manually
+    // specified
+    if (!isRedirect) {
+      for (const [name, value] of Object.entries(indexes)) {
+        if (!(name in query)) {
+          query[name] = value;
+        }
       }
     }
 

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -211,7 +211,7 @@ test('convertRedirects', () => {
     },
     {
       src: '^\\/projects(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
-      headers: { Location: '/projects.html?id=$1&action=$2' },
+      headers: { Location: '/projects.html' },
       status: 308,
     },
     {
@@ -236,7 +236,7 @@ test('convertRedirects', () => {
     },
     {
       src: '^\\/catchme(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
-      headers: { Location: '/api/user?id=$1' },
+      headers: { Location: '/api/user' },
       status: 308,
     },
     {

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -322,6 +322,7 @@ test('convertRewrites', () => {
     },
     { source: '/catchme/:id*', destination: '/api/user' },
     { source: '/:path', destination: '/test?path=:path' },
+    { source: '/:path/:two', destination: '/test?path=:path' },
   ]);
 
   const expected = [
@@ -392,6 +393,11 @@ test('convertRewrites', () => {
       dest: '/test?path=$1',
       check: true,
     },
+    {
+      check: true,
+      dest: '/test?path=$1&two=$2',
+      src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+    },
   ];
 
   deepEqual(actual, expected);
@@ -411,6 +417,7 @@ test('convertRewrites', () => {
     ['/another-catch/first/', '/another-catch/first/second/'],
     ['/catchme/id-1', '/catchme/id/2'],
     ['/first', '/another'],
+    ['/first/second', '/one/two'],
   ];
 
   const mustNotMatch = [
@@ -428,6 +435,7 @@ test('convertRewrites', () => {
     ['/another-catch/'],
     ['/catchm', '/random'],
     ['/another/one'],
+    ['/not', '/these'],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -321,6 +321,7 @@ test('convertRewrites', () => {
       destination: '/another-catch/:hello+',
     },
     { source: '/catchme/:id*', destination: '/api/user' },
+    { source: '/:path', destination: '/test?path=:path' },
   ]);
 
   const expected = [
@@ -386,6 +387,11 @@ test('convertRewrites', () => {
       dest: '/api/user?id=$1',
       check: true,
     },
+    {
+      src: '^(?:\\/([^\\/]+?))$',
+      dest: '/test?path=$1',
+      check: true,
+    },
   ];
 
   deepEqual(actual, expected);
@@ -404,6 +410,7 @@ test('convertRewrites', () => {
     ['/catchall/first/', '/catchall/first/second/'],
     ['/another-catch/first/', '/another-catch/first/second/'],
     ['/catchme/id-1', '/catchme/id/2'],
+    ['/first', '/another'],
   ];
 
   const mustNotMatch = [
@@ -420,6 +427,7 @@ test('convertRewrites', () => {
     ['/random-catch/'],
     ['/another-catch/'],
     ['/catchm', '/random'],
+    ['/another/one'],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);


### PR DESCRIPTION
As discussed this removes automatically adding path segments to redirect's destination query and only adds them if manually specified

x-ref: https://github.com/zeit/next.js/pull/11497