### PR TITLE
[next] Fix config `functions` src file

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -757,13 +757,16 @@ export const build = async ({
           ],
         };
 
-        const lambdaOptions = await getLambdaOptionsFromFunction({
-          sourceFile: await getSourceFilePathFromPage({
-            workPath: entryPath,
-            page,
-          }),
-          config,
-        });
+        let lambdaOptions = {};
+        if (config && config.functions) {
+          lambdaOptions = await getLambdaOptionsFromFunction({
+            sourceFile: await getSourceFilePathFromPage({
+              workPath: entryPath,
+              page,
+            }),
+            config,
+          });
+        }
 
         debug(`Creating serverless function for page: "${page}"...`);
         lambdas[path.join(entryDirectory, pathname)] = await createLambda({

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -1009,7 +1009,7 @@ async function getSourceFilePathFromPage({
     return path.relative(workPath, fsPath);
   }
 
-  const extensionless = fsPath.slice(0, -3); // remove "".js"
+  const extensionless = fsPath.slice(0, -3); // remove ".js"
   fsPath = extensionless + '.ts';
   if (fs.existsSync(fsPath)) {
     return path.relative(workPath, fsPath);

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/now.json
@@ -7,6 +7,15 @@
         "functions": {
           "src/pages/api/memory.js": {
             "memory": 128
+          },
+          "src/pages/api/index.js": {
+            "memory": 192
+          },
+          "src/pages/api/sub/index.ts": {
+            "memory": 128
+          },
+          "src/pages/api/sub/another.ts": {
+            "memory": 192
           }
         }
       }
@@ -17,6 +26,21 @@
       "path": "/api/memory",
       "status": 200,
       "mustContain": "128"
+    },
+    {
+      "path": "/api",
+      "status": 200,
+      "mustContain": "192"
+    },
+    {
+      "path": "/api/sub",
+      "status": 200,
+      "mustContain": "128"
+    },
+    {
+      "path": "/api/sub/another",
+      "status": 200,
+      "mustContain": "192"
     },
     {
       "logMustContain": "WARNING: Your application is being opted out of \"@vercel/next\" optimized lambdas mode due to `functions` config"

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/package.json
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/package.json
@@ -1,7 +1,11 @@
 {
+  "private": true,
   "dependencies": {
+    "@types/node": "^12.12.56",
+    "@types/react": "^16.9.49",
     "next": "canary",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "typescript": "^4.0.2"
   }
 }

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/index.js
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/index.js
@@ -1,0 +1,3 @@
+export default function (req, res) {
+  res.end(`${process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE}`);
+}

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/sub/another.ts
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/sub/another.ts
@@ -1,0 +1,3 @@
+export default function (req: any, res: any) {
+  res.end(`${process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE}`);
+}

--- a/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/sub/index.ts
+++ b/packages/now-next/test/fixtures/06-lambda-with-memory/src/pages/api/sub/index.ts
@@ -1,0 +1,3 @@
+export default function (req: any, res: any) {
+  res.end(`${process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE}`);
+}

--- a/packages/now-next/test/test.js
+++ b/packages/now-next/test/test.js
@@ -35,7 +35,7 @@ beforeAll(async () => {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
-for (const fixture of fs.readdirSync(fixturesPath)) {
+for (const fixture of ['06-lambda-with-memory']) {
   const context = {};
 
   // eslint-disable-next-line no-loop-func

--- a/packages/now-next/test/test.js
+++ b/packages/now-next/test/test.js
@@ -35,7 +35,7 @@ beforeAll(async () => {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
-for (const fixture of ['06-lambda-with-memory']) {
+for (const fixture of fs.readdirSync(fixturesPath)) {
   const context = {};
 
   // eslint-disable-next-line no-loop-func


### PR DESCRIPTION
The [functions](https://vercel.com/docs/configuration#project/functions) property matches source files and it wasn't working for `index.js` or `.ts` files because `next build` converts the source file `pages/api/index.js` to the output `.next/server/pages/api.js`. So this PR fixes the logic to reverse the output page to source file.