### PR TITLE
[now-next] Update error throwing to use NowBuildError

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -19,6 +19,7 @@ import {
   runPackageJsonScript,
   execCommand,
   getNodeBinPath,
+  NowBuildError,
 } from '@now/build-utils';
 import { Route, Handler } from '@now/routing-utils';
 import {
@@ -212,9 +213,11 @@ export const build = async ({
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
   if (!nextVersion) {
-    throw new Error(
-      'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"'
-    );
+    throw new NowBuildError({
+      code: '',
+      message:
+        'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
+    });
   }
 
   if (meta.isDev) {
@@ -428,14 +431,18 @@ export const build = async ({
           nextBasePath = routesManifest.basePath;
 
           if (!nextBasePath.startsWith('/')) {
-            throw new Error(
-              'basePath must start with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.'
-            );
+            throw new NowBuildError({
+              code: '',
+              message:
+                'basePath must start with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
+            });
           }
           if (nextBasePath.endsWith('/')) {
-            throw new Error(
-              'basePath must not end with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.'
-            );
+            throw new NowBuildError({
+              code: '',
+              message:
+                'basePath must not end with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
+            });
           }
 
           nextBasePathRoute.push({
@@ -448,10 +455,12 @@ export const build = async ({
       }
       default: {
         // update MIN_ROUTES_MANIFEST_VERSION in ./utils.ts
-        throw new Error(
-          'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
-            'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.'
-        );
+        throw new NowBuildError({
+          code: '',
+          message:
+            'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
+            'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
+        });
       }
     }
   }
@@ -464,15 +473,18 @@ export const build = async ({
 
     const resultingExport = await getExportStatus(entryPath);
     if (!resultingExport) {
-      throw new Error(
-        'Exporting Next.js app failed. Please check your build logs and contact us if this continues.'
-      );
+      throw new NowBuildError({
+        code: '',
+        message:
+          'Exporting Next.js app failed. Please check your build logs and contact us if this continues.',
+      });
     }
 
     if (resultingExport.success !== true) {
-      throw new Error(
-        'Export of Next.js app failed. Please check your build logs.'
-      );
+      throw new NowBuildError({
+        code: '',
+        message: 'Export of Next.js app failed. Please check your build logs.',
+      });
     }
 
     const outDirectory = resultingExport.outDirectory;
@@ -615,7 +627,7 @@ export const build = async ({
       console.error(
         'BUILD_ID not found in ".next". The "package.json" "build" script did not run "next build"'
       );
-      throw new Error('Missing BUILD_ID');
+      throw new NowBuildError({ code: '', message: 'Missing BUILD_ID' });
     }
     const dotNextRootFiles = await glob(`${outputDirectory}/*`, entryPath);
     const dotNextServerRootFiles = await glob(
@@ -759,9 +771,11 @@ export const build = async ({
         console.info();
       }
 
-      throw new Error(
-        'No serverless pages were built. https://err.sh/zeit/now/now-next-no-serverless-pages-built'
-      );
+      throw new NowBuildError({
+        code: '',
+        message:
+          'No serverless pages were built. https://err.sh/zeit/now/now-next-no-serverless-pages-built',
+      });
     }
 
     // Assume tracing to be safe, bail if we know we don't need it.
@@ -968,9 +982,10 @@ export const build = async ({
       { isBlocking, isFallback }: { isBlocking: boolean; isFallback: boolean }
     ) => {
       if (isBlocking && isFallback) {
-        throw new Error(
-          'invariant: isBlocking and isFallback cannot both be true'
-        );
+        throw new NowBuildError({
+          code: '',
+          message: 'invariant: isBlocking and isFallback cannot both be true',
+        });
       }
 
       // Get the route file as it'd be mounted in the builder output
@@ -1010,7 +1025,10 @@ export const build = async ({
         // @ts-ignore
         if (initialRevalidate === false) {
           // Lazy routes cannot be "snapshotted" in time.
-          throw new Error('invariant isLazy: initialRevalidate !== false');
+          throw new NowBuildError({
+            code: '',
+            message: 'invariant isLazy: initialRevalidate !== false',
+          });
         }
         srcRoute = null;
         dataRoute = pr.dataRoute;
@@ -1031,12 +1049,18 @@ export const build = async ({
 
       const lambda = lambdas[outputSrcPathPage];
       if (lambda == null) {
-        throw new Error(`Unable to find lambda for route: ${routeFileNoExt}`);
+        throw new NowBuildError({
+          code: '',
+          message: `Unable to find lambda for route: ${routeFileNoExt}`,
+        });
       }
 
       if (initialRevalidate === false) {
         if (htmlFsRef == null || jsonFsRef == null) {
-          throw new Error('invariant: htmlFsRef != null && jsonFsRef != null');
+          throw new NowBuildError({
+            code: '',
+            message: 'invariant: htmlFsRef != null && jsonFsRef != null',
+          });
         }
       }
 
@@ -1150,9 +1174,10 @@ export const build = async ({
       routeKey === '/' ? '/index' : routeKey
     );
     if (typeof lambdas[routeFileNoExt] === undefined) {
-      throw new Error(
-        `invariant: unknown lambda ${routeKey} (lookup: ${routeFileNoExt}) | please report this immediately`
-      );
+      throw new NowBuildError({
+        code: '',
+        message: `invariant: unknown lambda ${routeKey} (lookup: ${routeFileNoExt}) | please report this immediately`,
+      });
     }
     delete lambdas[routeFileNoExt];
   });
@@ -1287,7 +1312,11 @@ export const prepareCache = async ({
 
   const pkg = await readPackageJson(entryPath);
   const nextVersion = getNextVersion(pkg);
-  if (!nextVersion) throw new Error('Could not parse Next.js version');
+  if (!nextVersion)
+    throw new NowBuildError({
+      code: '',
+      message: 'Could not parse Next.js version',
+    });
   const isLegacy = isLegacyNext(nextVersion);
 
   if (isLegacy) {

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -214,7 +214,7 @@ export const build = async ({
 
   if (!nextVersion) {
     throw new NowBuildError({
-      code: '',
+      code: 'NOW_NEXT_NO_VERSION',
       message:
         'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
     });
@@ -432,14 +432,14 @@ export const build = async ({
 
           if (!nextBasePath.startsWith('/')) {
             throw new NowBuildError({
-              code: '',
+              code: 'NOW_NEXT_BASEPATH_STARTING_SLASH',
               message:
                 'basePath must start with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
             });
           }
           if (nextBasePath.endsWith('/')) {
             throw new NowBuildError({
-              code: '',
+              code: 'NOW_NEXT_BASEPATH_TRAILING_SLASH',
               message:
                 'basePath must not end with `/`. Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
             });
@@ -456,7 +456,7 @@ export const build = async ({
       default: {
         // update MIN_ROUTES_MANIFEST_VERSION in ./utils.ts
         throw new NowBuildError({
-          code: '',
+          code: 'NOW_NEXT_VERSION_OUTDATED',
           message:
             'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
             'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
@@ -474,7 +474,7 @@ export const build = async ({
     const resultingExport = await getExportStatus(entryPath);
     if (!resultingExport) {
       throw new NowBuildError({
-        code: '',
+        code: 'NOW_NEXT_EXPORT_FAILED',
         message:
           'Exporting Next.js app failed. Please check your build logs and contact us if this continues.',
       });
@@ -482,7 +482,7 @@ export const build = async ({
 
     if (resultingExport.success !== true) {
       throw new NowBuildError({
-        code: '',
+        code: 'NOW_NEXT_EXPORT_FAILED',
         message: 'Export of Next.js app failed. Please check your build logs.',
       });
     }
@@ -627,7 +627,7 @@ export const build = async ({
       console.error(
         'BUILD_ID not found in ".next". The "package.json" "build" script did not run "next build"'
       );
-      throw new NowBuildError({ code: '', message: 'Missing BUILD_ID' });
+      throw new NowBuildError({ code: 'NOW_NEXT_NO_BUILD_ID', message: 'Missing BUILD_ID' });
     }
     const dotNextRootFiles = await glob(`${outputDirectory}/*`, entryPath);
     const dotNextServerRootFiles = await glob(
@@ -772,7 +772,7 @@ export const build = async ({
       }
 
       throw new NowBuildError({
-        code: '',
+        code: 'NOW_NEXT_NO_SERVERLESS_PAGES',
         message: 'No serverless pages were built',
         link: 'https://err.sh/zeit/now/now-next-no-serverless-pages-built',
       });
@@ -983,7 +983,7 @@ export const build = async ({
     ) => {
       if (isBlocking && isFallback) {
         throw new NowBuildError({
-          code: '',
+          code: 'NOW_NEXT_ISBLOCKING_ISFALLBACK',
           message: 'invariant: isBlocking and isFallback cannot both be true',
         });
       }
@@ -1026,7 +1026,7 @@ export const build = async ({
         if (initialRevalidate === false) {
           // Lazy routes cannot be "snapshotted" in time.
           throw new NowBuildError({
-            code: '',
+            code: 'NOW_NEXT_ISLAZY_INITIALREVALIDATE',
             message: 'invariant isLazy: initialRevalidate !== false',
           });
         }
@@ -1050,7 +1050,7 @@ export const build = async ({
       const lambda = lambdas[outputSrcPathPage];
       if (lambda == null) {
         throw new NowBuildError({
-          code: '',
+          code: 'NOW_NEXT_MISSING_LAMBDA',
           message: `Unable to find lambda for route: ${routeFileNoExt}`,
         });
       }
@@ -1058,7 +1058,7 @@ export const build = async ({
       if (initialRevalidate === false) {
         if (htmlFsRef == null || jsonFsRef == null) {
           throw new NowBuildError({
-            code: '',
+            code: 'NOW_NEXT_HTMLFSREF_JSONFSREF',
             message: 'invariant: htmlFsRef != null && jsonFsRef != null',
           });
         }
@@ -1175,7 +1175,7 @@ export const build = async ({
     );
     if (typeof lambdas[routeFileNoExt] === undefined) {
       throw new NowBuildError({
-        code: '',
+        code: 'NOW_NEXT__UNKNOWN_ROUTE_KEY',
         message: `invariant: unknown lambda ${routeKey} (lookup: ${routeFileNoExt}) | please report this immediately`,
       });
     }
@@ -1314,7 +1314,7 @@ export const prepareCache = async ({
   const nextVersion = getNextVersion(pkg);
   if (!nextVersion)
     throw new NowBuildError({
-      code: '',
+      code: 'NOW_NEXT_VERSION_PARSE_FAILED',
       message: 'Could not parse Next.js version',
     });
   const isLegacy = isLegacyNext(nextVersion);

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -773,8 +773,8 @@ export const build = async ({
 
       throw new NowBuildError({
         code: '',
-        message:
-          'No serverless pages were built. https://err.sh/zeit/now/now-next-no-serverless-pages-built',
+        message: 'No serverless pages were built',
+        link: 'https://err.sh/zeit/now/now-next-no-serverless-pages-built',
       });
     }
 

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -11,6 +11,7 @@ import {
   FileFsRef,
   streamToBuffer,
   Lambda,
+  NowBuildError,
   isSymbolicLink,
 } from '@now/build-utils';
 import { Route, Source, NowHeader, NowRewrite } from '@now/routing-utils';
@@ -38,9 +39,11 @@ function validateEntrypoint(entrypoint: string) {
     !/package\.json$/.exec(entrypoint) &&
     !/next\.config\.js$/.exec(entrypoint)
   ) {
-    throw new Error(
-      'Specified "src" for "@now/next" has to be "package.json" or "next.config.js"'
-    );
+    throw new NowBuildError({
+      message:
+        'Specified "src" for "@now/next" has to be "package.json" or "next.config.js"',
+      code: '',
+    });
   }
 }
 
@@ -339,9 +342,11 @@ export async function getRoutesManifest(
     .catch(() => false);
 
   if (shouldHaveManifest && !hasRoutesManifest) {
-    throw new Error(
-      `A "routes-manifest.json" couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases. More info: https://err.sh/zeit/now/now-next-routes-manifest`
-    );
+    throw new NowBuildError({
+      message: `A "routes-manifest.json" couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases`,
+      link: 'https://err.sh/zeit/now/now-next-routes-manifest',
+      code: '',
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -380,10 +385,12 @@ export async function getDynamicRoutes(
       }
       default: {
         // update MIN_ROUTES_MANIFEST_VERSION
-        throw new Error(
-          'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
-            'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.'
-        );
+        throw new NowBuildError({
+          message:
+            'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
+            'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
+          code: '',
+        });
       }
     }
   }
@@ -420,9 +427,11 @@ export async function getDynamicRoutes(
   }
 
   if (!getRouteRegex || !getSortedRoutes) {
-    throw new Error(
-      'Found usage of dynamic routes but not on a new enough version of Next.js.'
-    );
+    throw new NowBuildError({
+      message:
+        'Found usage of dynamic routes but not on a new enough version of Next.js.',
+      code: '',
+    });
   }
 
   const pageMatchers = getSortedRoutes(dynamicPages).map(pageName => ({

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -42,7 +42,7 @@ function validateEntrypoint(entrypoint: string) {
     throw new NowBuildError({
       message:
         'Specified "src" for "@now/next" has to be "package.json" or "next.config.js"',
-      code: '',
+      code: 'NOW_NEXT_INCORRECT_SRC',
     });
   }
 }
@@ -345,7 +345,7 @@ export async function getRoutesManifest(
     throw new NowBuildError({
       message: `A "routes-manifest.json" couldn't be found. Is the correct output directory configured? This setting does not need to be changed in most cases`,
       link: 'https://err.sh/zeit/now/now-next-routes-manifest',
-      code: '',
+      code: 'NOW_NEXT_NO_ROUTES_MANIFEST',
     });
   }
 
@@ -389,7 +389,7 @@ export async function getDynamicRoutes(
           message:
             'This version of `@now/next` does not support the version of Next.js you are trying to deploy.\n' +
             'Please upgrade your `@now/next` builder and try again. Contact support if this continues to happen.',
-          code: '',
+          code: 'NOW_NEXT_VERSION_UPGRADE',
         });
       }
     }
@@ -430,7 +430,7 @@ export async function getDynamicRoutes(
     throw new NowBuildError({
       message:
         'Found usage of dynamic routes but not on a new enough version of Next.js.',
-      code: '',
+      code: 'NOW_NEXT_DYNAMIC_ROUTES_OUTDATED',
     });
   }
 


### PR DESCRIPTION
Per https://github.com/zeit/now/pull/4161#discussion_r416042826 this updates to use `NowBuildError` for our errors instead of the standard `Error` instance