### PR TITLE
[cli] Add logs when installing Runtimes in dev

### DIFF
--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -7,6 +7,10 @@ import wait from './wait';
 export type Output = ReturnType<typeof createOutput>;
 
 export default function createOutput({ debug: debugEnabled = false } = {}) {
+  function isDebugEnabled() {
+    return debugEnabled;
+  }
+
   function print(str: string) {
     process.stderr.write(str);
   }
@@ -125,6 +129,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   }
 
   return {
+    isDebugEnabled,
     print,
     log,
     warn,


### PR DESCRIPTION
This PR consolidates the `npm install` for Runtimes during `vercel dev` and adds some additional logging.