### PR TITLE
[now-build-utils] Use `@now` runtimes for zero-config

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -391,11 +391,11 @@ function getApiMatches({ tag }: Options = {}) {
   const config = { zeroConfig: true };
 
   return [
-    { src: 'api/**/*.js', use: `@vercel/node${withTag}`, config },
-    { src: 'api/**/*.ts', use: `@vercel/node${withTag}`, config },
-    { src: 'api/**/!(*_test).go', use: `@vercel/go${withTag}`, config },
-    { src: 'api/**/*.py', use: `@vercel/python${withTag}`, config },
-    { src: 'api/**/*.rb', use: `@vercel/ruby${withTag}`, config },
+    { src: 'api/**/*.js', use: `@now/node${withTag}`, config },
+    { src: 'api/**/*.ts', use: `@now/node${withTag}`, config },
+    { src: 'api/**/!(*_test).go', use: `@now/go${withTag}`, config },
+    { src: 'api/**/*.py', use: `@now/python${withTag}`, config },
+    { src: 'api/**/*.rb', use: `@now/ruby${withTag}`, config },
   ];
 }
 
@@ -457,7 +457,7 @@ function detectFrontBuilder(
   }
 
   if (framework === 'nextjs') {
-    return { src: 'package.json', use: `@vercel/next${withTag}`, config };
+    return { src: 'package.json', use: `@now/next${withTag}`, config };
   }
 
   // Entrypoints for other frameworks
@@ -480,7 +480,7 @@ function detectFrontBuilder(
 
   return {
     src: source || 'package.json',
-    use: `@vercel/static-build${withTag}`,
+    use: `@now/static-build${withTag}`,
     config,
   };
 }

--- a/packages/now-build-utils/test/integration.test.js
+++ b/packages/now-build-utils/test/integration.test.js
@@ -119,10 +119,7 @@ it('Test `detectBuilders` and `detectRoutes`', async () => {
     JSON.stringify(nowConfig, null, 2)
   );
 
-  const deployment = await testDeployment(
-    { builderUrl, buildUtilsUrl },
-    fixture
-  );
+  const deployment = await testDeployment({ builderUrl }, fixture);
   expect(deployment).toBeDefined();
 });
 
@@ -200,9 +197,6 @@ it('Test `detectBuilders` with `index` files', async () => {
     JSON.stringify(nowConfig, null, 2)
   );
 
-  const deployment = await testDeployment(
-    { builderUrl, buildUtilsUrl },
-    fixture
-  );
+  const deployment = await testDeployment({ builderUrl }, fixture);
   expect(deployment).toBeDefined();
 });

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -35,7 +35,7 @@ describe('Test `detectBuilders`', () => {
     };
     const files = ['package.json', 'pages/index.js'];
     const { builders, errors } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(errors).toBe(null);
   });
 
@@ -46,7 +46,7 @@ describe('Test `detectBuilders`', () => {
     };
     const files = ['package.json', 'pages/index.js'];
     const { builders, errors } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(errors).toBe(null);
   });
 
@@ -75,7 +75,7 @@ describe('Test `detectBuilders`', () => {
   it('no package.json + no build + raw static + api', async () => {
     const files = ['api/users.js', 'index.html'];
     const { builders, errors } = await detectBuilders(files);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/users.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -86,7 +86,7 @@ describe('Test `detectBuilders`', () => {
   it('package.json + no build + root + api', async () => {
     const files = ['index.html', 'api/[endpoint].js', 'static/image.png'];
     const { builders, errors } = await detectBuilders(files);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -102,7 +102,7 @@ describe('Test `detectBuilders`', () => {
     ];
 
     const { builders } = await detectBuilders(files);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint]/[id].js');
     expect(builders!.length).toBe(1);
   });
@@ -115,9 +115,9 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'api/endpoint.js', 'public/index.html'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![1].use).toBe('@now/next');
     expect(builders![1].src).toBe('package.json');
     expect(builders!.length).toBe(2);
   });
@@ -130,9 +130,9 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'api/endpoint.js', 'index.html'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![1].use).toBe('@now/next');
     expect(builders![1].src).toBe('package.json');
     expect(builders!.length).toBe(2);
   });
@@ -141,7 +141,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['api/endpoint.js', 'index.html', 'favicon.ico'];
 
     const { builders } = await detectBuilders(files);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -157,7 +157,7 @@ describe('Test `detectBuilders`', () => {
     ];
 
     const { builders } = await detectBuilders(files);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('public/**/*');
@@ -201,7 +201,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'public/index.html', 'README.md'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -214,7 +214,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'pages/index.js'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/static-build');
+    expect(builders![0].use).toBe('@now/static-build');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -227,7 +227,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'pages/index.js'];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'canary' });
-    expect(builders![0].use).toBe('@vercel/static-build@canary');
+    expect(builders![0].use).toBe('@now/static-build@canary');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -237,7 +237,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['package.json', 'api/[endpoint].js'];
 
     const { builders } = await detectBuilders(files, pkg);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders!.length).toBe(1);
   });
