### PR TITLE
[cli] Fix `vc env rm` with advanced env variables

### DIFF
--- a/packages/now-cli/src/commands/env/rm.ts
+++ b/packages/now-cli/src/commands/env/rm.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { ProjectEnvTarget, Project } from '../../types';
+import { ProjectEnvTarget, Project, ProjectEnvVariableV5 } from '../../types';
 import { Output } from '../../util/output';
 import confirm from '../../util/input/confirm';
 import removeEnvRecord from '../../util/env/remove-env-record';
@@ -69,7 +69,20 @@ export default async function rm(
     envName = inputName;
   }
 
-  const { envs } = await getEnvVariables(output, client, project.id);
+  const data = await getEnvVariables(output, client, project.id);
+
+  // we expand env vars with multiple targets
+  const envs: ProjectEnvVariableV5[] = [];
+  for (let env of data.envs) {
+    if (Array.isArray(env.target)) {
+      for (let target of env.target) {
+        envs.push({ ...env, target });
+      }
+    } else {
+      envs.push({ ...env, target: env.target });
+    }
+  }
+
   const existing = new Set(
     envs.filter(r => r.key === envName).map(r => r.target)
   );


### PR DESCRIPTION
### Related Issues

Running `vc env rm` on an env variable created with an array of target currently fails with:
![image](https://user-images.githubusercontent.com/6616955/98956693-9ed63c00-2500-11eb-8d9e-196608418cfd.png)

This PR brings back a fix in https://github.com/vercel/vercel/pull/5372 that was reverted in https://github.com/vercel/vercel/pull/5410.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
