### PR TITLE
[next] Correct i18n trailing slash redirect priority

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -10,7 +10,7 @@ import {
   PrepareCacheOptions,
   Prerender,
 } from '@vercel/build-utils';
-import { Handler, Route } from '@vercel/routing-utils';
+import { Handler, Route, Source } from '@vercel/routing-utils';
 import {
   convertHeaders,
   convertRedirects,
@@ -1968,22 +1968,27 @@ export const build = async ({
       ...headers,
 
       // redirects
-      ...redirects.map(redir => {
+      ...redirects.map(_redir => {
         if (i18n) {
+          const redir = _redir as Source;
           // detect the trailing slash redirect and make sure it's
           // kept above the wildcard mapping to prevent erroneous redirects
           // since non-continue routes come after continue the $wildcard
           // route will come before the redirect otherwise and if the
           // redirect is triggered it breaks locale mapping
+
+          const location =
+            redir.headers && (redir.headers.location || redir.headers.Location);
+
           if (
             redir.status === 308 &&
-            (redir.dest === '/$1' || redir.dest === '/$1/')
+            (location === '/$1' || location === '/$1/')
           ) {
             // we set continue true
-            (redir as any).continue = true;
+            redir.continue = true;
           }
         }
-        return redir;
+        return _redir;
       }),
 
       ...(i18n


### PR DESCRIPTION
This makes sure the trailing slash route is detected correctly and ensures the priority is higher than the `$wildcard` route to prevent the redirect from causing locale mapping to fail. Adding tests for this doesn't currently work as we need to be able to assign domains to the test deployment to test it properly. This was manually tested with the builder `@ijjk/now-next@0.0.17-i18n` with https://i18n-support.vercel.app


x-ref: https://github.com/vercel/next.js/pull/17370
x-ref: https://github.com/vercel/vercel/pull/5298