### PR TITLE
[now-cli] Update `now env add` to skip value if system var

### DIFF
--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -96,7 +96,9 @@ export default async function add(
 
   let envValue: string;
 
-  if (stdInput) {
+  if (isSystemEnvVariable(envName)) {
+    envValue = '';
+  } else if (stdInput) {
     envValue = stdInput;
   } else {
     const { inputValue } = await inquirer.prompt({
@@ -145,4 +147,8 @@ export default async function add(
   );
 
   return 0;
+}
+
+function isSystemEnvVariable(envName: string) {
+  return envName.startsWith('VERCEL_') || envName.startsWith('NOW_');
 }

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -150,5 +150,5 @@ export default async function add(
 }
 
 function isSystemEnvVariable(envName: string) {
-  return envName.startsWith('VERCEL_') || envName.startsWith('NOW_');
+  return envName.startsWith('VERCEL_');
 }

--- a/packages/now-cli/src/commands/env/add.ts
+++ b/packages/now-cli/src/commands/env/add.ts
@@ -96,10 +96,10 @@ export default async function add(
 
   let envValue: string;
 
-  if (isSystemEnvVariable(envName)) {
-    envValue = '';
-  } else if (stdInput) {
+  if (stdInput) {
     envValue = stdInput;
+  } else if (isSystemEnvVariable(envName)) {
+    envValue = '';
   } else {
     const { inputValue } = await inquirer.prompt({
       type: 'password',

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -410,6 +410,28 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
   }
 
+  async function nowEnvAddSystemEnv() {
+    const now = execa(
+      binaryPath,
+      ['env', 'add', 'VERCEL_URL', ...defaultArgs],
+      {
+        reject: false,
+        cwd: target,
+      }
+    );
+
+    await waitForPrompt(
+      now,
+      chunk =>
+        chunk.includes('which Environments') && chunk.includes('VERCEL_URL')
+    );
+    now.stdin.write('a\n'); // select all
+
+    const { exitCode, stderr, stdout } = await now;
+
+    t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+  }
+
   async function nowEnvLsIncludesVar() {
     const { exitCode, stderr, stdout } = await execa(
       binaryPath,
@@ -434,6 +456,12 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     const myStdinVars = lines.filter(line => line.includes('MY_STDIN_VAR'));
     t.is(myStdinVars.length, 1);
     t.regex(myStdinVars.join('\n'), /preview/gm);
+
+    const vercelVars = lines.filter(line => line.includes('VERCEL_URL'));
+    t.is(vercelVars.length, 3);
+    t.regex(vercelVars.join('\n'), /development/gm);
+    t.regex(vercelVars.join('\n'), /preview/gm);
+    t.regex(vercelVars.join('\n'), /production/gm);
   }
 
   async function nowEnvPull() {
@@ -450,7 +478,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     t.regex(stderr, /Created .env file/gm);
 
     const contents = fs.readFileSync(path.join(target, '.env'), 'utf8');
-    t.is(contents, 'MY_ENV_VAR="MY_VALUE"\n');
+    t.is(contents, 'MY_ENV_VAR="MY_VALUE"\nVERCEL_URL=""\n');
   }
 
   async function nowDeployWithVar() {
@@ -472,6 +500,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     const apiJson = await apiRes.json();
     t.is(apiJson['MY_ENV_VAR'], 'MY_VALUE');
     t.is(apiJson['MY_STDIN_VAR'], 'MY_STDIN_VALUE');
+    t.is(apiJson['VERCEL_URL'], host);
 
     const homeUrl = `https://${host}`;
     console.log({ homeUrl });
@@ -480,6 +509,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     const homeJson = await homeRes.json();
     t.is(homeJson['MY_ENV_VAR'], 'MY_VALUE');
     t.is(homeJson['MY_STDIN_VAR'], 'MY_STDIN_VALUE');
+    t.is(apiJson['VERCEL_URL'], host);
   }
 
   async function nowEnvRemove() {
@@ -521,6 +551,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowEnvLsIsEmpty();
   await nowEnvAdd();
   await nowEnvAddFromStdin();
+  await nowEnvAddSystemEnv();
   await nowEnvLsIncludesVar();
   await nowEnvPull();
   await nowDeployWithVar();

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -478,7 +478,9 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     t.regex(stderr, /Created .env file/gm);
 
     const contents = fs.readFileSync(path.join(target, '.env'), 'utf8');
-    t.is(contents, 'MY_ENV_VAR="MY_VALUE"\nVERCEL_URL=""\n');
+    const lines = new Set(contents.split('\n'));
+    t.true(lines.has('MY_ENV_VAR="MY_VALUE"'));
+    t.true(lines.has('VERCEL_URL=""'));
   }
 
   async function nowDeployWithVar() {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -25,7 +25,7 @@ import { fetchTokenWithRetry } from '../../../test/lib/deployment/now-deploy';
 
 // log command when running `execa`
 function execa(file, args, options) {
-  console.log(`$ now ${args.join(' ')}`);
+  console.log(`$ vercel ${args.join(' ')}`);
   return _execa(file, args, options);
 }
 
@@ -550,22 +550,23 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   }
 
   async function nowEnvRemoveWithNameOnly() {
-    const now = execa(binaryPath, ['env', 'rm', 'VERCEL_URL', ...defaultArgs], {
-      reject: false,
-      cwd: target,
-    });
+    const vc = execa(
+      binaryPath,
+      ['env', 'rm', 'VERCEL_URL', '-y', ...defaultArgs],
+      {
+        reject: false,
+        cwd: target,
+      }
+    );
 
     await waitForPrompt(
-      now,
+      vc,
       chunk =>
         chunk.includes('which Environments') && chunk.includes('VERCEL_URL')
     );
-    now.stdin.write('a\n'); // select all
+    vc.stdin.write('a\n'); // select all
 
-    await waitForPrompt(now, chunk => chunk.includes('you sure?'));
-    now.stdin.write('y\n'); // yes
-
-    const { exitCode, stderr, stdout } = await now;
+    const { exitCode, stderr, stdout } = await vc;
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
   }
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -549,6 +549,26 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
     t.is(exitCode, 0, formatOutput({ stderr, stdout }));
   }
 
+  async function nowEnvRemoveWithNameOnly() {
+    const now = execa(binaryPath, ['env', 'rm', 'VERCEL_URL', ...defaultArgs], {
+      reject: false,
+      cwd: target,
+    });
+
+    await waitForPrompt(
+      now,
+      chunk =>
+        chunk.includes('which Environments') && chunk.includes('VERCEL_URL')
+    );
+    now.stdin.write('a\n'); // select all
+
+    await waitForPrompt(now, chunk => chunk.includes('you sure?'));
+    now.stdin.write('y\n'); // yes
+
+    const { exitCode, stderr, stdout } = await now;
+    t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+  }
+
   await nowDeploy();
   await nowEnvLsIsEmpty();
   await nowEnvAdd();
@@ -559,6 +579,7 @@ test('Deploy `api-env` fixture and test `now env` command', async t => {
   await nowDeployWithVar();
   await nowEnvRemove();
   await nowEnvRemoveWithArgs();
+  await nowEnvRemoveWithNameOnly();
   await nowEnvLsIsEmpty();
 });
 


### PR DESCRIPTION
This PR updates the CLI to work the same as the dashboard and skip the env var value if the name indicates that it is a [System Environment Variables](https://vercel.com/docs/v2/build-step#system-environment-variables).