### PR TITLE
[go] Add filesystem write fallback for `startDevServer()`

### DIFF
--- a/packages/now-go/dev-server.go
+++ b/packages/now-go/dev-server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -18,11 +19,17 @@ func main() {
 	}
 
 	port := listener.Addr().(*net.TCPAddr).Port
+	portBytes := []byte(strconv.Itoa(port))
 
 	file := os.NewFile(3, "pipe")
-	_, err2 := file.Write([]byte(strconv.Itoa(port)))
+	_, err2 := file.Write(portBytes)
 	if err2 != nil {
-		panic(err2)
+		portFile := os.Getenv("VERCEL_DEV_PORT_FILE")
+		os.Unsetenv("VERCEL_DEV_PORT_FILE")
+		err3 := ioutil.WriteFile(portFile, portBytes, 0644)
+		if err3 != nil {
+			panic(err3)
+		}
 	}
 
 	panic(http.Serve(listener, handler))

--- a/packages/now-go/dev-server.go
+++ b/packages/now-go/dev-server.go
@@ -13,7 +13,7 @@ func main() {
 	handler := http.HandlerFunc(__HANDLER_FUNC_NAME)
 
 	// https://stackoverflow.com/a/43425461/376773
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
 	}

--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -584,7 +584,7 @@ Learn more: https://vercel.com/docs/runtimes#official-runtimes/go`
       `Failed to start dev server for "${entrypointWithExt}" (code=${result[0]}, signal=${result[1]})`
     );
   } else {
-    throw new Error('Unexpected error');
+    throw new Error(`Unexpected result type: ${typeof result}`);
   }
 }
 

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -20,10 +20,12 @@
   ],
   "devDependencies": {
     "@tootallnate/once": "1.1.2",
+    "@types/async-retry": "1.4.2",
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "^4.0.0",
+    "async-retry": "1.3.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",
     "node-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,7 +1569,7 @@
   dependencies:
     "@types/retry" "*"
 
-"@types/async-retry@^1.2.1":
+"@types/async-retry@1.4.2", "@types/async-retry@^1.2.1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.2.tgz#7f910188cd3893b51e32df51765ee8d5646053e3"
   integrity sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==
@@ -2770,7 +2770,7 @@ async-retry@1.2.3:
   dependencies:
     retry "0.12.0"
 
-async-retry@^1.3.1:
+async-retry@1.3.1, async-retry@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
   integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==


### PR DESCRIPTION
This is for `@vercel/go` to work on Windows, which currently fails with
this error:

```
panic: write pipe: The handle is invalid.

goroutine 1 [running]:
main.main()
	C:/Users/Nathan/Code/casca/vercel-go-test/.vercel/cache/go/2flefmhra8o/api/vercel-dev-server-main.go:25 +0x1ec
exit status 2
```

So this fallback writes the port number to a temp file that
`startDevServer()` polls for in order to figure out the port number.