### PR TITLE
[next] Fix root-most optional-catchall with i18n

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -511,6 +511,7 @@ export const build = async ({
             const { i18n } = routesManifest;
 
             if (i18n) {
+              const origSrc = route.src;
               route.src = route.src.replace(
                 // we need to double escape the build ID here
                 // to replace it properly
@@ -521,6 +522,21 @@ export const build = async ({
                   .map(locale => escapeStringRegexp(locale))
                   .join('|')})/`
               );
+
+              // optional-catchall routes don't have slash between
+              // build-id and the regex
+              if (route.src === origSrc) {
+                route.src = route.src.replace(
+                  // we need to double escape the build ID here
+                  // to replace it properly
+                  `/${escapedBuildId}`,
+                  `/${escapedBuildId}/(?${
+                    ssgDataRoute ? '<nextLocale>' : ':'
+                  }${i18n.locales
+                    .map(locale => escapeStringRegexp(locale))
+                    .join('|')})[/]?`
+                );
+              }
 
               // make sure to route to the correct prerender output
               if (ssgDataRoute) {

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
@@ -1,0 +1,182 @@
+/* eslint-env jest */
+const fetch = require('node-fetch');
+const cheerio = require('cheerio');
+
+module.exports = function (ctx) {
+  it('should revalidate content properly from /', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    const res = await fetch(`${ctx.deploymentUrl}/`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    const res = await fetch(`${ctx.deploymentUrl}/fr`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/index.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    const res = await fetch(`${ctx.deploymentUrl}/nl-NL`);
+    expect(res.status).toBe(200);
+
+    let $ = cheerio.load(await res.text());
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+
+  it('should revalidate content properly from /second', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/second.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/second`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/second`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr/second', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/second.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/fr/second`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr/second`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL/second', async () => {
+    // we have to hit the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/second.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/nl-NL/second`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL/second`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+};

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/next.config.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/next.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  i18n: {
+    locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
+    defaultLocale: 'en-US',
+    // TODO: testing locale domains support, will require custom
+    // testing set-up as test accounts are used currently
+    domains: [
+      {
+        domain: 'example.be',
+        defaultLocale: 'nl-BE',
+      },
+      {
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+      },
+    ],
+  },
+};

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/now.json
@@ -1,0 +1,192 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/hello.txt",
+      "status": 200,
+      "mustContain": "hello world!"
+    },
+    {
+      "path": "/",
+      "headers": {
+        "accept-language": "en;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//en/"
+      }
+    },
+    {
+      "path": "/",
+      "headers": {
+        "accept-language": "nl;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//nl/"
+      }
+    },
+    {
+      "path": "/",
+      "headers": {
+        "accept-language": "nl-NL;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//nl-NL/"
+      }
+    },
+    {
+      "path": "/",
+      "headers": {
+        "accept-language": "fr;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//fr/"
+      }
+    },
+    {
+      "path": "/",
+      "headers": {
+        "accept-language": "en-US;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/en-US",
+      "headers": {
+        "accept-language": "nl;q=0.9"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": ">en-US<"
+    },
+    {
+      "path": "/en",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/en",
+      "status": 200,
+      "mustContain": ">en<"
+    },
+    {
+      "path": "/fr",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/fr",
+      "status": 200,
+      "mustContain": ">fr<"
+    },
+    {
+      "path": "/nl",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/nl",
+      "status": 200,
+      "mustContain": ">nl<"
+    },
+    {
+      "path": "/nl-NL",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/nl-NL",
+      "status": 200,
+      "mustContain": ">nl-NL<"
+    },
+
+    {
+      "path": "/first",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/first",
+      "status": 200,
+      "mustContain": ">en-US<"
+    },
+    {
+      "path": "/en/first",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/en/first",
+      "status": 200,
+      "mustContain": ">en<"
+    },
+    {
+      "path": "/fr/first",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/fr/first",
+      "status": 200,
+      "mustContain": ">fr<"
+    },
+    {
+      "path": "/nl/first",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/nl/first",
+      "status": 200,
+      "mustContain": ">nl<"
+    },
+    {
+      "path": "/nl-NL/first",
+      "status": 200,
+      "mustContain": "catchall page"
+    },
+    {
+      "path": "/nl-NL/first",
+      "status": 200,
+      "mustContain": ">nl-NL<"
+    }
+  ]
+}

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/package.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/pages/[[...slug]].js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/pages/[[...slug]].js
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+const Slug = props => {
+  const router = useRouter();
+
+  // invariant ensuring fallback is never accidentally flipped
+  if (router.isFallback) {
+    return 'Loading...';
+  }
+
+  return (
+    <div>
+      <p>catchall page</p>
+      <p id="props">{JSON.stringify(props)}</p>
+      <p id="router-locale">{router.locale}</p>
+      <p id="router-locales">{JSON.stringify(router.locales)}</p>
+      <p id="router-query">{JSON.stringify(router.query)}</p>
+      <p id="router-pathname">{router.pathname}</p>
+      <p id="router-as-path">{router.asPath}</p>
+      <Link href="/gsp/blocking/hallo-wereld" locale={'nl-NL'}>
+        <a>/nl-NL/gsp/blocking/hallo-wereld</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/42" locale={'nl-NL'}>
+        <a>/nl-NL/gsp/blocking/42</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/hallo-welt" locale={'fr'}>
+        <a>/fr/gsp/blocking/hallo-welt</a>
+      </Link>
+      <br />
+      <Link href="/gsp/blocking/42" locale={'fr'}>
+        <a>/fr/gsp/blocking/42</a>
+      </Link>
+      <br />
+      <Link href="/">
+        <a>/</a>
+      </Link>
+    </div>
+  );
+};
+
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      params,
+      random: Math.random(),
+      catchall: 'yes',
+    },
+    revalidate: 1,
+  };
+};
+
+export const getStaticPaths = ({ locales }) => {
+  const paths = [];
+
+  for (const locale of locales) {
+    paths.push({ params: { slug: ['first'] }, locale });
+    paths.push({ params: { slug: ['first'] }, locale });
+  }
+
+  return {
+    paths,
+    fallback: 'blocking',
+  };
+};
+
+export default Slug;

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/public/hello.txt
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/public/hello.txt
@@ -1,0 +1,1 @@
+hello world!

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -4,6 +4,14 @@ const cheerio = require('cheerio');
 
 module.exports = function (ctx) {
   it('should revalidate content properly from /', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/index.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(`${ctx.deploymentUrl}/`);
     expect(res.status).toBe(200);
 
@@ -25,6 +33,14 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /fr', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/index.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(`${ctx.deploymentUrl}/fr`);
     expect(res.status).toBe(200);
 
@@ -46,6 +62,14 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /nl-NL', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/index.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL`);
     expect(res.status).toBe(200);
 
@@ -66,7 +90,107 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('nl-NL');
   });
 
+  it('should revalidate content properly from /gsp/fallback/first', async () => {
+    // check the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/gsp/fallback/first.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/gsp/fallback/first`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('en-US');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/gsp/fallback/first`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('en-US');
+  });
+
+  it('should revalidate content properly from /fr/gsp/fallback/first', async () => {
+    // check the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/gsp/fallback/first.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/first`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('fr');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/first`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('fr');
+  });
+
+  it('should revalidate content properly from /nl-NL/gsp/fallback/first', async () => {
+    // check the _next/data URL first
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/gsp/fallback/first.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/first`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    let $ = cheerio.load(html);
+    const props = JSON.parse($('#props').text());
+    const initialRandom = props.random;
+    expect($('#router-locale').text()).toBe('nl-NL');
+
+    // wait for revalidation to occur
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/first`);
+    expect(res2.status).toBe(200);
+
+    $ = cheerio.load(await res2.text());
+    const props2 = JSON.parse($('#props').text());
+    expect(initialRandom).not.toBe(props2.random);
+    expect($('#router-locale').text()).toBe('nl-NL');
+  });
+  //
+
   it('should revalidate content properly from /gsp/fallback/new-page', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/gsp/fallback/new-page.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
     const initRes = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
     expect(initRes.status).toBe(200);
 
@@ -156,6 +280,14 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /gsp/no-fallback/first', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/gsp/no-fallback/first.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(`${ctx.deploymentUrl}/gsp/no-fallback/first`);
     expect(res.status).toBe(200);
 
@@ -177,6 +309,14 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /fr/gsp/no-fallback/first', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/gsp/no-fallback/first.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/no-fallback/first`);
     expect(res.status).toBe(200);
 
@@ -198,6 +338,14 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /nl-NL/gsp/no-fallback/second', async () => {
+    const dataRes = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/gsp/no-fallback/second.json`
+    );
+    expect(dataRes.status).toBe(200);
+    await dataRes.json();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const res = await fetch(
       `${ctx.deploymentUrl}/nl-NL/gsp/no-fallback/second`
     );

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -349,6 +349,9 @@
       "mustContain": "lang=\"en\""
     },
     {
+      "delay": 2000
+    },
+    {
       "path": "/en/not-found/fallback/first",
       "status": 200,
       "mustNotContain": "gsp page"
@@ -380,6 +383,9 @@
       "path": "/fr/not-found/fallback/first",
       "status": 200,
       "mustContain": "lang=\"fr\""
+    },
+    {
+      "delay": 2000
     },
     {
       "path": "/fr/not-found/fallback/first",

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/fallback/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/gsp/fallback/[slug].js
@@ -35,12 +35,17 @@ export const getStaticProps = ({ params, locale, locales }) => {
   };
 };
 
-export const getStaticPaths = () => {
+export const getStaticPaths = ({ locales }) => {
+  const paths = [];
+
+  for (const locale of locales) {
+    paths.push({ params: { slug: 'first' }, locale });
+    paths.push({ params: { slug: 'second' }, locale });
+  }
+
   return {
     // the default locale will be used since one isn't defined here
-    paths: ['first', 'second'].map(slug => ({
-      params: { slug },
-    })),
+    paths,
     fallback: true,
   };
 };


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/vercel/pull/5350 which ensures that root-most catch-all routes work correctly with i18n. An additional test suite has been added to ensure this works correctly. 

Additional tests have also been added to ensure dynamic SSG pages that were prerendered are revalidated correctly and all data routes return valid JSON

Closes: https://github.com/vercel/next.js/issues/18503