### PR TITLE
[now-cli] Prefer `.env` over `.env.build` during `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -27,6 +27,8 @@ import {
   BuilderOutput,
   BuildResultV3,
   BuilderOutputs,
+  BuilderParams,
+  EnvConfigs,
 } from './types';
 import { normalizeRoutes } from '@now/routing-utils';
 import getUpdateCommand from '../get-update-command';
@@ -45,7 +47,7 @@ const treeKill = promisify(_treeKill);
 
 async function createBuildProcess(
   match: BuildMatch,
-  buildEnv: EnvConfig,
+  envConfigs: EnvConfigs,
   workPath: string,
   output: Output,
   yarnPath?: string
@@ -64,7 +66,7 @@ async function createBuildProcess(
   const env: EnvConfig = {
     ...process.env,
     PATH,
-    ...buildEnv,
+    ...envConfigs.all,
     NOW_REGION: 'dev1',
   };
 
@@ -109,7 +111,7 @@ export async function executeBuild(
     builderWithPkg: { runInProcess, builder, package: pkg },
   } = match;
   const { entrypoint } = match;
-  const { env, debug, buildEnv, yarnPath, cwd: workPath } = devServer;
+  const { debug, envConfigs, yarnPath, cwd: workPath } = devServer;
 
   const startTime = Date.now();
   const showBuildTimestamp =
@@ -131,14 +133,14 @@ export async function executeBuild(
     devServer.output.debug(`Creating build process for ${entrypoint}`);
     buildProcess = await createBuildProcess(
       match,
-      buildEnv,
+      envConfigs,
       workPath,
       devServer.output,
       yarnPath
     );
   }
 
-  const buildParams = {
+  const buildParams: BuilderParams = {
     files,
     entrypoint,
     workPath,
@@ -148,8 +150,10 @@ export async function executeBuild(
       requestPath,
       filesChanged,
       filesRemoved,
-      env,
-      buildEnv,
+      // This env distiniction is only necessary to maintain
+      // backwards compatibility with the `@now/next` builder.
+      env: envConfigs.run,
+      buildEnv: envConfigs.build,
     },
   };
 
@@ -359,9 +363,8 @@ export async function executeBuild(
           MemorySize: asset.memory || 3008,
           Environment: {
             Variables: {
-              ...nowConfig.env,
               ...asset.environment,
-              ...env,
+              ...envConfigs.all,
               NOW_REGION: 'dev1',
             },
           },

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -66,7 +66,7 @@ async function createBuildProcess(
   const env: EnvConfig = {
     ...process.env,
     PATH,
-    ...envConfigs.all,
+    ...envConfigs.allEnv,
     NOW_REGION: 'dev1',
   };
 
@@ -152,8 +152,8 @@ export async function executeBuild(
       filesRemoved,
       // This env distiniction is only necessary to maintain
       // backwards compatibility with the `@now/next` builder.
-      env: envConfigs.run,
-      buildEnv: envConfigs.build,
+      env: envConfigs.runEnv,
+      buildEnv: envConfigs.buildEnv,
     },
   };
 
@@ -365,7 +365,7 @@ export async function executeBuild(
             Variables: {
               ...nowConfig.env,
               ...asset.environment,
-              ...envConfigs.run,
+              ...envConfigs.runEnv,
               NOW_REGION: 'dev1',
             },
           },

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -363,8 +363,9 @@ export async function executeBuild(
           MemorySize: asset.memory || 3008,
           Environment: {
             Variables: {
+              ...nowConfig.env,
               ...asset.environment,
-              ...envConfigs.all,
+              ...envConfigs.run,
               NOW_REGION: 'dev1',
             },
           },

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -142,7 +142,7 @@ export default class DevServer {
     this.cwd = cwd;
     this.debug = options.debug;
     this.output = options.output;
-    this.envConfigs = { build: {}, run: {}, all: {} };
+    this.envConfigs = { buildEnv: {}, runEnv: {}, allEnv: {} };
     this.files = {};
     this.address = '';
     this.devCommand = options.devCommand;
@@ -739,13 +739,13 @@ export default class DevServer {
     // Retrieve the path of the native module
     const nowConfig = await this.getNowConfig(false);
     const nowConfigBuild = nowConfig.build || {};
-    const [env, buildEnv] = await Promise.all([
+    const [runEnv, buildEnv] = await Promise.all([
       this.getLocalEnv('.env', nowConfig.env),
       this.getLocalEnv('.env.build', nowConfigBuild.env),
     ]);
-    const allEnv = { ...buildEnv, ...env };
+    const allEnv = { ...buildEnv, ...runEnv };
     Object.assign(process.env, allEnv);
-    this.envConfigs = { build: buildEnv, run: env, all: allEnv };
+    this.envConfigs = { buildEnv, runEnv, allEnv };
 
     const opts = { output: this.output, isBuilds: true };
     const files = await getFiles(this.cwd, nowConfig, opts);
@@ -1688,7 +1688,7 @@ export default class DevServer {
       FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
       ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
       ...process.env,
-      ...this.envConfigs.all,
+      ...this.envConfigs.allEnv,
       NOW_REGION: 'dev1',
       PORT: `${port}`,
     };

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -30,17 +30,17 @@ export interface EnvConfigs {
   /**
    * environment variables from `.env.build` file (deprecated)
    */
-  build: EnvConfig;
+  buildEnv: EnvConfig;
 
   /**
    * environment variables from `.env` file
    */
-  run: EnvConfig;
+  runEnv: EnvConfig;
 
   /**
    * environment variables from `.env` and `.env.build`
    */
-  all: EnvConfig;
+  allEnv: EnvConfig;
 }
 
 export interface BuildMatch extends BuildConfig {

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -26,6 +26,23 @@ export interface EnvConfig {
   [name: string]: string | undefined;
 }
 
+export interface EnvConfigs {
+  /**
+   * environment variables from `.env.build` file (deprecated)
+   */
+  build: EnvConfig;
+
+  /**
+   * environment variables from `.env` file
+   */
+  run: EnvConfig;
+
+  /**
+   * environment variables from `.env` and `.env.build`
+   */
+  all: EnvConfig;
+}
+
 export interface BuildMatch extends BuildConfig {
   entrypoint: string;
   builderWithPkg: BuilderWithPackage;

--- a/packages/now-cli/test/dev/fixtures/27-zero-config-env/.env
+++ b/packages/now-cli/test/dev/fixtures/27-zero-config-env/.env
@@ -1,0 +1,1 @@
+FOO="build-and-runtime"

--- a/packages/now-cli/test/dev/fixtures/27-zero-config-env/.nowignore
+++ b/packages/now-cli/test/dev/fixtures/27-zero-config-env/.nowignore
@@ -1,0 +1,2 @@
+public
+.now

--- a/packages/now-cli/test/dev/fixtures/27-zero-config-env/api/print.js
+++ b/packages/now-cli/test/dev/fixtures/27-zero-config-env/api/print.js
@@ -1,0 +1,1 @@
+module.exports = (_req, res) => res.end(process.env.FOO);

--- a/packages/now-cli/test/dev/fixtures/27-zero-config-env/package.json
+++ b/packages/now-cli/test/dev/fixtures/27-zero-config-env/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir public && echo $FOO > public/index.html"
+  }
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1259,6 +1259,16 @@ test(
 );
 
 test(
+  '[now dev] 27-zero-config-env',
+  testFixtureStdio('27-zero-config-env', async (t, port) => {
+    const api = await fetchWithRetry(`http://localhost:${port}/api/print`);
+    const index = await fetchWithRetry(`http://localhost:${port}`);
+    t.regex(await api.text(), new RegExp('build-and-runtime'));
+    t.regex(await index.text(), new RegExp('build-and-runtime'));
+  })
+);
+
+test(
   '[now dev] Use `@now/python` with Flask requirements.txt',
   testFixtureStdio('python-flask', async (t, port) => {
     const name = 'Alice';


### PR DESCRIPTION
The latest `now env` subcommand no longer makes the distinction between build time and runtime environment variables so this PR updates `now dev` to no longer make the distinction either.

The only exception is that some builders such as `@now/next` might still rely on the separation so we must preserve the distinction for legacy builders.