### PR TITLE
[now-cli] Fix for adding secret with hyphen prefix

### DIFF
--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -110,7 +110,7 @@ const main = async ctx => {
   }
 
   try {
-    await run({ output, token, contextName, currentTeam });
+    await run({ output, token, contextName, currentTeam, ctx });
   } catch (err) {
     handleError(err);
     exit(1);
@@ -126,7 +126,7 @@ export default async ctx => {
   }
 };
 
-async function run({ output, token, contextName, currentTeam }) {
+async function run({ output, token, contextName, currentTeam, ctx }) {
   const secrets = new NowSecrets({ apiUrl, token, debug, currentTeam });
   const args = argv._.slice(1);
   const start = Date.now();
@@ -260,7 +260,20 @@ async function run({ output, token, contextName, currentTeam }) {
       return exit(1);
     }
 
-    const [name, value] = args;
+    const [name, parsedValue] = args;
+    const [originalName, originalValue] = ctx.argv.slice(-2);
+
+    let value = parsedValue;
+    if (
+      name === originalName &&
+      typeof parsedValue === 'boolean' &&
+      parsedValue !== originalValue
+    ) {
+      // Corner case where `mri` transforms the secret value into a boolean because
+      // it starts with a `-` so it thinks its a flag, so we use the original value instead.
+      value = originalValue;
+    }
+
     await secrets.add(name, value);
     const elapsed = ms(new Date() - start);
 

--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -269,9 +269,17 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       typeof parsedValue === 'boolean' &&
       parsedValue !== originalValue
     ) {
-      // Corner case where `mri` transforms the secret value into a boolean because
-      // it starts with a `-` so it thinks its a flag, so we use the original value instead.
-      value = originalValue;
+      if (typeof originalValue === 'boolean') {
+        const example = chalk.cyan(`$ now secret add -- "${args[0]}"`);
+        console.log(
+          `If your secret starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
+        );
+        return exit(1);
+      } else {
+        // Corner case where `mri` transforms the secret value into a boolean because
+        // it starts with a `-` so it thinks its a flag, so we use the original value instead.
+        value = originalValue;
+      }
     }
 
     await secrets.add(name, value);

--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -269,17 +269,17 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       typeof parsedValue === 'boolean' &&
       parsedValue !== originalValue
     ) {
-      if (typeof originalValue === 'boolean') {
-        const example = chalk.cyan(`$ now secret add -- "${args[0]}"`);
-        console.log(
-          `If your secret starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
-        );
-        return exit(1);
-      } else {
-        // Corner case where `mri` transforms the secret value into a boolean because
-        // it starts with a `-` so it thinks its a flag, so we use the original value instead.
-        value = originalValue;
-      }
+      // Corner case where `mri` transforms the secret value into a boolean because
+      // it starts with a `-` so it thinks its a flag, so we use the original value instead.
+      value = originalValue;
+    }
+
+    if (typeof value === 'boolean') {
+      const example = chalk.cyan(`$ now secret add -- "${name}"`);
+      console.log(
+        `If your secret starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
+      );
+      return exit(1);
     }
 
     await secrets.add(name, value);

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -327,7 +327,7 @@ CMD ["node", "index.js"]`,
       'package.json': JSON.stringify({
         private: true,
         scripts: {
-          build: 'echo $MY_SECRET > public/index.txt',
+          build: 'mkdir public && echo $MY_SECRET > public/index.txt',
         },
       }),
       'now.json': JSON.stringify({

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -323,6 +323,21 @@ CMD ["node", "index.js"]`,
       'index.html': 'Home page',
       'secret/file.txt': 'my secret',
     },
+    'build-secret': {
+      'package.json': JSON.stringify({
+        private: true,
+        scripts: {
+          build: 'echo $MY_SECRET > public/index.txt',
+        },
+      }),
+      'now.json': JSON.stringify({
+        build: {
+          env: {
+            MY_SECRET: '@mysecret',
+          },
+        },
+      }),
+    },
     'alias-rules': {
       'rules.json': JSON.stringify({
         rules: [

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -397,7 +397,7 @@ test('should add secret with hyphen prefix', async t => {
 
   let secretCall = await execa(
     binaryPath,
-    ['secrets', 'add', key, value, ...defaultArgs],
+    ['secrets', 'add', ...defaultArgs, key, value],
     {
       cwd: target,
       reject: false,
@@ -421,7 +421,7 @@ test('should add secret with hyphen prefix', async t => {
     formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
   );
   const { host } = new URL(targetCall.stdout);
-  const response = await fetch(`https://${host}/ignored.txt`);
+  const response = await fetch(`https://${host}`);
   t.is(
     response.status,
     200,
@@ -429,7 +429,7 @@ test('should add secret with hyphen prefix', async t => {
   );
   t.is(
     await response.text(),
-    value,
+    `${value}\n`,
     formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
   );
 });

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -390,6 +390,50 @@ test('should error with suggestion for secrets subcommand', async t => {
   );
 });
 
+test('should add secret with hyphen prefix', async t => {
+  const target = fixture('build-secret');
+  const key = 'mysecret';
+  const value = '-foo_bar';
+
+  let secretCall = await execa(
+    binaryPath,
+    ['secrets', 'add', key, value, ...defaultArgs],
+    {
+      cwd: target,
+      reject: false,
+    }
+  );
+
+  t.is(
+    secretCall.exitCode,
+    0,
+    formatOutput({ stderr: secretCall.stderr, stdout: secretCall.stdout })
+  );
+
+  let targetCall = await execa(binaryPath, [...defaultArgs, '--confirm'], {
+    cwd: target,
+    reject: false,
+  });
+
+  t.is(
+    targetCall.exitCode,
+    0,
+    formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
+  );
+  const { host } = new URL(targetCall.stdout);
+  const response = await fetch(`https://${host}/ignored.txt`);
+  t.is(
+    response.status,
+    200,
+    formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
+  );
+  t.is(
+    await response.text(),
+    value,
+    formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
+  );
+});
+
 test('login with unregistered user', async t => {
   const { stdout, stderr, exitCode } = await execa(
     binaryPath,


### PR DESCRIPTION
Follow up to #3982 which didn't actually fix the secret value. Instead it was adding `true` as the value.