### PR TITLE
[tests] Bump cancel action to 0.4.1

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: styfle/cancel-workflow-action@0.3.2
+      - uses: styfle/cancel-workflow-action@0.4.1
         with:
           workflow_id: 849295, 849296, 849297, 849298
           access_token: ${{ github.token }}


### PR DESCRIPTION
Bump `cancel-workflow-action` to [0.4.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.4.1) to fix a bug where the wrong branch was cancelled.