### PR TITLE
[cli] Fix api url for `vc env add`

### DIFF
--- a/packages/now-cli/src/util/env/add-env-record.ts
+++ b/packages/now-cli/src/util/env/add-env-record.ts
@@ -19,10 +19,9 @@ export default async function addEnvRecord(
   let values: string[] | undefined;
 
   if (envValue) {
-    const urlSecret = `/v2/now/secrets/${encodeURIComponent(envName)}`;
     const secrets = await Promise.all(
       targets.map(target =>
-        client.fetch<Secret>(urlSecret, {
+        client.fetch<Secret>('/v2/now/secrets', {
           method: 'POST',
           body: JSON.stringify({
             name: generateSecretName(envName, target),


### PR DESCRIPTION
This PR fixes a POST request url to match the [api docs](https://vercel.com/docs/api#endpoints/secrets/create-a-new-secret) recommendation so that all data is in the body, not the query string.