### PR TITLE
[cli] Pin `@vercel/static-build` to v0.17.5-canary.0

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -68,7 +68,7 @@
     "@vercel/node": "1.7.2-canary.1",
     "@vercel/python": "1.2.2",
     "@vercel/ruby": "1.2.3-canary.0",
-    "@vercel/static-build": "0.17.4-canary.1"
+    "@vercel/static-build": "0.17.5-canary.0"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",


### PR DESCRIPTION
It got de-synced in fa0f1b90b4b42d61332bcdc5b8855d5dd356df8b.