### PR TITLE
[cli] Fix dev server unit tests timing out

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -916,7 +916,6 @@ export default class DevServer {
     }
 
     ops.push(close(this.server));
-    ops.push(close(this.proxy));
 
     if (this.watcher) {
       debug(`Closing file watcher`);


### PR DESCRIPTION
This is a follow-up to #4241, which apparently caused the `vc dev` unit
tests to start timing out. After some digging, it seems the root cause
is that `proxy.close()` callback is never invoked. This makes sense
because we never call `proxy.listen()` or have the `httpProxy` actually
bind to a port.