### PR TITLE
[now-node] Add `NowApiHandler` type

### DIFF
--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -15,3 +15,8 @@ export type NowResponse = ServerResponse & {
   json: (jsonBody: any) => NowResponse;
   status: (statusCode: number) => NowResponse;
 };
+
+export type NowApiHandler = (
+  req: NowRequest,
+  res: NowResponse
+) => void;

--- a/packages/now-node/test/fixtures/15-helpers/ts/handler.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts/handler.ts
@@ -1,0 +1,8 @@
+import { NowApiHandler } from './types';
+
+const listener: NowApiHandler = (req, res) => {
+  res.status(200);
+  res.send('hello:RANDOMNESS_PLACEHOLDER');
+};
+
+export default listener;


### PR DESCRIPTION
`now` equivalent of `NextApiHandler` introduced https://github.com/zeit/next.js/pull/10573
