### PR TITLE
[next] Add additional tests for i18n revalidate params

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1560,8 +1560,9 @@ export const build = async ({
 
                   if (!currentPage) {
                     console.error(
-                      "Failed to find matching page for", {toRender, header: req.headers['x-nextjs-page'], url: req.url, pages: Object.keys(pages) }, "in lambda"
+                      "Failed to find matching page for", {toRender, header: req.headers['x-nextjs-page'], url: req.url }, "in lambda"
                     )
+                    console.error('pages in lambda', Object.keys(pages))
                     res.statusCode = 500
                     return res.end('internal server error')
                   }
@@ -2144,6 +2145,10 @@ export const build = async ({
             },
 
             // Auto-prefix non-locale path with default locale
+            // note for prerendered pages this will cause
+            // x-now-route-matches to contain the path minus the locale
+            // e.g. for /de/posts/[slug] x-now-route-matches would have
+            // 1=posts%2Fpost-1
             {
               src: `^${path.join(
                 '/',

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -19,6 +19,7 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('en-US');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -30,6 +31,7 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('en-US');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
   });
 
   it('should revalidate content properly from /fr', async () => {
@@ -48,6 +50,7 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('fr');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -59,6 +62,7 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('fr');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
   });
 
   it('should revalidate content properly from /nl-NL', async () => {
@@ -77,6 +81,7 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -88,6 +93,7 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(JSON.parse($('#router-query').text())).toEqual({});
   });
 
   it('should revalidate content properly from /gsp/fallback/first', async () => {
@@ -108,6 +114,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -119,6 +127,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props2.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
   });
 
   it('should revalidate content properly from /fr/gsp/fallback/first', async () => {
@@ -139,6 +149,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('fr');
+    expect(props.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -150,6 +162,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('fr');
+    expect(props2.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
   });
 
   it('should revalidate content properly from /nl-NL/gsp/fallback/first', async () => {
@@ -170,6 +184,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -181,6 +197,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props2.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
   });
   //
 
@@ -204,6 +222,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props.params).toEqual({ slug: 'new-page' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -215,6 +235,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props2.params).toEqual({ slug: 'new-page' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
   });
 
   it('should revalidate content properly from /fr/gsp/fallback/new-page', async () => {
@@ -234,6 +256,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('fr');
+    expect(props.params).toEqual({ slug: 'new-page' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -264,6 +288,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props.params).toEqual({ slug: 'new-page' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -277,6 +303,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props2.params).toEqual({ slug: 'new-page' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
   });
 
   it('should revalidate content properly from /gsp/no-fallback/first', async () => {
@@ -295,6 +323,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -306,6 +336,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('en-US');
+    expect(props2.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
   });
 
   it('should revalidate content properly from /fr/gsp/no-fallback/first', async () => {
@@ -324,6 +356,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('fr');
+    expect(props.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -335,6 +369,8 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('fr');
+    expect(props2.params).toEqual({ slug: 'first' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
   });
 
   it('should revalidate content properly from /nl-NL/gsp/no-fallback/second', async () => {
@@ -355,6 +391,8 @@ module.exports = function (ctx) {
     const props = JSON.parse($('#props').text());
     const initialRandom = props.random;
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props.params).toEqual({ slug: 'second' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'second' });
 
     // wait for revalidation to occur
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -368,5 +406,7 @@ module.exports = function (ctx) {
     const props2 = JSON.parse($('#props').text());
     expect(initialRandom).not.toBe(props2.random);
     expect($('#router-locale').text()).toBe('nl-NL');
+    expect(props2.params).toEqual({ slug: 'second' });
+    expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'second' });
   });
 };


### PR DESCRIPTION
As noticed in https://github.com/vercel/next.js/discussions/18443, when revalidating a prerendered page with the default locale the `x-now-route-matches` can be incorrect. This adds additional checks to ensure the correct params are generated. These tests will fail until the changes in https://github.com/vercel/next.js/pull/18569 are landed on canary
