### PR TITLE
[tests] Don't revoke `VERCEL_TOKEN` after tests run

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -243,8 +243,10 @@ test.after.always(async () => {
     loginApiServer.close();
   }
 
-  // Make sure the token gets revoked
-  await execa(binaryPath, ['logout', ...defaultArgs]);
+  // Make sure the token gets revoked unless it's passed in via environment
+  if (!process.env.VERCEL_TOKEN) {
+    await execa(binaryPath, ['logout', ...defaultArgs]);
+  }
 
   if (tmpDir) {
     // Remove config directory entirely


### PR DESCRIPTION
`VERCEL_TOKEN` will no longer be invalidated during tests

Story: https://app.clubhouse.io/vercel/story/2281