### PR TITLE
[cli][build-utils] Use `handle: error` for api 404

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -971,10 +971,10 @@ function getRouteResult(
       }
 
       rewriteRoutes.push(...dynamicRoutes);
-      rewriteRoutes.push({
-        src: '^/api(/.*)?$',
+      errorRoutes.push({
         status: 404,
-        continue: true,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
       });
     } else {
       defaultRoutes.push(...apiRoutes);

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -929,11 +929,10 @@ function getRouteResult(
   const redirectRoutes: Route[] = [];
   const rewriteRoutes: Route[] = [];
   const errorRoutes: Route[] = [];
-  const isNextjs =
-    frontendBuilder &&
-    ((frontendBuilder.use && frontendBuilder.use.startsWith('@vercel/next')) ||
-      (frontendBuilder.config &&
-        frontendBuilder.config.framework === 'nextjs'));
+  const framework = frontendBuilder?.config?.framework || '';
+  const use = frontendBuilder?.use || '';
+  const isNextjs = framework === 'nextjs' || use.startsWith('@vercel/next');
+  const ignoreRuntimes = slugToFramework.get(framework)?.ignoreRuntimes;
 
   if (apiRoutes && apiRoutes.length > 0) {
     if (options.featHandleMiss) {
@@ -971,10 +970,13 @@ function getRouteResult(
       }
 
       rewriteRoutes.push(...dynamicRoutes);
-      errorRoutes.push({
-        status: 404,
-        src: '^/api(/.*)?$',
-      });
+
+      if (ignoreRuntimes === undefined) {
+        errorRoutes.push({
+          status: 404,
+          src: '^/api(/.*)?$',
+        });
+      }
     } else {
       defaultRoutes.push(...apiRoutes);
 

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -971,7 +971,11 @@ function getRouteResult(
 
       rewriteRoutes.push(...dynamicRoutes);
 
-      if (ignoreRuntimes === undefined) {
+      if (typeof ignoreRuntimes === 'undefined') {
+        // This route is only necessary to hide the directory listing
+        // to avoid enumerating serverless function names.
+        // But it causes issues in `vc dev` for frameworks that handle
+        // their own functions such as redwood, so we ignore.
         errorRoutes.push({
           status: 404,
           src: '^/api(/.*)?$',

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -974,7 +974,6 @@ function getRouteResult(
       errorRoutes.push({
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       });
     } else {
       defaultRoutes.push(...apiRoutes);

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -952,7 +952,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -988,7 +987,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1039,7 +1037,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1078,7 +1075,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
     ]);
   });
@@ -1112,7 +1108,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
     ]);
   });
@@ -1192,7 +1187,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1231,7 +1225,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1261,7 +1254,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1301,7 +1293,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1389,7 +1380,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1533,7 +1523,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -1937,7 +1926,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2077,7 +2065,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2147,7 +2134,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2413,7 +2399,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2522,7 +2507,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2571,7 +2555,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2620,7 +2603,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2662,7 +2644,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2701,7 +2682,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2741,7 +2721,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2777,7 +2756,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2818,7 +2796,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2914,7 +2891,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2955,7 +2931,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -2997,7 +2972,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3030,7 +3004,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3062,7 +3035,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3094,7 +3066,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3122,7 +3093,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3164,7 +3134,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3230,7 +3199,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3271,7 +3239,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3313,7 +3280,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3339,7 +3305,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3371,7 +3336,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3403,7 +3367,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,
@@ -3431,7 +3394,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       {
         status: 404,
         src: '^/api(/.*)?$',
-        dest: '/_vc_no_match_',
       },
       {
         status: 404,

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -947,10 +947,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes!.length).toBe(2);
     expect((errorRoutes![0] as Source).status).toBe(404);
+    expect((errorRoutes![1] as Source).status).toBe(404);
   });
 
   it('no package.json + no build + raw static + api', async () => {
@@ -974,9 +974,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes!.length).toBe(2);
+    expect((errorRoutes![0] as Source).status).toBe(404);
     expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
@@ -1015,10 +1015,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(2);
+    expect(rewriteRoutes!.length).toBe(1);
     expect((rewriteRoutes![0] as Source).src).toBe('^/api/([^/]+)/([^/]+)$');
-    expect((rewriteRoutes![1] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
+    expect(errorRoutes!.length).toBe(2);
+    expect((errorRoutes![0] as Source).status).toBe(404);
     expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
@@ -1046,9 +1046,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes).toStrictEqual([]);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+    ]);
   });
 
   it('api + next + raw static', async () => {
@@ -1075,9 +1080,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes).toStrictEqual([]);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+    ]);
   });
 
   it('Using "Other" framework with Storybook should NOT autodetect Next.js', async () => {
@@ -1121,8 +1131,13 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         },
       },
     ]);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('api + raw static', async () => {
@@ -1145,10 +1160,19 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('api + raw static + package.json no build script', async () => {
@@ -1175,10 +1199,19 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('api + public', async () => {
@@ -1197,8 +1230,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![1].use).toBe('@vercel/static');
     expect(builders![1].src).toBe('public/**/*');
     expect(builders!.length).toBe(2);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('api go with test files', async () => {
@@ -1217,13 +1260,28 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       'api/src/controllers/user.module_test.go',
     ];
 
-    const { builders, errorRoutes } = await detectBuilders(files, undefined, {
-      featHandleMiss,
-    });
+    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      undefined,
+      {
+        featHandleMiss,
+      }
+    );
     expect(builders!.length).toBe(7);
     expect(builders!.some(b => b.src.endsWith('_test.go'))).toBe(false);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('just public', async () => {
@@ -1300,8 +1358,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders!.length).toBe(1);
-    expect(errorRoutes!.length).toBe(1);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('package.json with no build + public directory', async () => {
@@ -1420,16 +1488,22 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
   it('many static files + one api file', async () => {
     const files = Array.from({ length: 5000 }).map((_, i) => `file${i}.html`);
     files.push('api/index.ts');
-    const { builders, errorRoutes } = await detectBuilders(files, undefined, {
-      featHandleMiss,
-    });
+    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      undefined,
+      {
+        featHandleMiss,
+      }
+    );
 
     expect(builders!.length).toBe(2);
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('api/index.ts');
     expect(builders![1].use).toBe('@vercel/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
-    expect(errorRoutes!.length).toBe(1);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes!.length).toBe(2);
+    expect((errorRoutes![0] as Source).status).toBe(404);
     expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
@@ -1822,10 +1896,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
-    expect((rewriteRoutes![0] as Source).status).toBe(404);
-    expect(errorRoutes!.length).toBe(1);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes!.length).toBe(2);
     expect((errorRoutes![0] as Source).status).toBe(404);
+    expect((errorRoutes![1] as Source).status).toBe(404);
   });
 
   it('Framework with non-package.json entrypoint', async () => {
@@ -1953,14 +2027,13 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/(?!.*api).*$',
@@ -1998,10 +2071,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['config.rb', 'api/date.rb'];
     const projectSettings = { framework: 'middleman' };
 
-    const { builders, errorRoutes } = await detectBuilders(files, null, {
-      projectSettings,
-      featHandleMiss,
-    });
+    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        projectSettings,
+        featHandleMiss,
+      }
+    );
 
     expect(builders).toEqual([
       {
@@ -2020,8 +2097,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         },
       },
     ]);
-    expect(errorRoutes!.length).toBe(1);
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes!.length).toBe(2);
     expect((errorRoutes![0] as Source).status).toBe(404);
+    expect((errorRoutes![1] as Source).status).toBe(404);
   });
 
   it('Error for non-api functions', async () => {
@@ -2275,14 +2354,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/(?!.*api).*$',
@@ -2290,7 +2368,8 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       },
     ]);
 
-    const pattern = new RegExp(errorRoutes![0].src!);
+    const apiPattern = new RegExp(errorRoutes![0].src!);
+    const customPattern = new RegExp(errorRoutes![1].src!);
 
     [
       '/',
@@ -2304,7 +2383,8 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       '/another/sub/page.html',
       '/another/sub/page',
     ].forEach(file => {
-      expect(file).toMatch(pattern);
+      expect(file).not.toMatch(apiPattern);
+      expect(file).toMatch(customPattern);
     });
 
     [
@@ -2318,7 +2398,8 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       '/api/sub/page.html',
       '/api/sub/page',
     ].forEach(file => {
-      expect(file).not.toMatch(pattern);
+      expect(file).toMatch(apiPattern);
+      expect(file).not.toMatch(customPattern);
     });
   }
 
