### PR TITLE
[cli][client] Fix windows unit tests

### DIFF
--- a/packages/now-cli/test/unit.js
+++ b/packages/now-cli/test/unit.js
@@ -68,7 +68,7 @@ const getStaticFiles = async (dir, isBuilds = false) => {
 
 const normalizeWindowsPaths = files => {
   if (process.platform === 'win32') {
-    const prefix = 'D:/a/now/now/packages/now-cli/test/fixtures/';
+    const prefix = 'D:/a/vercel/vercel/packages/now-cli/test/fixtures/unit/';
     return files.map(f => f.replace(/\\/g, '/').slice(prefix.length));
   }
   return files;

--- a/packages/now-cli/test/unit.js
+++ b/packages/now-cli/test/unit.js
@@ -68,7 +68,7 @@ const getStaticFiles = async (dir, isBuilds = false) => {
 
 const normalizeWindowsPaths = files => {
   if (process.platform === 'win32') {
-    const prefix = 'D:/a/now/now/packages/now-cli/test/fixtures/unit/';
+    const prefix = 'D:/a/now/now/packages/now-cli/test/fixtures/';
     return files.map(f => f.replace(/\\/g, '/').slice(prefix.length));
   }
   return files;

--- a/packages/now-client/tests/unit.utils.test.ts
+++ b/packages/now-client/tests/unit.utils.test.ts
@@ -17,7 +17,9 @@ describe('buildFileTree', () => {
       'tests/fixtures/nowignore/index.txt',
     ].map(p => path.join(process.cwd(), p));
     const actual = await buildFileTree(ignoreFixturePath, true, () => {});
-    expect(normalizeWindowsPaths(actual).sort()).toEqual(expected.sort());
+    expect(normalizeWindowsPaths(expected).sort()).toEqual(
+      normalizeWindowsPaths(actual).sort()
+    );
   });
 });
 
@@ -36,6 +38,8 @@ describe('readdirRelative', () => {
       ignores,
       process.cwd()
     );
-    expect(normalizeWindowsPaths(actual).sort()).toEqual(expected.sort());
+    expect(normalizeWindowsPaths(expected).sort()).toEqual(
+      normalizeWindowsPaths(actual).sort()
+    );
   });
 });

--- a/packages/now-client/tests/unit.utils.test.ts
+++ b/packages/now-client/tests/unit.utils.test.ts
@@ -3,6 +3,13 @@ import { buildFileTree, getVercelIgnore, readdirRelative } from '../src/utils';
 
 const ignoreFixturePath = path.resolve(__dirname, 'fixtures', 'nowignore');
 
+const normalizeWindowsPaths = (files: string[]) => {
+  if (process.platform === 'win32') {
+    return files.map(f => f.replace(/\\/g, '/'));
+  }
+  return files;
+};
+
 describe('buildFileTree', () => {
   it('will include the correct files', async () => {
     const expected = [
@@ -10,7 +17,7 @@ describe('buildFileTree', () => {
       'tests/fixtures/nowignore/index.txt',
     ].map(p => path.join(process.cwd(), p));
     const actual = await buildFileTree(ignoreFixturePath, true, () => {});
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(normalizeWindowsPaths(actual).sort()).toEqual(expected.sort());
   });
 });
 
@@ -29,6 +36,6 @@ describe('readdirRelative', () => {
       ignores,
       process.cwd()
     );
-    expect(actual.sort()).toEqual(expected.sort());
+    expect(normalizeWindowsPaths(actual).sort()).toEqual(expected.sort());
   });
 });


### PR DESCRIPTION
Follow up to #4463 to fix failing windows unit tests in `now-client`.
This also fixes `now-cli` tests that started failing after renaming the repo to `vercel/vercel`.