### PR TITLE
[next] Update next.config backup name to be deterministic

### DIFF
--- a/packages/now-next/src/create-serverless-config.ts
+++ b/packages/now-next/src/create-serverless-config.ts
@@ -59,7 +59,7 @@ export default async function createServerlessConfig(
 
   const primaryConfigPath = path.join(entryPath, 'next.config.js');
   const secondaryConfigPath = path.join(workPath, 'next.config.js');
-  const backupConfigName = `next.config.original.${Date.now()}.js`;
+  const backupConfigName = `next.config.__vercel_builder_backup__.js`;
 
   const hasPrimaryConfig = fs.existsSync(primaryConfigPath);
   const hasSecondaryConfig = fs.existsSync(secondaryConfigPath);

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -207,7 +207,9 @@ it(
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(
-      contents.some(name => name.includes('next.config.original.'))
+      contents.some(name =>
+        name.includes('next.config.__vercel_builder_backup__')
+      )
     ).toBeTruthy();
   },
   FOUR_MINUTES
@@ -278,7 +280,9 @@ it(
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(
-      contents.some(name => name.includes('next.config.original.'))
+      contents.some(name =>
+        name.includes('next.config.__vercel_builder_backup__')
+      )
     ).toBeTruthy();
   },
   FOUR_MINUTES
@@ -345,7 +349,9 @@ it(
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(
-      contents.some(name => name.includes('next.config.original.'))
+      contents.some(name =>
+        name.includes('next.config.__vercel_builder_backup__')
+      )
     ).toBeTruthy();
   },
   FOUR_MINUTES
@@ -380,7 +386,9 @@ it(
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(
-      contents.some(name => name.includes('next.config.original.'))
+      contents.some(name =>
+        name.includes('next.config.__vercel_builder_backup__')
+      )
     ).toBeFalsy();
   },
   FOUR_MINUTES
@@ -422,7 +430,9 @@ it(
 
     expect(contents.some(name => name === 'next.config.js')).toBeTruthy();
     expect(
-      contents.some(name => name.includes('next.config.original.'))
+      contents.some(name =>
+        name.includes('next.config.__vercel_builder_backup__')
+      )
     ).toBeFalsy();
   },
   FOUR_MINUTES


### PR DESCRIPTION
This updates the backup name used for the `next.config.js` file to be deterministic instead of using a time based filename which causes the webpack 5 cache to fail to resolve. Testing this stably will require custom set-up since we need to test that the cache is restored and used correctly by webpack 5 without error.