### PR TITLE
[build-utils] Revert type of routing errors

### DIFF
--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -223,23 +223,18 @@ function checkRedirect(r: NowRedirect, index: number) {
 
 function createError(
   code: string,
-  errors: string | string[],
+  allErrors: string | string[],
   link: string,
   action: string
 ): RouteApiError | null {
-  let message: string;
-  let otherErrors: string[] = [];
-  if (Array.isArray(errors)) {
-    [message, ...otherErrors] = errors;
-  } else {
-    message = errors;
-  }
+  const errors = Array.isArray(allErrors) ? allErrors : [allErrors];
+  const message = errors[0];
   const error: RouteApiError = {
     code,
     message,
     link,
     action,
-    otherErrors,
+    errors,
   };
   return error;
 }

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -5,7 +5,7 @@ export type RouteApiError = {
   message: string;
   link?: string; // link to error message details
   action?: string; // label for error link
-  otherErrors?: string[];
+  errors?: string[]; // array of all error messages
 };
 
 export type Source = {


### PR DESCRIPTION
In PR #4498, the type of the routing error was changed from first error and then the remaining errors. This PR changes the type back such that `error.errors` returns all errors. This will avoid any breaking change.