### PR TITLE
[cli] Fix `vercel link` command when `vercel.json` contains `builds`

### DIFF
--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -509,6 +509,12 @@ CMD ["node", "index.js"]`,
     'project-link-dev': {
       'package.json': JSON.stringify({}),
     },
+    'project-link-builds': {
+      'index.html': 'Hello',
+      'vercel.json': JSON.stringify({
+        builds: [{ src: '*.html', use: '@vercel/static' }],
+      }),
+    },
     'dev-proxy-headers-and-env': {
       'package.json': JSON.stringify({}),
       'server.js': `require('http').createServer((req, res) => {

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -501,19 +501,17 @@ CMD ["node", "index.js"]`,
       }),
     },
     'project-link-zeroconf': {
-      'package.json': JSON.stringify({}),
+      'package.json': '{}',
     },
     'project-link-confirm': {
-      'package.json': JSON.stringify({}),
+      'package.json': '{}',
     },
     'project-link-dev': {
-      'package.json': JSON.stringify({}),
+      'package.json': '{}',
     },
-    'project-link-builds': {
+    'project-link-legacy': {
       'index.html': 'Hello',
-      'vercel.json': JSON.stringify({
-        builds: [{ src: '*.html', use: '@vercel/static' }],
-      }),
+      'vercel.json': '{"builds":[{"src":"*.html","use":"@vercel/static"}]}',
     },
     'dev-proxy-headers-and-env': {
       'package.json': JSON.stringify({}),

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -500,6 +500,9 @@ CMD ["node", "index.js"]`,
         },
       }),
     },
+    'project-link-deploy': {
+      'package.json': '{}',
+    },
     'project-link-zeroconf': {
       'package.json': '{}',
     },

--- a/packages/now-cli/test/helpers/prepare.js
+++ b/packages/now-cli/test/helpers/prepare.js
@@ -500,7 +500,7 @@ CMD ["node", "index.js"]`,
         },
       }),
     },
-    'project-link': {
+    'project-link-zeroconf': {
       'package.json': JSON.stringify({}),
     },
     'project-link-confirm': {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -3288,8 +3288,8 @@ test('reject deploying with wrong team .vercel config', async t => {
 });
 
 test('[vc link] should show prompts to set up project', async t => {
-  const dir = fixture('project-link');
-  const projectName = `project-link-${
+  const dir = fixture('project-link-zeroconf');
+  const projectName = `project-link-zeroconf-${
     Math.random().toString(36).split('.')[1]
   }`;
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2661,9 +2661,9 @@ test('ensure `github` and `scope` are not sent to the API', async t => {
   t.is(output.exitCode, 0, formatOutput(output));
 });
 
-test('should show prompts to set up project', async t => {
-  const directory = fixture('project-link');
-  const projectName = `project-link-${
+test('should show prompts to set up project during first deploy', async t => {
+  const directory = fixture('project-link-deploy');
+  const projectName = `project-link-deploy-${
     Math.random().toString(36).split('.')[1]
   }`;
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -3499,8 +3499,8 @@ test('[vc dev] should show prompts to set up project', async t => {
 });
 
 test('[vc link] should show project prompts but not framework when `builds` defined', async t => {
-  const dir = fixture('project-link-builds');
-  const projectName = `project-link-builds-${
+  const dir = fixture('project-link-legacy');
+  const projectName = `project-link-legacy-${
     Math.random().toString(36).split('.')[1]
   }`;
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2321,7 +2321,11 @@ test('render build errors', async t => {
   console.log(output.exitCode);
 
   t.is(output.exitCode, 1, formatOutput(output));
-  t.regex(output.stderr, /Command "yarn run build" exited with 1/gm, formatOutput(output));
+  t.regex(
+    output.stderr,
+    /Command "yarn run build" exited with 1/gm,
+    formatOutput(output)
+  );
 });
 
 test('invalid deployment, projects and alias names', async t => {
@@ -3492,6 +3496,61 @@ test('[vc dev] should show prompts to set up project', async t => {
   } finally {
     process.kill(dev.pid, 'SIGTERM');
   }
+});
+
+test('[vc link] should show project prompts but not framework when `builds` defined', async t => {
+  const dir = fixture('project-link-builds');
+  const projectName = `project-link-builds-${
+    Math.random().toString(36).split('.')[1]
+  }`;
+
+  // remove previously linked project if it exists
+  await remove(path.join(dir, '.vercel'));
+
+  const vc = execa(binaryPath, ['link', ...defaultArgs], { cwd: dir });
+
+  await waitForPrompt(vc, chunk => /Set up [^?]+\?/.test(chunk));
+  vc.stdin.write('yes\n');
+
+  await waitForPrompt(vc, chunk =>
+    chunk.includes('Which scope should contain your project?')
+  );
+  vc.stdin.write('\n');
+
+  await waitForPrompt(vc, chunk => chunk.includes('Link to existing project?'));
+  vc.stdin.write('no\n');
+
+  await waitForPrompt(vc, chunk =>
+    chunk.includes('What’s your project’s name?')
+  );
+  vc.stdin.write(`${projectName}\n`);
+
+  await waitForPrompt(vc, chunk =>
+    chunk.includes('In which directory is your code located?')
+  );
+  vc.stdin.write('\n');
+
+  await waitForPrompt(vc, chunk => chunk.includes('Linked to'));
+
+  const output = await vc;
+
+  // Ensure the exit code is right
+  t.is(output.exitCode, 0, formatOutput(output));
+
+  // Ensure .gitignore is created
+  t.is((await readFile(path.join(dir, '.gitignore'))).toString(), '.vercel');
+
+  // Ensure .vercel/project.json and .vercel/README.txt are created
+  t.is(
+    await exists(path.join(dir, '.vercel', 'project.json')),
+    true,
+    'project.json should be created'
+  );
+  t.is(
+    await exists(path.join(dir, '.vercel', 'README.txt')),
+    true,
+    'README.txt should be created'
+  );
 });
 
 test('[vc dev] should send the platform proxy request headers to frontend dev server ', async t => {


### PR DESCRIPTION
This PR fixes a bug when running `vercel link` command in a directory with `vercel.json` that contains `builds` property. The problem is that framework auto-detection doesn't run when `builds` is used, only for zero config. So we skip the API and instead create the project without auto-detection during `vc link`.