### PR TITLE
Fix missing `readyStateAt` error

### DIFF
--- a/packages/now-cli/src/commands/inspect.js
+++ b/packages/now-cli/src/commands/inspect.js
@@ -164,7 +164,8 @@ export default async function main(ctx) {
 
     for (const build of builds) {
       const { id, createdAt, readyStateAt } = build;
-      times[id] = createdAt ? elapsed(readyStateAt - createdAt) : null;
+      times[id] =
+        createdAt && readyStateAt ? elapsed(readyStateAt - createdAt) : null;
     }
 
     print(chalk.bold('  Builds\n\n'));


### PR DESCRIPTION
Ensure the API response without `readyStateAt` doesn't cause an error