### PR TITLE
[tests] Bump cancel-workflow-action to 0.3.2

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.3.1
+      - uses: styfle/cancel-workflow-action@0.3.2
         with:
           workflow_id: 849295, 849296, 849297, 849298
-          access_token: ${{ secrets.GITHUB_WORKFLOW_TOKEN }}
+          access_token: ${{ github.token }}
 

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -9,7 +9,7 @@ jobs:
   cancel:
     name: 'Cancel Previous Runs'
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
     steps:
       - uses: styfle/cancel-workflow-action@0.3.2
         with:


### PR DESCRIPTION
Bumps the `cancel-workflow-action` to version [0.3.2](https://github.com/styfle/cancel-workflow-action/releases/tag/0.3.2)