### PR TITLE
Revert "[frameworks] Remove blitz demo"

### DIFF
--- a/packages/frameworks/frameworks.json
+++ b/packages/frameworks/frameworks.json
@@ -2,6 +2,7 @@
   {
     "name": "Blitz.js",
     "slug": "blitzjs",
+    "demo": "https://blitzjs.now-examples.now.sh",
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/blitz.svg",
     "tagline": "Blitz.js: The Fullstack React Framework",
     "description": "A brand new Blitz.js app: the output of running `blitz new`",


### PR DESCRIPTION
Reverts #4816

This PR adds back the Blitz.js demo now that we confirmed the example works and is deployed to the correct account.

Thanks to @flybayer for the demo 👍 