### PR TITLE
[next][routing-utils] Fix unnamed multi-match custom route

### DIFF
--- a/packages/now-next/test/fixtures/23-custom-routes-verbose/next.config.js
+++ b/packages/now-next/test/fixtures/23-custom-routes-verbose/next.config.js
@@ -38,6 +38,10 @@ module.exports = {
           destination: '/hello',
         },
         {
+          source: '/(.*)-:id(\\d+).html',
+          destination: '/blog/:id',
+        },
+        {
           source: '/blog/post-1',
           destination: '/blog/post-2',
         },

--- a/packages/now-next/test/fixtures/23-custom-routes-verbose/now.json
+++ b/packages/now-next/test/fixtures/23-custom-routes-verbose/now.json
@@ -238,6 +238,13 @@
       "fetchOptions": {
         "redirect": "manual"
       }
+    },
+
+    // should apply un-named multi-match correctly
+    {
+      "path": "/hello/post-123.html",
+      "status": 200,
+      "mustContain": "123"
     }
   ]
 }

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -2,10 +2,11 @@
  * This converts Superstatic configuration to vercel.json Routes
  * See https://github.com/firebase/superstatic#configuration
  */
-import { isString } from 'util';
 import { parse as parseUrl, format as formatUrl } from 'url';
 import { pathToRegexp, compile, Key } from 'path-to-regexp';
 import { Route, NowRedirect, NowRewrite, NowHeader } from './types';
+
+const UN_NAMED_SEGMENT = '__UN_NAMED_SEGMENT__';
 
 export function getCleanUrls(
   filePaths: string[]
@@ -147,7 +148,14 @@ export function sourceToRegex(
     sensitive: true,
     delimiter: '/',
   });
-  const segments = keys.map(k => k.name).filter(isString);
+  const segments = keys
+    .map(k => k.name)
+    .map(name => {
+      if (typeof name !== 'string') {
+        return UN_NAMED_SEGMENT;
+      }
+      return name;
+    });
   return { src: r.source, segments };
 }
 
@@ -164,7 +172,10 @@ function replaceSegments(
   let { pathname, hash, query, ...rest } = parsedDestination;
   pathname = pathname || '';
   hash = hash || '';
-  if (segments.length > 0) {
+
+  const namedSegments = segments.filter(name => name !== UN_NAMED_SEGMENT);
+
+  if (namedSegments.length > 0) {
     const indexes: { [k: string]: string } = {};
     segments.forEach((name, index) => {
       indexes[name] = toSegmentDest(index);
@@ -187,7 +198,7 @@ function replaceSegments(
     // specified
     if (!isRedirect) {
       for (const [name, value] of Object.entries(indexes)) {
-        if (!(name in query)) {
+        if (!(name in query) && name !== UN_NAMED_SEGMENT) {
           query[name] = value;
         }
       }

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -349,6 +349,7 @@ test('convertRewrites', () => {
     { source: '/catchme/:id*', destination: '/api/user' },
     { source: '/:path', destination: '/test?path=:path' },
     { source: '/:path/:two', destination: '/test?path=:path' },
+    { source: '/(.*)-:id(\\d+).html', destination: '/blog/:id' },
   ]);
 
   const expected = [
@@ -424,6 +425,7 @@ test('convertRewrites', () => {
       dest: '/test?path=$1&two=$2',
       src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
     },
+    { check: true, dest: '/blog/$2?id=$2', src: '^(?:\\/(.*))-(\\d+)\\.html$' },
   ];
 
   deepEqual(actual, expected);
@@ -444,6 +446,7 @@ test('convertRewrites', () => {
     ['/catchme/id-1', '/catchme/id/2'],
     ['/first', '/another'],
     ['/first/second', '/one/two'],
+    ['/hello/post-123.html', '/post-123.html'],
   ];
 
   const mustNotMatch = [
@@ -462,6 +465,7 @@ test('convertRewrites', () => {
     ['/catchm', '/random'],
     ['/another/one'],
     ['/not', '/these'],
+    ['/hello/post.html'],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);


### PR DESCRIPTION
This adds a failing test for the regex from https://github.com/zeit/next.js/discussions/13347#discussion-4546 

It appears the reason the regex does not work when deployed on Vercel is due to us not indexing the un-named segments and instead we filter them out as noticed by @dav-is. 

This PR adds one approach to resolve this by accounting for the un-named indexes while not allowing them to be used in the destination still.  