### PR TITLE
[all] Change prettier config `arrowParens: avoid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "prettier": {
     "trailingComma": "es5",
-    "singleQuote": true
+    "singleQuote": true,
+    "arrowParens": "avoid"
   },
   "eslintConfig": {
     "root": true,

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -29,7 +29,7 @@ export function resolveRouteParameters(
 export function getRoutesTypes(routes: Route[] = []) {
   const handleMap = new Map<HandleValue | null, Route[]>();
   let prevHandle: HandleValue | null = null;
-  routes.forEach((route) => {
+  routes.forEach(route => {
     if (isHandler(route)) {
       prevHandle = route.handle;
     } else {

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -17,8 +17,8 @@ const isCanary = () => getDistTag(cliVersion) === 'canary';
 let port = 3000;
 
 const binaryPath = resolve(__dirname, `../../scripts/start.js`);
-const fixture = (name) => join('test', 'dev', 'fixtures', name);
-const fixtureAbsolute = (name) => join(__dirname, 'fixtures', name);
+const fixture = name => join('test', 'dev', 'fixtures', name);
+const fixtureAbsolute = name => join(__dirname, 'fixtures', name);
 
 let processCounter = 0;
 const processList = new Map();
@@ -57,7 +57,7 @@ function fetchWithRetry(url, retries = 3, opts = {}) {
 
 function createResolver() {
   let resolver;
-  const p = new Promise((res) => (resolver = res));
+  const p = new Promise(res => (resolver = res));
   p.resolve = resolver;
   return p;
 }
@@ -75,7 +75,7 @@ function printOutput(fixture, stdout, stderr) {
     stderr
   ).split('\n');
 
-  const getPrefix = (nr) => {
+  const getPrefix = nr => {
     return nr === 0 ? '╭' : nr === lines.length - 1 ? '╰' : '│';
   };
 
@@ -196,10 +196,10 @@ async function testFixture(directory, opts = {}, args = []) {
   dev.stdout.setEncoding('utf8');
   dev.stderr.setEncoding('utf8');
 
-  dev.stdout.on('data', (data) => {
+  dev.stdout.on('data', data => {
     stdout += data;
   });
-  dev.stderr.on('data', (data) => {
+  dev.stderr.on('data', data => {
     stderr += data;
 
     if (stderr.includes('Ready! Available at')) {
@@ -243,7 +243,7 @@ function testFixtureStdio(
   fn,
   { expectedCode = 0, skipDeploy } = {}
 ) {
-  return async (t) => {
+  return async t => {
     const cwd = fixtureAbsolute(directory);
     const token = await fetchTokenWithRetry();
     let deploymentUrl;
@@ -298,11 +298,11 @@ function testFixtureStdio(
       dev.stdout.pipe(process.stdout);
       dev.stderr.pipe(process.stderr);
 
-      dev.stdout.on('data', (data) => {
+      dev.stdout.on('data', data => {
         stdout += data;
       });
 
-      dev.stderr.on('data', (data) => {
+      dev.stderr.on('data', data => {
         stderr += data;
 
         if (stderr.includes('Ready! Available at')) {
@@ -380,7 +380,7 @@ test.afterEach(async () => {
   );
 });
 
-test('[vercel dev] prints `npm install` errors', async (t) => {
+test('[vercel dev] prints `npm install` errors', async t => {
   const dir = fixture('runtime-not-installed');
   const result = await exec(dir);
   t.truthy(result.stderr.includes('npm ERR! 404'));
@@ -392,7 +392,7 @@ test('[vercel dev] prints `npm install` errors', async (t) => {
   );
 });
 
-test('[vercel dev] `vercel.json` should be invalidated if deleted', async (t) => {
+test('[vercel dev] `vercel.json` should be invalidated if deleted', async t => {
   const dir = fixture('invalidate-vercel-config');
   const configPath = join(dir, 'vercel.json');
   const originalConfig = await fs.readJSON(configPath);
@@ -423,7 +423,7 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async (t) =>
   }
 });
 
-test('[vercel dev] reflects changes to config and env without restart', async (t) => {
+test('[vercel dev] reflects changes to config and env without restart', async t => {
   const dir = fixture('node-helpers');
   const configPath = join(dir, 'vercel.json');
   const originalConfig = await fs.readJSON(configPath);
@@ -527,7 +527,7 @@ test('[vercel dev] reflects changes to config and env without restart', async (t
   }
 });
 
-test('[vercel dev] `@vercel/node` TypeScript should be resolved by default', async (t) => {
+test('[vercel dev] `@vercel/node` TypeScript should be resolved by default', async t => {
   // The purpose of this test is to test that `@vercel/node` can properly
   // resolve the default "typescript" module when the project doesn't include
   // its own version. To properly test for this, a fixture needs to be created
@@ -558,14 +558,14 @@ test('[vercel dev] `@vercel/node` TypeScript should be resolved by default', asy
 
 test(
   '[vercel dev] validate routes that use `check: true`',
-  testFixtureStdio('routes-check-true', async (testPath) => {
+  testFixtureStdio('routes-check-true', async testPath => {
     await testPath(200, '/blog/post', 'Blog Home');
   })
 );
 
 test(
   '[vercel dev] validate routes that use `check: true` and `status` code',
-  testFixtureStdio('routes-check-true-status', async (testPath) => {
+  testFixtureStdio('routes-check-true-status', async testPath => {
     await testPath(403, '/secret');
     await testPath(200, '/post', 'This is a post.');
     await testPath(200, '/post.html', 'This is a post.');
@@ -574,7 +574,7 @@ test(
 
 test(
   '[vercel dev] validate routes that use custom 404 page',
-  testFixtureStdio('routes-custom-404', async (testPath) => {
+  testFixtureStdio('routes-custom-404', async testPath => {
     await testPath(200, '/', 'Home Page');
     await testPath(404, '/nothing', 'Custom User 404');
     await testPath(404, '/exact', 'Exact Custom 404');
@@ -585,7 +585,7 @@ test(
 
 test(
   '[vercel dev] handles miss after route',
-  testFixtureStdio('handle-miss-after-route', async (testPath) => {
+  testFixtureStdio('handle-miss-after-route', async testPath => {
     await testPath(200, '/post', 'Blog Post Page', {
       test: '1',
       override: 'one',
@@ -595,7 +595,7 @@ test(
 
 test(
   '[vercel dev] handles miss after rewrite',
-  testFixtureStdio('handle-miss-after-rewrite', async (testPath) => {
+  testFixtureStdio('handle-miss-after-rewrite', async testPath => {
     await testPath(200, '/post', 'Blog Post Page', {
       test: '1',
       override: 'one',
@@ -621,7 +621,7 @@ test(
 
 test(
   '[vercel dev] does not display directory listing after 404',
-  testFixtureStdio('handle-miss-hide-dir-list', async (testPath) => {
+  testFixtureStdio('handle-miss-hide-dir-list', async testPath => {
     await testPath(404, '/post');
     await testPath(200, '/post/one.html', 'First Post');
   })
@@ -629,7 +629,7 @@ test(
 
 test(
   '[vercel dev] should preserve query string even after miss phase',
-  testFixtureStdio('handle-miss-querystring', async (testPath) => {
+  testFixtureStdio('handle-miss-querystring', async testPath => {
     await testPath(200, '/', 'Index Page');
     if (process.env.CI && process.platform === 'darwin') {
       console.log('Skipping since GH Actions hangs for some reason');
@@ -642,28 +642,28 @@ test(
 
 test(
   '[vercel dev] handles hit after handle: filesystem',
-  testFixtureStdio('handle-hit-after-fs', async (testPath) => {
+  testFixtureStdio('handle-hit-after-fs', async testPath => {
     await testPath(200, '/blog.html', 'Blog Page', { test: '1' });
   })
 );
 
 test(
   '[vercel dev] handles hit after dest',
-  testFixtureStdio('handle-hit-after-dest', async (testPath) => {
+  testFixtureStdio('handle-hit-after-dest', async testPath => {
     await testPath(200, '/post', 'Blog Post', { test: '1', override: 'one' });
   })
 );
 
 test(
   '[vercel dev] handles hit after rewrite',
-  testFixtureStdio('handle-hit-after-rewrite', async (testPath) => {
+  testFixtureStdio('handle-hit-after-rewrite', async testPath => {
     await testPath(200, '/post', 'Blog Post', { test: '1', override: 'one' });
   })
 );
 
 test(
   '[vercel dev] should serve the public directory and api functions',
-  testFixtureStdio('public-and-api', async (testPath) => {
+  testFixtureStdio('public-and-api', async testPath => {
     await testPath(200, '/', 'This is the home page');
     await testPath(200, '/about.html', 'This is the about page');
     await testPath(200, '/.well-known/humans.txt', 'We come in peace');
@@ -677,7 +677,7 @@ test(
 
 test(
   '[vercel dev] should allow user rewrites for path segment files',
-  testFixtureStdio('test-zero-config-rewrite', async (testPath) => {
+  testFixtureStdio('test-zero-config-rewrite', async testPath => {
     await testPath(404, '/');
     await testPath(200, '/echo/1', '{"id":"1"}', {
       'Access-Control-Allow-Origin': '*',
@@ -688,7 +688,7 @@ test(
   })
 );
 
-test('[vercel dev] validate builds', async (t) => {
+test('[vercel dev] validate builds', async t => {
   const directory = fixture('invalid-builds');
   const output = await exec(directory);
 
@@ -699,7 +699,7 @@ test('[vercel dev] validate builds', async (t) => {
   );
 });
 
-test('[vercel dev] validate routes', async (t) => {
+test('[vercel dev] validate routes', async t => {
   const directory = fixture('invalid-routes');
   const output = await exec(directory);
 
@@ -710,7 +710,7 @@ test('[vercel dev] validate routes', async (t) => {
   );
 });
 
-test('[vercel dev] validate cleanUrls', async (t) => {
+test('[vercel dev] validate cleanUrls', async t => {
   const directory = fixture('invalid-clean-urls');
   const output = await exec(directory);
 
@@ -721,7 +721,7 @@ test('[vercel dev] validate cleanUrls', async (t) => {
   );
 });
 
-test('[vercel dev] validate trailingSlash', async (t) => {
+test('[vercel dev] validate trailingSlash', async t => {
   const directory = fixture('invalid-trailing-slash');
   const output = await exec(directory);
 
@@ -732,7 +732,7 @@ test('[vercel dev] validate trailingSlash', async (t) => {
   );
 });
 
-test('[vercel dev] validate rewrites', async (t) => {
+test('[vercel dev] validate rewrites', async t => {
   const directory = fixture('invalid-rewrites');
   const output = await exec(directory);
 
@@ -743,7 +743,7 @@ test('[vercel dev] validate rewrites', async (t) => {
   );
 });
 
-test('[vercel dev] validate redirects', async (t) => {
+test('[vercel dev] validate redirects', async t => {
   const directory = fixture('invalid-redirects');
   const output = await exec(directory);
 
@@ -754,7 +754,7 @@ test('[vercel dev] validate redirects', async (t) => {
   );
 });
 
-test('[vercel dev] validate headers', async (t) => {
+test('[vercel dev] validate headers', async t => {
   const directory = fixture('invalid-headers');
   const output = await exec(directory);
 
@@ -765,7 +765,7 @@ test('[vercel dev] validate headers', async (t) => {
   );
 });
 
-test('[vercel dev] validate mixed routes and rewrites', async (t) => {
+test('[vercel dev] validate mixed routes and rewrites', async t => {
   const directory = fixture('invalid-mixed-routes-rewrites');
   const output = await exec(directory);
 
@@ -778,7 +778,7 @@ test('[vercel dev] validate mixed routes and rewrites', async (t) => {
 });
 
 // Test seems unstable: It won't return sometimes.
-test('[vercel dev] validate env var names', async (t) => {
+test('[vercel dev] validate env var names', async t => {
   const directory = fixture('invalid-env-var-name');
   const { dev } = await testFixture(directory, { stdio: 'pipe' });
 
@@ -787,7 +787,7 @@ test('[vercel dev] validate env var names', async (t) => {
     dev.stderr.setEncoding('utf8');
 
     await new Promise((resolve, reject) => {
-      dev.stderr.on('data', (b) => {
+      dev.stderr.on('data', b => {
         stderr += b.toString();
 
         if (
@@ -817,7 +817,7 @@ test('[vercel dev] validate env var names', async (t) => {
 
 test(
   '[vercel dev] test rewrites with segments serve correct content',
-  testFixtureStdio('test-rewrites-with-segments', async (testPath) => {
+  testFixtureStdio('test-rewrites-with-segments', async testPath => {
     await testPath(200, '/api/users/first', 'first');
     await testPath(200, '/api/fourty-two', '42');
     await testPath(200, '/rand', '42');
@@ -828,14 +828,14 @@ test(
 
 test(
   '[vercel dev] test rewrites serve correct content',
-  testFixtureStdio('test-rewrites', async (testPath) => {
+  testFixtureStdio('test-rewrites', async testPath => {
     await testPath(200, '/hello', 'Hello World');
   })
 );
 
 test(
   '[vercel dev] test rewrites and redirects is case sensitive',
-  testFixtureStdio('test-routing-case-sensitive', async (testPath) => {
+  testFixtureStdio('test-routing-case-sensitive', async testPath => {
     await testPath(200, '/Path', 'UPPERCASE');
     await testPath(200, '/path', 'lowercase');
     await testPath(308, '/GoTo', 'Redirecting to /upper.html (308)', {
@@ -849,7 +849,7 @@ test(
 
 test(
   '[vercel dev] test cleanUrls serve correct content',
-  testFixtureStdio('test-clean-urls', async (testPath) => {
+  testFixtureStdio('test-clean-urls', async testPath => {
     await testPath(200, '/', 'Index Page');
     await testPath(200, '/about', 'About Page');
     await testPath(200, '/sub', 'Sub Index Page');
@@ -875,7 +875,7 @@ test(
 
 test(
   '[vercel dev] should serve custom 404 when `cleanUrls: true`',
-  testFixtureStdio('test-clean-urls-custom-404', async (testPath) => {
+  testFixtureStdio('test-clean-urls-custom-404', async testPath => {
     await testPath(200, '/', 'This is the home page');
     await testPath(200, '/about', 'The about page');
     await testPath(200, '/contact/me', 'Contact Me Subdirectory');
@@ -886,7 +886,7 @@ test(
 
 test(
   '[vercel dev] test cleanUrls and trailingSlash serve correct content',
-  testFixtureStdio('test-clean-urls-trailing-slash', async (testPath) => {
+  testFixtureStdio('test-clean-urls-trailing-slash', async testPath => {
     await testPath(200, '/', 'Index Page');
     await testPath(200, '/about/', 'About Page');
     await testPath(200, '/sub/', 'Sub Index Page');
@@ -913,7 +913,7 @@ test(
 
 test(
   '[vercel dev] test cors headers work with OPTIONS',
-  testFixtureStdio('test-cors-routes', async (testPath) => {
+  testFixtureStdio('test-cors-routes', async testPath => {
     const headers = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Headers':
@@ -932,7 +932,7 @@ test(
 
 test(
   '[vercel dev] test trailingSlash true serve correct content',
-  testFixtureStdio('test-trailing-slash', async (testPath) => {
+  testFixtureStdio('test-trailing-slash', async testPath => {
     await testPath(200, '/', 'Index Page');
     await testPath(200, '/index.html', 'Index Page');
     await testPath(200, '/about.html', 'About Page');
@@ -954,7 +954,7 @@ test(
 
 test(
   '[vercel dev] should serve custom 404 when `trailingSlash: true`',
-  testFixtureStdio('test-trailing-slash-custom-404', async (testPath) => {
+  testFixtureStdio('test-trailing-slash-custom-404', async testPath => {
     await testPath(200, '/', 'This is the home page');
     await testPath(200, '/about.html', 'The about page');
     await testPath(200, '/contact/', 'Contact Subdirectory');
@@ -964,7 +964,7 @@ test(
 
 test(
   '[vercel dev] test trailingSlash false serve correct content',
-  testFixtureStdio('test-trailing-slash-false', async (testPath) => {
+  testFixtureStdio('test-trailing-slash-false', async testPath => {
     await testPath(200, '/', 'Index Page');
     await testPath(200, '/index.html', 'Index Page');
     await testPath(200, '/about.html', 'About Page');
@@ -993,7 +993,7 @@ test(
   '[vercel dev] throw when invalid builder routes detected',
   testFixtureStdio(
     'invalid-builder-routes',
-    async (testPath) => {
+    async testPath => {
       await testPath(
         500,
         '/',
@@ -1006,14 +1006,14 @@ test(
 
 test(
   '[vercel dev] support legacy `@now` scope runtimes',
-  testFixtureStdio('legacy-now-runtime', async (testPath) => {
+  testFixtureStdio('legacy-now-runtime', async testPath => {
     await testPath(200, '/', /A simple deployment with the Vercel API!/m);
   })
 );
 
 test(
   '[vercel dev] support dynamic next.js routes in monorepos',
-  testFixtureStdio('monorepo-dynamic-paths', async (testPath) => {
+  testFixtureStdio('monorepo-dynamic-paths', async testPath => {
     await testPath(200, '/', /This is our homepage/m);
     await testPath(200, '/about', /This is the about static page./m);
     await testPath(
@@ -1026,7 +1026,7 @@ test(
 
 test(
   '[vercel dev] 00-list-directory',
-  testFixtureStdio('00-list-directory', async (testPath) => {
+  testFixtureStdio('00-list-directory', async testPath => {
     await testPath(200, '/', /Files within/m);
     await testPath(200, '/', /test[0-3]\.txt/m);
     await testPath(200, '/', /\.well-known/m);
@@ -1036,13 +1036,13 @@ test(
 
 test(
   '[vercel dev] 01-node',
-  testFixtureStdio('01-node', async (testPath) => {
+  testFixtureStdio('01-node', async testPath => {
     await testPath(200, '/', /A simple deployment with the Vercel API!/m);
   })
 );
 
 // Angular has `engines: { node: "10.x" }` in its `package.json`
-test('[vercel dev] 02-angular-node', async (t) => {
+test('[vercel dev] 02-angular-node', async t => {
   if (shouldSkip(t, '02-angular-node', '10.x')) return;
 
   const directory = fixture('02-angular-node');
@@ -1053,7 +1053,7 @@ test('[vercel dev] 02-angular-node', async (t) => {
   let stderr = '';
 
   try {
-    dev.stderr.on('data', async (data) => {
+    dev.stderr.on('data', async data => {
       stderr += data.toString();
     });
 
@@ -1083,7 +1083,7 @@ test(
   '[vercel dev] 03-aurelia',
   testFixtureStdio(
     '03-aurelia',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Aurelia Navigation Skeleton/m);
     },
     { skipDeploy: true }
@@ -1092,7 +1092,7 @@ test(
 
 test(
   '[vercel dev] 04-create-react-app',
-  testFixtureStdio('04-create-react-app', async (testPath) => {
+  testFixtureStdio('04-create-react-app', async testPath => {
     await testPath(200, '/', /React App/m);
   })
 );
@@ -1106,7 +1106,7 @@ test(
 */
 test(
   '[vercel dev] 06-gridsome',
-  testFixtureStdio('06-gridsome', async (testPath) => {
+  testFixtureStdio('06-gridsome', async testPath => {
     await testPath(200, '/');
     await testPath(200, '/about');
     await testPath(308, '/support', 'Redirecting to /about?ref=support (308)', {
@@ -1120,7 +1120,7 @@ test(
 
 test(
   '[vercel dev] 07-hexo-node',
-  testFixtureStdio('07-hexo-node', async (testPath) => {
+  testFixtureStdio('07-hexo-node', async testPath => {
     await testPath(200, '/', /Hexo \+ Node.js API/m);
     await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     await testPath(200, '/contact.html', /Contact Us/m);
@@ -1128,13 +1128,13 @@ test(
   })
 );
 
-test('[vercel dev] 08-hugo', async (t) => {
+test('[vercel dev] 08-hugo', async t => {
   if (process.platform === 'darwin') {
     // Update PATH to find the Hugo executable installed via GH Actions
     process.env.PATH = `${resolve(fixture('08-hugo'))}${delimiter}${
       process.env.PATH
     }`;
-    const tester = testFixtureStdio('08-hugo', async (testPath) => {
+    const tester = testFixtureStdio('08-hugo', async testPath => {
       await testPath(200, '/', /Hugo/m);
     });
     await tester(t);
@@ -1146,7 +1146,7 @@ test('[vercel dev] 08-hugo', async (t) => {
 
 test(
   '[vercel dev] 10-nextjs-node',
-  testFixtureStdio('10-nextjs-node', async (testPath) => {
+  testFixtureStdio('10-nextjs-node', async testPath => {
     await testPath(200, '/', /Next.js \+ Node.js API/m);
     await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     await testPath(200, '/contact', /Contact Page/);
@@ -1159,7 +1159,7 @@ test(
   '[vercel dev] 12-polymer-node',
   testFixtureStdio(
     '12-polymer-node',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Polymer \+ Node.js API/m);
       await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
@@ -1171,7 +1171,7 @@ test(
   '[vercel dev] 13-preact-node',
   testFixtureStdio(
     '13-preact-node',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Preact/m);
       await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
@@ -1183,7 +1183,7 @@ test(
   '[vercel dev] 14-svelte-node',
   testFixtureStdio(
     '14-svelte-node',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Svelte/m);
       await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
@@ -1195,7 +1195,7 @@ test(
   '[vercel dev] 16-vue-node',
   testFixtureStdio(
     '16-vue-node',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Vue.js \+ Node.js API/m);
       await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
@@ -1207,7 +1207,7 @@ test(
   '[vercel dev] 17-vuepress-node',
   testFixtureStdio(
     '17-vuepress-node',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /VuePress \+ Node.js API/m);
       await testPath(200, '/api/date', new RegExp(new Date().getFullYear()));
     },
@@ -1267,7 +1267,7 @@ test(
   '[vercel dev] 18-marko',
   testFixtureStdio(
     '18-marko',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Marko Starter/m);
     },
     { skipDeploy: true }
@@ -1278,7 +1278,7 @@ test(
   '[vercel dev] 19-mithril',
   testFixtureStdio(
     '19-mithril',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Mithril on Vercel/m);
     },
     { skipDeploy: true }
@@ -1289,7 +1289,7 @@ test(
   '[vercel dev] 20-riot',
   testFixtureStdio(
     '20-riot',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Riot on Vercel/m);
     },
     { skipDeploy: true }
@@ -1300,7 +1300,7 @@ test(
   '[vercel dev] 21-charge',
   testFixtureStdio(
     '21-charge',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Welcome to my new Charge site/m);
     },
     { skipDeploy: true }
@@ -1311,7 +1311,7 @@ test(
   '[vercel dev] 22-brunch',
   testFixtureStdio(
     '22-brunch',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /Bon Appétit./m);
     },
     { skipDeploy: true }
@@ -1322,19 +1322,19 @@ test(
   '[vercel dev] 23-docusaurus',
   testFixtureStdio(
     '23-docusaurus',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /My Site/m);
     },
     { skipDeploy: true }
   )
 );
 
-test('[vercel dev] 24-ember', async (t) => {
+test('[vercel dev] 24-ember', async t => {
   if (shouldSkip(t, '24-ember', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
 
   const tester = await testFixtureStdio(
     '24-ember',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/', /HelloWorld/m);
     },
     { skipDeploy: true }
@@ -1376,7 +1376,7 @@ test(
   )
 );
 
-test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', async (t) => {
+test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', async t => {
   const directory = fixture('trigger-static-build');
 
   await fs.unlink(join(directory, 'package.json')).catch(() => null);
@@ -1419,7 +1419,7 @@ test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', asyn
   await tester(t);
 });
 
-test('[vercel dev] no build matches warning', async (t) => {
+test('[vercel dev] no build matches warning', async t => {
   const directory = fixture('no-build-matches');
   const { dev } = await testFixture(directory, {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -1430,8 +1430,8 @@ test('[vercel dev] no build matches warning', async (t) => {
     dev.unref();
 
     dev.stderr.setEncoding('utf8');
-    await new Promise((resolve) => {
-      dev.stderr.on('data', (str) => {
+    await new Promise(resolve => {
+      dev.stderr.on('data', str => {
         if (str.includes('did not match any source files')) {
           resolve();
         }
@@ -1446,13 +1446,13 @@ test('[vercel dev] no build matches warning', async (t) => {
 
 test(
   '[vercel dev] do not recursivly check the path',
-  testFixtureStdio('handle-filesystem-missing', async (testPath) => {
+  testFixtureStdio('handle-filesystem-missing', async testPath => {
     await testPath(200, '/', /hello/m);
     await testPath(404, '/favicon.txt');
   })
 );
 
-test('[vercel dev] render warning for empty cwd dir', async (t) => {
+test('[vercel dev] render warning for empty cwd dir', async t => {
   const directory = fixture('empty');
   const { dev, port } = await testFixture(directory, {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -1464,8 +1464,8 @@ test('[vercel dev] render warning for empty cwd dir', async (t) => {
     // Monitor `stderr` for the warning
     dev.stderr.setEncoding('utf8');
     const msg = 'There are no files inside your deployment.';
-    await new Promise((resolve) => {
-      dev.stderr.on('data', (str) => {
+    await new Promise(resolve => {
+      dev.stderr.on('data', str => {
         if (str.includes(msg)) {
           resolve();
         }
@@ -1482,7 +1482,7 @@ test('[vercel dev] render warning for empty cwd dir', async (t) => {
   }
 });
 
-test('[vercel dev] do not rebuild for changes in the output directory', async (t) => {
+test('[vercel dev] do not rebuild for changes in the output directory', async t => {
   const directory = fixture('output-is-source');
 
   // Pack the builder and set it in the `vercel.json`
@@ -1511,7 +1511,7 @@ test('[vercel dev] do not rebuild for changes in the output directory', async (t
     let stderr = [];
     const start = Date.now();
 
-    dev.stderr.on('data', (str) => stderr.push(str));
+    dev.stderr.on('data', str => stderr.push(str));
 
     while (stderr.join('').includes('Ready') === false) {
       await sleep(ms('3s'));
@@ -1540,7 +1540,7 @@ test('[vercel dev] do not rebuild for changes in the output directory', async (t
 
 test(
   '[vercel dev] 25-nextjs-src-dir',
-  testFixtureStdio('25-nextjs-src-dir', async (testPath) => {
+  testFixtureStdio('25-nextjs-src-dir', async testPath => {
     await testPath(200, '/', /Next.js \+ Node.js API/m);
   })
 );
@@ -1549,7 +1549,7 @@ test(
   '[vercel dev] 26-nextjs-secrets',
   testFixtureStdio(
     '26-nextjs-secrets',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/api/user', /runtime/m);
       await testPath(200, '/', /buildtime/m);
     },
@@ -1561,7 +1561,7 @@ test(
   '[vercel dev] 27-zero-config-env',
   testFixtureStdio(
     '27-zero-config-env',
-    async (testPath) => {
+    async testPath => {
       await testPath(200, '/api/print', /build-and-runtime/m);
       await testPath(200, '/', /build-and-runtime/m);
     },
@@ -1571,7 +1571,7 @@ test(
 
 test(
   '[vercel dev] 28-vercel-json-and-ignore',
-  testFixtureStdio('28-vercel-json-and-ignore', async (testPath) => {
+  testFixtureStdio('28-vercel-json-and-ignore', async testPath => {
     await testPath(200, '/api/one', 'One');
     await testPath(404, '/api/two');
     await testPath(200, '/api/three', 'One');
@@ -1580,7 +1580,7 @@ test(
 
 test(
   '[vercel dev] Use `@vercel/python` with Flask requirements.txt',
-  testFixtureStdio('python-flask', async (testPath) => {
+  testFixtureStdio('python-flask', async testPath => {
     const name = 'Alice';
     const year = new Date().getFullYear();
     await testPath(200, `/api/user?name=${name}`, new RegExp(`Hello ${name}`));
@@ -1591,7 +1591,7 @@ test(
 
 test(
   '[vercel dev] Use custom runtime from the "functions" property',
-  testFixtureStdio('custom-runtime', async (testPath) => {
+  testFixtureStdio('custom-runtime', async testPath => {
     await testPath(200, `/api/user`, /Hello, from Bash!/m);
     await testPath(200, `/api/user.sh`, /Hello, from Bash!/m);
   })
@@ -1599,7 +1599,7 @@ test(
 
 test(
   '[vercel dev] Should work with nested `tsconfig.json` files',
-  testFixtureStdio('nested-tsconfig', async (testPath) => {
+  testFixtureStdio('nested-tsconfig', async testPath => {
     await testPath(200, `/`, /Nested tsconfig.json test page/);
     await testPath(200, `/api`, 'Nested `tsconfig.json` API endpoint');
   })
@@ -1607,7 +1607,7 @@ test(
 
 test(
   '[vercel dev] Should force `tsc` option "module: commonjs" for `startDevServer()`',
-  testFixtureStdio('force-module-commonjs', async (testPath) => {
+  testFixtureStdio('force-module-commonjs', async testPath => {
     await testPath(200, `/`, /Force &quot;module: commonjs&quot; test page/);
     await testPath(
       200,
@@ -1624,7 +1624,7 @@ test(
 
 test(
   '[vercel dev] should prioritize index.html over other file named index.*',
-  testFixtureStdio('index-html-priority', async (testPath) => {
+  testFixtureStdio('index-html-priority', async testPath => {
     await testPath(200, '/', 'This is index.html');
     await testPath(200, '/index.css', 'This is index.css');
   })
@@ -1632,7 +1632,7 @@ test(
 
 test(
   '[vercel dev] Should support `*.go` API serverless functions',
-  testFixtureStdio('go', async (testPath) => {
+  testFixtureStdio('go', async testPath => {
     await testPath(200, `/api`, 'This is the index page');
     await testPath(200, `/api/index`, 'This is the index page');
     await testPath(200, `/api/index.go`, 'This is the index page');
@@ -1645,7 +1645,7 @@ test(
 
 test(
   '[vercel dev] Should set the `ts-node` "target" to match Node.js version',
-  testFixtureStdio('node-ts-node-target', async (testPath) => {
+  testFixtureStdio('node-ts-node-target', async testPath => {
     await testPath(200, `/api/subclass`, '{"ok":true}');
     await testPath(
       200,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -219,9 +219,7 @@ const createUser = async () => {
 
       email = user.email;
       contextName = user.username;
-      session = Math.random()
-        .toString(36)
-        .split('.')[1];
+      session = Math.random().toString(36).split('.')[1];
     },
     { retries: 3, factor: 1 }
   );
@@ -2470,9 +2468,7 @@ test('change user', async t => {
 test('should show prompts to set up project', async t => {
   const directory = fixture('project-link');
   const projectName = `project-link-${
-    Math.random()
-      .toString(36)
-      .split('.')[1]
+    Math.random().toString(36).split('.')[1]
   }`;
 
   // remove previously linked project if it exists
@@ -2598,9 +2594,7 @@ test('should show prompts to set up project', async t => {
 
 test('should prefill "project name" prompt with folder name', async t => {
   const projectName = `static-deployment-${
-    Math.random()
-      .toString(36)
-      .split('.')[1]
+    Math.random().toString(36).split('.')[1]
   }`;
 
   const src = fixture('static-deployment');
@@ -2648,9 +2642,7 @@ test('should prefill "project name" prompt with folder name', async t => {
 test('should prefill "project name" prompt with --name', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
-    Math.random()
-      .toString(36)
-      .split('.')[1]
+    Math.random().toString(36).split('.')[1]
   }`;
 
   // remove previously linked project if it exists
@@ -2708,9 +2700,7 @@ test('should prefill "project name" prompt with --name', async t => {
 test('should prefill "project name" prompt with now.json `name`', async t => {
   const directory = fixture('static-deployment');
   const projectName = `static-deployment-${
-    Math.random()
-      .toString(36)
-      .split('.')[1]
+    Math.random().toString(36).split('.')[1]
   }`;
 
   // remove previously linked project if it exists


### PR DESCRIPTION
In PR #4760, Prettier was upgraded to 2.0 which changed the default configuration for `arrowParens` from `avoid` to `always`. This PR changes it back to `avoid` so we don't have PRs changing unnecessary lines during in the commit hook.

See the [Prettier 2.0 Announcement](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev) for more.