### PR TITLE
[now-cli] Assert 200 status code in dev server unit tests

### DIFF
--- a/packages/now-cli/test/dev-server.unit.js
+++ b/packages/now-cli/test/dev-server.unit.js
@@ -257,6 +257,7 @@ test(
   testFixture('now-dev-static-routes', async (t, server) => {
     {
       const res = await fetch(`${server.address}/`);
+      t.is(res.status, 200);
       const body = await res.text();
       t.is(body, '<body>Hello!</body>\n');
     }
@@ -268,6 +269,7 @@ test(
   testFixture('now-dev-static-build-routing', async (t, server) => {
     {
       const res = await fetch(`${server.address}/api/date`);
+      t.is(res.status, 200);
       const body = await res.text();
       t.is(body.startsWith('The current date:'), true);
     }


### PR DESCRIPTION
Test for the proper status code as a sanity check for failing tests like this one: https://github.com/zeit/now/runs/627256008