### PR TITLE
[now-node][now-static-build] Add test for timezone utc

### DIFF
--- a/packages/now-node/test/fixtures/60-timezone-utc/api/offset.js
+++ b/packages/now-node/test/fixtures/60-timezone-utc/api/offset.js
@@ -1,0 +1,3 @@
+export default (_req, res) => {
+  res.end(`RANDOMNESS_PLACEHOLDER:offset:${new Date().getTimezoneOffset()}`);
+};

--- a/packages/now-node/test/fixtures/60-timezone-utc/now.json
+++ b/packages/now-node/test/fixtures/60-timezone-utc/now.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/**/*.js", "use": "@now/node" }],
+  "probes": [
+    { "path": "/offset.js", "mustContain": "RANDOMNESS_PLACEHOLDER:offset:0" }
+  ]
+}

--- a/packages/now-node/test/fixtures/60-timezone-utc/now.json
+++ b/packages/now-node/test/fixtures/60-timezone-utc/now.json
@@ -2,6 +2,9 @@
   "version": 2,
   "builds": [{ "src": "api/**/*.js", "use": "@now/node" }],
   "probes": [
-    { "path": "/offset.js", "mustContain": "RANDOMNESS_PLACEHOLDER:offset:0" }
+    {
+      "path": "/api/offset.js",
+      "mustContain": "RANDOMNESS_PLACEHOLDER:offset:0"
+    }
   ]
 }

--- a/packages/now-static-build/test/fixtures/60-timezone-utc/now.json
+++ b/packages/now-static-build/test/fixtures/60-timezone-utc/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "." }
+    }
+  ],
+  "probes": [
+    { "path": "/index.txt", "mustContain": "RANDOMNESS_PLACEHOLDER:offset:0" }
+  ]
+}

--- a/packages/now-static-build/test/fixtures/60-timezone-utc/offset.js
+++ b/packages/now-static-build/test/fixtures/60-timezone-utc/offset.js
@@ -1,0 +1,1 @@
+console.log(`RANDOMNESS_PLACEHOLDER:offset:${new Date().getTimezoneOffset()}`);

--- a/packages/now-static-build/test/fixtures/60-timezone-utc/package.json
+++ b/packages/now-static-build/test/fixtures/60-timezone-utc/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "node offset.js > index.txt"
+  }
+}


### PR DESCRIPTION
This PR adds a couple tests to ensure that the timezone offset is `0` meaning [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).