### PR TITLE
[now-cli] Allow to accept equal sign(=) as a value for meta

### DIFF
--- a/packages/now-cli/src/util/parse-meta.js
+++ b/packages/now-cli/src/util/parse-meta.js
@@ -10,8 +10,8 @@ export default function parseMeta(meta) {
   const parsed = {};
 
   meta.forEach(item => {
-    const [key, value] = item.split('=');
-    parsed[key] = value || '';
+    const [key, ...rest] = item.split('=');
+    parsed[key] = rest.join('=');
   });
 
   return parsed;

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -247,8 +247,7 @@ test('deploy using only now.json with `redirects` defined', async t => {
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
 
-  const i = stdout.lastIndexOf('https://');
-  const url = stdout.slice(i);
+  const url = stdout;
   const res = await fetch(`${url}/foo/bar`, { redirect: 'manual' });
   const location = res.headers.get('location');
   t.is(location, 'https://example.com/foo/bar');

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -519,24 +519,25 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowEnvLsIsEmpty();
 });
 
-test('deploy with metadata with = as the value', async t => {
+test('deploy with metadata containing "=" in the value', async t => {
   const target = fixture('redirects-v2');
 
   const { exitCode, stderr, stdout } = await execa(
     binaryPath,
     [target, ...defaultArgs, '--confirm', '--meta', 'someKey=='],
-    {
-      reject: false,
-    }
+    { reject: false }
   );
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
 
-  const i = stdout.lastIndexOf('https://');
-  const url = stdout.slice(i);
-  const res = await fetch(`${url}/foo/bar`, { redirect: 'manual' });
-  const location = res.headers.get('location');
-  t.is(location, 'https://example.com/foo/bar');
+  const url = stdout.split('https://'.lenght);
+
+  const res = await fetch(
+    `https://api.vercel.com/v12/now/deployments/get?url=${url}`,
+    { headers: { authorization: `Bearer ${token}` } }
+  );
+  const deployment = await res.json();
+  t.is(deployment.meta.someKey, '=');
 });
 
 test('print the deploy help message', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -530,7 +530,7 @@ test('deploy with metadata containing "=" in the value', async t => {
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
 
-  const url = stdout.split('https://'.lenght);
+  const url = stdout.split('https://'.length);
 
   const res = await fetch(
     `https://api.vercel.com/v12/now/deployments/get?url=${url}`,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -530,7 +530,7 @@ test('deploy with metadata containing "=" in the value', async t => {
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
 
-  const url = stdout.split('https://'.length);
+  const url = stdout.substring('https://'.length);
 
   const res = await fetch(
     `https://api.vercel.com/v12/now/deployments/get?url=${url}`,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -519,6 +519,26 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowEnvLsIsEmpty();
 });
 
+test('deploy with metadata with = as the value', async t => {
+  const target = fixture('redirects-v2');
+
+  const { exitCode, stderr, stdout } = await execa(
+    binaryPath,
+    [target, ...defaultArgs, '--confirm', '--meta', 'someKey=='],
+    {
+      reject: false,
+    }
+  );
+
+  t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+
+  const i = stdout.lastIndexOf('https://');
+  const url = stdout.slice(i);
+  const res = await fetch(`${url}/foo/bar`, { redirect: 'manual' });
+  const location = res.headers.get('location');
+  t.is(location, 'https://example.com/foo/bar');
+});
+
 test('print the deploy help message', async t => {
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -518,7 +518,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowEnvLsIsEmpty();
 });
 
-test('deploy with metadata containing "=" in the value', async t => {
+test.only('deploy with metadata containing "=" in the value', async t => {
   const target = fixture('redirects-v2');
 
   const { exitCode, stderr, stdout } = await execa(
@@ -529,10 +529,9 @@ test('deploy with metadata containing "=" in the value', async t => {
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
 
-  const url = stdout.substring('https://'.length);
-
+  const { host } = new URL(stdout);
   const res = await fetch(
-    `https://api.vercel.com/v12/now/deployments/get?url=${url}`,
+    `https://api.vercel.com/v12/now/deployments/get?url=${host}`,
     { headers: { authorization: `Bearer ${token}` } }
   );
   const deployment = await res.json();


### PR DESCRIPTION
Currently if the value is `=` it will throw an error from the API.