### PR TITLE
[cli] Revert "Remove caching of `vercel.json` config in `vc dev`"

### DIFF
--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -411,6 +411,8 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async t => {
     {
       // Env var should not be set after `vercel.json` is deleted
       await fs.remove(configPath);
+      await sleep(1000);
+
       const res = await fetch(`http://localhost:${port}/api`);
       const body = await res.json();
       t.is(body.FOO, undefined);
@@ -452,6 +454,8 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         ],
       };
       await fs.writeJSON(configPath, config);
+      await sleep(1000);
+
       const res = await fetch(`http://localhost:${port}/?foo=bar`);
       const body = await res.json();
       t.is(body.hasHelpers, false);
@@ -472,6 +476,8 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         ],
       };
       await fs.writeJSON(configPath, config);
+      await sleep(1000);
+
       const res = await fetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       t.is(body.hasHelpers, true);
@@ -489,6 +495,8 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         },
       };
       await fs.writeJSON(configPath, config);
+      await sleep(1000);
+
       const res = await fetch(`http://localhost:${port}/?foo=baz`);
       const body = await res.json();
       t.is(body.hasHelpers, false);
@@ -506,6 +514,8 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
         },
       };
       await fs.writeJSON(configPath, config);
+      await sleep(1000);
+
       const res = await fetch(`http://localhost:${port}/?foo=boo`);
       const body = await res.json();
       t.is(body.hasHelpers, true);


### PR DESCRIPTION
This reverts commit ffb98781f1990201813818a50492e3362e6a4489 (#4697),
because it was realized that `vc dev` reads this configuration file many
times per HTTP request, causing the server to feel extremely slow.

Reverting this optimization for now until the over-reading issue is
addressed.