### PR TITLE
[cli] Improve validation error message for vercel.json

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "preinstall": "node ./scripts/preinstall.js",
-    "test-unit": "nyc ava test/unit.js test/dev-builder.unit.js test/dev-router.unit.js test/dev-server.unit.js --serial --fail-fast --verbose",
+    "test-unit": "nyc ava test/unit.js test/dev-builder.unit.js test/dev-router.unit.js test/dev-server.unit.js test/dev-validate.unit.js --serial --fail-fast --verbose",
     "test-integration-cli": "ava test/integration.js --serial --fail-fast --verbose",
     "test-integration-v1": "ava test/integration-v1.js --serial --fail-fast",
     "test-integration-dev": "ava test/dev/integration.js --serial --fail-fast --verbose",

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -3,12 +3,12 @@ import bytes from 'bytes';
 import { join } from 'path';
 import { write as copy } from 'clipboardy';
 import chalk from 'chalk';
-import title from 'title';
 import { fileNameSymbol } from '@vercel/client';
 import Client from '../../util/client';
 import { handleError } from '../../util/error';
 import getArgs from '../../util/get-args';
 import toHumanPath from '../../util/humanize-path';
+import humanizeAjvError from '../../../src/util/humanize-ajv-error';
 import Now from '../../util';
 import stamp from '../../util/output/stamp.ts';
 import createDeploy from '../../util/deploy/create-deploy';
