### PR TITLE
[next] Skip Lambda Deployment for Static Sites

### DIFF
--- a/packages/now-next/test/fixtures/05-spr-support/pages/api/noop.js
+++ b/packages/now-next/test/fixtures/05-spr-support/pages/api/noop.js
@@ -1,0 +1,3 @@
+export default (_, res) => {
+  res.send('OK');
+};

--- a/packages/now-next/test/fixtures/18-ssg-fallback-support/pages/api/noop.js
+++ b/packages/now-next/test/fixtures/18-ssg-fallback-support/pages/api/noop.js
@@ -1,0 +1,3 @@
+export default (_, res) => {
+  res.send('OK');
+};

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/api/noop.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/api/noop.js
@@ -1,0 +1,3 @@
+export default (_, res) => {
+  res.send('OK');
+};

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -35,6 +35,20 @@ it(
 );
 
 it(
+  'Should not deploy preview lambdas for static site',
+  async () => {
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(path.join(__dirname, 'static-site'));
+    expect(output['index']).toBeDefined();
+    expect(output['another']).toBeDefined();
+    expect(output['index'].type).toBe('FileFsRef');
+    expect(output['another'].type).toBe('FileFsRef');
+  },
+  FOUR_MINUTES
+);
+
+it(
   'Should opt-out of shared lambdas when routes are detected',
   async () => {
     const {

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -41,9 +41,15 @@ it(
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'static-site'));
     expect(output['index']).toBeDefined();
-    expect(output['another']).toBeDefined();
     expect(output['index'].type).toBe('FileFsRef');
+
+    expect(output['another']).toBeDefined();
+
     expect(output['another'].type).toBe('FileFsRef');
+
+    expect(output['dynamic']).toBeDefined();
+    expect(output['dynamic'].type).toBe('Prerender');
+    expect(output['dynamic'].lambda).toBeDefined();
   },
   FOUR_MINUTES
 );

--- a/packages/now-next/test/integration/static-site/package.json
+++ b/packages/now-next/test/integration/static-site/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/now-next/test/integration/static-site/pages/another.js
+++ b/packages/now-next/test/integration/static-site/pages/another.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return 'hello';
+}
+
+export function getStaticProps() {
+  return { props: {} };
+}

--- a/packages/now-next/test/integration/static-site/pages/dynamic.js
+++ b/packages/now-next/test/integration/static-site/pages/dynamic.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return 'hello';
+}
+
+export function getStaticProps() {
+  return { props: {}, unstable_revalidate: 10 };
+}

--- a/packages/now-next/test/integration/static-site/pages/index.js
+++ b/packages/now-next/test/integration/static-site/pages/index.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return 'hello';
+}
+
+export function getStaticProps() {
+  return { props: {} };
+}

--- a/packages/now-next/test/integration/static-site/vercel.json
+++ b/packages/now-next/test/integration/static-site/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,11 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@vercel/static-build@0.17.4-canary.1":
+  version "0.17.4-canary.1"
+  resolved "https://registry.yarnpkg.com/@vercel/static-build/-/static-build-0.17.4-canary.1.tgz#42ba89d5dee7ced3a20ec0a3a2986d293405530a"
+  integrity sha512-SWvu9zm6sQGuQeouHDnxOYxDlgvKSk7pb4m2QuVufFXrhOkx7OL6e91riHXCpmscv8Pb9mD7DFVl2o78FK7viA==
+
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,11 +2190,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@vercel/static-build@0.17.4-canary.1":
-  version "0.17.4-canary.1"
-  resolved "https://registry.yarnpkg.com/@vercel/static-build/-/static-build-0.17.4-canary.1.tgz#42ba89d5dee7ced3a20ec0a3a2986d293405530a"
-  integrity sha512-SWvu9zm6sQGuQeouHDnxOYxDlgvKSk7pb4m2QuVufFXrhOkx7OL6e91riHXCpmscv8Pb9mD7DFVl2o78FK7viA==
-
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"


### PR DESCRIPTION
This implements a deployment speed optimization by completely skipping lambdas in the event of a fully static site without API routes.

Without API routes, it's impossible to enter Preview Mode, so the Preview Mode lambdas are not necessary.

Fixes https://github.com/vercel/next.js/issues/14430