### PR TITLE
[now-cli] Add getTitleName() and update getCommandName()

### DIFF
--- a/packages/now-cli/src/commands/alias/ls.js
+++ b/packages/now-cli/src/commands/alias/ls.js
@@ -9,8 +9,7 @@ import getScope from '../../util/get-scope.ts';
 import stamp from '../../util/output/stamp.ts';
 import strlen from '../../util/strlen.ts';
 import getCommandFlags from '../../util/get-command-flags';
-import cmd from '../../util/output/cmd.ts';
-import { getPkgName } from '../../util/pkg-name.ts';
+import { getCommandName } from '../../util/pkg-name.ts';
 
 export default async function ls(ctx, opts, args, output) {
   const {
@@ -56,7 +55,7 @@ export default async function ls(ctx, opts, args, output) {
   if (args.length > 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} alias ls [alias]`
+        `${getCommandName('alias ls [alias]')}`
       )}`
     );
     return 1;
@@ -107,8 +106,8 @@ export default async function ls(ctx, opts, args, output) {
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} alias ls${flags} --next ${pagination.next}`
+      `To display the next page run ${getCommandName(
+        `alias ls${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/alias/rm.js
+++ b/packages/now-cli/src/commands/alias/rm.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import ms from 'ms';
 import table from 'text-table';
 import Now from '../../util';
-import cmd from '../../util/output/cmd.ts';
 import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
 import removeAliasById from '../../util/alias/remove-alias-by-id';
@@ -11,7 +10,7 @@ import strlen from '../../util/strlen.ts';
 import promptBool from '../../util/prompt-bool';
 import { isValidName } from '../../util/is-valid-name';
 import findAliasByAliasOrId from '../../util/alias/find-alias-by-alias-or-id';
-import { getPkgName } from '../../util/pkg-name.ts';
+import { getCommandName } from '../../util/pkg-name.ts';
 
 export default async function rm(ctx, opts, args, output) {
   const {
@@ -47,16 +46,14 @@ export default async function rm(ctx, opts, args, output) {
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} alias rm <alias>`
+        `${getCommandName('alias rm <alias>')}`
       )}`
     );
     return 1;
   }
 
   if (!aliasOrId) {
-    output.error(
-      `${cmd(`${getPkgName()} alias rm <alias>`)} expects one argument`
-    );
+    output.error(`${getCommandName('alias rm <alias>')} expects one argument`);
     return 1;
   }
 
@@ -71,7 +68,7 @@ export default async function rm(ctx, opts, args, output) {
     output.error(
       `Alias not found by "${aliasOrId}" under ${chalk.bold(contextName)}`
     );
-    output.log(`Run ${cmd(`${getPkgName} alias ls`)} to see your aliases.`);
+    output.log(`Run ${getCommandName('alias ls')} to see your aliases.`);
     return 1;
   }
 

--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -7,7 +7,6 @@ import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import assignAlias from '../../util/alias/assign-alias';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import formatDnsTable from '../../util/format-dns-table';
 import formatNSTable from '../../util/format-ns-table';
 import getDeploymentForAlias from '../../util/alias/get-deployment-for-alias';
@@ -23,7 +22,7 @@ import handleCertError from '../../util/certs/handle-cert-error';
 import isWildcardAlias from '../../util/alias/is-wildcard-alias';
 import link from '../../util/output/link';
 import { User } from '../../types';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -78,8 +77,8 @@ export default async function set(
   // If there are more than two args we have to error
   if (args.length > 2) {
     output.error(
-      `${cmd(
-        `${getPkgName()} alias <deployment> <target>`
+      `${getCommandName(
+        `alias <deployment> <target>`
       )} accepts at most two arguments`
     );
     return 1;
@@ -129,7 +128,7 @@ export default async function set(
     output.error(
       `To ship to production, optionally configure your domains (${link(
         'https://vercel.com/docs/v2/custom-domains'
-      )}) and run ${cmd(`${getPkgName()} --prod`)}.`
+      )}) and run ${getCommandName(`--prod`)}.`
     );
     return 1;
   }
@@ -304,8 +303,8 @@ function handleSetupDomainError<T>(
         )}\n\n`
       );
       output.print(
-        `  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${cmd(
-          `${getPkgName()} domains verify <domain>`
+        `  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${getCommandName(
+          'domains verify <domain>'
         )}.\n`
       );
       output.print(
@@ -313,8 +312,8 @@ function handleSetupDomainError<T>(
       );
     } else {
       output.print(
-        `  Once your domain uses the nameservers from above, run again ${cmd(
-          `${getPkgName()} domains verify <domain>`
+        `  Once your domain uses the nameservers from above, run again ${getCommandName(
+          'domains verify <domain>'
         )}.\n`
       );
     }
@@ -477,7 +476,7 @@ function handleCreateAliasError<T>(
     output.log(
       `Update the scale settings on ${chalk.dim(
         error.meta.url
-      )} with \`${getPkgName()} scale\` and try again`
+      )} with ${getCommandName('scale')} and try again`
     );
     output.log('Read more: https://err.sh/now/v2-no-min');
     return 1;
@@ -493,7 +492,7 @@ function handleCreateAliasError<T>(
     output.log(
       `Update the scale settings on ${chalk.dim(
         error.meta.url
-      )} with \`${getPkgName()} scale\` and try again`
+      )} with ${getCommandName('scale')} and try again`
     );
     return 1;
   }
@@ -513,7 +512,7 @@ function handleCreateAliasError<T>(
     output.log(
       `Update the scale settings on ${chalk.dim(
         error.meta.url
-      )} with \`${getPkgName()} scale\` and try again`
+      )} with ${getCommandName('scale')} and try again`
     );
     return 1;
   }
@@ -523,8 +522,8 @@ function handleCreateAliasError<T>(
       `There is no certificate for the domain ${error.meta.domain} and it could not be created.`
     );
     output.log(
-      `Please generate a new certificate manually with ${cmd(
-        `${getPkgName()} certs issue ${error.meta.domain}`
+      `Please generate a new certificate manually with ${getCommandName(
+        `certs issue ${error.meta.domain}`
       )}`
     );
     return 1;

--- a/packages/now-cli/src/commands/certs/add.ts
+++ b/packages/now-cli/src/commands/certs/add.ts
@@ -9,7 +9,7 @@ import createCertFromFile from '../../util/certs/create-cert-from-file';
 import createCertForCns from '../../util/certs/create-cert-for-cns';
 import { NowContext } from '../../types';
 import { Output } from '../../util/output';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 interface Options {
   '--overwrite'?: boolean;
@@ -77,7 +77,9 @@ async function add(
       );
       output.print(
         `  ${chalk.cyan(
-          `${getPkgName()} certs add --crt <domain.crt> --key <domain.key> --ca <ca.crt>`
+          `${getCommandName(
+            'certs add --crt <domain.crt> --key <domain.key> --ca <ca.crt>'
+          )}`
         )}\n`
       );
       now.close();
@@ -89,9 +91,9 @@ async function add(
   } else {
     output.warn(
       `${chalk.cyan(
-        `${getPkgName()} certs add`
+        getCommandName('certs add')
       )} will be soon deprecated. Please use ${chalk.cyan(
-        `${getPkgName()} certs issue <cn> <cns>`
+        getCommandName('certs issue <cn> <cns>')
       )} instead`
     );
 
@@ -100,7 +102,7 @@ async function add(
         `Invalid number of arguments to create a custom certificate entry. Usage:`
       );
       output.print(
-        `  ${chalk.cyan(`${getPkgName()} certs add <cn>[, <cn>]`)}\n`
+        `  ${chalk.cyan(getCommandName('certs add <cn>[, <cn>]'))}\n`
       );
       now.close();
       return 1;

--- a/packages/now-cli/src/commands/certs/issue.ts
+++ b/packages/now-cli/src/commands/certs/issue.ts
@@ -14,7 +14,7 @@ import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import startCertOrder from '../../util/certs/start-cert-order';
 import handleCertError from '../../util/certs/handle-cert-error';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--ca': string;
@@ -81,7 +81,9 @@ export default async function issue(
       );
       output.print(
         `  ${chalk.cyan(
-          `${getPkgName()} certs issue --crt <domain.crt> --key <domain.key> --ca <ca.crt>`
+          getCommandName(
+            'certs issue --crt <domain.crt> --key <domain.key> --ca <ca.crt>'
+          )
         )}\n`
       );
       return 1;
@@ -109,7 +111,7 @@ export default async function issue(
       `Invalid number of arguments to create a custom certificate entry. Usage:`
     );
     output.print(
-      `  ${chalk.cyan(`${getPkgName()} certs issue <cn>[, <cn>]`)}\n`
+      `  ${chalk.cyan(getCommandName('certs issue <cn>[, <cn>]'))}\n`
     );
     return 1;
   }
@@ -193,7 +195,7 @@ async function runStartOrder(
       `  There are no pending challenges. Finish the issuance by running: \n`
     );
     output.print(
-      `  ${chalk.cyan(`${getPkgName()} certs issue ${cns.join(' ')}`)}\n`
+      `  ${chalk.cyan(getCommandName(`certs issue ${cns.join(' ')}`))}\n`
     );
     return 0;
   }
@@ -226,7 +228,7 @@ async function runStartOrder(
   process.stdout.write(`${rows.join('\n')}\n\n`);
   output.log(`To issue the certificate once the records are added, run:`);
   output.print(
-    `  ${chalk.cyan(`${getPkgName()} certs issue ${cns.join(' ')}`)}\n`
+    `  ${chalk.cyan(getCommandName(`certs issue ${cns.join(' ')}`))}\n`
   );
   output.print('  Read more: https://err.sh/now/solve-challenges-manually\n');
   return 0;

--- a/packages/now-cli/src/commands/certs/ls.ts
+++ b/packages/now-cli/src/commands/certs/ls.ts
@@ -3,7 +3,6 @@ import ms from 'ms';
 import table from 'text-table';
 // @ts-ignore
 import Now from '../../util';
-import cmd from '../../util/output/cmd';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
@@ -12,7 +11,7 @@ import strlen from '../../util/strlen';
 import { Output } from '../../util/output';
 import { NowContext, Cert } from '../../types';
 import getCommandFlags from '../../util/get-command-flags';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 interface Options {
   '--debug'?: boolean;
@@ -55,7 +54,7 @@ async function ls(
   if (args.length !== 0) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} certs ls`
+        `${getCommandName('certs ls')}`
       )}`
     );
     return 1;
@@ -79,8 +78,8 @@ async function ls(
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} certs ls${flags} --next ${pagination.next}`
+      `To display the next page run ${getCommandName(
+        `certs ls${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/certs/rm.ts
+++ b/packages/now-cli/src/commands/certs/rm.ts
@@ -12,7 +12,7 @@ import Client from '../../util/client';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import param from '../../util/output/param';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -50,7 +50,7 @@ async function rm(
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} certs rm <id or cn>`
+        `${getCommandName('certs rm <id or cn>')}`
       )}`
     );
     return 1;

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -54,7 +54,7 @@ import validatePaths, {
   validateRootDirectory,
 } from '../../util/validate-paths';
 import { readLocalConfig } from '../../util/config/files';
-import { getPkgName } from '../../util/pkg-name.ts';
+import { getCommandName } from '../../util/pkg-name.ts';
 
 const addProcessEnv = async (log, env) => {
   let val;
@@ -668,8 +668,8 @@ export default async function main(
     if (err instanceof BuildError) {
       output.error('Build failed');
       output.error(
-        `Check your logs at https://${now.url}/_logs or run ${code(
-          `${getPkgName()} logs ${now.url}`,
+        `Check your logs at https://${now.url}/_logs or run ${getCommandName(
+          `logs ${now.url}`,
           {
             // Backticks are interpreted as part of the URL, causing CMD+Click
             // behavior to fail in editors like VSCode.
@@ -800,7 +800,7 @@ function handleCreateDeployError(output, error) {
   if (error instanceof BuildsRateLimited) {
     output.error(error.message);
     output.note(
-      `Run ${code(`${getPkgName()} upgrade`)} to increase your builds limit.`
+      `Run ${getCommandName('upgrade')} to increase your builds limit.`
     );
     return 1;
   }

--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -13,7 +13,7 @@ import cmd from '../../util/output/cmd';
 import dev from './dev';
 import readPackage from '../../util/read-package';
 import readConfig from '../../util/config/read-config';
-import { getPkgName } from '../../util/pkg-name';
+import { getPkgName, getCommandName } from '../../util/pkg-name';
 
 const COMMAND_CONFIG = {
   dev: ['dev'],
@@ -110,9 +110,7 @@ export default async function main(ctx: NowContext) {
   }
 
   if (argv._.length > 2) {
-    output.error(
-      `${cmd(`${getPkgName()} dev [dir]`)} accepts at most one argument`
-    );
+    output.error(`${getCommandName(`dev [dir]`)} accepts at most one argument`);
     return 1;
   }
 

--- a/packages/now-cli/src/commands/dns/add.ts
+++ b/packages/now-cli/src/commands/dns/add.ts
@@ -13,7 +13,7 @@ import getScope from '../../util/get-scope';
 import parseAddDNSRecordArgs from '../../util/dns/parse-add-dns-record-args';
 import stamp from '../../util/output/stamp';
 import getDNSData from '../../util/dns/get-dns-data';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -50,7 +50,7 @@ export default async function add(
   if (!parsedParams) {
     output.error(
       `Invalid number of arguments. See: ${chalk.cyan(
-        `${getPkgName()} dns --help`
+        `${getCommandName('dns --help')}`
       )} for usage.`
     );
     return 1;

--- a/packages/now-cli/src/commands/dns/import.ts
+++ b/packages/now-cli/src/commands/dns/import.ts
@@ -6,7 +6,7 @@ import getScope from '../../util/get-scope';
 import { DomainNotFound, InvalidDomain } from '../../util/errors-ts';
 import stamp from '../../util/output/stamp';
 import importZonefile from '../../util/dns/import-zonefile';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -42,7 +42,7 @@ export default async function add(
   if (args.length !== 2) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} dns import <domain> <zonefile>`
+        `${getCommandName('dns import <domain> <zonefile>')}`
       )}`
     );
     return 1;

--- a/packages/now-cli/src/commands/dns/ls.ts
+++ b/packages/now-cli/src/commands/dns/ls.ts
@@ -12,8 +12,7 @@ import getDomainDNSRecords from '../../util/dns/get-domain-dns-records';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import getCommandFlags from '../../util/get-command-flags';
-import cmd from '../../util/output/cmd';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -53,7 +52,7 @@ export default async function ls(
   if (args.length > 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} dns ls [domain]`
