### PR TITLE
[now-next] Fix some typos related to fixtures

### DIFF
--- a/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
@@ -12,7 +12,7 @@
       }
     }
   ],
-  "propes": [
+  "probes": [
     {
       "path": "/api/memory",
       "status": 200,

--- a/packages/now-next/test/fixtures/24-custom-output-dir/now.json
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/now.json
@@ -9,7 +9,7 @@
       }
     }
   ],
-  "propes": [
+  "probes": [
     {
       "path": "/",
       "status": 200,


### PR DESCRIPTION
They should be `probes` I guess.