### PR TITLE
[next] files within the buildId directory are immutable

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -732,7 +732,7 @@ export const build = async ({
           src: path.join(
             '/',
             entryDirectory,
-            '_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|media)/.+'
+            `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|media|${escapedBuildId})/.+`
           ),
           // Next.js assets contain a hash or entropy in their filenames, so they
           // are guaranteed to be unique and cacheable indefinitely.
@@ -2296,7 +2296,7 @@ export const build = async ({
         src: path.join(
           '/',
           entryDirectory,
-          '_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|media)/.+'
+          `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|media|${escapedBuildId})/.+`
         ),
         // Next.js assets contain a hash or entropy in their filenames, so they
         // are guaranteed to be unique and cacheable indefinitely.

--- a/packages/now-next/test/fixtures/01-cache-headers/now.json
+++ b/packages/now-next/test/fixtures/01-cache-headers/now.json
@@ -9,6 +9,12 @@
       }
     },
     {
+      "path": "/_next/static/testing-build-id/_buildManifest.js",
+      "responseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
+    },
+    {
       "path": "/_next/static/invalid-build-id/pages/non-existent.js",
       "notResponseHeaders": {
         "cache-control": "public,max-age=31536000,immutable"

--- a/packages/now-next/test/fixtures/10-export-cache-headers/now.json
+++ b/packages/now-next/test/fixtures/10-export-cache-headers/now.json
@@ -9,6 +9,12 @@
       }
     },
     {
+      "path": "/_next/static/testing-build-id/_buildManifest.js",
+      "responseHeaders": {
+        "cache-control": "public,max-age=31536000,immutable"
+      }
+    },
+    {
       "path": "/",
       "mustContain": "nextExport\":true"
     }


### PR DESCRIPTION
We were not caching _all_ files within the `buildId` directory. This PR fixes that.

---

Fixes https://github.com/vercel/next.js/issues/18767