### PR TITLE
[now-cli] Update `now env` to support empty values

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /packages/now-cli/src/util/dev/          @tootallnate @leo @styfle @AndyBitz
 /packages/now-cli/src/commands/domains/  @javivelasco @mglagola @anatrajkovska
 /packages/now-cli/src/commands/certs/    @javivelasco @mglagola @anatrajkovska
+/packages/now-cli/src/commands/env       @styfle @lucleray
 /packages/now-client                     @leo @rdev
 /packages/now-build-utils                @styfle @AndyBitz
 /packages/now-node                       @styfle @tootallnate @lucleray

--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -14,6 +14,7 @@ export const latestHelp = () => `
         '(default)'
       )}
       dev                              Start a local development server
+      env                              Manages the Environment Variables for your current Project
       init                 [example]   Initialize an example project
       ls | list            [app]       Lists deployments
       inspect              [id]        Displays information related to a deployment

--- a/packages/now-cli/src/commands/deploy/args.js
+++ b/packages/now-cli/src/commands/deploy/args.js
@@ -29,7 +29,7 @@ export const latestHelp = () => `
       domains              [name]      Manages your domain names
       dns                  [name]      Manages your DNS records
       certs                [cmd]       Manages your SSL certificates
-      secrets              [name]      Manages your secret environment variables
+      secrets              [name]      Manages your global Secrets, for use in Environment Variables
       logs                 [url]       Displays the logs for a deployment
       teams                            Manages your teams
       whoami                           Shows the username of the currently logged in user
