### PR TITLE
[cli][redwood] Update frontend framework detection in `vc dev`

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -103,6 +103,7 @@
     "@types/universal-analytics": "0.4.2",
     "@types/which": "1.3.2",
     "@types/write-json-file": "2.2.1",
+    "@vercel/frameworks": "0.0.18-canary.5",
     "@zeit/fun": "0.11.2",
     "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -2332,8 +2332,7 @@ async function checkForPort(
 }
 
 function filterFrontendBuilds(build: Builder) {
-  const parsed = npa(build.use);
-  const { name } = parsed;
+  const { name } = npa(build.use);
   return !frontendRuntimeSet.has(name || '');
 }
 

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -61,21 +61,9 @@ export async function build({
   );
 
   if (meta.isDev) {
-    debug('Detected @vercel/redwood dev, returning routes...');
-
-    let srcBase = mountpoint.replace(/^\.\/?/, '');
-
-    if (srcBase.length > 0) {
-      srcBase = `/${srcBase}`;
-    }
-
+    console.log('WARN: Detected @vercel/redwood dev but this is not supported');
     return {
-      routes: [
-        {
-          src: `${srcBase}/(.*)`,
-          dest: `http://localhost:$PORT/$1`,
-        },
-      ],
+      routes: [],
       output: {},
     };
   }

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -61,11 +61,7 @@ export async function build({
   );
 
   if (meta.isDev) {
-    console.log('WARN: Detected @vercel/redwood dev but this is not supported');
-    return {
-      routes: [],
-      output: {},
-    };
+    throw new Error('Detected `@vercel/redwood` dev but this is not supported');
   }
 
   const { buildCommand } = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,11 +2227,6 @@
     async-retry "1.2.3"
     lru-cache "5.1.1"
 
-"@zeit/dockerignore@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@zeit/dockerignore/-/dockerignore-0.0.5.tgz#b12a693f6ee79aaeffd97914457dc874d5f8386e"
-  integrity sha512-SQ9/wXM1sjv8HnjbAWVSl6KOgitAWiPpjk5AZFXP6rBpmevsLWqtR1L0COIYnHY2UrHC5yXuUG/jh+Sqq0kK8Q==
-
 "@zeit/fetch-cached-dns@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@zeit/fetch-cached-dns/-/fetch-cached-dns-1.2.0.tgz#2529bea33732df1044f72465b8f7760af7b53d46"
@@ -6487,11 +6482,6 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-ini@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-  integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
 
 ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"


### PR DESCRIPTION
This PR uses the the new property added in PR #5034 to determine if a framework has a frontend runtime defined.

It also reverts a couple workarounds add in PR #4937 which was added for RedwoodJS which is no longer necessary since RedwoodJS defines a frontend framework the same way Next.js does.