### PR TITLE
[api] Update build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "publish-from-github": "./utils/publish.sh",
     "changelog": "node utils/changelog.js",
     "build": "node utils/run.js build all",
+    "now-build": "mkdir -p public && echo '<a href=\"https://vercel.com/import\">Import</a>' > public/output.html",
     "test-unit": "node utils/run.js test-unit",
     "test-integration-cli": "node utils/run.js test-integration-cli",
     "test-integration-once": "node utils/run.js test-integration-once",

--- a/utils/run.js
+++ b/utils/run.js
@@ -82,12 +82,6 @@ async function main() {
   for (const pkgName of matches) {
     await runScript(pkgName, script);
   }
-
-  if (process.env.NOW_GITHUB_DEPLOYMENT) {
-    execSync(
-      `rm -rf public && mkdir public && echo '<a href="https://vercel.com/import">https://vercel.com/import</a>' > public/output.html`
-    );
-  }
 }
 
 function runScript(pkgName, script) {


### PR DESCRIPTION
In PR #3514, we added a `/api` directory for functions and a `/public` directory which was created at build time.

This moves the build script to be `now-build` so we don't don't need to build everything in the repo and also no longer need to special case the git env vars.