### PR TITLE
[now-cli] Bump mri to 1.1.5

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -141,7 +141,7 @@
     "micro": "9.1.2",
     "mime-types": "2.1.24",
     "minimatch": "3.0.4",
-    "mri": "1.1.0",
+    "mri": "1.1.5",
     "ms": "2.1.2",
     "node-fetch": "2.6.0",
     "npm-package-arg": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7776,6 +7776,11 @@ mri@1.1.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
   integrity sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o=
 
+mri@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.5.tgz#ce21dba2c69f74a9b7cf8a1ec62307e089e223e0"
+  integrity sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
This fixes the error when attempting to add a secret with a hyphen and underscore such as the following:

```
$ now secret add name '-foo_bar'
Error! argv._.slice is not a function
```