### PR TITLE
[cli] Update `@vercel/next` to v2.6.5

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@vercel/build-utils": "2.3.2-canary.5",
     "@vercel/go": "1.1.2-canary.2",
-    "@vercel/next": "2.6.3-canary.6",
+    "@vercel/next": "2.6.5",
     "@vercel/node": "1.6.2-canary.5",
     "@vercel/python": "1.2.2-canary.2",
     "@vercel/ruby": "1.2.2-canary.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,11 +2190,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@vercel/next@2.6.3-canary.6":
-  version "2.6.3-canary.6"
-  resolved "https://registry.yarnpkg.com/@vercel/next/-/next-2.6.3-canary.6.tgz#e6d789bdef3e8561926dd9074c904704fae1de4b"
-  integrity sha512-cRH2fP0OUSnC1dH5K426JGEm4Jv7341GqoFLjHBpnR6qQyGOdaRVx7vROmmB2GmF1EGjyYoQKPLiV1OzaJCWxQ==
-
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"


### PR DESCRIPTION
It got out of sync somehow in 55c60d30e68539b5a687aabec174affc9dfa5115.