### PR TITLE
[now-next] Correctly Exclude API Routes from Pages

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -829,7 +829,7 @@ export const build = async ({
       } = await nodeFileTrace(apiPages, { base: workPath });
 
       const { fileList, reasons: nonApiReasons } = await nodeFileTrace(
-        Object.keys(pages).map(page => pages[page].fsPath),
+        nonApiPages,
         { base: workPath }
       );
 


### PR DESCRIPTION
This pull request correctly omits dependencies for API Routes from pages.