### PR TITLE
Fix dynamic routes in multi-zone next deployment

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1207,9 +1207,6 @@ export const build = async ({
       );
     }
 
-    let dynamicPrefix = path.join('/', entryDirectory);
-    dynamicPrefix = dynamicPrefix === '/' ? '' : dynamicPrefix;
-
     dynamicRoutes = await getDynamicRoutes(
       entryPath,
       entryDirectory,
@@ -1217,11 +1214,6 @@ export const build = async ({
       false,
       routesManifest,
       new Set(prerenderManifest.omittedRoutes)
-    ).then((arr) =>
-      arr.map((route) => {
-        route.src = route.src.replace('^', `^${dynamicPrefix}`);
-        return route;
-      })
     );
 
     if (isSharedLambdas) {
@@ -1236,11 +1228,6 @@ export const build = async ({
         dynamicPages,
         false,
         routesManifest
-      ).then((arr) =>
-        arr.map((route) => {
-          route.src = route.src.replace('^', `^${dynamicPrefix}`);
-          return route;
-        })
       );
 
       await Promise.all(


### PR DESCRIPTION
I'm not AT ALL suggesting this is ready to merge. I only know that creating my own builder with these changes has fixed the problem in my deployments.
This comment may be useful for context: https://github.com/vercel/vercel/pull/4510#issuecomment-645978269
Thanks @jeantil !