### PR TITLE
[frameworks][api] Add sort order

### DIFF
--- a/api/_lib/util/with-api-handler.ts
+++ b/api/_lib/util/with-api-handler.ts
@@ -1,4 +1,4 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { errorHandler } from './error-handler';
 
 type Handler = (req: NowRequest, res: NowResponse) => Promise<any>;

--- a/api/examples/download/[segment].ts
+++ b/api/examples/download/[segment].ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 // @ts-ignore
 import tar from 'tar-fs';
 import { extract } from '../../_lib/examples/extract';
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { withApiHandler } from '../../_lib/util/with-api-handler';
 
 const TMP_DIR = '/tmp';
@@ -15,8 +15,8 @@ function notFound(res: NowResponse, message: string) {
   return res.status(404).send({
     error: {
       code: 'not_found',
-      message
-    }
+      message,
+    },
   });
 }
 
@@ -35,7 +35,10 @@ function streamToBuffer(stream: any) {
   });
 }
 
-export default withApiHandler(async function(req: NowRequest, res: NowResponse) {
+export default withApiHandler(async function (
+  req: NowRequest,
+  res: NowResponse
+) {
   const ext = '.tar.gz';
   const { segment = '' } = req.query;
 

--- a/api/examples/info.ts
+++ b/api/examples/info.ts
@@ -3,12 +3,12 @@
 
 // @ts-ignore
 import parseGitUrl from 'parse-github-url';
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { withApiHandler } from '../_lib/util/with-api-handler';
 import { getGitHubRepoInfo } from '../_lib/examples/github-repo-info';
 import { getGitLabRepoInfo } from '../_lib/examples/gitlab-repo-info';
 
-export default withApiHandler(async function(
+export default withApiHandler(async function (
   req: NowRequest,
   res: NowResponse
 ) {

--- a/api/examples/list-all.ts
+++ b/api/examples/list-all.ts
@@ -1,8 +1,8 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { getExampleList } from '../_lib/examples/example-list';
 import { withApiHandler } from '../_lib/util/with-api-handler';
 
-export default withApiHandler(async function(
+export default withApiHandler(async function (
   req: NowRequest,
   res: NowResponse
 ) {

--- a/api/examples/list.ts
+++ b/api/examples/list.ts
@@ -1,10 +1,10 @@
 import { extract } from '../_lib/examples/extract';
 import { summary } from '../_lib/examples/summary';
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { mapOldToNew } from '../_lib/examples/map-old-to-new';
 import { withApiHandler } from '../_lib/util/with-api-handler';
 
-export default withApiHandler(async function(
+export default withApiHandler(async function (
   req: NowRequest,
   res: NowResponse
 ) {

--- a/api/frameworks.ts
+++ b/api/frameworks.ts
@@ -1,21 +1,27 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 import { withApiHandler } from './_lib/util/with-api-handler';
-import frameworkList, { Framework } from '../packages/frameworks';
+import _frameworks, { Framework } from '../packages/frameworks';
 
-const frameworks = (frameworkList as Framework[]).map(frameworkItem => {
-  const framework = {
-    ...frameworkItem,
-    detectors: undefined,
-  };
+const frameworks = (_frameworks as Framework[])
+  .sort(
+    (a, b) =>
+      (a.sort || Number.MAX_SAFE_INTEGER) - (b.sort || Number.MAX_SAFE_INTEGER)
+  )
+  .map(frameworkItem => {
+    const framework = {
+      ...frameworkItem,
+      detectors: undefined,
+      sort: undefined,
+    };
 
-  if (framework.logo) {
-    framework.logo = `https://res.cloudinary.com/zeit-inc/image/fetch/${framework.logo}`;
-  }
+    if (framework.logo) {
+      framework.logo = `https://res.cloudinary.com/zeit-inc/image/fetch/${framework.logo}`;
+    }
 
-  return framework;
-});
+    return framework;
+  });
 
-export default withApiHandler(async function(
+export default withApiHandler(async function (
   req: NowRequest,
   res: NowResponse
 ) {

--- a/api/package.json
+++ b/api/package.json
@@ -9,16 +9,16 @@
   },
   "dependencies": {
     "@sentry/node": "5.11.1",
+    "@vercel/node": "1.7.1",
     "got": "10.2.1",
     "node-fetch": "2.6.0",
     "parse-github-url": "1.0.2",
     "tar-fs": "2.0.0",
-    "typescript": "3.7.4",
     "unzip-stream": "0.3.0"
   },
   "devDependencies": {
-    "@now/node": "1.3.3",
     "@types/node": "13.1.4",
-    "@types/node-fetch": "2.5.4"
+    "@types/node-fetch": "2.5.4",
+    "typescript": "3.9.6"
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@now/node@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@now/node/-/node-1.3.3.tgz#5407cb6a730d4dd9b6b6b0bc4a316f29086c9feb"
-  integrity sha512-s1qajtQttWhhSs1k6FX0/6eTFYFUplzultrQeKfOPMoYzzz6OxDq5qrQ3elpsGlZlDVmO+x+JOJ7yad+3yBgpg==
-  dependencies:
-    "@types/node" "*"
-
 "@sentry/apm@5.11.1":
   version "5.11.1"
   resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.11.1.tgz#cc89fa4150056fbf009f92eca94fccc3980db34e"
@@ -141,10 +134,24 @@
   dependencies:
     "@types/node" "*"
 
+"@vercel/node@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-1.7.1.tgz#cdf9b2226cbc469228aae6369b2b21db4c83dc69"
+  integrity sha512-Lp6l3526xQ/srCqkXE9/E+gykAcpM/vut4zFo5NA9+syGxZt1nlVAznhNVkgsSW4mbRIE67KIfi7SII55dW7uw==
+  dependencies:
+    "@types/node" "*"
+    ts-node "8.9.1"
+    typescript "3.9.3"
+
 agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 binary@^0.3.0:
   version "0.3.0"
@@ -160,6 +167,11 @@ bl@^3.0.0:
   integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
     readable-stream "^3.0.1"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffers@~0.1.1:
   version "0.1.1"
@@ -228,6 +240,11 @@ defer-to-connect@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.1.tgz#88ae694b93f67b81815a2c8c769aef6574ac8f2f"
   integrity sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -313,6 +330,11 @@ lru_map@^0.3.3:
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -396,6 +418,19 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -434,6 +469,17 @@ to-readable-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
+ts-node@8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -444,10 +490,15 @@ type-fest@^0.8.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 unzip-stream@0.3.0:
   version "0.3.0"
@@ -466,3 +517,8 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==

--- a/packages/frameworks/frameworks.json
+++ b/packages/frameworks/frameworks.json
@@ -5,7 +5,7 @@
     "demo": "https://blitzjs.now-examples.now.sh",
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/blitz.svg",
     "tagline": "Blitz.js: The Fullstack React Framework",
-    "description": "A brand new Blitz.js app: the output of running `blitz new`",
+    "description": "A Blitz.js app, created with the `blitz new` command.",
     "website": "https://blitzjs.com",
     "detectors": {
       "every": [
@@ -32,9 +32,10 @@
     "slug": "nextjs",
     "demo": "https://nextjs.now-examples.now.sh",
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/next.svg",
-    "tagline": "Next.js makes you productive with React instantly — whether you want to build static or dynamic sites. ",
+    "tagline": "Next.js makes you productive with React instantly — whether you want to build static or dynamic sites.",
     "description": "A Next.js app and a Serverless Function API.",
     "website": "https://nextjs.org",
+    "sort": 1,
     "detectors": {
       "every": [
         {
@@ -63,6 +64,7 @@
     "tagline": "Gatsby helps developers build blazing fast websites and apps with React.",
     "description": "A Gatsby app, using the default starter theme and a Serverless Function API.",
     "website": "https://gatsbyjs.org",
+    "sort": 2,
     "detectors": {
       "every": [
         {
@@ -90,7 +92,8 @@
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/hexo.svg",
     "tagline": "Hexo is a fast, simple & powerful blog framework powered by Node.js.",
     "description": "A Hexo site, created with the Hexo CLI.",
-    "website": "https://hexo.io/",
+    "website": "https://hexo.io",
+    "sort": 3,
     "detectors": {
       "every": [
         {
@@ -118,7 +121,8 @@
     "logo": "https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/eleventy.svg",
     "tagline": "11ty is a simpler static site generator written in JavaScript, created to be an alternative to Jekyll.",
     "description": "An Eleventy site, created with npm init.",
-    "website": "https://www.11ty.dev/",
+    "website": "https://www.11ty.dev",
+    "sort": 4,
     "detectors": {
       "every": [
         {
@@ -686,6 +690,7 @@
     "tagline": "Hugo is the world’s fastest framework for building websites, written in Go.",
     "description": "A Hugo site, created with the Hugo CLI.",
     "website": "https://gohugo.io",
+    "sort": 5,
     "detectors": {
       "some": [
         {

--- a/packages/frameworks/index.d.ts
+++ b/packages/frameworks/index.d.ts
@@ -19,6 +19,7 @@ export interface Framework {
   tagline?: string;
   website?: string;
   description: string;
+  sort?: number;
   detectors?: {
     every?: FrameworkDetectionItem[];
     some?: FrameworkDetectionItem[];

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -1,7 +1,8 @@
 import Ajv from 'ajv';
-import path from 'path';
+import { join } from 'path';
 import { existsSync } from 'fs';
 import { Framework } from '../';
+const frameworkList = require('../frameworks.json') as Framework[];
 
 function isString(arg: any): arg is string {
   return typeof arg === 'string';
@@ -60,6 +61,7 @@ const Schema = {
     properties: {
       name: { type: 'string' },
       slug: { type: ['string', 'null'] },
+      sort: { type: 'number' },
       logo: { type: 'string' },
       demo: { type: 'string' },
       tagline: { type: 'string' },
@@ -89,12 +91,10 @@ const Schema = {
 
 describe('frameworks', () => {
   it('ensure there is an example for every framework', async () => {
-    const root = path.join(__dirname, '..', '..', '..');
-    const getExample = (name: string) => path.join(root, 'examples', name);
+    const root = join(__dirname, '..', '..', '..');
+    const getExample = (name: string) => join(root, 'examples', name);
 
-    const frameworks = require('../frameworks.json') as Framework[];
-
-    const result = frameworks
+    const result = frameworkList
       .map(f => f.slug)
       .filter(isString)
       .filter(f => existsSync(getExample(f)) === false);
@@ -103,10 +103,8 @@ describe('frameworks', () => {
   });
 
   it('ensure schema', async () => {
-    const frameworks = require('../frameworks.json') as Framework[];
-
     const ajv = new Ajv();
-    const result = ajv.validate(Schema, frameworks);
+    const result = ajv.validate(Schema, frameworkList);
 
     if (ajv.errors) {
       console.error(ajv.errors);
@@ -116,17 +114,26 @@ describe('frameworks', () => {
   });
 
   it('ensure logo', async () => {
-    const frameworks = require('../frameworks.json') as Framework[];
-
-    const missing = frameworks
+    const missing = frameworkList
       .map(f => f.logo)
       .filter(url => {
         const prefix =
           'https://raw.githubusercontent.com/vercel/vercel/master/packages/frameworks/logos/';
         const name = url.replace(prefix, '');
-        return existsSync(path.join(__dirname, '..', 'logos', name)) === false;
+        return existsSync(join(__dirname, '..', 'logos', name)) === false;
       });
 
     expect(missing).toEqual([]);
+  });
+
+  it('ensure unique sort number', async () => {
+    const sortNumToSlug = new Map<number, string | null>();
+    frameworkList.forEach(f => {
+      if (f.sort) {
+        const duplicateSlug = sortNumToSlug.get(f.sort);
+        expect(duplicateSlug).toStrictEqual(undefined);
+        sortNumToSlug.set(f.sort, f.slug);
+      }
+    });
   });
 });


### PR DESCRIPTION
This PR adds an optional property called `sort` to each framework so that we can change the order returned in the API. 
The reason this is necessary is because the order of the original array determines the precedence of framework detection. So we need another way to indicate the order of templates/examples returned from the API.

In particular, we need "Next.js" to be first and "Other" to be last.

I also updated the deprecated `@now/node` usage to `@vercel/node` in the API.