### PR TITLE
[tests] Fix cancel workflow pattern

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on:
   push:
     branches:
-    - '*'
+    - '**'
     - '!master'
 
 jobs:


### PR DESCRIPTION
Sometimes, the "Cancel" workflow wouldn't run because it didn't match the branch name.
This PR will fix the glob to match any branch name.

- `*`: Matches zero or more characters, but does not match the `/` character.
- `**`: Matches zero or more of any character.

https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet