### PR TITLE
[routing-utils][next] Make sure root catch-all rewrite matches root itself

### DIFF
--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -13,8 +13,8 @@ export function getCleanUrls(
 ): { html: string; clean: string }[] {
   const htmlFiles = filePaths
     .map(toRoute)
-    .filter(f => f.endsWith('.html'))
-    .map(f => ({
+    .filter((f) => f.endsWith('.html'))
+    .map((f) => ({
       html: f,
       clean: f.slice(0, -5),
     }));
@@ -48,7 +48,7 @@ export function convertRedirects(
   redirects: NowRedirect[],
   defaultStatus = 308
 ): Route[] {
-  return redirects.map(r => {
+  return redirects.map((r) => {
     const { src, segments } = sourceToRegex(r.source);
     try {
       const loc = replaceSegments(segments, r.destination, true);
@@ -73,7 +73,7 @@ export function convertRedirects(
 }
 
 export function convertRewrites(rewrites: NowRewrite[]): Route[] {
-  return rewrites.map(r => {
+  return rewrites.map((r) => {
     const { src, segments } = sourceToRegex(r.source);
     try {
       const dest = replaceSegments(segments, r.destination);
@@ -86,10 +86,10 @@ export function convertRewrites(rewrites: NowRewrite[]): Route[] {
 }
 
 export function convertHeaders(headers: NowHeader[]): Route[] {
-  return headers.map(h => {
+  return headers.map((h) => {
     const obj: { [key: string]: string } = {};
     const { src, segments } = sourceToRegex(h.source);
-    const namedSegments = segments.filter(name => name !== UN_NAMED_SEGMENT);
+    const namedSegments = segments.filter((name) => name !== UN_NAMED_SEGMENT);
     const indexes: { [k: string]: string } = {};
 
     segments.forEach((name, index) => {
@@ -144,13 +144,13 @@ export function sourceToRegex(
 ): { src: string; segments: string[] } {
   const keys: Key[] = [];
   const r = pathToRegexp(source, keys, {
-    strict: true,
+    strict: false,
     sensitive: true,
     delimiter: '/',
   });
   const segments = keys
-    .map(k => k.name)
-    .map(name => {
+    .map((k) => k.name)
+    .map((name) => {
       if (typeof name !== 'string') {
         return UN_NAMED_SEGMENT;
       }
@@ -173,7 +173,7 @@ function replaceSegments(
   pathname = pathname || '';
   hash = hash || '';
 
-  const namedSegments = segments.filter(name => name !== UN_NAMED_SEGMENT);
+  const namedSegments = segments.filter((name) => name !== UN_NAMED_SEGMENT);
 
   if (namedSegments.length > 0) {
     const indexes: { [k: string]: string } = {};
@@ -225,7 +225,7 @@ function safelyCompile(str: string, indexes: { [k: string]: string }): string {
   // path-to-regexp cannot compile question marks
   return str
     .split('?')
-    .map(part => {
+    .map((part) => {
       const compiler = compile(part);
       return compiler(indexes);
     })

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -96,7 +96,7 @@ describe('normalizeRoutes', () => {
     assert.notEqual(normalized.routes, null);
 
     if (normalized.routes) {
-      normalized.routes.forEach(route => {
+      normalized.routes.forEach((route) => {
         if (isHandler(route)) {
           assert.fail(
             `Normalizer returned: { handle: ${route.handle} } instead of { src: ${expected} }`
@@ -772,17 +772,17 @@ describe('getTransformedRoutes', () => {
         status: 308,
       },
       {
-        src: '^/help$',
+        src: '^/help[/]?$',
         headers: { Location: '/support' },
         status: 302,
       },
       {
-        src: '^/bug$',
+        src: '^/bug[/]?$',
         headers: { Location: 'https://example.com/bug' },
         status: 308,
       },
       { handle: 'filesystem' },
-      { src: '^/v1$', dest: '/v2/api.py', check: true },
+      { src: '^/v1[/]?$', dest: '/v2/api.py', check: true },
     ];
     assert.deepEqual(actual.error, null);
     assert.deepEqual(actual.routes, expected);
@@ -972,7 +972,7 @@ describe('getTransformedRoutes', () => {
           'x-frame-options': 'sameorigin',
           'x-xss-protection': '1; mode=block',
         },
-        src: '^(?:/(.*))$',
+        src: '^(?:/(.*))[/]?$',
       },
     ]);
   });

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -14,12 +14,12 @@ function routesToRegExps(routeArray) {
   if (error) {
     throw error;
   }
-  return routes.map(r => new RegExp(r.src));
+  return routes.map((r) => new RegExp(r.src));
 }
 
 function assertMatches(actual, matches, isExpectingMatch) {
   routesToRegExps(actual).forEach((r, i) => {
-    matches[i].forEach(text => {
+    matches[i].forEach((text) => {
       deepEqual(r.test(text), isExpectingMatch, `${text} ${r.source}`);
     });
   });
@@ -194,67 +194,67 @@ test('convertRedirects', () => {
 
   const expected = [
     {
-      src: '^\\/some\\/old\\/path$',
+      src: '^\\/some\\/old\\/path[\\/]?$',
       headers: { Location: '/some/new/path' },
       status: 308,
     },
     {
-      src: '^\\/next(\\.js)?$',
+      src: '^\\/next(\\.js)?[\\/]?$',
       headers: { Location: 'https://nextjs.org' },
       status: 308,
     },
     {
-      src: '^\\/proxy(?:\\/(.*))$',
+      src: '^\\/proxy(?:\\/(.*))[\\/]?$',
       headers: { Location: 'https://www.firebase.com' },
       status: 302,
     },
     {
-      src: '^\\/proxy-regex(?:\\/([a-zA-Z]{1,}))$',
+      src: '^\\/proxy-regex(?:\\/([a-zA-Z]{1,}))[\\/]?$',
       headers: { Location: 'https://firebase.com/$1' },
       status: 308,
     },
     {
-      src: '^\\/proxy-port(?:\\/([a-zA-Z]{1,}))$',
+      src: '^\\/proxy-port(?:\\/([a-zA-Z]{1,}))[\\/]?$',
       headers: { Location: 'https://firebase.com:8080/$1' },
       status: 308,
     },
     {
-      src: '^\\/projects(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+      src: '^\\/projects(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))[\\/]?$',
       headers: { Location: '/projects.html' },
       status: 308,
     },
     {
-      src: '^\\/old(?:\\/([^\\/]+?))\\/path$',
+      src: '^\\/old(?:\\/([^\\/]+?))\\/path[\\/]?$',
       headers: { Location: '/new/path/$1' },
       status: 308,
     },
     {
-      src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+      src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?[\\/]?$',
       headers: { Location: '/catchall/$1/' },
       status: 308,
     },
     {
-      src: '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))$',
+      src: '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))[\\/]?$',
       headers: { Location: '/another-catch/$1/' },
       status: 308,
     },
     {
-      src: '^\\/feedback(?:\\/((?!general).*))$',
+      src: '^\\/feedback(?:\\/((?!general).*))[\\/]?$',
       headers: { Location: '/feedback/general' },
       status: 308,
     },
     {
-      src: '^\\/catchme(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+      src: '^\\/catchme(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?[\\/]?$',
       headers: { Location: '/api/user' },
       status: 308,
     },
     {
-      src: '^\\/hello(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+      src: '^\\/hello(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?[\\/]?$',
       headers: { Location: '/something#$1' },
       status: 308,
     },
     {
-      src: '^\\/external(?:\\/([^\\/]+?))$',
+      src: '^\\/external(?:\\/([^\\/]+?))[\\/]?$',
       headers: {
         Location:
           'https://example.com/?utm_source=google.com#/guides/$1/page?dynamic=code',
@@ -262,7 +262,7 @@ test('convertRedirects', () => {
       status: 308,
     },
     {
-      src: '^\\/optional(?:\\/([^\\/]+?))?$',
+      src: '^\\/optional(?:\\/([^\\/]+?))?[\\/]?$',
       headers: { Location: '/api/optional/$1' },
       status: 308,
     },
@@ -353,79 +353,88 @@ test('convertRewrites', () => {
   ]);
 
   const expected = [
-    { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', check: true },
     {
-      src: '^\\/proxy(?:\\/(.*))$',
+      src: '^\\/some\\/old\\/path[\\/]?$',
+      dest: '/some/new/path',
+      check: true,
+    },
+    {
+      src: '^\\/proxy(?:\\/(.*))[\\/]?$',
       dest: 'https://www.firebase.com',
       check: true,
     },
     {
-      src: '^\\/proxy-regex(?:\\/([a-zA-Z]{1,}))$',
+      src: '^\\/proxy-regex(?:\\/([a-zA-Z]{1,}))[\\/]?$',
       dest: 'https://firebase.com/$1',
       check: true,
     },
     {
-      src: '^\\/proxy-port(?:\\/([a-zA-Z]{1,}))$',
+      src: '^\\/proxy-port(?:\\/([a-zA-Z]{1,}))[\\/]?$',
       dest: 'https://firebase.com:8080/$1',
       check: true,
     },
     {
-      src: '^\\/projects(?:\\/([^\\/]+?))\\/edit$',
+      src: '^\\/projects(?:\\/([^\\/]+?))\\/edit[\\/]?$',
       dest: '/projects.html?id=$1',
       check: true,
     },
     {
-      src: '^\\/users(?:\\/([^\\/]+?))$',
+      src: '^\\/users(?:\\/([^\\/]+?))[\\/]?$',
       dest: '/api/user?identifier=$1&version=v2&id=$1',
       check: true,
     },
     {
-      src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+      src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))[\\/]?$',
       dest: '/$1/get?identifier=$2&file=$1&id=$2',
       check: true,
     },
     {
-      src: '^\\/qs-and-hash(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+      src: '^\\/qs-and-hash(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))[\\/]?$',
       dest: '/api/get?identifier=$1&id=$1&hash=$2#$2',
       check: true,
     },
     {
-      src: '^\\/fullurl$',
+      src: '^\\/fullurl[\\/]?$',
       dest:
         'https://user:pass@sub.example.com:8080/path/goes/here?v=1&id=2#hash',
       check: true,
     },
     {
-      src: '^\\/dont-override-qs(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+      src: '^\\/dont-override-qs(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))[\\/]?$',
       dest: '/final?name=bob&age=',
       check: true,
     },
     {
-      src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?\\/$',
+      src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?\\/[\\/]?$',
       dest: '/catchall/$1?hello=$1',
       check: true,
     },
     {
-      src: '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+      src:
+        '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/[\\/]?$',
       dest: '/another-catch/$1?hello=$1',
       check: true,
     },
     {
-      src: '^\\/catchme(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+      src: '^\\/catchme(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?[\\/]?$',
       dest: '/api/user?id=$1',
       check: true,
     },
     {
-      src: '^(?:\\/([^\\/]+?))$',
+      src: '^(?:\\/([^\\/]+?))[\\/]?$',
       dest: '/test?path=$1',
       check: true,
     },
     {
       check: true,
       dest: '/test?path=$1&two=$2',
-      src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
+      src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))[\\/]?$',
     },
-    { check: true, dest: '/blog/$2?id=$2', src: '^(?:\\/(.*))-(\\d+)\\.html$' },
+    {
+      check: true,
+      dest: '/blog/$2?id=$2',
+      src: '^(?:\\/(.*))-(\\d+)\\.html[\\/]?$',
+    },
   ];
 
   deepEqual(actual, expected);
@@ -512,17 +521,17 @@ test('convertHeaders', () => {
 
   const expected = [
     {
-      src: '^(.*)+(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)$',
+      src: '^(.*)+(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)[\\/]?$',
       headers: { 'Access-Control-Allow-Origin': '*' },
       continue: true,
     },
     {
-      src: '^404\\.html$',
+      src: '^404\\.html[\\/]?$',
       headers: { 'Cache-Control': 'max-age=300', 'Set-Cookie': 'error=404' },
       continue: true,
     },
     {
-      src: '^\\/blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+      src: '^\\/blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?[\\/]?$',
       headers: { 'on-blog': '$1', $1: 'blog' },
       continue: true,
     },


### PR DESCRIPTION
Since we are able to disable the `strict: true` config in Next.js and this was added to match Next.js' behavior this updates it here also to ensure they are still matching

x-ref: https://github.com/vercel/next.js/pull/14931