### PR TITLE
[static-build] Expect routes array directly

### DIFF
--- a/packages/now-static-build/src/utils/read-build-output.ts
+++ b/packages/now-static-build/src/utils/read-build-output.ts
@@ -1,8 +1,8 @@
 import { FileBlob, Files, Lambda } from '@vercel/build-utils';
-import { getTransformedRoutes, Route } from '@vercel/routing-utils';
 import { isObjectEmpty } from './_shared';
 import { makeNowLauncher } from '../launcher';
 import { promises as fs } from 'fs';
+import { Route } from '@vercel/routing-utils';
 import buildUtils from '../build-utils';
 import path from 'path';
 
@@ -146,14 +146,7 @@ async function readRoutesConfig({
   );
 
   try {
-    const rawRoutes = JSON.parse(await fs.readFile(routesConfigPath, 'utf8'));
-    const { routes, error } = getTransformedRoutes({ nowConfig: rawRoutes });
-
-    if (error) {
-      throw error;
-    }
-
-    return routes || [];
+    return JSON.parse(await fs.readFile(routesConfigPath, 'utf8')) || [];
   } catch (error) {
     if (error.code === 'ENOENT') {
       return [];

--- a/packages/now-static-build/test/fixtures/61-build-output-directory/fake/config/routes.json
+++ b/packages/now-static-build/test/fixtures/61-build-output-directory/fake/config/routes.json
@@ -1,6 +1,10 @@
-{
-  "rewrites": [
-    { "source": "/", "destination": "/.vercel/functions/root" },
-    { "source": "/:path*", "destination": "/.vercel/functions/:path*" }
-  ]
-}
+[
+  {
+    "src": "/",
+    "dest": "/.vercel/functions/root/"
+  },
+  {
+    "src": "/(.*)",
+    "dest": "/.vercel/functions/$1"
+  }
+]

--- a/packages/now-static-build/test/fixtures/62-build-output-directory-with-public/fake/config/routes.json
+++ b/packages/now-static-build/test/fixtures/62-build-output-directory-with-public/fake/config/routes.json
@@ -1,6 +1,10 @@
-{
-  "rewrites": [
-    { "source": "/", "destination": "/.vercel/functions/root" },
-    { "source": "/:path*", "destination": "/.vercel/functions/:path*" }
-  ]
-}
+[
+  {
+    "src": "/",
+    "dest": "/.vercel/functions/root/"
+  },
+  {
+    "src": "/(.*)",
+    "dest": "/.vercel/functions/$1"
+  }
+]

--- a/packages/now-static-build/test/fixtures/63-build-output-directory-with-static/fake/config/routes.json
+++ b/packages/now-static-build/test/fixtures/63-build-output-directory-with-static/fake/config/routes.json
@@ -1,6 +1,10 @@
-{
-  "rewrites": [
-    { "source": "/", "destination": "/.vercel/functions/root" },
-    { "source": "/:path*", "destination": "/.vercel/functions/:path*" }
-  ]
-}
+[
+  {
+    "src": "/",
+    "dest": "/.vercel/functions/root/"
+  },
+  {
+    "src": "/(.*)",
+    "dest": "/.vercel/functions/$1"
+  }
+]


### PR DESCRIPTION
#### Story
https://app.clubhouse.io/vercel/story/14739

#### Description
Follow up to https://github.com/vercel/vercel/pull/5396

Makes sure to use routes directly instead of expecting an object of properties that need to get transformed into routes.