### PR TITLE
[next] Add redirecting domain specific locales

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -2021,13 +2021,26 @@ export const build = async ({
                   {
                     // TODO: enable redirecting between domains, will require
                     // updating the src with the desired locales to redirect
-                    src: '/',
+                    src: `^${path.join(
+                      '/',
+                      entryDirectory
+                    )}/?(?:${i18n.locales
+                      .map(locale => escapeStringRegexp(locale))
+                      .join('|')})?/?$`,
                     locale: {
                       redirect: i18n.domains.reduce(
                         (prev: Record<string, string>, item) => {
                           prev[item.defaultLocale] = `http${
                             item.http ? '' : 's'
                           }://${item.domain}/`;
+
+                          if (item.locales) {
+                            item.locales.map(locale => {
+                              prev[locale] = `http${item.http ? '' : 's'}://${
+                                item.domain
+                              }/${locale}`;
+                            });
+                          }
                           return prev;
                         },
                         {}

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -332,6 +332,7 @@ export type RoutesManifest = {
     domains?: Array<{
       http?: boolean;
       domain: string;
+      locales?: string[];
       defaultLocale: string;
     }>;
   };


### PR DESCRIPTION
As discussed this re-adds redirecting locale specific domains to the accept-language preferred (unless NEXT_COKIE is used) to help prevent duplicate content on separate domains. 

Since this specific change can't be tested with our E2E tests yet since they require domains be assigned this was tested manually with https://i18n-support.vercel.app

x-ref: https://github.com/vercel/next.js/pull/18274