### PR TITLE
[cli] Fix new routing props to be case sensitive

### DIFF
--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -79,7 +79,8 @@ export async function devRouter(
       }
 
       const keys: string[] = [];
-      const matcher = PCRE(`%${src}%i`, keys);
+      const flags = devServer && devServer.isCaseSensitive() ? '' : 'i';
+      const matcher = PCRE(`%${src}%${flags}`, keys);
       const match =
         matcher.exec(reqPathname) || matcher.exec(reqPathname.substring(1));
 

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -115,6 +115,7 @@ export default class DevServer {
   public address: string;
 
   private cachedNowConfig: NowConfig | null;
+  private caseSensitive: boolean;
   private apiDir: string | null;
   private apiExtensions: Set<string>;
   private server: http.Server;
@@ -149,6 +150,7 @@ export default class DevServer {
     this.yarnPath = '/';
 
     this.cachedNowConfig = null;
+    this.caseSensitive = false;
     this.apiDir = null;
     this.apiExtensions = new Set<string>();
     this.server = http.createServer(this.devServerHandler);
@@ -609,6 +611,7 @@ export default class DevServer {
     await this.validateNowConfig(config);
 
     this.cachedNowConfig = config;
+    this.caseSensitive = hasNewRoutingProperties(config);
     this.apiDir = detectApiDirectory(config.builds || []);
     this.apiExtensions = detectApiExtensions(config.builds || []);
     return config;
@@ -1679,6 +1682,10 @@ export default class DevServer {
     return false;
   }
 
+  isCaseSensitive(): boolean {
+    return this.caseSensitive;
+  }
+
   async runDevCommand() {
     const { devCommand, cwd } = this;
 
@@ -2044,5 +2051,15 @@ function filterFrontendBuilds(build: Builder) {
   return (
     !isOfficialRuntime('static-build', build.use) &&
     !isOfficialRuntime('next', build.use)
+  );
+}
+
+function hasNewRoutingProperties(nowConfig: NowConfig) {
+  return (
+    typeof nowConfig.cleanUrls !== undefined ||
+    typeof nowConfig.headers !== undefined ||
+    typeof nowConfig.redirects !== undefined ||
+    typeof nowConfig.rewrites !== undefined ||
+    typeof nowConfig.trailingSlash !== undefined
   );
 }

--- a/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/lower.html
+++ b/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/lower.html
@@ -1,0 +1,1 @@
+lowercase

--- a/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/upper.html
+++ b/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/upper.html
@@ -1,0 +1,1 @@
+UPPERCASE

--- a/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/test-routing-case-sensitive/vercel.json
@@ -1,0 +1,10 @@
+{
+  "rewrites": [
+    { "source": "/Path", "destination": "/upper.html" },
+    { "source": "/path", "destination": "/lower.html" }
+  ],
+  "redirects": [
+    { "source": "/GoTo", "destination": "/upper.html" },
+    { "source": "/goto", "destination": "/lower.html" }
+  ]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -614,6 +614,20 @@ test(
 );
 
 test(
+  '[now dev] test rewrites and redirects is case sensitive',
+  testFixtureStdio('test-routing-case-sensitive', async testPath => {
+    await testPath(200, '/Path', 'UPPERCASE');
+    await testPath(200, '/path', 'lowercase');
+    await testPath(308, '/GoTo', 'Redirecting to /upper.html (308)', {
+      Location: '/upper.html',
+    });
+    await testPath(308, '/goto', 'Redirecting to /lower.html (308)', {
+      Location: '/lower.html',
+    });
+  })
+);
+
+test(
   '[now dev] test cleanUrls serve correct content',
   testFixtureStdio('test-clean-urls', async testPath => {
     await testPath(200, '/', 'Index Page');


### PR DESCRIPTION
This PR fixes a bug where `vc dev` acted differently than real deployments which are supposed to have case sensitive `rewrites` and `redirects`.