### PR TITLE
[redwood] Fix file permissions and add support for `build` script

### DIFF
--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -1,4 +1,5 @@
 import { join, dirname, relative, parse as parsePath, sep } from 'path';
+import { statSync } from 'fs';
 import {
   BuildOptions,
   Lambda,
@@ -119,9 +120,10 @@ export async function build({
       }),
     };
 
-    dependencies.forEach(fsPath => {
-      lambdaFiles[relative(workPath, fsPath)] = new FileFsRef({ fsPath });
-    });
+    for (const fsPath of dependencies) {
+      const { mode } = statSync(fsPath);
+      lambdaFiles[relative(workPath, fsPath)] = new FileFsRef({ fsPath, mode });
+    }
 
     lambdaFiles[relative(workPath, fileFsRef.fsPath)] = fileFsRef;
 

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -1,5 +1,4 @@
 import { join, dirname, relative, parse as parsePath, sep } from 'path';
-import { statSync } from 'fs';
 import {
   BuildOptions,
   Lambda,
@@ -121,8 +120,7 @@ export async function build({
     };
 
     for (const fsPath of dependencies) {
-      const { mode } = statSync(fsPath);
-      lambdaFiles[relative(workPath, fsPath)] = new FileFsRef({ fsPath, mode });
+      lambdaFiles[relative(workPath, fsPath)] = await FileFsRef.fromFsPath({ fsPath });
     }
 
     lambdaFiles[relative(workPath, fileFsRef.fsPath)] = fileFsRef;

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/src/functions/permission.js
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/src/functions/permission.js
@@ -1,0 +1,22 @@
+import { promises, constants } from 'fs'
+const { access } = promises
+const { X_OK } = constants
+
+async function isExecutable(fsPath) {
+  try {
+    await access(fsPath, X_OK)
+    return true
+  } catch (e) {
+    console.error(e)
+    return e.message
+  }
+}
+
+export async function handler() {
+  const isExec = await isExecutable('../permission/test.sh')
+  return {
+    statusCode: 200,
+    headers: {},
+    body: `File is executable: ${isExec}`,
+  }
+}

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/src/functions/permission.js
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/src/functions/permission.js
@@ -1,8 +1,10 @@
-import { promises, constants } from 'fs'
-const { access } = promises
-const { X_OK } = constants
+const {
+  promises: { access },
+  constants: { X_OK },
+} = require('fs')
 
 async function isExecutable(fsPath) {
+  console.log(`Testing is file is executable: ${fsPath}`)
   try {
     await access(fsPath, X_OK)
     return true
@@ -12,11 +14,13 @@ async function isExecutable(fsPath) {
   }
 }
 
-export async function handler() {
-  const isExec = await isExecutable('../permission/test.sh')
+async function handler() {
+  const isExec = await isExecutable(module.id)
   return {
     statusCode: 200,
     headers: {},
     body: `File is executable: ${isExec}`,
   }
 }
+
+module.exports = { handler }

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/src/permission/test.sh
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/src/permission/test.sh
@@ -1,0 +1,1 @@
+echo 'This file should be executable'

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/src/permission/test.sh
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/src/permission/test.sh
@@ -1,1 +1,0 @@
-echo 'This file should be executable'

--- a/packages/redwood/test/fixtures/01-create-redwood-app/package.json
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/package.json
@@ -6,6 +6,9 @@
       "web"
     ]
   },
+  "scripts": {
+    "build": "rw db up --no-db-client --auto-approve && rw build"
+  },
   "devDependencies": {
     "@redwoodjs/core": "0.15.0"
   },

--- a/packages/redwood/test/fixtures/01-create-redwood-app/vercel.json
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/vercel.json
@@ -15,6 +15,10 @@
       "headers": { "Accept": "application/json" },
       "body": { "query": "{ redwood { version } }" },
       "mustContain": "0.15.0"
+    },
+    {
+      "path": "/api/permission",
+      "mustContain": "File is executable: true"
     }
   ]
 }

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -3,6 +3,7 @@ const { createHash } = require('crypto');
 const path = require('path');
 const _fetch = require('node-fetch');
 const fetch = require('./fetch-retry.js');
+const fileModeSymbol = Symbol('fileMode');
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function nowDeploy(bodies, randomness, uploadNowJson) {
@@ -14,7 +15,9 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
       sha: digestOfFile(bodies[n]),
       size: bodies[n].length,
       file: n,
-      mode: path.extname(n) === '.sh' ? 0o100755 : 0o100644,
+      mode:
+        bodies[n][fileModeSymbol] ||
+        (path.extname(n) === '.sh' ? 0o100755 : 0o100644),
     }));
 
   const { FORCE_BUILD_IN_REGION, NOW_DEBUG, VERCEL_DEBUG } = process.env;
@@ -80,9 +83,7 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
 }
 
 function digestOfFile(body) {
-  return createHash('sha1')
-    .update(body)
-    .digest('hex');
+  return createHash('sha1').update(body).digest('hex');
 }
 
 async function filePost(body, digest) {
@@ -247,4 +248,5 @@ module.exports = {
   fetchWithAuth,
   nowDeploy,
   fetchTokenWithRetry,
+  fileModeSymbol,
 };

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -6,7 +6,7 @@ const glob = require('util').promisify(require('glob'));
 const path = require('path');
 const { spawn } = require('child_process');
 const fetch = require('./fetch-retry.js');
-const { nowDeploy } = require('./now-deploy.js');
+const { nowDeploy, fileModeSymbol } = require('./now-deploy.js');
 
 async function packAndDeploy(builderPath) {
   await spawnAsync('npm', ['--loglevel', 'warn', 'pack'], {
@@ -37,6 +37,7 @@ async function testDeployment(
   const bodies = globResult.reduce((b, f) => {
     const r = path.relative(fixturePath, f);
     b[r] = fs.readFileSync(f);
+    b[r][fileModeSymbol] = fs.statSync(f).mode;
     return b;
   }, {});
 


### PR DESCRIPTION
Some files require execution privileges, such as Prisma, so we must preserve the file mode.

We also want redwood to behave the same as other frameworks and use `yarn build` if available.