### PR TITLE
[next] Fix index data path for non-locale path

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1725,7 +1725,7 @@ export const build = async ({
         outputPathData = outputPathData.replace(
           new RegExp(`${escapeStringRegexp(origRouteFileNoExt)}.json$`),
           `${routeFileNoExt}${
-            origRouteFileNoExt === '/index' ? '/index' : ''
+            locale && origRouteFileNoExt === '/index' ? '/index' : ''
           }.json`
         );
       }

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1725,7 +1725,10 @@ export const build = async ({
         outputPathData = outputPathData.replace(
           new RegExp(`${escapeStringRegexp(origRouteFileNoExt)}.json$`),
           `${routeFileNoExt}${
-            locale && origRouteFileNoExt === '/index' ? '/index' : ''
+            routeFileNoExt !== origRouteFileNoExt &&
+            origRouteFileNoExt === '/index'
+              ? '/index'
+              : ''
           }.json`
         );
       }

--- a/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/next.config.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/next.config.js
@@ -2,22 +2,20 @@ module.exports = {
   generateBuildId() {
     return 'testing-build-id';
   },
-  experimental: {
-    i18n: {
-      locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
-      defaultLocale: 'en-US',
-      // TODO: testing locale domains support, will require custom
-      // testing set-up as test accounts are used currently
-      domains: [
-        {
-          domain: 'example.be',
-          defaultLocale: 'nl-BE',
-        },
-        {
-          domain: 'example.fr',
-          defaultLocale: 'fr',
-        },
-      ],
-    },
+  i18n: {
+    locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
+    defaultLocale: 'en-US',
+    // TODO: testing locale domains support, will require custom
+    // testing set-up as test accounts are used currently
+    domains: [
+      {
+        domain: 'example.be',
+        defaultLocale: 'nl-BE',
+      },
+      {
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+      },
+    ],
   },
 };

--- a/packages/now-next/test/fixtures/00-i18n-support/next.config.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/next.config.js
@@ -2,22 +2,20 @@ module.exports = {
   generateBuildId() {
     return 'testing-build-id';
   },
-  experimental: {
-    i18n: {
-      locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
-      defaultLocale: 'en-US',
-      // TODO: testing locale domains support, will require custom
-      // testing set-up as test accounts are used currently
-      domains: [
-        {
-          domain: 'example.be',
-          defaultLocale: 'nl-BE',
-        },
-        {
-          domain: 'example.fr',
-          defaultLocale: 'fr',
-        },
-      ],
-    },
+  i18n: {
+    locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
+    defaultLocale: 'en-US',
+    // TODO: testing locale domains support, will require custom
+    // testing set-up as test accounts are used currently
+    domains: [
+      {
+        domain: 'example.be',
+        defaultLocale: 'nl-BE',
+      },
+      {
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+      },
+    ],
   },
 };

--- a/packages/now-next/test/fixtures/22-ssg-v2/now.json
+++ b/packages/now-next/test/fixtures/22-ssg-v2/now.json
@@ -153,6 +153,16 @@
       }
     },
     {
+      "path": "/",
+      "status": 200,
+      "mustContain": "Hi"
+    },
+    {
+      "path": "/_next/data/testing-build-id/index.json",
+      "status": 200,
+      "mustContain": "\"hello\":\"index\""
+    },
+    {
       "path": "/_next/data/testing-build-id/api-docs/second.json",
       "status": 200
     },

--- a/packages/now-next/test/fixtures/22-ssg-v2/pages/index.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/pages/index.js
@@ -1,1 +1,9 @@
 export default () => 'Hi';
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'index',
+    },
+  };
+};


### PR DESCRIPTION
This ensures we only add `/index` to the data path for locale `/` paths, this also adds a test to ensure index `getStaticProps` routes are working properly 