### PR TITLE
[docs] Refactor "Developing a Runtime" docs and add `startDevServer()`

### DIFF
--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -24,7 +24,10 @@ enhance functionality. These functions are documented in more detail below.
 
 Official Runtimes are published to [the npm registry](https://npmjs.com) as a package and referenced in the `use` property of the `vercel.json` configuration file.
 
-> **Note:** The `use` property in the `builds` array will work with any [npm install argument](https://docs.npmjs.com/cli/install) such as a git repo URL, which is useful for testing your Runtime.
+> **Note:** The `use` property in the `builds` array will work with any [npm
+> install argument](https://docs.npmjs.com/cli/install) such as a git repo URL,
+> which is useful for testing your Runtime. Alternatively, the `functions` property
+> requires that you specify a specifc tag published to npm, for stability purposes.
 
 See the [Runtimes Documentation](https://vercel.com/docs/runtimes) to view example usage.
 

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -47,9 +47,9 @@ export const version = 3;
 
 ### `build()`
 
-A **required** exported function that returns a [Serverless Function](#serverless-function).
+A **required** exported function that returns a Serverless Function.
 
-What's a Serverless Function? Read about [Serverless Functions](https://vercel.com/docs/v2/serverless-functions/introduction) to learn more.
+> What's a Serverless Function? Read about [Serverless Functions](https://vercel.com/docs/v2/serverless-functions/introduction) to learn more.
 
 **Example:**
 

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -1,10 +1,28 @@
 # Runtime Developer Reference
 
-The following page is a reference for how to create a Runtime using the available Runtime API.
+The following page is a reference for how to create a Runtime by implementing
+the Runtime API interface.
 
-A Runtime is an npm module that exposes a `build` function and optionally an `analyze` function and `prepareCache` function.
-Official Runtimes are published to [npmjs.com](https://npmjs.com) as a package and referenced in the `use` property of the `vercel.json` configuration file.
-However, the `use` property will work with any [npm install argument](https://docs.npmjs.com/cli/install) such as a git repo url which is useful for testing your Runtime.
+A Runtime is an npm module that implements the following interface:
+
+```typescript
+interface Runtime {
+  version: number;
+  build: (opts: BuildOptions) =>
+  analyze?: (opts: AnalyzeOptions) => string | Promise<string>;
+  prepareCache?: (opts: PrepareCacheOptions) =>
+  shouldServe?: (opts: ShouldServeOptions) => boolean | Promise<boolean>;
+  startDevServer?: (opts: StartDevServerOptions) => Promise<StartDevServerResult>;
+}
+```
+
+The `version` property and the `build()` are the only required fields. The rest
+are optional extensions that a Runtime _may_ implement in order to enhance
+functionality. These functions are documented in more detail below.
+
+Official Runtimes are published to [the npm registry](https://npmjs.com) as a package and referenced in the `use` property of the `vercel.json` configuration file.
+
+> **Note:** The `use` property in the `builds` array will work with any [npm install argument](https://docs.npmjs.com/cli/install) such as a git repo URL, which is useful for testing your Runtime.
 
 See the [Runtimes Documentation](https://vercel.com/docs/runtimes) to view example usage.
 

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -303,7 +303,7 @@ This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 import { Lambda } from '@vercel/build-utils';
 ```
 
-This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents a Serverless Function. An instance is by supplying `files`, `handler`, `runtime`, and `environment` as an object to the [`createLambda`](#createlambda) helper. The instances of this class should not be created directly. Instead, invoke the [`createLambda`](#createlambda) helper function.
+This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents a Serverless Function. An instance can be created by supplying `files`, `handler`, `runtime`, and `environment` as an object to the [`createLambda`](#createlambda) helper. The instances of this class should not be created directly. Instead, invoke the [`createLambda`](#createlambda) helper function.
 
 **Properties:**
 

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -147,8 +147,8 @@ rather than going through the entire `build()` process that is used in productio
 This function is invoked _once per HTTP request_ and is expected to spawn a child
 process which creates an HTTP server that will execute the entrypoint code when
 an HTTP request is received. This child process is _single-serve_ (only used for
-a single HTTP request), so after `vercel dev` completes the HTTP request to the
-child process, it sends a shut down signal to the child process.
+a single HTTP request). After the HTTP response is complete, `vercel dev` sends
+a shut down signal to the child process.
 
 The `startDevServer()` function returns an object with the `port` number that the
 child process' HTTP server is listening on (which should be an [ephemeral

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -171,13 +171,22 @@ import { spawn } from 'child_process';
 import { StartDevServerOptions } from '@vercel/build-utils';
 
 export async function startDevServer(options: StartDevServerOptions) {
-  // Create a child process which will create an HTTP server
-  const child = spawn('my-runtimes-dev-server', [options.entrypoint], {
+  // Create a child process which will create an HTTP server.
+  //
+  // Note: `my-runtime-dev-server` is an example dev server program name.
+  // Your implementation will spawn a different program specific to your runtime.
+  const child = spawn('my-runtime-dev-server', [options.entrypoint], {
     stdio: ['ignore', 'inherit', 'inherit', 'pipe'],
   });
 
   // In this example, the child process will write the port number to FD 3…
-  const childPort = Number(await bufferStream(child.stdio[3]));
+  const portPipe = child.stdio[3];
+  const childPort = await new Promise(resolve => {
+    portPipe.setEncoding('utf8');
+    portPipe.once('data', data => {
+      resolve(Number(data));
+    });
+  });
 
   return { pid: child.pid, port: childPort };
 }

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -208,7 +208,7 @@ The env and secrets specified by the user as `build.env` are passed to the Runti
 
 When you publish your Runtime to npm, make sure to not specify `@vercel/build-utils` (as seen below in the API definitions) as a dependency, but rather as part of `peerDependencies`.
 
-## Types
+## `@vercel/build-utils` Types
 
 ### `Files`
 
@@ -250,16 +250,16 @@ Valid `File` types include:
 import { FileRef } from '@vercel/build-utils';
 ```
 
-This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract file instance stored in our platform, based on the file identifier string (its checksum). When a `Files` object is passed as an input to `analyze` or `build`, all its values will be instances of `FileRef`.
+This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract file instance stored in our platform, based on the file identifier string (its checksum). When a `Files` object is passed as an input to `analyze` or `build`, all its values will be instances of `FileRef`.
 
 **Properties:**
 
-- `mode : Number` file mode
-- `digest : String` a checksum that represents the file
+- `mode: Number` file mode
+- `digest: String` a checksum that represents the file
 
 **Methods:**
 
-- `toStream() : Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
+- `toStream(): Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
 
 ### `FileFsRef`
 
@@ -267,17 +267,17 @@ This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 import { FileFsRef } from '@vercel/build-utils';
 ```
 
-This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract instance of a file present in the filesystem that the build process is executing in.
+This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract instance of a file present in the filesystem that the build process is executing in.
 
 **Properties:**
 
-- `mode : Number` file mode
-- `fsPath : String` the absolute path of the file in file system
+- `mode: Number` file mode
+- `fsPath: String` the absolute path of the file in file system
 
 **Methods:**
 
-- `static async fromStream({ mode : Number, stream : Stream, fsPath : String }) : FileFsRef` creates an instance of a [FileFsRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) from `Stream`, placing file at `fsPath` with `mode`
-- `toStream() : Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
+- `static async fromStream({ mode: Number, stream: Stream, fsPath: String }): FileFsRef` creates an instance of a [FileFsRef](#FileFsRef) from `Stream`, placing file at `fsPath` with `mode`
+- `toStream(): Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
 
 ### `FileBlob`
 
@@ -285,17 +285,17 @@ This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 import { FileBlob } from '@vercel/build-utils';
 ```
 
-This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract instance of a file present in memory.
+This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents an abstract instance of a file present in memory.
 
 **Properties:**
 
-- `mode : Number` file mode
-- `data : String | Buffer` the body of the file
+- `mode: Number` file mode
+- `data: String | Buffer` the body of the file
 
 **Methods:**
 
-- `static async fromStream({ mode : Number, stream : Stream }) :FileBlob` creates an instance of a [FileBlob](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) from [`Stream`](https://nodejs.org/api/stream.html) with `mode`
-- `toStream() : Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
+- `static async fromStream({ mode: Number, stream: Stream }): FileBlob` creates an instance of a [FileBlob](#FileBlob) from [`Stream`](https://nodejs.org/api/stream.html) with `mode`
+- `toStream(): Stream` creates a [Stream](https://nodejs.org/api/stream.html) of the file body
 
 ### `Lambda`
 
@@ -303,14 +303,14 @@ This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 import { Lambda } from '@vercel/build-utils';
 ```
 
-This is a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), called a Serverless Function, that can be created by supplying `files`, `handler`, `runtime`, and `environment` as an object to the [`createLambda`](#createlambda) helper. The instances of this class should not be created directly. Instead, invoke the [`createLambda`](#createlambda) helper function.
+This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) that represents a Serverless Function. An instance is by supplying `files`, `handler`, `runtime`, and `environment` as an object to the [`createLambda`](#createlambda) helper. The instances of this class should not be created directly. Instead, invoke the [`createLambda`](#createlambda) helper function.
 
 **Properties:**
 
-- `files : Files` the internal filesystem of the lambda
-- `handler : String` path to handler file and (optionally) a function name it exports
-- `runtime : LambdaRuntime` the name of the lambda runtime
-- `environment : Object` key-value map of handler-related (aside of those passed by user) environment variables
+- `files: Files` the internal filesystem of the lambda
+- `handler: String` path to handler file and (optionally) a function name it exports
+- `runtime: LambdaRuntime` the name of the lambda runtime
+- `environment: Object` key-value map of handler-related (aside of those passed by user) environment variables
 
 ### `LambdaRuntime`
 
@@ -326,7 +326,7 @@ This is an abstract enumeration type that is implemented by one of the following
 - `ruby2.5`
 - `provided`
 
-## JavaScript API
+## `@vercel/build-utils` Helper Functions
 
 The following is exposed by `@vercel/build-utils` to simplify the process of writing Runtimes, manipulating the file system, using the above types, etc.
 

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -138,7 +138,7 @@ If this function is not defined, Vercel CLI will use the [default implementation
 An **optional** exported function that is only used by `vercel dev` in [Vercel
 CLI](https://vercel.com/download). If this function is defined, Vercel CLI will
 **not** invoke the `build()` function, and instead invoke this function for every
-HTTP request, so it is an opportunity to provide a faster development experience
+HTTP request. It is an opportunity to provide an optimized development experience
 rather than going through the entire `build()` process that is used in production.
 
 This function is invoked _once per HTTP request_ and is expected to spawn a child

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -158,7 +158,7 @@ Process ID, which `vercel dev` uses to send the shut down signal to.
 > **Hint:** To determine which ephemeral port the child process is listening on,
 > some form of [IPC](https://en.wikipedia.org/wiki/Inter-process_communication) is
 > required. For example, in `@vercel/go` the child process writes the port number
-> to _file descriptor 3_, which is read by the `startDevServer()` function
+> to [_file descriptor 3_](https://en.wikipedia.org/wiki/File_descriptor), which is read by the `startDevServer()` function
 > implementation.
 
 It may also return `null` to opt-out of this behavior for a particular request

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -223,7 +223,7 @@ When used as an input, the `Files` object will only contain `FileRefs`. When `Fi
 
 An example of a valid output `Files` object is:
 
-```json
+```javascript
 {
   "index.html": FileRef,
   "api/index.js": Lambda

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -183,7 +183,7 @@ export async function startDevServer(options: StartDevServerOptions) {
 ### Execution Context
 
 - Runtimes are executed in a Linux container that closely matches the Servereless Function runtime environment.
-- The Runtime code is executed using Node.js version **12**.
+- The Runtime code is executed using Node.js version **12.x**.
 - A brand new sandbox is created for each deployment, for security reasons.
 - The sandbox is cleaned up between executions to ensure no lingering temporary files are shared from build to build.
 


### PR DESCRIPTION
This is a general updating and refactoring of the `DEVELOPING_A_RUNTIME.md` documentation file for developing Runtimes.

Documentation for the newly added `startDevServer()` function is also included.

It's probably easier to just view the [Markdown formatted file](https://github.com/vercel/vercel/blob/refactor/developing-a-runtime-docs/DEVELOPING_A_RUNTIME.md) than sift through the diff.