### PR TITLE
[next] Update tests for stabilized field

### DIFF
--- a/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/not-found/fallback/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/not-found/fallback/[slug].js
@@ -26,7 +26,7 @@ export default function Page(props) {
 export const getStaticProps = ({ params, locale, locales }) => {
   if (locale === 'en' || locale === 'nl') {
     return {
-      unstable_notFound: true,
+      notFound: true,
     };
   }
 

--- a/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/not-found/index.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/not-found/index.js
@@ -24,7 +24,7 @@ export default function Page(props) {
 export const getStaticProps = ({ locale, locales }) => {
   if (locale === 'en' || locale === 'nl') {
     return {
-      unstable_notFound: true,
+      notFound: true,
     };
   }
 

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/not-found/fallback/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/not-found/fallback/[slug].js
@@ -26,7 +26,7 @@ export default function Page(props) {
 export const getStaticProps = ({ params, locale, locales }) => {
   if (locale === 'en' || locale === 'nl') {
     return {
-      unstable_notFound: true,
+      notFound: true,
     };
   }
 

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/not-found/index.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/not-found/index.js
@@ -24,7 +24,7 @@ export default function Page(props) {
 export const getStaticProps = ({ locale, locales }) => {
   if (locale === 'en' || locale === 'nl') {
     return {
-      unstable_notFound: true,
+      notFound: true,
     };
   }
 


### PR DESCRIPTION
This updates tests for the `notFound` field having the `unstable_` prefix removed

x-ref: https://github.com/vercel/next.js/pull/18283