### PR TITLE
[now-cli] Fix for RangeError invalid count value

### DIFF
--- a/packages/now-cli/src/util/format-table.ts
+++ b/packages/now-cli/src/util/format-table.ts
@@ -20,7 +20,7 @@ import strlen from './strlen';
 export default function formatTable(
   header: string[],
   align: Array<'l' | 'r' | 'c' | '.'>,
-  blocks: { name: string, rows: string[][] }[],
+  blocks: { name: string; rows: string[][] }[],
   hsep = '    '
 ) {
   const nrCols = header.length;
@@ -50,8 +50,8 @@ export default function formatTable(
         for (let j = 0; j < nrCols; j++) {
           const col = `${row[j]}`;
           const al = align[j] || 'l';
-          const pad =
-            padding[j] > 1 ? ' '.repeat(padding[j] * 8 - strlen(col)) : '';
+          const spaces = Math.max(padding[j] * 8 - strlen(col), 0);
+          const pad = ' '.repeat(spaces);
           rows[i][j] = al === 'l' ? col + pad : pad + col;
         }
       }


### PR DESCRIPTION
This PR fixes a [sentry error](https://sentry.io/organizations/zeithq/issues/1611628097/events/75ed28bc6aef42868721a0912875fdbd/) where `repeat()` is passed a negative number and throws [`RangeError: invalid count value`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Resulting_string_too_large).

This PR ensures `repeat()` is always passed 0 or greater.