### PR TITLE
[all] Bump ncc to 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "2.0.0",
     "@typescript-eslint/parser": "2.0.0",
-    "@zeit/ncc": "0.20.4",
+    "@vercel/ncc": "0.24.0",
     "async-retry": "1.2.3",
     "buffer-replace": "1.0.0",
     "cheerio": "1.0.0-rc.3",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/build-utils",
-  "version": "2.5.1-canary.1",
+  "version": "2.5.1-canary.0",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",
@@ -30,6 +30,7 @@
     "@types/semver": "6.0.0",
     "@types/yazl": "^2.4.1",
     "@vercel/frameworks": "0.1.0",
+    "@vercel/ncc": "0.24.0",
     "aggregate-error": "3.0.1",
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/now-build-utils/package.json
+++ b/packages/now-build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/build-utils",
-  "version": "2.5.1-canary.0",
+  "version": "2.5.1-canary.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -101,6 +101,7 @@
     "@types/which": "1.3.2",
     "@types/write-json-file": "2.2.1",
     "@vercel/frameworks": "0.1.0",
+    "@vercel/ncc": "0.24.0",
     "@zeit/fun": "0.11.2",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.12.2",

--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -102,7 +102,6 @@
     "@types/write-json-file": "2.2.1",
     "@vercel/frameworks": "0.1.0",
     "@zeit/fun": "0.11.2",
-    "@zeit/ncc": "0.18.5",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.12.2",
     "alpha-sort": "2.0.1",

--- a/packages/now-cli/scripts/build.ts
+++ b/packages/now-cli/scripts/build.ts
@@ -49,12 +49,12 @@ async function main() {
   // Do the initial `ncc` build
   console.log();
   const src = join(dirRoot, 'src');
-  const args = ['@zeit/ncc', 'build', '--external', 'update-notifier'];
+  const args = ['ncc', 'build', '--external', 'update-notifier'];
   if (isDev) {
     args.push('--source-map');
   }
   args.push(src);
-  await execa('npx', args, { stdio: 'inherit' });
+  await execa('yarn', args, { stdio: 'inherit' });
 
   // `ncc` has some issues with `@zeit/fun`'s runtime files:
   //   - Executable bits on the `bootstrap` files appear to be lost:

--- a/packages/now-client/package.json
+++ b/packages/now-client/package.json
@@ -26,7 +26,6 @@
     "@types/node": "12.0.4",
     "@types/node-fetch": "2.5.4",
     "@types/recursive-readdir": "2.2.0",
-    "@zeit/ncc": "0.18.5",
     "typescript": "3.9.3"
   },
   "jest": {

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/go",
-  "version": "1.1.6-canary.0",
+  "version": "1.1.5",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/go",
@@ -25,6 +25,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "^4.0.0",
+    "@vercel/ncc": "0.24.0",
     "async-retry": "1.3.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",

--- a/packages/now-go/package.json
+++ b/packages/now-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/go",
-  "version": "1.1.5",
+  "version": "1.1.6-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/go",

--- a/packages/now-node/@types/zeit__ncc/index.d.ts
+++ b/packages/now-node/@types/zeit__ncc/index.d.ts
@@ -40,6 +40,6 @@ declare namespace ncc {
   }
 }
 
-declare module '@zeit/ncc' {
+declare module '@vercel/ncc' {
   export = ncc;
 }

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -32,6 +32,7 @@
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
+    "@vercel/ncc": "0.24.0",
     "@zeit/node-file-trace": "0.8.2",
     "content-type": "1.0.4",
     "cookie": "0.4.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -32,7 +32,6 @@
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
-    "@zeit/ncc": "0.20.4",
     "@zeit/node-file-trace": "0.8.2",
     "content-type": "1.0.4",
     "cookie": "0.4.0",

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/python",
-  "version": "1.2.3-canary.0",
+  "version": "1.2.2",
   "main": "./dist/index.js",
   "license": "MIT",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/python",
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@types/execa": "^0.9.0",
+    "@vercel/ncc": "0.24.0",
     "execa": "^1.0.0",
     "typescript": "3.9.3"
   }

--- a/packages/now-python/package.json
+++ b/packages/now-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/python",
-  "version": "1.2.2",
+  "version": "1.2.3-canary.0",
   "main": "./dist/index.js",
   "license": "MIT",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/python",

--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vercel/ruby",
   "author": "Nathan Cahill <nathan@nathancahill.com>",
-  "version": "1.2.3",
+  "version": "1.2.4-canary.0",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/ruby",

--- a/packages/now-ruby/package.json
+++ b/packages/now-ruby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vercel/ruby",
   "author": "Nathan Cahill <nathan@nathancahill.com>",
-  "version": "1.2.4-canary.0",
+  "version": "1.2.3",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/ruby",
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/fs-extra": "8.0.0",
     "@types/semver": "6.0.0",
+    "@vercel/ncc": "0.24.0",
     "execa": "2.0.4",
     "fs-extra": "^7.0.1",
     "semver": "6.1.1",

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@vercel/static-build",
-  "version": "0.17.7",
+  "version": "0.17.8-canary.0",
   "license": "MIT",
   "main": "./dist/index",
-  "homepage": "https://vercel.com/docs/runtimes#official-runtimes/static-builds",
+  "homepage": "https://vercel.com/docs/build-step",
   "files": [
     "dist"
   ],

--- a/packages/now-static-build/package.json
+++ b/packages/now-static-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/static-build",
-  "version": "0.17.8-canary.0",
+  "version": "0.17.7",
   "license": "MIT",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/build-step",
@@ -23,6 +23,7 @@
     "@types/ms": "0.7.31",
     "@types/node-fetch": "2.5.4",
     "@types/promise-timeout": "1.3.0",
+    "@vercel/ncc": "0.24.0",
     "get-port": "5.0.0",
     "is-port-reachable": "2.0.1",
     "ms": "2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,6 +2216,11 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@vercel/ncc@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
+  integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
+
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"
@@ -2276,16 +2281,6 @@
     uuid "3.3.2"
     xdg-app-paths "5.1.0"
     yauzl-promise "2.1.3"
-
-"@zeit/ncc@0.18.5":
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.18.5.tgz#5687df6c32f1a2e2486aa110b3454ccebda4fb9c"
-  integrity sha512-F+SbvEAh8rchiRXqQbmD1UmbePY7dCOKTbvfFtbVbK2xMH/tyri5YKfNxXKK7eL9EWkkbqB3NTVQO6nokApeBA==
-
-"@zeit/ncc@0.20.4":
-  version "0.20.4"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
-  integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
 
 "@zeit/node-file-trace@0.8.2":
   version "0.8.2"


### PR DESCRIPTION
- Bump ncc to [0.24.0](https://github.com/vercel/ncc/releases/tag/0.24.0)
- Install ncc in each package that depends on it