### PR TITLE
[node][next] Bump node-file-trace to 0.8.1

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -26,7 +26,7 @@
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.1",
-    "@zeit/node-file-trace": "0.8.0",
+    "@zeit/node-file-trace": "0.8.1",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",
     "escape-string-regexp": "3.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -33,7 +33,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@zeit/ncc": "0.20.4",
-    "@zeit/node-file-trace": "0.8.0",
+    "@zeit/node-file-trace": "0.8.1",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,10 +2292,10 @@
   resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
   integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
-"@zeit/node-file-trace@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.8.0.tgz#fe597a8f63c1a6eb38cee92ab4eef322897b4173"
-  integrity sha512-itrVZUwqJSbURaRNxOAJUVkhCjl8BgQpTxy+i5m4Akdacn5CzKAHlschTcTvdcnYGtKoilDwYFuPenS5zHfDQw==
+"@zeit/node-file-trace@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@zeit/node-file-trace/-/node-file-trace-0.8.1.tgz#ace86b366c86f0522e953a2441dfc915fd485df4"
+  integrity sha512-r92pdExhK1cf9Ao5LaT/Ii7JLwv9O4o987cB1SiFIbAnxvW4+xqR1oCYRRvtjU1ildKKGpiBBjGRChyeYRcvxw==
   dependencies:
     acorn "^7.1.1"
     acorn-class-fields "^0.3.2"


### PR DESCRIPTION
This PR bumps `node-file-trace` to [0.8.1](https://github.com/vercel/node-file-trace/releases/tag/0.8.1) to fix ESM packages used with `require()`.

Fixes https://github.com/vercel/node-file-trace/issues/141