@@ -278,9 +278,9 @@ describe('Test `detectBuilders`', () => {
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'canary' });
-    expect(builders![0].use).toBe('@vercel/node@canary');
-    expect(builders![1].use).toBe('@vercel/node@canary');
-    expect(builders![2].use).toBe('@vercel/next@canary');
+    expect(builders![0].use).toBe('@now/node@canary');
+    expect(builders![1].use).toBe('@now/node@canary');
+    expect(builders![2].use).toBe('@now/next@canary');
     expect(builders!.length).toBe(3);
   });
 
@@ -296,9 +296,9 @@ describe('Test `detectBuilders`', () => {
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'latest' });
-    expect(builders![0].use).toBe('@vercel/node@latest');
-    expect(builders![1].use).toBe('@vercel/node@latest');
-    expect(builders![2].use).toBe('@vercel/next@latest');
+    expect(builders![0].use).toBe('@now/node@latest');
+    expect(builders![1].use).toBe('@now/node@latest');
+    expect(builders![2].use).toBe('@now/next@latest');
     expect(builders!.length).toBe(3);
   });
 
@@ -314,9 +314,9 @@ describe('Test `detectBuilders`', () => {
     ];
 
     const { builders } = await detectBuilders(files, pkg, { tag: 'haha' });
-    expect(builders![0].use).toBe('@vercel/node@haha');
-    expect(builders![1].use).toBe('@vercel/node@haha');
-    expect(builders![2].use).toBe('@vercel/next@haha');
+    expect(builders![0].use).toBe('@now/node@haha');
+    expect(builders![1].use).toBe('@now/node@haha');
+    expect(builders![2].use).toBe('@now/next@haha');
     expect(builders!.length).toBe(3);
   });
 
