### PR TITLE
[now-next] Provide a better error when failing to load routes-manifest

### DIFF
--- a/errors/now-next-routes-manifest.md
+++ b/errors/now-next-routes-manifest.md
@@ -1,0 +1,11 @@
+# Routes Manifest Could Not Be Found
+
+#### Why This Error Occurred
+
+This could be caused by a failure during the build or an incorrect output directory being configured for your Next.js project.
+
+#### Possible Ways to Fix It
+
+Check for any build errors in the logs and ensure that the output directory setting is either not changed or is pointing to the location of the `.next` output folder (`distDir`).
+
+If you are running `next export` you should **not** need to customize the output directory to `out` since the builder automatically detects `next export` being run and uses the output from it.

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -340,7 +340,7 @@ export async function getRoutesManifest(
 
   if (shouldHaveManifest && !hasRoutesManifest) {
     throw new Error(
-      `A routes-manifest.json couldn't be found. This could be due to a failure during the build`
+      `A routes-manifest.json couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases. See more info here: https://err.sh/zeit/now/now-next-routes-manifest`
     );
   }
 

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -340,7 +340,7 @@ export async function getRoutesManifest(
 
   if (shouldHaveManifest && !hasRoutesManifest) {
     throw new Error(
-      `A routes-manifest.json couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases. See more info here: https://err.sh/zeit/now/now-next-routes-manifest`
+      `A "routes-manifest.json" couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases. More info: https://err.sh/zeit/now/now-next-routes-manifest`
     );
   }
 


### PR DESCRIPTION
This updates the error message shown when we fail to load the `routes-manifest` which appears to be happening most often when an incorrect output directory is configured for a Next.js application