### PR TITLE
[cli] Show error when removing env variable from no target environment

### DIFF
--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -92,7 +92,7 @@ export default async function rm(
     return 1;
   }
 
-  if (envTargets.length === 0) {
+  while (envTargets.length === 0) {
     const choices = getEnvTargetChoices().filter(c => existing.has(c.value));
     if (choices.length === 0) {
       output.error(
@@ -110,6 +110,13 @@ export default async function rm(
         message: `Remove ${envName} from which Environments (select multiple)?`,
         choices,
       });
+
+      if (inputTargets.length === 0) {
+        output.error(
+          'Please select an Environment to remove the Environment Variable from.'
+        );
+      }
+
       envTargets = inputTargets;
     }
   }

--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -30,6 +30,9 @@ export default async function rm(
   args: string[],
   output: Output
 ) {
+  // improve the way we show inquirer prompts
+  require('../../util/input/patch-inquirer');
+
   if (args.length > 2) {
     output.error(
       `Invalid number of arguments. Usage: ${getCommandName(

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -778,6 +778,20 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     );
     now.stdin.write('MY_PLAINTEXT_ENV_VAR\n');
 
+    // expect error if no environment is selected
+    await waitForPrompt(
+      now,
+      chunk =>
+        chunk.includes('which Environments') &&
+        chunk.includes('MY_PLAINTEXT_ENV_VAR')
+    );
+    now.stdin.write('\n'); // select none
+    await waitForPrompt(now, chunk =>
+      chunk.includes(
+        'Please select an Environment to remove the Environment Variable from.'
+      )
+    );
+
     await waitForPrompt(
       now,
       chunk =>


### PR DESCRIPTION
Ref: https://app.clubhouse.io/vercel/story/14077

Show an error when removing an env variable but selecting no target environments to remove it from.

The error looks like this:
![image](https://user-images.githubusercontent.com/6616955/98315212-03146f80-1fd8-11eb-8c59-b47bca093160.png)

Also updates the UI of the prompts.