### PR TITLE
[frameworks] Fix build command placeholder `nuxt generate`

### DIFF
--- a/packages/frameworks/frameworks.json
+++ b/packages/frameworks/frameworks.json
@@ -640,7 +640,7 @@
     },
     "settings": {
       "buildCommand": {
-        "placeholder": "`npm run build` or `nuxt build`"
+        "placeholder": "`npm run build` or `nuxt generate`"
       },
       "devCommand": {
         "value": "nuxt"


### PR DESCRIPTION
The Nuxt placeholder was wrong, it should be `nuxt generate` like the build command here: https://github.com/vercel/vercel/blob/ca2786420104b4ade9ac46cf7b9776f0ac1ab0ea/packages/now-static-build/src/frameworks.ts#L516