### PR TITLE
[client] Add `@vercel/build-utils` as a "dependency"

### DIFF
--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "@vercel/build-utils": "2.4.1-canary.1",
     "@zeit/fetch": "5.2.0",
     "async-retry": "1.2.3",
     "async-sema": "3.0.0",


### PR DESCRIPTION
Fixes: https://github.com/philcockfield/sample.vercel.client-error