### PR TITLE
[build-utils] Fix framework "Other" with Next.js for old projects

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -26,6 +26,7 @@ interface Options {
     devCommand?: string | null;
     buildCommand?: string | null;
     outputDirectory?: string | null;
+    createdAt?: number;
   };
   cleanUrls?: boolean;
   trailingSlash?: boolean;
@@ -434,6 +435,7 @@ function detectFrontBuilder(
 ): Builder {
   const { tag, projectSettings = {} } = options;
   const withTag = tag ? `@${tag}` : '';
+  const { createdAt = 0 } = projectSettings;
   let { framework } = projectSettings;
 
   const config: Config = {
@@ -456,7 +458,7 @@ function detectFrontBuilder(
     config.outputDirectory = projectSettings.outputDirectory;
   }
 
-  if (pkg && framework !== null) {
+  if (pkg && (framework !== null || createdAt < Date.parse('2020-03-01'))) {
     const deps: PackageJson['dependencies'] = {
       ...pkg.dependencies,
       ...pkg.devDependencies,

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1112,7 +1112,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
   });
 
-  it('Using "Other" framework with Storybook should NOT autodetect Next.js', async () => {
+  it('Using "Other" framework with Storybook should NOT autodetect Next.js for new projects', async () => {
     const pkg = {
       scripts: {
         dev: 'next dev',
@@ -1136,6 +1136,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const projectSettings = {
       framework: null, // Selected "Other" framework
       buildCommand: 'yarn build-storybook',
+      createdAt: Date.parse('2020-07-01'),
     };
 
     const { builders, errorRoutes } = await detectBuilders(files, pkg, {
@@ -1160,6 +1161,41 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         dest: '/404.html',
       },
     ]);
+  });
+
+  it('Using "Other" framework should autodetect Next.js for old projects', async () => {
+    const pkg = {
+      scripts: {
+        dev: 'next dev',
+        build: 'next build',
+      },
+      dependencies: {
+        next: '9.3.5',
+        react: '16.13.1',
+        'react-dom': '16.13.1',
+      },
+    };
+    const files = ['package.json', 'pages/api/foo.js', 'index.html'];
+    const projectSettings = {
+      framework: null, // Selected "Other" framework
+      createdAt: Date.parse('2020-02-01'),
+    };
+
+    const { builders, errorRoutes } = await detectBuilders(files, pkg, {
+      projectSettings,
+      featHandleMiss,
+    });
+
+    expect(builders).toEqual([
+      {
+        use: '@vercel/next',
+        src: 'package.json',
+        config: {
+          zeroConfig: true,
+        },
+      },
+    ]);
+    expect(errorRoutes).toStrictEqual([]);
   });
 
   it('api + raw static', async () => {


### PR DESCRIPTION
Since released PR #5009, we had some users that depend on the broken behavior. This adds an arbitrary date so that old projects will use the old broken behavior, and new projects will use the new behavior from #5009.

The reason for the date is that we don't want to force users to create new projects who noticed this broken behavior months ago like this discussion: https://github.com/vercel/vercel/discussions/4138

Its better to be a bit aggressive and set the date far back because users with that want the old behavior have a workaround: select Next.js in the framework dropdown. However, users that want the new behavior with an old project will be stuck without a solution.