### PR TITLE
[cli] Update 502 error template for `vc dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1591,7 +1591,7 @@ export default class DevServer {
           req,
           res,
           nowRequestId,
-          'NO_STATUS_CODE_FROM_DEV_SERVER',
+          'NO_RESPONSE_FROM_FUNCTION',
           502
         );
         return;
@@ -1751,7 +1751,7 @@ export default class DevServer {
             req,
             res,
             nowRequestId,
-            'NO_STATUS_CODE_FROM_LAMBDA',
+            'NO_RESPONSE_FROM_FUNCTION',
             502
           );
           return;

--- a/packages/now-cli/src/util/dev/templates/error_502.jst
+++ b/packages/now-cli/src/util/dev/templates/error_502.jst
@@ -53,7 +53,7 @@
   <p>
     <ul>
       <li>
-        Please open a <a target="_blank" href="https://github.com/vercel/vercel/issues/new">GitHub issue</a> describing the problem you are experiencing with <code>vercel dev</code>.
+        Please open a <a target="_blank" href="https://github.com/vercel/vercel/issues/new/choose">GitHub issue</a> describing the problem you are experiencing with <code>vercel dev</code>.
       </li>
     </ul>
   </p>

--- a/packages/now-cli/src/util/dev/templates/error_502.jst
+++ b/packages/now-cli/src/util/dev/templates/error_502.jst
@@ -44,22 +44,16 @@
   <p>
     <ul>
       <li>
-        If you are a visitor; contact the website owner or try again later.
-      </li>
-      <li>
-        If you are the owner; <a href="/_logs" target="_blank">check the logs</a> for the application error.
+        Check the logs in your terminal window to see the application error.
       </li>
     </ul>
-    <a target="_blank" href="https://vercel.com/docs/router-status/{{= it.http_status_code }}" class="docs-link" rel="noopener noreferrer">Developer Documentation →</a>
+    <a target="_blank" href="https://vercel.com/docs/error/application/{{= it.error_code }}" class="docs-link" rel="noopener noreferrer">Developer Documentation →</a>
   </p>
   {{??}}
   <p>
     <ul>
       <li>
-        If you are a visitor, please try again later.
-      </li>
-      <li>
-        If you are the owner, no action is needed. Our engineers have been notified.
+        Please open a <a target="_blank" href="https://github.com/vercel/vercel/issues/new">GitHub issue</a> describing the problem you are experiencing with <code>vercel dev</code>.
       </li>
     </ul>
   </p>


### PR DESCRIPTION
* Fix the "Developer Documentation" link.
 * Remove the "If you're a visitor" section - doesn't make sense for `vc dev` since there are no "visitors".
 * Don't link to `_logs` since it's not supported in `vc dev`. Instead direct the user to look at their terminal window to see error logs.
 * Link to new GH issue for non-app error 502 (I don't think this code path ever happens in `vc dev`, but might as well make it correct in case we do in the future).

<img width="1077" alt="Screen Shot 2020-06-05 at 4 15 16 PM" src="https://user-images.githubusercontent.com/71256/83929319-c7832a00-a747-11ea-9cae-b0adac97dfa5.png">
