### PR TITLE
[now-cli][now-go][now-python] Use `<project>/.vercel/cache' dir during dev

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -51,7 +51,7 @@ export interface Meta {
   isDev?: boolean;
   devCacheDir?: string;
   skipDownload?: boolean;
-  requestPath?: string;
+  requestPath?: string | null;
   filesChanged?: string[];
   filesRemoved?: string[];
   env?: Env;

--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -49,6 +49,7 @@ export interface Config {
 
 export interface Meta {
   isDev?: boolean;
+  devCacheDir?: string;
   skipDownload?: boolean;
   requestPath?: string;
   filesChanged?: string[];

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -39,7 +39,7 @@ import {
 } from './types';
 import { normalizeRoutes } from '@vercel/routing-utils';
 import getUpdateCommand from '../get-update-command';
-import { getProjectDirectory } from '../projects/link';
+import { getVercelDirectory } from '../projects/link';
 
 interface BuildMessage {
   type: string;
@@ -148,8 +148,8 @@ export async function executeBuild(
     );
   }
 
-  const projectDir = getProjectDirectory(workPath);
-  const devCacheDir = join(projectDir, 'cache');
+  const vercelDir = getVercelDirectory(workPath);
+  const devCacheDir = join(vercelDir, 'cache');
 
   const buildParams: BuilderParams = {
     files,

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -39,6 +39,7 @@ import {
 } from './types';
 import { normalizeRoutes } from '@vercel/routing-utils';
 import getUpdateCommand from '../get-update-command';
+import { getProjectDirectory } from '../projects/link';
 
 interface BuildMessage {
   type: string;
@@ -147,6 +148,9 @@ export async function executeBuild(
     );
   }
 
+  const dir = getProjectDirectory();
+  const devCacheDir = join(dir, 'cache');
+
   const buildParams: BuilderParams = {
     files,
     entrypoint,
@@ -155,6 +159,7 @@ export async function executeBuild(
     meta: {
       isDev: true,
       requestPath,
+      devCacheDir,
       filesChanged,
       filesRemoved,
       // This env distiniction is only necessary to maintain

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -148,8 +148,8 @@ export async function executeBuild(
     );
   }
 
-  const dir = getProjectDirectory();
-  const devCacheDir = join(dir, 'cache');
+  const projectDir = getProjectDirectory(workPath);
+  const devCacheDir = join(projectDir, 'cache');
 
   const buildParams: BuilderParams = {
     files,

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -8,6 +8,7 @@ import {
   Lambda,
   PackageJson,
   Config,
+  Meta,
 } from '@vercel/build-utils';
 import { NowConfig } from '@vercel/client';
 import { HandleValue, Route } from '@vercel/routing-utils';
@@ -82,14 +83,7 @@ export interface BuilderParamsBase {
   files: BuilderInputs;
   entrypoint: string;
   config: Config;
-  meta?: {
-    isDev?: boolean;
-    requestPath?: string | null;
-    filesChanged?: string[];
-    filesRemoved?: string[];
-    env?: EnvConfig;
-    buildEnv?: EnvConfig;
-  };
+  meta?: Meta;
 }
 
 export interface BuilderParams extends BuilderParamsBase {

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -38,11 +38,14 @@ const linkSchema = {
   },
 };
 
-async function getLink(path?: string): Promise<ProjectLink | null> {
+export function getProjectDirectory(path?: string) {
   const cwd = path || process.cwd();
   const possibleDirs = [join(cwd, VERCEL_DIR), join(cwd, VERCEL_DIR_FALLBACK)];
+  return possibleDirs.find(d => isDirectory(d)) || possibleDirs[0];
+}
 
-  const dir = possibleDirs.find(d => isDirectory(d)) || possibleDirs[0];
+async function getLink(path?: string): Promise<ProjectLink | null> {
+  const dir = getProjectDirectory(path);
   return getLinkFromDir(dir);
 }
 

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -42,8 +42,7 @@ const linkSchema = {
  * Returns the `<cwd>/.vercel` directory for the current project
  * with a fallback to <cwd>/.now` if it exists.
  */
-export function getVercelDirectory(path?: string) {
-  const cwd = path || process.cwd();
+export function getVercelDirectory(cwd: string = process.cwd()) {
   const possibleDirs = [join(cwd, VERCEL_DIR), join(cwd, VERCEL_DIR_FALLBACK)];
   return possibleDirs.find(d => isDirectory(d)) || possibleDirs[0];
 }

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -38,14 +38,18 @@ const linkSchema = {
   },
 };
 
