### PR TITLE
[now-cli] Improve pagination message

### DIFF
--- a/packages/now-cli/src/commands/alias/ls.js
+++ b/packages/now-cli/src/commands/alias/ls.js
@@ -8,6 +8,8 @@ import getAliases from '../../util/alias/get-aliases';
 import getScope from '../../util/get-scope.ts';
 import stamp from '../../util/output/stamp.ts';
 import strlen from '../../util/strlen.ts';
+import getCommandFlags from '../../util/get-command-flags';
+import cmd from '../../util/output/cmd.ts';
 
 export default async function ls(ctx, opts, args, output) {
   const {
@@ -102,8 +104,11 @@ export default async function ls(ctx, opts, args, output) {
   }
 
   if (pagination && aliases.length === 20) {
+    const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page use the flag --next ${pagination.next}`
+      `To display the next page run ${cmd(
+        `now alias ls${flags} --next ${pagination.next}`
+      )}`
     );
   }
 

--- a/packages/now-cli/src/commands/domains/ls.ts
+++ b/packages/now-cli/src/commands/domains/ls.ts
@@ -9,6 +9,8 @@ import stamp from '../../util/output/stamp';
 import strlen from '../../util/strlen';
 import { Output } from '../../util/output';
 import { Domain, NowContext } from '../../types';
+import getCommandFlags from '../../util/get-command-flags';
+import cmd from '../../util/output/cmd';
 
 type Options = {
   '--debug': boolean;
@@ -69,8 +71,11 @@ export default async function ls(
   }
 
   if (pagination && domains.length === 20) {
+    const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page use the flag --next ${pagination.next}`
+      `To display the next page run ${cmd(
+        `now domains ls${flags} --next ${pagination.next}`
+      )}`
     );
   }
 

--- a/packages/now-cli/src/commands/list.js
+++ b/packages/now-cli/src/commands/list.js
@@ -17,6 +17,7 @@ import getScope from '../util/get-scope.ts';
 import toHost from '../util/to-host';
 import parseMeta from '../util/parse-meta';
 import { isValidName } from '../util/is-valid-name';
+import getCommandFlags from '../util/get-command-flags';
 
 const help = () => {
   console.log(`
@@ -332,11 +333,16 @@ export default async function main(ctx) {
         hsep: ' '.repeat(4),
         stringLength: strlen,
       }
-    ).replace(/^/gm, '  ')}\n\n`
+    ).replace(/^/gm, '  ')}\n`
   );
 
   if (pagination && deployments.length === 20) {
-    log(`To display the next page use the flag --next ${pagination.next}`);
+    const flags = getCommandFlags(argv, ['_', '--next']);
+    log(
+      `To display the next page run ${cmd(
+        `now ls ${app}${flags} --next ${pagination.next}`
+      )}`
+    );
   }
 }
 

--- a/packages/now-cli/src/util/get-command-flags.ts
+++ b/packages/now-cli/src/util/get-command-flags.ts
@@ -1,0 +1,20 @@
+/* 
+    This function returns the provided arguments from a command in a string format.
+
+    Example: if `argv` is { '--debug': true, '--all': true, '--scope': 'zeit' },
+    the output will be '--debug --all --scope zeit'.
+
+    Flags can be excluded using the `excludeFlags` param.
+*/
+export default function getCommandFlags(
+  argv: { [key: string]: any },
+  excludeFlags: string[] = []
+) {
+  const flags = Object.keys(argv)
+    .filter(key => !excludeFlags.includes(key))
+    .map(
+      key => `${key}${typeof argv[key] !== 'boolean' ? ' ' + argv[key] : ''}`
+    );
+
+  return flags.length > 0 ? ` ${flags.join(' ')}` : '';
+}


### PR DESCRIPTION
This PR improves the pagination message which is shown for the commands `now ls <project>`, `now domains ls` and `now alias ls`.

The new improved message includes the full command which should be run instead of just the `--next` flag.

Example when running `now alias ls`:

Before: "To display the next page use the flag --next 1586359057860".
After: "To display the next page run `now alias ls --next 1586359057860`".

If the command contains additional flags, they will be also included in the pagination message.