### PR TITLE
[node] Fix `tsCompile` uninitialized error

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -129,7 +129,7 @@ async function compile(
   watch: string[];
 }> {
   const inputFiles = new Set<string>([entrypointPath]);
-
+  const preparedFiles: Files = {};
   const sourceCache = new Map<string, string | Buffer | null>();
   const fsCache = new Map<string, File>();
   const tsCompiled = new Set<string>();
@@ -149,17 +149,7 @@ async function compile(
           const { fsPath } = entry;
           const relPath = relative(baseDir, fsPath);
           fsCache.set(relPath, entry);
-          const stream = entry.toStream();
-          const { data } = await FileBlob.fromStream({ stream });
-          if (relPath.endsWith('.ts') || relPath.endsWith('.tsx')) {
-            sourceCache.set(
-              relPath,
-              compileTypeScript(fsPath, data.toString())
-            );
-          } else {
-            sourceCache.set(relPath, data);
-          }
-          inputFiles.add(fsPath);
+          preparedFiles[relPath] = entry;
         })
       );
     }
@@ -169,8 +159,6 @@ async function compile(
     'Tracing input files: ' +
       [...inputFiles].map(p => relative(workPath, p)).join(', ')
   );
-
-  const preparedFiles: Files = {};
 
   let tsCompile: Register;
   function compileTypeScript(path: string, source: string): string {

--- a/packages/node/test/fixtures/09-include-files/file.ts
+++ b/packages/node/test/fixtures/09-include-files/file.ts
@@ -1,1 +1,1 @@
-const foo = 'TS File';
+const foo = 'hello TS!';

--- a/packages/node/test/fixtures/09-include-files/file.ts
+++ b/packages/node/test/fixtures/09-include-files/file.ts
@@ -1,0 +1,1 @@
+const foo = 'TS File';

--- a/packages/node/test/fixtures/09-include-files/include-ts-file.js
+++ b/packages/node/test/fixtures/09-include-files/include-ts-file.js
@@ -1,0 +1,8 @@
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+module.exports = (req, res) => {
+  const file = join(__dirname, 'file.ts');
+  const content = readFileSync(file, 'utf8');
+  res.end(content);
+};

--- a/packages/node/test/fixtures/09-include-files/vercel.json
+++ b/packages/node/test/fixtures/09-include-files/vercel.json
@@ -42,6 +42,10 @@
     {
       "path": "/root.js",
       "mustContain": "hello Root!"
+    },
+    {
+      "path": "/include-ts-file.js",
+      "mustContain": "hello TS!"
     }
   ]
 }

--- a/packages/node/test/fixtures/09-include-files/vercel.json
+++ b/packages/node/test/fixtures/09-include-files/vercel.json
@@ -21,6 +21,13 @@
       "config": {
         "includeFiles": "templates/accepts-string.edge"
       }
+    },
+    {
+      "src": "include-ts-file.js",
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": "file.ts"
+      }
     }
   ],
   "probes": [


### PR DESCRIPTION
This PR fixes an error that happens when `includeFiles` has `.ts` files:

```
ReferenceError: Cannot access 'tsCompile' before initialization
```

~~However its not clear what the expected behavior is. Should the `.ts` files be compiled to `.js` or should they be considered assets and included as-is?~~

We will assume that `includeFiles` is only for assets and thus `.ts` files should not be compiled, they're included as-is.

[ch20529]