### PR TITLE
[now-node] Make "without helpers" config option work as expected in `startDevServer()`

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -201,6 +201,12 @@ export interface StartDevServerOptions {
    * build process. This directory will be populated with the restored cache.
    */
   workPath: string;
+
+  /**
+   * An arbitrary object passed by the user in the build definition defined
+   * in `now.json`.
+   */
+  config: Config;
 }
 
 export interface StartDevServerSuccess {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1473,6 +1473,7 @@ export default class DevServer {
         devServerResult = await builder.startDevServer({
           entrypoint: match.entrypoint,
           workPath: this.cwd,
+          config: match.config || {},
         });
       } catch (err) {
         // `starDevServer()` threw an error. Most likely this means the dev

--- a/packages/now-node/src/dev-server.ts
+++ b/packages/now-node/src/dev-server.ts
@@ -39,27 +39,23 @@ function listen(
 
 async function main() {
   const entrypoint = process.env.NOW_DEV_ENTRYPOINT;
+  delete process.env.NOW_DEV_ENTRYPOINT;
+
   if (!entrypoint) {
     throw new Error('`NOW_DEV_ENTRYPOINT` must be defined');
   }
 
-  //const shouldAddHelpers = true;
+  const config = JSON.parse(process.env.NOW_DEV_CONFIG || '{}');
+  delete process.env.NOW_DEV_CONFIG;
+
+  const shouldAddHelpers = config.helpers !== false;
 
   const entrypointPath = path.join(process.cwd(), entrypoint);
   const handler = await import(entrypointPath);
 
-  /*
-  const server = http.createServer((req, res) => {
-    Promise.resolve(true).then(() => handler.default(req, res)).catch(err => {
-      console.error('Caught error from HTTP handler:', err);
-      if (!res.headersSent) {
-        res.statusCode = 500;
-        res.end('Internal server error\n');
-      }
-    });
-  });
-  */
-  const server = createServerWithHelpers(handler.default);
+  const server = shouldAddHelpers
+    ? createServerWithHelpers(handler.default)
+    : http.createServer(handler.default);
 
   await listen(server, 0, '127.0.0.1');
 

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -419,6 +419,7 @@ export async function prepareCache({
 export async function startDevServer({
   entrypoint,
   workPath,
+  config,
 }: StartDevServerOptions): Promise<StartDevServerResult> {
   const devServerPath = join(__dirname, 'dev-server.js');
   const child = fork(devServerPath, [], {
@@ -426,6 +427,7 @@ export async function startDevServer({
     env: {
       ...process.env,
       NOW_DEV_ENTRYPOINT: entrypoint,
+      NOW_DEV_CONFIG: JSON.stringify(config),
     },
   });
 
@@ -443,7 +445,7 @@ export async function startDevServer({
     if (ext === '.ts' || ext === '.tsx') {
       // Invoke `tsc --noEmit` asynchronously in the background, so
       // that the HTTP request is not blocked by the type checking.
-      doTypeCheck({ entrypoint, workPath }).catch((err: Error) => {
+      doTypeCheck({ entrypoint, workPath, config }).catch((err: Error) => {
         console.error('Type check for %j failed:', entrypoint, err);
       });
     }


### PR DESCRIPTION
For [PRODUCT-2417].