### PR TITLE
[next] Update test fixtures for latest changes

### DIFF
--- a/packages/now-next/test/fixtures/01-cache-headers/now.json
+++ b/packages/now-next/test/fixtures/01-cache-headers/now.json
@@ -3,13 +3,13 @@
   "builds": [{ "src": "package.json", "use": "@vercel/next" }],
   "probes": [
     {
-      "path": "/_next/static/testing-build-id/pages/index.js",
+      "path": "/_next/__NEXT_SCRIPT__(/)",
       "responseHeaders": {
         "cache-control": "public,max-age=31536000,immutable"
       }
     },
     {
-      "path": "/_next/static/invalid-build-id/pages/index.js",
+      "path": "/_next/static/invalid-build-id/pages/non-existent.js",
       "notResponseHeaders": {
         "cache-control": "public,max-age=31536000,immutable"
       }

--- a/packages/now-next/test/fixtures/01-cache-headers/package.json
+++ b/packages/now-next/test/fixtures/01-cache-headers/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "latest",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/package.json
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "^9.1.2-canary.8",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/17-static-404/package.json
+++ b/packages/now-next/test/fixtures/17-static-404/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "9.2.1-canary.3",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/19-pages-404/package.json
+++ b/packages/now-next/test/fixtures/19-pages-404/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "latest",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/now-next/test/fixtures/24-custom-output-dir/package.json
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/package.json
@@ -3,7 +3,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "^9.1.2-canary.8",
+    "next": "canary",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }


### PR DESCRIPTION
This updates our Next.js test fixtures to run against canary. 

It looks like the mono-repo fixtures will need to be updated to run against canary separately since there may be a conflict with legacy routes and the trailing slash redirect