### PR TITLE
[cli] Show npm output when failing to install Runtimes in `vc dev`

### DIFF
--- a/packages/now-build-utils/src/errors.ts
+++ b/packages/now-build-utils/src/errors.ts
@@ -7,11 +7,13 @@ export class NowBuildError extends Error {
   public hideStackTrace = true;
   public code: string;
   public link?: string;
+  public action?: string;
 
-  constructor({ message, code, link }: Props) {
+  constructor({ message, code, link, action }: Props) {
     super(message);
     this.code = code;
     this.link = link;
+    this.action = action;
   }
 }
 
@@ -31,4 +33,8 @@ interface Props {
    * link to more information about this error.
    */
   link?: string;
+  /**
+   * Optional "action" to display before the `link`, such as "More details".
+   */
+  action?: string;
 }

--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -119,7 +119,7 @@ export default async function main(ctx: NowContext) {
   try {
     return await dev(ctx, argv, args, output);
   } catch (err) {
-    output.error(err.message);
+    output.prettyError(err);
     output.debug(stringifyError(err));
     return 1;
   }

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -3,12 +3,12 @@ import semver from 'semver';
 import npa from 'npm-package-arg';
 import pluralize from 'pluralize';
 import { basename, join } from 'path';
-import { PackageJson } from '@vercel/build-utils';
 import XDGAppPaths from 'xdg-app-paths';
 import { mkdirp, readJSON, writeJSON } from 'fs-extra';
+import { NowBuildError, PackageJson } from '@vercel/build-utils';
 import cliPkg from '../pkg';
 
-import { NoBuilderCacheError, NpmInstallError } from '../errors-ts';
+import { NoBuilderCacheError } from '../errors-ts';
 import { Output } from '../output';
 import { getDistTag } from '../get-dist-tag';
 
@@ -258,11 +258,14 @@ async function npmInstall(
       if (result.stderr) {
         console.error(result.stderr);
       }
-      const isEnoent = (result as any).code === 'ENOENT';
-      throw new NpmInstallError(
-        'Failed to install `vercel dev` dependencies.',
-        isEnoent
-      );
+      throw new NowBuildError({
+        message:
+          (result as any).code === 'ENOENT'
+            ? '`npm` is not installed'
+            : 'Failed to install `vercel dev` dependencies',
+        code: 'NPM_INSTALL_ERROR',
+        link: 'https://vercel.link/npm-install-error',
+      });
     }
   } finally {
     stopSpinner();

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -8,7 +8,7 @@ import XDGAppPaths from 'xdg-app-paths';
 import { mkdirp, readJSON, writeJSON } from 'fs-extra';
 import cliPkg from '../pkg';
 
-import { NoBuilderCacheError } from '../errors-ts';
+import { NoBuilderCacheError, NpmInstallError } from '../errors-ts';
 import { Output } from '../output';
 import { getDistTag } from '../get-dist-tag';
 
@@ -258,7 +258,11 @@ async function npmInstall(
       if (result.stderr) {
         console.error(result.stderr);
       }
-      throw result;
+      const isEnoent = (result as any).code === 'ENOENT';
+      throw new NpmInstallError(
+        'Failed to install `vercel dev` dependencies.',
+        isEnoent
+      );
     }
   } finally {
     stopSpinner();

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -564,7 +564,7 @@ export default class DevServer {
       nowConfig: config,
     });
     if (routeError) {
-      this.output.error(routeError.message, null, routeError.link);
+      this.output.prettyError(routeError);
       await this.exit();
     }
     config.routes = maybeRoutes || [];

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1238,7 +1238,7 @@ export class BuildError extends NowError<'BUILD_ERROR', {}> {
 }
 
 /**
- * This Error subclass can be used by the `output.error()` function.
+ * This Error subclass can be used by the `output.prettyError()` function.
  */
 export class LinkableError extends Error {
   link: string;

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -3,7 +3,6 @@ import { Response } from 'node-fetch';
 import { NowError } from './now-error';
 import code from './output/code';
 import { getCommandName } from './pkg-name';
-import { NowBuildError } from '@vercel/build-utils';
 
 /**
  * This error is thrown when there is an API error with a payload. The error
@@ -1234,19 +1233,6 @@ export class BuildError extends NowError<'BUILD_ERROR', {}> {
       code: 'BUILD_ERROR',
       meta,
       message,
-    });
-  }
-}
-
-export class NpmInstallError extends NowBuildError {
-  constructor(message: string, isEnoent = false) {
-    if (isEnoent) {
-      message += ' Make sure `npm` is installed.';
-    }
-    super({
-      message,
-      code: 'NPM_INSTALL_ERROR',
-      link: 'https://vercel.link/npm-install-error',
     });
   }
 }

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1236,3 +1236,26 @@ export class BuildError extends NowError<'BUILD_ERROR', {}> {
     });
   }
 }
+
+/**
+ * This Error subclass can be used by the `output.error()` function.
+ */
+export class LinkableError extends Error {
+  link: string;
+  action?: string;
+
+  constructor(message: string, link: string, action?: string) {
+    super(message);
+    this.link = link;
+    this.action = action;
+  }
+}
+
+export class NpmInstallError extends LinkableError {
+  constructor(message: string, isEnoent = false) {
+    if (isEnoent) {
+      message += ' Make sure `npm` is installed.';
+    }
+    super(message, 'https://vercel.link/npm-install-error');
+  }
+}

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -3,6 +3,7 @@ import { Response } from 'node-fetch';
 import { NowError } from './now-error';
 import code from './output/code';
 import { getCommandName } from './pkg-name';
+import { NowBuildError } from '@vercel/build-utils';
 
 /**
  * This error is thrown when there is an API error with a payload. The error
@@ -1237,25 +1238,15 @@ export class BuildError extends NowError<'BUILD_ERROR', {}> {
   }
 }
 
-/**
- * This Error subclass can be used by the `output.prettyError()` function.
- */
-export class LinkableError extends Error {
-  link: string;
-  action?: string;
-
-  constructor(message: string, link: string, action?: string) {
-    super(message);
-    this.link = link;
-    this.action = action;
-  }
-}
-
-export class NpmInstallError extends LinkableError {
+export class NpmInstallError extends NowBuildError {
   constructor(message: string, isEnoent = false) {
     if (isEnoent) {
       message += ' Make sure `npm` is installed.';
     }
-    super(message, 'https://vercel.link/npm-install-error');
+    super({
+      message,
+      code: 'NPM_INSTALL_ERROR',
+      link: 'https://vercel.link/npm-install-error',
+    });
   }
 }

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -77,16 +77,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
   }
 
   function prettyError(err: Error & { link?: string; action?: string }) {
-    let str = err.message;
-    let link: string | undefined = undefined;
-    let action: string | undefined = undefined;
-    if (err.link) {
-      link = err.link;
-    }
-    if (err.action) {
-      action = err.action;
-    }
-    return error(str, undefined, link, action);
+    return error(err.message, undefined, err.link, err.action);
   }
 
   function ready(str: string) {

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -2,7 +2,9 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { format } from 'util';
 import { Console } from 'console';
+import renderLink from './link';
 import wait from './wait';
+import { LinkableError } from '../errors-ts';
 
 export type Output = ReturnType<typeof createOutput>;
 
@@ -41,7 +43,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
       boxen(
         chalk.bold.yellow('WARN! ') +
           str +
-          (details ? `\nMore details: ${details}` : ''),
+          (details ? `\nMore details: ${renderLink(details)}` : ''),
         {
           padding: {
             top: 0,
@@ -71,8 +73,19 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     print(`${chalk.red(`Error!`)} ${str}\n`);
     const details = slug ? `https://err.sh/now/${slug}` : link;
     if (details) {
-      print(`${action}: ${details}\n`);
+      print(`${chalk.bold(action)}: ${renderLink(details)}\n`);
     }
+  }
+
+  function prettyError(err: Error) {
+    let str = err.message;
+    let link: string | null = null;
+    let action: string | undefined = undefined;
+    if (err instanceof LinkableError) {
+      link = err.link;
+      action = err.action;
+    }
+    return error(str, null, link, action);
   }
 
   function ready(str: string) {
@@ -135,6 +148,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     log,
     warn,
     error,
+    prettyError,
     ready,
     success,
     debug,

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -4,7 +4,6 @@ import { format } from 'util';
 import { Console } from 'console';
 import renderLink from './link';
 import wait from './wait';
-import { LinkableError } from '../errors-ts';
 
 export type Output = ReturnType<typeof createOutput>;
 
@@ -66,8 +65,8 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
 
   function error(
     str: string,
-    slug: string | null = null,
-    link: string | null = null,
+    slug?: string,
+    link?: string,
     action = 'More details'
   ) {
     print(`${chalk.red(`Error!`)} ${str}\n`);
@@ -77,15 +76,17 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
-  function prettyError(err: Error) {
+  function prettyError(err: Error & { link?: string; action?: string }) {
     let str = err.message;
-    let link: string | null = null;
+    let link: string | undefined = undefined;
     let action: string | undefined = undefined;
-    if (err instanceof LinkableError) {
+    if (err.link) {
       link = err.link;
+    }
+    if (err.action) {
       action = err.action;
     }
-    return error(str, null, link, action);
+    return error(str, undefined, link, action);
   }
 
   function ready(str: string) {
@@ -120,8 +121,6 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     return wait(message, delay);
   }
 
-  // This is pretty hacky, but since we control the version of Node.js
-  // being used because of `pkg` it's safe to do in this case.
   const c = {
     _times: new Map(),
     log(a: string, ...args: string[]) {

--- a/packages/now-cli/test/dev/fixtures/runtime-not-installed/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/runtime-not-installed/vercel.json
@@ -1,0 +1,3 @@
+{
+  "builds": [{ "src": "*.js", "use": "@vercel/does-not-exist" }]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -375,6 +375,16 @@ test.afterEach(async () => {
   );
 });
 
+test('[vercel dev] prints `npm install` errors', async t => {
+  const dir = fixture('runtime-not-installed');
+  const result = await exec(dir);
+  t.truthy(result.stderr.includes('npm ERR! 404'));
+  t.truthy(
+    result.stderr.includes('Failed to install `vercel dev` dependencies')
+  );
+  t.truthy(result.stderr.includes('https://vercel.link/npm-install-error'));
+});
+
 test(
   '[vercel dev] validate routes that use `check: true`',
   testFixtureStdio('routes-check-true', async testPath => {

--- a/packages/now-routing-utils/src/index.ts
+++ b/packages/now-routing-utils/src/index.ts
@@ -230,6 +230,7 @@ function createError(
   const errors = Array.isArray(allErrors) ? allErrors : [allErrors];
   const message = errors[0];
   const error: RouteApiError = {
+    name: 'RouteApiError',
     code,
     message,
     link,

--- a/packages/now-routing-utils/src/types.ts
+++ b/packages/now-routing-utils/src/types.ts
@@ -1,6 +1,7 @@
 import { HandleValue } from './index';
 
 export type RouteApiError = {
+  name: string;
   code: string;
   message: string;
   link?: string; // link to error message details


### PR DESCRIPTION
If `npm install` doesn't exit with 0, then log the output to the
termial.

This was already happening with `--debug` due to `stdio: "inherit"`
when debug is enabled, so this change is really only relevant for the
non-debug case.

### Before

```
$ vc dev
Vercel CLI 19.0.2-canary.13 dev (beta) — https://vercel.com/feedback
Error! Command failed with exit code 1: npm install --save-exact --no-package-lock --no-audit --no-progress @now/build-utils@canary @vercel/build-utils@canary now-php@0.0.0
```

### After

Bad dependency:

<img width="641" alt="Screen Shot 2020-06-08 at 12 22 00 PM" src="https://user-images.githubusercontent.com/71256/84071523-b07c4c00-a982-11ea-9200-f18498ae917c.png">

No `npm` installed:

<img width="672" alt="Screen Shot 2020-06-08 at 12 21 16 PM" src="https://user-images.githubusercontent.com/71256/84071456-95114100-a982-11ea-87cc-05ed7fb2cb80.png">