@@ -2356,9 +2437,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/[endpoint].js', 'api/[endpoint]/[id].js'];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2378,10 +2463,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2393,9 +2485,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       'api/[endpoint]/[id].js',
     ];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2416,10 +2512,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2437,9 +2540,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
 
     const files = ['public/index.html', 'api/[endpoint].js'];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, pkg, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      pkg,
+      {
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2454,10 +2561,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2474,9 +2588,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/date/index.js', 'api/date.js'];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2485,12 +2603,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2498,9 +2621,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/date.js', 'api/[date]/index.js'];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2515,10 +2642,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2532,9 +2666,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       'api/food.ts',
       'api/ts/gold.ts',
     ];
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
 
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -2544,12 +2682,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2559,10 +2702,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
     const functions = { 'api/user.php': { runtime: 'vercel-php@0.1.0' } };
     const files = ['api/user.php'];
 
-    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
-      functions,
-      featHandleMiss,
-    });
+    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
+      files,
+      null,
+      {
+        functions,
+        featHandleMiss,
+      }
+    );
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2571,12 +2718,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
       },
     ]);
   }
@@ -2607,14 +2759,13 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/(?!.*api).*$',
@@ -2689,6 +2840,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2703,10 +2855,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2722,6 +2881,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2736,10 +2896,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2761,6 +2928,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, pkg, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2770,10 +2938,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2792,14 +2967,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2811,6 +2993,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2820,10 +3003,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2841,14 +3031,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2862,14 +3059,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, { functions, ...options });
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2897,14 +3101,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
 
