### PR TITLE
[next] Fix trailing slash and 404 with next export

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -623,7 +623,8 @@ export const build = async ({
         },
 
         // error handling
-        ...(output[path.join('./', entryDirectory, '404')]
+        ...(output[path.join('./', entryDirectory, '404')] ||
+        output[path.join('./', entryDirectory, '404/index')]
           ? [
               { handle: 'error' } as Handler,
 

--- a/packages/now-next/test/fixtures/00-trailing-slash-add-export/next.config.js
+++ b/packages/now-next/test/fixtures/00-trailing-slash-add-export/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  trailingSlash: true,
+};

--- a/packages/now-next/test/fixtures/00-trailing-slash-add-export/now.json
+++ b/packages/now-next/test/fixtures/00-trailing-slash-add-export/now.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "probes": [
+    { "path": "/foo/", "status": 200, "mustContain": "foo page" },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/foo",
+      "status": 308,
+      "responseHeaders": {
+        "refresh": "/url=/foo/$/"
+      }
+    },
+    {
+      "path": "/non-existent",
+      "status": 404,
+      "mustContain": "oops 404"
+    },
+    {
+      "path": "/non-existent/",
+      "status": 404,
+      "fetchOptions": { "redirect": "manual" },
+      "mustContain": "oops 404"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/00-trailing-slash-add-export/package.json
+++ b/packages/now-next/test/fixtures/00-trailing-slash-add-export/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "build": "next build && next export"
+  },
+  "dependencies": {
+    "next": "canary",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/00-trailing-slash-add-export/pages/404.js
+++ b/packages/now-next/test/fixtures/00-trailing-slash-add-export/pages/404.js
@@ -1,0 +1,1 @@
+export default () => 'oops 404';

--- a/packages/now-next/test/fixtures/00-trailing-slash-add-export/pages/foo.js
+++ b/packages/now-next/test/fixtures/00-trailing-slash-add-export/pages/foo.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>foo page</p>;
+}


### PR DESCRIPTION
This fixes the case where `trailingSlash: true` is used with `next export` causing the `404` page to be output as `404/index.html` and we were previously only checking for the 404 output at `404`. This also adds a regression test for this behavior. 

Closes: https://github.com/vercel/next.js/issues/16218