### PR TITLE
[now-cli] Pass in env vars to `startDevServer()` in `now dev`

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -207,6 +207,12 @@ export interface StartDevServerOptions {
    * in `now.json`.
    */
   config: Config;
+
+  /**
+   * Runtime environment variables configuration from the project's `now.json`
+   * and local `.env` file.
+   */
+  env: Env;
 }
 
 export interface StartDevServerSuccess {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1474,9 +1474,10 @@ export default class DevServer {
           entrypoint: match.entrypoint,
           workPath: this.cwd,
           config: match.config || {},
+          env: this.envConfigs.runEnv || {},
         });
       } catch (err) {
-        // `starDevServer()` threw an error. Most likely this means the dev
+        // `startDevServer()` threw an error. Most likely this means the dev
         // server process exited before sending the port information message
         // (missing dependency at runtime, for example).
         debug(`Error starting "${builderPkg.name}" dev server: ${err}`);

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -416,11 +416,10 @@ export async function prepareCache({
   return cache;
 }
 
-export async function startDevServer({
-  entrypoint,
-  workPath,
-  config,
-}: StartDevServerOptions): Promise<StartDevServerResult> {
+export async function startDevServer(
+  opts: StartDevServerOptions
+): Promise<StartDevServerResult> {
+  const { entrypoint, workPath, config } = opts;
   const devServerPath = join(__dirname, 'dev-server.js');
   const child = fork(devServerPath, [], {
     cwd: workPath,
@@ -445,7 +444,7 @@ export async function startDevServer({
     if (ext === '.ts' || ext === '.tsx') {
       // Invoke `tsc --noEmit` asynchronously in the background, so
       // that the HTTP request is not blocked by the type checking.
-      doTypeCheck({ entrypoint, workPath, config }).catch((err: Error) => {
+      doTypeCheck(opts).catch((err: Error) => {
         console.error('Type check for %j failed:', entrypoint, err);
       });
     }


### PR DESCRIPTION
The Runtime is expected to set up these env vars in the dev server
child processes that it spawns.