### PR TITLE
[@vercel/static-build] Cache `.cache` for Eleventy

### DIFF
--- a/packages/now-static-build/src/frameworks.ts
+++ b/packages/now-static-build/src/frameworks.ts
@@ -100,6 +100,7 @@ const frameworkList: Framework[] = [
     dependency: '@11ty/eleventy',
     buildCommand: 'npx @11ty/eleventy',
     getOutputDirName: async () => '_site',
+    cachePattern: '.cache/**',
   },
   {
     name: 'Docusaurus 2',


### PR DESCRIPTION
https://app.clubhouse.io/vercel/story/4909

Adds `.cache` directory to the Build Cache for Eleventy.