### PR TITLE
[now-cli] Change precedence of auth directory

### DIFF
--- a/packages/now-cli/src/util/config/global-path.ts
+++ b/packages/now-cli/src/util/config/global-path.ts
@@ -32,8 +32,8 @@ const getGlobalPathConfig = (): string => {
 
   const possibleConfigPaths = [
     ...vercelDirectories, // latest vercel directory
-    ...XDGAppPaths('now').dataDirs(), // legacy now directory
-    path.join(homedir(), '.now'), // legacy config in user's home directory.
+    path.join(homedir(), '.now'), // legacy config in user's home directory
+    ...XDGAppPaths('now').dataDirs(), // legacy XDG directory
   ];
 
   // The customPath flag is the preferred location,


### PR DESCRIPTION
The XDG directory was used by other applications, perhaps Now Desktop, so we need to give the home directory precedence over the old now XDG directory. The vercel directory will remain the highest precedence. 