### PR TITLE
[cli] Update runtimes in dev should not audit

### DIFF
--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -234,7 +234,14 @@ async function npmInstall(
   try {
     await execa(
       'npm',
-      ['install', '--save-exact', '--no-package-lock', ...sortedPackages],
+      [
+        'install',
+        '--save-exact',
+        '--no-package-lock',
+        '--no-audit',
+        '--no-progress',
+        ...sortedPackages,
+      ],
       {
         cwd,
         stdio: output.isDebugEnabled() ? 'inherit' : undefined,


### PR DESCRIPTION
This PR adds two additional flags to `npm install` when updating Runtimes:

- `--no-audit`:  disable sending of audit reports to the configured registries
- `--no-progress`: disable the progress bar