### PR TITLE
Switch to Vercel in the command help for now domains

### DIFF
--- a/packages/now-cli/src/commands/alias/index.js
+++ b/packages/now-cli/src/commands/alias/index.js
@@ -67,11 +67,11 @@ const help = () => {
   )} in the URLs are unneeded and ignored.
 
   ${chalk.gray('–')} Add and modify path based aliases for ${chalk.underline(
-    'zeit.ninja'
+    'vercel.com'
   )}
 
       ${chalk.cyan(
-        `$ now alias ${chalk.underline('zeit.ninja')} -r ${chalk.underline(
+        `$ now alias ${chalk.underline('vercel.com')} -r ${chalk.underline(
           'rules.json'
         )}`
       )}

--- a/packages/now-cli/src/commands/alias/index.js
+++ b/packages/now-cli/src/commands/alias/index.js
@@ -67,11 +67,11 @@ const help = () => {
   )} in the URLs are unneeded and ignored.
 
   ${chalk.gray('–')} Add and modify path based aliases for ${chalk.underline(
-    'vercel.com'
+    'example.com'
   )}
 
       ${chalk.cyan(
-        `$ now alias ${chalk.underline('vercel.com')} -r ${chalk.underline(
+        `$ now alias ${chalk.underline('example.com')} -r ${chalk.underline(
           'rules.json'
         )}`
       )}

--- a/packages/now-cli/src/commands/domains/index.ts
+++ b/packages/now-cli/src/commands/domains/index.ts
@@ -28,7 +28,7 @@ const help = () => {
     rm           [name]                 Remove a domain
     buy          [name]                 Buy a domain that you don't yet own
     move         [name] [destination]   Move a domain to another user or team.
-    transfer-in  [name]                 Transfer in a domain to Zeit
+    transfer-in  [name]                 Transfer in a domain to Vercel
     verify       [name]                 Run a verification for a domain
 
   ${chalk.dim('Options:')}
@@ -54,7 +54,7 @@ const help = () => {
       ${chalk.cyan(`$ now domains add ${chalk.underline('domain-name.com')}`)}
 
       Make sure the domain's DNS nameservers are at least 2 of the
-      ones listed on ${chalk.underline('https://zeit.world')}.
+      ones listed on ${chalk.underline('https://vercel.com/edge-network')}.
 
       ${chalk.yellow('NOTE:')} Running ${chalk.dim(
     '`now alias`'


### PR DESCRIPTION
Noticed that we still say `Zeit` while using the now cli.

The inspect command still points to zeit.co when I tested it some hours ago but that seems to be fixed already :smile: 