### PR TITLE
[now-cli] Rename bin to support `vercel` and `vc`

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -40,10 +40,7 @@
     "instrument": true,
     "all": true
   },
-  "bin": {
-    "now": "./dist/index.js",
-    "vercel": "./dist/index.js"
-  },
+  "bin": "./dist/index.js",
   "files": [
     "dist",
     "scripts/preinstall.js"

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -40,7 +40,10 @@
     "instrument": true,
     "all": true
   },
-  "bin": "./dist/index.js",
+  "bin": {
+    "vc": "./dist/index.js",
+    "vercel": "./dist/index.js"
+  },
   "files": [
     "dist",
     "scripts/preinstall.js"

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -41,7 +41,6 @@
     "all": true
   },
   "bin": {
-    "now": "./dist/index.js",
     "vercel": "./dist/index.js"
   },
   "files": [

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -41,6 +41,7 @@
     "all": true
   },
   "bin": {
+    "now": "./dist/index.js",
     "vercel": "./dist/index.js"
   },
   "files": [

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -36,6 +36,10 @@ if (pkg.name === '@vercel/client') {
   pkg.name = 'now-client';
 } else {
   pkg.name = pkg.name.replace('vercel', 'now');
+  if (pkg.bin && pkg.bin.vercel) {
+    // The legacy "bin" for Now CLI is "now"
+    pkg.bin = { now: pkg.bin.vercel };
+  }
 }
 
 console.error(`Updated package name: "${originalName}" -> "${pkg.name}"`);

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -36,6 +36,10 @@ if (pkg.name === '@vercel/client') {
   pkg.name = 'now-client';
 } else {
   pkg.name = pkg.name.replace('vercel', 'now');
+  if (pkg.bin && pkg.bin.vercel) {
+    pkg.bin.now = pkg.bin.vercel;
+    delete pkg.bin.vercel;
+  }
 }
 
 console.error(`Updated package name: "${originalName}" -> "${pkg.name}"`);

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -36,10 +36,6 @@ if (pkg.name === '@vercel/client') {
   pkg.name = 'now-client';
 } else {
   pkg.name = pkg.name.replace('vercel', 'now');
-  if (pkg.bin && pkg.bin.vercel) {
-    pkg.bin.now = pkg.bin.vercel;
-    delete pkg.bin.vercel;
-  }
 }
 
 console.error(`Updated package name: "${originalName}" -> "${pkg.name}"`);


### PR DESCRIPTION
We want to make sure the bin matches the [installed package name](https://docs.npmjs.com/files/package.json#bin).

This means `npm i -g now` will remain `now` and `npm i -g vercel` will use `vercel` as the binary name.

This allows support for different versions on one machine such as `npm i -g now@17 vercel@19` for example.

In addition, we will also install a shorthand `vc` so you can do `vc env pull` for example.