### PR TITLE
[now-cli] Fix update Changelog URL

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -157,7 +157,7 @@ const main = async argv_ => {
 
     console.log(
       info(
-        `Changelog: https://github.com/zeit/now/releases/tag/now@${update.latest}`
+        `Changelog: https://github.com/zeit/now/releases/tag/vercel@${update.latest}`
       )
     );
   }


### PR DESCRIPTION
Incorrect URL: https://github.com/zeit/now/releases/tag/now@19.0.0

Correct URL: https://github.com/zeit/now/releases/tag/vercel@19.0.0