@@ -334,8 +334,8 @@ describe('Test `detectBuilders`', () => {
     expect(warnings[0].code).toBe('conflicting_files');
     expect(builders).toBeDefined();
     expect(builders!.length).toBe(2);
-    expect(builders![0].use).toBe('@vercel/node');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/node');
+    expect(builders![1].use).toBe('@now/next');
   });
 
   it('many static files + one api file', async () => {
@@ -344,7 +344,7 @@ describe('Test `detectBuilders`', () => {
     const { builders } = await detectBuilders(files);
 
     expect(builders!.length).toBe(2);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/index.ts');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -374,7 +374,7 @@ describe('Test `detectBuilders`', () => {
     expect(builders!.length).toBe(1);
     expect(builders![0]).toEqual({
       src: 'package.json',
-      use: '@vercel/next',
+      use: '@now/next',
       config: {
         zeroConfig: true,
         functions: {
@@ -412,7 +412,7 @@ describe('Test `detectBuilders`', () => {
     expect(builders!.length).toBe(3);
     expect(builders![0]).toEqual({
       src: 'api/teams/members.ts',
-      use: '@vercel/node',
+      use: '@now/node',
       config: {
         zeroConfig: true,
         functions: {
@@ -437,7 +437,7 @@ describe('Test `detectBuilders`', () => {
     });
     expect(builders![2]).toEqual({
       src: 'package.json',
-      use: '@vercel/next',
+      use: '@now/next',
       config: {
         zeroConfig: true,
       },
@@ -538,7 +538,7 @@ describe('Test `detectBuilders`', () => {
     expect(errors![0].code).toBe('invalid_function');
   });
 
-  it('Do not allow functions that are not used by @vercel/next', async () => {
+  it('Do not allow functions that are not used by @now/next', async () => {
     const pkg = {
       scripts: { build: 'next build' },
       dependencies: { next: '9.0.0' },
@@ -564,7 +564,7 @@ describe('Test `detectBuilders`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -584,7 +584,7 @@ describe('Test `detectBuilders`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -607,7 +607,7 @@ describe('Test `detectBuilders`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -705,7 +705,7 @@ describe('Test `detectBuilders`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'config.yaml',
         config: {
           zeroConfig: true,
@@ -727,7 +727,7 @@ describe('Test `detectBuilders`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'package.json',
         config: {
           zeroConfig: true,
@@ -744,14 +744,14 @@ describe('Test `detectBuilders`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/ruby',
+        use: '@now/ruby',
         src: 'api/date.rb',
         config: {
           zeroConfig: true,
         },
       },
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'config.rb',
         config: {
           zeroConfig: true,
@@ -765,7 +765,7 @@ describe('Test `detectBuilders`', () => {
     const files = ['server/hello.ts', 'public/index.html'];
     const functions = {
       'server/**/*.ts': {
-        runtime: '@vercel/node@1.3.1',
+        runtime: '@now/node@1.3.1',
       },
     };
 
@@ -868,7 +868,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(errors).toBe(null);
     expect(defaultRoutes).toStrictEqual([]);
     expect(redirectRoutes).toStrictEqual([]);
@@ -888,7 +888,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(errors).toBe(null);
     expect(defaultRoutes).toStrictEqual([]);
     expect(redirectRoutes).toStrictEqual([]);
@@ -950,7 +950,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, null, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/users.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -970,7 +970,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const { builders, errors } = await detectBuilders(files, null, {
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -991,7 +991,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, undefined, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint]/[id].js');
     expect(builders!.length).toBe(1);
 
@@ -1017,9 +1017,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![1].use).toBe('@now/next');
     expect(builders![1].src).toBe('package.json');
     expect(builders!.length).toBe(2);
 
@@ -1044,9 +1044,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![1].use).toBe('@now/next');
     expect(builders![1].src).toBe('package.json');
     expect(builders!.length).toBe(2);
 
@@ -1067,7 +1067,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, null, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -1094,7 +1094,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       redirectRoutes,
       rewriteRoutes,
     } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/version.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -1119,7 +1119,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const { builders } = await detectBuilders(files, undefined, {
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/endpoint.js');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('public/**/*');
@@ -1167,7 +1167,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['package.json', 'public/index.html', 'README.md'];
 
     const { builders } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/next');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -1180,7 +1180,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['package.json', 'pages/index.js'];
 
     const { builders } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/static-build');
+    expect(builders![0].use).toBe('@now/static-build');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -1196,7 +1196,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       tag: 'canary',
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/static-build@canary');
+    expect(builders![0].use).toBe('@now/static-build@canary');
     expect(builders![0].src).toBe('package.json');
     expect(builders!.length).toBe(1);
   });
@@ -1206,7 +1206,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['package.json', 'api/[endpoint].js'];
 
     const { builders } = await detectBuilders(files, pkg, { featHandleMiss });
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders!.length).toBe(1);
   });
@@ -1256,9 +1256,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       tag: 'canary',
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/node@canary');
-    expect(builders![1].use).toBe('@vercel/node@canary');
-    expect(builders![2].use).toBe('@vercel/next@canary');
+    expect(builders![0].use).toBe('@now/node@canary');
+    expect(builders![1].use).toBe('@now/node@canary');
+    expect(builders![2].use).toBe('@now/next@canary');
     expect(builders!.length).toBe(3);
   });
 
@@ -1277,9 +1277,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       tag: 'latest',
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/node@latest');
-    expect(builders![1].use).toBe('@vercel/node@latest');
-    expect(builders![2].use).toBe('@vercel/next@latest');
+    expect(builders![0].use).toBe('@now/node@latest');
+    expect(builders![1].use).toBe('@now/node@latest');
+    expect(builders![2].use).toBe('@now/next@latest');
     expect(builders!.length).toBe(3);
   });
 
@@ -1298,9 +1298,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       tag: 'haha',
       featHandleMiss,
     });
-    expect(builders![0].use).toBe('@vercel/node@haha');
-    expect(builders![1].use).toBe('@vercel/node@haha');
-    expect(builders![2].use).toBe('@vercel/next@haha');
+    expect(builders![0].use).toBe('@now/node@haha');
+    expect(builders![1].use).toBe('@now/node@haha');
+    expect(builders![2].use).toBe('@now/next@haha');
     expect(builders!.length).toBe(3);
   });
 
@@ -1320,8 +1320,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(warnings[0].code).toBe('conflicting_files');
     expect(builders).toBeDefined();
     expect(builders!.length).toBe(2);
-    expect(builders![0].use).toBe('@vercel/node');
-    expect(builders![1].use).toBe('@vercel/next');
+    expect(builders![0].use).toBe('@now/node');
+    expect(builders![1].use).toBe('@now/next');
   });
 
   it('many static files + one api file', async () => {
@@ -1332,7 +1332,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     });
 
     expect(builders!.length).toBe(2);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].src).toBe('api/index.ts');
     expect(builders![1].use).toBe('@now/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
@@ -1363,7 +1363,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders!.length).toBe(1);
     expect(builders![0]).toEqual({
       src: 'package.json',
-      use: '@vercel/next',
+      use: '@now/next',
       config: {
         zeroConfig: true,
         functions: {
@@ -1404,7 +1404,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders!.length).toBe(3);
     expect(builders![0]).toEqual({
       src: 'api/teams/members.ts',
-      use: '@vercel/node',
+      use: '@now/node',
       config: {
         zeroConfig: true,
         functions: {
@@ -1429,7 +1429,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     });
     expect(builders![2]).toEqual({
       src: 'package.json',
-      use: '@vercel/next',
+      use: '@now/next',
       config: {
         zeroConfig: true,
       },
@@ -1538,7 +1538,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(errors![0].code).toBe('invalid_function');
   });
 
-  it('Do not allow functions that are not used by @vercel/next', async () => {
+  it('Do not allow functions that are not used by @now/next', async () => {
     const pkg = {
       scripts: { build: 'next build' },
       dependencies: { next: '9.0.0' },
@@ -1568,7 +1568,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -1589,7 +1589,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -1613,7 +1613,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(errors).toBe(null);
     expect(builders).not.toBe(null);
-    expect(builders![0].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
     expect(builders![0].config).toMatchObject({
       functions,
       zeroConfig: true,
@@ -1737,7 +1737,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'config.yaml',
         config: {
           zeroConfig: true,
@@ -1759,7 +1759,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'package.json',
         config: {
           zeroConfig: true,
@@ -1779,14 +1779,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(builders).toEqual([
       {
-        use: '@vercel/ruby',
+        use: '@now/ruby',
         src: 'api/date.rb',
         config: {
           zeroConfig: true,
         },
       },
       {
-        use: '@vercel/static-build',
+        use: '@now/static-build',
         src: 'config.rb',
         config: {
           zeroConfig: true,
@@ -1800,7 +1800,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['server/hello.ts', 'public/index.html'];
     const functions = {
       'server/**/*.ts': {
-        runtime: '@vercel/node@1.3.1',
+        runtime: '@now/node@1.3.1',
       },
     };
 
@@ -2000,10 +2000,10 @@ it('Test `detectRoutes`', async () => {
     const { builders, defaultRoutes } = await detectBuilders(files);
 
     expect(builders!.length).toBe(4);
-    expect(builders![0].use).toBe('@vercel/node');
-    expect(builders![1].use).toBe('@vercel/node');
-    expect(builders![2].use).toBe('@vercel/node');
-    expect(builders![3].use).toBe('@vercel/node');
+    expect(builders![0].use).toBe('@now/node');
+    expect(builders![1].use).toBe('@now/node');
+    expect(builders![2].use).toBe('@now/node');
+    expect(builders![3].use).toBe('@now/node');
     expect(defaultRoutes!.length).toBe(5);
   }
 
@@ -2883,7 +2883,7 @@ describe('Test `detectOutputDirectory`', () => {
         config: { zeroConfig: true },
       },
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/index.js',
       },
     ];
@@ -2896,7 +2896,7 @@ describe('Test `detectApiDirectory`', () => {
   it('should be `null` with no config', async () => {
     const builders = [
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/**/*.js',
       },
     ];
@@ -2907,7 +2907,7 @@ describe('Test `detectApiDirectory`', () => {
   it('should be `null` with no zero config builds', async () => {
     const builders = [
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/**/*.js',
         config: {},
       },
@@ -2919,7 +2919,7 @@ describe('Test `detectApiDirectory`', () => {
   it('should be `api` with one zero config', async () => {
     const builders = [
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/**/*.js',
         config: { zeroConfig: true },
       },
@@ -2931,12 +2931,12 @@ describe('Test `detectApiDirectory`', () => {
   it('should be `api` with one zero config and one without config', async () => {
     const builders = [
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/**/*.js',
         config: { zeroConfig: true },
       },
       {
-        use: '@vercel/php',
+        use: '@now/php',
         src: 'api/**/*.php',
       },
     ];
@@ -2947,7 +2947,7 @@ describe('Test `detectApiDirectory`', () => {
   it('should be `null` with zero config but without api directory', async () => {
     const builders = [
       {
-        use: '@vercel/next',
+        use: '@now/next',
         src: 'package.json',
         config: { zeroConfig: true },
       },
@@ -2961,28 +2961,28 @@ describe('Test `detectApiExtensions`', () => {
   it('should have correct extensions', async () => {
     const builders = [
       {
-        use: '@vercel/node',
+        use: '@now/node',
         src: 'api/**/*.js',
         config: {
           zeroConfig: true,
         },
       },
       {
-        use: '@vercel/python',
+        use: '@now/python',
         src: 'api/**/*.py',
         config: {
           zeroConfig: true,
         },
       },
       {
-        use: '@vercel/go',
+        use: '@now/go',
         src: 'api/**/*.go',
         config: {
           zeroConfig: true,
         },
       },
       {
-        use: '@vercel/ruby',
+        use: '@now/ruby',
         src: 'api/**/*.rb',
         config: {
           zeroConfig: true,
@@ -3002,7 +3002,7 @@ describe('Test `detectApiExtensions`', () => {
         },
       },
       {
-        use: '@vercel/next',
+        use: '@now/next',
         src: 'package.json',
         // No api directory should not be added
         config: {


### PR DESCRIPTION
This is a temporary change until the `@vercel` runtimes work in
production.