### PR TITLE
[next] Add test case for root optional revalidate params

### DIFF
--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
@@ -18,7 +18,7 @@ module.exports = function (ctx) {
     const props = await getProps('/', { params: {} });
     expect(props.params).toEqual({});
 
-    await waitFor(1000);
+    await waitFor(2000);
     await getProps('/');
 
     const newProps = await getProps('/', { params: {} });
@@ -30,7 +30,7 @@ module.exports = function (ctx) {
     const props = await getProps('/index');
     expect(props.params).toEqual({});
 
-    await waitFor(1000);
+    await waitFor(2000);
     await getProps('/index');
 
     const newProps = await getProps('/index');
@@ -42,7 +42,7 @@ module.exports = function (ctx) {
     const props = await getProps('/a');
     expect(props.params).toEqual({ slug: ['a'] });
 
-    await waitFor(1000);
+    await waitFor(2000);
     await getProps('/a');
 
     const newProps = await getProps('/a');
@@ -54,7 +54,7 @@ module.exports = function (ctx) {
     const props = await getProps('/hello/world');
     expect(props.params).toEqual({ slug: ['hello', 'world'] });
 
-    await waitFor(1000);
+    await waitFor(2000);
     await getProps('/hello/world');
 
     const newProps = await getProps('/hello/world');

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+const fetch = require('node-fetch');
+const cheerio = require('cheerio');
+
+const waitFor = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+module.exports = function (ctx) {
+  const getProps = async path => {
+    const html = await fetch(`${ctx.deploymentUrl}/${path}`).then(res =>
+      res.text()
+    );
+
+    const $ = cheerio.load(html);
+    return JSON.parse($('#props').text());
+  };
+
+  it('should render / correctly', async () => {
+    const props = await getProps('/', { params: {} });
+    expect(props.params).toEqual({});
+
+    await waitFor(1000);
+    await getProps('/');
+
+    const newProps = await getProps('/', { params: {} });
+    expect(newProps.params).toEqual({});
+    expect(props.random).not.toBe(newProps.random);
+  });
+
+  it('should render /index correctly', async () => {
+    const props = await getProps('/index');
+    expect(props.params).toEqual({});
+
+    await waitFor(1000);
+    await getProps('/index');
+
+    const newProps = await getProps('/index');
+    expect(newProps.params).toEqual({});
+    expect(props.random).not.toBe(newProps.random);
+  });
+
+  it('should render /a correctly', async () => {
+    const props = await getProps('/a');
+    expect(props.params).toEqual({ slug: ['a'] });
+
+    await waitFor(1000);
+    await getProps('/a');
+
+    const newProps = await getProps('/a');
+    expect(newProps.params).toEqual({ slug: ['a'] });
+    expect(props.random).not.toBe(newProps.random);
+  });
+
+  it('should render /hello/world correctly', async () => {
+    const props = await getProps('/hello/world');
+    expect(props.params).toEqual({ slug: ['hello', 'world'] });
+
+    await waitFor(1000);
+    await getProps('/hello/world');
+
+    const newProps = await getProps('/hello/world');
+    expect(newProps.params).toEqual({ slug: ['hello', 'world'] });
+    expect(props.random).not.toBe(newProps.random);
+  });
+};

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
@@ -26,18 +26,6 @@ module.exports = function (ctx) {
     expect(props.random).not.toBe(newProps.random);
   });
 
-  it('should render /index correctly', async () => {
-    const props = await getProps('/index');
-    expect(props.params).toEqual({});
-
-    await waitFor(2000);
-    await getProps('/index');
-
-    const newProps = await getProps('/index');
-    expect(newProps.params).toEqual({});
-    expect(props.random).not.toBe(newProps.random);
-  });
-
   it('should render /a correctly', async () => {
     const props = await getProps('/a');
     expect(props.params).toEqual({ slug: ['a'] });

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/now.json
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/now.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/non-existent",
+      "status": 404
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/package.json
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/pages/[[...slug]].js
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/pages/[[...slug]].js
@@ -1,0 +1,24 @@
+export default function Home(props) {
+  return <pre id="props">{JSON.stringify(props)}</pre>;
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [
+      { params: { slug: false } },
+      { params: { slug: ['a'] } },
+      { params: { slug: ['hello', 'world'] } },
+    ],
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      random: Math.random(),
+    },
+    revalidate: 1,
+  };
+}


### PR DESCRIPTION
This adds test cases from https://github.com/vercel/next.js/pull/16451 which are currently failing and will pass after a new canary of Next.js has been published