### PR TITLE
[now-node] Throw an error if "exit" event happens in dev server

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -401,6 +401,14 @@ export async function prepareCache({
   return cache;
 }
 
+interface PortInfo {
+  port: number;
+}
+
+function isPortInfo(v: any): v is PortInfo {
+  return v && typeof v.port === 'number';
+}
+
 export async function startDevServer({
   entrypoint,
   workPath,
@@ -420,6 +428,18 @@ export async function startDevServer({
     },
   });
   const { pid } = child;
-  const { port } = await once<{ port: number }>(child, 'message');
-  return { port, pid };
+  const onMessage = once<{ port: number }>(child, 'message');
+  const onExit = once<{ code: number; signal: string | null }>(child, 'exit');
+  const result = await Promise.race([onMessage, onExit]);
+  onExit.cancel();
+  onMessage.cancel();
+  if (isPortInfo(result)) {
+    // "message" event
+    return { port: result.port, pid };
+  } else {
+    // "exit" event
+    throw new Error(
+      `Failed to start dev server for "${entrypoint}" (code=${result.code}, signal=${result.signal})`
+    );
+  }
 }


### PR DESCRIPTION
If the process exits before the "message" event is sent, then the dev
server crashed upon bootup. Often times caused by a missing dependency.