### PR TITLE
[next] Ensure auto-export dynamic routes are routed properly

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1411,17 +1411,23 @@ export const build = async ({
           const isFallback = prerenderManifest.fallbackRoutes[pathname!];
           const isBlocking =
             prerenderManifest.blockingFallbackRoutes[pathname!];
+          const isAutoExport =
+            staticPages[
+              addLocaleOrDefault(pathname!, routesManifest).substr(1)
+            ];
+
+          const isLocalePrefixed = isFallback || isBlocking || isAutoExport;
 
           route.src = route.src.replace(
             '^',
             `^${dynamicPrefix ? `${dynamicPrefix}[/]?` : '[/]?'}(?${
-              isFallback || isBlocking ? '<nextLocale>' : ':'
+              isLocalePrefixed ? '<nextLocale>' : ':'
             }${i18n.locales
               .map(locale => escapeStringRegexp(locale))
               .join('|')})?`
           );
 
-          if (isFallback || isBlocking) {
+          if (isLocalePrefixed) {
             // ensure destination has locale prefix to match prerender output
             // path so that the prerender object is used
             route.dest = route.dest!.replace(

--- a/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
@@ -162,6 +162,47 @@
     },
 
     {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en-US\""
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en\""
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"nl\""
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"fr\""
+    },
+
+    {
       "path": "/gsp",
       "status": 200,
       "mustContain": "gsp page"

--- a/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/pages/dynamic/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/pages/dynamic/[slug].js
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+
+export default function Dynamic(props) {
+  const router = useRouter();
+
+  return (
+    <>
+      <p>dynamic page</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+    </>
+  );
+}

--- a/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/now.json
@@ -173,6 +173,47 @@
     },
 
     {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en-US\""
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en\""
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"nl\""
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"fr\""
+    },
+
+    {
       "path": "/gsp",
       "status": 200,
       "mustContain": "gsp page"

--- a/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/dynamic/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-shared-lambdas/pages/dynamic/[slug].js
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+
+export default function Dynamic(props) {
+  const router = useRouter();
+
+  return (
+    <>
+      <p>dynamic page</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+    </>
+  );
+}

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -170,6 +170,47 @@
     },
 
     {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en-US\""
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/en/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"en\""
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/nl/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"nl\""
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "path": "/fr/dynamic/hello",
+      "status": 200,
+      "mustContain": "\"fr\""
+    },
+
+    {
       "path": "/gsp",
       "status": 200,
       "mustContain": "gsp page"

--- a/packages/now-next/test/fixtures/00-i18n-support/pages/dynamic/[slug].js
+++ b/packages/now-next/test/fixtures/00-i18n-support/pages/dynamic/[slug].js
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+
+export default function Dynamic(props) {
+  const router = useRouter();
+
+  return (
+    <>
+      <p>dynamic page</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+    </>
+  );
+}


### PR DESCRIPTION
Since automatically statically optimized dynamic pages are output under their locale for i18n this makes sure the dynamic route is prefixed with the locale properly. Additional tests to ensure this is working correctly have also been added for the i18n fixtures. 

Fixes: https://github.com/vercel/next.js/issues/18397