### PR TITLE
[static-build] Ignore framework routes if config/routes.json is present

### DIFF
--- a/packages/now-static-build/src/index.ts
+++ b/packages/now-static-build/src/index.ts
@@ -523,16 +523,14 @@ export async function build({
         Object.assign(output, extraOutputs.functions);
       }
 
-      if (framework) {
+      if (extraOutputs.routes) {
+        routes.push(...extraOutputs.routes);
+      } else if (framework) {
         const frameworkRoutes = await getFrameworkRoutes(
           framework,
           outputDirPrefix
         );
         routes.push(...frameworkRoutes);
-      }
-
-      if (extraOutputs.routes) {
-        routes.push(...extraOutputs.routes);
       }
     }
 


### PR DESCRIPTION
#### Story
https://app.clubhouse.io/vercel/story/14739

#### Description
Follow up to https://github.com/vercel/vercel/pull/5399 and https://github.com/vercel/vercel/pull/5396.
If `config/routes.json` was added, we except it to be complete, so we don't need to add our own.
