### PR TITLE
[now-cli] Fix flicker from file upload progress bar

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -111,7 +111,7 @@ export default async function processDeployment({
 
   let deployingSpinner = output.spinner(
     isSettingUpProject
-      ? `Setting up project`
+      ? 'Setting up project'
       : `Deploying ${chalk.bold(`${org.slug}/${projectName}`)}`,
     0
   );
@@ -142,6 +142,18 @@ export default async function processDeployment({
         .map((sha: string) => event.payload.total.get(sha).data.length)
         .reduce((a: number, b: number) => a + b, 0);
 
+      if (queuedSpinner) {
+        queuedSpinner();
+      }
+      if (buildSpinner) {
+        buildSpinner();
+      }
+      if (deploySpinner) {
+        deploySpinner();
+      }
+      if (deployingSpinner) {
+        deployingSpinner();
+      }
       bar = new Progress(`${chalk.gray('>')} Upload [:bar] :percent :etas`, {
         width: 20,
         complete: '=',


### PR DESCRIPTION
This PR fixes a bug where deploying a new project would flicker between two states: the upload progress bar and "Setting up Project" spinner.