### PR TITLE
[cli] Pin `@vercel/next` to v2.6.2

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@vercel/build-utils": "2.3.2-canary.0",
     "@vercel/go": "1.1.1",
-    "@vercel/next": "2.6.2-canary.0",
+    "@vercel/next": "2.6.2",
     "@vercel/node": "1.6.2-canary.0",
     "@vercel/python": "1.2.1",
     "@vercel/ruby": "1.2.1",


### PR DESCRIPTION
To keep the `lerna` monorepo version pinning intact.

It should have been updated in c23b9ccd1d9178652754c8baabcc8c713bdd8fc7, but was not because the commit was created manually instead of with `lerna`.