### PR TITLE
[now-cli] Remove custom error when fetching frameworks fail

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -37,7 +37,7 @@ export default async function dev(
   // retrieve dev command
   const [link, frameworks] = await Promise.all([
     getLinkedProject(output, client, cwd),
-    getFrameworks(),
+    getFrameworks(client),
   ]);
 
   if (link.status === 'error') {

--- a/packages/now-cli/src/util/client.ts
+++ b/packages/now-cli/src/util/client.ts
@@ -23,7 +23,7 @@ export default class Client extends EventEmitter {
   _forceNew: boolean;
   _withCache: boolean;
   _output: Output;
-  _token?: string;
+  _token: string;
   currentTeam?: string;
 
   constructor({
@@ -35,7 +35,7 @@ export default class Client extends EventEmitter {
     debug = false,
   }: {
     apiUrl: string;
-    token?: string;
+    token: string;
     currentTeam?: string;
     forceNew?: boolean;
     withCache?: boolean;
@@ -95,11 +95,8 @@ export default class Client extends EventEmitter {
     }
 
     opts.headers = opts.headers || {};
+    opts.headers.Authorization = `Bearer ${this._token}`;
     opts.headers['user-agent'] = ua;
-
-    if (this._token) {
-      opts.headers.Authorization = `Bearer ${this._token}`;
-    }
 
     const url = `${apiUrl ? '' : this._apiUrl}${_url}`;
     return this._output.time(

--- a/packages/now-cli/src/util/client.ts
+++ b/packages/now-cli/src/util/client.ts
@@ -23,7 +23,7 @@ export default class Client extends EventEmitter {
   _forceNew: boolean;
   _withCache: boolean;
   _output: Output;
-  _token: string;
+  _token?: string;
   currentTeam?: string;
 
   constructor({
@@ -35,7 +35,7 @@ export default class Client extends EventEmitter {
     debug = false,
   }: {
     apiUrl: string;
-    token: string;
+    token?: string;
     currentTeam?: string;
     forceNew?: boolean;
     withCache?: boolean;
@@ -95,8 +95,11 @@ export default class Client extends EventEmitter {
     }
 
     opts.headers = opts.headers || {};
-    opts.headers.Authorization = `Bearer ${this._token}`;
     opts.headers['user-agent'] = ua;
+
+    if (this._token) {
+      opts.headers.Authorization = `Bearer ${this._token}`;
+    }
 
     const url = `${apiUrl ? '' : this._apiUrl}${_url}`;
     return this._output.time(

--- a/packages/now-cli/src/util/get-frameworks.ts
+++ b/packages/now-cli/src/util/get-frameworks.ts
@@ -1,10 +1,6 @@
 import { Framework } from '@now/frameworks';
 import Client from './client';
 
-export async function getFrameworks(): Promise<Framework[]> {
-  const client = new Client({
-    apiUrl: 'https://api.zeit.co',
-  });
-
+export async function getFrameworks(client: Client) {
   return await client.fetch<Framework[]>('/v1/frameworks');
 }

--- a/packages/now-cli/src/util/get-frameworks.ts
+++ b/packages/now-cli/src/util/get-frameworks.ts
@@ -1,14 +1,10 @@
-import fetch from 'node-fetch';
 import { Framework } from '@now/frameworks';
+import Client from './client';
 
 export async function getFrameworks(): Promise<Framework[]> {
-  const res = await fetch('https://api.zeit.co/v1/frameworks');
+  const client = new Client({
+    apiUrl: 'https://api.zeit.co',
+  });
 
-  if (!res.ok) {
-    throw new Error('Could not retrieve frameworks');
-  }
-
-  const json: Framework[] = await res.json();
-
-  return json;
+  return await client.fetch<Framework[]>('/v1/frameworks');
 }


### PR DESCRIPTION
Fix PRODUCT-2364.

Use `Client` instead of `node-fetch` to retrieve frameworks list.