### PR TITLE
[next] Ensure index GSP data is available at correct path

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1724,7 +1724,9 @@ export const build = async ({
       if (nonDynamicSsg || isFallback) {
         outputPathData = outputPathData.replace(
           new RegExp(`${escapeStringRegexp(origRouteFileNoExt)}.json$`),
-          `${routeFileNoExt}.json`
+          `${routeFileNoExt}${
+            origRouteFileNoExt === '/index' ? '/index' : ''
+          }.json`
         );
       }
 

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -385,6 +385,48 @@
       "path": "/fr/not-found/fallback/first",
       "status": 200,
       "mustContain": "gsp page"
+    },
+
+    {
+      "path": "/_next/data/testing-build-id/en-US/index.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"en-US\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/index.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"en\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/fr/index.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"fr\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/nl/index.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"nl\""
+    },
+
+    {
+      "path": "/_next/data/testing-build-id/en-US/gsp.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"en-US\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/gsp.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"en\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/fr/gsp.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"fr\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/nl/gsp.json",
+      "status": 200,
+      "mustContain": "\"locale\":\"nl\""
     }
   ]
 }


### PR DESCRIPTION
This ensures the locale prefixed data route is available at the correct location 

x-ref: https://github.com/vercel/next.js/pull/17370