### PR TITLE
[next] Handle restricted output names

### DIFF
--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -957,6 +957,29 @@ async function getSourceFilePathFromPage({
   return path.join('pages', page);
 }
 
+const restrictedOutputNames = new Set<string>(
+  Object.getOwnPropertyNames(({} as any).__proto__)
+);
+
+export function handleRestrictedOutputNames(outputs: Files): Route[] {
+  const restrictedNameRewrites: Route[] = [];
+
+  for (const outputName of Object.keys(outputs)) {
+    if (restrictedOutputNames.has(outputName)) {
+      outputs[`__${outputName}`] = outputs[outputName];
+      delete outputs[outputName];
+
+      restrictedNameRewrites.push({
+        src: `^/${outputName}$`,
+        dest: `/__${outputName}`,
+        check: true,
+      });
+    }
+  }
+
+  return restrictedNameRewrites;
+}
+
 export {
   excludeFiles,
   validateEntrypoint,

--- a/packages/now-next/test/fixtures/07-custom-routes/pages/constructor.js
+++ b/packages/now-next/test/fixtures/07-custom-routes/pages/constructor.js
@@ -1,0 +1,7 @@
+// this is making sure a object prototype name doesn't
+// cause conflict as an output name
+
+const Page = () => 'hi';
+Page.getInitialProps = () => ({ hello: 'world' });
+
+export default Page;

--- a/packages/now-next/test/fixtures/07-custom-routes/pages/hasOwnProperty.js
+++ b/packages/now-next/test/fixtures/07-custom-routes/pages/hasOwnProperty.js
@@ -1,0 +1,7 @@
+// this is making sure a object prototype name doesn't
+// cause conflict as an output name
+
+const Page = () => 'hi';
+Page.getInitialProps = () => ({ hello: 'world' });
+
+export default Page;


### PR DESCRIPTION
This is one approach to handle a prototype collision occurring during output name checking which occurs when an output is named `constructor`, `hasOwnProperty`, or another prototype member name. A more ideal approach has also been opened to handle this outside of the builder to prevent this from having to be handled at the builder level 