### PR TITLE
[cli] Add support for the sourceFilesOutsideRootDirectory option

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -276,6 +276,7 @@ export default async function main(
   let { org, project, status } = link;
   let newProjectName = null;
   let rootDirectory = project ? project.rootDirectory : null;
+  let sourceFilesOutsideRootDirectory = true;
 
   if (status === 'not_linked') {
     const shouldStartSetup =
@@ -333,6 +334,7 @@ export default async function main(
     } else {
       project = projectOrNewProjectName;
       rootDirectory = project.rootDirectory;
+      sourceFilesOutsideRootDirectory = project.sourceFilesOutsideRootDirectory;
 
       // we can already link the project
       await linkFolderToProject(
@@ -349,7 +351,13 @@ export default async function main(
     }
   }
 
-  const sourcePath = rootDirectory ? join(path, rootDirectory) : path;
+  // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
+  // and upload the entire directory.
+  const sourcePath = rootDirectory
+    ? sourceFilesOutsideRootDirectory
+      ? path
+      : join(path, rootDirectory)
+    : path;
 
   if (
     rootDirectory &&

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -530,6 +530,7 @@ export default async function main(
       deployStamp,
       target,
       skipAutoDetectionConfirmation: autoConfirm,
+      projectSettings: { sourceFilesOutsideRootDirectory },
     };
 
     deployment = await createDeploy(
@@ -551,6 +552,9 @@ export default async function main(
 
       if (rootDirectory) {
         projectSettings.rootDirectory = rootDirectory;
+      }
+      if (sourceFilesOutsideRootDirectory) {
+        projectSettings.sourceFilesOutsideRootDirectory = sourceFilesOutsideRootDirectory;
       }
 
       const settings = await editProjectSettings(

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -530,8 +530,12 @@ export default async function main(
       deployStamp,
       target,
       skipAutoDetectionConfirmation: autoConfirm,
-      projectSettings: { sourceFilesOutsideRootDirectory },
     };
+
+    if (!localConfig.builds || localConfig.builds.length === 0) {
+      // Only add projectSettings for zero config deployments
+      createArgs.projectSettings = { sourceFilesOutsideRootDirectory };
+    }
 
     deployment = await createDeploy(
       output,
@@ -553,7 +557,10 @@ export default async function main(
       if (rootDirectory) {
         projectSettings.rootDirectory = rootDirectory;
       }
-      projectSettings.sourceFilesOutsideRootDirectory = sourceFilesOutsideRootDirectory;
+
+      if (typeof sourceFilesOutsideRootDirectory !== 'undefined') {
+        projectSettings.sourceFilesOutsideRootDirectory = sourceFilesOutsideRootDirectory;
+      }
 
       const settings = await editProjectSettings(
         output,

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -553,9 +553,7 @@ export default async function main(
       if (rootDirectory) {
         projectSettings.rootDirectory = rootDirectory;
       }
-      if (sourceFilesOutsideRootDirectory) {
-        projectSettings.sourceFilesOutsideRootDirectory = sourceFilesOutsideRootDirectory;
-      }
+      projectSettings.sourceFilesOutsideRootDirectory = sourceFilesOutsideRootDirectory;
 
       const settings = await editProjectSettings(
         output,

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -353,11 +353,7 @@ export default async function main(
 
   // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
   // and upload the entire directory.
-  const sourcePath = rootDirectory
-    ? sourceFilesOutsideRootDirectory
-      ? path
-      : join(path, rootDirectory)
-    : path;
+  const sourcePath = (rootDirectory && !sourceFilesOutsideRootDirectory) ? join(path, rootDirectory) : path;
 
   if (
     rootDirectory &&

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -353,7 +353,10 @@ export default async function main(
 
   // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
   // and upload the entire directory.
-  const sourcePath = (rootDirectory && !sourceFilesOutsideRootDirectory) ? join(path, rootDirectory) : path;
+  const sourcePath =
+    rootDirectory && !sourceFilesOutsideRootDirectory
+      ? join(path, rootDirectory)
+      : path;
 
   if (
     rootDirectory &&
@@ -372,7 +375,7 @@ export default async function main(
   // If Root Directory is used we'll try to read the config
   // from there instead and use it if it exists.
   if (rootDirectory) {
-    const rootDirectoryConfig = readLocalConfig(sourcePath);
+    const rootDirectoryConfig = readLocalConfig(join(path, rootDirectory));
 
     if (rootDirectoryConfig) {
       debug(`Read local config from root directory (${rootDirectory})`);

--- a/packages/now-cli/src/util/link/setup-and-link.ts
+++ b/packages/now-cli/src/util/link/setup-and-link.ts
@@ -179,8 +179,12 @@ export default async function setupAndLink(
         deployStamp: stamp(),
         target: undefined,
         skipAutoDetectionConfirmation: false,
-        projectSettings: { sourceFilesOutsideRootDirectory },
       };
+
+      if (!localConfig.builds || localConfig.builds.length === 0) {
+        // Only add projectSettings for zero config deployments
+        createArgs.projectSettings = { sourceFilesOutsideRootDirectory };
+      }
 
       const deployment = await createDeploy(
         output,

--- a/packages/now-cli/src/util/link/setup-and-link.ts
+++ b/packages/now-cli/src/util/link/setup-and-link.ts
@@ -59,6 +59,7 @@ export default async function setupAndLink(
   const isTTY = process.stdout.isTTY;
   const quiet = !isTTY;
   let rootDirectory: string | null = null;
+  let sourceFilesOutsideRootDirectory = true;
   let newProjectName: string;
   let org;
 
@@ -129,7 +130,13 @@ export default async function setupAndLink(
     );
     return { status: 'linked', org, project };
   }
-  const sourcePath = rootDirectory ? join(path, rootDirectory) : path;
+
+  // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
+  // and upload the entire directory.
+  const sourcePath =
+    rootDirectory && !sourceFilesOutsideRootDirectory
+      ? join(path, rootDirectory)
+      : path;
 
   if (
     rootDirectory &&
@@ -172,6 +179,7 @@ export default async function setupAndLink(
         deployStamp: stamp(),
         target: undefined,
         skipAutoDetectionConfirmation: false,
+        projectSettings: { sourceFilesOutsideRootDirectory },
       };
 
       const deployment = await createDeploy(


### PR DESCRIPTION
If the value is set to `true` in the project settings, we don't cd into `rootDirectory`. 
We default it to `true` for new projects.
