### PR TITLE
[next] Optimize page loading for shared lambdas

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1324,7 +1324,7 @@ export const build = async ({
                     ${groupPageKeys
                       .map(
                         page =>
-                          `'${page}': require('./${path.join(
+                          `'${page}': () => require('./${path.join(
                             './',
                             group.pages[page].pageFileName
                           )}')`
@@ -1333,7 +1333,7 @@ export const build = async ({
                     ${
                       '' /*
                       creates a mapping of the page and the page's module e.g.
-                      '/about': require('./.next/serverless/pages/about.js')
+                      '/about': () => require('./.next/serverless/pages/about.js')
                     */
                     }
                   }
@@ -1393,7 +1393,10 @@ export const build = async ({
                     res.statusCode = 500
                     return res.end('internal server error')
                   }
-                  const method = currentPage.render || currentPage.default || currentPage
+
+                  const mod = currentPage()
+                  const method = mod.render || mod.default || mod
+
                   return method(req, res)
                 } catch (err) {
                   console.error('Unhandled error during request:', err)


### PR DESCRIPTION
This updates to prevent loading all pages at once for shared lambdas and waits to require the page when it's needed

Fixes https://github.com/vercel/next.js/issues/16990