### PR TITLE
[all] Fix runtimes to work with old versions of CLI

### DIFF
--- a/packages/now-go/build-utils.ts
+++ b/packages/now-go/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-go/build.sh
+++ b/packages/now-go/build.sh
@@ -1,4 +1,4 @@
-ncc build index.ts -e @vercel/build-utils -o dist
-ncc build install.ts -e @vercel/build-utils -o dist/install
+ncc build index.ts -e @vercel/build-utils -e @now/build-utils -o dist
+ncc build install.ts -e @vercel/build-utils -e @now/build-utils -o dist/install
 mv dist/install/index.js dist/install.js
 rm -rf dist/install

--- a/packages/now-go/go-helpers.ts
+++ b/packages/now-go/go-helpers.ts
@@ -4,9 +4,9 @@ import fetch from 'node-fetch';
 import { mkdirp, pathExists } from 'fs-extra';
 import { dirname, join } from 'path';
 import { homedir } from 'os';
-import { debug } from '@vercel/build-utils';
+import buildUtils from './build-utils';
 import stringArgv from 'string-argv';
-
+const { debug } = buildUtils;
 const archMap = new Map([['x64', 'amd64'], ['x86', '386']]);
 const platformMap = new Map([['win32', 'windows']]);
 

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -2,18 +2,17 @@ import { join, sep, dirname, basename, normalize } from 'path';
 import { readFile, writeFile, pathExists, move } from 'fs-extra';
 import { homedir } from 'os';
 import execa from 'execa';
+import { BuildOptions, Meta, Files } from '@vercel/build-utils';
+import buildUtils from './build-utils';
 
-import {
+const {
   glob,
   download,
   createLambda,
   getWriteableDirectory,
-  BuildOptions,
-  Meta,
   shouldServe,
-  Files,
   debug,
-} from '@vercel/build-utils';
+} = buildUtils;
 
 import { createGo, getAnalyzedEntrypoint, OUT_EXTENSION } from './go-helpers';
 const handlerFileName = `handler${OUT_EXTENSION}`;

--- a/packages/now-next/build.sh
+++ b/packages/now-next/build.sh
@@ -7,10 +7,10 @@ cp -v "$bridge_defs" src/now__bridge.ts
 
 tsc
 
-ncc build src/dev-server.ts -e @vercel/build-utils -o dist/dev
+ncc build src/dev-server.ts -e @vercel/build-utils -e @now/build-utils -o dist/dev
 mv dist/dev/index.js dist/dev-server.js
 rm -rf dist/dev
 
-ncc build src/index.ts -e @vercel/build-utils -o dist/main
+ncc build src/index.ts -e @vercel/build-utils -e @now/build-utils -o dist/main
 mv dist/main/index.js dist/index.js
 rm -rf dist/main

