### PR TITLE
[now-routing-utils] Fix validation for rewrite/redirect `destination` segments

### DIFF
--- a/errors/invalid-route-source.md
+++ b/errors/invalid-route-source.md
@@ -13,7 +13,7 @@ Wrap the `RegExp` part of your `source` as an un-named parameter.
 ```js
 {
   source: '/feedback/(?!general)',
-  destination: '/feedback/general'
+  destination: '/api/feedback/general'
 }
 ```
 
@@ -22,7 +22,27 @@ Wrap the `RegExp` part of your `source` as an un-named parameter.
 ```js
 {
   source: '/feedback/((?!general).*)',
-  destination: '/feedback/general'
+  destination: '/api/feedback/general'
+}
+```
+
+Ensure any segments used in the `destination` property are also used in the `source` property.
+
+**Before**
+
+```js
+{
+  source: '/feedback/:type',
+  destination: '/api/feedback/:id'
+}
+```
+
+**After**
+
+```js
+{
+  source: '/feedback/:id',
+  destination: '/api/feedback/:id'
 }
 ```
 

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -58,7 +58,7 @@ export function convertRedirects(
       };
       return route;
     } catch (e) {
-      throw new Error('Failed to parse destination: ' + r.destination);
+      throw new Error(`Failed to parse redirect: ${JSON.stringify(r)}`);
     }
   });
 }
@@ -71,7 +71,7 @@ export function convertRewrites(rewrites: NowRewrite[]): Route[] {
       const route: Route = { src, dest, check: true };
       return route;
     } catch (e) {
-      throw new Error('Failed to parse destination: ' + r.destination);
+      throw new Error(`Failed to parse rewrite: ${JSON.stringify(r)}`);
     }
   });
 }

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -640,6 +640,11 @@ describe('getTransformedRoutes', () => {
       rewrites: [{ source: '/v1', destination: '/v2/api.py' }],
       redirects: [
         { source: '/help', destination: '/support', statusCode: 302 },
+        {
+          source: '/bug',
+          destination: 'https://example.com/bug',
+          statusCode: 308,
+        },
       ],
     };
     const actual = getTransformedRoutes({ nowConfig });
@@ -658,6 +663,11 @@ describe('getTransformedRoutes', () => {
         src: '^/help$',
         headers: { Location: '/support' },
         status: 302,
+      },
+      {
+        src: '^/bug$',
+        headers: { Location: 'https://example.com/bug' },
+        status: 308,
       },
       { handle: 'filesystem' },
       { src: '^/v1$', dest: '/v2/api.py', check: true },
@@ -715,5 +725,43 @@ describe('getTransformedRoutes', () => {
     const nowConfig = { routes: null };
     const actual = getTransformedRoutes({ nowConfig });
     assert.equal(actual.routes, null);
+  });
+
+  test('should error when segment is defined in `destination` but not `source`', () => {
+    const nowConfig = {
+      redirects: [
+        {
+          source: '/iforgot/:id',
+          destination: '/:another',
+        },
+      ],
+    };
+    const actual = getTransformedRoutes({ nowConfig });
+    assert.deepEqual(actual.routes, null);
+    assert.ok(
+      actual.error.message.includes(
+        'in "destination" pattern but not in "source"'
+      ),
+      actual.error.message
+    );
+  });
+
+  test('should error when segment is defined in HTTPS `destination` but not `source`', () => {
+    const nowConfig = {
+      redirects: [
+        {
+          source: '/iforgot/:id',
+          destination: 'https://example.com/:another',
+        },
+      ],
+    };
+    const actual = getTransformedRoutes({ nowConfig });
+    assert.deepEqual(actual.routes, null);
+    assert.ok(
+      actual.error.message.includes(
+        'in "destination" pattern but not in "source"'
+      ),
+      actual.error.message
+    );
   });
 });


### PR DESCRIPTION
- Print an error instead of throwing when `destination` has segment not found in `source`
- Update docs to explain how to fix this error
- Add a couple tests
- Update uncaught `path-to-regexp` error message to print the full route that caused the error