### PR TITLE
[cli] Pin `@vercel/static-build` to "0.17.6-canary.0"

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -68,7 +68,7 @@
     "@vercel/node": "1.7.2",
     "@vercel/python": "1.2.2",
     "@vercel/ruby": "1.2.3",
-    "@vercel/static-build": "0.17.5"
+    "@vercel/static-build": "0.17.6-canary.0"
   },
   "devDependencies": {
     "@sentry/node": "5.5.0",


### PR DESCRIPTION
It got de-synced in c68e83f9726e622c3366653aee2674e35ccf4bc9.