### PR TITLE
[now-cli] Fix encoding domain names

### DIFF
--- a/packages/now-cli/src/util/dns/add-dns-record.ts
+++ b/packages/now-cli/src/util/dns/add-dns-record.ts
@@ -19,7 +19,7 @@ export default async function addDNSRecord(
 ) {
   try {
     const record = await client.fetch<Response>(
-      `/v3/domains/${domain}/records`,
+      `/v3/domains/${encodeURIComponent(domain)}/records`,
       {
         body: recordData,
         method: 'POST',

--- a/packages/now-cli/src/util/dns/import-zonefile.ts
+++ b/packages/now-cli/src/util/dns/import-zonefile.ts
@@ -22,12 +22,15 @@ export default async function importZonefile(
   const zonefile = readFileSync(resolve(zonefilePath), 'utf8');
 
   try {
-    const res = await client.fetch<Response>(`/v3/domains/${domain}/records`, {
-      headers: { 'Content-Type': 'text/dns' },
-      body: zonefile,
-      method: 'PUT',
-      json: false,
-    });
+    const res = await client.fetch<Response>(
+      `/v3/domains/${encodeURIComponent(domain)}/records`,
+      {
+        headers: { 'Content-Type': 'text/dns' },
+        body: zonefile,
+        method: 'PUT',
+        json: false,
+      }
+    );
 
     const { recordIds } = (await res.json()) as JSONResponse;
     cancelWait();

--- a/packages/now-cli/src/util/domains/check-transfer.ts
+++ b/packages/now-cli/src/util/domains/check-transfer.ts
@@ -22,5 +22,7 @@ type Response = {
 };
 
 export default async function checkTransfer(client: Client, name: string) {
-  return client.fetch<Response>(`/v4/domains/${name}/registry`);
+  return client.fetch<Response>(
+    `/v4/domains/${encodeURIComponent(name)}/registry`
+  );
 }

--- a/packages/now-cli/src/util/domains/get-domain-by-name.ts
+++ b/packages/now-cli/src/util/domains/get-domain-by-name.ts
@@ -18,7 +18,7 @@ async function getDomainByName(
   );
   try {
     const { domain } = await client.fetch<Response>(
-      `/v4/domains/${domainName}`
+      `/v4/domains/${encodeURIComponent(domainName)}`
     );
     cancelWait();
     return domain;

--- a/packages/now-cli/src/util/domains/move-out-domain.ts
+++ b/packages/now-cli/src/util/domains/move-out-domain.ts
@@ -13,10 +13,13 @@ export default async function moveOutDomain(
   destination: string
 ) {
   try {
-    return await client.fetch<Response>(`/v4/domains/${name}`, {
-      body: { op: 'move-out', destination },
-      method: 'PATCH',
-    });
+    return await client.fetch<Response>(
+      `/v4/domains/${encodeURIComponent(name)}`,
+      {
+        body: { op: 'move-out', destination },
+        method: 'PATCH',
+      }
+    );
   } catch (error) {
     if (error.code === 'forbidden') {
       return new ERRORS.DomainPermissionDenied(name, contextName);

--- a/packages/now-cli/src/util/domains/remove-domain-by-name.ts
+++ b/packages/now-cli/src/util/domains/remove-domain-by-name.ts
@@ -7,7 +7,9 @@ export default async function removeDomainByName(
   domain: string
 ) {
   try {
-    return await now.fetch(`/v3/domains/${domain}`, { method: 'DELETE' });
+    return await now.fetch(`/v3/domains/${encodeURIComponent(domain)}`, {
+      method: 'DELETE',
+    });
   } catch (error) {
     if (error.code === 'not_found') {
       return new ERRORS.DomainNotFound(domain);


### PR DESCRIPTION
Fixes [sentry error](https://sentry.io/organizations/zeithq/issues/1611174358/events/c3455f32ce1743b58cc248d548538b21/) so that domain name is always encoded because this input comes from the user.