### PR TITLE
Ensure the npm registry is used during "Publish" workflow

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,13 @@
 {
-    "npmClient": "yarn",
-    "useWorkspaces": true,
-    "packages": ["packages/*"],
-    "command": {
-      "publish": {
-        "npmClient": "npm",
-        "allowBranch": ["master", "canary"],
-        "registry": "https://registry.npmjs.org/"
-      }
-    },
-    "version": "independent"
-  }
-  
+  "npmClient": "yarn",
+  "useWorkspaces": true,
+  "packages": ["packages/*"],
+  "command": {
+    "publish": {
+      "npmClient": "npm",
+      "allowBranch": ["master"],
+      "registry": "https://registry.npmjs.org/"
+    }
+  },
+  "version": "independent"
+}

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -24,5 +24,5 @@ for tag in $tags; do
   fi
 
   echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
-  echo "DRY: npm publish $npm_tag"
+  npm publish $npm_tag
 done

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -23,6 +23,6 @@ for tag in $tags; do
     npm_tag="--tag canary"
   fi
 
-  echo "Running \`npm publish --registry=https://registry.npmjs.com $npm_tag\` in \"$(pwd)\""
-  echo "DRY: npm publish --registry=https://registry.npmjs.com $npm_tag"
+  echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
+  echo "DRY: npm publish $npm_tag"
 done

--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# `yarn` overwrites this value to use the yarn registry, which we
+# can't publish to. Unset so that the default npm registry is used.
+unset npm_config_registry
+
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "__dirname: ${__dirname}"
 


### PR DESCRIPTION
Unset the `npm_config_registry` env var which yarn overwrites to the
yarn registry, which we don't want since the `.npmrc` file that gets
created is configured to the npm registry.