### PR TITLE
[cli] Better errors for conflicting configuration files

### DIFF
--- a/packages/now-build-utils/src/index.ts
+++ b/packages/now-build-utils/src/index.ts
@@ -27,6 +27,7 @@ import {
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
 } from './fs/node-version';
+import { NowBuildError } from './errors';
 import streamToBuffer from './fs/stream-to-buffer';
 import shouldServe from './should-serve';
 import debug from './debug';
@@ -111,9 +112,11 @@ export const getPlatformEnv = (name: string): string | undefined => {
   const n = process.env[nName];
   if (typeof v === 'string') {
     if (typeof n === 'string') {
-      throw new Error(
-        `Both "${vName}" and "${nName}" env vars are defined. Please only define the "${vName}" env var`
-      );
+      throw new NowBuildError({
+        code: 'CONFLICTING_ENV_VAR_NAMES',
+        message: `Both "${vName}" and "${nName}" env vars are defined. Please only define the "${vName}" env var.`,
+        link: 'https://vercel.link/combining-old-and-new-config',
+      });
     }
     return v;
   }

--- a/packages/now-build-utils/test/unit.get-platform-env.test.ts
+++ b/packages/now-build-utils/test/unit.get-platform-env.test.ts
@@ -39,7 +39,7 @@ describe('Test `getPlatformEnv()`', () => {
     assert(err);
     assert.equal(
       err!.message,
-      'Both "VERCEL_FOO" and "NOW_FOO" env vars are defined. Please only define the "VERCEL_FOO" env var'
+      'Both "VERCEL_FOO" and "NOW_FOO" env vars are defined. Please only define the "VERCEL_FOO" env var.'
     );
   });
 });

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -24,6 +24,7 @@ import checkForUpdate from 'update-check';
 import ms from 'ms';
 import { URL } from 'url';
 import * as Sentry from '@sentry/node';
+import { NowBuildError } from '@vercel/build-utils';
 import getGlobalPathConfig from './util/config/global-path';
 import {
   getDefaultConfig,
@@ -114,10 +115,10 @@ const main = async argv_ => {
   }
 
   if (
-    localConfig instanceof NowError &&
+    (localConfig instanceof NowError || localConfig instanceof NowBuildError) &&
     !(localConfig instanceof ERRORS.CantFindConfig)
   ) {
-    output.error(`Failed to load local config file: ${localConfig.message}`);
+    output.prettyError(localConfig);
     return 1;
   }
 
@@ -644,27 +645,6 @@ const main = async argv_ => {
         )} could not be resolved. Please verify your internet connectivity and DNS configuration.`
       );
       output.debug(err.stack);
-
-      return 1;
-    }
-
-    await reportError(Sentry, err, apiUrl, configFiles);
-
-    // If there is a code we should not consider the error unexpected
-    // but instead show the message. Any error that is handled by this should
-    // actually be handled in the sub command instead. Please make sure
-    // that happens for anything that lands here. It should NOT bubble up to here.
-    if (err.code) {
-      output.debug(err.stack);
-      output.error(err.message);
-
-      if (shouldCollectMetrics) {
-        metric
-          .event(eventCategory, '1', pkg.version)
-          .exception(err.message)
-          .send();
-      }
-
       return 1;
     }
 
@@ -675,9 +655,23 @@ const main = async argv_ => {
         .send();
     }
 
-    // Otherwise it is an unexpected error and we should show the trace
-    // and an unexpected error message
-    output.error(`An unexpected error occurred in ${subcommand}: ${err.stack}`);
+    // If there is a code we should not consider the error unexpected
+    // but instead show the message. Any error that is handled by this should
+    // actually be handled in the sub command instead. Please make sure
+    // that happens for anything that lands here. It should NOT bubble up to here.
+    if (err.code) {
+      output.debug(err.stack);
+      output.prettyError(err);
+    } else {
+      await reportError(Sentry, err, apiUrl, configFiles);
+
+      // Otherwise it is an unexpected error and we should show the trace
+      // and an unexpected error message
+      output.error(
+        `An unexpected error occurred in ${subcommand}: ${err.stack}`
+      );
+    }
+
     return 1;
   }
 
@@ -687,8 +681,6 @@ const main = async argv_ => {
 
   return exitCode;
 };
-
-debug('start');
 
 const handleRejection = async err => {
   debug('handling rejection');

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -1,5 +1,6 @@
 import bytes from 'bytes';
 import { Response } from 'node-fetch';
+import { NowBuildError } from '@vercel/build-utils';
 import { NowError } from './now-error';
 import code from './output/code';
 import { getCommandName } from './pkg-name';
@@ -771,17 +772,17 @@ export class CantParseJSONFile extends NowError<
   }
 }
 
-export class ConflictingConfigFiles extends NowError<
-  'CONFLICTING_CONFIG_FILES',
-  { files: string[] }
-> {
+export class ConflictingConfigFiles extends NowBuildError {
+  files: string[];
+
   constructor(files: string[]) {
     super({
       code: 'CONFLICTING_CONFIG_FILES',
-      meta: { files },
       message:
         'Cannot use both a `vercel.json` and `now.json` file. Please delete the `now.json` file.',
+      link: 'https://vercel.link/combining-old-and-new-config',
     });
+    this.files = files;
   }
 }
 

--- a/packages/now-cli/src/util/output/error.ts
+++ b/packages/now-cli/src/util/output/error.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { metrics, shouldCollectMetrics } from '../metrics';
 import { APIError } from '../errors-ts';
+import renderLink from './link';
 
 const metric = metrics();
 
@@ -9,10 +10,9 @@ export default function error(...input: string[] | [APIError]) {
   if (typeof input[0] === 'object') {
     const { slug, message, link } = input[0];
     messages = [message];
-    if (slug) {
-      messages.push(`> More details: https://err.sh/now/${slug}`);
-    } else if (link) {
-      messages.push(`> More details: ${link}`);
+    const details = slug ? `https://err.sh/now/${slug}` : link;
+    if (details) {
+      messages.push(`${chalk.bold('More details')}: ${renderLink(details)}`);
     }
   }
 

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import { prependEmoji, emoji } from '../emoji';
 import AJV from 'ajv';
 import { isDirectory } from '../config/global-path';
