### PR TITLE
Add support for reading the `public` directory from `.next`

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1928,6 +1928,10 @@ export async function build({
     '**',
     path.join(entryPath, outputDirectory, 'static')
   );
+  const nextPublicFiles = await glob(
+    '**',
+    path.join(entryPath, outputDirectory, 'public')
+  );
   const staticFolderFiles = await glob('**', path.join(entryPath, 'static'));
   const publicFolderFiles = await glob('**', path.join(entryPath, 'public'));
 
@@ -1944,6 +1948,15 @@ export async function build({
     (mappedFiles, file) => ({
       ...mappedFiles,
       [path.join(entryDirectory, 'static', file)]: staticFolderFiles[file],
+    }),
+    {}
+  );
+  const publicFiles = Object.keys(nextPublicFiles).reduce(
+    (mappedFiles, file) => ({
+      ...mappedFiles,
+      [path.join(entryDirectory, file.replace(/^public[/\\]+/, ''))]: nextPublicFiles[
+        file
+      ],
     }),
     {}
   );
@@ -2047,6 +2060,7 @@ export async function build({
 
   return {
     output: {
+      ...publicFiles,
       ...publicDirectoryFiles,
       ...lambdas,
       // Prerenders may override Lambdas -- this is an intentional behavior.


### PR DESCRIPTION
When support for the `public` directory was added to the Next.js Builder, we forgot to add support for making it read `public` from within `.next` if it's present there (we're already doing that for `static`).

In order to solve [this story](https://app.clubhouse.io/vercel/story/15096/support-reading-the-next-js-public-directory-from-the-next-directory) and make [NX](https://nx.dev/) work great on Vercel, we have to fix this.