### PR TITLE
[cli] Fix progress bar completion

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -172,6 +172,10 @@ export default async function processDeployment({
       if (event.type === 'created') {
         deployingSpinner();
 
+        if (bar && !bar.complete) {
+          bar.tick(bar.total + 1);
+        }
+
         now._host = event.payload.url;
 
         await linkFolderToProject(


### PR DESCRIPTION
In some rare cases, the progress bar will still be in progress when the deployment completes, which causes the  "Inspect" URL to print on the same line as the progress bar instead of a new line.

This PR fixes that corner case.