### PR TITLE
[now-cli] Proxy everything except Lambdas to the dev server

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1456,19 +1456,24 @@ export default class DevServer {
       foundAsset = findAsset(match, requestPath, nowConfig);
     }
 
-    if (!foundAsset) {
-      // if the dev command is started, proxy to it
-      if (this.devProcessPort) {
-        this.output.debug('Proxy to dev command server');
-        return proxyPass(
-          req,
-          res,
-          `http://localhost:${this.devProcessPort}`,
-          this.output,
-          false
-        );
-      }
+    // Proxy to the dev server:
+    // - when there is no asset
+    // - when the asset is not a Lambda (the dev server must take care of all static files)
+    if (
+      this.devProcessPort &&
+      (!foundAsset || (foundAsset && foundAsset.asset.type !== 'Lambda'))
+    ) {
+      this.output.debug('Proxy to dev command server');
+      return proxyPass(
+        req,
+        res,
+        `http://localhost:${this.devProcessPort}`,
+        this.output,
+        false
+      );
+    }
 
+    if (!foundAsset) {
       await this.send404(req, res, nowRequestId);
       return;
     }


### PR DESCRIPTION
https://zeit.atlassian.net/browse/PRODUCT-2363

This PR ensures that, if there is a `dev process`, we'll use it for all static files, instead of trying to use `public` as a fallback. This has to be done, since sometimes `public` is used by the framework/dev-script itself.