### PR TITLE
[now-cli] Fix error message link to build logs

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -666,7 +666,7 @@ export default async function main(
     if (err instanceof BuildError) {
       output.error('Build failed');
       output.error(
-        `Check your logs at ${now.url}/_logs or run ${code(
+        `Check your logs at https://${now.url}/_logs or run ${code(
           `now logs ${now.url}`,
           {
             // Backticks are interpreted as part of the URL, causing CMD+Click


### PR DESCRIPTION
The current error message prints a link that is not clickable from the terminal.

This PR adds the missing `https://` protocol prefix, so that the link is clickable.