### PR TITLE
[node][next] Bump node-file-trace to 0.6.5

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -26,7 +26,7 @@
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.1",
-    "@zeit/node-file-trace": "0.6.4",
+    "@zeit/node-file-trace": "0.6.5",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",
     "escape-string-regexp": "3.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -33,7 +33,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
-    "@zeit/node-file-trace": "0.6.4",
+    "@zeit/node-file-trace": "0.6.5",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
   integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
-"@zeit/node-file-trace@0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.6.4.tgz#3fbd49747e751915c2e9f0216c09453b1ec9d611"
-  integrity sha512-tn1H8/9rQvMaH2SXXf6HeiphXJCqWY4KCapoCUfwaZ9dixs2fhpHzA1ui92TQZzx/DJ6b5Q7/6Z/V9a3dyv0Bw==
+"@zeit/node-file-trace@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.6.5.tgz#ffd443e4648eb88591c53b1a871a47bff651b62e"
+  integrity sha512-PbxtiZBU+axKtR9dU2/iQgK9+aP/ip94SqI/FCMWppmFPGlxGKHf8UnJZskFuqLZeWWzL+L+8SeipsNHATO9nw==
   dependencies:
     acorn "^7.1.1"
     acorn-class-fields "^0.3.2"


### PR DESCRIPTION
Bump `node-file-trace` to version [0.6.5](https://github.com/vercel/node-file-trace/releases/tag/0.6.5) to fix a webpack wrappers bug