### PR TITLE
[now-cli] Prevent infinite loop for Runtime "module not found" in `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -351,7 +351,8 @@ export async function updateBuilders(
 export async function getBuilder(
   builderPkg: string,
   output: Output,
-  builderDir?: string
+  builderDir?: string,
+  isRetry = false
 ): Promise<BuilderWithPackage> {
   let builderWithPkg: BuilderWithPackage = localBuilders[builderPkg];
   if (!builderWithPkg) {
@@ -370,7 +371,7 @@ export async function getBuilder(
         package: Object.freeze(pkg),
       };
     } catch (err) {
-      if (err.code === 'MODULE_NOT_FOUND') {
+      if (err.code === 'MODULE_NOT_FOUND' && !isRetry) {
         output.debug(
           `Attempted to require ${builderPkg}, but it is not installed`
         );
@@ -378,7 +379,7 @@ export async function getBuilder(
         await installBuilders(pkgSet, output, builderDir);
 
         // Run `getBuilder()` again now that the builder has been installed
-        return getBuilder(builderPkg, output, builderDir);
+        return getBuilder(builderPkg, output, builderDir, true);
       }
       throw err;
     }


### PR DESCRIPTION
This should prevent tests from hanging, and instead make them fail quickly.