### PR TITLE
Revert "[now-next] Update to pass dynamic page values in the query (#4196)"

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -86,7 +86,6 @@ interface BuildParamsType extends BuildOptions {
 export const version = 2;
 const htmlContentType = 'text/html; charset=utf-8';
 const nowDevChildProcesses = new Set<ChildProcess>();
-const yarnPreferOffline = true;
 
 ['SIGINT', 'SIGTERM'].forEach(signal => {
   process.once(signal as NodeJS.Signals, () => {
@@ -320,12 +319,7 @@ export const build = async ({
   }
 
   console.log('Installing dependencies...');
-  await runNpmInstall(
-    entryPath,
-    [...(yarnPreferOffline ? ['--prefer-offline'] : [])],
-    spawnOpts,
-    meta
-  );
+  await runNpmInstall(entryPath, ['--prefer-offline'], spawnOpts, meta);
 
   let realNextVersion: string | undefined;
   try {
@@ -416,22 +410,17 @@ export const build = async ({
             }
 
             dataRoutes.push({
-              src: (
-                dataRoute.namedDataRouteRegex || dataRoute.dataRouteRegex
-              ).replace(/^\^/, `^${appMountPrefixNoTrailingSlash}`),
+              src: dataRoute.dataRouteRegex.replace(
+                /^\^/,
+                `^${appMountPrefixNoTrailingSlash}`
+              ),
               dest: path.join(
                 '/',
                 entryDirectory,
                 // make sure to route SSG data route to the data prerender
                 // output, we don't do this for SSP routes since they don't
                 // have a separate data output
-                `${(ssgDataRoute && ssgDataRoute.dataRoute) || dataRoute.page}${
-                  dataRoute.routeKeys
-                    ? `?${dataRoute.routeKeys
-                        .map(key => `${key}=$${key}`)
-                        .join('&')}`
-                    : ''
-                }`
+                (ssgDataRoute && ssgDataRoute.dataRoute) || dataRoute.page
               ),
               check: true,
             });
@@ -612,7 +601,7 @@ export const build = async ({
     debug('Running npm install --production...');
     await runNpmInstall(
       entryPath,
-      [...(yarnPreferOffline ? ['--prefer-offline'] : []), '--production'],
+      ['--prefer-offline', '--production'],
       spawnOpts,
       meta
     );
@@ -643,7 +632,7 @@ export const build = async ({
         'BUILD_ID not found in ".next". The "package.json" "build" script did not run "next build"'
       );
       throw new NowBuildError({
-        code: 'NEXT_NO_BUILD_ID',
+        code: 'NOW_NEXT_NO_BUILD_ID',
         message: 'Missing BUILD_ID',
       });
     }

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -312,16 +312,9 @@ export type RoutesManifest = {
   dynamicRoutes: {
     page: string;
     regex: string;
-    namedRegex?: string;
-    routeKeys?: string[];
   }[];
   version: number;
-  dataRoutes?: Array<{
-    page: string;
-    routeKeys?: string[];
-    dataRouteRegex: string;
-    namedDataRouteRegex?: string;
-  }>;
+  dataRoutes?: Array<{ page: string; dataRouteRegex: string }>;
 };
 
 export async function getRoutesManifest(
@@ -377,14 +370,10 @@ export async function getDynamicRoutes(
           .filter(({ page }) =>
             omittedRoutes ? !omittedRoutes.has(page) : true
           )
-          .map(({ page, regex, namedRegex, routeKeys }) => {
+          .map(({ page, regex }: { page: string; regex: string }) => {
             return {
-              src: namedRegex || regex,
-              dest: `${!isDev ? path.join('/', entryDirectory, page) : page}${
-                routeKeys
-                  ? `?${routeKeys.map(key => `${key}=$${key}`).join('&')}`
-                  : ''
-              }`,
+              src: regex,
+              dest: !isDev ? path.join('/', entryDirectory, page) : page,
               check: true,
             };
           });

--- a/packages/now-next/test/fixtures/07-custom-routes/package.json
+++ b/packages/now-next/test/fixtures/07-custom-routes/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "9.2.1-canary.8",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }


### PR DESCRIPTION
This reverts using named regexes for dynamic routes until https://github.com/zeit/now/pull/4355 is landed

This reverts commit dfdef0f6fd1f336f3efd5914fa7b2d565d098ac0.
