### PR TITLE
[build-utils] Detect invalid `engines` pattern in package.json

### DIFF
--- a/packages/now-build-utils/src/fs/node-version.ts
+++ b/packages/now-build-utils/src/fs/node-version.ts
@@ -1,4 +1,4 @@
-import { intersects } from 'semver';
+import { intersects, validRange } from 'semver';
 import boxen from 'boxen';
 import { NodeVersion } from '../types';
 import { NowBuildError } from '../errors';
@@ -40,12 +40,14 @@ export async function getSupportedNodeVersion(
   let selection = getLatestNodeVersion();
 
   if (engineRange) {
-    const found = allOptions.some(o => {
-      // the array is already in order so return the first
-      // match which will be the newest version of node
-      selection = o;
-      return intersects(o.range, engineRange);
-    });
+    const found =
+      validRange(engineRange) &&
+      allOptions.some(o => {
+        // the array is already in order so return the first
+        // match which will be the newest version of node
+        selection = o;
+        return intersects(o.range, engineRange);
+      });
     if (!found) {
       const intro =
         isAuto || !engineRange

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
-const assert = require('assert');
+const assert = require('assert').strict;
 const { createZip } = require('../dist/lambda');
 const { glob, spawnAsync, download } = require('../');
 const { getSupportedNodeVersion } = require('../dist/fs/node-version');
@@ -9,6 +9,20 @@ const {
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
 } = require('../dist');
+
+async function expectBuilderError(promise, pattern) {
+  let result;
+  try {
+    result = await promise;
+  } catch (error) {
+    result = error;
+  }
+  assert('message' in result, `Expected error message but found ${result}`);
+  assert(
+    pattern.test(result.message),
+    `Expected ${pattern} but found "${result.message}"`
+  );
+}
 
 it('should re-create symlinks properly', async () => {
   if (process.platform === 'win32') {
@@ -72,6 +86,16 @@ it('should only match supported node versions', async () => {
   expect(getSupportedNodeVersion('999.x', false)).rejects.toThrow();
   expect(getSupportedNodeVersion('foo', false)).rejects.toThrow();
 
+  const autoMessage = /This project is using an invalid version of Node.js and must be changed/;
+  await expectBuilderError(
+    getSupportedNodeVersion('8.11.x', true),
+    autoMessage
+  );
+  await expectBuilderError(getSupportedNodeVersion('6.x', true), autoMessage);
+  await expectBuilderError(getSupportedNodeVersion('999.x', true), autoMessage);
+  await expectBuilderError(getSupportedNodeVersion('foo', true), autoMessage);
+  await expectBuilderError(getSupportedNodeVersion('=> 10', true), autoMessage);
+
   expect(await getSupportedNodeVersion('10.x', true)).toHaveProperty(
     'major',
     10
@@ -80,10 +104,21 @@ it('should only match supported node versions', async () => {
     'major',
     12
   );
-  expect(getSupportedNodeVersion('8.11.x', true)).rejects.toThrow();
-  expect(getSupportedNodeVersion('6.x', true)).rejects.toThrow();
-  expect(getSupportedNodeVersion('999.x', true)).rejects.toThrow();
-  expect(getSupportedNodeVersion('foo', true)).rejects.toThrow();
+  const foundMessage = /Found `engines` in `package\.json` with an invalid Node\.js version range/;
+  await expectBuilderError(
+    getSupportedNodeVersion('8.11.x', false),
+    foundMessage
+  );
+  await expectBuilderError(getSupportedNodeVersion('6.x', false), foundMessage);
+  await expectBuilderError(
+    getSupportedNodeVersion('999.x', false),
+    foundMessage
+  );
+  await expectBuilderError(getSupportedNodeVersion('foo', false), foundMessage);
+  await expectBuilderError(
+    getSupportedNodeVersion('=> 10', false),
+    foundMessage
+  );
 });
 
 it('should match all semver ranges', async () => {


### PR DESCRIPTION
This PR improves the error message when a user provides an invalid pattern in package.json `engines` field.

## Before

```
TypeError: Invalid comparator: => 10
at Comparator.module.exports.Comparator.parse (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10262:11) 
at new Comparator (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10245:8) 
at Range.<anonymous> (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10439:12) 
at Array.map (<anonymous>) 
at Range.module.exports.Range.parseRange (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10438:13) 
at Range.<anonymous> (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10381:17) 
at Array.map (<anonymous>) 
at new Range (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10380:40) 
at Function.intersects (/zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:10998:8) 
at /zeit/9cd49d8c66a9bd43/.build-utils/node_modules/@vercel/build-utils/dist/index.js:25847:29
```

## After

```
Found `engines` in `package.json` with an invalid Node.js version range: "=> 10".
Please set "engines": { "node": "12.x" } in your `package.json` file to upgrade to Node.js 12.
More details: https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
```

In this case, the `=>` operator is not valid so the user probably meant `>=` but we only suggest the `10.x` or `12.x` syntax because we can only guarantee a major version.