@@ -2945,6 +3156,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2959,10 +3171,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -2978,6 +3197,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2992,10 +3212,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -3017,6 +3244,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, pkg, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3026,10 +3254,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -3041,14 +3276,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -3060,6 +3302,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3069,10 +3312,17 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -3090,14 +3340,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }
@@ -3111,14 +3368,21 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
+      errorRoutes,
     } = await detectBuilders(files, null, { functions, ...options });
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-        continue: true,
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404',
       },
     ]);
   }

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -2012,7 +2012,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
   });
 
-  it('RedwoodJS should allow usage of non-js API', async () => {
+  it('RedwoodJS should allow usage of non-js API and not add 404 api route', async () => {
     const files = [...redwoodFiles, 'api/golang.go', 'api/python.py'].sort();
     const projectSettings = {
       framework: 'redwoodjs',
@@ -2062,10 +2062,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
     expect(rewriteRoutes).toStrictEqual([]);
     expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
       {
         status: 404,
         src: '^/(?!.*api).*$',

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -948,9 +948,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
     expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![1] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('no package.json + no build + raw static + api', async () => {
@@ -975,9 +984,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
     expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('package.json + no build + root + api', async () => {
@@ -1017,9 +1035,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(redirectRoutes).toStrictEqual([]);
     expect(rewriteRoutes!.length).toBe(1);
     expect((rewriteRoutes![0] as Source).src).toBe('^/api/([^/]+)/([^/]+)$');
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('api + next + public', async () => {
@@ -1502,9 +1529,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![1].use).toBe('@vercel/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
     expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('functions with nextjs', async () => {
@@ -1897,9 +1933,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
     expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![1] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('Framework with non-package.json entrypoint', async () => {
@@ -2098,9 +2143,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       },
     ]);
     expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes!.length).toBe(2);
-    expect((errorRoutes![0] as Source).status).toBe(404);
-    expect((errorRoutes![1] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        dest: '/_vc_no_match_',
+      },
+      {
+        status: 404,
+        src: '^/(?!.*api).*$',
+        dest: '/404.html',
+      },
+    ]);
   });
 
   it('Error for non-api functions', async () => {

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -55,6 +55,7 @@ export async function devRouter(
   missRoutes?: Route[],
   phase?: HandleValue | null
 ): Promise<RouteResult> {
+  console.log('Phase routing: ' + phase || 'null');
   let result: RouteResult | undefined;
   let { query, pathname: reqPathname = '/' } = url.parse(reqUrl, true);
   const combinedHeaders: HttpHeadersConfig = { ...previousHeaders };

--- a/packages/now-cli/src/util/dev/router.ts
+++ b/packages/now-cli/src/util/dev/router.ts
@@ -55,7 +55,6 @@ export async function devRouter(
   missRoutes?: Route[],
   phase?: HandleValue | null
 ): Promise<RouteResult> {
-  console.log('Phase routing: ' + phase || 'null');
   let result: RouteResult | undefined;
   let { query, pathname: reqPathname = '/' } = url.parse(reqUrl, true);
   const combinedHeaders: HttpHeadersConfig = { ...previousHeaders };

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1487,6 +1487,7 @@ export default class DevServer {
           [],
           'error'
         );
+        const { matched_route } = routeResultForError;
 
         const matchForError = await findBuildMatch(
           this.buildMatches,
@@ -1497,9 +1498,27 @@ export default class DevServer {
         );
 
         if (matchForError) {
-          // error phase only applies if the file was found
+          this.output.debug(
+            `Route match detected in error phase, breaking loop`
+          );
           routeResult = routeResultForError;
           match = matchForError;
+        } else if (matched_route && matched_route.src && !matched_route.dest) {
+          this.output.debug(
+            'Route without `dest` detected in error phase, attempting to exit early'
+          );
+          if (
+            await this.exitWithStatus(
+              matchForError,
+              routeResultForError,
+              'error',
+              req,
+              res,
+              nowRequestId
+            )
+          ) {
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
This PR does a few things:

- Consolidates build-utils to use both 404 routes in `handle: error` phase
- Fixes `vc dev` to process `handle: error` phase after the `handle: filesystem` phase
- Updates `/api` 404 route to be excluded for frameworks like RedwoodJS which use their own functions