### PR TITLE
[frameworks] Fix unit tests on Windows

### DIFF
--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -4,7 +4,7 @@
   "main": "frameworks.json",
   "license": "UNLICENSED",
   "scripts": {
-    "test-unit": "jest --env node --verbose --runInBand --bail test/*unit.*test.*"
+    "test-unit": "jest --env node --verbose --runInBand --bail"
   },
   "devDependencies": {
     "@types/jest": "24.0.22",


### PR DESCRIPTION
For some reason, the glob selector was causing problems on Windows:

```
[frameworks] Running yarn test-unit
$ jest --env node --verbose --runInBand --bail test/*unit.*test.*
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In D:\a\now\now\packages\frameworks
  6 files checked.
  testMatch: **/__tests__/**/*.[jt]s?(x), **/?(*.)+(spec|test).[tj]s?(x) - 1 match
  testPathIgnorePatterns: \\node_modules\\ - 6 matches
  testRegex:  - 0 matches
Pattern: test\\*unit.*test.* - 0 matches
error Command failed with exit code 1.
```

Removing the glob pattern fixes the issue, though it's not clear why it causes an issue in the first place.

See: https://github.com/zeit/now/runs/701043212