### PR TITLE
[now dev] Fix `handle: miss` override headers

### DIFF
--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -130,7 +130,7 @@ export async function devRouter(
                 reqMethod,
                 missRoutes,
                 devServer,
-                previousHeaders,
+                combinedHeaders,
                 [],
                 'miss'
               );

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -395,16 +395,25 @@ test(
     });
   })
 );
-/*
+
 test(
   '[now dev] handles miss after rewrite',
-  testFixtureStdio('handle-miss-after-rewrite', async (testPath) => {
-    await testPath(200, '/post', 'Blog Post Page', { test: '1', override: 'two' });
-    await testPath(200, '/blog/post', 'Blog Post Page', { test: '1', override: 'two' });
-    await testPath(200, '/blog/about.html', 'About Page', { test: null, override: null });
+  testFixtureStdio('handle-miss-after-rewrite', async testPath => {
+    await testPath(200, '/post', 'Blog Post Page', {
+      test: '1',
+      override: 'one',
+    });
+    await testPath(200, '/blog/post', 'Blog Post Page', {
+      test: '1',
+      override: 'two',
+    });
+    await testPath(404, '/blog/about.html', undefined, {
+      test: '1',
+      override: 'two',
+    });
   })
 );
-
+/*
 test(
   '[now dev] displays directory listing after miss',
   testFixtureStdio('handle-miss-display-dir-list', async (testPath) => {


### PR DESCRIPTION
Fixes a bug with `now dev` where headers from the `miss` phase were overriding when they shouldn't be.

```json
{
  "version": 2,
  "routes": [
    {
      "handle": "filesystem"
    },
    {
      "src": "/([^/]+)",
      "headers": { "override": "one" },
      "dest": "/blog/$1",
      "check": true
    },
    {
      "handle": "miss"
    },
    {
      "src": "/(.*)",
      "dest": "/src/$1",
      "check": true
    },
    {
      "src": "/src/blog/([^/]+)",
      "headers": { "test": "1", "override": "two" },
      "dest": "/src/blog/$1.html",
      "check": true
    }
  ]
}
```