### PR TITLE
[next] Image Optimization for default loader

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -655,12 +655,13 @@ export const build = async ({
 
     return {
       output,
-      images: imagesManifest?.images
-        ? {
-            domains: imagesManifest.images.domains,
-            sizes: imagesManifest.images.sizes,
-          }
-        : undefined,
+      images:
+        imagesManifest?.images?.loader === 'default'
+          ? {
+              domains: imagesManifest.images.domains,
+              sizes: imagesManifest.images.sizes,
+            }
+          : undefined,
       routes: [
         // User headers
         ...headers,
@@ -1952,12 +1953,13 @@ export const build = async ({
           };
         })
       : undefined,
-    images: imagesManifest?.images
-      ? {
-          domains: imagesManifest.images.domains,
-          sizes: imagesManifest.images.sizes,
-        }
-      : undefined,
+    images:
+      imagesManifest?.images?.loader === 'default'
+        ? {
+            domains: imagesManifest.images.domains,
+            sizes: imagesManifest.images.sizes,
+          }
+        : undefined,
     /*
       Desired routes order
       - Runtime headers

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -511,9 +511,12 @@ export async function getDynamicRoutes(
   return routes;
 }
 
+type LoaderKey = 'imgix' | 'cloudinary' | 'akamai' | 'default';
+
 type ImagesManifest = {
   version: number;
   images: {
+    loader: LoaderKey;
     sizes: number[];
     domains: string[];
   };


### PR DESCRIPTION
We currently pass through `images` whenever its defined, but this is enabling Image Optimization in the Proxy for every Next.js project.

Instead, we should check to see if the default loader is used (the same use for `next dev`) as a signal to enable this feature in the deployment.

Related to https://github.com/vercel/next.js/issues/18122