### PR TITLE
[cli] Add delay before updating Runtimes in background

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -6,6 +6,7 @@ import plural from 'pluralize';
 import rawBody from 'raw-body';
 import listen from 'async-listen';
 import minimatch from 'minimatch';
+import ms from 'ms';
 import httpProxy from 'http-proxy';
 import { randomBytes } from 'crypto';
 import serveHandler from 'serve-handler';
@@ -780,16 +781,18 @@ export default class DevServer {
 
     // Updating builders happens lazily, and any builders that were updated
     // get their "build matches" invalidated so that the new version is used.
-    this.updateBuildersPromise = updateBuilders(builders, this.output)
-      .then(updatedBuilders => {
-        this.updateBuildersPromise = null;
-        this.invalidateBuildMatches(nowConfig, updatedBuilders);
-      })
-      .catch(err => {
-        this.updateBuildersPromise = null;
-        this.output.error(`Failed to update builders: ${err.message}`);
-        this.output.debug(err.stack);
-      });
+    setTimeout(() => {
+      this.updateBuildersPromise = updateBuilders(builders, this.output)
+        .then(updatedBuilders => {
+          this.updateBuildersPromise = null;
+          this.invalidateBuildMatches(nowConfig, updatedBuilders);
+        })
+        .catch(err => {
+          this.updateBuildersPromise = null;
+          this.output.error(`Failed to update builders: ${err.message}`);
+          this.output.debug(err.stack);
+        });
+    }, ms('30s'));
 
     // Now Builders that do not define a `shouldServe()` function need to be
     // executed at boot-up time in order to get the initial assets and/or routes

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -143,6 +143,7 @@ export default class DevServer {
   private getNowConfigPromise: Promise<NowConfig> | null;
   private blockingBuildsPromise: Promise<void> | null;
   private updateBuildersPromise: Promise<void> | null;
+  private updateBuildersTimeout: NodeJS.Timeout | undefined;
 
   constructor(cwd: string, options: DevServerOptions) {
     this.cwd = cwd;
@@ -781,7 +782,7 @@ export default class DevServer {
 
     // Updating builders happens lazily, and any builders that were updated
     // get their "build matches" invalidated so that the new version is used.
-    setTimeout(() => {
+    this.updateBuildersTimeout = setTimeout(() => {
       this.updateBuildersPromise = updateBuilders(builders, this.output)
         .then(updatedBuilders => {
           this.updateBuildersPromise = null;
@@ -894,6 +895,10 @@ export default class DevServer {
     if (this.stopping) return;
 
     this.stopping = true;
+
+    if (typeof this.updateBuildersTimeout !== 'undefined') {
+      clearTimeout(this.updateBuildersTimeout);
+    }
 
     const ops: Promise<any>[] = [];
 


### PR DESCRIPTION
Similar to #4427 but instead of an option to turn on or off, we delay the background task that updates the Runtimes during development. The idea is that the initial install runs immediately using the bundled Runtimes from the CLI. Then if the user plans to keep developing, we'll check to see if we should update to the latest Runtime version after 30 seconds.