+        `${getCommandName('dns ls [domain]')}`
       )}`
     );
     return 1;
@@ -93,10 +92,8 @@ export default async function ls(
     if (pagination && pagination.count === 20) {
       const flags = getCommandFlags(opts, ['_', '--next']);
       output.log(
-        `To display the next page run ${cmd(
-          `${getPkgName()} dns ls ${domainName}${flags} --next ${
-            pagination.next
-          }`
+        `To display the next page run ${getCommandName(
+          `dns ls ${domainName}${flags} --next ${pagination.next}`
         )}`
       );
     }
@@ -120,8 +117,8 @@ export default async function ls(
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} dns ls${flags} --next ${pagination.next}`
+      `To display the next page run ${getCommandName(
+        `dns ls${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/dns/rm.ts
+++ b/packages/now-cli/src/commands/dns/rm.ts
@@ -8,7 +8,7 @@ import deleteDNSRecordById from '../../util/dns/delete-dns-record-by-id';
 import getDNSRecordById from '../../util/dns/get-dns-record-by-id';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -44,7 +44,7 @@ export default async function rm(
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} dns rm <id>`
+        `${getCommandName('dns rm <id>')}`
       )}`
     );
     return 1;

--- a/packages/now-cli/src/commands/domains/add.ts
+++ b/packages/now-cli/src/commands/domains/add.ts
@@ -12,7 +12,7 @@ import formatNSTable from '../../util/format-ns-table';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import param from '../../util/output/param';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName, getTitleName } from '../../util/pkg-name';
 
 type Options = {
   '--cdn': boolean;
@@ -48,13 +48,13 @@ export default async function add(
   }
 
   if (opts['--cdn'] !== undefined || opts['--no-cdn'] !== undefined) {
-    output.error(`Toggling CF from ${getPkgName()} CLI is deprecated.`);
+    output.error(`Toggling CF from ${getTitleName()} CLI is deprecated.`);
     return 1;
   }
 
   if (args.length !== 1) {
     output.error(
-      `${cmd(`${getPkgName()} domains add <domain>`)} expects one argument`
+      `${getCommandName('domains add <domain>')} expects one argument`
     );
     return 1;
   }
@@ -76,7 +76,7 @@ export default async function add(
     output.error(
       `You are adding '${domainName}' as a domain name containing a subdomain part '${subdomain}'\n` +
         `  This feature is deprecated, please add just the root domain: ${chalk.cyan(
-          `${getPkgName()} domain add ${domain}`
+          `${getCommandName(`domain add ${domain}`)}`
         )}`
     );
     return 1;
@@ -142,7 +142,7 @@ export default async function add(
     );
     output.print(
       `  If you want to force running a verification, you can run ${cmd(
-        `${getPkgName()} domains verify <domain>`
+        `${getCommandName('domains verify <domain>')}`
       )}\n`
     );
     output.print('  Read more: https://err.sh/now/domain-verification\n\n');

--- a/packages/now-cli/src/commands/domains/buy.ts
+++ b/packages/now-cli/src/commands/domains/buy.ts
@@ -5,7 +5,6 @@ import { NowContext } from '../../types';
 import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import getDomainPrice from '../../util/domains/get-domain-price';
 import getDomainStatus from '../../util/domains/get-domain-status';
 import getScope from '../../util/get-scope';
@@ -13,7 +12,7 @@ import param from '../../util/output/param';
 import promptBool from '../../util/input/prompt-bool';
 import purchaseDomain from '../../util/domains/purchase-domain';
 import stamp from '../../util/output/stamp';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -49,7 +48,7 @@ export default async function buy(
   const [domainName] = args;
   if (!domainName) {
     output.error(
-      `Missing domain name. Run ${cmd(`${getPkgName()} domains --help`)}`
+      `Missing domain name. Run ${getCommandName(`domains --help`)}`
     );
     return 1;
   }
@@ -63,8 +62,8 @@ export default async function buy(
   const { domain: rootDomain, subdomain } = parsedDomain;
   if (subdomain || !rootDomain) {
     output.error(
-      `Invalid domain name "${domainName}". Run ${cmd(
-        `${getPkgName()} domains --help`
+      `Invalid domain name "${domainName}". Run ${getCommandName(
+        `domains --help`
       )}`
     );
     return 1;
@@ -121,8 +120,8 @@ export default async function buy(
 
   if (buyResult instanceof ERRORS.SourceNotFound) {
     output.error(
-      `Could not purchase domain. Please add a payment method using ${cmd(
-        `${getPkgName()} billing add`
+      `Could not purchase domain. Please add a payment method using ${getCommandName(
+        `billing add`
       )}.`
     );
     return 1;
@@ -189,8 +188,8 @@ export default async function buy(
       );
     } else {
       output.note(
-        `You may now use your domain as an alias to your deployments. Run ${cmd(
-          `${getPkgName()} alias --help`
+        `You may now use your domain as an alias to your deployments. Run ${getCommandName(
+          `alias --help`
         )}`
       );
     }

--- a/packages/now-cli/src/commands/domains/inspect.ts
+++ b/packages/now-cli/src/commands/domains/inspect.ts
@@ -3,7 +3,6 @@ import { DomainNotFound, DomainPermissionDenied } from '../../util/errors-ts';
 import { NowContext } from '../../types';
 import { Output } from '../../util/output';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import stamp from '../../util/output/stamp';
 import dnsTable from '../../util/format-dns-table';
 import formatDate from '../../util/format-date';
@@ -11,7 +10,7 @@ import formatNSTable from '../../util/format-ns-table';
 import getDomainByName from '../../util/domains/get-domain-by-name';
 import getScope from '../../util/get-scope';
 import getDomainPrice from '../../util/domains/get-domain-price';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -50,7 +49,7 @@ export default async function inspect(
 
   if (!domainName) {
     output.error(
-      `${cmd(`${getPkgName()} domains inspect <domain>`)} expects one argument`
+      `${getCommandName(`domains inspect <domain>`)} expects one argument`
     );
     return 1;
   }
@@ -58,7 +57,7 @@ export default async function inspect(
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} domains inspect <domain>`
+        `${getCommandName('domains inspect <domain>')}`
       )}`
     );
     return 1;
@@ -75,7 +74,7 @@ export default async function inspect(
     output.error(
       `Domain not found by "${domainName}" under ${chalk.bold(contextName)}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -85,7 +84,7 @@ export default async function inspect(
         contextName
       )}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -172,8 +171,8 @@ export default async function inspect(
       `  We will run a verification for you and you will receive an email upon completion.\n`
     );
     output.print(
-      `  If you want to force running a verification, you can run ${cmd(
-        `${getPkgName()} domains verify <domain>`
+      `  If you want to force running a verification, you can run ${getCommandName(
+        `domains verify <domain>`
       )}\n`
     );
     output.print('  Read more: https://err.sh/now/domain-verification\n\n');

--- a/packages/now-cli/src/commands/domains/ls.ts
+++ b/packages/now-cli/src/commands/domains/ls.ts
@@ -10,8 +10,7 @@ import strlen from '../../util/strlen';
 import { Output } from '../../util/output';
 import { Domain, NowContext } from '../../types';
 import getCommandFlags from '../../util/get-command-flags';
-import cmd from '../../util/output/cmd';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -55,7 +54,7 @@ export default async function ls(
   if (args.length !== 0) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} domains ls`
+        `${getCommandName('domains ls')}`
       )}`
     );
     return 1;
@@ -76,8 +75,8 @@ export default async function ls(
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} domains ls${flags} --next ${pagination.next}`
+      `To display the next page run ${getCommandName(
+        `domains ls${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/domains/move.ts
+++ b/packages/now-cli/src/commands/domains/move.ts
@@ -5,7 +5,6 @@ import { NowContext, User, Team } from '../../types';
 import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import getScope from '../../util/get-scope';
 import withSpinner from '../../util/with-spinner';
 import moveOutDomain from '../../util/domains/move-out-domain';
@@ -16,7 +15,7 @@ import getDomainAliases from '../../util/alias/get-domain-aliases';
 import getDomainByName from '../../util/domains/get-domain-by-name';
 import promptBool from '../../util/input/prompt-bool';
 import getTeams from '../../util/get-teams';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -54,8 +53,8 @@ export default async function move(
   const { domainName, destination } = await getArgs(args);
   if (!isRootDomain(domainName)) {
     output.error(
-      `Invalid domain name "${domainName}". Run ${cmd(
-        `${getPkgName()} domains --help`
+      `Invalid domain name "${domainName}". Run ${getCommandName(
+        `domains --help`
       )}`
     );
     return 1;
@@ -64,7 +63,7 @@ export default async function move(
   const domain = await getDomainByName(client, contextName, domainName);
   if (domain instanceof ERRORS.DomainNotFound) {
     output.error(`Domain not found under ${chalk.bold(contextName)}`);
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
   if (domain instanceof ERRORS.DomainPermissionDenied) {
@@ -103,9 +102,7 @@ export default async function move(
       output.warn(
         `This domain's ${chalk.bold(
           plural('alias', aliases.length, true)
-        )} will be removed. Run ${chalk.dim(
-          `${getPkgName()} alias ls`
-        )} to list them.`
+        )} will be removed. Run ${getCommandName(`alias ls`)} to list them.`
       );
       if (
         !(await promptBool(
@@ -145,7 +142,7 @@ export default async function move(
   }
   if (moveTokenResult instanceof ERRORS.DomainNotFound) {
     output.error(`Domain not found under ${chalk.bold(contextName)}`);
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
   if (moveTokenResult instanceof ERRORS.DomainPermissionDenied) {

--- a/packages/now-cli/src/commands/domains/rm.ts
+++ b/packages/now-cli/src/commands/domains/rm.ts
@@ -5,7 +5,6 @@ import { DomainNotFound, DomainPermissionDenied } from '../../util/errors-ts';
 import { NowContext, Domain } from '../../types';
 import { Output } from '../../util/output';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import deleteCertById from '../../util/certs/delete-cert-by-id';
 import getDomainByName from '../../util/domains/get-domain-by-name';
 import getScope from '../../util/get-scope';
@@ -16,7 +15,7 @@ import * as ERRORS from '../../util/errors-ts';
 import param from '../../util/output/param';
 import promptBool from '../../util/input/prompt-bool';
 import setCustomSuffix from '../../util/domains/set-custom-suffix';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -53,7 +52,7 @@ export default async function rm(
 
   if (!domainName) {
     output.error(
-      `${cmd(`${getPkgName()} domains rm <domain>`)} expects one argument`
+      `${getCommandName(`domains rm <domain>`)} expects one argument`
     );
     return 1;
   }
@@ -61,7 +60,7 @@ export default async function rm(
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} domains rm <domain>`
+        `${getCommandName('domains rm <domain>')}`
       )}`
     );
     return 1;
@@ -72,7 +71,7 @@ export default async function rm(
     output.error(
       `Domain not found by "${domainName}" under ${chalk.bold(contextName)}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -82,7 +81,7 @@ export default async function rm(
         contextName
       )}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -149,7 +148,7 @@ async function removeDomain(
 
   if (removeResult instanceof ERRORS.DomainNotFound) {
     output.error(`Domain not found under ${chalk.bold(contextName)}`);
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -207,9 +206,7 @@ async function removeDomain(
       output.warn(
         `This domain's ${chalk.bold(
           plural('alias', aliases.length, true)
-        )} will be removed. Run ${chalk.dim(
-          `${getPkgName()} alias ls`
-        )} to list them.`
+        )} will be removed. Run ${getCommandName(`alias ls`)} to list them.`
       );
     }
 
@@ -217,9 +214,7 @@ async function removeDomain(
       output.warn(
         `This domain's ${chalk.bold(
           plural('certificate', certs.length, true)
-        )} will be removed. Run ${chalk.dim(
-          `${getPkgName()} cert ls`
-        )} to list them.`
+        )} will be removed. Run ${getCommandName(`cert ls`)} to list them.`
       );
     }
 

--- a/packages/now-cli/src/commands/domains/transfer-in.ts
+++ b/packages/now-cli/src/commands/domains/transfer-in.ts
@@ -4,7 +4,6 @@ import { NowContext } from '../../types';
 import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import getScope from '../../util/get-scope';
 import param from '../../util/output/param';
 import transferInDomain from '../../util/domains/transfer-in-domain';
@@ -15,7 +14,7 @@ import getDomainPrice from '../../util/domains/get-domain-price';
 import checkTransfer from '../../util/domains/check-transfer';
 import promptBool from '../../util/input/prompt-bool';
 import isRootDomain from '../../util/is-root-domain';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -52,15 +51,15 @@ export default async function transferIn(
   const [domainName] = args;
   if (!domainName) {
     output.error(
-      `Missing domain name. Run ${cmd(`${getPkgName()} domains --help`)}`
+      `Missing domain name. Run ${getCommandName(`domains --help`)}`
     );
     return 1;
   }
 
   if (!isRootDomain(domainName)) {
     output.error(
-      `Invalid domain name ${param(domainName)}. Run ${cmd(
-        `${getPkgName()} domains --help`
+      `Invalid domain name ${param(domainName)}. Run ${getCommandName(
+        `domains --help`
       )}`
     );
     return 1;
@@ -130,8 +129,8 @@ export default async function transferIn(
 
   if (transferInResult instanceof ERRORS.SourceNotFound) {
     output.error(
-      `Could not purchase domain. Please add a payment method using ${cmd(
-        `${getPkgName()} billing add`
+      `Could not purchase domain. Please add a payment method using ${getCommandName(
+        `billing add`
       )}.`
     );
     return 1;
@@ -161,7 +160,7 @@ export default async function transferIn(
   );
   output.print(`  Then import it to Vercel DNS by using:\n`);
   output.print(
-    `    ${cmd(`${getPkgName()} dns import ${domainName} <zonefile>`)}\n\n`
+    `    ${getCommandName(`dns import ${domainName} <zonefile>`)}\n\n`
   );
   return 0;
 }

--- a/packages/now-cli/src/commands/domains/verify.ts
+++ b/packages/now-cli/src/commands/domains/verify.ts
@@ -3,14 +3,13 @@ import { NowContext } from '../../types';
 import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
-import cmd from '../../util/output/cmd';
 import formatDnsTable from '../../util/format-dns-table';
 import formatNSTable from '../../util/format-ns-table';
 import getDomainByName from '../../util/domains/get-domain-by-name';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import verifyDomain from '../../util/domains/verify-domain';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -48,7 +47,7 @@ export default async function verify(
 
   if (!domainName) {
     output.error(
-      `${cmd(`${getPkgName()} domains verify <domain>`)} expects one argument`
+      `${getCommandName(`domains verify <domain>`)} expects one argument`
     );
     return 1;
   }
@@ -56,7 +55,7 @@ export default async function verify(
   if (args.length !== 1) {
     output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
-        `${getPkgName()} domains verify <domain>`
+        `${getCommandName('domains verify <domain>')}`
       )}`
     );
     return 1;
@@ -67,7 +66,7 @@ export default async function verify(
     output.error(
       `Domain not found by "${domainName}" under ${chalk.bold(contextName)}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -77,7 +76,7 @@ export default async function verify(
         contextName
       )}`
     );
-    output.log(`Run ${cmd(`${getPkgName()} domains ls`)} to see your domains.`);
+    output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
   }
 
@@ -114,8 +113,8 @@ export default async function verify(
       )}\n\n`
     );
     output.print(
-      `  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${cmd(
-        `${getPkgName()} domains verify <domain>`
+      `  Once your domain uses either the nameservers or the TXT DNS record from above, run again ${getCommandName(
+        `domains verify <domain>`
       )}.\n`
     );
     output.print(
@@ -140,8 +139,8 @@ export default async function verify(
     )} was verified using DNS TXT record. ${verifyStamp()}`
   );
   output.print(
-    `  You can verify with nameservers too. Run ${cmd(
-      `${getPkgName()} domains inspect ${domain.name}`
+    `  You can verify with nameservers too. Run ${getCommandName(
+      `domains inspect ${domain.name}`
     )} to find out the intended set.\n`
   );
   return 0;

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -12,12 +12,11 @@ import {
   getEnvTargetChoices,
 } from '../../util/env/env-target';
 import readStandardInput from '../../util/input/read-standard-input';
-import cmd from '../../util/output/cmd';
 import param from '../../util/output/param';
 import withSpinner from '../../util/with-spinner';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -35,8 +34,8 @@ export default async function add(
 
   if (args.length > 2) {
     output.error(
-      `Invalid number of arguments. Usage: ${cmd(
-        `${getPkgName()} env add <name> ${getEnvTargetPlaceholder()}`
+      `Invalid number of arguments. Usage: ${getCommandName(
+        `env add <name> ${getEnvTargetPlaceholder()}`
       )}`
     );
     return 1;
@@ -44,8 +43,8 @@ export default async function add(
 
   if (stdInput && (!envName || !envTarget)) {
     output.error(
-      `Invalid number of arguments. Usage: ${cmd(
-        `${getPkgName()} env add <name> <target> < <file>`
+      `Invalid number of arguments. Usage: ${getCommandName(
+        `env add <name> <target> < <file>`
       )}`
     );
     return 1;
@@ -88,8 +87,8 @@ export default async function add(
     output.error(
       `The variable ${param(
         envName
-      )} has already been added to all Environments. To remove, run ${cmd(
-        `${getPkgName()} env rm ${envName}`
+      )} has already been added to all Environments. To remove, run ${getCommandName(
+        `env rm ${envName}`
       )}.`
     );
     return 1;

--- a/packages/now-cli/src/commands/env/ls.ts
+++ b/packages/now-cli/src/commands/env/ls.ts
@@ -10,10 +10,9 @@ import {
   getEnvTargetPlaceholder,
 } from '../../util/env/env-target';
 import stamp from '../../util/output/stamp';
-import cmd from '../../util/output/cmd';
 import param from '../../util/output/param';
 import getCommandFlags from '../../util/get-command-flags';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -31,8 +30,8 @@ export default async function ls(
 
   if (args.length > 1) {
     output.error(
-      `Invalid number of arguments. Usage: ${cmd(
-        `${getPkgName()} env ls ${getEnvTargetPlaceholder()}`
+      `Invalid number of arguments. Usage: ${getCommandName(
+        `env ls ${getEnvTargetPlaceholder()}`
       )}`
     );
     return 1;
@@ -75,8 +74,8 @@ export default async function ls(
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(opts, ['_', '--next']);
     output.log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} env ls${flags} --next ${pagination.next}`
+      `To display the next page run ${getCommandName(
+        `env ls${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/env/pull.ts
+++ b/packages/now-cli/src/commands/env/pull.ts
@@ -6,13 +6,12 @@ import Client from '../../util/client';
 import stamp from '../../util/output/stamp';
 import getEnvVariables from '../../util/env/get-env-records';
 import getDecryptedSecret from '../../util/env/get-decrypted-secret';
-import cmd from '../../util/output/cmd';
 import param from '../../util/output/param';
 import withSpinner from '../../util/with-spinner';
 import { join } from 'path';
 import { promises, existsSync } from 'fs';
 import { emoji, prependEmoji } from '../../util/emoji';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 const { writeFile } = promises;
 
 type Options = {
@@ -29,9 +28,7 @@ export default async function pull(
 ) {
   if (args.length > 1) {
     output.error(
-      `Invalid number of arguments. Usage: ${cmd(
-        `${getPkgName()} env pull <file>`
-      )}`
+      `Invalid number of arguments. Usage: ${getCommandName(`env pull <file>`)}`
     );
     return 1;
   }

--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -12,12 +12,11 @@ import {
 } from '../../util/env/env-target';
 import Client from '../../util/client';
 import stamp from '../../util/output/stamp';
-import cmd from '../../util/output/cmd';
 import param from '../../util/output/param';
 import withSpinner from '../../util/with-spinner';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -33,8 +32,8 @@ export default async function rm(
 ) {
   if (args.length > 2) {
     output.error(
-      `Invalid number of arguments. Usage: ${cmd(
-        `${getPkgName()} env rm <name> ${getEnvTargetPlaceholder()}`
+      `Invalid number of arguments. Usage: ${getCommandName(
+        `env rm <name> ${getEnvTargetPlaceholder()}`
       )}`
     );
     return 1;

--- a/packages/now-cli/src/commands/init/init.ts
+++ b/packages/now-cli/src/commands/init/init.ts
@@ -15,7 +15,7 @@ import success from '../../util/output/success';
 import info from '../../util/output/info';
 import cmd from '../../util/output/cmd';
 import didYouMean from '../../util/init/did-you-mean';
-import { getPkgName } from '../../util/pkg-name';
+import { getCommandName } from '../../util/pkg-name';
 
 type Options = {
   '--debug': boolean;
@@ -153,11 +153,11 @@ async function extractExample(
       const folderRel = path.relative(process.cwd(), folder);
       const deployHint =
         folderRel === ''
-          ? listItem(`To deploy, run ${cmd(getPkgName())}.`)
+          ? listItem(`To deploy, run ${getCommandName()}.`)
           : listItem(
-              `To deploy, ${cmd(`cd ${folderRel}`)} and run ${cmd(
-                getPkgName()
-              )}.`
+              `To deploy, ${cmd(
+                `cd ${folderRel}`
+              )} and run ${getCommandName()}.`
             );
       console.log(success(`${successLog}\n${deployHint}`));
       return 0;
@@ -207,8 +207,8 @@ function prepareFolder(cwd: string, folder: string, force?: boolean) {
  */
 async function guess(exampleList: string[], name: string) {
   const GuessError = new Error(
-    `No example found for ${chalk.bold(name)}, run ${cmd(
-      `${getPkgName()} init`
+    `No example found for ${chalk.bold(name)}, run ${getCommandName(
+      `init`
     )} to see the list of available examples.`
   );
 

--- a/packages/now-cli/src/commands/inspect.js
+++ b/packages/now-cli/src/commands/inspect.js
@@ -4,7 +4,6 @@ import getArgs from '../util/get-args';
 import buildsList from '../util/output/builds';
 import routesList from '../util/output/routes';
 import indent from '../util/output/indent';
-import cmd from '../util/output/cmd.ts';
 import createOutput from '../util/output';
 import Now from '../util';
 import logo from '../util/output/logo';
@@ -13,7 +12,7 @@ import { handleError } from '../util/error';
 import strlen from '../util/strlen.ts';
 import Client from '../util/client.ts';
 import getScope from '../util/get-scope.ts';
-import { getPkgName } from '../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const STATIC = 'STATIC';
 
@@ -74,9 +73,7 @@ export default async function main(ctx) {
   id = argv._[1];
 
   if (argv._.length !== 2) {
-    error(
-      `${cmd(`${getPkgName()} inspect <url>`)} expects exactly one argument`
-    );
+    error(`${getCommandName('inspect <url>')} expects exactly one argument`);
     help();
     return 1;
   }

--- a/packages/now-cli/src/commands/list.js
+++ b/packages/now-cli/src/commands/list.js
@@ -18,7 +18,7 @@ import toHost from '../util/to-host';
 import parseMeta from '../util/parse-meta';
 import { isValidName } from '../util/is-valid-name';
 import getCommandFlags from '../util/get-command-flags';
-import { getPkgName } from '../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const help = () => {
   console.log(`
@@ -98,7 +98,7 @@ export default async function main(ctx) {
   });
 
   if (argv._.length > 2) {
-    error(`${cmd(`${getPkgName()} ls [app]`)} accepts at most one argument`);
+    error(`${getCommandName('ls [app]')} accepts at most one argument`);
     return 1;
   }
 
@@ -166,7 +166,9 @@ export default async function main(ctx) {
   const asHost = app ? toHost(app) : '';
   if (asHost.endsWith('.now.sh') || asHost.endsWith('.vercel.app')) {
     note(
-      `We suggest using \`${getPkgName()} inspect <deployment>\` for retrieving details about a single deployment`
+      `We suggest using ${getCommandName(
+        'inspect <deployment>'
+      )} for retrieving details about a single deployment`
     );
 
     const hostParts = asHost.split('-');
@@ -234,9 +236,7 @@ export default async function main(ctx) {
         now.close();
         stopSpinner();
         log(`Found matching path alias: ${chalk.cyan(item.alias)}`);
-        log(
-          `Please run ${cmd(`${getPkgName()} alias ls ${item.alias}`)} instead`
-        );
+        log(`Please run ${getCommandName(`alias ls ${item.alias}`)} instead`);
         return 0;
       }
 
@@ -287,13 +287,13 @@ export default async function main(ctx) {
   if (app == null) {
     log(
       `To list more deployments for a project run ${cmd(
-        `${getPkgName()} ls [project]`
+        `${getCommandName('ls [project]')}`
       )}`
     );
   } else if (!argv['--all']) {
     log(
       `To list deployment instances run ${cmd(
-        `${getPkgName()} ls --all [project]`
+        `${getCommandName('ls --all [project]')}`
       )}`
     );
   }
@@ -348,10 +348,8 @@ export default async function main(ctx) {
   if (pagination && pagination.count === 20) {
     const flags = getCommandFlags(argv, ['_', '--next']);
     log(
-      `To display the next page run ${cmd(
-        `${getPkgName()} ls${app ? ' ' + app : ''}${flags} --next ${
-          pagination.next
-        }`
+      `To display the next page run ${getCommandName(
+        `ls${app ? ' ' + app : ''}${flags} --next ${pagination.next}`
       )}`
     );
   }

--- a/packages/now-cli/src/commands/login.js
+++ b/packages/now-cli/src/commands/login.js
@@ -10,7 +10,6 @@ import getArgs from '../util/get-args';
 import error from '../util/output/error';
 import highlight from '../util/output/highlight';
 import ok from '../util/output/ok';
-import cmd from '../util/output/cmd.ts';
 import param from '../util/output/param.ts';
 import eraseLines from '../util/output/erase-lines';
 import sleep from '../util/sleep';
@@ -115,8 +114,8 @@ const readEmail = async () => {
     if (err.message === 'stdin lacks setRawMode support') {
       throw new Error(
         error(
-          `Interactive mode not supported – please run ${cmd(
-            `${getPkgName()} login you@domain.com`
+          `Interactive mode not supported – please run ${getCommandName(
+            `login you@domain.com`
           )}`
         )
       );

--- a/packages/now-cli/src/commands/projects.js
+++ b/packages/now-cli/src/commands/projects.js
@@ -10,10 +10,9 @@ import logo from '../util/output/logo';
 import getScope from '../util/get-scope';
 import createOutput from '../util/output';
 import getCommandFlags from '../util/get-command-flags';
-import cmd from '../util/output/cmd.ts';
 import wait from '../util/output/wait';
 import getPrefixedFlags from '../util/get-prefixed-flags';
-import { getPkgName } from '../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const e = encodeURIComponent;
 
@@ -123,7 +122,7 @@ async function run({ client, contextName }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} projects ls`
+            `${getCommandName('projects ls')}`
           )}`
         )
       );
@@ -184,10 +183,8 @@ async function run({ client, contextName }) {
           '-d',
           '-y',
         ]);
-        const nextCmd = `${getPkgName()} projects ls${flags} --next ${
-          pagination.next
-        }`;
-        console.log(`To display the next page run ${cmd(nextCmd)}`);
+        const nextCmd = `projects ls${flags} --next ${pagination.next}`;
+        console.log(`To display the next page run ${getCommandName(nextCmd)}`);
       }
     }
     return;
@@ -198,7 +195,7 @@ async function run({ client, contextName }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} project rm <name>`
+            `${getCommandName('project rm <name>')}`
           )}`
         )
       );
@@ -240,14 +237,14 @@ async function run({ client, contextName }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} projects add <name>`
+            `${getCommandName('projects add <name>')}`
           )}`
         )
       );
 
       if (args.length > 1) {
         const example = chalk.cyan(
-          `$ ${getPkgName()} projects add "${args.join(' ')}"`
+          `${getCommandName(`projects add "${args.join(' ')}"`)}`
         );
         console.log(
           `> If your project name  has spaces, make sure to wrap it in quotes. Example: \n  ${example} `

--- a/packages/now-cli/src/commands/remove.js
+++ b/packages/now-cli/src/commands/remove.js
@@ -7,7 +7,6 @@ import Now from '../util';
 import getAliases from '../util/alias/get-aliases';
 import createOutput from '../util/output';
 import logo from '../util/output/logo';
-import cmd from '../util/output/cmd.ts';
 import elapsed from '../util/output/elapsed.ts';
 import { normalizeURL } from '../util/url';
 import Client from '../util/client.ts';
@@ -18,7 +17,7 @@ import removeProject from '../util/projects/remove-project';
 import getProjectByIdOrName from '../util/projects/get-project-by-id-or-name';
 import getDeploymentByIdOrHost from '../util/deploy/get-deployment-by-id-or-host';
 import getDeploymentsByProjectId from '../util/deploy/get-deployments-by-project-id';
-import { getPkgName } from '../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const help = () => {
   console.log(`
@@ -94,7 +93,7 @@ export default async function main(ctx) {
   }
 
   if (ids.length < 1) {
-    error(`${cmd(`${getPkgName()} rm`)} expects at least one argument`);
+    error(`${getCommandName('rm')} expects at least one argument`);
     help();
     return 1;
   }
@@ -215,9 +214,9 @@ export default async function main(ctx) {
     log(
       `Could not find ${argv.safe ? 'unaliased' : 'any'} deployments ` +
         `or projects matching ` +
-        `${ids.map(id => chalk.bold(`"${id}"`)).join(', ')}. Run ${cmd(
-          `${getPkgName()} ls`
-        )} to list.`
+        `${ids
+          .map(id => chalk.bold(`"${id}"`))
+          .join(', ')}. Run ${getCommandName('ls')} to list.`
     );
     client.close();
     return 1;

--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -12,9 +12,8 @@ import getScope from '../util/get-scope.ts';
 import createOutput from '../util/output';
 import confirm from '../util/input/confirm';
 import getCommandFlags from '../util/get-command-flags';
-import cmd from '../util/output/cmd.ts';
 import getPrefixedFlags from '../util/get-prefixed-flags';
-import { getPkgName } from '../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const help = () => {
   console.log(`
@@ -149,7 +148,7 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} secret ls`
+            `${getCommandName('secret ls')}`
           )}`
         )
       );
@@ -197,10 +196,8 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
         '-d',
         '-y',
       ]);
-      const nextCmd = `${getPkgName()} secrets ${subcommand}${flags} --next ${
-        pagination.next
-      }`;
-      output.log(`To display the next page run ${cmd(nextCmd)}`);
+      const nextCmd = `secrets ${subcommand}${flags} --next ${pagination.next}`;
+      output.log(`To display the next page run ${getCommandName(nextCmd)}`);
     }
     return secrets.close();
   }
@@ -210,7 +207,7 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} secret rm <name>`
+            `${getCommandName('secret rm <name>')}`
           )}`
         )
       );
@@ -252,7 +249,7 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} secret rename <old-name> <new-name>`
+            `${getCommandName('secret rename <old-name> <new-name>')}`
           )}`
         )
       );
@@ -275,14 +272,14 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
       console.error(
         error(
           `Invalid number of arguments. Usage: ${chalk.cyan(
-            `${getPkgName()} secret add <name> <value>`
+            `${getCommandName('secret add <name> <value>')}`
           )}`
         )
       );
 
       if (args.length > 2) {
         const example = chalk.cyan(
-          `$ ${getPkgName()} secret add -- "${args[0]}"`
+          `$ ${getCommandName('secret add -- "${args[0]}"')}`
         );
         console.log(
           `If your secret has spaces or starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
@@ -307,7 +304,9 @@ async function run({ output, token, contextName, currentTeam, ctx }) {
     }
 
     if (typeof value === 'boolean') {
-      const example = chalk.cyan(`$ ${getPkgName()} secret add -- "${name}"`);
+      const example = chalk.cyan(
+        `$ ${getCommandName('secret add -- "${name}"')}`
+      );
       console.log(
         `If your secret starts with '-', make sure to terminate command options with double dash and wrap it in quotes. Example: \n  ${example} `
       );

--- a/packages/now-cli/src/commands/teams/add.js
+++ b/packages/now-cli/src/commands/teams/add.js
@@ -7,12 +7,11 @@ import rightPad from '../../util/output/right-pad';
 import eraseLines from '../../util/output/erase-lines';
 import chars from '../../util/output/chars';
 import success from '../../util/output/success';
-import cmd from '../../util/output/cmd.ts';
 import note from '../../util/output/note';
 import textInput from '../../util/input/text';
 import invite from './invite';
 import { writeToConfigFile } from '../../util/config/files';
-import { getPkgName } from '../../util/pkg-name.ts';
+import { getPkgName, getCommandName } from '../../util/pkg-name.ts';
 
 const validateSlugKeypress = (data, value) =>
   // TODO: the `value` here should contain the current value + the keypress
@@ -27,8 +26,8 @@ const validateNameKeypress = (data, value) =>
 const gracefulExit = () => {
   console.log(); // Blank line
   note(
-    `Your team is now active for all ${getPkgName()} commands!\n  Run ${cmd(
-      `${getPkgName()} switch`
+    `Your team is now active for all ${getPkgName()} commands!\n  Run ${getCommandName(
+      `switch`
     )} to change it in the future.`
   );
   return 0;
@@ -152,8 +151,8 @@ export default async function({ apiUrl, token, teams, config }) {
     apiUrl,
     config,
     introMsg: 'Invite your teammates! When done, press enter on an empty field',
-    noopMsg: `You can invite teammates later by running ${cmd(
-      `${getPkgName()} teams invite`
+    noopMsg: `You can invite teammates later by running ${getCommandName(
+      `teams invite`
     )}`,
   });
 

--- a/packages/now-cli/src/commands/teams/invite.js
+++ b/packages/now-cli/src/commands/teams/invite.js
@@ -14,7 +14,7 @@ import eraseLines from '../../util/output/erase-lines';
 import success from '../../util/output/success';
 import getUser from '../../util/get-user.ts';
 import Client from '../../util/client.ts';
-import { getPkgName } from '../../util/pkg-name.ts';
+import { getCommandName } from '../../util/pkg-name.ts';
 
 const validateEmail = data => regexEmail.test(data.trim()) || data.length === 0;
 
@@ -97,8 +97,8 @@ export default async function({
     // We specifically need a team scope here
     let err = `You can't run this command under ${param(
       user.username || user.email
-    )}.\nPlease select a team scope using ${cmd(
-      `${getPkgName()} switch`
+    )}.\nPlease select a team scope using ${getCommandName(
+      `switch`
     )} or use ${cmd('--scope')}`;
     return fatalError(err);
   }

--- a/packages/now-cli/src/commands/update.ts
+++ b/packages/now-cli/src/commands/update.ts
@@ -7,7 +7,7 @@ import getArgs from '../util/get-args';
 import { NowContext } from '../types';
 import createOutput from '../util/output';
 import getUpdateCommand from '../util/get-update-command';
-import { getPkgName } from '../util/pkg-name';
+import { getPkgName, getTitleName } from '../util/pkg-name';
 
 const help = () => {
   console.log(`
@@ -27,7 +27,7 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Update ${getPkgName()} CLI to the latest "canary" version
+  ${chalk.gray('–')} Update ${getTitleName()} CLI to the latest "canary" version
 
       ${chalk.cyan(`$ ${getPkgName()} update --channel=canary`)}
   `);
@@ -58,7 +58,9 @@ export default async function main(ctx: NowContext): Promise<number> {
   const debugEnabled = argv['--debug'];
   const output = createOutput({ debug: debugEnabled });
   output.log(
-    `Please run ${cmd(await getUpdateCommand())} to update ${getPkgName()} CLI`
+    `Please run ${cmd(
+      await getUpdateCommand()
+    )} to update ${getTitleName()} CLI`
   );
   return 0;
 }

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -48,7 +48,7 @@ import { NowError } from './util/now-error';
 import { SENTRY_DSN } from './util/constants.ts';
 import getUpdateCommand from './util/get-update-command';
 import { metrics, shouldCollectMetrics } from './util/metrics.ts';
-import { getPkgName } from './util/pkg-name.ts';
+import { getCommandName, getTitleName } from './util/pkg-name.ts';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -151,7 +151,7 @@ const main = async argv_ => {
         `${chalk.bgRed('UPDATE AVAILABLE')} ` +
           `Run ${cmd(
             await getUpdateCommand()
-          )} to install ${getPkgName()} CLI ${update.latest}`
+          )} to install ${getTitleName()} CLI ${update.latest}`
       )
     );
 
@@ -164,7 +164,7 @@ const main = async argv_ => {
 
   output.print(
     `${chalk.grey(
-      `${getPkgName()} CLI ${pkg.version}${
+      `${getTitleName()} CLI ${pkg.version}${
         targetOrSubcommand === 'dev' ? ' dev (beta)' : ''
       }${
         pkg.version.includes('canary') || targetOrSubcommand === 'dev'
@@ -322,7 +322,9 @@ const main = async argv_ => {
       console.error(
         error(
           `The content of "${hp(VERCEL_AUTH_CONFIG_PATH)}" is invalid. ` +
-            `No \`token\` property found inside. Run \`${getPkgName()} login\` to authorize.`
+            `No \`token\` property found inside. Run ${getCommandName(
+              'login'
+            )} to authorize.`
         )
       );
       return 1;
@@ -464,7 +466,7 @@ const main = async argv_ => {
         error({
           message:
             'No existing credentials found. Please run ' +
-            `${param(`${getPkgName()} login`)} or pass ${param('--token')}`,
+            `${getCommandName('login')} or pass ${param('--token')}`,
           slug: 'no-credentials-found',
         })
       );

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1,10 +1,8 @@
 import bytes from 'bytes';
 import { Response } from 'node-fetch';
 import { NowError } from './now-error';
-import param from './output/param';
-import cmd from './output/cmd';
 import code from './output/code';
-import { getPkgName } from './pkg-name';
+import { getCommandName } from './pkg-name';
 
 /**
  * This error is thrown when there is an API error with a payload. The error
@@ -52,8 +50,8 @@ export class TeamDeleted extends NowError<'TEAM_DELETED', {}> {
   constructor() {
     super({
       code: 'TEAM_DELETED',
-      message: `Your team was deleted. You can switch to a different one using ${param(
-        `${getPkgName()} switch`
+      message: `Your team was deleted. You can switch to a different one using ${getCommandName(
+        `switch`
       )}.`,
       meta: {},
     });
@@ -143,8 +141,8 @@ export class SourceNotFound extends NowError<'SOURCE_NOT_FOUND', {}> {
     super({
       code: 'SOURCE_NOT_FOUND',
       meta: {},
-      message: `Not able to purchase. Please add a payment method using ${cmd(
-        `${getPkgName()} billing add`
+      message: `Not able to purchase. Please add a payment method using ${getCommandName(
+        `billing add`
       )}.`,
     });
   }

--- a/packages/now-cli/src/util/pkg-name.ts
+++ b/packages/now-cli/src/util/pkg-name.ts
@@ -1,13 +1,36 @@
+// @ts-ignore
+import title from 'title';
+
 import pkg from './pkg';
 import cmd from './output/cmd';
 
+/**
+ * Returns the package name such as `vercel` or `now`.
+ */
 export function getPkgName(): string {
   if (!pkg.name) {
-    throw new Error('Expected package.json to have a `name` property.');
+    throw new Error('Expected `package.json` to have a `name` property.');
   }
   return pkg.name;
 }
 
-export function getCommandName() {
-  return cmd(getPkgName());
+/**
+ * Returns the package name with title-case
+ * such as `Vercel` or `Now`.
+ */
+export function getTitleName(): string {
+  const str = getPkgName();
+  return title(str);
+}
+
+/**
+ * Returns the package name with subcommand(s)
+ * as a suffix such as `vercel env pull` or `now env pull`.
+ */
+export function getCommandName(subcommands?: string): string {
+  let vercel = getPkgName();
+  if (subcommands) {
+    vercel = `${vercel} ${subcommands}`;
+  }
+  return cmd(vercel);
 }

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -246,16 +246,7 @@ function testFixtureStdio(
       const gitignoreOrig = await fs.exists(gitignore);
       let { stdout, stderr, exitCode } = await execa(
         binaryPath,
-        [
-          '-t',
-          token,
-          '--confirm',
-          '--public',
-          '--no-clipboard',
-          '--debug',
-          '-b',
-          'FORCE_BUILD_IN_REGION=bru1',
-        ],
+        ['-t', token, '--confirm', '--public', '--no-clipboard', '--debug'],
         { cwd, reject: false }
       );
       console.log({ stdout, stderr, exitCode });

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -246,7 +246,16 @@ function testFixtureStdio(
       const gitignoreOrig = await fs.exists(gitignore);
       let { stdout, stderr, exitCode } = await execa(
         binaryPath,
-        ['-t', token, '--confirm', '--public', '--no-clipboard', '--debug'],
+        [
+          '-t',
+          token,
+          '--confirm',
+          '--public',
+          '--no-clipboard',
+          '--debug',
+          '-b',
+          'FORCE_BUILD_IN_REGION=bru1',
+        ],
         { cwd, reject: false }
       );
       console.log({ stdout, stderr, exitCode });


### PR DESCRIPTION
This PR adds two functions:

* `getTitleName()` - used to get the uppercase Vercel or Now package name, for example `vercel --version`
* `getCommandName()` - used to get the `vercel` command followed by subcommands, for example in error suggestions