### PR TITLE
chore(deps): Jekyll's current stable release

### DIFF
--- a/examples/jekyll/Gemfile
+++ b/examples/jekyll/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.8.6"
+gem "jekyll", "~> 4.0"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"


### PR DESCRIPTION
Use Jekyll 4.0 by default