### PR TITLE
[node] Use `ts.readConfigFile()` to parse `tsconfig.json` file

### DIFF
--- a/packages/now-cli/test/dev/fixtures/node-ts-node-target/tsconfig.json
+++ b/packages/now-cli/test/dev/fixtures/node-ts-node-target/tsconfig.json
@@ -1,5 +1,68 @@
 {
   "compilerOptions": {
-    "module": "CommonJS"
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "module": "CommonJS",
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }

--- a/packages/now-node/src/dev-server.ts
+++ b/packages/now-node/src/dev-server.ts
@@ -8,11 +8,10 @@ if (!entrypoint) {
   throw new Error('`VERCEL_DEV_ENTRYPOINT` must be defined');
 }
 
-import fs from 'fs';
 import { register } from 'ts-node';
 
 // Use the project's version of TypeScript if available,
-// otherwise fall back to using the copy that `@now/node` uses.
+// otherwise fall back to using the copy that `@vercel/node` uses.
 let compiler: string;
 try {
   compiler = require.resolve('typescript', {
@@ -34,12 +33,11 @@ if (nodeMajor >= 14) {
 
 if (tsconfig) {
   try {
-    const tsconfigParsed = JSON.parse(fs.readFileSync(tsconfig, 'utf8'));
-    if (
-      tsconfigParsed.compilerOptions &&
-      tsconfigParsed.compilerOptions.target
-    ) {
-      target = tsconfigParsed.compilerOptions.target;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const ts: typeof import('typescript') = require(compiler);
+    const { config } = ts.readConfigFile(tsconfig, ts.sys.readFile);
+    if (config?.compilerOptions?.target) {
+      target = config.compilerOptions.target;
     }
   } catch (err) {
     if (err.code !== 'ENOENT') {

--- a/packages/now-node/tsconfig.json
+++ b/packages/now-node/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "esModuleInterop": true,
     "lib": ["esnext"],
-    "target": "esnext",
+    "target": "es2018",
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": false,


### PR DESCRIPTION
TypeScript supports comments in the `tsconfig.json` file, which is not
compatible with `JSON.parse()` so we have to use the built-in function
to parse the config file.