### PR TITLE
[next] Re-disable shared lambdas by default

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -70,7 +70,7 @@ import {
   syncEnvVars,
   validateEntrypoint,
 } from './utils';
-import findUp from 'find-up';
+// import findUp from 'find-up';
 
 interface BuildParamsMeta {
   isDev: boolean | undefined;
@@ -205,39 +205,6 @@ export const build = async ({
 }> => {
   validateEntrypoint(entrypoint);
 
-  const nowJsonPath = await findUp(['now.json', 'vercel.json'], {
-    type: 'file',
-  });
-  let hasLegacyRoutes = false;
-  const hasFunctionsConfig = !!config.functions;
-
-  if (nowJsonPath) {
-    const nowJsonData = JSON.parse(await readFile(nowJsonPath, 'utf8'));
-
-    if (Array.isArray(nowJsonData.routes) && nowJsonData.routes.length > 0) {
-      hasLegacyRoutes = true;
-      console.warn(
-        `WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes in ${path.basename(
-          nowJsonPath
-        )}. http://err.sh/vercel/vercel/next-legacy-routes-optimized-lambdas`
-      );
-    }
-  }
-
-  if (hasFunctionsConfig) {
-    console.warn(
-      `WARNING: Your application is being opted out of "@vercel/next" optimized lambdas mode due to \`functions\` config.\nMore info: http://err.sh/vercel/vercel/next-functions-config-optimized-lambdas`
-    );
-  }
-
-  // default to true but still allow opting out with the config
-  const isSharedLambdas =
-    !hasLegacyRoutes &&
-    !hasFunctionsConfig &&
-    typeof config.sharedLambdas === 'undefined'
-      ? true
-      : !!config.sharedLambdas;
-
   // Limit for max size each lambda can be, 50 MB if no custom limit
   const lambdaCompressedByteLimit = config.maxLambdaSize || 50 * 1000 * 1000;
 
@@ -261,6 +228,48 @@ export const build = async ({
         'No Next.js version could be detected in "package.json". Make sure `"next"` is installed in "dependencies" or "devDependencies"',
     });
   }
+
+  // let nowJsonPath = Object.keys(files).find(file => {
+  //   return file.endsWith('now.json') || file.endsWith('vercel.json')
+  // })
+
+  // if (nowJsonPath) nowJsonPath = files[nowJsonPath].fsPath
+
+  // if (!nowJsonPath) {
+  //   nowJsonPath = await findUp(['now.json', 'vercel.json'], {
+  //     cwd: path.join(workPath, path.dirname(entrypoint))
+  //   })
+  // }
+
+  // let hasLegacyRoutes = false;
+  // const hasFunctionsConfig = !!config.functions;
+
+  // if (nowJsonPath) {
+  //   const nowJsonData = JSON.parse(await readFile(nowJsonPath, 'utf8'));
+
+  //   if (Array.isArray(nowJsonData.routes) && nowJsonData.routes.length > 0) {
+  //     hasLegacyRoutes = true;
+  //     console.warn(
+  //       `WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes in ${path.basename(
+  //         nowJsonPath
+  //       )}. http://err.sh/vercel/vercel/next-legacy-routes-optimized-lambdas`
+  //     );
+  //   }
+  // }
+
+  // if (hasFunctionsConfig) {
+  //   console.warn(
+  //     `WARNING: Your application is being opted out of "@vercel/next" optimized lambdas mode due to \`functions\` config.\nMore info: http://err.sh/vercel/vercel/next-functions-config-optimized-lambdas`
+  //   );
+  // }
+
+  // default to true but still allow opting out with the config
+  const isSharedLambdas = !!config.sharedLambdas;
+  // !hasLegacyRoutes &&
+  // !hasFunctionsConfig &&
+  // typeof config.sharedLambdas === 'undefined'
+  //   ? true
+  //   : !!config.sharedLambdas;
 
   if (meta.isDev) {
     let childProcess: ChildProcess | undefined;

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -34,6 +34,28 @@ it(
   FOUR_MINUTES
 );
 
+// it(
+//   'Should opt-out of shared lambdas when routes are detected',
+//   async () => {
+//     const {
+//       buildResult: { output },
+//     } = await runBuildLambda(path.join(__dirname, '../fixtures/26-mono-repo-404-lambda'));
+//     expect(output['packages/webapp/404']).toBeDefined();
+//     expect(output['packages/webapp/index']).toBeDefined();
+//     expect(output['packages/webapp/__NEXT_PAGE_LAMBDA_0']).not.toBeDefined();
+//     const filePaths = Object.keys(output);
+//     const hasUnderScoreAppStaticFile = filePaths.some(filePath =>
+//       filePath.match(/static.*\/pages\/_app\.js$/)
+//     );
+//     const hasUnderScoreErrorStaticFile = filePaths.some(filePath =>
+//       filePath.match(/static.*\/pages\/_error\.js$/)
+//     );
+//     expect(hasUnderScoreAppStaticFile).toBeTruthy();
+//     expect(hasUnderScoreErrorStaticFile).toBeTruthy();
+//   },
+//   FOUR_MINUTES
+// );
+
 it(
   'Should build the monorepo example',
   async () => {

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -15,8 +15,8 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'standard'));
     expect(output['index']).toBeDefined();
-    expect(output.goodbye).not.toBeDefined();
-    expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    expect(output.__NEXT_PAGE_LAMBDA_0).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -63,8 +63,8 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'monorepo'));
 
-    expect(output['www/index']).not.toBeDefined();
-    expect(output['www/__NEXT_PAGE_LAMBDA_0']).toBeDefined();
+    expect(output['www/index']).toBeDefined();
+    expect(output['www/__NEXT_PAGE_LAMBDA_0']).not.toBeDefined();
     expect(output['www/static/test.txt']).toBeDefined();
     expect(output['www/data.txt']).toBeDefined();
     const filePaths = Object.keys(output);
@@ -164,9 +164,9 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'serverless-config'));
 
