### PR TITLE
[cli] Fix `.gitignore` append during project link

### DIFF
--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -244,7 +244,7 @@ export async function linkFolderToProject(
     const gitIgnore = await readFile(gitIgnorePath)
       .then(buf => buf.toString())
       .catch(() => null);
-    const EOL = gitIgnore && gitIgnore.includes('\r\n') ? '\r\n' : '\n'
+    const EOL = gitIgnore && gitIgnore.includes('\r\n') ? '\r\n' : '\n';
 
     if (!gitIgnore || !gitIgnore.split(EOL).includes(VERCEL_DIR)) {
       await writeFile(

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -16,7 +16,6 @@ import AJV from 'ajv';
 import { isDirectory } from '../config/global-path';
 import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
 import outputCode from '../output/code';
-import os from 'os';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -245,11 +244,12 @@ export async function linkFolderToProject(
     const gitIgnore = await readFile(gitIgnorePath)
       .then(buf => buf.toString())
       .catch(() => null);
+    const EOL = gitIgnore && gitIgnore.includes('\r\n') ? '\r\n' : '\n'
 
-    if (!gitIgnore || !gitIgnore.split(os.EOL).includes(VERCEL_DIR)) {
+    if (!gitIgnore || !gitIgnore.split(EOL).includes(VERCEL_DIR)) {
       await writeFile(
         gitIgnorePath,
-        gitIgnore ? `${gitIgnore}\n${VERCEL_DIR}` : VERCEL_DIR
+        gitIgnore ? `${gitIgnore}${EOL}${VERCEL_DIR}` : VERCEL_DIR
       );
       isGitIgnoreUpdated = true;
     }

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -249,7 +249,7 @@ export async function linkFolderToProject(
     if (!gitIgnore || !gitIgnore.split(EOL).includes(VERCEL_DIR)) {
       await writeFile(
         gitIgnorePath,
-        gitIgnore ? `${gitIgnore}${EOL}${VERCEL_DIR}` : VERCEL_DIR
+        gitIgnore ? `${gitIgnore}${EOL}${VERCEL_DIR}${EOL}` : `${VERCEL_DIR}${EOL}`
       );
       isGitIgnoreUpdated = true;
     }

--- a/packages/now-cli/src/util/projects/link.ts
+++ b/packages/now-cli/src/util/projects/link.ts
@@ -16,6 +16,7 @@ import AJV from 'ajv';
 import { isDirectory } from '../config/global-path';
 import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
 import outputCode from '../output/code';
+import os from 'os';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -245,7 +246,7 @@ export async function linkFolderToProject(
       .then(buf => buf.toString())
       .catch(() => null);
 
-    if (!gitIgnore || !gitIgnore.split('\n').includes(VERCEL_DIR)) {
+    if (!gitIgnore || !gitIgnore.split(os.EOL).includes(VERCEL_DIR)) {
       await writeFile(
         gitIgnorePath,
         gitIgnore ? `${gitIgnore}\n${VERCEL_DIR}` : VERCEL_DIR


### PR DESCRIPTION
~~On Windows~~, if `.gitignore` is using CRLF as EOL, the Vercel CLI will always add `.vercel` into `.gitignore` regardless of its existence. This is because the code is using LF (`\n`) to split the lines.

![image](https://user-images.githubusercontent.com/44045911/89121748-34226700-d4f4-11ea-91a5-fb0e76cd2aec.png)

This PR should fix the problem, by detecting and using the EOL of `.gitignore` instead of hard-coded LF (`\n`).

EDIT: after submitting the PR, I realized it has nothing to do with the system line ending. I should check the file line ending instead.