### PR TITLE
[tests] Fix remaining lint errors

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -26,8 +26,9 @@ jobs:
       - run: yarn install
       - run: yarn run build
       - run: yarn run lint
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 12 # only run lint once
       - run: yarn run test-unit --clean false
       - run: yarn workspace now run coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 12 # only run once
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 12 # only run coverage once
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v1
       - run: yarn install
       - run: yarn run build
-      - run: yarn run test-lint
+      - run: yarn run lint
       - run: yarn run test-unit --clean false
       - run: yarn workspace now run coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node == 12 # only run once

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "publish-from-github": "./utils/publish.sh",
     "changelog": "node utils/changelog.js",
     "build": "node utils/run.js build all",
-    "test-lint": "node utils/run.js test-lint",
     "test-unit": "node utils/run.js test-unit",
     "test-integration-cli": "node utils/run.js test-integration-cli",
     "test-integration-once": "node utils/run.js test-integration-once",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
       "@typescript-eslint/camelcase": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-explicit-any": 0,
+      "@typescript-eslint/no-non-null-assertion": 0,
       "@typescript-eslint/no-unused-vars": 2,
       "@typescript-eslint/no-use-before-define": 0
     },

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { Source, Route, Handler } from '@now/routing-utils';
 import { detectBuilders } from '../src';
 import {

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { Source, Route, Handler } from '@now/routing-utils';
 import { detectBuilders } from '../src';
 import {

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -19,8 +19,7 @@
     "prepublishOnly": "yarn build",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "build": "ts-node ./scripts/build.ts",
-    "build-dev": "ts-node ./scripts/build.ts --dev",
-    "test-lint": "eslint . --ext .ts,.js --ignore-path ../../.eslintignore"
+    "build-dev": "ts-node ./scripts/build.ts --dev"
   },
   "nyc": {
     "include": [

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -15,8 +15,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test-integration-once": "jest --verbose --runInBand",
-    "test-lint": "eslint . --ext .js,.ts --ignore-path ../../.eslintignore"
+    "test-integration-once": "jest --verbose --runInBand"
   },
   "devDependencies": {
     "@types/async-retry": "1.4.1",


### PR DESCRIPTION
As a follow up to #4178, this fixes the final lint errors so we can run in CI.

Since lint is very quick, about 8 seconds, we can run it on the entire repo instead of only changed files.

I also disabled a couple rules that were leading to 500 warnings we would likely never change.