### PR TITLE
Update next-legacy-routes-optimized-lambdas.md

### DIFF
--- a/errors/next-legacy-routes-optimized-lambdas.md
+++ b/errors/next-legacy-routes-optimized-lambdas.md
@@ -7,7 +7,7 @@ When legacy `routes` are added in `now.json` or `vercel.json`, they cause confli
 
 #### Possible Ways to Fix It
 
-Migrate from using legacy `routes` to the new `rewrites`, `redirects`, and `headers` configurations in your `now.json` or `vercel.json` file or leverage them directly in your `next.config.js` with the built-in [custom routes support](https://github.com/zeit/next.js/issues/9081)
+Migrate from using legacy `routes` to the new `rewrites`, `redirects`, and `headers` configurations in your `now.json` or `vercel.json` file or leverage them directly in your `next.config.js` with the built-in [custom routes support](https://github.com/zeit/next.js/issues/9081) under the `experimental` key.
 
 ### Useful Links
 


### PR DESCRIPTION
This document doesn't clearly state that using redirects in `next.config.js` needs to be under `experimental`. Linking to a conversation is confusing and misleading.