### PR TITLE
[cli] Await the FS watcher closing when shutting down `vc dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -920,7 +920,7 @@ export default class DevServer {
 
     if (this.watcher) {
       debug(`Closing file watcher`);
-      this.watcher.close();
+      ops.push(this.watcher.close());
     }
 
     if (this.updateBuildersPromise) {


### PR DESCRIPTION
This was missing for some reason :thinking_cat: