### PR TITLE
[tests] Remove `test.only()` so all tests will execute

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -284,6 +284,9 @@ CMD ["node", "index.js"]`,
         files: ['.gitignore', 'folder', 'index.js', 'test.html'],
       }),
     },
+    'static-v2-meta': {
+      'index.html': 'Static V2',
+    },
     'redirects-v2': {
       'now.json': JSON.stringify({
         version: 2,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -525,12 +525,11 @@ test('deploy with metadata containing "=" in the value', async t => {
 
   const { exitCode, stderr, stdout } = await execa(
     binaryPath,
-    [target, ...defaultArgs, '--confirm', '--meta', 'someKey=='],
+    [target, ...defaultArgs, '--confirm', '--force', '--meta', 'someKey=='],
     { reject: false }
   );
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
-  console.log(stdout);
 
   const { host } = new URL(stdout);
   const res = await fetch(
@@ -538,7 +537,6 @@ test('deploy with metadata containing "=" in the value', async t => {
     { headers: { authorization: `Bearer ${token}` } }
   );
   const deployment = await res.json();
-  console.log(deployment);
   t.is(deployment.meta.someKey, '=');
 });
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -520,7 +520,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowEnvLsIsEmpty();
 });
 
-test.only('deploy with metadata containing "=" in the value', async t => {
+test('deploy with metadata containing "=" in the value', async t => {
   const target = fixture('redirects-v2');
 
   const { exitCode, stderr, stdout } = await execa(

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -530,6 +530,7 @@ test('deploy with metadata containing "=" in the value', async t => {
   );
 
   t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+  console.log(stdout);
 
   const { host } = new URL(stdout);
   const res = await fetch(
@@ -537,6 +538,7 @@ test('deploy with metadata containing "=" in the value', async t => {
     { headers: { authorization: `Bearer ${token}` } }
   );
   const deployment = await res.json();
+  console.log(deployment);
   t.is(deployment.meta.someKey, '=');
 });
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -521,11 +521,11 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
 });
 
 test('deploy with metadata containing "=" in the value', async t => {
-  const target = fixture('redirects-v2');
+  const target = fixture('static-v2-meta');
 
   const { exitCode, stderr, stdout } = await execa(
     binaryPath,
-    [target, ...defaultArgs, '--confirm', '--force', '--meta', 'someKey=='],
+    [target, ...defaultArgs, '--confirm', '--meta', 'someKey=='],
     { reject: false }
   );
 


### PR DESCRIPTION
Fix a regression from #4160, specifically bab5794641acbf2ae3f419faf0b1d3565fbf1de3 that was preventing the CLI tests from running.