### PR TITLE
[tests] Deprecate "now" npm package in favor of "vercel"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 10
+        node-version: 12
     - name: Install
       run: yarn install --check-files --frozen-lockfile
     - name: Build

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -14,7 +14,14 @@ commit="$(git log --format="%H" -n 1)"
 
 tags="$(git show-ref --tags -d | grep ^"$commit" | sed -e 's,.* refs/tags/,,' -e 's/\^{}//')"
 for tag in $tags; do
-  package_dir="$(node "${__dirname}/update-legacy-name.js" "$tag")"
+  str="$(node "${__dirname}/update-legacy-name.js" "$tag")"
+
+  IFS='|' # set delimiter
+  read -ra ADDR <<< "$str" # str is read into an array as tokens separated by IFS
+  package_dir="${ADDR[0]}"
+  old_name="${ADDR[1]}"
+  new_name="${ADDR[2]}"
+  IFS=' ' # reset to default after usage
 
   cd "${__dirname}/../packages/${package_dir}"
 
@@ -25,4 +32,6 @@ for tag in $tags; do
 
   echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
   npm publish $npm_tag
+  echo "Running \`npm deprecate $old_name\` in \"$(pwd)\""
+  npm deprecate "$old_name" "\"$old_name\" is deprecated and will stop receiving updates January 2021. Please use \"$new_name\" instead."
 done

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -34,5 +34,5 @@ for tag in $tags; do
   echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
   npm publish $npm_tag
   echo "Running \`npm deprecate $old_name@$version\` in favor of $new_name"
-  npm deprecate "$old_name@$version" "\"$old_name\" is deprecated and will stop receiving updates January 2021. Please use \"$new_name\" instead."
+  npm deprecate "$old_name@$version" "\"$old_name\" is deprecated and will stop receiving updates on December 31, 2020. Please use \"$new_name\" instead."
 done

--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -21,6 +21,7 @@ for tag in $tags; do
   package_dir="${ADDR[0]}"
   old_name="${ADDR[1]}"
   new_name="${ADDR[2]}"
+  version="${ADDR[3]}"
   IFS=' ' # reset to default after usage
 
   cd "${__dirname}/../packages/${package_dir}"
@@ -32,6 +33,6 @@ for tag in $tags; do
 
   echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
   npm publish $npm_tag
-  echo "Running \`npm deprecate $old_name\` in \"$(pwd)\""
-  npm deprecate "$old_name" "\"$old_name\" is deprecated and will stop receiving updates January 2021. Please use \"$new_name\" instead."
+  echo "Running \`npm deprecate $old_name@$version\` in favor of $new_name"
+  npm deprecate "$old_name@$version" "\"$old_name\" is deprecated and will stop receiving updates January 2021. Please use \"$new_name\" instead."
 done

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -29,7 +29,7 @@ if (!packageDir) {
 
 const pkgJsonPath = join(packagesDir, packageDir, 'package.json');
 const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-const originalName = pkg.name;
+const oldName = pkg.name;
 
 if (pkg.name === '@vercel/client') {
   // The legacy name for `@vercel/client` is `now-client` (global scope)
@@ -42,10 +42,12 @@ if (pkg.name === '@vercel/client') {
   }
 }
 
-console.error(`Updated package name: "${originalName}" -> "${pkg.name}"`);
+const newName = pkg.name;
+console.error(`Updated package name: "${oldName}" -> "${newName}"`);
 
 fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
 // Log the directory name to stdout for the `publish-legacy.sh`
 // script to consume for the `npm publish` that happens next.
-console.log(packageDir);
+const IFS = '|';
+console.log([packageDir, oldName, newName].join(IFS));

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -30,6 +30,7 @@ if (!packageDir) {
 const pkgJsonPath = join(packagesDir, packageDir, 'package.json');
 const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
 const oldName = pkg.name;
+const version = pkg.version;
 
 if (pkg.name === '@vercel/client') {
   // The legacy name for `@vercel/client` is `now-client` (global scope)
@@ -50,4 +51,4 @@ fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
 // Log the directory name to stdout for the `publish-legacy.sh`
 // script to consume for the `npm publish` that happens next.
 const IFS = '|';
-console.log([packageDir, oldName, newName].join(IFS));
+console.log([packageDir, oldName, newName, version].join(IFS));


### PR DESCRIPTION
We deprecated all the `now` scoped packages in favor of the `vercel` equivalents, however the deprecation message disappears after each publish, so we must to run `npm deprecate` after `npm publish` for legacy packages.