### PR TITLE
[now-cli] Fix undefined teams and cache result

### DIFF
--- a/packages/now-cli/src/util/get-teams.ts
+++ b/packages/now-cli/src/util/get-teams.ts
@@ -6,7 +6,7 @@ import NowTeams from './teams.js';
 
 let teams: Team[] | undefined;
 
-export default async function getTeams(client: Client) {
+export default async function getTeams(client: Client): Promise<Team[]> {
   if (teams) return teams;
 
   try {
@@ -17,8 +17,8 @@ export default async function getTeams(client: Client) {
       debug: client._debug,
     });
 
-    const teams = (await teamClient.ls()).teams;
-    return teams as Team[];
+    teams = (await teamClient.ls()).teams;
+    return teams || [];
   } catch (error) {
     if (error instanceof APIError && error.status === 403) {
       throw new InvalidToken();

--- a/packages/now-cli/src/util/teams.js
+++ b/packages/now-cli/src/util/teams.js
@@ -4,7 +4,7 @@ export default class Teams extends Now {
   async create({ slug }) {
     return this.retry(async (bail, attempt) => {
       if (this._debug) {
-        console.time(`> [debug] #${attempt} POST /teams}`);
+        console.time(`> [debug] #${attempt} POST /teams`);
       }
 
       const res = await this._fetch(`/teams`, {
@@ -42,7 +42,7 @@ export default class Teams extends Now {
   async edit({ id, slug, name }) {
     return this.retry(async (bail, attempt) => {
       if (this._debug) {
-        console.time(`> [debug] #${attempt} PATCH /teams/${id}}`);
+        console.time(`> [debug] #${attempt} PATCH /teams/${id}`);
       }
 
       const payload = {};
@@ -86,7 +86,7 @@ export default class Teams extends Now {
   async inviteUser({ teamId, email }) {
     return this.retry(async (bail, attempt) => {
       if (this._debug) {
-        console.time(`> [debug] #${attempt} POST /teams/${teamId}/members}`);
+        console.time(`> [debug] #${attempt} POST /teams/${teamId}/members`);
       }
 
       const publicRes = await this._fetch(`/www/user/public?email=${email}`);
@@ -100,7 +100,7 @@ export default class Teams extends Now {
       });
 
       if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} POST /teams/${teamId}/members}`);
+        console.timeEnd(`> [debug] #${attempt} POST /teams/${teamId}/members`);
       }
 
       if (res.status === 403) {
@@ -128,7 +128,7 @@ export default class Teams extends Now {
   async ls() {
     return this.retry(async (bail, attempt) => {
       if (this._debug) {
-        console.time(`> [debug] #${attempt} GET /teams}`);
+        console.time(`> [debug] #${attempt} GET /teams`);
       }
 
       const res = await this._fetch(`/teams`);

--- a/packages/now-cli/src/util/teams.js
+++ b/packages/now-cli/src/util/teams.js
@@ -2,21 +2,13 @@ import Now from './index';
 
 export default class Teams extends Now {
   async create({ slug }) {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} POST /teams`);
-      }
-
+    return this.retry(async bail => {
       const res = await this._fetch(`/teams`, {
         method: 'POST',
         body: {
           slug,
         },
       });
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} POST /teams`);
-      }
 
       if (res.status === 403) {
         return bail(new Error('Unauthorized'));
@@ -40,11 +32,7 @@ export default class Teams extends Now {
   }
 
   async edit({ id, slug, name }) {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} PATCH /teams/${id}`);
-      }
-
+    return this.retry(async bail => {
       const payload = {};
       if (name) {
         payload.name = name;
@@ -57,10 +45,6 @@ export default class Teams extends Now {
         method: 'PATCH',
         body: payload,
       });
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} PATCH /teams/${id}`);
-      }
 
       if (res.status === 403) {
         return bail(new Error('Unauthorized'));
@@ -84,11 +68,7 @@ export default class Teams extends Now {
   }
 
   async inviteUser({ teamId, email }) {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} POST /teams/${teamId}/members`);
-      }
-
+    return this.retry(async bail => {
       const publicRes = await this._fetch(`/www/user/public?email=${email}`);
       const { name, username } = await publicRes.json();
 
@@ -98,10 +78,6 @@ export default class Teams extends Now {
           email,
         },
       });
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} POST /teams/${teamId}/members`);
-      }
 
       if (res.status === 403) {
         return bail(new Error('Unauthorized'));
@@ -126,16 +102,8 @@ export default class Teams extends Now {
   }
 
   async ls() {
-    return this.retry(async (bail, attempt) => {
-      if (this._debug) {
-        console.time(`> [debug] #${attempt} GET /teams`);
-      }
-
+    return this.retry(async bail => {
       const res = await this._fetch(`/teams`);
-
-      if (this._debug) {
-        console.timeEnd(`> [debug] #${attempt} GET /teams`);
-      }
 
       if (res.status === 403) {
         const error = new Error('Unauthorized');


### PR DESCRIPTION
- Fix [sentry error](https://sentry.io/organizations/zeithq/issues/1610513448/events/12bde04e921442a4aae8b7b10a759ecb/) where the `teams` might be undefined.
- Fix regression from #3740 which accidentally removed caching `teams`.
- Fix superflous `console.time()` calls for the same `GET /teams` API call. See below:

```sh
> [debug] [2020-04-14T18:31:00.220Z] GET https://api.zeit.co/www/user
> [debug] [2020-04-14T18:31:00.533Z] GET https://api.zeit.co/www/user : 313.078ms
> [debug] [2020-04-14T18:31:00.543Z] GET https://api.zeit.co/teams
> [debug] [2020-04-14T18:31:00.799Z] GET https://api.zeit.co/teams : 255.459ms
> [debug] #1 GET /teams: 260.198ms
```