### PR TITLE
[frameworks] Add recommended integrations and related dependencies

### DIFF
--- a/packages/frameworks/frameworks.json
+++ b/packages/frameworks/frameworks.json
@@ -56,7 +56,13 @@
       "outputDirectory": {
         "placeholder": "Next.js default"
       }
-    }
+    },
+    "recommendedIntegrations": [
+      {
+        "id": "oac_5lUsiANun1DEzgLg0NZx5Es3",
+        "dependencies": ["next-plugin-sentry", "next-sentry-source-maps"]
+      }
+    ]
   },
   {
     "name": "Gatsby.js",

--- a/packages/frameworks/index.d.ts
+++ b/packages/frameworks/index.d.ts
@@ -31,4 +31,8 @@ export interface Framework {
     devCommand: Setting;
     outputDirectory: Setting;
   };
+  recommendedIntegrations?: {
+    id: string;
+    dependencies: string[];
+  }[];
 }

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -101,6 +101,8 @@ const Schema = {
         type: 'array',
         items: {
           type: 'object',
+          required: ['id', 'dependencies'],
+          additionalProperties: false,
           properties: {
             id: {
               type: 'string',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -97,6 +97,23 @@ const Schema = {
           outputDirectory: SchemaSettings,
         },
       },
+      recommendedIntegrations: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+            dependencies: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
Adds the `recommendedIntegrations` property to the frameworks list with related dependencies.

Story https://app.clubhouse.io/vercel/story/13391