### PR TITLE
[tests] Cleanup fixture folder before running CLI test

### DIFF
--- a/packages/now-cli/package.json
+++ b/packages/now-cli/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "preinstall": "node ./scripts/preinstall.js",
     "test-unit": "nyc ava test/unit.js test/dev-builder.unit.js test/dev-router.unit.js test/dev-server.unit.js test/dev-validate.unit.js --serial --fail-fast --verbose",
-    "test-integration-cli": "ava test/integration.js --serial --fail-fast --verbose",
+    "test-integration-cli": "rimraf test/fixtures/integration && ava test/integration.js --serial --fail-fast --verbose",
     "test-integration-dev": "ava test/dev/integration.js --serial --fail-fast --verbose",
     "prepublishOnly": "yarn build",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
@@ -158,6 +158,7 @@
     "psl": "1.1.31",
     "qr-image": "3.2.0",
     "raw-body": "2.4.1",
+    "rimraf": "3.0.2",
     "semver": "5.5.0",
     "serve-handler": "6.1.1",
     "sinon": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9949,17 +9949,17 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2, rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
This adds `rimraf test/fixtures/integration` in the CLI integration test script to clean up the fixtures folder before running the tests.

When running the tests twice without cleaning up the folder, the tests usually fail because the tests update the fixtures folders and have side-effects.