### PR TITLE
[cli] Fix devServer for routes rewritten to query params

### DIFF
--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -150,7 +150,9 @@ export async function devRouter(
               if (routeConfig.status && phase === 'miss') {
                 status = routeConfig.status;
               }
-              reqPathname = destPath;
+              const destParsed = url.parse(destPath, true);
+              query = Object.assign(destParsed.query, query);
+              reqPathname = destParsed.pathname || '/';
               continue;
             }
           }

--- a/packages/now-cli/test/dev-server.unit.js
+++ b/packages/now-cli/test/dev-server.unit.js
@@ -175,6 +175,18 @@ test(
     t.is(parsed.query['route-param'], 'b');
   })
 );
+test(
+  '[DevServer] Maintains query when builder defines routes through rewrites',
+  testFixture('vc-dev-next-rewrites', async (t, server) => {
+    const res = await fetch(`${server.address}/something?url-param=a`);
+    validateResponseHeaders(t, res);
+
+    const parsed = await res.json();
+
+    t.is(parsed.query['url-param'], 'a');
+    t.is(parsed.query['routeparam'], 'something');
+  })
+);
 
 test(
   '[DevServer] Allow `cache-control` to be overwritten',

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/.gitignore
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/.gitignore
@@ -1,0 +1,4 @@
+.next
+yarn.lock
+
+.vercel

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/next.config.js
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless',
+};

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/package.json
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "build": "next build",
+    "dev": "next"
+  },
+  "dependencies": {
+    "next": "^9.4.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/pages/api/index.js
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/pages/api/index.js
@@ -1,0 +1,5 @@
+export default async function preview(req, res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ query: req.query }));
+}

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/pages/index.js
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/pages/index.js
@@ -1,0 +1,11 @@
+import { withRouter } from 'next/router';
+
+function Index({ router }) {
+  const data = {
+    pathname: router.pathname,
+    query: router.query,
+  };
+  return <div>{JSON.stringify(data)}</div>;
+}
+
+export default withRouter(Index);

--- a/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/vercel.json
+++ b/packages/now-cli/test/fixtures/unit/vc-dev-next-rewrites/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next@canary" }],
+  "rewrites": [
+    {
+      "source": "/:routeparam",
+      "destination": "/api"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,7 +1569,7 @@
   dependencies:
     "@types/retry" "*"
 
-"@types/async-retry@^1.2.1":
+"@types/async-retry@1.4.2", "@types/async-retry@^1.2.1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.2.tgz#7f910188cd3893b51e32df51765ee8d5646053e3"
   integrity sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==


### PR DESCRIPTION
Routes which use the `rewrites` field in now.json were incorrectly routed by `vercel dev` as demonstrated in the unit test added in this PR. 

given a path param rewrite : 
```
{
  "rewrites":[
   {"source": "/:path, "dest":"/foo"}
  ]
}
```
the rewrite is converted by vercel to the following route: 
```
{src: '^(?:/([^/]+?))$', dest: '/foo?path=$1', check: true}
```
However when running in dev, the server will attempt to resolve that with `devServer.hasFileSystem` which may fail if the target is a nextjs route. When failing, the des including the query param was assigned to the `reqPathname` instead of separating `path ` and `query`. The rest of the routing would end up encoding the query params to make the string a valid path and then it would attempt to find a route for that incorrectly encoded string.


This pr addresses this issue