### PR TITLE
[cli] Fix domains ls pagination

### DIFF
--- a/packages/now-cli/src/commands/domains/ls.ts
+++ b/packages/now-cli/src/commands/domains/ls.ts
@@ -66,7 +66,10 @@ export default async function ls(
 
   const cancelWait = wait(`Fetching Domains under ${chalk.bold(contextName)}`);
 
-  const { domains, pagination } = await getDomains(client).finally(() => {
+  const { domains, pagination } = await getDomains(
+    client,
+    nextTimestamp
+  ).finally(() => {
     cancelWait();
   });
 


### PR DESCRIPTION
Fixes pagination for vercel cli `domains ls --next <timestamp>` 
