### PR TITLE
[next] Fix API page check

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -872,7 +872,7 @@ export const build = async ({
         };
 
     const isApiPage = (page: string) =>
-      page.replace(/\\/g, '/').match(/serverless\/pages\/api/);
+      page.replace(/\\/g, '/').match(/serverless\/pages\/api(\/|\.js$)/);
 
     const canUsePreviewMode = Object.keys(pages).some(page =>
       isApiPage(pages[page].fsPath)

--- a/packages/now-next/test/fixtures/22-ssg-v2/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/now.json
@@ -136,6 +136,27 @@
       "status": 404
     },
     {
+      "path": "/api-docs/first",
+      "status": 200,
+      "mustContain": "API Docs"
+    },
+    {
+      "path": "/api-docs/second",
+      "status": 200,
+      "mustContain": "Loading..."
+    },
+    {
+      "path": "/_next/data/testing-build-id/api-docs/first.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-vercel-cache": "/HIT|STALE|PRERENDER/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/api-docs/second.json",
+      "status": 200
+    },
+    {
       "logMustNotContain": "WARNING: your application is being opted out of @vercel/next's optimized lambdas mode due to legacy routes"
     },
     {

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/api-docs/[...slug].js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/api-docs/[...slug].js
@@ -1,0 +1,27 @@
+import { useRouter } from 'next/router';
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'world',
+    },
+  };
+};
+
+export const getStaticPaths = () => {
+  return {
+    paths: ['/api-docs/first'],
+    fallback: true,
+  };
+};
+
+export default function Slug(props) {
+  if (useRouter().isFallback) return 'Loading...';
+
+  return (
+    <>
+      <p id="api-docs">API Docs</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  );
+}


### PR DESCRIPTION
This corrects the `isApiPage` check to not incorrectly detect `/api-docs` as an API route. 

Note: tests won't pass until a new canary with the below Next.js PR has been landed

x-ref: https://github.com/vercel/next.js/pull/17092
Closes: https://github.com/vercel/next.js/issues/17091