### PR TITLE
[api] Use 405 method not allowed

### DIFF
--- a/api/_lib/util/with-api-handler.ts
+++ b/api/_lib/util/with-api-handler.ts
@@ -17,9 +17,9 @@ export function withApiHandler(handler: Handler): Handler {
     }
 
     if (req.method !== 'GET') {
-      return res.status(404).json({
+      return res.status(405).json({
         error: {
-          code: 'not_found',
+          code: 'method_not_allowed',
           message: 'Only GET requests are supported for this endpoint.',
         },
       });


### PR DESCRIPTION
I was doing a diff and noticed this returns the wrong status code.

This PR changes the unknown method response to [405 Method Not Allowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405) status code.