### PR TITLE
[next] Fix nested public files being renamed incorrectly

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1561,7 +1561,7 @@ export const build = async ({
       ...mappedFiles,
       [path.join(
         entryDirectory,
-        file.replace(/public[/\\]+/, '')
+        file.replace(/^public[/\\]+/, '')
       )]: publicFolderFiles[file],
     }),
     {}

--- a/packages/now-next/test/fixtures/28-nested-public/next.config.js
+++ b/packages/now-next/test/fixtures/28-nested-public/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/now-next/test/fixtures/28-nested-public/now.json
+++ b/packages/now-next/test/fixtures/28-nested-public/now.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/republic/test.txt",
+      "status": 200,
+      "mustContain": "hello world"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/28-nested-public/package.json
+++ b/packages/now-next/test/fixtures/28-nested-public/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/28-nested-public/pages/index.js
+++ b/packages/now-next/test/fixtures/28-nested-public/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index page</p>;
+}

--- a/packages/now-next/test/fixtures/28-nested-public/public/republic/test.txt
+++ b/packages/now-next/test/fixtures/28-nested-public/public/republic/test.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
This corrects the file rename for public files to not incorrectly rename nested `public` files

x-ref: https://github.com/vercel-support/next-nested-public-dir