### PR TITLE
[cli] Expose system envs when autoExposeSystemEnvs is enabled on vc dev

### DIFF
--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -243,6 +243,7 @@ export interface Project extends ProjectSettings {
   framework?: string | null;
   rootDirectory?: string | null;
   latestDeployments?: Partial<Deployment>[];
+  autoExposeSystemEnvs?: boolean;
 }
 
 export interface Org {

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -66,9 +66,9 @@ async function createBuildProcess(
   let PATH = `${dirname(process.execPath)}${delimiter}${process.env.PATH}`;
 
   const env: Env = {
-    ...systemEnvs.buildEnv,
     ...process.env,
     PATH,
+    ...systemEnvs.buildEnv,
     ...envConfigs.allEnv,
   };
 

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -35,6 +35,7 @@ import {
   BuildResultV3,
   BuilderOutputs,
   EnvConfigs,
+  SystemEnvs,
 } from './types';
 import { normalizeRoutes } from '@vercel/routing-utils';
 import getUpdateCommand from '../get-update-command';
@@ -53,6 +54,7 @@ interface BuildMessageResult extends BuildMessage {
 async function createBuildProcess(
   match: BuildMatch,
   envConfigs: EnvConfigs,
+  systemEnvs: SystemEnvs,
   workPath: string,
   output: Output
 ): Promise<ChildProcess> {
@@ -64,6 +66,7 @@ async function createBuildProcess(
   let PATH = `${dirname(process.execPath)}${delimiter}${process.env.PATH}`;
 
   const env: Env = {
+    ...systemEnvs.buildEnv,
     ...process.env,
     PATH,
     ...envConfigs.allEnv,
@@ -109,7 +112,13 @@ export async function executeBuild(
     builderWithPkg: { runInProcess, requirePath, builder, package: pkg },
   } = match;
   const { entrypoint } = match;
-  const { debug, envConfigs, cwd: workPath, devCacheDir } = devServer;
+  const {
+    debug,
+    envConfigs,
+    systemEnvs,
+    cwd: workPath,
+    devCacheDir,
+  } = devServer;
 
   const startTime = Date.now();
   const showBuildTimestamp =
@@ -131,6 +140,7 @@ export async function executeBuild(
     buildProcess = await createBuildProcess(
       match,
       envConfigs,
+      systemEnvs,
       workPath,
       devServer.output
     );
@@ -149,8 +159,8 @@ export async function executeBuild(
       filesRemoved,
       // This env distiniction is only necessary to maintain
       // backwards compatibility with the `@vercel/next` builder.
-      env: envConfigs.runEnv,
-      buildEnv: envConfigs.buildEnv,
+      env: { ...systemEnvs.runEnv, ...envConfigs.runEnv },
+      buildEnv: { ...systemEnvs.buildEnv, ...envConfigs.buildEnv },
     },
   };
 

--- a/packages/now-cli/src/util/dev/expose-system-envs.ts
+++ b/packages/now-cli/src/util/dev/expose-system-envs.ts
@@ -9,7 +9,7 @@ export default async function exposeSystemEnvs(
   projectId: string
 ) {
   const systemEnvs: SystemEnvs = {
-    buildEnv: { VERCEL: '1', VERCEL_ENV: 'development', CI: '1' },
+    buildEnv: { VERCEL: '1', VERCEL_ENV: 'development' },
     runEnv: { VERCEL: '1', VERCEL_ENV: 'development' },
   };
 

--- a/packages/now-cli/src/util/dev/expose-system-envs.ts
+++ b/packages/now-cli/src/util/dev/expose-system-envs.ts
@@ -9,11 +9,8 @@ export default async function exposeSystemEnvs(
   projectId: string
 ) {
   const systemEnvs: SystemEnvs = {
-    buildEnv: { CI: '1' },
-    runEnv: {
-      VERCEL: '1',
-      VERCEL_ENV: 'development',
-    },
+    buildEnv: { VERCEL: '1', VERCEL_ENV: 'development', CI: '1' },
+    runEnv: { VERCEL: '1', VERCEL_ENV: 'development' },
   };
 
   const { systemEnvValues } = await getSystemEnvValues(
@@ -22,6 +19,7 @@ export default async function exposeSystemEnvs(
     projectId
   );
   for (const key of systemEnvValues) {
+    systemEnvs.buildEnv[key] = '';
     systemEnvs.runEnv[key] = '';
   }
 

--- a/packages/now-cli/src/util/dev/expose-system-envs.ts
+++ b/packages/now-cli/src/util/dev/expose-system-envs.ts
@@ -1,0 +1,29 @@
+import { SystemEnvs } from './types';
+import getSystemEnvValues from '../env/get-system-env-values';
+import Client from '../client';
+import { Output } from '../output';
+
+export default async function exposeSystemEnvs(
+  output: Output,
+  client: Client,
+  projectId: string
+) {
+  const systemEnvs: SystemEnvs = {
+    buildEnv: { CI: '1' },
+    runEnv: {
+      VERCEL: '1',
+      VERCEL_ENV: 'development',
+    },
+  };
+
+  const { systemEnvValues } = await getSystemEnvValues(
+    output,
+    client,
+    projectId
+  );
+  for (const key of systemEnvValues) {
+    systemEnvs.runEnv[key] = '';
+  }
+
+  return systemEnvs;
+}

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -2012,7 +2012,7 @@ export default class DevServer {
       FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
       ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
       ...process.env,
-      ...this.systemEnvs.runEnv,
+      ...this.systemEnvs.buildEnv,
       ...this.envConfigs.allEnv,
       PORT: `${port}`,
     };

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -2011,8 +2011,8 @@ export default class DevServer {
       // Most frameworks use `chalk`/`supports-color` so we enable it anyway.
       FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
       ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
-      ...this.systemEnvs.runEnv,
       ...process.env,
+      ...this.systemEnvs.runEnv,
       ...this.envConfigs.allEnv,
       PORT: `${port}`,
     };

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -28,6 +28,7 @@ export interface DevServerOptions {
   frameworkSlug?: string;
   projectSettings?: ProjectSettings;
   environmentVars?: Env;
+  systemEnvs?: SystemEnvs;
 }
 
 export interface EnvConfigs {
@@ -45,6 +46,11 @@ export interface EnvConfigs {
    * environment variables from `.env` and `.env.build`
    */
   allEnv: Env;
+}
+
+export interface SystemEnvs {
+  buildEnv: Env;
+  runEnv: Env;
 }
 
 export interface BuildMatch extends BuildConfig {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -731,7 +731,6 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const vc = execa(binaryPath, ['dev', ...defaultArgs], {
       reject: false,
       cwd: target,
-      extendEnv: false,
     });
 
     let localhost = undefined;
@@ -793,7 +792,6 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const vc = execa(binaryPath, ['dev', ...defaultArgs], {
       reject: false,
       cwd: target,
-      extendEnv: false,
     });
 
     let localhost = undefined;

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -809,7 +809,6 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const localhostNoProtocol = localhost[0].slice('http://'.length);
 
     const apiJson = await apiRes.json();
-    t.is(apiJson['CI'], undefined);
     t.is(apiJson['VERCEL'], '1');
     t.is(apiJson['VERCEL_URL'], localhostNoProtocol);
     t.is(apiJson['VERCEL_ENV'], 'development');
@@ -819,7 +818,6 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const homeUrl = localhost[0];
     const homeRes = await fetch(homeUrl);
     const homeJson = await homeRes.json();
-    t.is(homeJson['CI'], '1');
     t.is(homeJson['VERCEL'], '1');
     t.is(homeJson['VERCEL_URL'], localhostNoProtocol);
     t.is(homeJson['VERCEL_ENV'], 'development');

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -731,6 +731,7 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const vc = execa(binaryPath, ['dev', ...defaultArgs], {
       reject: false,
       cwd: target,
+      extendEnv: false,
     });
 
     let localhost = undefined;
@@ -792,6 +793,7 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     const vc = execa(binaryPath, ['dev', ...defaultArgs], {
       reject: false,
       cwd: target,
+      extendEnv: false,
     });
 
     let localhost = undefined;

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -762,6 +762,70 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     t.is(homeJson['VERCEL_URL'], localhostNoProtocol);
     t.is(homeJson['MY_STDIN_VAR'], '{"expect":"quotes"}');
 
+    // system env vars are not automatically exposed
+    t.is(apiJson['VERCEL'], undefined);
+    t.is(homeJson['VERCEL'], undefined);
+
+    vc.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
+
+    const { exitCode, stderr, stdout } = await vc;
+    t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+  }
+
+  async function enableAutoExposeSystemEnvs() {
+    const link = require(path.join(target, '.vercel/project.json'));
+
+    const res = await apiFetch(`/v2/projects/${link.projectId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ autoExposeSystemEnvs: true }),
+    });
+
+    t.is(res.status, 200);
+    if (res.status === 200) {
+      console.log(
+        `Set autoExposeSystemEnvs=true for project ${link.projectId}`
+      );
+    }
+  }
+
+  async function nowDevAndFetchSystemVars() {
+    const vc = execa(binaryPath, ['dev', ...defaultArgs], {
+      reject: false,
+      cwd: target,
+    });
+
+    let localhost = undefined;
+    await waitForPrompt(vc, chunk => {
+      if (chunk.includes('Ready! Available at')) {
+        localhost = /(https?:[^\s]+)/g.exec(chunk);
+        return true;
+      }
+      return false;
+    });
+
+    const apiUrl = `${localhost[0]}/api/get-env`;
+    const apiRes = await fetch(apiUrl);
+
+    const localhostNoProtocol = localhost[0].slice('http://'.length);
+
+    const apiJson = await apiRes.json();
+    t.is(apiJson['CI'], undefined);
+    t.is(apiJson['VERCEL'], '1');
+    t.is(apiJson['VERCEL_URL'], localhostNoProtocol);
+    t.is(apiJson['VERCEL_ENV'], 'development');
+    t.is(apiJson['VERCEL_GIT_PROVIDER'], '');
+    t.is(apiJson['VERCEL_GIT_REPO_SLUG'], '');
+
+    const homeUrl = localhost[0];
+    const homeRes = await fetch(homeUrl);
+    const homeJson = await homeRes.json();
+    t.is(homeJson['CI'], '1');
+    t.is(homeJson['VERCEL'], '1');
+    t.is(homeJson['VERCEL_URL'], localhostNoProtocol);
+    t.is(homeJson['VERCEL_ENV'], 'development');
+    t.is(homeJson['VERCEL_GIT_PROVIDER'], '');
+    t.is(homeJson['VERCEL_GIT_REPO_SLUG'], '');
+
     vc.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
 
     const { exitCode, stderr, stdout } = await vc;
@@ -869,6 +933,8 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
   await nowDevWithEnv();
   fs.unlinkSync(path.join(target, '.env'));
   await nowDevAndFetchCloudVars();
+  await enableAutoExposeSystemEnvs();
+  await nowDevAndFetchSystemVars();
   await nowEnvRemove();
   await nowEnvRemoveWithArgs();
   await nowEnvRemoveWithNameOnly();


### PR DESCRIPTION
Ref: https://app.clubhouse.io/vercel/story/15112

We added a property called `autoExposeSystemEnvs` to projects. If that property is `true`, we automatically expose system env variables such as `VERCEL=1`, `VERCEL_ENV=<production | preview>`, ... to the runtime and build time.

This PR makes sure we mirror this behavior when running `vc dev` locally.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
