### PR TITLE
Revert "[build-utils] Use `handle: error` for api 404"

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -972,6 +972,7 @@ function getRouteResult(
       }
 
       rewriteRoutes.push(...dynamicRoutes);
+
       if (typeof ignoreRuntimes === 'undefined') {
         // This route is only necessary to hide the directory listing
         // to avoid enumerating serverless function names.

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -931,10 +931,11 @@ function getRouteResult(
   const redirectRoutes: Route[] = [];
   const rewriteRoutes: Route[] = [];
   const errorRoutes: Route[] = [];
-  const framework = frontendBuilder?.config?.framework || '';
-  const use = frontendBuilder?.use || '';
-  const isNextjs = framework === 'nextjs' || use.startsWith('@vercel/next');
-  const ignoreRuntimes = slugToFramework.get(framework)?.ignoreRuntimes;
+  const isNextjs =
+    frontendBuilder &&
+    ((frontendBuilder.use && frontendBuilder.use.startsWith('@vercel/next')) ||
+      (frontendBuilder.config &&
+        frontendBuilder.config.framework === 'nextjs'));
 
   if (apiRoutes && apiRoutes.length > 0) {
     if (options.featHandleMiss) {
@@ -972,17 +973,11 @@ function getRouteResult(
       }
 
       rewriteRoutes.push(...dynamicRoutes);
-
-      if (typeof ignoreRuntimes === 'undefined') {
-        // This route is only necessary to hide the directory listing
-        // to avoid enumerating serverless function names.
-        // But it causes issues in `vc dev` for frameworks that handle
-        // their own functions such as redwood, so we ignore.
-        errorRoutes.push({
-          status: 404,
-          src: '^/api(/.*)?$',
-        });
-      }
+      rewriteRoutes.push({
+        src: '^/api(/.*)?$',
+        status: 404,
+        continue: true,
+      });
     } else {
       defaultRoutes.push(...apiRoutes);
 

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -931,11 +931,10 @@ function getRouteResult(
   const redirectRoutes: Route[] = [];
   const rewriteRoutes: Route[] = [];
   const errorRoutes: Route[] = [];
-  const isNextjs =
-    frontendBuilder &&
-    ((frontendBuilder.use && frontendBuilder.use.startsWith('@vercel/next')) ||
-      (frontendBuilder.config &&
-        frontendBuilder.config.framework === 'nextjs'));
+  const framework = frontendBuilder?.config?.framework || '';
+  const use = frontendBuilder?.use || '';
+  const isNextjs = framework === 'nextjs' || use.startsWith('@vercel/next');
+  const ignoreRuntimes = slugToFramework.get(framework)?.ignoreRuntimes;
 
   if (apiRoutes && apiRoutes.length > 0) {
     if (options.featHandleMiss) {
@@ -973,11 +972,17 @@ function getRouteResult(
       }
 
       rewriteRoutes.push(...dynamicRoutes);
-      rewriteRoutes.push({
-        src: '^/api(/.*)?$',
-        status: 404,
-        continue: true,
-      });
+      if (typeof ignoreRuntimes === 'undefined') {
+        // This route is only necessary to hide the directory listing
+        // to avoid enumerating serverless function names.
+        // But it causes issues in `vc dev` for frameworks that handle
+        // their own functions such as redwood, so we ignore.
+        rewriteRoutes.push({
+          src: '^/api(/.*)?$',
+          status: 404,
+          continue: true,
+        });
+      }
     } else {
       defaultRoutes.push(...apiRoutes);
 

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1941,7 +1941,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
   });
 
-  it('RedwoodJS should allow usage of non-js API', async () => {
+  it('RedwoodJS should allow usage of non-js API and not add 404 api route', async () => {
     const files = [...redwoodFiles, 'api/golang.go', 'api/python.py'].sort();
     const projectSettings = {
       framework: 'redwoodjs',

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -947,18 +947,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('no package.json + no build + raw static + api', async () => {
@@ -982,18 +974,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('package.json + no build + root + api', async () => {
@@ -1031,19 +1015,11 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes!.length).toBe(1);
+    expect(rewriteRoutes!.length).toBe(2);
     expect((rewriteRoutes![0] as Source).src).toBe('^/api/([^/]+)/([^/]+)$');
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect((rewriteRoutes![1] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('api + next + public', async () => {
@@ -1070,13 +1046,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([]);
   });
 
   it('api + next + raw static', async () => {
@@ -1103,13 +1075,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes).toStrictEqual([]);
   });
 
   it('Using "Other" framework with Storybook should NOT autodetect Next.js for new projects', async () => {
@@ -1154,13 +1122,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         },
       },
     ]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('Using "Other" framework should autodetect Next.js for old projects', async () => {
@@ -1218,18 +1181,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('api + raw static + package.json no build script', async () => {
@@ -1256,18 +1211,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('api + public', async () => {
@@ -1286,17 +1233,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![1].use).toBe('@vercel/static');
     expect(builders![1].src).toBe('public/**/*');
     expect(builders!.length).toBe(2);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('api go with test files', async () => {
@@ -1315,27 +1253,13 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       'api/src/controllers/user.module_test.go',
     ];
 
-    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      undefined,
-      {
-        featHandleMiss,
-      }
-    );
+    const { builders, errorRoutes } = await detectBuilders(files, undefined, {
+      featHandleMiss,
+    });
     expect(builders!.length).toBe(7);
     expect(builders!.some(b => b.src.endsWith('_test.go'))).toBe(false);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('just public', async () => {
@@ -1412,17 +1336,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('api/[endpoint].js');
     expect(builders!.length).toBe(1);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('package.json with no build + public directory', async () => {
@@ -1541,31 +1456,17 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
   it('many static files + one api file', async () => {
     const files = Array.from({ length: 5000 }).map((_, i) => `file${i}.html`);
     files.push('api/index.ts');
-    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      undefined,
-      {
-        featHandleMiss,
-      }
-    );
+    const { builders, errorRoutes } = await detectBuilders(files, undefined, {
+      featHandleMiss,
+    });
 
     expect(builders!.length).toBe(2);
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('api/index.ts');
     expect(builders![1].use).toBe('@vercel/static');
     expect(builders![1].src).toBe('!{api/**,package.json}');
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('functions with nextjs', async () => {
@@ -1957,18 +1858,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect((defaultRoutes![0] as Handler).handle).toBe('miss');
     expect((defaultRoutes![1] as Source).dest).toBe('/api/$1');
     expect(redirectRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(rewriteRoutes!.length).toBe(1);
+    expect((rewriteRoutes![0] as Source).status).toBe(404);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('Framework with non-package.json entrypoint', async () => {
@@ -2048,7 +1941,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
   });
 
-  it('RedwoodJS should allow usage of non-js API and not add 404 api route', async () => {
+  it('RedwoodJS should allow usage of non-js API', async () => {
     const files = [...redwoodFiles, 'api/golang.go', 'api/python.py'].sort();
     const projectSettings = {
       framework: 'redwoodjs',
@@ -2096,7 +1989,13 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
+    expect(rewriteRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+        continue: true,
+      },
+    ]);
     expect(errorRoutes).toStrictEqual([
       {
         status: 404,
@@ -2135,14 +2034,10 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     const files = ['config.rb', 'api/date.rb'];
     const projectSettings = { framework: 'middleman' };
 
-    const { builders, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        projectSettings,
-        featHandleMiss,
-      }
-    );
+    const { builders, errorRoutes } = await detectBuilders(files, null, {
+      projectSettings,
+      featHandleMiss,
+    });
 
     expect(builders).toEqual([
       {
@@ -2161,18 +2056,8 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         },
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
-      },
-    ]);
+    expect(errorRoutes!.length).toBe(1);
+    expect((errorRoutes![0] as Source).status).toBe(404);
   });
 
   it('Error for non-api functions', async () => {
@@ -2426,12 +2311,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
+        continue: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/(?!.*api).*$',
@@ -2439,8 +2326,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       },
     ]);
 
-    const apiPattern = new RegExp(errorRoutes![0].src!);
-    const customPattern = new RegExp(errorRoutes![1].src!);
+    const pattern = new RegExp(errorRoutes![0].src!);
 
     [
       '/',
@@ -2454,8 +2340,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       '/another/sub/page.html',
       '/another/sub/page',
     ].forEach(file => {
-      expect(file).not.toMatch(apiPattern);
-      expect(file).toMatch(customPattern);
+      expect(file).toMatch(pattern);
     });
 
     [
@@ -2469,8 +2354,7 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       '/api/sub/page.html',
       '/api/sub/page',
     ].forEach(file => {
-      expect(file).toMatch(apiPattern);
-      expect(file).not.toMatch(customPattern);
+      expect(file).not.toMatch(pattern);
     });
   }
 
@@ -2508,13 +2392,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/[endpoint].js', 'api/[endpoint]/[id].js'];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2534,16 +2414,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2555,13 +2429,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       'api/[endpoint]/[id].js',
     ];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2582,16 +2452,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2609,13 +2473,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
 
     const files = ['public/index.html', 'api/[endpoint].js'];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      pkg,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, pkg, {
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2630,16 +2490,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2656,13 +2510,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/date/index.js', 'api/date.js'];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2671,16 +2521,12 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2688,13 +2534,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   {
     const files = ['api/date.js', 'api/[date]/index.js'];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2709,16 +2551,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2732,13 +2568,9 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
       'api/food.ts',
       'api/ts/gold.ts',
     ];
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
 
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
@@ -2748,16 +2580,12 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2767,14 +2595,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
     const functions = { 'api/user.php': { runtime: 'vercel-php@0.1.0' } };
     const files = ['api/user.php'];
 
-    const { defaultRoutes, rewriteRoutes, errorRoutes } = await detectBuilders(
-      files,
-      null,
-      {
-        functions,
-        featHandleMiss,
-      }
-    );
+    const { defaultRoutes, rewriteRoutes } = await detectBuilders(files, null, {
+      functions,
+      featHandleMiss,
+    });
     expect(defaultRoutes).toStrictEqual([
       { handle: 'miss' },
       {
@@ -2783,16 +2607,12 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404.html',
+        continue: true,
       },
     ]);
   }
@@ -2823,12 +2643,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
+        continue: true,
       },
+    ]);
+    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/(?!.*api).*$',
@@ -2903,7 +2725,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2918,16 +2739,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -2943,7 +2758,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2958,16 +2772,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -2989,7 +2797,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, pkg, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -2999,16 +2806,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3027,20 +2828,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3052,7 +2847,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3062,16 +2856,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3089,20 +2877,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3116,20 +2898,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`', async () 
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, { functions, ...options });
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3157,20 +2933,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
 
@@ -3211,7 +2981,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3226,16 +2995,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3251,7 +3014,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3266,16 +3028,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3297,7 +3053,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, pkg, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3307,16 +3062,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[endpoint]?endpoint=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3328,20 +3077,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3353,7 +3096,6 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
@@ -3363,16 +3105,10 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
         dest: '/api/[date]/index?date=$1',
         check: true,
       },
-    ]);
-    expect(errorRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3390,20 +3126,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, options);
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }
@@ -3417,20 +3147,14 @@ it('Test `detectRoutes` with `featHandleMiss=true`, `cleanUrls=true`, `trailingS
       defaultRoutes,
       redirectRoutes,
       rewriteRoutes,
-      errorRoutes,
     } = await detectBuilders(files, null, { functions, ...options });
     testHeaders(redirectRoutes);
     expect(defaultRoutes).toStrictEqual([]);
-    expect(rewriteRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([
+    expect(rewriteRoutes).toStrictEqual([
       {
         status: 404,
         src: '^/api(/.*)?$',
-      },
-      {
-        status: 404,
-        src: '^/(?!.*api).*$',
-        dest: '/404',
+        continue: true,
       },
     ]);
   }

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -1989,13 +1989,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
         check: true,
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-        continue: true,
-      },
-    ]);
+    expect(rewriteRoutes).toStrictEqual([]);
     expect(errorRoutes).toStrictEqual([
       {
         status: 404,

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1475,39 +1475,57 @@ export default class DevServer {
         routeResult.status = prevStatus;
       }
 
-      if (!match && errorRoutes.length > 0) {
-        // error phase
-        const routeResultForError = await devRouter(
-          getReqUrl(routeResult),
-          req.method,
-          errorRoutes,
-          this,
-          nowConfig,
-          routeResult.headers,
-          [],
-          'error'
-        );
-
-        const matchForError = await findBuildMatch(
-          this.buildMatches,
-          this.files,
-          routeResultForError.dest,
-          this,
-          nowConfig
-        );
-
-        if (matchForError) {
-          // error phase only applies if the file was found
-          routeResult = routeResultForError;
-          match = matchForError;
-        }
-      }
-
       statusCode = routeResult.status;
 
       if (match) {
         // end the phase
         break;
+      }
+    }
+
+    if (!match && routeResult && errorRoutes.length > 0) {
+      // error phase
+      const routeResultForError = await devRouter(
+        getReqUrl(routeResult),
+        req.method,
+        errorRoutes,
+        this,
+        nowConfig,
+        routeResult.headers,
+        [],
+        'error'
+      );
+      const { matched_route } = routeResultForError;
+
+      const matchForError = await findBuildMatch(
+        this.buildMatches,
+        this.files,
+        routeResultForError.dest,
+        this,
+        nowConfig
+      );
+
+      if (matchForError) {
+        debug(`Route match detected in error phase, breaking loop`);
+        routeResult = routeResultForError;
+        statusCode = routeResultForError.status;
+        match = matchForError;
+      } else if (matched_route && matched_route.src && !matched_route.dest) {
+        debug(
+          'Route without `dest` detected in error phase, attempting to exit early'
+        );
+        if (
+          await this.exitWithStatus(
+            matchForError,
+            routeResultForError,
+            'error',
+            req,
+            res,
+            nowRequestId
+          )
+        ) {
+          return;
+        }
       }
     }
 

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -1475,57 +1475,39 @@ export default class DevServer {
         routeResult.status = prevStatus;
       }
 
+      if (!match && errorRoutes.length > 0) {
+        // error phase
+        const routeResultForError = await devRouter(
+          getReqUrl(routeResult),
+          req.method,
+          errorRoutes,
+          this,
+          nowConfig,
+          routeResult.headers,
+          [],
+          'error'
+        );
+
+        const matchForError = await findBuildMatch(
+          this.buildMatches,
+          this.files,
+          routeResultForError.dest,
+          this,
+          nowConfig
+        );
+
+        if (matchForError) {
+          // error phase only applies if the file was found
+          routeResult = routeResultForError;
+          match = matchForError;
+        }
+      }
+
       statusCode = routeResult.status;
 
       if (match) {
         // end the phase
         break;
-      }
-    }
-
-    if (!match && routeResult && errorRoutes.length > 0) {
-      // error phase
-      const routeResultForError = await devRouter(
-        getReqUrl(routeResult),
-        req.method,
-        errorRoutes,
-        this,
-        nowConfig,
-        routeResult.headers,
-        [],
-        'error'
-      );
-      const { matched_route } = routeResultForError;
-
-      const matchForError = await findBuildMatch(
-        this.buildMatches,
-        this.files,
-        routeResultForError.dest,
-        this,
-        nowConfig
-      );
-
-      if (matchForError) {
-        debug(`Route match detected in error phase, breaking loop`);
-        routeResult = routeResultForError;
-        statusCode = routeResultForError.status;
-        match = matchForError;
-      } else if (matched_route && matched_route.src && !matched_route.dest) {
-        debug(
-          'Route without `dest` detected in error phase, attempting to exit early'
-        );
-        if (
-          await this.exitWithStatus(
-            matchForError,
-            routeResultForError,
-            'error',
-            req,
-            res,
-            nowRequestId
-          )
-        ) {
-          return;
-        }
       }
     }
 


### PR DESCRIPTION
Reverts #5064 but only the `build-utils` changes for `handle: error`. This leaves the changes to CLI and Redwood ignore.

This is because the `handle: error` phase does not actually disable the directory listing so we need to continue using a rewrite to handle this case.