### PR TITLE
[now-build-utils][now-cli] Fix `isOfficialRuntime()` edge case bug

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -96,6 +96,10 @@ export const isOfficialRuntime = (desired: string, name?: string): boolean => {
   );
 };
 
+export const isStaticRuntime = (name?: string): boolean => {
+  return isOfficialRuntime('static', name);
+};
+
 /**
  * Helper function to support both `VERCEL_` and legacy `NOW_` env vars.
  */

--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -85,10 +85,14 @@ export * from './errors';
  * Helper function to support both `@vercel` and legacy `@now` official Runtimes.
  */
 export const isOfficialRuntime = (desired: string, name?: string): boolean => {
+  if (typeof name !== 'string') {
+    return false;
+  }
   return (
-    typeof name === 'string' &&
-    (name.startsWith(`@vercel/${desired}`) ||
-      name.startsWith(`@now/${desired}`))
+    name === `@vercel/${desired}` ||
+    name === `@now/${desired}` ||
+    name.startsWith(`@vercel/${desired}@`) ||
+    name.startsWith(`@now/${desired}@`)
   );
 };
 

--- a/packages/now-build-utils/test/unit.is-official-runtime.test.ts
+++ b/packages/now-build-utils/test/unit.is-official-runtime.test.ts
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { isOfficialRuntime, isStaticRuntime } from '../src';
+
+describe('Test `isOfficialRuntime()`', () => {
+  it('should be correct', () => {
+    assert.equal(true, isOfficialRuntime('static', '@vercel/static'));
+    assert.equal(true, isOfficialRuntime('static', '@now/static'));
+    assert.equal(false, isOfficialRuntime('static', '@vercel/static-build'));
+    assert.equal(false, isOfficialRuntime('static', '@now/static-build'));
+
+    assert.equal(true, isOfficialRuntime('node', '@vercel/node'));
+    assert.equal(true, isOfficialRuntime('node', '@now/node'));
+    assert.equal(true, isOfficialRuntime('node', '@vercel/node@1.0.0'));
+    assert.equal(true, isOfficialRuntime('node', '@now/node@1.0.0'));
+    assert.equal(false, isOfficialRuntime('node', '@my-fork/node'));
+    assert.equal(false, isOfficialRuntime('node', '@now/node-server'));
+
+    assert.equal(
+      true,
+      isOfficialRuntime('static-build', '@vercel/static-build')
+    );
+    assert.equal(true, isOfficialRuntime('static-build', '@now/static-build'));
+    assert.equal(
+      true,
+      isOfficialRuntime('static-build', '@vercel/static-build@1.0.0')
+    );
+    assert.equal(false, isOfficialRuntime('static-build', '@vercel/static'));
+    assert.equal(false, isOfficialRuntime('static-build', '@now/static'));
+  });
+});
+
+describe('Test `isStaticRuntime()`', () => {
+  it('should be correct', () => {
+    assert.equal(true, isStaticRuntime('@vercel/static'));
+    assert.equal(true, isStaticRuntime('@now/static'));
+    assert.equal(false, isStaticRuntime('@vercel/static-build'));
+    assert.equal(false, isStaticRuntime('@now/static-build'));
+    assert.equal(false, isStaticRuntime('@now/node'));
+  });
+});

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -12,12 +12,12 @@ import {
   Lambda,
   FileBlob,
   FileFsRef,
+  isOfficialRuntime,
 } from '@vercel/build-utils';
 import plural from 'pluralize';
 import minimatch from 'minimatch';
 import _treeKill from 'tree-kill';
 
-import { isOfficialRuntime } from '../is-official-runtime';
 import { Output } from '../output';
 import highlight from '../output/highlight';
 import { relative } from '../path-helpers';

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -32,6 +32,7 @@ import {
   detectApiDirectory,
   detectApiExtensions,
   spawnCommand,
+  isOfficialRuntime,
 } from '@vercel/build-utils';
 
 import { once } from '../once';
@@ -41,7 +42,6 @@ import { relative } from '../path-helpers';
 import { getDistTag } from '../get-dist-tag';
 import getNowConfigPath from '../config/local-path';
 import { MissingDotenvVarsError } from '../errors-ts';
-import { isOfficialRuntime } from '../is-official-runtime';
 import { version as cliVersion } from '../../../package.json';
 import { staticFiles as getFiles, getAllProjectFiles } from '../get-files';
 import {

--- a/packages/now-cli/src/util/is-official-runtime.ts
+++ b/packages/now-cli/src/util/is-official-runtime.ts
@@ -1,7 +1,0 @@
-export const isOfficialRuntime = (desired: string, name?: string): boolean => {
-  return (
-    typeof name === 'string' &&
-    (name.startsWith(`@vercel/${desired}`) ||
-      name.startsWith(`@now/${desired}`))
-  );
-};


### PR DESCRIPTION
Fixes a bug where `isOfficialRuntime('static', '@now/static-build')` was returning `true` when it should have been `false`.

And use the function from `@vercel/build-utils` in Vercel CLI.