### PR TITLE
[now-routing-utils] Fix redirect `//` when `cleanUrls` and `trailingSlash` enabled

### DIFF
--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -654,7 +654,7 @@ test(
   })
 );
 
-test.only(
+test(
   '[now dev] test cleanUrls and trailingSlash serve correct content',
   testFixtureStdio(
     'test-clean-urls-trailing-slash',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -654,31 +654,36 @@ test(
   })
 );
 
-test(
+test.only(
   '[now dev] test cleanUrls and trailingSlash serve correct content',
-  testFixtureStdio('test-clean-urls-trailing-slash', async testPath => {
-    await testPath(200, '/', 'Index Page');
-    await testPath(200, '/about/', 'About Page');
-    await testPath(200, '/sub/', 'Sub Index Page');
-    await testPath(200, '/sub/another/', 'Sub Another Page');
-    await testPath(200, '/style.css', 'body { color: green }');
-    //TODO: fix this test so that location is `/` instead of `//`
-    //await testPath(308, '/index.html', 'Redirecting to / (308)', { Location: '/' });
-    await testPath(308, '/about.html', 'Redirecting to /about/ (308)', {
-      Location: '/about/',
-    });
-    await testPath(308, '/sub/index.html', 'Redirecting to /sub/ (308)', {
-      Location: '/sub/',
-    });
-    await testPath(
-      308,
-      '/sub/another.html',
-      'Redirecting to /sub/another/ (308)',
-      {
-        Location: '/sub/another/',
-      }
-    );
-  })
+  testFixtureStdio(
+    'test-clean-urls-trailing-slash',
+    async testPath => {
+      await testPath(200, '/', 'Index Page');
+      await testPath(200, '/about/', 'About Page');
+      await testPath(200, '/sub/', 'Sub Index Page');
+      await testPath(200, '/sub/another/', 'Sub Another Page');
+      await testPath(200, '/style.css', 'body { color: green }');
+      await testPath(308, '/index.html', 'Redirecting to / (308)', {
+        Location: '/',
+      });
+      await testPath(308, '/about.html', 'Redirecting to /about/ (308)', {
+        Location: '/about/',
+      });
+      await testPath(308, '/sub/index.html', 'Redirecting to /sub/ (308)', {
+        Location: '/sub/',
+      });
+      await testPath(
+        308,
+        '/sub/another.html',
+        'Redirecting to /sub/another/ (308)',
+        {
+          Location: '/sub/another/',
+        }
+      );
+    },
+    { skipDeploy: true } /* TODO: remove after update routing-utils in prod */
+  )
 );
 
 test(

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -28,14 +28,14 @@ export function convertCleanUrls(
 ): Route[] {
   const routes: Route[] = [];
   if (cleanUrls) {
-    const loc = trailingSlash ? '/$1/' : '/$1';
+    const loc = trailingSlash ? '$1/' : '$1';
     routes.push({
-      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
+      src: '^(.*)/index(?:\\.html)?/?$',
       headers: { Location: loc },
       status,
     });
     routes.push({
-      src: '^/(.*)\\.html/?$',
+      src: '^(/.*)\\.html/?$',
       headers: { Location: loc },
       status,
     });

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -714,13 +714,13 @@ describe('getTransformedRoutes', () => {
     const actual = getTransformedRoutes({ nowConfig });
     const expected = [
       {
-        src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
-        headers: { Location: '/$1' },
+        src: '^(.*)/index(?:\\.html)?/?$',
+        headers: { Location: '$1' },
         status: 308,
       },
       {
-        src: '^/(.*)\\.html/?$',
-        headers: { Location: '/$1' },
+        src: '^(/.*)\\.html/?$',
+        headers: { Location: '$1' },
         status: 308,
       },
       {

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -56,13 +56,13 @@ test('convertCleanUrls true', () => {
   const actual = convertCleanUrls(true);
   const expected = [
     {
-      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
-      headers: { Location: '/$1' },
+      src: '^(.*)/index(?:\\.html)?/?$',
+      headers: { Location: '$1' },
       status: 308,
     },
     {
-      src: '^/(.*)\\.html/?$',
-      headers: { Location: '/$1' },
+      src: '^(/.*)\\.html/?$',
+      headers: { Location: '$1' },
       status: 308,
     },
   ];
@@ -92,13 +92,13 @@ test('convertCleanUrls true, trailingSlash true', () => {
   const actual = convertCleanUrls(true, true);
   const expected = [
     {
-      src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
-      headers: { Location: '/$1/' },
+      src: '^(.*)/index(?:\\.html)?/?$',
+      headers: { Location: '$1/' },
       status: 308,
     },
     {
-      src: '^/(.*)\\.html/?$',
-      headers: { Location: '/$1/' },
+      src: '^(/.*)\\.html/?$',
+      headers: { Location: '$1/' },
       status: 308,
     },
   ];


### PR DESCRIPTION
This PR fixed a corner case when the user defined both `cleanUrls: true` and `trailingSlash: true` and then visited `/index.html` which would attempt to redirect to the invalid `//` path.