### PR TITLE
[cli] Add `bundledDependencies` to package.json

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -72,6 +72,17 @@
     "@vercel/static-build": "0.17.7-canary.1",
     "update-notifier": "4.1.0"
   },
+  "bundledDependencies": [
+    "@vercel/build-utils",
+    "@vercel/go",
+    "@vercel/next",
+    "@vercel/node",
+    "@vercel/python",
+    "@vercel/redwood",
+    "@vercel/ruby",
+    "@vercel/static-build",
+    "update-notifier"
+  ],
   "devDependencies": {
     "@sentry/node": "5.5.0",
     "@sindresorhus/slugify": "0.11.0",


### PR DESCRIPTION
This PR adds the [`bundledDependencies`](https://docs.npmjs.com/files/package.json#bundleddependencies) property to `package.json` so that `npm publish` will include a copy of the `dependencies` in the tarball.

This should reduce the time it takes to run `npm install -g vercel` because it will require fewer http requests.

We will need to make sure that `bundledDependencies` matches `dependencies` in the future.