### PR TITLE
[cli] Set `server: Vercel` header and remove `x-now` response headers in `vercel dev`

### DIFF
--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1097,10 +1097,7 @@ export default class DevServer {
     const allHeaders = {
       'cache-control': 'public, max-age=0, must-revalidate',
       ...headers,
-      server: 'now',
-      'x-now-trace': 'dev1',
-      'x-now-id': nowRequestId,
-      'x-now-cache': 'MISS',
+      server: 'Vercel',
       'x-vercel-id': nowRequestId,
       'x-vercel-cache': 'MISS',
     };

--- a/packages/now-cli/test/dev-server.unit.js
+++ b/packages/now-cli/test/dev-server.unit.js
@@ -71,7 +71,7 @@ function testFixture(name, fn) {
 }
 
 function validateResponseHeaders(t, res, podId = null) {
-  t.is(res.headers.get('server'), 'now');
+  t.is(res.headers.get('server'), 'Vercel');
   t.truthy(res.headers.get('cache-control').length > 0);
   t.truthy(
     /^dev1::(dev1::)?[0-9a-z]{5}-[1-9][0-9]+-[a-f0-9]{12}$/.test(


### PR DESCRIPTION
This matches production.