### PR TITLE
[next] Ensure root-most index GSP page is located correctly

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1651,7 +1651,8 @@ export const build = async ({
       // if there isn't a srcRoute then it's a non-dynamic SSG page and
       if (nonDynamicSsg || isFallback) {
         routeFileNoExt = addLocaleOrDefault(
-          routeFileNoExt,
+          // root index files are located without folder/index.html
+          routeKey === '/' ? '' : routeFileNoExt,
           routesManifest,
           locale
         );

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1652,7 +1652,7 @@ export const build = async ({
       if (nonDynamicSsg || isFallback) {
         routeFileNoExt = addLocaleOrDefault(
           // root index files are located without folder/index.html
-          routeKey === '/' ? '' : routeFileNoExt,
+          routeFileNoExt,
           routesManifest,
           locale
         );

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -1110,7 +1110,9 @@ export function addLocaleOrDefault(
   if (!routesManifest?.i18n) return pathname;
   if (!locale) locale = routesManifest.i18n.defaultLocale;
 
-  return locale ? `/${locale}${pathname}` : pathname;
+  return locale
+    ? `/${locale}${pathname === '/index' ? '' : pathname}`
+    : pathname;
 }
 
 export {

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/index.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/index.js
@@ -44,3 +44,12 @@ export default function Page(props) {
     </>
   );
 }
+
+export const getStaticProps = ({ locale, locales }) => {
+  return {
+    props: {
+      locale,
+      locales,
+    },
+  };
+};


### PR DESCRIPTION
This fixes root-most index GSP pages not being located correctly, this also uncovered the initial revalidate value not being stored to the `prerender-manifest` correctly causing an incorrect `Prerender` output to be built which is fixed in https://github.com/vercel/next.js/pull/18053

Note: tests won't pass until the above mentioned Next.js PR is landed to canary

x-ref: https://github.com/vercel/next.js/pull/17370