@@ -738,16 +738,14 @@ function handleCreateDeployError(output, error, localConfig) {
     return 1;
   }
   if (error instanceof SchemaValidationFailed) {
-    const { message, params, keyword, dataPath } = error.meta;
-
+    const ajvError = error.meta;
+    const fileName = localConfig[fileNameSymbol];
+    const humanError = humanizeAjvError(ajvError, fileName);
+    output.prettyError(humanError);
+    return 1;
+    /*
     if (params && params.additionalProperty) {
       const prop = params.additionalProperty;
-
-      output.error(
-        `The property ${code(prop)} is not allowed in ${highlight(
-          localConfig[fileNameSymbol]
-        )} – please remove it.`
-      );
 
       if (prop === 'build.env' || prop === 'builds.env') {
         output.note(
@@ -759,33 +757,7 @@ function handleCreateDeployError(output, error, localConfig) {
 
       return 1;
     }
-
-    if (dataPath === '.name') {
-      output.error(message);
-      return 1;
-    }
-
-    if (keyword === 'type') {
-      const prop = dataPath.substr(1, dataPath.length);
-
-      output.error(
-        `The property ${code(prop)} in ${highlight(
-          localConfig[fileNameSymbol]
-        )} can only be of type ${code(title(params.type))}.`
-      );
-
-      return 1;
-    }
-
-    const link = 'https://vercel.com/docs/configuration';
-
-    output.error(
-      `Failed to validate ${highlight(
-        localConfig[fileNameSymbol]
-      )}: ${message}\nDocumentation: ${link}`
-    );
-
-    return 1;
+    */
   }
   if (error instanceof TooManyRequests) {
     output.error(

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -743,21 +743,6 @@ function handleCreateDeployError(output, error, localConfig) {
     const humanError = humanizeAjvError(ajvError, fileName);
     output.prettyError(humanError);
     return 1;
-    /*
-    if (params && params.additionalProperty) {
-      const prop = params.additionalProperty;
-
-      if (prop === 'build.env' || prop === 'builds.env') {
-        output.note(
-          `Do you mean ${code('build')} (object) with a property ${code(
-            'env'
-          )} (object) instead of ${code(prop)}?`
-        );
-      }
-
-      return 1;
-    }
-    */
   }
   if (error instanceof TooManyRequests) {
     output.error(

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -50,17 +50,7 @@ import { MissingDotenvVarsError } from '../errors-ts';
 import cliPkg from '../pkg';
 import { getVercelDirectory } from '../projects/link';
 import { staticFiles as getFiles, getAllProjectFiles } from '../get-files';
-import {
-  validateNowConfigBuilds,
-  validateNowConfigRoutes,
-  validateNowConfigCleanUrls,
-  validateNowConfigHeaders,
-  validateNowConfigRedirects,
-  validateNowConfigRewrites,
-  validateNowConfigTrailingSlash,
-  validateNowConfigFunctions,
-} from './validate';
-
+import { validateConfig } from './validate';
 import { devRouter, getRoutesTypes } from './router';
 import getMimeType from './mime-type';
 import { executeBuild, getBuildMatches, shutdownBuilder } from './builder';
@@ -693,14 +683,12 @@ export default class DevServer {
       return;
     }
 
-    await this.tryValidateOrExit(config, validateNowConfigBuilds);
-    await this.tryValidateOrExit(config, validateNowConfigRoutes);
-    await this.tryValidateOrExit(config, validateNowConfigCleanUrls);
-    await this.tryValidateOrExit(config, validateNowConfigHeaders);
-    await this.tryValidateOrExit(config, validateNowConfigRedirects);
-    await this.tryValidateOrExit(config, validateNowConfigRewrites);
-    await this.tryValidateOrExit(config, validateNowConfigTrailingSlash);
-    await this.tryValidateOrExit(config, validateNowConfigFunctions);
+    const error = validateConfig(config);
+
+    if (error) {
+      this.output.prettyError(error);
+      await this.exit(1);
+    }
   }
 
   validateEnvConfig(type: string, env: Env = {}, localEnv: Env = {}): Env {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -532,7 +532,7 @@ export default class DevServer {
       configPath = getNowConfigPath(this.cwd);
       this.output.debug(`Reading ${configPath}`);
       config = JSON.parse(await fs.readFile(configPath, 'utf8'));
-      config[fileNameSymbol] = configPath;
+      config[fileNameSymbol] = basename(configPath);
     } catch (err) {
       if (err.code === 'ENOENT') {
         this.output.debug(err.toString());

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -44,12 +44,12 @@ export function validateConfig(config: NowConfig) {
     console.log({ error }); // TODO: remove
     const { dataPath, schemaPath, message, params } = error;
     const [hash, type, property] = schemaPath.split('/');
-    if (hash === '#' && type === 'properties' && property) {
-      let prettyMessage = `Configuration property \`${property}\``;
+    if (hash === '#' && type === 'properties' && dataPath) {
+      let prettyMessage = `Configuration property \`${dataPath.slice(1)}\``;
       if ('additionalProperty' in params) {
         prettyMessage += ` should NOT have additional property \`${params.additionalProperty}\`.`;
       } else if ('type' in params) {
-        prettyMessage += ` should be of type ${params.type} but found type object.`;
+        prettyMessage += ` should be of type ${params.type}.`;
       } else if ('missingProperty' in params) {
         prettyMessage += ` is missing property \`${params.missingProperty}\`.`;
       }
@@ -65,18 +65,6 @@ export function validateConfig(config: NowConfig) {
       code: 'DEV_VALIDATE_CONFIG',
       message: `${dataPath} ${message} ${JSON.stringify(params)}`,
     });
-
-    /*
-    if ('additionalProperty' in error.params) {
-      const { additionalProperty } = error.params;
-      return `Unknown property ${additionalProperty} at \`${String(key)}\`${error.dataPath}, ${
-        error.message
-      }`;
-    }
-
-    return `Invalid \`${String(key)}\` property: ${error.dataPath} ${
-      error.message
-    }`;*/
   }
 
   return null;

--- a/packages/now-cli/src/util/dev/validate.ts
+++ b/packages/now-cli/src/util/dev/validate.ts
@@ -45,11 +45,17 @@ export function validateConfig(config: NowConfig) {
     const { dataPath, schemaPath, message, params } = error;
     const [hash, type, property] = schemaPath.split('/');
     if (hash === '#' && type === 'properties' && property) {
+      let prettyMessage = `Configuration property \`${property}\``;
+      if ('additionalProperty' in params) {
+        prettyMessage += ` should NOT have additional property \`${params.additionalProperty}\`.`;
+      } else if ('type' in params) {
+        prettyMessage += ` should be of type ${params.type} but found type object.`;
+      } else if ('missingProperty' in params) {
+        prettyMessage += ` is missing property \`${params.missingProperty}\`.`;
+      }
       return new NowBuildError({
         code: 'DEV_VALIDATE_CONFIG',
-        message: `Configuration property \`${property}\` ${message} ${JSON.stringify(
-          params
-        )} ${dataPath}`,
+        message: prettyMessage,
         link: `https://vercel.com/docs/configuration#project/${property.toLowerCase()}`,
         action: 'Learn More',
       });

--- a/packages/now-cli/src/util/humanize-ajv-error.ts
+++ b/packages/now-cli/src/util/humanize-ajv-error.ts
@@ -5,30 +5,36 @@ export default function humanizeAjvError(
   error: ErrorObject,
   fileName = 'vercel.json'
 ): NowBuildError {
-  console.log({ error }); // TODO: remove
+  const docsUrl = 'https://vercel.com/docs/configuration';
   try {
     const { dataPath, params } = error;
-    let message = `Invalid ${fileName} - property \`${dataPath.slice(1)}\``;
+    let message = `Invalid ${fileName} -`;
+    if (dataPath && dataPath.startsWith('.')) {
+      message += ` property \`${dataPath.slice(1)}\``;
+    }
+
     if ('additionalProperty' in params) {
-      message += ` should NOT have additional property \`${params.additionalProperty}\`.`;
+      message += ` should NOT have additional property \`${params.additionalProperty}\`. Please remove it.`;
     } else if ('type' in params) {
       message += ` should be of type ${params.type}.`;
     } else if ('missingProperty' in params) {
       message += ` is missing property \`${params.missingProperty}\`.`;
+    } else {
+      message += ' should match configuration schema.';
     }
 
-    const fragment = getTopLevelPropertyName(dataPath).toLowerCase();
+    const prop = getTopLevelPropertyName(dataPath);
     return new NowBuildError({
       code: 'DEV_VALIDATE_CONFIG',
       message: message,
-      link: `https://vercel.com/docs/configuration#project/${fragment}`,
+      link: prop ? `${docsUrl}#project/${prop.toLowerCase()}` : docsUrl,
       action: 'View Documentation',
     });
   } catch (e) {
     return new NowBuildError({
       code: 'DEV_VALIDATE_CONFIG',
       message: `Failed to validate ${fileName} configuration.`,
-      link: `https://vercel.com/docs/configuration`,
+      link: docsUrl,
       action: 'View Documentation',
     });
   }
@@ -39,8 +45,12 @@ export default function humanizeAjvError(
  * `.cleanUrls` => `cleanUrls`
  * `.headers[0].source` => `headers`
  * `.headers[0].headers[0]` => `headers`
+ * `` => ``
  */
-function getTopLevelPropertyName(dataPath: string) {
-  const lastIndex = dataPath.indexOf('[');
-  return lastIndex > -1 ? dataPath.slice(1, lastIndex) : dataPath.slice(1);
+function getTopLevelPropertyName(dataPath: string): string {
+  if (dataPath && dataPath.startsWith('.')) {
+    const lastIndex = dataPath.indexOf('[');
+    return lastIndex > -1 ? dataPath.slice(1, lastIndex) : dataPath.slice(1);
+  }
+  return '';
 }

--- a/packages/now-cli/src/util/humanize-ajv-error.ts
+++ b/packages/now-cli/src/util/humanize-ajv-error.ts
@@ -17,10 +17,7 @@ export default function humanizeAjvError(
 
     if ('additionalProperty' in params) {
       const suggestion = getSuggestion(prop, params.additionalProperty);
-      const solution = suggestion
-        ? `Did you mean \`${suggestion}\`?`
-        : 'Please remove it.';
-      message += ` should NOT have additional property \`${params.additionalProperty}\`. ${solution}`;
+      message += ` should NOT have additional property \`${params.additionalProperty}\`. ${suggestion}`;
     } else if ('type' in params) {
       message += ` should be of type ${params.type}.`;
     } else if ('missingProperty' in params) {
@@ -61,7 +58,11 @@ function getTopLevelPropertyName(dataPath: string): string {
 }
 
 const mapTypoToSuggestion: { [key: string]: { [key: string]: string } } = {
-  '': { 'build.env': 'build', 'builds.env': 'build', builder: 'builds' },
+  '': {
+    builder: 'builds',
+    'build.env': '{ "build": { "env": {"name": "value"} } }',
+    'builds.env': '{ "build": { "env": {"name": "value"} } }',
+  },
   rewrites: { src: 'source', dest: 'destination' },
   redirects: { src: 'source', dest: 'destination', status: 'statusCode' },
   headers: { src: 'source', header: 'headers' },
@@ -75,5 +76,6 @@ const mapTypoToSuggestion: { [key: string]: { [key: string]: string } } = {
 
 function getSuggestion(topLevelProp: string, additionalProperty: string) {
   const choices = mapTypoToSuggestion[topLevelProp];
-  return choices ? choices[additionalProperty] : undefined;
+  const choice = choices ? choices[additionalProperty] : undefined;
+  return choice ? `Did you mean \`${choice}\`?` : 'Please remove it.';
 }

--- a/packages/now-cli/src/util/humanize-ajv-error.ts
+++ b/packages/now-cli/src/util/humanize-ajv-error.ts
@@ -22,6 +22,8 @@ export default function humanizeAjvError(
       message += ` should be of type ${params.type}.`;
     } else if ('missingProperty' in params) {
       message += ` is missing property \`${params.missingProperty}\`.`;
+    } else if ('limit' in params) {
+      message += ` should NOT have more than ${params.limit} items in the array.`;
     } else {
       message += ' should match configuration schema.';
     }

--- a/packages/now-cli/src/util/humanize-ajv-error.ts
+++ b/packages/now-cli/src/util/humanize-ajv-error.ts
@@ -1,0 +1,46 @@
+import { ErrorObject } from 'ajv';
+import { NowBuildError } from '@vercel/build-utils';
+
+export default function humanizeAjvError(
+  error: ErrorObject,
+  fileName = 'vercel.json'
+): NowBuildError {
+  console.log({ error }); // TODO: remove
+  try {
+    const { dataPath, params } = error;
+    let message = `Invalid ${fileName} - property \`${dataPath.slice(1)}\``;
+    if ('additionalProperty' in params) {
+      message += ` should NOT have additional property \`${params.additionalProperty}\`.`;
+    } else if ('type' in params) {
+      message += ` should be of type ${params.type}.`;
+    } else if ('missingProperty' in params) {
+      message += ` is missing property \`${params.missingProperty}\`.`;
+    }
+
+    const fragment = getTopLevelPropertyName(dataPath).toLowerCase();
+    return new NowBuildError({
+      code: 'DEV_VALIDATE_CONFIG',
+      message: message,
+      link: `https://vercel.com/docs/configuration#project/${fragment}`,
+      action: 'View Documentation',
+    });
+  } catch (e) {
+    return new NowBuildError({
+      code: 'DEV_VALIDATE_CONFIG',
+      message: `Failed to validate ${fileName} configuration.`,
+      link: `https://vercel.com/docs/configuration`,
+      action: 'View Documentation',
+    });
+  }
+}
+
+/**
+ * Get the top level property from the dataPath.
+ * `.cleanUrls` => `cleanUrls`
+ * `.headers[0].source` => `headers`
+ * `.headers[0].headers[0]` => `headers`
+ */
+function getTopLevelPropertyName(dataPath: string) {
+  const lastIndex = dataPath.indexOf('[');
+  return lastIndex > -1 ? dataPath.slice(1, lastIndex) : dataPath.slice(1);
+}

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -40,7 +40,7 @@ test('[dev-validate] should error with invalid rewrites due to additional proper
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `rewrites[0]` should NOT have additional property `src`.'
+    'Invalid vercel.json - property `rewrites[0]` should NOT have additional property `src`.'
   );
   t.deepEqual(
     error.link,
@@ -55,7 +55,7 @@ test('[dev-validate] should error with invalid routes array type', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `routes` should be of type array.'
+    'Invalid vercel.json - property `routes` should be of type array.'
   );
   t.deepEqual(
     error.link,
@@ -74,7 +74,7 @@ test('[dev-validate] should error with invalid redirects array object', async t 
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `redirects[0]` is missing property `source`.'
+    'Invalid vercel.json - property `redirects[0]` is missing property `source`.'
   );
   t.deepEqual(
     error.link,
@@ -89,7 +89,7 @@ test('[dev-validate] should error with invalid redirects.permanent poperty', asy
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `redirects[0].permanent` should be of type boolean.'
+    'Invalid vercel.json - property `redirects[0].permanent` should be of type boolean.'
   );
   t.deepEqual(
     error.link,
@@ -104,7 +104,7 @@ test('[dev-validate] should error with invalid cleanUrls type', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `cleanUrls` should be of type boolean.'
+    'Invalid vercel.json - property `cleanUrls` should be of type boolean.'
   );
   t.deepEqual(
     error.link,
@@ -119,7 +119,7 @@ test('[dev-validate] should error with invalid trailingSlash type', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `trailingSlash` should be of type boolean.'
+    'Invalid vercel.json - property `trailingSlash` should be of type boolean.'
   );
   t.deepEqual(
     error.link,
@@ -134,7 +134,7 @@ test('[dev-validate] should error with invalid headers property', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `headers[0]` should NOT have additional property `Content-Type`.'
+    'Invalid vercel.json - property `headers[0]` should NOT have additional property `Content-Type`.'
   );
   t.deepEqual(
     error.link,
@@ -144,12 +144,12 @@ test('[dev-validate] should error with invalid headers property', async t => {
 
 test('[dev-validate] should error with invalid headers.source type', async t => {
   const config = {
-    headers: [{ source: [{ ' Content-Type': 'text/html' }] }],
+    headers: [{ source: [{ 'Content-Type': 'text/html' }] }],
   };
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `headers[0].source` should be of type string.'
+    'Invalid vercel.json - property `headers[0].source` should be of type string.'
   );
   t.deepEqual(
     error.link,
@@ -159,12 +159,12 @@ test('[dev-validate] should error with invalid headers.source type', async t => 
 
 test('[dev-validate] should error with invalid headers additional property', async t => {
   const config = {
-    headers: [{ source: '/', stuff: [{ ' Content-Type': 'text/html' }] }],
+    headers: [{ source: '/', stuff: [{ 'Content-Type': 'text/html' }] }],
   };
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `headers[0]` should NOT have additional property `stuff`.'
+    'Invalid vercel.json - property `headers[0]` should NOT have additional property `stuff`.'
   );
   t.deepEqual(
     error.link,
@@ -174,12 +174,12 @@ test('[dev-validate] should error with invalid headers additional property', asy
 
 test('[dev-validate] should error with invalid headers wrong nested headers type', async t => {
   const config = {
-    headers: [{ source: '/', headers: [{ ' Content-Type': 'text/html' }] }],
+    headers: [{ source: '/', headers: [{ 'Content-Type': 'text/html' }] }],
   };
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `headers[0].headers[0]` should NOT have additional property ` Content-Type`.'
+    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `Content-Type`.'
   );
   t.deepEqual(
     error.link,
@@ -196,7 +196,7 @@ test('[dev-validate] should error with invalid headers wrong nested headers addi
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `headers[0].headers[0]` should NOT have additional property `val`.'
+    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `val`.'
   );
   t.deepEqual(
     error.link,

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -10,6 +10,7 @@ test('[dev-validate] should not error with empty config', async t => {
 test('[dev-validate] should not error with complete config', async t => {
   const config = {
     version: 2,
+    public: true,
     regions: ['sfo1', 'iad1'],
     builds: [{ src: 'package.json', use: '@vercel/next' }],
     cleanUrls: true,
@@ -39,7 +40,11 @@ test('[dev-validate] should error with invalid rewrites due to additional proper
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `rewrites` should NOT have additional property `src`.'
+    'Configuration property `rewrites[0]` should NOT have additional property `src`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/rewrites'
   );
 });
 
@@ -50,7 +55,11 @@ test('[dev-validate] should error with invalid routes array type', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `routes` should be of type array but found type object.'
+    'Configuration property `routes` should be of type array.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/routes'
   );
 });
 
@@ -65,7 +74,11 @@ test('[dev-validate] should error with invalid redirects array object', async t 
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `redirects` is missing property `source`.'
+    'Configuration property `redirects[0]` is missing property `source`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/redirects'
   );
 });
 
@@ -76,6 +89,117 @@ test('[dev-validate] should error with invalid redirects.permanent poperty', asy
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `redirects` should have property `permanent` of type boolean.'
+    'Configuration property `redirects[0].permanent` should be of type boolean.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/redirects'
+  );
+});
+
+test('[dev-validate] should error with invalid cleanUrls type', async t => {
+  const config = {
+    cleanUrls: 'true',
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `cleanUrls` should be of type boolean.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/cleanurls'
+  );
+});
+
+test('[dev-validate] should error with invalid trailingSlash type', async t => {
+  const config = {
+    trailingSlash: [true],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `trailingSlash` should be of type boolean.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/trailingslash'
+  );
+});
+
+test('[dev-validate] should error with invalid headers property', async t => {
+  const config = {
+    headers: [{ 'Content-Type': 'text/html' }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `headers[0]` should NOT have additional property `Content-Type`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
+  );
+});
+
+test('[dev-validate] should error with invalid headers.source type', async t => {
+  const config = {
+    headers: [{ source: [{ ' Content-Type': 'text/html' }] }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `headers[0].source` should be of type string.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
+  );
+});
+
+test('[dev-validate] should error with invalid headers additional property', async t => {
+  const config = {
+    headers: [{ source: '/', stuff: [{ ' Content-Type': 'text/html' }] }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `headers[0]` should NOT have additional property `stuff`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
+  );
+});
+
+test('[dev-validate] should error with invalid headers wrong nested headers type', async t => {
+  const config = {
+    headers: [{ source: '/', headers: [{ ' Content-Type': 'text/html' }] }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `headers[0].headers[0]` should NOT have additional property ` Content-Type`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
+  );
+});
+
+test('[dev-validate] should error with invalid headers wrong nested headers additional property', async t => {
+  const config = {
+    headers: [
+      { source: '/', headers: [{ key: 'Content-Type', val: 'text/html' }] },
+    ],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `headers[0].headers[0]` should NOT have additional property `val`.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
   );
 });

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -39,17 +39,43 @@ test('[dev-validate] should error with invalid rewrites due to additional proper
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `rewrites` should NOT have additional property `src`'
+    'Configuration property `rewrites` should NOT have additional property `src`.'
   );
 });
 
-test('[dev-validate] should error with invalid routes type', async t => {
+test('[dev-validate] should error with invalid routes array type', async t => {
   const config = {
     routes: { src: '/(.*)', dest: '/api/index.js' },
   };
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Configuration property `routes` should be of type array but found type object'
+    'Configuration property `routes` should be of type array but found type object.'
+  );
+});
+
+test('[dev-validate] should error with invalid redirects array object', async t => {
+  const config = {
+    redirects: [
+      {
+        /* intentionally empty */
+      },
+    ],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `redirects` is missing property `source`.'
+  );
+});
+
+test('[dev-validate] should error with invalid redirects.permanent poperty', async t => {
+  const config = {
+    redirects: [{ source: '/', destination: '/go', permanent: 'yes' }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `redirects` should have property `permanent` of type boolean.'
   );
 });

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -1,0 +1,55 @@
+import test from 'ava';
+import { validateConfig } from '../src/util/dev/validate';
+
+test('[dev-validate] should not error with empty config', async t => {
+  const config = {};
+  const error = validateConfig(config);
+  t.deepEqual(error, null);
+});
+
+test('[dev-validate] should not error with complete config', async t => {
+  const config = {
+    version: 2,
+    regions: ['sfo1', 'iad1'],
+    builds: [{ src: 'package.json', use: '@vercel/next' }],
+    cleanUrls: true,
+    headers: [{ source: '/', headers: [{ key: 'x-id', value: '123' }] }],
+    rewrites: [{ source: '/help', destination: '/support' }],
+    redirects: [{ source: '/kb', destination: 'https://example.com' }],
+    trailingSlash: false,
+    functions: { 'api/user.go': { memory: 128, maxDuration: 5 } },
+  };
+  const error = validateConfig(config);
+  t.deepEqual(error, null);
+});
+
+test('[dev-validate] should not error with builds and routes', async t => {
+  const config = {
+    builds: [{ src: 'api/index.js', use: '@vercel/node' }],
+    routes: [{ src: '/(.*)', dest: '/api/index.js' }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(error, null);
+});
+
+test('[dev-validate] should error with invalid rewrites due to additional property', async t => {
+  const config = {
+    rewrites: [{ src: '/(.*)', dest: '/api/index.js' }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `rewrites` should NOT have additional property `src`'
+  );
+});
+
+test('[dev-validate] should error with invalid routes type', async t => {
+  const config = {
+    routes: { src: '/(.*)', dest: '/api/index.js' },
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Configuration property `routes` should be of type array but found type object'
+  );
+});

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -40,7 +40,7 @@ test('[dev-validate] should error with invalid rewrites due to additional proper
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `rewrites[0]` should NOT have additional property `src`.'
+    'Invalid vercel.json - property `rewrites[0]` should NOT have additional property `src`. Please remove it.'
   );
   t.deepEqual(
     error.link,
@@ -134,7 +134,7 @@ test('[dev-validate] should error with invalid headers property', async t => {
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `headers[0]` should NOT have additional property `Content-Type`.'
+    'Invalid vercel.json - property `headers[0]` should NOT have additional property `Content-Type`. Please remove it.'
   );
   t.deepEqual(
     error.link,
@@ -164,7 +164,7 @@ test('[dev-validate] should error with invalid headers additional property', asy
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `headers[0]` should NOT have additional property `stuff`.'
+    'Invalid vercel.json - property `headers[0]` should NOT have additional property `stuff`. Please remove it.'
   );
   t.deepEqual(
     error.link,
@@ -179,7 +179,7 @@ test('[dev-validate] should error with invalid headers wrong nested headers type
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `Content-Type`.'
+    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `Content-Type`. Please remove it.'
   );
   t.deepEqual(
     error.link,
@@ -196,7 +196,7 @@ test('[dev-validate] should error with invalid headers wrong nested headers addi
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `val`.'
+    'Invalid vercel.json - property `headers[0].headers[0]` should NOT have additional property `val`. Please remove it.'
   );
   t.deepEqual(
     error.link,

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -218,3 +218,48 @@ test('[dev-validate] should error with invalid headers wrong nested headers addi
     'https://vercel.com/docs/configuration#project/headers'
   );
 });
+
+test('[dev-validate] should error with too many redirects', async t => {
+  const config = {
+    redirects: Array.from({ length: 5000 }).map((_, i) => ({
+      source: `/${i}`,
+      destination: `/v/${i}`,
+    })),
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Invalid vercel.json - property `redirects` should NOT have more than 1024 items in the array.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/redirects'
+  );
+});
+
+test('[dev-validate] should error with too many nested headers', async t => {
+  const config = {
+    headers: [
+      {
+        source: '/',
+        headers: [{ key: `x-id`, value: `123` }],
+      },
+      {
+        source: '/too-many',
+        headers: Array.from({ length: 5000 }).map((_, i) => ({
+          key: `${i}`,
+          value: `${i}`,
+        })),
+      },
+    ],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Invalid vercel.json - property `headers[1].headers` should NOT have more than 1024 items in the array.'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/headers'
+  );
+});

--- a/packages/now-cli/test/dev-validate.unit.js
+++ b/packages/now-cli/test/dev-validate.unit.js
@@ -33,18 +33,33 @@ test('[dev-validate] should not error with builds and routes', async t => {
   t.deepEqual(error, null);
 });
 
-test('[dev-validate] should error with invalid rewrites due to additional property', async t => {
+test('[dev-validate] should error with invalid rewrites due to additional property and offer suggestion', async t => {
   const config = {
     rewrites: [{ src: '/(.*)', dest: '/api/index.js' }],
   };
   const error = validateConfig(config);
   t.deepEqual(
     error.message,
-    'Invalid vercel.json - property `rewrites[0]` should NOT have additional property `src`. Please remove it.'
+    'Invalid vercel.json - property `rewrites[0]` should NOT have additional property `src`. Did you mean `source`?'
   );
   t.deepEqual(
     error.link,
     'https://vercel.com/docs/configuration#project/rewrites'
+  );
+});
+
+test('[dev-validate] should error with invalid routes due to additional property and offer suggestion', async t => {
+  const config = {
+    routes: [{ source: '/(.*)', destination: '/api/index.js' }],
+  };
+  const error = validateConfig(config);
+  t.deepEqual(
+    error.message,
+    'Invalid vercel.json - property `routes[0]` should NOT have additional property `source`. Did you mean `src`?'
+  );
+  t.deepEqual(
+    error.link,
+    'https://vercel.com/docs/configuration#project/routes'
   );
 });
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -694,7 +694,7 @@ test('[vercel dev] validate builds', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `builds` property: \[0\]\.src should be string/m
+    /Invalid vercel\.json - property `builds\[0\].src` should be of type string/m
   );
 });
 
@@ -705,7 +705,7 @@ test('[vercel dev] validate routes', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `routes` property: \[0\]\.src should be string/m
+    /Invalid vercel\.json - property `routes[0].src` should be of type string/m
   );
 });
 
@@ -714,7 +714,10 @@ test('[vercel dev] validate cleanUrls', async t => {
   const output = await exec(directory);
 
   t.is(output.exitCode, 1, formatOutput(output));
-  t.regex(output.stderr, /Invalid `cleanUrls` property:\s+should be boolean/m);
+  t.regex(
+    output.stderr,
+    /Invalid vercel\.json - property `cleanUrls` should be of type boolean/m
+  );
 });
 
 test('[vercel dev] validate trailingSlash', async t => {
@@ -724,7 +727,7 @@ test('[vercel dev] validate trailingSlash', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `trailingSlash` property:\s+should be boolean/m
+    /Invalid vercel\.json - property `trailingSlash` should be of type boolean/m
   );
 });
 
@@ -735,7 +738,7 @@ test('[vercel dev] validate rewrites', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `rewrites` property: \[0\]\.destination should be string/m
+    /Invalid vercel\.json - property `rewrites\[0\].destination` should be of type string/m
   );
 });
 
@@ -746,7 +749,7 @@ test('[vercel dev] validate redirects', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `redirects` property: \[0\]\.statusCode should be integer/m
+    /Invalid vercel\.json - property `redirects\[0\].statusCode` should be of type integer/m
   );
 });
 
@@ -757,7 +760,7 @@ test('[vercel dev] validate headers', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid `headers` property: \[0\]\.headers\[0\]\.value should be string/m
+    /Invalid vercel\.json - property `headers\[0\].headers\[0\].value` should be of type string/m
   );
 });
 

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -705,7 +705,7 @@ test('[vercel dev] validate routes', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Invalid vercel\.json - property `routes[0].src` should be of type string/m
+    /Invalid vercel\.json - property `routes\[0\].src` should be of type string/m
   );
 });
 

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -138,6 +138,10 @@ module.exports = async session => {
       'vercel.json': '{"fake": 1}',
       'index.html': '<h1>Fake</h1>',
     },
+    'builds-wrong-build-env': {
+      'vercel.json': '{ "build.env": { "key": "value" } }',
+      'index.html': '<h1>Should fail</h1>',
+    },
     'builds-no-list': {
       'now.json': `{
   "version": 2,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1557,6 +1557,31 @@ test('try to create a builds deployments with wrong vercel.json', async t => {
   t.true(stderr.includes('https://vercel.com/docs/configuration'));
 });
 
+test('try to create a builds deployments with wrong `build.env` property', async t => {
+  const directory = fixture('builds-wrong-build-env');
+
+  const { stderr, stdout, exitCode } = await execa(
+    binaryPath,
+    ['--public', ...defaultArgs, '--confirm'],
+    {
+      cwd: directory,
+      reject: false,
+    }
+  );
+
+  t.is(exitCode, 1, formatOutput({ stdout, stderr }));
+  t.true(
+    stderr.includes(
+      'Error! Invalid vercel.json - should NOT have additional property `build.env`. Did you mean `{ "build": { "env": {"name": "value"} } }`?'
+    ),
+    formatOutput({ stdout, stderr })
+  );
+  t.true(
+    stderr.includes('https://vercel.com/docs/configuration'),
+    formatOutput({ stdout, stderr })
+  );
+});
+
 test('create a builds deployments with no actual builds', async t => {
   const directory = fixture('builds-no-list');
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1491,7 +1491,7 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?.'
+      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
     )
   );
   t.true(stderr.includes('https://vercel.com/docs/configuration'));

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1491,7 +1491,7 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid now.json - should NOT have additional property `builder`. Please remove it.'
+      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?.'
     )
   );
   t.true(stderr.includes('https://vercel.com/docs/configuration'));

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1491,9 +1491,10 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! The property `builder` is not allowed in now.json – please remove it.'
+      'Error! Invalid now.json - should NOT have additional property `builder`. Please remove it.'
     )
   );
+  t.true(stderr.includes('https://vercel.com/docs/configuration'));
 });
 
 test('try to create a builds deployments with wrong vercel.json', async t => {
@@ -1514,9 +1515,10 @@ test('try to create a builds deployments with wrong vercel.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! The property `fake` is not allowed in vercel.json – please remove it.'
+      'Error! Invalid vercel.json - should NOT have additional property `fake`. Please remove it.'
     )
   );
+  t.true(stderr.includes('https://vercel.com/docs/configuration'));
 });
 
 test('create a builds deployments with no actual builds', async t => {


### PR DESCRIPTION
This PR improves the validation error message when the user has an invalid `vercel.json` file.

Previously, the error message did not account for nested properties so `{"foo": "will error"}` looked fine because it would mention there is an additional property `foo`. However, the error message for `{ "routes": [{ "foo": "will error" }] }` did not mention anything about `routes` when it explaining there was an additional property `foo`. This became more apparent as we added nested properties for `rewrites` and `redirects` (see tests in this PR).

This PR also adds suggestions for common mistakes such as `src` vs `source`.