### PR TITLE
[now-static-build] Fix 12-creact-react-app test fixture

### DIFF
--- a/packages/now-static-build/test/fixtures/12-create-react-app/package.json
+++ b/packages/now-static-build/test/fixtures/12-create-react-app/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Since enabling `CI` environment variable for cloud builds, this test fails because it is meant to emit a warning however that warning has turned into an error.

```
05:40:53.148  Treating warnings as errors because process.env.CI = true.
05:40:53.148  Most CI servers set it automatically.
05:40:53.148  Failed to compile.
05:40:53.149  ./src/App.js
05:40:53.149    Line 1:  'useState' is defined but never used  no-unused-vars
05:40:53.172  error Command failed with exit code 1.
```

We can again treat lint errors as warnings by setting `CI=false`.