### PR TITLE
[now-cli] Add the `x-vercel-id` and `x-vercel-cache` response headers to `now dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1060,6 +1060,8 @@ export default class DevServer {
       'x-now-trace': 'dev1',
       'x-now-id': nowRequestId,
       'x-now-cache': 'MISS',
+      'x-vercel-id': nowRequestId,
+      'x-vercel-cache': 'MISS',
     };
     for (const [name, value] of Object.entries(allHeaders)) {
       res.setHeader(name, value);


### PR DESCRIPTION
Matches current production.