@@ -85,7 +85,7 @@ export const latestHelp = () => `
 
     ${chalk.cyan('$ now /usr/src/project')}
 
-  ${chalk.gray('–')} Deploy with environment variables
+  ${chalk.gray('–')} Deploy with Environment Variables
 
     ${chalk.cyan('$ now -e NODE_ENV=production -e SECRET=@mysql-secret')}
 

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -116,18 +116,14 @@ export default async function add(
       return 1;
     }
 
-    while (!envValue) {
+    while (typeof envValue !== 'undefined') {
       const { inputValue } = await inquirer.prompt({
         type: 'password',
         name: 'inputValue',
         message: `What’s the value of ${envName}?`,
       });
 
-      envValue = inputValue;
-
-      if (!inputValue) {
-        output.error('Value cannot be empty');
-      }
+      envValue = inputValue || '';
     }
 
     while (envTargets.length === 0) {

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -51,7 +51,7 @@ export default async function add(
     return 1;
   } else {
     const { project } = link;
-    let envValue = await readStandardInput();
+    let stdInput = await readStandardInput();
     let [envName, envTarget] = args;
 
     if (args.length > 2) {
@@ -63,7 +63,7 @@ export default async function add(
       return 1;
     }
 
-    if (envValue && (!envName || !envTarget)) {
+    if (stdInput && (!envName || !envTarget)) {
       output.error(
         `Invalid number of arguments. Usage: ${cmd(
           `cat <file> | now env add <name> ${getEnvTargetPlaceholder()}`
@@ -116,13 +116,16 @@ export default async function add(
       return 1;
     }
 
-    while (typeof envValue !== 'undefined') {
+    let envValue: string;
+
+    if (stdInput) {
+      envValue = stdInput;
+    } else {
       const { inputValue } = await inquirer.prompt({
         type: 'password',
         name: 'inputValue',
         message: `What’s the value of ${envName}?`,
       });
-
       envValue = inputValue || '';
     }
 

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -151,9 +151,9 @@ export default async function add(
 
     output.print(
       `${prependEmoji(
-        `Added environment variable ${chalk.bold(
+        `Added Environment Variable ${chalk.bold(
           envName
-        )} to project ${chalk.bold(project.name)} ${chalk.gray(addStamp())}`,
+        )} to Project ${chalk.bold(project.name)} ${chalk.gray(addStamp())}`,
         emoji('success')
       )}\n`
     );

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -66,7 +66,7 @@ export default async function add(
     if (stdInput && (!envName || !envTarget)) {
       output.error(
         `Invalid number of arguments. Usage: ${cmd(
-          `cat <file> | now env add <name> ${getEnvTargetPlaceholder()}`
+          `now env add <name> <target> < <file>`
         )}`
       );
       return 1;

--- a/packages/now-cli/src/commands/env/index.ts
+++ b/packages/now-cli/src/commands/env/index.ts
@@ -21,10 +21,10 @@ const help = () => {
 
   ${chalk.dim('Commands:')}
 
-    ls      [environment]              List all variables for the specified environment
-    add     [name] [environment]       Add an environment variable (see examples below)
-    rm      [name] [environment]       Remove an environment variable (see examples below)
-    pull    [filename]                 Read development environment from the cloud and write to a file [.env]
+    ls      [environment]              List all variables for the specified Environment
+    add     [name] [environment]       Add an Environment Variable (see examples below)
+    rm      [name] [environment]       Remove an Environment Variable (see examples below)
+    pull    [filename]                 Pull all Development Environment Variables from the cloud and write to a file [.env]
 
   ${chalk.dim('Options:')}
 
@@ -42,28 +42,28 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Add a new variable to multiple environments
+  ${chalk.gray('–')} Add a new variable to multiple Environments
 
       ${chalk.cyan('$ now env add <name>')}
       ${chalk.cyan('$ now env add API_TOKEN')}
 
-  ${chalk.gray('–')} Add a new variable for a specific environment
+  ${chalk.gray('–')} Add a new variable for a specific Environment
 
       ${chalk.cyan(`$ now env add <name> ${placeholder}`)}
       ${chalk.cyan('$ now env add DB_CONNECTION production')}
 
-  ${chalk.gray('–')} Add a new environment variable from stdin
+  ${chalk.gray('–')} Add a new Environment Variable from stdin
 
       ${chalk.cyan(`$ cat <file> | now env add <name> ${placeholder}`)}
       ${chalk.cyan('$ cat ~/.npmrc | now env add NPM_RC preview')}
       ${chalk.cyan('$ now env add DB_PASS production < secret.txt')}
 
-  ${chalk.gray('–')} Remove a variable from multiple environments
+  ${chalk.gray('–')} Remove an variable from multiple Environments
 
       ${chalk.cyan('$ now env rm <name>')}
       ${chalk.cyan('$ now env rm API_TOKEN')}
 
-  ${chalk.gray('–')} Remove a variable from a specific environment
+  ${chalk.gray('–')} Remove a variable from a specific Environment
 
       ${chalk.cyan(`$ now env rm <name> ${placeholder}`)}
       ${chalk.cyan('$ now env rm NPM_RC preview')}

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -101,7 +101,7 @@ function getTable(records: ProjectEnvVariable[]) {
 
 function getRow({
   key,
-  value = '',
+  system = false,
   target,
   createdAt = 0,
   updatedAt = 0,
@@ -109,7 +109,7 @@ function getRow({
   const now = Date.now();
   return [
     chalk.bold(key),
-    value.startsWith('sec_') ? chalk.gray(chalk.italic('encrypted')) : value,
+    chalk.gray(chalk.italic(system ? 'system' : 'encrypted')),
     target || '',
     `${ms(now - createdAt)} ago`,
     `${ms(now - updatedAt)} ago`,

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -77,7 +77,7 @@ export default async function ls(
       envTarget
     );
     output.log(
-      `${plural('Record', records.length, true)} found in project ${chalk.bold(
+      `${plural('Record', records.length, true)} found in Project ${chalk.bold(
         project.name
       )} ${chalk.gray(lsStamp())}`
     );

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -109,7 +109,7 @@ function getRow({
   const now = Date.now();
   return [
     chalk.bold(key),
-    chalk.gray(chalk.italic(system ? 'system' : 'encrypted')),
+    chalk.gray(chalk.italic(system ? 'Populated by System' : 'Encrypted')),
     target || '',
     `${ms(now - createdAt)} ago`,
     `${ms(now - updatedAt)} ago`,

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -77,9 +77,11 @@ export default async function ls(
       envTarget
     );
     output.log(
-      `${plural('Record', records.length, true)} found in Project ${chalk.bold(
-        project.name
-      )} ${chalk.gray(lsStamp())}`
+      `${plural(
+        'Environment Variable',
+        records.length,
+        true
+      )} found in Project ${chalk.bold(project.name)} ${chalk.gray(lsStamp())}`
     );
     console.log(getTable(records));
     return 0;
@@ -88,11 +90,11 @@ export default async function ls(
 
 function getTable(records: ProjectEnvVariable[]) {
   return formatTable(
-    ['name', 'value', 'environment', 'created', 'updated'],
+    ['name', 'value', 'environment', 'created'],
     ['l', 'l', 'l', 'l', 'l'],
     [
       {
-        name: 'Environment Variables',
+        name: '',
         rows: records.map(getRow),
       },
     ]
@@ -104,7 +106,6 @@ function getRow({
   system = false,
   target,
   createdAt = 0,
-  updatedAt = 0,
 }: ProjectEnvVariable) {
   const now = Date.now();
   return [
@@ -112,6 +113,5 @@ function getRow({
     chalk.gray(chalk.italic(system ? 'Populated by System' : 'Encrypted')),
     target || '',
     `${ms(now - createdAt)} ago`,
-    `${ms(now - updatedAt)} ago`,
   ];
 }

--- a/packages/now-cli/src/commands/env/pull.ts
+++ b/packages/now-cli/src/commands/env/pull.ts
@@ -74,7 +74,7 @@ export default async function pull(
     }
 
     output.print(
-      `Downloading Development environment variables for project ${chalk.bold(
+      `Downloading Development Environment Variables for Project ${chalk.bold(
         project.name
       )}\n`
     );

--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -98,7 +98,7 @@ export default async function rm(
 
     if (existing.size === 0) {
       output.error(
-        `The environment variable ${param(envName)} was not found.\n`
+        `The Environment Variable ${param(envName)} was not found.\n`
       );
       return 1;
     }
@@ -107,9 +107,9 @@ export default async function rm(
       const choices = getEnvTargetChoices().filter(c => existing.has(c.value));
       if (choices.length === 0) {
         output.error(
-          `The environment variable ${param(
+          `The Environment Variable ${param(
             envName
-          )} was found but it is not assign to any environments.\n`
+          )} was found but it is not assigned to any Environments.\n`
         );
         return 1;
       } else if (choices.length === 1) {
@@ -130,9 +130,9 @@ export default async function rm(
       !skipConfirmation &&
       !(await promptBool(
         output,
-        `Remove environment variable ${param(
+        `Remove Environment Variable ${param(
           envName
-        )} from project ${chalk.bold(project.name)}. Are you sure?`
+        )} from Project ${chalk.bold(project.name)}. Are you sure?`
       ))
     ) {
       output.log('Aborted');
@@ -149,7 +149,7 @@ export default async function rm(
 
     output.print(
       `${prependEmoji(
-        `Removed environment variable ${chalk.gray(rmStamp())}`,
+        `Removed Environment Variable ${chalk.gray(rmStamp())}`,
         emoji('success')
       )}\n`
     );

--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -130,7 +130,7 @@ export default async function rm(
       !skipConfirmation &&
       !(await promptBool(
         output,
-        `Remove Environment Variable ${param(
+        `Removing Environment Variable ${param(
           envName
         )} from Project ${chalk.bold(project.name)}. Are you sure?`
       ))

--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -240,6 +240,7 @@ export interface ProjectEnvVariable {
   createdAt?: number;
   updatedAt?: number;
   target?: ProjectEnvTarget;
+  system?: boolean;
 }
 
 export interface Project {

--- a/packages/now-cli/src/util/env/add-env-record.ts
+++ b/packages/now-cli/src/util/env/add-env-record.ts
@@ -16,7 +16,8 @@ export default async function addEnvRecord(
     `Adding environment variable ${envName} to ${targets.length} targets`
   );
 
-  let values: string[];
+  let values: string[] | undefined;
+
   if (envValue) {
     const urlSecret = `/v2/now/secrets/${encodeURIComponent(envName)}`;
     const secrets = await Promise.all(
@@ -37,7 +38,7 @@ export default async function addEnvRecord(
 
   const body = targets.map((target, i) => ({
     key: envName,
-    value: values[i] || '',
+    value: values ? values[i] : '',
     target,
   }));
 

--- a/packages/now-cli/src/util/env/add-env-record.ts
+++ b/packages/now-cli/src/util/env/add-env-record.ts
@@ -13,7 +13,7 @@ export default async function addEnvRecord(
   targets: ProjectEnvTarget[]
 ): Promise<void> {
   output.debug(
-    `Adding environment variable ${envName} to ${targets.length} targets`
+    `Adding Environment Variable ${envName} to ${targets.length} targets`
   );
 
   let values: string[] | undefined;

--- a/packages/now-cli/src/util/env/add-env-record.ts
+++ b/packages/now-cli/src/util/env/add-env-record.ts
@@ -9,31 +9,35 @@ export default async function addEnvRecord(
   client: Client,
   projectId: string,
   envName: string,
-  envValue: string,
+  envValue: string | undefined,
   targets: ProjectEnvTarget[]
 ): Promise<void> {
   output.debug(
     `Adding environment variable ${envName} to ${targets.length} targets`
   );
 
-  const urlSecret = `/v2/now/secrets/${encodeURIComponent(envName)}`;
-  const secrets = await Promise.all(
-    targets.map(target =>
-      client.fetch<Secret>(urlSecret, {
-        method: 'POST',
-        body: JSON.stringify({
-          name: generateSecretName(envName, target),
-          value: envValue,
-          projectId: projectId,
-          decryptable: target === ProjectEnvTarget.Development,
-        }),
-      })
-    )
-  );
+  let values: string[];
+  if (envValue) {
+    const urlSecret = `/v2/now/secrets/${encodeURIComponent(envName)}`;
+    const secrets = await Promise.all(
+      targets.map(target =>
+        client.fetch<Secret>(urlSecret, {
+          method: 'POST',
+          body: JSON.stringify({
+            name: generateSecretName(envName, target),
+            value: envValue,
+            projectId: projectId,
+            decryptable: target === ProjectEnvTarget.Development,
+          }),
+        })
+      )
+    );
+    values = secrets.map(secret => secret.uid);
+  }
 
   const body = targets.map((target, i) => ({
     key: envName,
-    value: secrets[i].uid,
+    value: values[i] || '',
     target,
   }));
 
@@ -52,5 +56,5 @@ const randomSecretSuffix = customAlphabet(
 function generateSecretName(envName: string, target: ProjectEnvTarget) {
   return `${
     slugify(envName).substring(0, 80) // we truncate because the max secret length is 100
-  }-${target}-${randomSecretSuffix()}`
+  }-${target}-${randomSecretSuffix()}`;
 }

--- a/packages/now-cli/src/util/env/get-decrypted-secret.ts
+++ b/packages/now-cli/src/util/env/get-decrypted-secret.ts
@@ -7,6 +7,9 @@ export default async function getDecryptedSecret(
   client: Client,
   secretId: string
 ): Promise<string> {
+  if (!secretId) {
+    return '';
+  }
   output.debug(`Fetching decrypted secret ${secretId}`);
   const url = `/v2/now/secrets/${secretId}?decrypt=true`;
   const secret = await client.fetch<Secret>(url);

--- a/packages/now-cli/src/util/env/get-env-records.ts
+++ b/packages/now-cli/src/util/env/get-env-records.ts
@@ -9,7 +9,7 @@ export default async function getEnvVariables(
   target?: ProjectEnvTarget
 ): Promise<ProjectEnvVariable[]> {
   output.debug(
-    `Fetching environment variables of project ${projectId} and target ${target}`
+    `Fetching Environment Variables of project ${projectId} and target ${target}`
   );
   const qs = target ? `?target=${encodeURIComponent(target)}` : '';
   const url = `/v4/projects/${projectId}/env${qs}`;

--- a/packages/now-cli/src/util/env/remove-env-record.ts
+++ b/packages/now-cli/src/util/env/remove-env-record.ts
@@ -22,17 +22,17 @@ export default async function removeEnvRecord(
     method: 'DELETE',
   });
 
-  const idOrName = (env.value || '').startsWith('@')
-    ? env.value.slice(1)
-    : env.value;
-  const urlSecret = `/v2/now/secrets/${idOrName}`;
-  const secret = await client.fetch<Secret>(urlSecret);
+  if (env && env.value) {
+    const idOrName = env.value.startsWith('@') ? env.value.slice(1) : env.value;
+    const urlSecret = `/v2/now/secrets/${idOrName}`;
+    const secret = await client.fetch<Secret>(urlSecret);
 
-  // Since integrations add global secrets, we must only delete if the secret was
-  // specifically added to this project
-  if (secret && secret.projectId === projectId) {
-    await client.fetch<Secret>(urlSecret, {
-      method: 'DELETE',
-    });
+    // Since integrations add global secrets, we must only delete if the secret was
+    // specifically added to this project
+    if (secret && secret.projectId === projectId) {
+      await client.fetch<Secret>(urlSecret, {
+        method: 'DELETE',
+      });
+    }
   }
 }

--- a/packages/now-cli/src/util/env/remove-env-record.ts
+++ b/packages/now-cli/src/util/env/remove-env-record.ts
@@ -10,7 +10,7 @@ export default async function removeEnvRecord(
   target?: ProjectEnvTarget
 ): Promise<void> {
   output.debug(
-    `Removing environment variable ${envName} from target ${target}`
+    `Removing Environment Variable ${envName} from target ${target}`
   );
 
   const qs = target ? `?target=${encodeURIComponent(target)}` : '';

--- a/packages/now-cli/src/util/input/read-standard-input.ts
+++ b/packages/now-cli/src/util/input/read-standard-input.ts
@@ -1,10 +1,8 @@
-export default async function readStandardInput(
-  wait = 100
-): Promise<string | undefined> {
-  return new Promise<string | undefined>(resolve => {
+export default async function readStandardInput(wait = 100): Promise<string> {
+  return new Promise<string>(resolve => {
     // There is no reliable way to determine if stdin is provided
     // so we use a timeout to resolve in case there is no stdin.
-    const t = setTimeout(() => resolve(undefined), wait);
+    const t = setTimeout(() => resolve(''), wait);
     process.stdin.setEncoding('utf8');
     process.stdin.once('data', data => {
       clearTimeout(t);

--- a/packages/now-cli/src/util/input/read-standard-input.ts
+++ b/packages/now-cli/src/util/input/read-standard-input.ts
@@ -1,8 +1,10 @@
-export default async function readStandardInput(wait = 150): Promise<string> {
-  return new Promise<string>(resolve => {
-    // There is no reliable way to determine if stdin was provided
+export default async function readStandardInput(
+  wait = 100
+): Promise<string | undefined> {
+  return new Promise<string | undefined>(resolve => {
+    // There is no reliable way to determine if stdin is provided
     // so we use a timeout to resolve in case there is no stdin.
-    const t = setTimeout(() => resolve(''), wait);
+    const t = setTimeout(() => resolve(undefined), wait);
     process.stdin.setEncoding('utf8');
     process.stdin.once('data', data => {
       clearTimeout(t);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -353,7 +353,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     );
 
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
-    t.regex(stderr, /0 Records found in project/gm);
+    t.regex(stderr, /0 Environment Variables found in Project/gm);
   }
 
   async function nowEnvAdd() {
@@ -409,6 +409,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     );
 
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+    t.regex(stdout, /4 Environment Variables found in Project/gm);
 
     const lines = stdout.split('\n');
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -409,7 +409,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     );
 
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
-    t.regex(stdout, /4 Environment Variables found in Project/gm);
+    t.regex(stderr, /4 Environment Variables found in Project/gm);
 
     const lines = stdout.split('\n');
 


### PR DESCRIPTION
This PR adds support for empty values when using `now env add|ls|rm|pull`.

This is necessary when using system environment variables such as `NOW_GITHUB_COMMIT_SHA` which will not receive a value from the user but will instead assign a value automatically during deployment.