### PR TITLE
[now-cli] Fix `now env` stdin detection and don't throw for known errors

### DIFF
--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -51,7 +51,7 @@ export default async function add(
     return 1;
   } else {
     const { project } = link;
-    let stdInput = await readStandardInput();
+    const stdInput = await readStandardInput();
     let [envName, envTarget] = args;
 
     if (args.length > 2) {
@@ -76,7 +76,7 @@ export default async function add(
     if (envTarget) {
       if (!isValidEnvTarget(envTarget)) {
         output.error(
-          `The environment ${param(
+          `The Environment ${param(
             envTarget
           )} is invalid. It must be one of: ${getEnvTargetPlaceholder()}.`
         );
@@ -109,7 +109,7 @@ export default async function add(
       output.error(
         `The variable ${param(
           envName
-        )} has already been added to all environments. To remove, run ${cmd(
+        )} has already been added to all Environments. To remove, run ${cmd(
           `now env rm ${envName}`
         )}.`
       );
@@ -133,14 +133,14 @@ export default async function add(
       const { inputTargets } = await inquirer.prompt({
         name: 'inputTargets',
         type: 'checkbox',
-        message: `Add ${envName} to which environments (select multiple)?`,
+        message: `Add ${envName} to which Environments (select multiple)?`,
         choices,
       });
 
       envTargets = inputTargets;
 
       if (inputTargets.length === 0) {
-        output.error('Please select at least one environment');
+        output.error('Please select at least one Environment');
       }
     }
 

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -61,7 +61,7 @@ export default async function ls(
 
     if (!isValidEnvTarget(envTarget)) {
       output.error(
-        `The environment ${param(
+        `The Environment ${param(
           envTarget
         )} is invalid. It must be one of: ${getEnvTargetPlaceholder()}.`
       );

--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -67,7 +67,7 @@ export default async function rm(
     if (envTarget) {
       if (!isValidEnvTarget(envTarget)) {
         output.error(
-          `The environment ${param(
+          `The Environment ${param(
             envTarget
           )} is invalid. It must be one of: ${getEnvTargetPlaceholder()}.`
         );
@@ -118,7 +118,7 @@ export default async function rm(
         const { inputTargets } = await inquirer.prompt({
           name: 'inputTargets',
           type: 'checkbox',
-          message: `Remove ${envName} from which environments (select multiple)?`,
+          message: `Remove ${envName} from which Environments (select multiple)?`,
           choices,
         });
         envTargets = inputTargets;

--- a/packages/now-cli/src/util/env/known-error.ts
+++ b/packages/now-cli/src/util/env/known-error.ts
@@ -1,0 +1,13 @@
+const knownErrorsCodes = new Set([
+  'payment_required',
+  'BAD_REQUEST',
+  'SYSTEM_ENV_WITH_VALUE',
+  'RESERVED_ENV_VARIABLE',
+  'ENV_ALREADY_EXISTS',
+  'ENV_SHOULD_BE_A_SECRET',
+]);
+
+export function isKnownError(error: { code?: string }) {
+  const code = error && typeof error.code === 'string' ? error.code : '';
+  return knownErrorsCodes.has(code);
+}

--- a/packages/now-cli/src/util/env/known-error.ts
+++ b/packages/now-cli/src/util/env/known-error.ts
@@ -1,5 +1,5 @@
 const knownErrorsCodes = new Set([
-  'payment_required',
+  'PAYMENT_REQUIRED',
   'BAD_REQUEST',
   'SYSTEM_ENV_WITH_VALUE',
   'RESERVED_ENV_VARIABLE',
@@ -9,5 +9,5 @@ const knownErrorsCodes = new Set([
 
 export function isKnownError(error: { code?: string }) {
   const code = error && typeof error.code === 'string' ? error.code : '';
-  return knownErrorsCodes.has(code);
+  return knownErrorsCodes.has(code.toUpperCase());
 }

--- a/packages/now-cli/src/util/input/read-standard-input.ts
+++ b/packages/now-cli/src/util/input/read-standard-input.ts
@@ -1,12 +1,11 @@
-export default async function readStandardInput(wait = 100): Promise<string> {
+export default async function readStandardInput(): Promise<string> {
   return new Promise<string>(resolve => {
-    // There is no reliable way to determine if stdin is provided
-    // so we use a timeout to resolve in case there is no stdin.
-    const t = setTimeout(() => resolve(''), wait);
-    process.stdin.setEncoding('utf8');
-    process.stdin.once('data', data => {
-      clearTimeout(t);
-      resolve(data);
-    });
+    if (process.stdin.isTTY) {
+      // found tty so we know there is nothing piped to stdin
+      resolve('');
+    } else {
+      process.stdin.setEncoding('utf8');
+      process.stdin.once('data', resolve);
+    }
   });
 }

--- a/packages/now-cli/src/util/input/read-standard-input.ts
+++ b/packages/now-cli/src/util/input/read-standard-input.ts
@@ -1,5 +1,16 @@
 export default async function readStandardInput(): Promise<string> {
   return new Promise<string>(resolve => {
+    if (process.env.__NOW_STDIN_CI) {
+      // special case CI to avoid hanging
+      const t = setTimeout(() => resolve(''), 200);
+      process.stdin.setEncoding('utf8');
+      process.stdin.once('data', data => {
+        clearTimeout(t);
+        resolve(data);
+      });
+      return;
+    }
+
     if (process.stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');

--- a/packages/now-cli/src/util/input/read-standard-input.ts
+++ b/packages/now-cli/src/util/input/read-standard-input.ts
@@ -1,15 +1,6 @@
 export default async function readStandardInput(): Promise<string> {
   return new Promise<string>(resolve => {
-    if (process.env.__NOW_STDIN_CI) {
-      // special case CI to avoid hanging
-      const t = setTimeout(() => resolve(''), 200);
-      process.stdin.setEncoding('utf8');
-      process.stdin.once('data', data => {
-        clearTimeout(t);
-        resolve(data);
-      });
-      return;
-    }
+    setTimeout(() => resolve(''), 500);
 
     if (process.stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -137,7 +137,7 @@ const apiFetch = (url, { headers, ...options } = {}) => {
 const waitForPrompt = (cp, assertion) =>
   new Promise((resolve, reject) => {
     console.log('Waiting for prompt...');
-    setTimeout(() => reject(new Error('timeout in waitForPrompt'), 10000));
+    setTimeout(() => reject(new Error('timeout in waitForPrompt')), 60000);
     const listener = chunk => {
       console.log('> ' + chunk);
       if (assertion(chunk)) {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -360,6 +360,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     const now = execa(binaryPath, ['env', 'add', ...defaultArgs], {
       reject: false,
       cwd: target,
+      env: { __NOW_STDIN_CI: 1 },
     });
     await waitForPrompt(now, chunk =>
       chunk.includes('What’s the name of the variable?')
@@ -391,6 +392,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
       {
         reject: false,
         cwd: target,
+        env: { __NOW_STDIN_CI: 1 },
       }
     );
     now.stdin.end('MY_STDIN_VALUE');

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -135,9 +135,11 @@ const apiFetch = (url, { headers, ...options } = {}) => {
 };
 
 const waitForPrompt = (cp, assertion) =>
-  new Promise(resolve => {
+  new Promise((resolve, reject) => {
     console.log('Waiting for prompt...');
+    setTimeout(() => reject(new Error('timeout in waitForPrompt'), 10000));
     const listener = chunk => {
+      console.log('> ' + chunk);
       if (assertion(chunk)) {
         cp.stdout.off && cp.stdout.off('data', listener);
         cp.stderr.off && cp.stderr.off('data', listener);
@@ -360,7 +362,6 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     const now = execa(binaryPath, ['env', 'add', ...defaultArgs], {
       reject: false,
       cwd: target,
-      env: { __NOW_STDIN_CI: 1 },
     });
     await waitForPrompt(now, chunk =>
       chunk.includes('What’s the name of the variable?')
@@ -376,7 +377,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     await waitForPrompt(
       now,
       chunk =>
-        chunk.includes('which environments') && chunk.includes('MY_ENV_VAR')
+        chunk.includes('which Environments') && chunk.includes('MY_ENV_VAR')
     );
     now.stdin.write('a\n'); // select all
 
@@ -392,7 +393,6 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
       {
         reject: false,
         cwd: target,
-        env: { __NOW_STDIN_CI: 1 },
       }
     );
     now.stdin.end('MY_STDIN_VALUE');
@@ -485,7 +485,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     await waitForPrompt(
       now,
       chunk =>
-        chunk.includes('which environments') && chunk.includes('MY_ENV_VAR')
+        chunk.includes('which Environments') && chunk.includes('MY_ENV_VAR')
     );
     now.stdin.write('a\n'); // select all
 


### PR DESCRIPTION
- Capitalize `Environment` in all outputs
- Fix stdin detection so there is no need for timeouts
- Dont throw if the error is bad user input, only throw for unexpected errors
- Fix tests so waiting for prompt will throw if expected output is never received