### PR TITLE
[now-cli] Use `yarn` for `now dev` integration tests

### DIFF
--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -116,10 +116,9 @@ async function exec(directory, args = []) {
 
 async function runNpmInstall(fixturePath) {
   if (await fs.exists(path.join(fixturePath, 'package.json'))) {
-    await execa('npm', ['install'], {
+    await execa('yarn', ['install'], {
       cwd: fixturePath,
       shell: true,
-      stdio: 'inherit',
     });
   }
 }


### PR DESCRIPTION
This was switched to `npm` for debugging purposes in #4124, but at this
point we can switch it back to `yarn` so the tests don't take as long.