### PR TITLE
[tests] Fix Windows tests filtering logic and branch name detection

### DIFF
--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -1,4 +1,3 @@
-// Temporary change in `now-node` to force tests to be selected
 import { fork, spawn } from 'child_process';
 import {
   readFileSync,

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -1,3 +1,4 @@
+// Temporary change in `now-node` to force tests to be selected
 import { fork, spawn } from 'child_process';
 import {
   readFileSync,

--- a/utils/run.js
+++ b/utils/run.js
@@ -49,7 +49,7 @@ async function main() {
     }
 
     console.log(
-      `Running "${script}" on branch "${branch}" with the following packages:`
+      `Running "${script}" on branch "${branch}" with the following packages:\n`
     );
   }
 
@@ -79,7 +79,9 @@ async function main() {
     return b - a;
   });
 
-  console.log(matches.join('\n') + '\n');
+  for (const m of matches) {
+    console.log(` - ${m}`);
+  }
 
   for (const pkgName of matches) {
     await runScript(pkgName, script);

--- a/utils/run.js
+++ b/utils/run.js
@@ -1,5 +1,5 @@
 const { execSync, spawn } = require('child_process');
-const { join, relative } = require('path');
+const { join, relative, sep } = require('path');
 const { readdirSync } = require('fs');
 
 if (
@@ -26,7 +26,7 @@ async function main() {
     matches = readdirSync(join(__dirname, '..', 'packages'));
     console.log(`Running script "${script}" for all packages`);
   } else {
-    const branch = execSync('git branch | grep "*" | cut -d " " -f2')
+    const branch = execSync('git rev-parse --abbrev-ref HEAD')
       .toString()
       .trim();
 
@@ -35,8 +35,8 @@ async function main() {
 
     const changed = diff
       .split('\n')
-      .filter(item => Boolean(item) && item.includes('packages/'))
-      .map(item => relative('packages', item).split('/')[0])
+      .filter(item => Boolean(item) && item.startsWith('packages'))
+      .map(item => relative('packages', item).split(sep)[0])
       .concat('now-cli'); // Always run tests for Now CLI
 
     matches = Array.from(new Set(changed));

--- a/utils/run.js
+++ b/utils/run.js
@@ -1,4 +1,3 @@
-console.log(process.env);
 const { execSync, spawn } = require('child_process');
 const { join, relative, sep } = require('path');
 const { readdirSync } = require('fs');
@@ -27,9 +26,11 @@ async function main() {
     matches = readdirSync(join(__dirname, '..', 'packages'));
     console.log(`Running script "${script}" for all packages`);
   } else {
-    const branch = execSync('git branch --show-current')
-      .toString()
-      .trim();
+    const branch =
+      process.env.GITHUB_HEAD_REF ||
+      execSync('git branch --show-current')
+        .toString()
+        .trim();
 
     const gitPath = branch === 'master' ? 'HEAD~1' : 'origin/master...HEAD';
     const diff = execSync(`git diff ${gitPath} --name-only`).toString();

--- a/utils/run.js
+++ b/utils/run.js
@@ -26,7 +26,7 @@ async function main() {
     matches = readdirSync(join(__dirname, '..', 'packages'));
     console.log(`Running script "${script}" for all packages`);
   } else {
-    const branch = execSync('git rev-parse --abbrev-ref HEAD')
+    const branch = execSync('git branch --show-current')
       .toString()
       .trim();
 

--- a/utils/run.js
+++ b/utils/run.js
@@ -1,3 +1,4 @@
+console.log(process.env);
 const { execSync, spawn } = require('child_process');
 const { join, relative, sep } = require('path');
 const { readdirSync } = require('fs');


### PR DESCRIPTION
Currently, CI is printing this:

```
Running "test-unit" on branch "(HEAD" with the following packages:
now-cli\test\dev-server.unit.js
now-cli\test\fixtures\unit\now-dev-request-body\api\data-events.js
now-cli\test\fixtures\unit\now-dev-request-body\api\req-body.js
now-node-bridge\src\bridge.ts
now-node\src\dev-server.ts
now-node\src\helpers.ts
now-node\src\launcher.ts
now-cli

[now-cli\test\dev-server.unit.js] Skipping since script "test-unit" is missing from package.json
[now-cli\test\fixtures\unit\now-dev-request-body\api\data-events.js] Skipping since script "test-unit" is missing from package.json
[now-cli\test\fixtures\unit\now-dev-request-body\api\req-body.js] Skipping since script "test-unit" is missing from package.json
[now-node-bridge\src\bridge.ts] Skipping since script "test-unit" is missing from package.json
[now-node\src\dev-server.ts] Skipping since script "test-unit" is missing from package.json
[now-node\src\helpers.ts] Skipping since script "test-unit" is missing from package.json
[now-node\src\launcher.ts] Skipping since script "test-unit" is missing from package.json
```

So, other than `now-cli` which is hard-coded to always run, no other tests were being selected on Windows. This change uses the proper path separator for the OS to fix this.

Also, the branch name detection command is changed to fix the `"(HEAD"` name that is being detected in CI.

With this change, it looks like:

```
Running "test-unit" on branch "fix/tests-windows" with the following packages:

 - now-node
 - now-cli

[now-node] Running yarn test-unit
…
[now-cli] Running yarn test-unit
…
```