### PR TITLE
[now-routing-utils] Catch error from compile route

### DIFF
--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -82,11 +82,11 @@ export function convertHeaders(headers: NowHeader[]): Route[] {
     h.headers.forEach(({ key, value }) => {
       if (hasSegments) {
         if (key.includes(':')) {
-          const keyCompiler = compile(key);
+          const keyCompiler = tryCompile(key);
           key = keyCompiler(indexes);
         }
         if (value.includes(':')) {
-          const valueCompiler = compile(value);
+          const valueCompiler = tryCompile(value);
           value = valueCompiler(indexes);
         }
       }
@@ -157,15 +157,15 @@ function replaceSegments(
     });
 
     if (destination.includes(':') && segments.length > 0) {
-      const pathnameCompiler = compile(pathname);
-      const hashCompiler = compile(hash);
+      const pathnameCompiler = tryCompile(pathname);
+      const hashCompiler = tryCompile(hash);
       pathname = pathnameCompiler(indexes);
       hash = hash ? `${hashCompiler(indexes)}` : null;
 
       for (const [key, strOrArray] of Object.entries(query)) {
         let value = Array.isArray(strOrArray) ? strOrArray[0] : strOrArray;
         if (value) {
-          const queryCompiler = compile(value);
+          const queryCompiler = tryCompile(value);
           value = queryCompiler(indexes);
         }
         query[key] = value;
@@ -203,4 +203,12 @@ function toSegmentDest(index: number): string {
 
 function toRoute(filePath: string): string {
   return filePath.startsWith('/') ? filePath : '/' + filePath;
+}
+
+function tryCompile(str: string) {
+  try {
+    return compile(str);
+  } catch (e) {
+    throw new Error('Unable to compile input: ' + str);
+  }
 }


### PR DESCRIPTION
Some inputs cause `compile()` to throw but its not clear which route caused it to fail.

> TypeError: Unexpected MODIFIER at 29, expected END [see source](https://sentry.io/organizations/zeithq/issues/1593291118/?project=1351065)

This PR adds logs so we can see the bad user input and correct accordingly.