### PR TITLE
[next] Ensure correct route order for i18n + custom-routes

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -2036,7 +2036,7 @@ export async function build({
 
       if (redir.status === 308 && (location === '/$1' || location === '/$1/')) {
         // we set continue here to prevent the redirect from
-        // be moving underneath i18n routes
+        // moving underneath i18n routes
         redir.continue = true;
         trailingSlashRedirect = redir;
         return false;

--- a/packages/now-next/test/fixtures/00-i18n-support/next.config.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/next.config.js
@@ -18,4 +18,81 @@ module.exports = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/en-US/redirect-1',
+        destination: '/somewhere-else',
+        permanent: false,
+        locale: false,
+      },
+      {
+        source: '/nl/redirect-2',
+        destination: '/somewhere-else',
+        permanent: false,
+        locale: false,
+      },
+      {
+        source: '/redirect-3',
+        destination: '/somewhere-else',
+        permanent: false,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/en-US/rewrite-1',
+        destination: '/another',
+        locale: false,
+      },
+      {
+        source: '/nl/rewrite-2',
+        destination: '/nl/another',
+        locale: false,
+      },
+      {
+        source: '/fr/rewrite-3',
+        destination: '/nl/another',
+        locale: false,
+      },
+      {
+        source: '/rewrite-4',
+        destination: '/another',
+      },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/en-US/add-header-1',
+        locale: false,
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+      {
+        source: '/nl/add-header-2',
+        locale: false,
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+      {
+        source: '/add-header-3',
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+    ];
+  },
 };

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -520,6 +520,280 @@
       "path": "/_next/data/testing-build-id/fr/gsp/blocking/first.json",
       "status": 200,
       "mustContain": "\"catchall\":\"yes\""
+    },
+
+    {
+      "path": "/en-US/redirect-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/en/redirect-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404
+    },
+    {
+      "path": "/nl/redirect-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/en-US/redirect-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404
+    },
+    {
+      "path": "/redirect-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/en-US/redirect-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/fr/redirect-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/nl-NL/redirect-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 307,
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+
+    {
+      "path": "/en-US/rewrite-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/en-US/rewrite-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"en-US\""
+    },
+    {
+      "path": "/nl/rewrite-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404
+    },
+    {
+      "path": "/nl/rewrite-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/nl/rewrite-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"nl\""
+    },
+    {
+      "path": "/rewrite-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404
+    },
+    {
+      "path": "/fr/rewrite-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/fr/rewrite-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"nl\""
+    },
+    {
+      "path": "/rewrite-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404
+    },
+    {
+      "path": "/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"en-US\""
+    },
+    {
+      "path": "/en/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/en/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"en\""
+    },
+    {
+      "path": "/fr/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/fr/rewrite-4",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+
+    {
+      "path": "/en-US/add-header-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
+    },
+    {
+      "path": "/en/add-header-1",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": null
+      }
+    },
+    {
+      "path": "/nl/add-header-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
+    },
+    {
+      "path": "/en-US/add-header-2",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": null
+      }
+    },
+    {
+      "path": "/add-header-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
+    },
+    {
+      "path": "/en-US/add-header-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
+    },
+    {
+      "path": "/fr/add-header-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
+    },
+    {
+      "path": "/nl-NL/add-header-3",
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "status": 404,
+      "responseHeaders": {
+        "x-hello": "world"
+      }
     }
   ]
 }

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -251,7 +251,9 @@ async function testDeployment(
         const expected = probe.responseHeaders[header];
         const isEqual = Array.isArray(expected)
           ? expected.every(h => actual.includes(h))
-          : expected.startsWith('/') && expected.endsWith('/')
+          : typeof expected === 'string' &&
+            expected.startsWith('/') &&
+            expected.endsWith('/')
           ? new RegExp(expected.slice(1, -1)).test(actual)
           : expected === actual;
         if (!isEqual) {


### PR DESCRIPTION
This updates the routes order to match the handling added in https://github.com/vercel/next.js/pull/19164 for i18n + custom-routes. The tests added in this PR will currently fail until https://github.com/vercel/next.js/pull/19164 is landed. The changes in this PR were tested against the changes in the Next.js PR using https://github.com/ijjk/next-update-loader.git

### Related Issues

https://github.com/vercel/next.js/pull/19164
https://github.com/vercel/next.js/issues/18927
https://github.com/vercel/next.js/issues/18795

