### PR TITLE
[next] Use correct data route regex

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -91,7 +91,7 @@ export const version = 2;
 const htmlContentType = 'text/html; charset=utf-8';
 const nowDevChildProcesses = new Set<ChildProcess>();
 
-['SIGINT', 'SIGTERM'].forEach(signal => {
+['SIGINT', 'SIGTERM'].forEach((signal) => {
   process.once(signal as NodeJS.Signals, () => {
     for (const child of nowDevChildProcesses) {
       debug(
@@ -451,10 +451,9 @@ export const build = async ({
             }
 
             dataRoutes.push({
-              src: dataRoute.dataRouteRegex.replace(
-                /^\^/,
-                `^${appMountPrefixNoTrailingSlash}`
-              ),
+              src: (
+                dataRoute.namedDataRouteRegex || dataRoute.dataRouteRegex
+              ).replace(/^\^/, `^${appMountPrefixNoTrailingSlash}`),
               dest: path.join(
                 '/',
                 entryDirectory,
@@ -465,7 +464,7 @@ export const build = async ({
                 `${
                   dataRoute.routeKeys
                     ? `?${Object.keys(dataRoute.routeKeys)
-                        .map(key => `${dataRoute.routeKeys![key]}=$${key}`)
+                        .map((key) => `${dataRoute.routeKeys![key]}=$${key}`)
                         .join('&')}`
                     : ''
                 }`
@@ -696,7 +695,7 @@ export const build = async ({
     );
     const nodeModules = excludeFiles(
       await glob('node_modules/**', entryPath),
-      file => file.startsWith('node_modules/.cache')
+      (file) => file.startsWith('node_modules/.cache')
     );
     const launcherFiles = {
       'now__bridge.js': new FileFsRef({
@@ -725,7 +724,7 @@ export const build = async ({
     const launcherData = await readFile(launcherPath, 'utf8');
 
     await Promise.all(
-      Object.keys(pages).map(async page => {
+      Object.keys(pages).map(async (page) => {
         // These default pages don't have to be handled as they'd always 404
         if (['_app.js', '_error.js', '_document.js'].includes(page)) {
           return;
@@ -886,7 +885,7 @@ export const build = async ({
 
       const apiPages: string[] = [];
       const nonApiPages: string[] = [];
-      const allPagePaths = Object.keys(pages).map(page => pages[page].fsPath);
+      const allPagePaths = Object.keys(pages).map((page) => pages[page].fsPath);
 
       for (const page of allPagePaths) {
         if (isApiPage(page)) {
@@ -902,10 +901,10 @@ export const build = async ({
         reasons: apiReasons,
       } = await nodeFileTrace(apiPages, { base: workPath });
 
-      const { fileList, reasons: nonApiReasons } = await nodeFileTrace(
-        nonApiPages,
-        { base: workPath }
-      );
+      const {
+        fileList,
+        reasons: nonApiReasons,
+      } = await nodeFileTrace(nonApiPages, { base: workPath });
 
       debug(`node-file-trace result for pages: ${fileList}`);
 
@@ -979,7 +978,7 @@ export const build = async ({
         debug(
           'detected (legacy) assets to be bundled with serverless function:'
         );
-        assetKeys.forEach(assetFile => debug(`\t${assetFile}`));
+        assetKeys.forEach((assetFile) => debug(`\t${assetFile}`));
         debug(
           '\nPlease upgrade to Next.js 9.1 to leverage modern asset handling.'
         );
@@ -1119,7 +1118,7 @@ export const build = async ({
       }
     } else {
       await Promise.all(
-        pageKeys.map(async page => {
+        pageKeys.map(async (page) => {
           // These default pages don't have to be handled as they'd always 404
           if (['_app.js', '_document.js'].includes(page)) {
             return;
@@ -1200,8 +1199,8 @@ export const build = async ({
       false,
       routesManifest,
       new Set(prerenderManifest.omittedRoutes)
-    ).then(arr =>
-      arr.map(route => {
+    ).then((arr) =>
+      arr.map((route) => {
         route.src = route.src.replace('^', `^${dynamicPrefix}`);
         return route;
       })
@@ -1225,7 +1224,7 @@ export const build = async ({
                   const pages = {
                     ${groupPageKeys
                       .map(
-                        page =>
+                        (page) =>
                           `'${page}': require('./${path.join(
                             './',
                             group.pages[page].pageFileName
@@ -1270,7 +1269,7 @@ export const build = async ({
                       // for prerendered dynamic routes (/blog/post-1) we need to
                       // find the match since it won't match the page directly
                       const dynamicRoutes = ${JSON.stringify(
-                        dynamicRoutes.map(route => ({
+                        dynamicRoutes.map((route) => ({
                           src: route.src,
                           dest: route.dest,
                         }))
@@ -1484,13 +1483,13 @@ export const build = async ({
       }
     };
 
-    Object.keys(prerenderManifest.staticRoutes).forEach(route =>
+    Object.keys(prerenderManifest.staticRoutes).forEach((route) =>
       onPrerenderRoute(route, { isBlocking: false, isFallback: false })
     );
-    Object.keys(prerenderManifest.fallbackRoutes).forEach(route =>
+    Object.keys(prerenderManifest.fallbackRoutes).forEach((route) =>
       onPrerenderRoute(route, { isBlocking: false, isFallback: true })
     );
-    Object.keys(prerenderManifest.legacyBlockingRoutes).forEach(route =>
+    Object.keys(prerenderManifest.legacyBlockingRoutes).forEach((route) =>
       onPrerenderRoute(route, { isBlocking: true, isFallback: false })
     );
 
@@ -1554,7 +1553,7 @@ export const build = async ({
     // We need to delete lambdas from output instead of omitting them from the
     // start since we rely on them for powering Preview Mode (read above in
     // onPrerenderRoute).
-    prerenderManifest.omittedRoutes.forEach(routeKey => {
+    prerenderManifest.omittedRoutes.forEach((routeKey) => {
       // Get the route file as it'd be mounted in the builder output
       const routeFileNoExt = path.posix.join(
         entryDirectory,
@@ -1700,9 +1699,12 @@ export const build = async ({
                   src: path.join('/', entryDirectory, '.*'),
                   // if static 404 is not present but we have pages/404.js
                   // it is a lambda due to _app getInitialProps
-                  dest: path.join('/', (static404Page
-                    ? static404Page
-                    : pageLambdaMap[page404Path]) as string),
+                  dest: path.join(
+                    '/',
+                    (static404Page
+                      ? static404Page
+                      : pageLambdaMap[page404Path]) as string
+                  ),
 
                   status: 404,
                   headers: {

--- a/packages/now-next/test/fixtures/21-server-props/package.json
+++ b/packages/now-next/test/fixtures/21-server-props/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "9.2.3-canary.13",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/21-server-props/pages/another.js
+++ b/packages/now-next/test/fixtures/21-server-props/pages/another.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getServerProps() {
+export async function getServerSideProps() {
   return {
     props: {
       world: 'world',

--- a/packages/now-next/test/fixtures/21-server-props/pages/another2.js
+++ b/packages/now-next/test/fixtures/21-server-props/pages/another2.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getServerProps() {
+export async function getServerSideProps() {
   return {
     props: {
       world: 'world',

--- a/packages/now-next/test/fixtures/21-server-props/pages/blog/[post]/[comment].js
+++ b/packages/now-next/test/fixtures/21-server-props/pages/blog/[post]/[comment].js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getServerProps ({ params }) {
+export async function getServerSideProps({ params }) {
   return {
     props: {
       post: params.post,

--- a/packages/now-next/test/fixtures/21-server-props/pages/blog/[post]/index.js
+++ b/packages/now-next/test/fixtures/21-server-props/pages/blog/[post]/index.js
@@ -1,19 +1,19 @@
-import React from 'react'
+import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getServerProps ({ params }) {
+export async function getServerSideProps({ params }) {
   if (params.post === 'post-10') {
-    await new Promise(resolve => {
-      setTimeout(() => resolve(), 1000)
-    })
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(), 1000);
+    });
   }
 
   return {
     props: {
       post: params.post,
-      time: (await import('perf_hooks')).performance.now()
+      time: (await import('perf_hooks')).performance.now(),
     },
-  }
+  };
 }
 
 export default ({ post, time }) => {
@@ -22,5 +22,5 @@ export default ({ post, time }) => {
       <p>Post: {post}</p>
       <span>time: {time}</span>
     </>
-  )
-}
+  );
+};

--- a/packages/now-next/test/fixtures/21-server-props/pages/forever.js
+++ b/packages/now-next/test/fixtures/21-server-props/pages/forever.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // eslint-disable-next-line camelcase
-export async function unstable_getServerProps() {
+export async function getServerSideProps() {
   return {
     props: {
       world: 'world',


### PR DESCRIPTION
For `getServerSideProps` routes the non-named data route was being used for routes causing dynamic route params that were being trusted from the proxy to be incorrect. Our tests weren't failing after trusting the values from the proxy was landed in Next.js on canary due to the `21-server-props` test suite not running against the latest canary which is updated in this PR. 

Note: the below Next.js PR is not needed or can be reverted if this PR is landed

x-ref: https://github.com/vercel/next.js/pull/14829