### PR TITLE
[cli] Handle 400 errors as user errors

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -46,6 +46,7 @@ import reportError from './util/report-error';
 import getConfig from './util/get-config';
 import * as ERRORS from './util/errors-ts';
 import { NowError } from './util/now-error';
+import { APIError } from './util/errors-ts.ts';
 import { SENTRY_DSN } from './util/constants.ts';
 import getUpdateCommand from './util/get-update-command';
 import { metrics, shouldCollectMetrics } from './util/metrics.ts';
@@ -190,8 +191,10 @@ const main = async argv_ => {
   } catch (err) {
     console.error(
       error(
-        `${'An unexpected error occurred while trying to find the ' +
-          'global directory: '}${err.message}`
+        `${
+          'An unexpected error occurred while trying to find the ' +
+          'global directory: '
+        }${err.message}`
       )
     );
 
@@ -204,8 +207,10 @@ const main = async argv_ => {
     } catch (err) {
       console.error(
         error(
-          `${'An unexpected error occurred while trying to create the ' +
-            `global directory "${hp(VERCEL_DIR)}" `}${err.message}`
+          `${
+            'An unexpected error occurred while trying to create the ' +
+            `global directory "${hp(VERCEL_DIR)}" `
+          }${err.message}`
         )
       );
     }
@@ -219,8 +224,10 @@ const main = async argv_ => {
   } catch (err) {
     console.error(
       error(
-        `${'An unexpected error occurred while trying to find the ' +
-          `config file "${hp(VERCEL_CONFIG_PATH)}" `}${err.message}`
+        `${
+          'An unexpected error occurred while trying to find the ' +
+          `config file "${hp(VERCEL_CONFIG_PATH)}" `
+        }${err.message}`
       )
     );
 
@@ -235,8 +242,10 @@ const main = async argv_ => {
     } catch (err) {
       console.error(
         error(
-          `${'An unexpected error occurred while trying to read the ' +
-            `config in "${hp(VERCEL_CONFIG_PATH)}" `}${err.message}`
+          `${
+            'An unexpected error occurred while trying to read the ' +
+            `config in "${hp(VERCEL_CONFIG_PATH)}" `
+          }${err.message}`
         )
       );
 
@@ -267,8 +276,10 @@ const main = async argv_ => {
     } catch (err) {
       console.error(
         error(
-          `${'An unexpected error occurred while trying to write the ' +
-            `default config to "${hp(VERCEL_CONFIG_PATH)}" `}${err.message}`
+          `${
+            'An unexpected error occurred while trying to write the ' +
+            `default config to "${hp(VERCEL_CONFIG_PATH)}" `
+          }${err.message}`
         )
       );
 
@@ -283,8 +294,10 @@ const main = async argv_ => {
   } catch (err) {
     console.error(
       error(
-        `${'An unexpected error occurred while trying to find the ' +
-          `auth file "${hp(VERCEL_AUTH_CONFIG_PATH)}" `}${err.message}`
+        `${
+          'An unexpected error occurred while trying to find the ' +
+          `auth file "${hp(VERCEL_AUTH_CONFIG_PATH)}" `
+        }${err.message}`
       )
     );
 
@@ -301,8 +314,10 @@ const main = async argv_ => {
     } catch (err) {
       console.error(
         error(
-          `${'An unexpected error occurred while trying to read the ' +
-            `auth config in "${hp(VERCEL_AUTH_CONFIG_PATH)}" `}${err.message}`
+          `${
+            'An unexpected error occurred while trying to read the ' +
+            `auth config in "${hp(VERCEL_AUTH_CONFIG_PATH)}" `
+          }${err.message}`
         )
       );
 
@@ -326,10 +341,10 @@ const main = async argv_ => {
     } catch (err) {
       console.error(
         error(
-          `${'An unexpected error occurred while trying to write the ' +
-            `default config to "${hp(VERCEL_AUTH_CONFIG_PATH)}" `}${
-            err.message
-          }`
+          `${
+            'An unexpected error occurred while trying to write the ' +
+            `default config to "${hp(VERCEL_AUTH_CONFIG_PATH)}" `
+          }${err.message}`
         )
       );
       return 1;
@@ -636,6 +651,12 @@ const main = async argv_ => {
         );
       }
       output.debug(err.stack);
+      return 1;
+    }
+
+    if (err instanceof APIError && 400 <= err.status && err.status <= 499) {
+      err.message = err.serverMessage;
+      output.prettyError(err);
       return 1;
     }
 

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -191,10 +191,9 @@ const main = async argv_ => {
   } catch (err) {
     console.error(
       error(
-        `${
-          'An unexpected error occurred while trying to find the ' +
-          'global directory: '
-        }${err.message}`
+        `An unexpected error occurred while trying to find the global directory: ${
+          err.message
+        }`
       )
     );
 

--- a/packages/now-cli/src/util/errors-ts.ts
+++ b/packages/now-cli/src/util/errors-ts.ts
@@ -14,6 +14,7 @@ export class APIError extends Error {
   status: number;
   serverMessage: string;
   link?: string;
+  action?: string;
   retryAfter: number | null | 'never';
   [key: string]: any;
 

--- a/packages/now-cli/src/util/response-error.ts
+++ b/packages/now-cli/src/util/response-error.ts
@@ -6,7 +6,6 @@ export default async function responseError(
   fallbackMessage = null,
   parsedBody = {}
 ) {
-  let message;
   let bodyError;
 
   if (res.status >= 400 && res.status < 500) {
@@ -20,12 +19,9 @@ export default async function responseError(
 
     // Some APIs wrongly return `err` instead of `error`
     bodyError = body.error || body.err || body;
-    message = bodyError.message;
   }
 
-  if (message == null) {
-    message = fallbackMessage === null ? 'Response Error' : fallbackMessage;
-  }
+  const msg = bodyError?.message || fallbackMessage || 'Response Error';
 
-  return new APIError(message, res, bodyError);
+  return new APIError(msg, res, bodyError);
 }


### PR DESCRIPTION
When a user performs an action such as trying to add a domain they don't own, the API returns a 400-499 response code.

Previously, we would save this error in Sentry but this PR changes the behavior so that the error is printed locally for the user but not saved in Sentry.