### PR TITLE
[next] Remove unstable_ prefix from unstable_blocking

### DIFF
--- a/packages/now-next/test/fixtures/31-blocking-fallback/pages/fixed/[slug].js
+++ b/packages/now-next/test/fixtures/31-blocking-fallback/pages/fixed/[slug].js
@@ -19,5 +19,5 @@ export function getStaticProps({ params }) {
 }
 
 export function getStaticPaths() {
-  return { paths: [], fallback: 'unstable_blocking' };
+  return { paths: [], fallback: 'blocking' };
 }

--- a/packages/now-next/test/fixtures/31-blocking-fallback/pages/regenerated/[slug].js
+++ b/packages/now-next/test/fixtures/31-blocking-fallback/pages/regenerated/[slug].js
@@ -19,5 +19,5 @@ export function getStaticProps({ params }) {
 }
 
 export function getStaticPaths() {
-  return { paths: [], fallback: 'unstable_blocking' };
+  return { paths: [], fallback: 'blocking' };
 }


### PR DESCRIPTION
This prepares the test files for the `unstable_` prefix being removed from `unstable_blocking`

x-ref: https://github.com/vercel/next.js/pull/18276