-    expect(output.index).not.toBeDefined();
-    expect(output.goodbye).not.toBeDefined();
-    expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
+    expect(output.index).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    expect(output.__NEXT_PAGE_LAMBDA_0).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -201,9 +201,9 @@ it(
       path.join(__dirname, 'serverless-config-monorepo-missing')
     );
 
-    expect(output['nested/index']).not.toBeDefined();
-    expect(output['nested/goodbye']).not.toBeDefined();
-    expect(output['nested/__NEXT_PAGE_LAMBDA_0']).toBeDefined();
+    expect(output['nested/index']).toBeDefined();
+    expect(output['nested/goodbye']).toBeDefined();
+    expect(output['nested/__NEXT_PAGE_LAMBDA_0']).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -235,9 +235,9 @@ it(
       path.join(__dirname, 'serverless-config-monorepo-present')
     );
 
-    expect(output['nested/index']).not.toBeDefined();
-    expect(output['nested/goodbye']).not.toBeDefined();
-    expect(output['nested/__NEXT_PAGE_LAMBDA_0']).toBeDefined();
+    expect(output['nested/index']).toBeDefined();
+    expect(output['nested/goodbye']).toBeDefined();
+    expect(output['nested/__NEXT_PAGE_LAMBDA_0']).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -303,8 +303,8 @@ it(
     } = await runBuildLambda(path.join(__dirname, 'serverless-config-object'));
 
     expect(output['index']).toBeDefined();
-    expect(output.goodbye).not.toBeDefined();
-    expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    expect(output.__NEXT_PAGE_LAMBDA_0).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)
@@ -338,8 +338,8 @@ it(
     } = await runBuildLambda(path.join(__dirname, 'serverless-no-config'));
 
     expect(output['index']).toBeDefined();
-    expect(output.goodbye).not.toBeDefined();
-    expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
+    expect(output.goodbye).toBeDefined();
+    expect(output.__NEXT_PAGE_LAMBDA_0).not.toBeDefined();
     const filePaths = Object.keys(output);
     const serverlessError = filePaths.some(filePath =>
       filePath.match(/_error/)


### PR DESCRIPTION
As noticed, `now.json` isn't available during the build currently which makes feature detecting and opting out when `routes` are used not work currently so this re-disables the shared lambdas optimization by default while we investigate detecting this