### PR TITLE
[frameworks] Remove blitz demo

### DIFF
--- a/packages/frameworks/frameworks.json
+++ b/packages/frameworks/frameworks.json
@@ -2,7 +2,6 @@
   {
     "name": "Blitz.js",
     "slug": "blitzjs",
-    "demo": "https://blitzjs.now-examples.now.sh",
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/blitz.svg",
     "tagline": "Blitz.js: The Fullstack React Framework",
     "description": "A brand new Blitz.js app: the output of running `blitz new`",


### PR DESCRIPTION
This is not ready yet. We need to confirm Blitz is working before we deploy the demo.