### PR TITLE
[now-cli] Don't print "Error starting dev server" message by default

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1478,7 +1478,7 @@ export default class DevServer {
         // `starDevServer()` threw an error. Most likely this means the dev
         // server process exited before sending the port information message
         // (missing dependency at runtime, for example).
-        console.error(`Error starting "${builderPkg.name}" dev server:`, err);
+        debug(`Error starting "${builderPkg.name}" dev server: ${err}`);
         await this.sendError(
           req,
           res,


### PR DESCRIPTION
It's not useful information and distracts from whatever the actual error
message was from the dev server, which is what the user is actually
interested in.