### PR TITLE
[build-utils] Fix redwood `/api` detection

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -309,6 +309,13 @@ export async function detectBuilders(
     options
   );
 
+  if (frontendBuilder && framework === 'redwoodjs') {
+    // RedwoodJS uses the /api directory differently so we must
+    // clear any existing builders and only use `@vercel/redwood`.
+    builders.length = 0;
+    builders.push(frontendBuilder);
+  }
+
   return {
     warnings,
     builders: builders.length ? builders : null,

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1808,6 +1808,36 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
+  it('RedwoodJS should only use redwood builder', async () => {
+    const files = [
+      'package.json',
+      'web/index.html',
+      'api/one.js',
+      'api/two.js',
+    ];
+    const projectSettings = {
+      framework: 'redwoodjs',
+    };
+
+    const { builders, errorRoutes } = await detectBuilders(files, null, {
+      projectSettings,
+      featHandleMiss,
+    });
+
+    expect(builders).toEqual([
+      {
+        use: '@vercel/redwood',
+        src: 'package.json',
+        config: {
+          zeroConfig: true,
+          framework: 'redwoodjs',
+        },
+      },
+    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
+  });
+
   it('No framework, only package.json', async () => {
     const files = ['package.json'];
     const pkg = {


### PR DESCRIPTION
Previously, the zero detection would see js files in the `/api` directory and attempt to use `@vercel/node`. However, this doesn't work with RedwoodJS which uses a different format for [`/api`](https://github.com/vercel/vercel/tree/master/examples/redwoodjs/api) so we must only use `@vercel/redwood` when RedwoodJS is detected.