### PR TITLE
[client] Lower upload sempahore size from 700 to 50 connections

### DIFF
--- a/packages/now-client/src/upload.ts
+++ b/packages/now-client/src/upload.ts
@@ -76,7 +76,8 @@ export async function* upload(
   const uploadList: { [key: string]: Promise<any> } = {};
   debug('Building an upload list...');
 
-  const semaphore = new Sema(700, { capacity: 700 });
+  const semaphore = new Sema(50, { capacity: 50 });
+  const agent = new Agent({ keepAlive: true });
 
   shas.map((sha: string): void => {
     uploadList[sha] = retry(
@@ -102,7 +103,7 @@ export async function* upload(
             API_FILES,
             token,
             {
-              agent: new Agent({ keepAlive: true }),
+              agent,
               method: 'POST',
               headers: {
                 'Content-Type': 'application/octet-stream',


### PR DESCRIPTION
CH Story:

https://app.clubhouse.io/vercel/story/5291/cli-connection-pooling

(Mac) script for watching count of active connections to API: 
`watch -n 0.1 'netstat -a -n | grep -E \'(13.52.46.156|52.9.164.177)\' | wc -l'`

Limiting the active connections to 50 greatly decreased the amount of active connections but did not noticeably increase the time to upload files. 

For each semaphore size below, I tested uploading 200 files of random size (between 50kb and 100kb) 5 times. More tests on varying file sizes / amounts showed similar results. 

Results:
```
Size: Average time in ms
50  : 25740 ms 
700 : 28763 ms
10  : 29339 ms
```

I also moved the the agent creation outside of the forEach loop when uploading. This is functionally the same (as node would use the same socket for the same hostname) but makes it easier to access the agent object if we need to debug in the future, and it seems unnecessary to create a new object each call. 