-export function getProjectDirectory(path?: string) {
+/**
+ * Returns the `<cwd>/.vercel` directory for the current project
+ * with a fallback to <cwd>/.now` if it exists.
+ */
+export function getVercelDirectory(path?: string) {
   const cwd = path || process.cwd();
   const possibleDirs = [join(cwd, VERCEL_DIR), join(cwd, VERCEL_DIR_FALLBACK)];
   return possibleDirs.find(d => isDirectory(d)) || possibleDirs[0];
 }
 
 async function getLink(path?: string): Promise<ProjectLink | null> {
-  const dir = getProjectDirectory(path);
+  const dir = getVercelDirectory(path);
   return getLinkFromDir(dir);
 }
 

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -9,10 +9,10 @@ import {
   createLambda,
   getWriteableDirectory,
   BuildOptions,
+  Meta,
   shouldServe,
   Files,
   debug,
-  Meta,
 } from '@vercel/build-utils';
 
 import { createGo, getAnalyzedEntrypoint, OUT_EXTENSION } from './go-helpers';
@@ -134,13 +134,12 @@ Learn more: https://vercel.com/docs/runtimes#official-runtimes/go
 
   if (meta.isDev) {
     // Create cache so Go rebuilds fast with `now dev`
-    goPath = join(
-      workPath,
-      '.now',
-      'cache',
-      'now-go',
-      basename(entrypoint, '.go')
-    );
+    let { devCacheDir } = meta;
+    if (!devCacheDir) {
+      // Old versions of the CLI don't assign this property
+      devCacheDir = join(workPath, '.now', 'cache');
+    }
+    goPath = join(devCacheDir, 'now-go', basename(entrypoint, '.go'));
     const destNow = join(goPath, 'src', 'lambda');
     await download(downloadedFiles, destNow);
     downloadedFiles = await glob('**', destNow);

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -134,11 +134,8 @@ Learn more: https://vercel.com/docs/runtimes#official-runtimes/go
 
   if (meta.isDev) {
     // Create cache so Go rebuilds fast with `now dev`
-    let { devCacheDir } = meta;
-    if (!devCacheDir) {
-      // Old versions of the CLI don't assign this property
-      devCacheDir = join(workPath, '.now', 'cache');
-    }
+    // Old versions of the CLI don't assign this property
+    const { devCacheDir = join(workPath, '.now', 'cache') } = meta;
     goPath = join(devCacheDir, 'now-go', basename(entrypoint, '.go'));
     const destNow = join(goPath, 'src', 'lambda');
     await download(downloadedFiles, destNow);

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -40,11 +40,8 @@ export async function downloadFilesInWorkPath({
   debug('Downloading user files...');
   let downloadedFiles = await download(files, workPath, meta);
   if (meta.isDev) {
-    let { devCacheDir } = meta;
-    if (!devCacheDir) {
-      // Old versions of the CLI don't assign this property
-      devCacheDir = join(workPath, '.now', 'cache');
-    }
+    // Old versions of the CLI don't assign this property
+    const { devCacheDir = join(workPath, '.now', 'cache') } = meta;
     const destNow = join(devCacheDir, basename(entrypoint, '.py'));
     await download(downloadedFiles, destNow);
     downloadedFiles = await glob('**', destNow);

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -40,12 +40,12 @@ export async function downloadFilesInWorkPath({
   debug('Downloading user files...');
   let downloadedFiles = await download(files, workPath, meta);
   if (meta.isDev) {
-    const destNow = join(
-      workPath,
-      '.now',
-      'cache',
-      basename(entrypoint, '.py')
-    );
+    let { devCacheDir } = meta;
+    if (!devCacheDir) {
+      // Old versions of the CLI don't assign this property
+      devCacheDir = join(workPath, '.now', 'cache');
+    }
+    const destNow = join(devCacheDir, basename(entrypoint, '.py'));
     await download(downloadedFiles, destNow);
     downloadedFiles = await glob('**', destNow);
     workPath = destNow;


### PR DESCRIPTION
We renamed `.now` to `.vercel` in #4234 but still fallback to `.now` if it exists. This is because we don't want users to have to re-link all their existing projects. So we need to make sure that the Runtimes know which directory to use for caching. This PR introduces the `devCacheDir` for this purpose.