### PR TITLE
[cli] Fix env commands when secret was deleted

### DIFF
--- a/packages/now-cli/src/commands/env/pull.ts
+++ b/packages/now-cli/src/commands/env/pull.ts
@@ -60,18 +60,40 @@ export default async function pull(
   const records = await withSpinner('Downloading', async () => {
     const dev = ProjectEnvTarget.Development;
     const envs = await getEnvVariables(output, client, project.id, 4, dev);
-    const values = await Promise.all(
-      envs.map(env => getDecryptedSecret(output, client, env.value))
+    const decryptedValues = await Promise.all(
+      envs.map(async env => {
+        try {
+          const value = await getDecryptedSecret(output, client, env.value);
+          return { value, found: true };
+        } catch (error) {
+          if (error && error.status === 404) {
+            return { value: '', found: false };
+          }
+          throw error;
+        }
+      })
     );
-    const results: { key: string; value: string }[] = [];
-    for (let i = 0; i < values.length; i++) {
-      results.push({ key: envs[i].key, value: values[i] });
+    const results: { key: string; value: string; found: boolean }[] = [];
+    for (let i = 0; i < decryptedValues.length; i++) {
+      const { key } = envs[i];
+      const { value, found } = decryptedValues[i];
+      results.push({ key, value, found });
     }
     return results;
   });
 
   const contents =
     records
+      .filter(obj => {
+        if (!obj.found) {
+          output.print('');
+          output.warn(
+            `Unable to download variable ${obj.key} because associated secret was deleted`
+          );
+          return false;
+        }
+        return true;
+      })
       .map(({ key, value }) => `${key}="${escapeValue(value)}"`)
       .join('\n') + '\n';
 

--- a/packages/now-cli/src/util/env/get-env-records.ts
+++ b/packages/now-cli/src/util/env/get-env-records.ts
@@ -21,8 +21,7 @@ export default async function getEnvVariables(
   client: Client,
   projectId: string,
   apiVersion: 4,
-  target?: ProjectEnvTarget,
-  next?: number
+  target?: ProjectEnvTarget
 ): Promise<APIV4Response>;
 
 export default async function getEnvVariables(


### PR DESCRIPTION
This PR fixes the scenario when a user adds an environment variable to a project but then deletes the secret associated with the environment variable.

For example:

```sh
echo 'foo' | vc env add FOO development
vc secrets rm foo-development-v1ln
vc env pull                # would error with 404 every time
vc env rm FOO development  # would error with 404 the first time
```

Now we'll warn for `vc env pull` and we will assume success for `vc env rm`.

Fixes https://sentry.io/organizations/zeithq/issues/1612188511/
Fixes https://sentry.io/organizations/zeithq/issues/1656997656/