### PR TITLE
[now-routing-utils] Add support for `permanent` in `redirects`

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -351,24 +351,3 @@ export interface BuilderFunctions {
     excludeFiles?: string;
   };
 }
-
-export interface NowRewrite {
-  source: string;
-  destination: string;
-}
-
-export interface NowRedirect {
-  source: string;
-  destination: string;
-  statusCode?: number;
-}
-
-export interface NowHeader {
-  source: string;
-  headers: NowHeaderKeyValue[];
-}
-
-export interface NowHeaderKeyValue {
-  key: string;
-  value: string;
-}

--- a/packages/now-routing-utils/src/schemas.ts
+++ b/packages/now-routing-utils/src/schemas.ts
@@ -92,6 +92,9 @@ export const redirectsSchema = {
         type: 'string',
         maxLength: 4096,
       },
+      permanent: {
+        type: 'boolean',
+      },
       statusCode: {
         type: 'integer',
         minimum: 100,

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -51,10 +51,18 @@ export function convertRedirects(
     const { src, segments } = sourceToRegex(r.source);
     try {
       const loc = replaceSegments(segments, r.destination, true);
+      let status: number;
+      if (typeof r.permanent === 'boolean') {
+        status = r.permanent ? 308 : 307;
+      } else if (r.statusCode) {
+        status = r.statusCode;
+      } else {
+        status = defaultStatus;
+      }
       const route: Route = {
         src,
         headers: { Location: loc },
-        status: r.statusCode || defaultStatus,
+        status,
       };
       return route;
     } catch (e) {

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -71,6 +71,7 @@ export interface NowRewrite {
 export interface NowRedirect {
   source: string;
   destination: string;
+  permanent?: boolean;
   statusCode?: number;
 }
 

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -503,31 +503,6 @@ describe('normalizeRoutes', () => {
     );
   });
 
-  test('fails if redirects defines both permanent and statusCode', () => {
-    assertError(
-      [
-        {
-          source: '/foo',
-          destination: '/bar',
-          permanent: true,
-          statusCode: 301,
-        },
-      ],
-      [
-        {
-          dataPath: '[0].statusCode',
-          keyword: 'type',
-          message: 'should be integer',
-          params: {
-            type: 'integer',
-          },
-          schemaPath: '#/items/properties/statusCode/type',
-        },
-      ],
-      redirectsSchema
-    );
-  });
-
   test('fails if routes after `handle: hit` use `dest`', () => {
     const input = [
       {
@@ -663,6 +638,22 @@ describe('getTransformedRoutes', () => {
   test('should error when redirects is invalid pattern', () => {
     const nowConfig = {
       redirects: [{ source: '/:?', destination: '/file.html' }],
+    };
+    const actual = getTransformedRoutes({ nowConfig });
+    assert.notEqual(actual.error, null);
+    assert.equal(actual.error.code, 'invalid_redirects');
+  });
+
+  test('should error when redirects defines both permanent and statusCode', () => {
+    const nowConfig = {
+      redirects: [
+        {
+          source: '^/both$',
+          destination: '/api/both',
+          permanent: false,
+          statusCode: 302,
+        },
+      ],
     };
     const actual = getTransformedRoutes({ nowConfig });
     assert.notEqual(actual.error, null);

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -455,6 +455,79 @@ describe('normalizeRoutes', () => {
     );
   });
 
+  test('fails if redirects permanent is not a boolean', () => {
+    assertError(
+      [
+        {
+          source: '/foo',
+          destination: '/bar',
+          permanent: 301,
+        },
+      ],
+      [
+        {
+          dataPath: '[0].permanent',
+          keyword: 'type',
+          message: 'should be boolean',
+          params: {
+            type: 'boolean',
+          },
+          schemaPath: '#/items/properties/permanent/type',
+        },
+      ],
+      redirectsSchema
+    );
+  });
+
+  test('fails if redirects statusCode is not a number', () => {
+    assertError(
+      [
+        {
+          source: '/foo',
+          destination: '/bar',
+          statusCode: '301',
+        },
+      ],
+      [
+        {
+          dataPath: '[0].statusCode',
+          keyword: 'type',
+          message: 'should be integer',
+          params: {
+            type: 'integer',
+          },
+          schemaPath: '#/items/properties/statusCode/type',
+        },
+      ],
+      redirectsSchema
+    );
+  });
+
+  test('fails if redirects defines both permanent and statusCode', () => {
+    assertError(
+      [
+        {
+          source: '/foo',
+          destination: '/bar',
+          permanent: true,
+          statusCode: 301,
+        },
+      ],
+      [
+        {
+          dataPath: '[0].statusCode',
+          keyword: 'type',
+          message: 'should be integer',
+          params: {
+            type: 'integer',
+          },
+          schemaPath: '#/items/properties/statusCode/type',
+        },
+      ],
+      redirectsSchema
+    );
+  });
+
   test('fails if routes after `handle: hit` use `dest`', () => {
     const input = [
       {
@@ -687,6 +760,7 @@ describe('getTransformedRoutes', () => {
       redirects: [
         { source: '/version1', destination: '/api1.py' },
         { source: '/version2', destination: '/api2.py', statusCode: 302 },
+        { source: '/version3', destination: '/api3.py', permanent: true },
       ],
       headers: [
         {


### PR DESCRIPTION
This adds `permanent` for `redirects` defined in Next.js RFC https://github.com/zeit/next.js/issues/9081

```json
{
  "redirects": [
    { "source": "/foo", "destination": "/api/foo", "permanent": true }
  ]
}
```
