### PR TITLE
[build-utils] Include `installCommand` when empty string

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -451,7 +451,7 @@ function detectFrontBuilder(
     config.devCommand = projectSettings.devCommand;
   }
 
-  if (projectSettings.installCommand) {
+  if (typeof projectSettings.installCommand === 'string') {
     config.installCommand = projectSettings.installCommand;
   }
 

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -20,48 +20,6 @@ describe('Test `detectBuilders`', () => {
     expect(builders![0].src).not.toBe('now.json');
   });
 
-  it('should select "installCommand"', async () => {
-    const pkg = {
-      scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' },
-    };
-    const files = ['package.json', 'pages/index.js', 'public/index.html'];
-    const { builders, errors } = await detectBuilders(files, pkg, {
-      projectSettings: {
-        installCommand: 'npx pnpm install',
-      },
-    });
-    expect(errors).toBe(null);
-    expect(builders).toBeDefined();
-    expect(builders!.length).toStrictEqual(1);
-    expect(builders![0].src).toStrictEqual('package.json');
-    expect(builders![0].use).toStrictEqual('@vercel/next');
-    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
-    expect(builders![0].config!.installCommand).toStrictEqual(
-      'npx pnpm install'
-    );
-  });
-
-  it('should select empty "installCommand"', async () => {
-    const pkg = {
-      scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' },
-    };
-    const files = ['package.json', 'pages/index.js', 'public/index.html'];
-    const { builders, errors } = await detectBuilders(files, pkg, {
-      projectSettings: {
-        installCommand: '',
-      },
-    });
-    expect(errors).toBe(null);
-    expect(builders).toBeDefined();
-    expect(builders!.length).toStrictEqual(1);
-    expect(builders![0].src).toStrictEqual('package.json');
-    expect(builders![0].use).toStrictEqual('@vercel/next');
-    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
-    expect(builders![0].config!.installCommand).toStrictEqual('');
-  });
-
   it('package.json + no build', async () => {
     const pkg = { dependencies: { next: '9.0.0' } };
     const files = ['package.json', 'pages/index.js', 'public/index.html'];
@@ -874,6 +832,50 @@ describe('Test `detectBuilders`', () => {
 
 describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
   const featHandleMiss = true;
+
+  it('should select "installCommand"', async () => {
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = ['package.json', 'pages/index.js', 'public/index.html'];
+    const { builders, errors } = await detectBuilders(files, pkg, {
+      featHandleMiss,
+      projectSettings: {
+        installCommand: 'npx pnpm install',
+      },
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBeDefined();
+    expect(builders!.length).toStrictEqual(1);
+    expect(builders![0].src).toStrictEqual('package.json');
+    expect(builders![0].use).toStrictEqual('@vercel/next');
+    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
+    expect(builders![0].config!.installCommand).toStrictEqual(
+      'npx pnpm install'
+    );
+  });
+
+  it('should select empty "installCommand"', async () => {
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = ['package.json', 'pages/index.js', 'public/index.html'];
+    const { builders, errors } = await detectBuilders(files, pkg, {
+      featHandleMiss,
+      projectSettings: {
+        installCommand: '',
+      },
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBeDefined();
+    expect(builders!.length).toStrictEqual(1);
+    expect(builders![0].src).toStrictEqual('package.json');
+    expect(builders![0].use).toStrictEqual('@vercel/next');
+    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
+    expect(builders![0].config!.installCommand).toStrictEqual('');
+  });
 
   it('should never select now.json src', async () => {
     const files = ['docs/index.md', 'mkdocs.yml', 'now.json'];

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -20,6 +20,48 @@ describe('Test `detectBuilders`', () => {
     expect(builders![0].src).not.toBe('now.json');
   });
 
+  it('should select "installCommand"', async () => {
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = ['package.json', 'pages/index.js', 'public/index.html'];
+    const { builders, errors } = await detectBuilders(files, pkg, {
+      projectSettings: {
+        installCommand: 'npx pnpm install',
+      },
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBeDefined();
+    expect(builders!.length).toStrictEqual(1);
+    expect(builders![0].src).toStrictEqual('package.json');
+    expect(builders![0].use).toStrictEqual('@vercel/next');
+    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
+    expect(builders![0].config!.installCommand).toStrictEqual(
+      'npx pnpm install'
+    );
+  });
+
+  it('should select empty "installCommand"', async () => {
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '9.0.0' },
+    };
+    const files = ['package.json', 'pages/index.js', 'public/index.html'];
+    const { builders, errors } = await detectBuilders(files, pkg, {
+      projectSettings: {
+        installCommand: '',
+      },
+    });
+    expect(errors).toBe(null);
+    expect(builders).toBeDefined();
+    expect(builders!.length).toStrictEqual(1);
+    expect(builders![0].src).toStrictEqual('package.json');
+    expect(builders![0].use).toStrictEqual('@vercel/next');
+    expect(builders![0].config!.zeroConfig).toStrictEqual(true);
+    expect(builders![0].config!.installCommand).toStrictEqual('');
+  });
+
   it('package.json + no build', async () => {
     const pkg = { dependencies: { next: '9.0.0' } };
     const files = ['package.json', 'pages/index.js', 'public/index.html'];


### PR DESCRIPTION
An empty string for the Project's `installCommand` setting has different behavior than `null`, so properly provide the empty string to the Runtime.