### PR TITLE
[now-cli] Print notice if `builds` property exists in `now.json`

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -392,6 +392,19 @@ export default async function main(
     );
   }
 
+  if (localConfig.builds) {
+    output.print(
+      `${prependEmoji(
+        `Zero-configuration deployments are recommended instead of a ${code(
+          'builds'
+        )} property in ${highlight(
+          'now.json'
+        )}. The “Build & Development Settings” in your Project will not apply. More details: https://zeit.co/blog/advanced-project-settings`,
+        emoji('notice')
+      )}\n`
+    );
+  }
+
   // build `env`
   const isObject = item =>
     Object.prototype.toString.call(item) === '[object Object]';


### PR DESCRIPTION
Implements [PRODUCT-1395]

```sh
Now CLI 18.0.0
📝  Zero-configuration deployments are recommended instead of a `builds` property in now.json. The “Build & Development Settings” in your Project will not apply. More details: https://zeit.co/blog/advanced-project-settings
```

[PRODUCT-1395]: https://zeit.atlassian.net/browse/PRODUCT-1395