### PR TITLE
[next] Correct data routes with basePath

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -421,7 +421,7 @@ export const build = async ({
     });
   }
 
-  const appMountPrefixNoTrailingSlash = path.posix
+  let appMountPrefixNoTrailingSlash = path.posix
     .join('/', entryDirectory)
     .replace(/\/+$/, '');
 
@@ -468,6 +468,30 @@ export const build = async ({
 
         if (routesManifest.headers) {
           headers.push(...convertHeaders(routesManifest.headers));
+        }
+
+        if (routesManifest.basePath && routesManifest.basePath !== '/') {
+          const nextBasePath = routesManifest.basePath;
+
+          if (!nextBasePath.startsWith('/')) {
+            throw new NowBuildError({
+              code: 'NEXT_BASEPATH_STARTING_SLASH',
+              message:
+                'basePath must start with `/`. Please upgrade your `@vercel/next` builder and try again. Contact support if this continues to happen.',
+            });
+          }
+          if (nextBasePath.endsWith('/')) {
+            throw new NowBuildError({
+              code: 'NEXT_BASEPATH_TRAILING_SLASH',
+              message:
+                'basePath must not end with `/`. Please upgrade your `@vercel/next` builder and try again. Contact support if this continues to happen.',
+            });
+          }
+
+          entryDirectory = path.join(entryDirectory, nextBasePath);
+          appMountPrefixNoTrailingSlash = path.posix
+            .join('/', entryDirectory)
+            .replace(/\/+$/, '');
         }
 
         if (routesManifest.dataRoutes) {
@@ -554,26 +578,6 @@ export const build = async ({
           hasPages404 = true;
         }
 
-        if (routesManifest.basePath && routesManifest.basePath !== '/') {
-          const nextBasePath = routesManifest.basePath;
-
-          if (!nextBasePath.startsWith('/')) {
-            throw new NowBuildError({
-              code: 'NEXT_BASEPATH_STARTING_SLASH',
-              message:
-                'basePath must start with `/`. Please upgrade your `@vercel/next` builder and try again. Contact support if this continues to happen.',
-            });
-          }
-          if (nextBasePath.endsWith('/')) {
-            throw new NowBuildError({
-              code: 'NEXT_BASEPATH_TRAILING_SLASH',
-              message:
-                'basePath must not end with `/`. Please upgrade your `@vercel/next` builder and try again. Contact support if this continues to happen.',
-            });
-          }
-
-          entryDirectory = path.join(entryDirectory, nextBasePath);
-        }
         break;
       }
       default: {

--- a/packages/now-next/test/fixtures/16-base-path/now.json
+++ b/packages/now-next/test/fixtures/16-base-path/now.json
@@ -55,6 +55,26 @@
     {
       "path": "/docs/blog/post-1/comments",
       "mustContain": "comments post: post-1"
+    },
+    {
+      "path": "/docs/_next/data/testing-build-id/blog/post-1.json",
+      "status": 200,
+      "mustContain": "\"post\""
+    },
+    {
+      "path": "/docs/_next/data/testing-build-id/blog/post-2/comments.json",
+      "status": 200,
+      "mustContain": "\"post\""
+    },
+    {
+      "path": "/docs/_next/data/testing-build-id/blog-ssg/post-1.json",
+      "status": 200,
+      "mustContain": "\"post\""
+    },
+    {
+      "path": "/docs/_next/data/testing-build-id/blog-ssg/post-2/comments.json",
+      "status": 200,
+      "mustContain": "\"post\""
     }
   ]
 }

--- a/packages/now-next/test/fixtures/16-base-path/pages/blog-ssg/[post]/comments.js
+++ b/packages/now-next/test/fixtures/16-base-path/pages/blog-ssg/[post]/comments.js
@@ -1,0 +1,16 @@
+export const getStaticProps = ({ params }) => ({
+  props: {
+    post: params.post,
+  },
+});
+
+export const getStaticPaths = () => {
+  return {
+    paths: [{ params: { post: 'post-1' } }, { params: { post: 'post-2' } }],
+    fallback: true,
+  };
+};
+
+export default function Comment({ post }) {
+  return `comments post: ${post}`;
+}

--- a/packages/now-next/test/fixtures/16-base-path/pages/blog-ssg/[post]/index.js
+++ b/packages/now-next/test/fixtures/16-base-path/pages/blog-ssg/[post]/index.js
@@ -1,0 +1,16 @@
+export const getStaticProps = ({ params }) => ({
+  props: {
+    post: params.post,
+  },
+});
+
+export const getStaticPaths = () => {
+  return {
+    paths: [{ params: { post: 'post-1' } }, { params: { post: 'post-2' } }],
+    fallback: true,
+  };
+};
+
+export default function Post({ post }) {
+  return `index post: ${post}`;
+}


### PR DESCRIPTION
This corrects the generated data routes with a `basePath` configured. Currently the `dataRoutes` are loaded before the `basePath` which causes the `dataRoutes` to not be prefixed with the `basePath`. This ensures the `dataRoutes` are loaded after the `basePath` and adds additional tests to make sure this is covered

Fixes: https://github.com/vercel/next.js/issues/18125