### PR TITLE
[cli] Improve startup perf - disable source maps and minification

### DIFF
--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -49,16 +49,7 @@ async function main() {
   // Do the initial `ncc` build
   console.log();
   const src = join(dirRoot, 'src');
-  const args = [
-    '@zeit/ncc',
-    'build',
-    '--source-map',
-    '--external',
-    'update-notifier',
-  ];
-  if (!isDev) {
-    args.push('--minify');
-  }
+  const args = ['@zeit/ncc', 'build', '--external', 'update-notifier'];
   args.push(src);
   await execa('npx', args, { stdio: 'inherit' });
 

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -50,6 +50,9 @@ async function main() {
   console.log();
   const src = join(dirRoot, 'src');
   const args = ['@zeit/ncc', 'build', '--external', 'update-notifier'];
+  if (isDev) {
+    args.push('--source-map');
+  }
   args.push(src);
   await execa('npx', args, { stdio: 'inherit' });
 


### PR DESCRIPTION
Currently on my machine, `vercel --version` takes 850ms to run. With this change, that execution time is reduced to ~550ms.

The reason is that source maps seem to significantly slow down Node.js execution, compounded by the size of the source map, even if it is not used.

I believe the benefits of this perf improvement outweigh the direct source maps and minification benefits.

If it is felt that direct per-file source maps are necessary for internal errors, then reducing the source map size should be investigated further to improve the runtime performance here.