### PR TITLE
[cli] Fix update message

### DIFF
--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -135,7 +135,7 @@ const main = async argv_ => {
   // (as in: `vercel ls`)
   const targetOrSubcommand = argv._[2];
 
-  if (notifier.update && isTTY) {
+  if (notifier.update && notifier.update.latest !== pkg.version && isTTY) {
     const { latest } = notifier.update;
     console.log(
       info(


### PR DESCRIPTION
The update message was sometimes printed when there was no update.

This PR fixes the update check to ensure the that it is only printed when the latest version differs from the current version.

![image](https://user-images.githubusercontent.com/229881/90397426-d0587c00-e065-11ea-8b22-8bf626fe2c73.png)