--- a/packages/now-next/src/build-utils.ts
+++ b/packages/now-next/src/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1,24 +1,28 @@
-import {
-  BuildOptions,
-  Config,
+import buildUtils from './build-utils';
+const {
   createLambda,
   debug,
   download,
-  FileBlob,
-  FileFsRef,
-  Files,
   getLambdaOptionsFromFunction,
   getNodeVersion,
   getSpawnOptions,
   glob,
-  Lambda,
-  PackageJson,
-  PrepareCacheOptions,
-  Prerender,
   runNpmInstall,
   runPackageJsonScript,
   execCommand,
   getNodeBinPath,
+} = buildUtils;
+
+import {
+  Lambda,
+  BuildOptions,
+  Config,
+  FileBlob,
+  FileFsRef,
+  Files,
+  PackageJson,
+  PrepareCacheOptions,
+  Prerender,
   NowBuildError,
 } from '@vercel/build-utils';
 import { Route, Handler } from '@vercel/routing-utils';

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -6,14 +6,9 @@ import { ZipFile } from 'yazl';
 import crc32 from 'buffer-crc32';
 import { Sema } from 'async-sema';
 import resolveFrom from 'resolve-from';
-import {
-  Files,
-  FileFsRef,
-  streamToBuffer,
-  Lambda,
-  NowBuildError,
-  isSymbolicLink,
-} from '@vercel/build-utils';
+import buildUtils from './build-utils';
+const { streamToBuffer, Lambda, NowBuildError, isSymbolicLink } = buildUtils;
+import { Files, FileFsRef } from '@vercel/build-utils';
 import { Route, Source, NowHeader, NowRewrite } from '@vercel/routing-utils';
 
 type stringMap = { [key: string]: string };

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -21,23 +21,23 @@ mv dist/types dist/index.d.ts
 
 # bundle helpers.ts with ncc
 rm dist/helpers.js
-ncc build src/helpers.ts -e @vercel/build-utils -o dist/helpers
+ncc build src/helpers.ts -e @vercel/build-utils -e @now/build-utils -o dist/helpers
 mv dist/helpers/index.js dist/helpers.js
 rm -rf dist/helpers
 
 # build source-map-support/register for source maps
-ncc build ../../node_modules/source-map-support/register -e @vercel/build-utils -o dist/source-map-support
+ncc build ../../node_modules/source-map-support/register -e @vercel/build-utils -e @now/build-utils -o dist/source-map-support
 mv dist/source-map-support/index.js dist/source-map-support.js
 rm -rf dist/source-map-support
 
 # build typescript
-ncc build ../../node_modules/typescript/lib/typescript -e @vercel/build-utils -o dist/typescript
+ncc build ../../node_modules/typescript/lib/typescript -e @vercel/build-utils -e @now/build-utils -o dist/typescript
 mv dist/typescript/index.js dist/typescript.js
 mkdir -p dist/typescript/lib
 mv dist/typescript/typescript/lib/*.js dist/typescript/lib/
 mv dist/typescript/typescript/lib/*.d.ts dist/typescript/lib/
 rm -r dist/typescript/typescript
 
-ncc build src/index.ts -e @vercel/build-utils -o dist/main
+ncc build src/index.ts -e @vercel/build-utils -e @now/build-utils -o dist/main
 mv dist/main/index.js dist/index.js
 rm -rf dist/main

--- a/packages/now-node/src/build-utils.ts
+++ b/packages/now-node/src/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -8,26 +8,29 @@ import {
   parse as parsePath,
 } from 'path';
 import nodeFileTrace from '@zeit/node-file-trace';
+import buildUtils from '@vercel/build-utils';
 import {
-  glob,
-  download,
   File,
-  FileBlob,
-  FileFsRef,
   Files,
   Meta,
+  PrepareCacheOptions,
+  BuildOptions,
+  Config,
+} from '@vercel/build-utils';
+const {
+  glob,
+  download,
+  FileBlob,
+  FileFsRef,
   createLambda,
   runNpmInstall,
   runPackageJsonScript,
   getNodeVersion,
   getSpawnOptions,
-  PrepareCacheOptions,
-  BuildOptions,
   shouldServe,
-  Config,
   debug,
   isSymbolicLink,
-} from '@vercel/build-utils';
+} = buildUtils;
 export { shouldServe };
 export { NowRequest, NowResponse } from './types';
 import { makeNowLauncher, makeAwsLauncher } from './launcher';
@@ -120,7 +123,7 @@ async function compile(
       const files = await glob(pattern, workPath);
       await Promise.all(
         Object.keys(files).map(async file => {
-          const entry: FileFsRef = files[file];
+          const entry = files[file];
           fsCache.set(file, entry);
           const stream = entry.toStream();
           const { data } = await FileBlob.fromStream({ stream });

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -8,7 +8,7 @@ import {
   parse as parsePath,
 } from 'path';
 import nodeFileTrace from '@zeit/node-file-trace';
-import buildUtils from '@vercel/build-utils';
+import buildUtils from './build-utils';
 import {
   File,
   Files,

--- a/packages/now-node/src/typescript.ts
+++ b/packages/now-node/src/typescript.ts
@@ -1,6 +1,7 @@
 import { relative, basename, resolve, dirname } from 'path';
 import _ts from 'typescript';
-import { NowBuildError } from '@vercel/build-utils';
+import buildUtils from './build-utils';
+const { NowBuildError } = buildUtils;
 
 /*
  * Fork of TS-Node - https://github.com/TypeStrong/ts-node

--- a/packages/now-python/build.sh
+++ b/packages/now-python/build.sh
@@ -1,1 +1,1 @@
-ncc build src/index.ts -e @vercel/build-utils -o dist
+ncc build src/index.ts -e @vercel/build-utils -e @now/build-utils -o dist

--- a/packages/now-python/src/build-utils.ts
+++ b/packages/now-python/src/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-python/src/index.ts
+++ b/packages/now-python/src/index.ts
@@ -4,16 +4,16 @@ import fs from 'fs';
 import { promisify } from 'util';
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
-import {
+import buildUtils from './build-utils';
+import { GlobOptions, BuildOptions } from '@vercel/build-utils';
+const {
   getWriteableDirectory,
   download,
   glob,
-  GlobOptions,
   createLambda,
   shouldServe,
-  BuildOptions,
   debug,
-} from '@vercel/build-utils';
+} = buildUtils;
 import { installRequirement, installRequirementsFile } from './install';
 
 async function pipenvConvert(cmd: string, srcDir: string) {

--- a/packages/now-python/src/install.ts
+++ b/packages/now-python/src/install.ts
@@ -1,5 +1,7 @@
 import execa from 'execa';
-import { debug, Meta } from '@vercel/build-utils';
+import { Meta } from '@vercel/build-utils';
+import buildUtils from './build-utils';
+const { debug } = buildUtils;
 const pipPath = 'pip3';
 
 const makeDependencyCheckCode = (dependency: string) => `

--- a/packages/now-ruby/build-utils.ts
+++ b/packages/now-ruby/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-ruby/build.sh
+++ b/packages/now-ruby/build.sh
@@ -1,1 +1,1 @@
-ncc build index.ts -e @vercel/build-utils -o dist
+ncc build index.ts -e @vercel/build-utils -e @now/build-utils -o dist

--- a/packages/now-ruby/index.ts
+++ b/packages/now-ruby/index.ts
@@ -8,15 +8,16 @@ import {
   readFile,
   writeFile,
 } from 'fs-extra';
-import {
+import buildUtils from './build-utils';
+import { BuildOptions } from '@vercel/build-utils';
+const {
   download,
   getWriteableDirectory,
   glob,
   createLambda,
-  BuildOptions,
   debug,
   walkParentDirs,
-} from '@vercel/build-utils';
+} = buildUtils;
 import { installBundler } from './install-ruby';
 
 async function matchPaths(

--- a/packages/now-ruby/install-ruby.ts
+++ b/packages/now-ruby/install-ruby.ts
@@ -1,7 +1,9 @@
 import { join } from 'path';
 import { intersects } from 'semver';
 import execa from 'execa';
-import { debug, Meta, NowBuildError, NodeVersion } from '@vercel/build-utils';
+import buildUtils from './build-utils';
+import { Meta, NodeVersion } from '@vercel/build-utils';
+const { debug, NowBuildError } = buildUtils;
 
 interface RubyVersion extends NodeVersion {
   minor: number;

--- a/packages/now-static-build/build.sh
+++ b/packages/now-static-build/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-ncc build src/index.ts -e @vercel/build-utils -o dist
+ncc build src/index.ts -e @vercel/build-utils -e @now/build-utils -o dist

--- a/packages/now-static-build/src/build-utils.ts
+++ b/packages/now-static-build/src/build-utils.ts
@@ -1,0 +1,10 @@
+let buildUtils: typeof import('@vercel/build-utils');
+
+try {
+  buildUtils = require('@vercel/build-utils');
+} catch (e) {
+  // Fallback for older CLI versions
+  buildUtils = require('@now/build-utils');
+}
+
+export default buildUtils;

--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -6,7 +6,16 @@ import isPortReachable from 'is-port-reachable';
 import { ChildProcess, SpawnOptions } from 'child_process';
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { frameworks, Framework } from './frameworks';
+import buildUtils from './build-utils';
 import {
+  Files,
+  FileFsRef,
+  BuildOptions,
+  Config,
+  PackageJson,
+  PrepareCacheOptions,
+} from '@vercel/build-utils';
+const {
   glob,
   download,
   spawnAsync,
@@ -20,15 +29,9 @@ import {
   runShellScript,
   getNodeVersion,
   getSpawnOptions,
-  Files,
-  FileFsRef,
-  BuildOptions,
-  Config,
   debug,
-  PackageJson,
-  PrepareCacheOptions,
   NowBuildError,
-} from '@vercel/build-utils';
+} = buildUtils;
 import { Route, Source } from '@vercel/routing-utils';
 import { getVercelIgnore } from '@vercel/client';
 


### PR DESCRIPTION
This PR fixes an issue where old versions of the CLI would update to the latest builder, but not have a copy of `@vercel/build-utils` because they only shipped with `@now/build-utils`. So in this case, we can fallback to the other package. We must be careful to only import types from `@vercel/build-utils` and anything needed at runtime must be imported from `./build-utils` wrapper.