### PR TITLE
[routing-utils] Update rewrite params query appending

### DIFF
--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -5,7 +5,6 @@
 import { parse as parseUrl, format as formatUrl } from 'url';
 import { pathToRegexp, compile, Key } from 'path-to-regexp';
 import { Route, NowRedirect, NowRewrite, NowHeader } from './types';
-import { isString } from 'util';
 
 const UN_NAMED_SEGMENT = '__UN_NAMED_SEGMENT__';
 
@@ -81,7 +80,6 @@ export function convertRewrites(rewrites: NowRewrite[]): Route[] {
       const route: Route = { src, dest, check: true };
       return route;
     } catch (e) {
-      console.error(e);
       throw new Error(`Failed to parse rewrite: ${JSON.stringify(r)}`);
     }
   });
@@ -197,9 +195,11 @@ function replaceSegments(
         // params from the destination
       }
 
-      destParams = new Set([...pathnameKeys, ...hashKeys]
-        .map(key => key.name)
-        .filter(isString));
+      destParams = new Set(
+        [...pathnameKeys, ...hashKeys]
+          .map(key => key.name)
+          .filter(val => typeof val === 'string') as string[]
+      );
 
       pathname = safelyCompile(pathname, indexes);
       hash = hash ? safelyCompile(hash, indexes) : null;
@@ -214,7 +214,8 @@ function replaceSegments(
     }
 
     // We only add path segments to redirect queries if manually
-    // specified
+    // specified and only automatically add them for rewrites if one
+    // or more params aren't already used in the destination's path
     const paramKeys = Object.keys(indexes);
 
     if (!isRedirect && !paramKeys.some(param => destParams.has(param))) {

--- a/packages/now-routing-utils/src/superstatic.ts
+++ b/packages/now-routing-utils/src/superstatic.ts
@@ -183,7 +183,7 @@ function replaceSegments(
       indexes[name] = toSegmentDest(index);
     });
 
-    let destParams: string[] = [];
+    let destParams = new Set<string>();
 
     if (destination.includes(':') && segments.length > 0) {
       const pathnameKeys: Key[] = [];
@@ -197,9 +197,9 @@ function replaceSegments(
         // params from the destination
       }
 
-      destParams = [...pathnameKeys, ...hashKeys]
+      destParams = new Set([...pathnameKeys, ...hashKeys]
         .map(key => key.name)
-        .filter(isString);
+        .filter(isString));
 
       pathname = safelyCompile(pathname, indexes);
       hash = hash ? safelyCompile(hash, indexes) : null;
@@ -217,7 +217,7 @@ function replaceSegments(
     // specified
     const paramKeys = Object.keys(indexes);
 
-    if (!isRedirect && !paramKeys.some(param => destParams.includes(param))) {
+    if (!isRedirect && !paramKeys.some(param => destParams.has(param))) {
       for (const param of paramKeys) {
         if (!(param in query) && param !== UN_NAMED_SEGMENT) {
           query[param] = indexes[param];

--- a/packages/now-routing-utils/test/superstatic.spec.js
+++ b/packages/now-routing-utils/test/superstatic.spec.js
@@ -381,12 +381,12 @@ test('convertRewrites', () => {
     },
     {
       src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
-      dest: '/$1/get?identifier=$2&file=$1&id=$2',
+      dest: '/$1/get?identifier=$2',
       check: true,
     },
     {
       src: '^\\/qs-and-hash(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
-      dest: '/api/get?identifier=$1&id=$1&hash=$2#$2',
+      dest: '/api/get?identifier=$1#$2',
       check: true,
     },
     {
@@ -402,12 +402,12 @@ test('convertRewrites', () => {
     },
     {
       src: '^\\/catchall(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?\\/$',
-      dest: '/catchall/$1?hello=$1',
+      dest: '/catchall/$1',
       check: true,
     },
     {
       src: '^\\/another-catch(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
-      dest: '/another-catch/$1?hello=$1',
+      dest: '/another-catch/$1',
       check: true,
     },
     {
@@ -425,7 +425,7 @@ test('convertRewrites', () => {
       dest: '/test?path=$1&two=$2',
       src: '^(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$',
     },
-    { check: true, dest: '/blog/$2?id=$2', src: '^(?:\\/(.*))-(\\d+)\\.html$' },
+    { check: true, dest: '/blog/$2', src: '^(?:\\/(.*))-(\\d+)\\.html$' },
   ];
 
   deepEqual(actual, expected);


### PR DESCRIPTION
This updates to not automatically append params to the query for rewrites if one or more of the params are already used in the destination's path. No other behavior is being changed and if the user still wants the params in the query after using them in the destination's path they can manually add them like with redirects.

x-ref: https://github.com/vercel/next.js/pull/16189