### PR TITLE
[cli] Update "set up" message

### DIFF
--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -53,7 +53,8 @@ export default async function dev(
       cwd,
       forceDelete,
       autoConfirm,
-      'link'
+      'link',
+      'Set up and develop'
     );
 
     if (link.status === 'not_linked') {

--- a/packages/now-cli/src/commands/link/index.ts
+++ b/packages/now-cli/src/commands/link/index.ts
@@ -75,7 +75,8 @@ export default async function main(ctx: NowContext) {
     path,
     forceDelete,
     autoConfirm,
-    'success'
+    'success',
+    'Set up'
   );
 
   if (link.status === 'error') {

--- a/packages/now-cli/src/commands/link/index.ts
+++ b/packages/now-cli/src/commands/link/index.ts
@@ -25,7 +25,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
-  --confirm                  Confirm default options and skip questions
+    --confirm                      Confirm default options and skip questions
 
   ${chalk.dim('Examples:')}
 
@@ -38,6 +38,10 @@ const help = () => {
   )} Link current directory with default options and skip questions
 
       ${chalk.cyan(`$ ${getPkgName()} link --confirm`)}
+
+  ${chalk.gray('–')} Link a specific directory to a Vercel Project
+
+      ${chalk.cyan(`$ ${getPkgName()} link /usr/src/project`)}
 `);
 };
 

--- a/packages/now-cli/src/util/link/setup-and-link.ts
+++ b/packages/now-cli/src/util/link/setup-and-link.ts
@@ -34,7 +34,8 @@ export default async function setupAndLink(
   path: string,
   forceDelete: boolean,
   autoConfirm: boolean,
-  successEmoji: EmojiLabel
+  successEmoji: EmojiLabel,
+  setupMsg: string
 ): Promise<ProjectLinkResult> {
   const {
     authConfig: { token },
@@ -73,7 +74,7 @@ export default async function setupAndLink(
   const shouldStartSetup =
     autoConfirm ||
     (await confirm(
-      `Set up and develop ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
+      `${setupMsg} ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
       true
     ));
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -3183,7 +3183,7 @@ test('[vc link] should show prompts to set up project', async t => {
 
   const vc = execa(binaryPath, ['link', ...defaultArgs], { cwd: dir });
 
-  await waitForPrompt(vc, chunk => /Set up and develop [^?]+\?/.test(chunk));
+  await waitForPrompt(vc, chunk => /Set up [^?]+\?/.test(chunk));
   vc.stdin.write('yes\n');
 
   await waitForPrompt(vc, chunk =>


### PR DESCRIPTION
Follow up to #4897 

* `vc link` - Update message to say `Set up ~/proj`
* `vc dev` - Update message  to say `Set up and develop ~/proj`
* `vc link --help` - Updated example message to include `vc link ~/proj` usage
