### PR TITLE
[node] Don't resolve "typescript" from the dist dir

### DIFF
--- a/packages/now-node/src/dev-server.ts
+++ b/packages/now-node/src/dev-server.ts
@@ -15,7 +15,7 @@ import { register } from 'ts-node';
 let compiler: string;
 try {
   compiler = require.resolve('typescript', {
-    paths: [process.cwd(), __dirname],
+    paths: [process.cwd()],
   });
 } catch (e) {
   compiler = 'typescript';


### PR DESCRIPTION
On Node 10, the `require.resolve()` with "paths" does not return the
proper value relative to the `node_modules` directory. To wit:

```
$ node -v
v10.16.3

$ node -p "require.resolve('typescript', { paths: [process.cwd()] })"
/Users/nrajlich/Code/vercel/vercel/packages/now-node/dist/typescript.js

$ node -v
v14.4.0

$ node -p "require.resolve('typescript', { paths: [process.cwd()] })"
/Users/nrajlich/Code/vercel/vercel/node_modules/typescript/lib/typescript.js
```

(**Note:** cwd when running these commands is the `dist` dir of `@vercel/node`)

So the solution is to just let `require.resolve()` throw an error so the
default string "typescript" is used instead of a resolved absolute path.