### PR TITLE
[cli] Remove extra newline in warning

### DIFF
--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -170,7 +170,6 @@ const printDeploymentStatus = async (
           chalk.dim(
             `${indication.action || 'Learn More'}: ${indication.link}`
           ) +
-          newline +
           newline;
       output.print(message + link);
     }


### PR DESCRIPTION
Warning learn more links only need a single newline