### PR TITLE
Add logging to debug failed npm publish for legacy package names in CI

### DIFF
--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 echo "Publishing legacy \"@now\" packages"
 
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "__dirname: ${__dirname}"
 
 echo "Logged in to npm as: $(npm whoami)"
 

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -3,8 +3,11 @@ set -euo pipefail
 
 # Modifies the tagged packages to contain the legacy `now` name.
 # This file will be deleted on Jan 1, 2021.
+echo "Publishing legacy \"@now\" packages"
 
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "Logged in to npm as: $(npm whoami)"
 
 commit="$(git log --format="%H" -n 1)"
 

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -22,6 +22,6 @@ for tag in $tags; do
     npm_tag="--tag canary"
   fi
 
-  echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
-  npm publish $npm_tag
+  echo "Running \`npm publish --registry=https://registry.npmjs.com $npm_tag\` in \"$(pwd)\""
+  echo "DRY: npm publish --registry=https://registry.npmjs.com $npm_tag"
 done

--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -15,6 +15,8 @@ if [ ! -e ~/.npmrc ]; then
   exit 0
 fi
 
+echo "Logged in to npm as: $(npm whoami)"
+
 npm_tag=""
 tag="$(git describe --tags --exact-match 2> /dev/null || :)"
 

--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "__dirname: ${__dirname}"
 
 if [ -z "$NPM_TOKEN" ]; then
   echo "NPM_TOKEN not found. Did you forget to assign the GitHub Action secret?"


### PR DESCRIPTION
As you can see in https://github.com/zeit/now/runs/647945621,
the final step for publishing the legacy `@now` packages failed
with a 401 error from npm.

This additional logging an to attempt to debug why that is happening.