### PR TITLE
[now-build-utils] Hide internal stack trace for errors

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -10,10 +10,14 @@ import { NowBuildError } from '../errors';
 import { Meta, PackageJson, NodeVersion, Config } from '../types';
 import { getSupportedNodeVersion, getLatestNodeVersion } from './node-version';
 
+interface SpawnOptionsExtended extends SpawnOptions {
+  prettyCommand?: string;
+}
+
 export function spawnAsync(
   command: string,
   args: string[],
-  opts: SpawnOptions = {}
+  opts: SpawnOptionsExtended = {}
 ) {
   return new Promise<void>((resolve, reject) => {
     const stderrLogs: Buffer[] = [];
@@ -30,12 +34,15 @@ export function spawnAsync(
         return resolve();
       }
 
+      const cmd = opts.prettyCommand
+        ? `Command "${opts.prettyCommand}"`
+        : 'Command';
       reject(
         new NowBuildError({
-          code: `NOW_BUILD_UTILS_SPAWN_${code}_${signal}`,
+          code: `NOW_BUILD_UTILS_SPAWN_${code || signal}`,
           message:
             opts.stdio === 'inherit'
-              ? `Command exited with ${code || signal}`
+              ? `${cmd} exited with ${code || signal}`
               : stderrLogs.map(line => line.toString()).join(''),
         })
       );
@@ -46,7 +53,7 @@ export function spawnAsync(
 export function execAsync(
   command: string,
   args: string[],
-  opts: SpawnOptions = {}
+  opts: SpawnOptionsExtended = {}
 ) {
   return new Promise<{ stdout: string; stderr: string; code: number }>(
     (resolve, reject) => {
@@ -68,10 +75,14 @@ export function execAsync(
       child.on('error', reject);
       child.on('close', (code, signal) => {
         if (code !== 0) {
+          const cmd = opts.prettyCommand
+            ? `Command "${opts.prettyCommand}"`
+            : 'Command';
+
           return reject(
             new NowBuildError({
-              code: `NOW_BUILD_UTILS_EXEC_${code}_${signal}`,
-              message: `Program "${command}" exited with non-zero exit code ${code} ${signal}.`,
+              code: `NOW_BUILD_UTILS_EXEC_${code || signal}`,
+              message: `${cmd} exited with ${code || signal}`,
             })
           );
         }
@@ -87,18 +98,20 @@ export function execAsync(
 }
 
 export function spawnCommand(command: string, options: SpawnOptions = {}) {
+  const opts = { ...options, prettyCommand: command };
   if (process.platform === 'win32') {
-    return spawn('cmd.exe', ['/C', command], options);
+    return spawn('cmd.exe', ['/C', command], opts);
   }
 
-  return spawn('sh', ['-c', command], options);
+  return spawn('sh', ['-c', command], opts);
 }
 
 export async function execCommand(command: string, options: SpawnOptions = {}) {
+  const opts = { ...options, prettyCommand: command };
   if (process.platform === 'win32') {
-    await spawnAsync('cmd.exe', ['/C', command], options);
+    await spawnAsync('cmd.exe', ['/C', command], opts);
   } else {
-    await spawnAsync('sh', ['-c', command], options);
+    await spawnAsync('sh', ['-c', command], opts);
   }
 
   return true;
@@ -125,9 +138,11 @@ export async function runShellScript(
   assert(path.isAbsolute(fsPath));
   const destPath = path.dirname(fsPath);
   await chmodPlusX(fsPath);
-  await spawnAsync(`./${path.basename(fsPath)}`, args, {
-    cwd: destPath,
+  const command = `./${path.basename(fsPath)}`;
+  await spawnAsync(command, args, {
     ...spawnOpts,
+    cwd: destPath,
+    prettyCommand: command,
   });
   return true;
 }
@@ -254,7 +269,7 @@ export async function runNpmInstall(
   debug(`Installing to ${destPath}`);
 
   const { hasPackageLockJson } = await scanParentDirs(destPath);
-  const opts: SpawnOptions = { cwd: destPath, ...spawnOpts };
+  const opts: SpawnOptionsExtended = { cwd: destPath, ...spawnOpts };
   const env = opts.env ? { ...opts.env } : { ...process.env };
   delete env.NODE_ENV;
   opts.env = env;
@@ -263,11 +278,13 @@ export async function runNpmInstall(
   let commandArgs: string[];
 
   if (hasPackageLockJson) {
+    opts.prettyCommand = 'npm install';
     command = 'npm';
     commandArgs = args
       .filter(a => a !== '--prefer-offline')
       .concat(['install', '--no-audit', '--unsafe-perm']);
   } else {
+    opts.prettyCommand = 'yarn install';
     command = 'yarn';
     commandArgs = args.concat(['install', '--ignore-engines']);
   }
@@ -290,7 +307,7 @@ export async function runBundleInstall(
   }
 
   assert(path.isAbsolute(destPath));
-  const opts = { cwd: destPath, ...spawnOpts };
+  const opts = { ...spawnOpts, cwd: destPath, prettyCommand: 'bundle install' };
 
   await spawnAsync(
     'bundle',
@@ -318,7 +335,7 @@ export async function runPipInstall(
   }
 
   assert(path.isAbsolute(destPath));
-  const opts = { cwd: destPath, ...spawnOpts };
+  const opts = { ...spawnOpts, cwd: destPath, prettyCommand: 'pip3 install' };
 
   await spawnAsync(
     'pip3',
@@ -345,18 +362,22 @@ export async function runPackageJsonScript(
   );
   if (!hasScript) return false;
 
-  const opts = { cwd: destPath, ...spawnOpts };
-
   if (hasPackageLockJson) {
-    console.log(`Running "npm run ${scriptName}"`);
-    await spawnAsync('npm', ['run', scriptName], opts);
+    const prettyCommand = `npm run ${scriptName}`;
+    console.log(`Running "${prettyCommand}"`);
+    await spawnAsync('npm', ['run', scriptName], {
+      ...spawnOpts,
+      cwd: destPath,
+      prettyCommand,
+    });
   } else {
-    console.log(`Running "yarn run ${scriptName}"`);
-    await spawnAsync(
-      'yarn',
-      ['--ignore-engines', '--cwd', destPath, 'run', scriptName],
-      opts
-    );
+    const prettyCommand = `yarn run ${scriptName}`;
+    console.log(`Running "${prettyCommand}"`);
+    await spawnAsync('yarn', ['--ignore-engines', 'run', scriptName], {
+      ...spawnOpts,
+      cwd: destPath,
+      prettyCommand,
+    });
   }
 
   return true;


### PR DESCRIPTION
Example build output given a user's build script named `shouldfail.js`:

## Before

```
/zeit/4af70cdc/shouldfail.js:3
throw new Error('This is my failure')
^
Error: This is my failure
    at Object.<anonymous> (/zeit/4af70cdc/shouldfail.js:3:7)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Exited with 1
    at ChildProcess.<anonymous> (/zeit/687b1c64/.build-utils/node_modules/@now/build-utils/dist/index.js:31350:24)
    at ChildProcess.emit (events.js:223:5)
    at ChildProcess.EventEmitter.emit (domain.js:475:20)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)
worker exited with code 20 and signal null
Done with "package.json"
```

## After 

```
/zeit/255bfdd/shouldfail.js:3
throw new Error('This is my failure')
^
Error: This is my failure
    at Object.<anonymous> (/zeit/255bfdd/shouldfail.js:3:7)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command "yarn run build" exited with 1
worker exited with code 20 and signal null
Done with "package.json"
```