### PR TITLE
[now-static-build] Add tests for gem install of native deps

### DIFF
--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 GEM="rmagick"
 gem install $GEM -v 3.1.0

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+mkdir dist
 GEM="rmagick"
 gem install $GEM -v 3.1.0
-ruby -e "require '$GEM'"
-mkdir dist
-echo "$GEM:RANDOMNESS_PLACEHOLDER" > "dist/$GEM.html"
+ruby -e "require '$GEM'; print Magick::Version" > "dist/$GEM.html"

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+GEM="rmagick"
+gem install $GEM -v 3.1.0
+ruby -e "require '$GEM'"
+mkdir dist
+echo "$GEM:RANDOMNESS_PLACEHOLDER" > "dist/$GEM.html"

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-rmagick.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir dist
+mkdir -p dist
 GEM="rmagick"
 gem install $GEM -v 3.1.0
 ruby -e "require '$GEM'; print Magick::Version" > "dist/$GEM.html"

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+GEM="ruby-vips"
+gem install $GEM -v 2.0.17
+ruby -e "require '$GEM'"
+mkdir dist
+echo "$GEM:RANDOMNESS_PLACEHOLDER" > "dist/$GEM.html"

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+mkdir dist
 GEM="ruby-vips"
 gem install $GEM -v 2.0.17
-ruby -e "require '$GEM'"
-mkdir dist
-echo "$GEM:RANDOMNESS_PLACEHOLDER" > "dist/$GEM.html"
+ruby -e "require '$GEM'; print Vips::VERSION" > "dist/$GEM.html"
+

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 GEM="ruby-vips"
 gem install $GEM -v 2.0.17

--- a/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
+++ b/packages/now-static-build/test/fixtures/53-native-gems/gem-install-ruby-vips.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir dist
+mkdir -p dist
 GEM="ruby-vips"
 gem install $GEM -v 2.0.17
 ruby -e "require '$GEM'; print Vips::VERSION" > "dist/$GEM.html"
-

--- a/packages/now-static-build/test/fixtures/53-native-gems/now.json
+++ b/packages/now-static-build/test/fixtures/53-native-gems/now.json
@@ -5,7 +5,7 @@
     { "src": "gem-install-ruby-vips.sh", "use": "@now/static-build" }
   ],
   "probes": [
-    { "path": "/rmagic", "mustContain": "rmagic:RANDOMNESS_PLACEHOLDER" },
-    { "path": "/ruby-vips", "mustContain": "ruby-vips:RANDOMNESS_PLACEHOLDER" }
+    { "path": "/rmagic", "mustContain": "RMagick 3.1.0" },
+    { "path": "/ruby-vips", "mustContain": "2.0.17" }
   ]
 }

--- a/packages/now-static-build/test/fixtures/53-native-gems/now.json
+++ b/packages/now-static-build/test/fixtures/53-native-gems/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "gem-install-rmagic.sh", "use": "@now/static-build" },
+    { "src": "gem-install-ruby-vips.sh", "use": "@now/static-build" }
+  ],
+  "probes": [
+    { "path": "/rmagic", "mustContain": "rmagic:RANDOMNESS_PLACEHOLDER" },
+    { "path": "/ruby-vips", "mustContain": "ruby-vips:RANDOMNESS_PLACEHOLDER" }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/53-native-gems/now.json
+++ b/packages/now-static-build/test/fixtures/53-native-gems/now.json
@@ -1,11 +1,11 @@
 {
   "version": 2,
   "builds": [
-    { "src": "gem-install-rmagic.sh", "use": "@now/static-build" },
+    { "src": "gem-install-rmagick.sh", "use": "@now/static-build" },
     { "src": "gem-install-ruby-vips.sh", "use": "@now/static-build" }
   ],
   "probes": [
-    { "path": "/rmagic", "mustContain": "RMagick 3.1.0" },
-    { "path": "/ruby-vips", "mustContain": "2.0.17" }
+    { "path": "/rmagick.html", "mustContain": "RMagick 3.1.0" },
+    { "path": "/ruby-vips.html", "mustContain": "2.0.17" }
   ]
 }


### PR DESCRIPTION
These tests ensure we can install native dependencies with `gem install` such as:
- `rmagic`
- `ruby-vips`