### PR TITLE
[now-cli] Add link to project linking doc to NOW_DIR_README.txt

### DIFF
--- a/packages/now-cli/src/util/projects/NOW_DIR_README.txt
+++ b/packages/now-cli/src/util/projects/NOW_DIR_README.txt
@@ -11,4 +11,4 @@ No, you should not share the ".now" folder with anyone.
 Upon creation, it will be automatically added to your ".gitignore" file.
 
 You can learn more about project linking on our documentation:
-https://zeit.co/docs/now-cli#commands/now/project-linking
+https://zeit.ink/2R8divK

--- a/packages/now-cli/src/util/projects/NOW_DIR_README.txt
+++ b/packages/now-cli/src/util/projects/NOW_DIR_README.txt
@@ -9,3 +9,6 @@ The "project.json" file contains:
 > Should I commit the ".now" folder?
 No, you should not share the ".now" folder with anyone.
 Upon creation, it will be automatically added to your ".gitignore" file.
+
+You can learn more about project linking on our documentation:
+https://zeit.co/docs/now-cli#commands/now/project-linking


### PR DESCRIPTION
We should make it easier for users to take a look at the documentation whenever possible.