### PR TITLE
[cli] Set Vercel proxy request headers in `startDevServer()`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -174,7 +174,7 @@ export default class DevServer {
     this.watchAggregationEvents = [];
     this.watchAggregationTimeout = 500;
 
-    this.filter = (path) => Boolean(path);
+    this.filter = path => Boolean(path);
     this.podId = Math.random().toString(32).slice(-5);
 
     this.devServerPids = new Set();
@@ -213,8 +213,8 @@ export default class DevServer {
       }
     }
 
-    events = events.filter((event) =>
-      distPaths.every((distPath) => !event.path.startsWith(distPath))
+    events = events.filter(event =>
+      distPaths.every(distPath => !event.path.startsWith(distPath))
     );
 
     // First, update the `files` mapping of source files
@@ -370,7 +370,7 @@ export default class DevServer {
       this,
       fileList
     );
-    const sources = matches.map((m) => m.src);
+    const sources = matches.map(m => m.src);
 
     if (isInitial && fileList.length === 0) {
       this.output.warn('There are no files inside your deployment.');
@@ -543,7 +543,7 @@ export default class DevServer {
       const { projectSettings, cleanUrls, trailingSlash } = config;
 
       const opts = { output: this.output, isBuilds: true };
-      const files = (await getFiles(this.cwd, config, opts)).map((f) =>
+      const files = (await getFiles(this.cwd, config, opts)).map(f =>
         relative(this.cwd, f)
       );
 
@@ -570,7 +570,7 @@ export default class DevServer {
       }
 
       if (warnings && warnings.length > 0) {
-        warnings.forEach((warning) => this.output.warn(warning.message));
+        warnings.forEach(warning => this.output.warn(warning.message));
       }
 
       if (builders) {
@@ -782,11 +782,11 @@ export default class DevServer {
     // get their "build matches" invalidated so that the new version is used.
     this.updateBuildersTimeout = setTimeout(() => {
       this.updateBuildersPromise = updateBuilders(builders, this.output)
-        .then((updatedBuilders) => {
+        .then(updatedBuilders => {
           this.updateBuildersPromise = null;
           this.invalidateBuildMatches(nowConfig, updatedBuilders);
         })
-        .catch((err) => {
+        .catch(err => {
           this.updateBuildersPromise = null;
           this.output.error(`Failed to update builders: ${err.message}`);
           this.output.debug(err.stack);
@@ -1104,23 +1104,24 @@ export default class DevServer {
    */
   getNowProxyHeaders(
     req: http.IncomingMessage,
-    nowRequestId: string
+    nowRequestId: string,
+    xfwd: boolean
   ): http.IncomingHttpHeaders {
     const ip = this.getRequestIp(req);
     const { host } = req.headers;
-    return {
-      ...req.headers,
-      Connection: 'close',
-      'x-forwarded-host': host,
-      'x-forwarded-proto': 'http',
-      'x-forwarded-for': ip,
+    const headers: http.IncomingHttpHeaders = {
+      connection: 'close',
       'x-real-ip': ip,
-      'x-now-trace': 'dev1',
-      'x-now-deployment-url': host,
-      'x-now-id': nowRequestId,
-      'x-now-log-id': nowRequestId.split('-')[2],
-      'x-zeit-co-forwarded-for': ip,
+      'x-vercel-deployment-url': host,
+      'x-vercel-forwarded-for': ip,
+      'x-vercel-id': nowRequestId,
     };
+    if (xfwd) {
+      headers['x-forwarded-host'] = host;
+      headers['x-forwarded-proto'] = 'http';
+      headers['x-forwarded-for'] = ip;
+    }
+    return headers;
   }
 
   async triggerBuild(
@@ -1612,6 +1613,12 @@ export default class DevServer {
           query: parsed.query,
         });
 
+        // Add the Vercel platform proxy request headers
+        const headers = this.getNowProxyHeaders(req, nowRequestId, false);
+        for (const [name, value] of Object.entries(headers)) {
+          req.headers[name] = value;
+        }
+
         this.setResponseHeaders(res, nowRequestId);
         return proxyPass(
           req,
@@ -1724,7 +1731,10 @@ export default class DevServer {
           method: req.method || 'GET',
           host: req.headers.host,
           path,
-          headers: this.getNowProxyHeaders(req, nowRequestId),
+          headers: {
+            ...req.headers,
+            ...this.getNowProxyHeaders(req, nowRequestId, true),
+          },
           encoding: 'base64',
           body: body.toString('base64'),
         };
@@ -1781,7 +1791,7 @@ export default class DevServer {
 
     const dirs: Set<string> = new Set();
     const files = Array.from(this.buildMatches.keys())
-      .filter((p) => {
+      .filter(p => {
         const base = basename(p);
         if (
           base === 'now.json' ||
@@ -1802,7 +1812,7 @@ export default class DevServer {
         }
         return true;
       })
-      .map((p) => {
+      .map(p => {
         let base = basename(p);
         let ext = '';
         let type = 'file';
@@ -2214,7 +2224,7 @@ function isIndex(path: string): boolean {
 
 function minimatches(files: string[], pattern: string): boolean {
   return files.some(
-    (file) => file === pattern || minimatch(file, pattern, { dot: true })
+    file => file === pattern || minimatch(file, pattern, { dot: true })
   );
 }
 
@@ -2244,7 +2254,7 @@ function needsBlockingBuild(buildMatch: BuildMatch): boolean {
 }
 
 async function sleep(n: number) {
-  return new Promise((resolve) => setTimeout(resolve, n));
+  return new Promise(resolve => setTimeout(resolve, n));
 }
 
 async function checkForPort(

--- a/packages/now-cli/test/dev/fixtures/node-ts-node-target/api/headers.js
+++ b/packages/now-cli/test/dev/fixtures/node-ts-node-target/api/headers.js
@@ -1,0 +1,5 @@
+module.exports = (req, res) => {
+  res.send({
+    headers: req.headers,
+  });
+};

--- a/packages/now-cli/test/dev/fixtures/python-flask/api/headers.py
+++ b/packages/now-cli/test/dev/fixtures/python-flask/api/headers.py
@@ -1,0 +1,8 @@
+from flask import Flask, Response, request
+app = Flask(__name__)
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def headers(path):
+    url = request.headers.get('x-vercel-deployment-url')
+    return Response(url, mimetype='text/plain')

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1647,5 +1647,6 @@ test(
       `/api/array`,
       '{"months":[1,2,3,4,5,6,7,8,9,10,11,12]}'
     );
+    await testPath(200, `/api/headers`, /"x-vercel-deployment-url"/);
   })
 );

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -153,6 +153,9 @@ async function testPath(
   if (typeof expectedText === 'string') {
     const actualText = await res.text();
     t.is(actualText.trim(), expectedText.trim(), msg);
+  } else if (typeof expectedText === 'function') {
+    const actualText = await res.text();
+    expectedText(t, actualText, res);
   } else if (expectedText instanceof RegExp) {
     const actualText = await res.text();
     expectedText.lastIndex = 0; // reset since we test twice
@@ -1581,6 +1584,10 @@ test(
     await testPath(200, `/api/user?name=${name}`, new RegExp(`Hello ${name}`));
     await testPath(200, `/api/date`, new RegExp(`Current date is ${year}`));
     await testPath(200, `/api/date.py`, new RegExp(`Current date is ${year}`));
+    await testPath(200, `/api/headers`, (t, body, res) => {
+      const { host } = new URL(res.url);
+      t.is(body, host);
+    });
   })
 );
 


### PR DESCRIPTION
The Vercel proxy request headers (`x-vercel-deployment-url` for example)
were not being sent to the dev server when the Runtime defines
`startDevServer()`. This is now fixed.

Also updates the header names to match production:

 - `now` -> `vercel`
 - 'x-now-trace', 'x-now-id', and 'x-now-log-id' are removed

Fixes https://github.com/vercel/vercel/discussions/4729.