### PR TITLE
[cli] Update the default env file for Next.js projects

### DIFF
--- a/packages/now-cli/src/commands/env/pull.ts
+++ b/packages/now-cli/src/commands/env/pull.ts
@@ -56,7 +56,13 @@ export default async function pull(
     return 1;
   }
 
-  const [filename = '.env'] = args;
+  let [filename] = args;
+
+  if (!filename) {
+    // TODO: do we want to migrate this for non-Next.js projects too?
+    filename = project.framework === 'nextjs' ? '.env.local' : '.env';
+  }
+
   const fullPath = join(process.cwd(), filename);
   const skipConfirmation = opts['--yes'];
 


### PR DESCRIPTION
Next.js recommends the env file containing sensitive values be named `.env.local` and not committed to the repo to prevent accidentally leaking the values. This updates the `vc env pull` command to default the env file name to `.env.local` to match this recommendation from Next.js. 

Closes: https://github.com/vercel/next.js/issues/16763