### PR TITLE
[cli] Set Vercel platform env vars for `startDevServer()` invocations

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -67,8 +67,6 @@ async function createBuildProcess(
     ...process.env,
     PATH,
     ...envConfigs.allEnv,
-    NOW_REGION: 'dev1',
-    VERCEL_REGION: 'dev1',
   };
 
   const buildProcess = fork(builderWorkerPath, [], {
@@ -365,8 +363,6 @@ export async function executeBuild(
               ...nowConfig.env,
               ...asset.environment,
               ...envConfigs.runEnv,
-              NOW_REGION: 'dev1',
-              VERCEL_REGION: 'dev1',
             },
           },
         });

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -485,7 +485,17 @@ export default class DevServer {
       }
     }
     try {
-      return this.validateEnvConfig(fileName, base || {}, env);
+      let host = '';
+      if (this.address) {
+        host = new URL(this.address).host;
+      }
+      return {
+        ...this.validateEnvConfig(fileName, base || {}, env),
+        NOW_REGION: 'dev1',
+        NOW_URL: host,
+        VERCEL_REGION: 'dev1',
+        VERCEL_URL: host,
+      };
     } catch (err) {
       if (err instanceof MissingDotenvVarsError) {
         this.output.error(err.message);
@@ -1904,8 +1914,6 @@ export default class DevServer {
       ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
       ...process.env,
       ...this.envConfigs.allEnv,
-      NOW_REGION: 'dev1',
-      VERCEL_REGION: 'dev1',
       PORT: `${port}`,
     };
 

--- a/packages/now-cli/test/dev/fixtures/node-ts-node-target/api/dump.js
+++ b/packages/now-cli/test/dev/fixtures/node-ts-node-target/api/dump.js
@@ -1,5 +1,6 @@
 module.exports = (req, res) => {
   res.send({
+    env: process.env,
     headers: req.headers,
   });
 };

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1657,11 +1657,10 @@ test(
     );
 
     await testPath(200, `/api/dump`, (t, body, res) => {
+      const { host } = new URL(res.url);
       const { env, headers } = JSON.parse(body);
 
       // Test that the API endpoint receives the Vercel proxy request headers
-      const { host } = new URL(res.url);
-      console.log({ headers });
       t.is(headers['x-forwarded-host'], host);
       t.is(headers['x-vercel-deployment-url'], host);
       t.truthy(isIP(headers['x-real-ip']));
@@ -1669,10 +1668,10 @@ test(
       t.truthy(isIP(headers['x-vercel-forwarded-for']));
 
       // Test that the API endpoint has the Vercel platform env vars defined
-      t.is(typeof env.NOW_URL, 'string');
-      t.is(typeof env.NOW_REGION, 'string');
-      t.is(typeof env.VERCEL_URL, 'string');
-      t.is(typeof env.VERCEL_REGION, 'string');
+      t.is(env.NOW_URL, host);
+      t.is(env.NOW_REGION, 'dev1');
+      t.is(env.VERCEL_URL, host);
+      t.is(env.VERCEL_REGION, 'dev1');
     });
   })
 );

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1669,7 +1669,7 @@ test(
       t.truthy(isIP(headers['x-vercel-forwarded-for']));
 
       // Test that the API endpoint has the Vercel platform env vars defined.
-      t.is(env.NOW_REGION, 'dev1');
+      t.regex(env.NOW_REGION, /^[a-z]{3}\d$/);
       if (isDev) {
         // Only dev is tested because in production these are opt-in.
         t.is(env.NOW_URL, host);

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1656,16 +1656,23 @@ test(
       '{"months":[1,2,3,4,5,6,7,8,9,10,11,12]}'
     );
 
-    // Test that the API endpoint receives the Vercel proxy request headers
-    await testPath(200, `/api/headers`, (t, body, res) => {
+    await testPath(200, `/api/dump`, (t, body, res) => {
+      const { env, headers } = JSON.parse(body);
+
+      // Test that the API endpoint receives the Vercel proxy request headers
       const { host } = new URL(res.url);
-      const { headers } = JSON.parse(body);
       console.log({ headers });
       t.is(headers['x-forwarded-host'], host);
       t.is(headers['x-vercel-deployment-url'], host);
       t.truthy(isIP(headers['x-real-ip']));
       t.truthy(isIP(headers['x-forwarded-for']));
       t.truthy(isIP(headers['x-vercel-forwarded-for']));
+
+      // Test that the API endpoint has the Vercel platform env vars defined
+      t.is(typeof env.NOW_URL, 'string');
+      t.is(typeof env.NOW_REGION, 'string');
+      t.is(typeof env.VERCEL_URL, 'string');
+      t.is(typeof env.VERCEL_REGION, 'string');
     });
   })
 );

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1669,10 +1669,10 @@ test(
       t.truthy(isIP(headers['x-vercel-forwarded-for']));
 
       // Test that the API endpoint has the Vercel platform env vars defined.
-      t.is(env.NOW_URL, host);
+      t.is(env.NOW_REGION, 'dev1');
       if (isDev) {
         // Only dev is tested because in production these are opt-in.
-        t.is(env.NOW_REGION, 'dev1');
+        t.is(env.NOW_URL, host);
         t.is(env.VERCEL_URL, host);
         t.is(env.VERCEL_REGION, 'dev1');
       }


### PR DESCRIPTION
Ensures that `VERCEL_REGION` is set for API calls when the runtime
implements `startDevServer()`.

Also adds `VERCEL_URL` which was previously not defined.