### PR TITLE
[cli] Fix `vc dev` proxy to upstream frontend dev server

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1503,16 +1503,15 @@ export default class DevServer {
     if (!match) {
       // If the dev command is started, then proxy to it
       if (this.devProcessPort) {
-        debug('Proxying to frontend dev server');
+        const upstream = `http://localhost:${this.devProcessPort}`;
+        debug(`Proxying to frontend dev server: ${upstream}`);
         this.setResponseHeaders(res, nowRequestId);
-        return proxyPass(
-          req,
-          res,
-          `http://localhost:${this.devProcessPort}`,
-          this,
-          nowRequestId,
-          false
-        );
+        const origUrl = url.parse(req.url || '/', true);
+        //delete origUrl.search;
+        origUrl.pathname = dest;
+        Object.assign(origUrl.query, uri_args);
+        req.url = url.format(origUrl);
+        return proxyPass(req, res, upstream, this, nowRequestId, false);
       }
 
       if (

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1507,7 +1507,7 @@ export default class DevServer {
         debug(`Proxying to frontend dev server: ${upstream}`);
         this.setResponseHeaders(res, nowRequestId);
         const origUrl = url.parse(req.url || '/', true);
-        //delete origUrl.search;
+        delete origUrl.search;
         origUrl.pathname = dest;
         Object.assign(origUrl.query, uri_args);
         req.url = url.format(origUrl);

--- a/packages/now-cli/test/dev/fixtures/06-gridsome/package.json
+++ b/packages/now-cli/test/dev/fixtures/06-gridsome/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "gridsome build",
-    "develop": "gridsome develop",
+    "dev": "gridsome develop -p $PORT",
     "explore": "gridsome explore"
   },
   "dependencies": {

--- a/packages/now-cli/test/dev/fixtures/06-gridsome/src/pages/404.vue
+++ b/packages/now-cli/test/dev/fixtures/06-gridsome/src/pages/404.vue
@@ -1,0 +1,14 @@
+<template>
+  <Layout>
+    <h1>Not Found</h1>
+    <p>This is a Custom Gridsome 404.</p>
+  </Layout>
+</template>
+
+<script>
+export default {
+  metaInfo: {
+    title: 'Not Found'
+  }
+}
+</script>

--- a/packages/now-cli/test/dev/fixtures/06-gridsome/src/pages/Index.vue
+++ b/packages/now-cli/test/dev/fixtures/06-gridsome/src/pages/Index.vue
@@ -1,11 +1,11 @@
 <template>
   <Layout>
-    
+
     <!-- Learn how to use images here: https://gridsome.org/docs/images -->
     <g-image alt="Example image" src="~/favicon.png" width="135" />
-    
-    <h1>Hello, world!</h1>
-   
+
+    <h1>Gridsome on Vercel</h1>
+
     <p>
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur excepturi labore tempore expedita, et iste tenetur suscipit explicabo! Dolores, aperiam non officia eos quod asperiores
     </p>

--- a/packages/now-cli/test/dev/fixtures/06-gridsome/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/06-gridsome/vercel.json
@@ -1,0 +1,3 @@
+{
+  "redirects": [{ "source": "/support", "destination": "/about?ref=support" }]
+}

--- a/packages/now-cli/test/dev/fixtures/07-hexo-node/source/contact.html
+++ b/packages/now-cli/test/dev/fixtures/07-hexo-node/source/contact.html
@@ -1,0 +1,1 @@
+<h1>Contact Us</h1>

--- a/packages/now-cli/test/dev/fixtures/07-hexo-node/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/07-hexo-node/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/support", "destination": "/contact" }]
+}

--- a/packages/now-cli/test/dev/fixtures/07-hexo-node/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/07-hexo-node/vercel.json
@@ -1,3 +1,3 @@
 {
-  "rewrites": [{ "source": "/support", "destination": "/contact" }]
+  "rewrites": [{ "source": "/support", "destination": "/contact.html" }]
 }

--- a/packages/now-cli/test/dev/fixtures/10-nextjs-node/pages/contact.js
+++ b/packages/now-cli/test/dev/fixtures/10-nextjs-node/pages/contact.js
@@ -1,0 +1,3 @@
+export default function Contact() {
+  return <h1>Contact Page</h1>;
+}

--- a/packages/now-cli/test/dev/fixtures/10-nextjs-node/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/10-nextjs-node/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/support", "destination": "/contact" }]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1213,7 +1213,6 @@ test(
     '18-marko',
     async testPath => {
       await testPath(200, '/', /Marko Starter/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1225,7 +1224,6 @@ test(
     '19-mithril',
     async testPath => {
       await testPath(200, '/', /Mithril on Vercel/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1237,7 +1235,6 @@ test(
     '20-riot',
     async testPath => {
       await testPath(200, '/', /Riot on Vercel/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1249,7 +1246,6 @@ test(
     '21-charge',
     async testPath => {
       await testPath(200, '/', /Welcome to my new Charge site/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1261,7 +1257,6 @@ test(
     '22-brunch',
     async testPath => {
       await testPath(200, '/', /Bon Appétit./m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1273,7 +1268,6 @@ test(
     '23-docusaurus',
     async testPath => {
       await testPath(200, '/', /My Site/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1286,7 +1280,6 @@ test('[vercel dev] 24-ember', async t => {
     '24-ember',
     async testPath => {
       await testPath(200, '/', /HelloWorld/m);
-      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   );

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1088,12 +1088,12 @@ test(
 test(
   '[vercel dev] 06-gridsome',
   testFixtureStdio('06-gridsome', async testPath => {
-    await testPath(200, '/', /Gridsome on Vercel/m);
-    await testPath(200, '/about', /About us/m);
+    await testPath(200);
+    await testPath(200, '/about');
     await testPath(308, '/support', 'Redirecting to /about?ref=support (308)', {
       Location: '/about?ref=support',
     });
-    await testPath(404, '/nothing', /Custom Gridsome 404/);
+    await testPath(404, '/nothing');
   })
 );
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1058,7 +1058,12 @@ test(
 test(
   '[vercel dev] 06-gridsome',
   testFixtureStdio('06-gridsome', async testPath => {
-    await testPath(200, '/');
+    await testPath(200, '/', /Gridsome on Vercel/m);
+    await testPath(200, '/about', /About us/m);
+    await testPath(308, '/support', 'Redirecting to /about?ref=support (308)', {
+      Location: '/about?ref=support',
+    });
+    await testPath(404, '/nothing', /Custom Gridsome 404/);
   })
 );
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1088,12 +1088,14 @@ test(
 test(
   '[vercel dev] 06-gridsome',
   testFixtureStdio('06-gridsome', async testPath => {
-    await testPath(200);
+    await testPath(200, '/');
     await testPath(200, '/about');
     await testPath(308, '/support', 'Redirecting to /about?ref=support (308)', {
       Location: '/about?ref=support',
     });
-    await testPath(404, '/nothing');
+    // Bug with gridsome's dev server: https://github.com/gridsome/gridsome/issues/831
+    // Works in prod only so leave out for now
+    // await testPath(404, '/nothing');
   })
 );
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1066,6 +1066,9 @@ test(
   '[vercel dev] 07-hexo-node',
   testFixtureStdio('07-hexo-node', async testPath => {
     await testPath(200, '/', /Hexo \+ Node.js API/m);
+    await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
+    await testPath(200, '/contact.html', /Contact Us/m);
+    await testPath(200, '/support', /Contact Us/m);
   })
 );
 
@@ -1090,6 +1093,8 @@ test(
   testFixtureStdio('10-nextjs-node', async testPath => {
     await testPath(200, '/', /Next.js \+ Node.js API/m);
     await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
+    await testPath(200, '/contact', /Contact Page/);
+    await testPath(200, '/support', /Contact Page/);
     await testPath(404, '/nothing', /Custom Next 404/);
   })
 );
@@ -1100,6 +1105,7 @@ test(
     '12-polymer-node',
     async testPath => {
       await testPath(200, '/', /Polymer \+ Node.js API/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1111,6 +1117,7 @@ test(
     '13-preact-node',
     async testPath => {
       await testPath(200, '/', /Preact/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1122,6 +1129,7 @@ test(
     '14-svelte-node',
     async testPath => {
       await testPath(200, '/', /Svelte/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1133,6 +1141,7 @@ test(
     '16-vue-node',
     async testPath => {
       await testPath(200, '/', /Vue.js \+ Node.js API/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1144,6 +1153,7 @@ test(
     '17-vuepress-node',
     async testPath => {
       await testPath(200, '/', /VuePress \+ Node.js API/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1203,6 +1213,7 @@ test(
     '18-marko',
     async testPath => {
       await testPath(200, '/', /Marko Starter/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1214,6 +1225,7 @@ test(
     '19-mithril',
     async testPath => {
       await testPath(200, '/', /Mithril on Vercel/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1225,6 +1237,7 @@ test(
     '20-riot',
     async testPath => {
       await testPath(200, '/', /Riot on Vercel/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1236,6 +1249,7 @@ test(
     '21-charge',
     async testPath => {
       await testPath(200, '/', /Welcome to my new Charge site/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1247,6 +1261,7 @@ test(
     '22-brunch',
     async testPath => {
       await testPath(200, '/', /Bon Appétit./m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1258,6 +1273,7 @@ test(
     '23-docusaurus',
     async testPath => {
       await testPath(200, '/', /My Site/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   )
@@ -1270,6 +1286,7 @@ test('[vercel dev] 24-ember', async t => {
     '24-ember',
     async testPath => {
       await testPath(200, '/', /HelloWorld/m);
+      await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
     { skipDeploy: true }
   );


### PR DESCRIPTION
This PR fixes a longstanding issue introduced in #3673 that prevents routing properties from applying to the framework's upstream dev server.

This mimic's the older proxy logic used in build matches here: https://github.com/vercel/vercel/blob/5035fa537f82181649d42778c60145d8890f3291/packages/now-cli/src/util/dev/server.ts#L1535-L1539

- Related to #3777
- Related to #4510 