### PR TITLE
[cli] Remove caching of `vercel.json` config in `vc dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -122,7 +122,6 @@ export default class DevServer {
   public address: string;
   public devCacheDir: string;
 
-  private cachedNowConfig: NowConfig | null;
   private caseSensitive: boolean;
   private apiDir: string | null;
   private apiExtensions: Set<string>;
@@ -141,7 +140,6 @@ export default class DevServer {
   private devProcessPort?: number;
   private devServerPids: Set<number>;
 
-  private getNowConfigPromise: Promise<NowConfig> | null;
   private blockingBuildsPromise: Promise<void> | null;
   private updateBuildersPromise: Promise<void> | null;
   private updateBuildersTimeout: NodeJS.Timeout | undefined;
@@ -155,7 +153,6 @@ export default class DevServer {
     this.address = '';
     this.devCommand = options.devCommand;
     this.frameworkSlug = options.frameworkSlug;
-    this.cachedNowConfig = null;
     this.caseSensitive = false;
     this.apiDir = null;
     this.apiExtensions = new Set();
@@ -171,7 +168,6 @@ export default class DevServer {
     this.inProgressBuilds = new Map();
     this.devCacheDir = join(getVercelDirectory(cwd), 'cache');
 
-    this.getNowConfigPromise = null;
     this.blockingBuildsPromise = null;
     this.updateBuildersPromise = null;
 
@@ -235,16 +231,7 @@ export default class DevServer {
       }
     }
 
-    const nowConfig = await this.getNowConfig(false);
-
-    // Update the env vars configuration
-    const nowConfigBuild = nowConfig.build || {};
-    const [runEnv, buildEnv] = await Promise.all([
-      this.getLocalEnv('.env', nowConfig.env),
-      this.getLocalEnv('.env.build', nowConfigBuild.env),
-    ]);
-    const allEnv = { ...buildEnv, ...runEnv };
-    this.envConfigs = { buildEnv, runEnv, allEnv };
+    const nowConfig = await this.getNowConfig();
 
     // Update the build matches in case an entrypoint was created or deleted
     await this.updateBuildMatches(nowConfig);
@@ -511,23 +498,7 @@ export default class DevServer {
     return {};
   }
 
-  async getNowConfig(canUseCache: boolean = true): Promise<NowConfig> {
-    if (this.getNowConfigPromise) {
-      return this.getNowConfigPromise;
-    }
-    this.getNowConfigPromise = this._getNowConfig(canUseCache);
-    try {
-      return await this.getNowConfigPromise;
-    } finally {
-      this.getNowConfigPromise = null;
-    }
-  }
-
-  async _getNowConfig(canUseCache: boolean = true): Promise<NowConfig> {
-    if (canUseCache && this.cachedNowConfig) {
-      return this.cachedNowConfig;
-    }
-
+  async getNowConfig(): Promise<NowConfig> {
     const pkg = await this.getPackageJson();
 
     // The default empty `vercel.json` is used to serve all files as static
@@ -644,10 +615,19 @@ export default class DevServer {
 
     await this.validateNowConfig(config);
 
-    this.cachedNowConfig = config;
     this.caseSensitive = hasNewRoutingProperties(config);
     this.apiDir = detectApiDirectory(config.builds || []);
     this.apiExtensions = detectApiExtensions(config.builds || []);
+
+    // Update the env vars configuration
+    const configBuild = config.build || {};
+    const [runEnv, buildEnv] = await Promise.all([
+      this.getLocalEnv('.env', config.env),
+      this.getLocalEnv('.env.build', configBuild.env),
+    ]);
+    const allEnv = { ...buildEnv, ...runEnv };
+    this.envConfigs = { buildEnv, runEnv, allEnv };
+
     return config;
   }
 
@@ -770,14 +750,7 @@ export default class DevServer {
     this.filter = ig.createFilter();
 
     // Retrieve the path of the native module
-    const nowConfig = await this.getNowConfig(false);
-    const nowConfigBuild = nowConfig.build || {};
-    const [runEnv, buildEnv] = await Promise.all([
-      this.getLocalEnv('.env', nowConfig.env),
-      this.getLocalEnv('.env.build', nowConfigBuild.env),
-    ]);
-    const allEnv = { ...buildEnv, ...runEnv };
-    this.envConfigs = { buildEnv, runEnv, allEnv };
+    const nowConfig = await this.getNowConfig();
 
     const opts = { output: this.output, isBuilds: true };
     const files = await getFiles(this.cwd, nowConfig, opts);

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -411,8 +411,6 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async t => {
     {
       // Env var should not be set after `vercel.json` is deleted
       await fs.remove(configPath);
-      await sleep(1000);
-
       const res = await fetch(`http://localhost:${port}/api`);
       const body = await res.json();
       t.is(body.FOO, undefined);
@@ -454,8 +452,6 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         ],
       };
       await fs.writeJSON(configPath, config);
-      await sleep(1000);
-
       const res = await fetch(`http://localhost:${port}/?foo=bar`);
       const body = await res.json();
       t.is(body.hasHelpers, false);
@@ -476,8 +472,6 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         ],
       };
       await fs.writeJSON(configPath, config);
-      await sleep(1000);
-
       const res = await fetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       t.is(body.hasHelpers, true);
@@ -495,8 +489,6 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         },
       };
       await fs.writeJSON(configPath, config);
-      await sleep(1000);
-
       const res = await fetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       t.is(body.hasHelpers, false);
@@ -514,8 +506,6 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         },
       };
       await fs.writeJSON(configPath, config);
-      await sleep(1000);
-
       const res = await fetch(`http://localhost:${port}/?foo=boo`);
       const body = await res.json();
       t.is(body.hasHelpers, true);


### PR DESCRIPTION
Since the filesystem watcher may be slow, it's actually faster and more
reliable to simply re-read the `vercel.json` configuration for every
HTTP request. This also simplifies the logic as an added benefit.

Some `sleep()` calls are removed from relevant tests that were
previously necessary due to the lag in the filesystem watcher.