### PR TITLE
[routing-utils] Add custom locale cookie

### DIFF
--- a/packages/now-routing-utils/src/schemas.ts
+++ b/packages/now-routing-utils/src/schemas.ts
@@ -60,6 +60,10 @@ export const routesSchema = {
             type: 'string',
             maxLength: 4096,
           },
+          cookie: {
+            type: 'string',
+            maxLength: 4096,
+          },
           default: {
             type: 'string',
             maxLength: 4096,

--- a/packages/now-routing-utils/test/index.spec.js
+++ b/packages/now-routing-utils/test/index.spec.js
@@ -42,6 +42,7 @@ describe('normalizeRoutes', () => {
           value: '$value',
           path: '$path',
           default: 'en',
+          cookie: 'NEXT_LOCALE',
         },
       },
       {


### PR DESCRIPTION
Add the validation to support custom locale cookies in routes:
```
    {
        src: '^(?:/(?<value>en|fr))?(?<path>/.*)$',
        locale: {
          value: '$value',
          path: '$path',
          default: 'en',
          cookie: 'NEXT_LOCALE', <----
        },
      },
```

CH-12507