### PR TITLE
[now-cli] Use `npx` to invoke `ncc` in build script

### DIFF
--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -104,13 +104,12 @@ async function main() {
   // Do the initial `ncc` build
   console.log();
   const src = join(dirRoot, 'src');
-  const ncc = join(dirRoot, 'node_modules/@zeit/ncc/dist/ncc/cli.js');
-  const args = [ncc, 'build', '--source-map'];
+  const args = ['@zeit/ncc', 'build', '--source-map'];
   if (!isDev) {
     args.push('--minify');
   }
   args.push(src);
-  await execa(process.execPath, args, { stdio: 'inherit' });
+  await execa('npx', args, { stdio: 'inherit' });
 
   // `ncc` has some issues with `@zeit/fun`'s runtime files:
   //   - Executable bits on the `bootstrap` files appear to be lost:


### PR DESCRIPTION
The previous file path for ncc isn't always reliable during development,
depending on which directory `yarn` is invoked in inside the monorepo.

Using `npx` ensures the version specified in the now-cli `package.json`
is used even if it's installed at the root of the monorepo.