-import { getPlatformEnv } from '@vercel/build-utils';
+import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -49,9 +49,12 @@ export function getVercelDirectory(cwd: string = process.cwd()): string {
   const possibleDirs = [join(cwd, VERCEL_DIR), join(cwd, VERCEL_DIR_FALLBACK)];
   const existingDirs = possibleDirs.filter(d => isDirectory(d));
   if (existingDirs.length > 1) {
-    throw new Error(
-      'Both `.vercel` and `.now` directories exist. Please remove the `.now` directory.'
-    );
+    throw new NowBuildError({
+      code: 'CONFLICTING_CONFIG_DIRECTORIES',
+      message:
+        'Both `.vercel` and `.now` directories exist. Please remove the `.now` directory.',
+      link: 'https://vercel.link/combining-old-and-new-config',
+    });
   }
   return existingDirs[0] || possibleDirs[0];
 }

--- a/packages/now-client/src/utils/index.ts
+++ b/packages/now-client/src/utils/index.ts
@@ -7,6 +7,7 @@ import qs from 'querystring';
 import ignore from 'ignore';
 type Ignore = ReturnType<typeof ignore>;
 import { pkgVersion } from '../pkg';
+import { NowBuildError } from '@vercel/build-utils';
 import { NowClientOptions, DeploymentOptions, NowConfig } from '../types';
 import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
@@ -166,9 +167,12 @@ export async function getVercelIgnore(
         maybeRead(join(cwd, '.nowignore'), ''),
       ]);
       if (vercelignore && nowignore) {
-        throw new Error(
-          'Cannot use both a `.vercelignore` and `.nowignore` file. Please delete the `.nowignore` file.'
-        );
+        throw new NowBuildError({
+          code: 'CONFLICTING_IGNORE_FILES',
+          message:
+            'Cannot use both a `.vercelignore` and `.nowignore` file. Please delete the `.nowignore` file.',
+          link: 'https://vercel.link/combining-old-and-new-config',
+        });
       }
       return vercelignore || nowignore;
     })


### PR DESCRIPTION
#### Conflicting `VERCEL_` and `NOW_` env vars:
<img width="1029" alt="Screen Shot 2020-06-09 at 4 13 02 PM" src="https://user-images.githubusercontent.com/71256/84209935-493ac680-aa6c-11ea-93e5-1f09d5e75b61.png">

#### Conflicting `.vercel` and `.now` project directories
<img width="719" alt="Screen Shot 2020-06-09 at 4 13 16 PM" src="https://user-images.githubusercontent.com/71256/84209940-4b048a00-aa6c-11ea-85af-1a788bafe998.png">

#### Conflicting `vercel.json` and `now.json` files
<img width="777" alt="Screen Shot 2020-06-09 at 4 13 43 PM" src="https://user-images.githubusercontent.com/71256/84209945-4e981100-aa6c-11ea-9efc-efe34d1d5dda.png">

#### Conflicting `.vercelignore` and `.nowignore` files
<img width="817" alt="Screen Shot 2020-06-09 at 4 14 05 PM" src="https://user-images.githubusercontent.com/71256/84209949-4fc93e00-aa6c-11ea-8389-6d43b39636eb.png">

* Ensures these user errors are not sent to Sentry
* Renders the link https://vercel.link/combining-old-and-new-config for all errors