### PR TITLE
[next] Ensure revalidation works with i18n

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -880,7 +880,9 @@ export const build = async ({
       // Next.js versions so we need to also not treat it as a static page here.
       if (
         prerenderManifest.staticRoutes[routeName] ||
-        prerenderManifest.fallbackRoutes[routeName]
+        prerenderManifest.fallbackRoutes[routeName] ||
+        prerenderManifest.staticRoutes[normalizePage(pathname)] ||
+        prerenderManifest.fallbackRoutes[normalizePage(pathname)]
       ) {
         return;
       }
@@ -1457,7 +1459,7 @@ export const build = async ({
                   )}).some((locale) => {
                     if (pathnameParts[1].toLowerCase() === locale.toLowerCase()) {
                       pathnameParts.splice(1, 1)
-                      pathname = pathnameParts.join('/') || '/'
+                      pathname = pathnameParts.join('/') || '/index'
                       return true
                     }
                     return false
@@ -1493,7 +1495,7 @@ export const build = async ({
                   if (!toRender) {
                     try {
                       const { pathname } = url.parse(req.url)
-                      toRender = stripLocalePath(pathname).replace(/\\/$/, '')
+                      toRender = stripLocalePath(pathname).replace(/\\/$/, '') || '/index'
                     } catch (_) {
                       // handle failing to parse url
                       res.statusCode = 400
@@ -1512,7 +1514,7 @@ export const build = async ({
                         .replace(new RegExp('/_next/data/${escapedBuildId}/'), '/')
                         .replace(/\\.json$/, '')
 
-                      toRender = stripLocalePath(toRender)
+                      toRender = stripLocalePath(toRender) || '/index'
                       currentPage = pages[toRender]
                     }
 
@@ -1540,7 +1542,7 @@ export const build = async ({
 
                   if (!currentPage) {
                     console.error(
-                      "Failed to find matching page for", toRender, "in lambda"
+                      "Failed to find matching page for", {toRender, header: req.headers['x-nextjs-page'], url: req.url, pages: Object.keys(pages) }, "in lambda"
                     )
                     res.statusCode = 500
                     return res.end('internal server error')

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -77,7 +77,6 @@ module.exports = function (ctx) {
 
     const html = await res.text();
     let $ = cheerio.load(html);
-    console.log({ props: $('#props').text(), html });
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('en-US');
@@ -108,7 +107,6 @@ module.exports = function (ctx) {
 
     const html = await res.text();
     let $ = cheerio.load(html);
-    console.log({ props: $('#props').text(), html });
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('fr');
@@ -139,7 +137,6 @@ module.exports = function (ctx) {
 
     const html = await res.text();
     let $ = cheerio.load(html);
-    console.log({ props: $('#props').text(), html });
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('nl-NL');

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -1,0 +1,227 @@
+/* eslint-env jest */
+const fetch = require('node-fetch');
+const cheerio = require('cheerio');
+
+module.exports = function (ctx) {
+  it('should revalidate content properly from /', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/fr`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/nl-NL`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+
+  it('should revalidate content properly from /gsp/fallback/new-page', async () => {
+    const initRes = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
+    expect(initRes.status).toBe(200);
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    console.log({ props: $('#props').text(), html });
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr/gsp/fallback/new-page', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/gsp/fallback/new-page.json`
+    );
+    expect(dataRes.status).toBe(200);
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/new-page`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    console.log({ props: $('#props').text(), html });
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/new-page`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL/gsp/fallback/new-page', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/gsp/fallback/new-page.json`
+    );
+    expect(dataRes.status).toBe(200);
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/new-page`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    console.log({ props: $('#props').text(), html });
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(
+      `${ctx.deploymentUrl}/nl-NL/gsp/fallback/new-page`
+    );
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+
+  it('should revalidate content properly from /gsp/no-fallback/first', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/gsp/no-fallback/first`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/gsp/no-fallback/first`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr/gsp/no-fallback/first', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/no-fallback/first`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/no-fallback/first`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL/gsp/no-fallback/second', async () => {
+    const res = await fetch(
+      `${ctx.deploymentUrl}/nl-NL/gsp/no-fallback/second`
+    );
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(
+      `${ctx.deploymentUrl}/nl-NL/gsp/no-fallback/second`
+    );
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+};

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -427,6 +427,52 @@
       "path": "/_next/data/testing-build-id/nl/gsp.json",
       "status": 200,
       "mustContain": "\"locale\":\"nl\""
+    },
+
+    {
+      "path": "/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "catchall"
+    },
+    {
+      "path": "/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "lang=\"en-US\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/en-US/gsp/blocking/first.json",
+      "status": 200,
+      "mustContain": "\"catchall\":\"yes\""
+    },
+    {
+      "path": "/nl-NL/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "catchall"
+    },
+    {
+      "path": "/nl-NL/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "lang=\"nl-NL\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/nl-NL/gsp/blocking/first.json",
+      "status": 200,
+      "mustContain": "\"catchall\":\"yes\""
+    },
+    {
+      "path": "/fr/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "catchall"
+    },
+    {
+      "path": "/fr/gsp/blocking/first",
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/fr/gsp/blocking/first.json",
+      "status": 200,
+      "mustContain": "\"catchall\":\"yes\""
     }
   ]
 }

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/blocking/[[...slug]].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/blocking/[[...slug]].js
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+const Slug = props => {
+  return (
+    <div>
+      <p id="props">{JSON.stringify(props)}</p>
+      <Link href="/gsp/blocking/hallo-wereld" locale={'nl-NL'}>
+        <a>/nl-NL/gsp/blocking/hallo-wereld</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/42" locale={'nl-NL'}>
+        <a>/nl-NL/gsp/blocking/42</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/hallo-welt" locale={'fr'}>
+        <a>/fr/gsp/blocking/hallo-welt</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/42" locale={'fr'}>
+        <a>/fr/gsp/blocking/42</a>
+      </Link>
+    </div>
+  );
+};
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      random: Math.random(),
+      catchall: 'yes',
+    },
+    revalidate: 1,
+  };
+};
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export default Slug;

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/fallback/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/fallback/[slug].js
@@ -26,10 +26,12 @@ export default function Page(props) {
 export const getStaticProps = ({ params, locale, locales }) => {
   return {
     props: {
+      random: Math.random(),
       params,
       locale,
       locales,
     },
+    revalidate: 1,
   };
 };
 

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/no-fallback/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/no-fallback/[slug].js
@@ -26,10 +26,12 @@ export default function Page(props) {
 export const getStaticProps = ({ params, locale, locales }) => {
   return {
     props: {
+      random: Math.random(),
       params,
       locale,
       locales,
     },
+    revalidate: 1,
   };
 };
 
@@ -40,6 +42,7 @@ export const getStaticPaths = () => {
       '/gsp/no-fallback/second',
       { params: { slug: 'first' }, locale: 'en-US' },
       '/nl-NL/gsp/no-fallback/second',
+      '/fr/gsp/no-fallback/first',
     ],
     fallback: false,
   };

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/index.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/index.js
@@ -48,8 +48,10 @@ export default function Page(props) {
 export const getStaticProps = ({ locale, locales }) => {
   return {
     props: {
+      random: Math.random(),
       locale,
       locales,
     },
+    revalidate: 1,
   };
 };


### PR DESCRIPTION
This corrects some i18n pages being considered staticPages instead of prerender items which was breaking revalidate behavior. This also adds more verbose tests for i18n ensuring revalidation is working correctly

x-ref: https://github.com/vercel/next.js/discussions/18443
Fixes: https://github.com/vercel/next.js/issues/18503