### PR TITLE
[tests] Fix deprecation message

### DIFF
--- a/utils/publish-legacy.sh
+++ b/utils/publish-legacy.sh
@@ -19,8 +19,8 @@ for tag in $tags; do
   IFS='|' # set delimiter
   read -ra ADDR <<< "$str" # str is read into an array as tokens separated by IFS
   package_dir="${ADDR[0]}"
-  old_name="${ADDR[1]}"
-  new_name="${ADDR[2]}"
+  vc_name="${ADDR[1]}"
+  now_name="${ADDR[2]}"
   version="${ADDR[3]}"
   IFS=' ' # reset to default after usage
 
@@ -33,6 +33,6 @@ for tag in $tags; do
 
   echo "Running \`npm publish $npm_tag\` in \"$(pwd)\""
   npm publish $npm_tag
-  echo "Running \`npm deprecate $old_name@$version\` in favor of $new_name"
-  npm deprecate "$old_name@$version" "\"$old_name\" is deprecated and will stop receiving updates on December 31, 2020. Please use \"$new_name\" instead."
+  echo "Running \`npm deprecate $now_name@$version\` in favor of $vc_name"
+  npm deprecate "$now_name@$version" "\"$now_name\" is deprecated and will stop receiving updates on December 31, 2020. Please use \"$vc_name\" instead."
 done

--- a/utils/update-legacy-name.js
+++ b/utils/update-legacy-name.js
@@ -29,7 +29,7 @@ if (!packageDir) {
 
 const pkgJsonPath = join(packagesDir, packageDir, 'package.json');
 const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-const oldName = pkg.name;
+const vcName = pkg.name;
 const version = pkg.version;
 
 if (pkg.name === '@vercel/client') {
@@ -43,12 +43,12 @@ if (pkg.name === '@vercel/client') {
   }
 }
 
-const newName = pkg.name;
-console.error(`Updated package name: "${oldName}" -> "${newName}"`);
+const nowName = pkg.name;
+console.error(`Updated package name: "${vcName}" -> "${nowName}"`);
 
 fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
 // Log the directory name to stdout for the `publish-legacy.sh`
 // script to consume for the `npm publish` that happens next.
 const IFS = '|';
-console.log([packageDir, oldName, newName, version].join(IFS));
+console.log([packageDir, vcName, nowName, version].join(IFS));


### PR DESCRIPTION
This PR is a follow up to #5119 which had the names backwards.

I fixed the variable names to avoid the confusion since "new" and "old" were ambiguous.

I also removed the incorrect deprecation message from packages published during commit c9597dc199bb040b5677605fcf6bf57e0356a5e7.