### PR TITLE
[now-cli] Add e2e test for `vercel.json` and `.vercelignore`

### DIFF
--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/.gitignore
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+public

--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/.vercelignore
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/.vercelignore
@@ -1,0 +1,3 @@
+.vercel
+public
+api/two.js

--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/api/one.js
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/api/one.js
@@ -1,0 +1,1 @@
+module.exports = (_req, res) => res.end('One');

--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/api/two.js
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/api/two.js
@@ -1,0 +1,1 @@
+module.exports = (_req, res) => res.end('Two');

--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/index.html
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/index.html
@@ -1,0 +1,5 @@
+<h1>Home Page</h1>
+
+<a href="/api/one">1. Should exist</a>
+<a href="/api/two">2. Should NOT exist</a>
+<a href="/api/three">3. Should rewrite to one</a>

--- a/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/28-vercel-json-and-ignore/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/api/three", "destination": "/api/one" }]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1286,6 +1286,15 @@ test(
 );
 
 test(
+  '[now dev] 28-vercel-json-and-ignore',
+  testFixtureStdio('28-vercel-json-and-ignore', async testPath => {
+    await testPath(200, '/api/one', 'One');
+    await testPath(404, '/api/two');
+    await testPath(200, '/api/three', 'One');
+  })
+);
+
+test(
   '[now dev] Use `@now/python` with Flask requirements.txt',
   testFixtureStdio('python-flask', async testPath => {
     const name = 'Alice';

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -7,7 +7,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function nowDeploy(bodies, randomness) {
   const files = Object.keys(bodies)
-    .filter(n => n !== 'now.json')
+    .filter(n => n !== 'vercel.json' && n !== 'now.json')
     .map(n => ({
       sha: digestOfFile(bodies[n]),
       size: bodies[n].length,
@@ -16,7 +16,7 @@ async function nowDeploy(bodies, randomness) {
     }));
 
   const { FORCE_BUILD_IN_REGION, NOW_DEBUG, VERCEL_DEBUG } = process.env;
-  const nowJson = JSON.parse(bodies['now.json']);
+  const nowJson = JSON.parse(bodies['vercel.json'] || bodies['now.json']);
 
   const nowDeployPayload = {
     version: 2,

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -53,8 +53,10 @@ async function testDeployment(
     );
   }
 
+  const configName = 'vercel.json' in bodies ? 'vercel.json' : 'now.json';
+
   // we use json5 to allow comments for probes
-  const nowJson = json5.parse(bodies['vercel.json'] || bodies['now.json']);
+  const nowJson = json5.parse(bodies[configName]);
 
   if (process.env.VERCEL_BUILDER_DEBUG) {
     if (!nowJson.build) {
@@ -90,7 +92,7 @@ async function testDeployment(
     }
   }
 
-  bodies['now.json'] = Buffer.from(JSON.stringify(nowJson));
+  bodies[configName] = Buffer.from(JSON.stringify(nowJson));
   delete bodies['probe.js'];
   const { deploymentId, deploymentUrl } = await nowDeploy(bodies, randomness);
 

--- a/test/lib/run-build-lambda.js
+++ b/test/lib/run-build-lambda.js
@@ -10,7 +10,7 @@ function runAnalyze(wrapper, context) {
 
 async function runBuildLambda(inputPath) {
   const inputFiles = await glob('**', inputPath);
-  const nowJsonRef = inputFiles['now.json'];
+  const nowJsonRef = inputFiles['vercel.json'] || inputFiles['now.json'];
   expect(nowJsonRef).toBeDefined();
   const nowJson = require(nowJsonRef.fsPath);
   expect(nowJson.builds.length).toBe(1);


### PR DESCRIPTION
This PR adds a test for a deployment as well as `now dev` to ensure both `vercel.json` and `.vercelignore` are applied.

I also fixed the remaining test helpers to work with `vercel.json`.