### PR TITLE
[cli] Fetch environment variables from project if `.env` is not present

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -93,5 +93,5 @@ export default async function dev(
   process.once('SIGINT', () => devServer.stop());
   process.once('SIGTERM', () => devServer.stop());
 
-  await devServer.start(client, link.project || undefined, ...listen);
+  await devServer.start(client, link.project, ...listen);
 }

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -93,5 +93,5 @@ export default async function dev(
   process.once('SIGINT', () => devServer.stop());
   process.once('SIGTERM', () => devServer.stop());
 
-  await devServer.start(client, link.project, ...listen);
+  await devServer.start(client, link.project || undefined, ...listen);
 }

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -9,7 +9,9 @@ import { getLinkedProject } from '../../util/projects/link';
 import { getFrameworks } from '../../util/get-frameworks';
 import { isSettingValue } from '../../util/is-setting-value';
 import { getCommandName } from '../../util/pkg-name';
-import { ProjectSettings } from '../../types';
+import { ProjectSettings, ProjectEnvTarget } from '../../types';
+import getDecryptedEnvRecords from '../../util/get-decrypted-env-records';
+import { Env } from '@vercel/build-utils';
 
 type Options = {
   '--debug'?: boolean;
@@ -54,6 +56,7 @@ export default async function dev(
   let devCommand: string | undefined;
   let frameworkSlug: string | undefined;
   let projectSettings: ProjectSettings | undefined;
+  let environmentVars: Env | undefined;
   if (link.status === 'linked') {
     const { project, org } = link;
     client.currentTeam = org.type === 'team' ? org.id : undefined;
@@ -80,6 +83,13 @@ export default async function dev(
     if (project.rootDirectory) {
       cwd = join(cwd, project.rootDirectory);
     }
+
+    environmentVars = await getDecryptedEnvRecords(
+      output,
+      client,
+      project,
+      ProjectEnvTarget.Development
+    );
   }
 
   const devServer = new DevServer(cwd, {
@@ -88,10 +98,11 @@ export default async function dev(
     devCommand,
     frameworkSlug,
     projectSettings,
+    environmentVars,
   });
 
   process.once('SIGINT', () => devServer.stop());
   process.once('SIGTERM', () => devServer.stop());
 
-  await devServer.start(client, link.project || undefined, ...listen);
+  await devServer.start(...listen);
 }

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -93,5 +93,5 @@ export default async function dev(
   process.once('SIGINT', () => devServer.stop());
   process.once('SIGTERM', () => devServer.stop());
 
-  await devServer.start(...listen);
+  await devServer.start(client, link.project || undefined, ...listen);
 }

--- a/packages/now-cli/src/commands/env/pull.ts
+++ b/packages/now-cli/src/commands/env/pull.ts
@@ -4,8 +4,7 @@ import { Output } from '../../util/output';
 import promptBool from '../../util/prompt-bool';
 import Client from '../../util/client';
 import stamp from '../../util/output/stamp';
-import getEnvVariables from '../../util/env/get-env-records';
-import getDecryptedSecret from '../../util/env/get-decrypted-secret';
+import getDecryptedEnvRecords from '../../util/get-decrypted-env-records';
 import param from '../../util/output/param';
 import withSpinner from '../../util/with-spinner';
 import { join } from 'path';
@@ -13,6 +12,7 @@ import { promises, openSync, closeSync, readSync } from 'fs';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { getCommandName } from '../../util/pkg-name';
 const { writeFile } = promises;
+import { Env } from '@vercel/build-utils';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -84,45 +84,21 @@ export default async function pull(
   );
   const pullStamp = stamp();
 
-  const records = await withSpinner('Downloading', async () => {
-    const dev = ProjectEnvTarget.Development;
-    const envs = await getEnvVariables(output, client, project.id, 4, dev);
-    const decryptedValues = await Promise.all(
-      envs.map(async env => {
-        try {
-          const value = await getDecryptedSecret(output, client, env.value);
-          return { value, found: true };
-        } catch (error) {
-          if (error && error.status === 404) {
-            return { value: '', found: false };
-          }
-          throw error;
-        }
-      })
-    );
-    const results: { key: string; value: string; found: boolean }[] = [];
-    for (let i = 0; i < decryptedValues.length; i++) {
-      const { key } = envs[i];
-      const { value, found } = decryptedValues[i];
-      results.push({ key, value, found });
-    }
-    return results;
-  });
+  const records: Env = await withSpinner(
+    'Downloading',
+    async () =>
+      await getDecryptedEnvRecords(
+        output,
+        client,
+        project,
+        ProjectEnvTarget.Development
+      )
+  );
 
   const contents =
     CONTENTS_PREFIX +
-    records
-      .filter(obj => {
-        if (!obj.found) {
-          output.print('');
-          output.warn(
-            `Unable to download variable ${obj.key} because associated secret was deleted`
-          );
-          return false;
-        }
-        return true;
-      })
-      .map(({ key, value }) => `${key}="${escapeValue(value)}"`)
+    Object.entries(records)
+      .map(([key, value]) => `${key}="${escapeValue(value)}"`)
       .join('\n') +
     '\n';
 
@@ -139,8 +115,10 @@ export default async function pull(
   return 0;
 }
 
-function escapeValue(value: string) {
+function escapeValue(value: string | undefined) {
   return value
-    .replace(new RegExp('\n', 'g'), '\\n') // combine newlines (unix) into one line
-    .replace(new RegExp('\r', 'g'), '\\r'); // combine newlines (windows) into one line
+    ? value
+        .replace(new RegExp('\n', 'g'), '\\n') // combine newlines (unix) into one line
+        .replace(new RegExp('\r', 'g'), '\\r') // combine newlines (windows) into one line
+    : '';
 }

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -789,7 +789,7 @@ export default class DevServer {
    */
   async start(
     client: Client,
-    project: Project | undefined,
+    project: Project | null,
     ...listenSpec: ListenSpec
   ): Promise<void> {
     if (!fs.existsSync(this.cwd)) {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -789,7 +789,7 @@ export default class DevServer {
    */
   async start(
     client: Client,
-    project: Project,
+    project: Project | undefined,
     ...listenSpec: ListenSpec
   ): Promise<void> {
     if (!fs.existsSync(this.cwd)) {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -775,6 +775,10 @@ export default class DevServer {
   }
 
   start(...listenSpec: ListenSpec): void {
+    if (this.startPromise) {
+      return;
+    }
+
     this.startPromise = this._start(...listenSpec);
     this.startPromise.catch(err => {
       this.stop();

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -749,9 +749,9 @@ export default class DevServer {
       return {};
     }
 
-    const host = new URL(this.address).host;
     for (const name of Object.keys(env)) {
       if (name === 'VERCEL_URL') {
+        const host = new URL(this.address).host;
         env['VERCEL_URL'] = host;
       } else if (name === 'VERCEL_REGION') {
         env['VERCEL_REGION'] = 'dev1';

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -774,16 +774,14 @@ export default class DevServer {
     return Object.keys(files).filter(this.filter);
   }
 
-  start(...listenSpec: ListenSpec): void {
-    if (this.startPromise) {
-      return;
+  start(...listenSpec: ListenSpec): Promise<void> {
+    if (!this.startPromise) {
+      this.startPromise = this._start(...listenSpec).catch(err => {
+        this.stop();
+        throw err;
+      });
     }
-
-    this.startPromise = this._start(...listenSpec);
-    this.startPromise.catch(err => {
-      this.stop();
-      throw err;
-    });
+    return this.startPromise;
   }
 
   /**

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -148,7 +148,7 @@ export default class DevServer {
     this.debug = options.debug;
     this.output = options.output;
     this.envConfigs = { buildEnv: {}, runEnv: {}, allEnv: {} };
-    this.environmentVars = options.environmentVars || {};
+    this.environmentVars = options.environmentVars;
     this.files = {};
     this.address = '';
     this.devCommand = options.devCommand;

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -476,7 +476,6 @@ export default class DevServer {
   async getLocalEnv(fileName: string, base?: Env): Promise<Env> {
     // TODO: use the file watcher to only invalidate the env `dotfile`
     // once a change to the `fileName` occurs
-    this.output.debug(`getlocalenv ${base}`);
     const filePath = join(this.cwd, fileName);
     let env: Env = {};
     try {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -494,7 +494,7 @@ export default class DevServer {
       }
       return {
         ...this.validateEnvConfig(fileName, base || {}, env),
-        ...this.populateEnvConfig(this.environmentVars, host),
+        ...this.populateVercelEnvVars(this.environmentVars, host),
       };
     } catch (err) {
       if (err instanceof MissingDotenvVarsError) {
@@ -742,7 +742,11 @@ export default class DevServer {
     return merged;
   }
 
-  populateEnvConfig(env: Env | undefined, address = '', region = 'dev1'): Env {
+  populateVercelEnvVars(
+    env: Env | undefined,
+    address = '',
+    region = 'dev1'
+  ): Env {
     if (!env) {
       return {};
     }

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -789,7 +789,7 @@ export default class DevServer {
    */
   async start(
     client: Client,
-    project: Project | null,
+    project: Project,
     ...listenSpec: ListenSpec
   ): Promise<void> {
     if (!fs.existsSync(this.cwd)) {

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -31,7 +31,7 @@ export interface DevServerOptions {
 
 export interface EnvConfigs {
   /**
-   * environment variables from `.env.build` file (deprecated)
+   * environment variables from `.env.build` file
    */
   buildEnv: Env;
 

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -27,6 +27,7 @@ export interface DevServerOptions {
   devCommand?: string;
   frameworkSlug?: string;
   projectSettings?: ProjectSettings;
+  environmentVars?: Env;
 }
 
 export interface EnvConfigs {

--- a/packages/now-cli/src/util/get-decrypted-env-records.ts
+++ b/packages/now-cli/src/util/get-decrypted-env-records.ts
@@ -9,13 +9,9 @@ import { Env } from '@vercel/build-utils';
 export default async function getDecryptedEnvRecords(
   output: Output,
   client: Client,
-  project: null | Project,
+  project: Project,
   target: ProjectEnvTarget
 ): Promise<Env> {
-  if (!project) {
-    return {};
-  }
-
   const envs = await getEnvVariables(output, client, project.id, 4, target);
   const decryptedValues = await Promise.all(
     envs.map(async env => {

--- a/packages/now-cli/src/util/get-decrypted-env-records.ts
+++ b/packages/now-cli/src/util/get-decrypted-env-records.ts
@@ -1,0 +1,50 @@
+import getEnvVariables from './env/get-env-records';
+import getDecryptedSecret from './env/get-decrypted-secret';
+import Client from './client';
+import { Output } from './output/create-output';
+import { ProjectEnvTarget, Project } from '../types';
+
+import { Env } from '@vercel/build-utils';
+
+export default async function getDecryptedEnvRecords(
+  output: Output,
+  client: Client,
+  project: null | Project,
+  target: ProjectEnvTarget
+): Promise<Env> {
+  if (!project) {
+    return {};
+  }
+
+  const envs = await getEnvVariables(output, client, project.id, 4, target);
+  const decryptedValues = await Promise.all(
+    envs.map(async env => {
+      try {
+        const value = await getDecryptedSecret(output, client, env.value);
+        return { value, found: true };
+      } catch (error) {
+        if (error && error.status === 404) {
+          return { value: '', found: false };
+        }
+        throw error;
+      }
+    })
+  );
+
+  const results: Env = {};
+  for (let i = 0; i < decryptedValues.length; i++) {
+    const { key } = envs[i];
+    const { value, found } = decryptedValues[i];
+
+    if (!found) {
+      output.print('');
+      output.warn(
+        `Unable to download variable ${key} because associated secret was deleted`
+      );
+      continue;
+    }
+
+    results[key] = value ? value : '';
+  }
+  return results;
+}

--- a/packages/now-cli/test/dev/fixtures/custom-runtime/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/custom-runtime/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/user.sh": {
-      "runtime": "vercel-bash@3.0.7"
+      "runtime": "vercel-bash@3.0.8"
     }
   }
 }

--- a/packages/now-cli/test/dev/fixtures/node-ts-node-target/.env
+++ b/packages/now-cli/test/dev/fixtures/node-ts-node-target/.env
@@ -1,0 +1,3 @@
+ # Created by Vercel CLI
+ VERCEL_REGION=""
+ VERCEL_URL=""

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1640,7 +1640,6 @@ test(
       t.regex(env.NOW_REGION, /^[a-z]{3}\d$/);
       if (isDev) {
         // Only dev is tested because in production these are opt-in.
-        t.is(env.NOW_URL, host);
         t.is(env.VERCEL_URL, host);
         t.is(env.VERCEL_REGION, 'dev1');
       }

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -365,7 +365,7 @@ CMD ["node", "index.js"]`,
       'package.json': JSON.stringify({
         private: true,
         scripts: {
-          build: 'mkdir public && node print.js > public/index.json',
+          build: 'mkdir -p public && node print.js > public/index.json',
         },
       }),
     },

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -661,6 +661,7 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const apiJson = await apiRes.json();
 
     t.is(apiJson['VERCEL_URL'], localhostNoProtocol);
+    t.is(apiJson['MY_ENV_VAR'], 'MY_VALUE');
 
     const homeUrl = localhost[0];
     const homeRes = await fetch(homeUrl);


### PR DESCRIPTION
Previously, users would have to run `vc env pull` to fetch cloud environment variables into `.env`. After this PR, if no `.env` or `.build.env` file is present, environment variables will be pulled by `vc dev` from your Vercel Environment Variables settings, no file necessary.