### PR TITLE
[build-utils] Make `getPlatformEnv()` throw if both NOW_ and VERCEL_ are defined

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -102,7 +102,20 @@ export const isStaticRuntime = (name?: string): boolean => {
 
 /**
  * Helper function to support both `VERCEL_` and legacy `NOW_` env vars.
+ * Throws an error if *both* env vars are defined.
  */
 export const getPlatformEnv = (name: string): string | undefined => {
-  return process.env[`VERCEL_${name}`] || process.env[`NOW_${name}`];
+  const vName = `VERCEL_${name}`;
+  const nName = `NOW_${name}`;
+  const v = process.env[vName];
+  const n = process.env[nName];
+  if (typeof v === 'string') {
+    if (typeof n === 'string') {
+      throw new Error(
+        `Both "${vName}" and "${nName}" env vars are defined. Please only define the "${vName}" env var`
+      );
+    }
+    return v;
+  }
+  return n;
 };

--- a/packages/now-build-utils/test/unit.get-platform-env.test.ts
+++ b/packages/now-build-utils/test/unit.get-platform-env.test.ts
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import { getPlatformEnv } from '../src';
+
+describe('Test `getPlatformEnv()`', () => {
+  it('should support `VERCEL_` prefix', () => {
+    try {
+      assert.equal(undefined, getPlatformEnv('FOO'));
+
+      process.env.VERCEL_FOO = 'bar';
+      assert.equal('bar', getPlatformEnv('FOO'));
+    } finally {
+      delete process.env.VERCEL_FOO;
+    }
+  });
+
+  it('should support `NOW_` prefix', () => {
+    try {
+      assert.equal(undefined, getPlatformEnv('FOO'));
+
+      process.env.NOW_FOO = 'bar';
+      assert.equal('bar', getPlatformEnv('FOO'));
+    } finally {
+      delete process.env.NOW_FOO;
+    }
+  });
+
+  it('should throw an error if both env vars exist', () => {
+    let err: Error | null = null;
+    try {
+      process.env.NOW_FOO = 'bar';
+      process.env.VERCEL_FOO = 'baz';
+      getPlatformEnv('FOO');
+    } catch (_err) {
+      err = _err;
+    } finally {
+      delete process.env.NOW_FOO;
+      delete process.env.VERCEL_FOO;
+    }
+    assert(err);
+    assert.equal(
+      err!.message,
+      'Both "VERCEL_FOO" and "NOW_FOO" env vars are defined. Please only define the "VERCEL_FOO" env var'
+    );
+  });
+});


### PR DESCRIPTION
Also adds unit tests.