### PR TITLE
[now-cli] Add the core Runtimes as npm `dependencies` for now dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ coverage
 *.swp
 *.bak
 *.tgz
-packages/now-cli/.builders
-packages/now-cli/assets
 packages/now-cli/src/util/dev/templates/*.ts
 packages/now-cli/src/util/constants.ts
 packages/now-cli/test/**/yarn.lock

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -61,6 +61,15 @@
   "engines": {
     "node": ">= 10"
   },
+  "dependencies": {
+    "@now/build-utils": "2.2.2-canary.1",
+    "@now/go": "1.0.7",
+    "@now/next": "2.5.5-canary.0",
+    "@now/node": "1.5.2-canary.2",
+    "@now/python": "1.1.6",
+    "@now/ruby": "1.1.0",
+    "@now/static-build": "0.16.1-canary.0"
+  },
   "devDependencies": {
     "@sentry/node": "5.5.0",
     "@sindresorhus/slugify": "0.11.0",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -62,13 +62,13 @@
     "node": ">= 10"
   },
   "dependencies": {
-    "@now/build-utils": "2.2.2-canary.1",
-    "@now/go": "1.0.7",
-    "@now/next": "2.5.5-canary.0",
-    "@now/node": "1.5.2-canary.2",
-    "@now/python": "1.1.6",
-    "@now/ruby": "1.1.0",
-    "@now/static-build": "0.16.1-canary.0"
+    "@now/build-utils": "2.2.2-canary.2",
+    "@now/go": "1.0.8-canary.0",
+    "@now/next": "2.5.5-canary.1",
+    "@now/node": "1.5.2-canary.3",
+    "@now/python": "1.1.7-canary.0",
+    "@now/ruby": "1.1.1-canary.0",
+    "@now/static-build": "0.16.1-canary.2"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -1,60 +1,9 @@
 import cpy from 'cpy';
-import tar from 'tar-fs';
 import execa from 'execa';
 import { join } from 'path';
-import pipe from 'promisepipe';
-import { createGzip } from 'zlib';
-import {
-  createWriteStream,
-  mkdirp,
-  remove,
-  writeJSON,
-  writeFile,
-} from 'fs-extra';
-
-import { getDistTag } from '../src/util/get-dist-tag';
-import pkg from '../package.json';
-import { getBundledBuilders } from '../src/util/dev/get-bundled-builders';
+import { remove, writeFile } from 'fs-extra';
 
 const dirRoot = join(__dirname, '..');
-
-async function createBuildersTarball() {
-  const distTag = getDistTag(pkg.version);
-  const builders = Array.from(getBundledBuilders()).map(b => `${b}@${distTag}`);
-  console.log(`Creating builders tarball with: ${builders.join(', ')}`);
-
-  const buildersDir = join(dirRoot, '.builders');
-  const assetsDir = join(dirRoot, 'assets');
-  await mkdirp(buildersDir);
-  await mkdirp(assetsDir);
-
-  const buildersTarballPath = join(assetsDir, 'builders.tar.gz');
-
-  try {
-    const buildersPkg = join(buildersDir, 'package.json');
-    await writeJSON(buildersPkg, { private: true }, { flag: 'wx' });
-  } catch (err) {
-    if (err.code !== 'EEXIST') {
-      throw err;
-    }
-  }
-
-  await execa(
-    'npm',
-    ['install', '--save-exact', '--no-package-lock', ...builders],
-    {
-      cwd: buildersDir,
-      stdio: 'inherit',
-    }
-  );
-
-  const packer = tar.pack(buildersDir);
-  await pipe(
-    packer,
-    createGzip(),
-    createWriteStream(buildersTarballPath)
-  );
-}
 
 async function createConstants() {
   console.log('Creating constants.ts');
@@ -83,10 +32,6 @@ async function main() {
     // Read the secrets from GitHub Actions and generate a file.
     // During local development, these secrets will be empty.
     await createConstants();
-
-    // Create a tarball from all the `@now` scoped builders which will be bundled
-    // with Now CLI
-    await createBuildersTarball();
 
     // `now dev` uses chokidar to watch the filesystem, but opts-out of the
     // `fsevents` feature using `useFsEvents: false`, so delete the module here so

--- a/packages/now-cli/src/util/dev/builder-worker.js
+++ b/packages/now-cli/src/util/dev/builder-worker.js
@@ -24,8 +24,8 @@ function onMessage(message) {
 }
 
 async function processMessage(message) {
-  const { builderName, buildOptions } = message;
-  const builder = require(builderName);
+  const { requirePath, buildOptions } = message;
+  const builder = require(requirePath);
 
   // Convert the `files` to back into `FileFsRef` instances
   for (const name of Object.keys(buildOptions.files)) {

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -24,7 +24,7 @@ import { relative } from '../path-helpers';
 import { LambdaSizeExceededError } from '../errors-ts';
 
 import DevServer from './server';
-import { builderModulePathPromise, getBuilder } from './builder-cache';
+import { getBuilder } from './builder-cache';
 import {
   NowConfig,
   BuildMatch,
@@ -55,7 +55,8 @@ async function createBuildProcess(
   output: Output
 ): Promise<ChildProcess> {
   const { execPath } = process;
-  const modulePath = await builderModulePathPromise;
+  //const modulePath = await builderModulePathPromise;
+  const modulePath = join(__dirname, 'builder-worker.js');
 
   // Ensure that `node` is in the builder's `PATH`
   let PATH = `${dirname(execPath)}${delimiter}${process.env.PATH}`;

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -54,12 +54,10 @@ async function createBuildProcess(
   workPath: string,
   output: Output
 ): Promise<ChildProcess> {
-  const { execPath } = process;
-  //const modulePath = await builderModulePathPromise;
-  const modulePath = join(__dirname, 'builder-worker.js');
+  const builderWorkerPath = join(__dirname, 'builder-worker.js');
 
   // Ensure that `node` is in the builder's `PATH`
-  let PATH = `${dirname(execPath)}${delimiter}${process.env.PATH}`;
+  let PATH = `${dirname(process.execPath)}${delimiter}${process.env.PATH}`;
 
   const env: Env = {
     ...process.env,
@@ -68,11 +66,9 @@ async function createBuildProcess(
     NOW_REGION: 'dev1',
   };
 
-  const buildProcess = fork(modulePath, [], {
+  const buildProcess = fork(builderWorkerPath, [], {
     cwd: workPath,
     env,
-    execPath,
-    execArgv: [],
   });
   match.buildProcess = buildProcess;
 
@@ -106,7 +102,7 @@ export async function executeBuild(
   filesRemoved?: string[]
 ): Promise<void> {
   const {
-    builderWithPkg: { runInProcess, builder, package: pkg },
+    builderWithPkg: { runInProcess, requirePath, builder, package: pkg },
   } = match;
   const { entrypoint } = match;
   const { debug, envConfigs, cwd: workPath } = devServer;
@@ -158,7 +154,7 @@ export async function executeBuild(
   if (buildProcess) {
     buildProcess.send({
       type: 'build',
-      builderName: pkg.name,
+      requirePath,
       buildOptions,
     });
 

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -39,7 +39,6 @@ import {
 
 import link from '../output/link';
 import { Output } from '../output';
-//import { treeKill } from '../tree-kill';
 import { relative } from '../path-helpers';
 import { getDistTag } from '../get-dist-tag';
 import getNowConfigPath from '../config/local-path';
@@ -937,7 +936,6 @@ export default class DevServer {
     debug(`Killing builder dev server with PID ${pid}`);
     this.devServerPids.delete(pid);
     try {
-      //await treeKill(pid);
       process.kill(pid, 'SIGTERM');
       debug(`Killed builder dev server with PID ${pid}`);
     } catch (err) {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -39,7 +39,7 @@ import {
 
 import link from '../output/link';
 import { Output } from '../output';
-import { treeKill } from '../tree-kill';
+//import { treeKill } from '../tree-kill';
 import { relative } from '../path-helpers';
 import { getDistTag } from '../get-dist-tag';
 import getNowConfigPath from '../config/local-path';
@@ -937,7 +937,8 @@ export default class DevServer {
     debug(`Killing builder dev server with PID ${pid}`);
     this.devServerPids.delete(pid);
     try {
-      await treeKill(pid);
+      //await treeKill(pid);
+      process.kill(pid, 'SIGTERM');
       debug(`Killed builder dev server with PID ${pid}`);
     } catch (err) {
       debug(`Failed to kill builder dev server with PID ${pid}: ${err}`);

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -121,6 +121,7 @@ export interface BuildResultV4 {
 
 export interface BuilderWithPackage {
   runInProcess?: boolean;
+  requirePath: string;
   builder: Readonly<Builder>;
   package: Readonly<PackageJson>;
 }

--- a/packages/now-cli/src/util/pkg.ts
+++ b/packages/now-cli/src/util/pkg.ts
@@ -1,13 +1,6 @@
-import path from 'path';
-import pkg from '../../package.json';
+import _pkg from '../../package.json';
+import { PackageJson } from '@now/build-utils';
 
-try {
-  const distDir = path.dirname(process.execPath);
-  // @ts-ignore
-  pkg._npmPkg = require(`${path.join(distDir, '../../package.json')}`);
-} catch (err) {
-  // @ts-ignore
-  pkg._npmPkg = null;
-}
+const pkg: PackageJson = _pkg;
 
 export default pkg;

--- a/packages/now-cli/test/dev-builder.unit.js
+++ b/packages/now-cli/test/dev-builder.unit.js
@@ -1,7 +1,8 @@
 import test from 'ava';
-import { filterPackage } from '../src/util/dev/builder-cache';
+import npa from 'npm-package-arg';
+import { filterPackage, isBundledBuilder } from '../src/util/dev/builder-cache';
 
-test('[dev-builder] filter install "latest", cached canary', async t => {
+test('[dev-builder] filter install "latest", cached canary', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1-canary.0',
@@ -11,7 +12,7 @@ test('[dev-builder] filter install "latest", cached canary', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install "canary", cached stable', async t => {
+test('[dev-builder] filter install "canary", cached stable', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1',
@@ -25,7 +26,7 @@ test('[dev-builder] filter install "canary", cached stable', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install "latest", cached stable', async t => {
+test('[dev-builder] filter install "latest", cached stable', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1',
@@ -35,7 +36,7 @@ test('[dev-builder] filter install "latest", cached stable', async t => {
   t.is(result, false);
 });
 
-test('[dev-builder] filter install "canary", cached canary', async t => {
+test('[dev-builder] filter install "canary", cached canary', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1-canary.0',
@@ -49,7 +50,7 @@ test('[dev-builder] filter install "canary", cached canary', async t => {
   t.is(result, false);
 });
 
-test('[dev-builder] filter install URL, cached stable', async t => {
+test('[dev-builder] filter install URL, cached stable', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1',
@@ -59,7 +60,7 @@ test('[dev-builder] filter install URL, cached stable', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install URL, cached canary', async t => {
+test('[dev-builder] filter install URL, cached canary', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': '0.0.1-canary.0',
@@ -69,7 +70,7 @@ test('[dev-builder] filter install URL, cached canary', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install "latest", cached URL - stable', async t => {
+test('[dev-builder] filter install "latest", cached URL - stable', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': 'https://tarball.now.sh',
@@ -79,7 +80,7 @@ test('[dev-builder] filter install "latest", cached URL - stable', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install "latest", cached URL - canary', async t => {
+test('[dev-builder] filter install "latest", cached URL - canary', t => {
   const buildersPkg = {
     dependencies: {
       '@now/build-utils': 'https://tarball.now.sh',
@@ -89,7 +90,7 @@ test('[dev-builder] filter install "latest", cached URL - canary', async t => {
   t.is(result, true);
 });
 
-test('[dev-builder] filter install not bundled version, cached same version', async t => {
+test('[dev-builder] filter install not bundled version, cached same version', t => {
   const buildersPkg = {
     dependencies: {
       'not-bundled-package': '0.0.1',
@@ -99,7 +100,7 @@ test('[dev-builder] filter install not bundled version, cached same version', as
   t.is(result, false);
 });
 
-test('[dev-builder] filter install not bundled version, cached different version', async t => {
+test('[dev-builder] filter install not bundled version, cached different version', t => {
   const buildersPkg = {
     dependencies: {
       'not-bundled-package': '0.0.9',
@@ -109,7 +110,7 @@ test('[dev-builder] filter install not bundled version, cached different version
   t.is(result, true);
 });
 
-test('[dev-builder] filter install not bundled stable, cached version', async t => {
+test('[dev-builder] filter install not bundled stable, cached version', t => {
   const buildersPkg = {
     dependencies: {
       'not-bundled-package': '0.0.1',
@@ -119,7 +120,7 @@ test('[dev-builder] filter install not bundled stable, cached version', async t 
   t.is(result, true);
 });
 
-test('[dev-builder] filter install not bundled tagged, cached tagged', async t => {
+test('[dev-builder] filter install not bundled tagged, cached tagged', t => {
   const buildersPkg = {
     dependencies: {
       'not-bundled-package': '16.9.0-alpha.0',
@@ -127,4 +128,90 @@ test('[dev-builder] filter install not bundled tagged, cached tagged', async t =
   };
   const result = filterPackage('not-bundled-package@alpha', '_', buildersPkg);
   t.is(result, true);
+});
+
+test('[dev-builder] isBundledBuilder() - stable', t => {
+  const nowCliPkg = {
+    dependencies: {
+      '@now/node': '1.5.2',
+    },
+  };
+
+  // "canary" tag
+  {
+    const parsed = npa('@now/node@canary');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
+
+  // "latest" tag
+  {
+    const parsed = npa('@now/node');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, true);
+  }
+
+  // specific matching version
+  {
+    const parsed = npa('@now/node@1.5.2');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, true);
+  }
+
+  // specific non-matching version
+  {
+    const parsed = npa('@now/node@1.5.1');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
+
+  // URL
+  {
+    const parsed = npa('https://example.com');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
+});
+
+test('[dev-builder] isBundledBuilder() - canary', t => {
+  const nowCliPkg = {
+    dependencies: {
+      '@now/node': '1.5.2-canary.3',
+    },
+  };
+
+  // "canary" tag
+  {
+    const parsed = npa('@now/node@canary');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, true);
+  }
+
+  // "latest" tag
+  {
+    const parsed = npa('@now/node');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
+
+  // specific matching version
+  {
+    const parsed = npa('@now/node@1.5.2-canary.3');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, true);
+  }
+
+  // specific non-matching version
+  {
+    const parsed = npa('@now/node@1.5.2-canary.2');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
+
+  // URL
+  {
+    const parsed = npa('https://example.com');
+    const result = isBundledBuilder(parsed, nowCliPkg);
+    t.is(result, false);
+  }
 });


### PR DESCRIPTION
Rather than creating a `builders.tar.gz` file with the core Runtimes and
bundling that tarball with Now CLI, simply have them be regular npm
dependencies so that they are installed into Now CLI's `node_modules`
directory.

When one of the core runtimes is specified for a build, the runtime will be
required as a regular module dependency of Now CLI, and the builders cache
will never touched.

Bundled runtimes are also no longer updated, making the runtime versions
pinned to the version of Now CLI.

Logic for the builders cache directory still remains, but will now only be
used when using a Community Runtime (or development tarball URL).