### PR TITLE
[cli] Fix update command

### DIFF
--- a/packages/now-cli/src/util/get-update-command.ts
+++ b/packages/now-cli/src/util/get-update-command.ts
@@ -2,6 +2,7 @@ import { Stats } from 'fs';
 import { sep, dirname, join, resolve } from 'path';
 import { readJSON, lstat, readlink, readFile, realpath } from 'fs-extra';
 import { isCanary } from './is-canary';
+import { getPkgName } from './pkg-name';
 
 // `npm` tacks a bunch of extra properties on the `package.json` file,
 // so check for one of them to determine yarn vs. npm.
@@ -93,12 +94,15 @@ async function isGlobal() {
 
 export default async function getUpdateCommand(): Promise<string> {
   const tag = isCanary() ? 'canary' : 'latest';
+  const pkgAndVersion = `${getPkgName()}@${tag}`;
 
   if (await isGlobal()) {
     return (await isYarn())
-      ? `yarn global add now@${tag}`
-      : `npm i -g now@${tag}`;
+      ? `yarn global add ${pkgAndVersion}`
+      : `npm i -g ${pkgAndVersion}`;
   }
 
-  return (await isYarn()) ? `yarn add now@${tag}` : `npm i now@${tag}`;
+  return (await isYarn())
+    ? `yarn add ${pkgAndVersion}`
+    : `npm i ${pkgAndVersion}`;
 }

--- a/packages/now-cli/test/integration-v1.js
+++ b/packages/now-cli/test/integration-v1.js
@@ -331,7 +331,7 @@ test('output the version', async t => {
 test('detect update command', async t => {
   {
     const { stderr } = await execute(['update']);
-    t.regex(stderr, /yarn add now@/gm, `Received: "${stderr}"`);
+    t.regex(stderr, /yarn add vercel@/gm, `Received: "${stderr}"`);
   }
 
   {

--- a/packages/now-cli/test/unit.js
+++ b/packages/now-cli/test/unit.js
@@ -1089,5 +1089,5 @@ test('check valid name', async t => {
 
 test('detect update command', async t => {
   const updateCommand = await getUpdateCommand();
-  t.is(updateCommand, `yarn add now@${isCanary() ? 'canary' : 'latest'}`);
+  t.is(updateCommand, `yarn add vercel@${isCanary() ? 'canary' : 'latest'}`);
 });


### PR DESCRIPTION
The CLI name was updated but not the command.

This PR fixes the command to show the correct package name.

https://app.clubhouse.io/vercel/story/311/wrong-vercel-cli-package-name-being-rendered-in-the-update-message
