### PR TITLE
[next] Correct non-dynamic index SSG data route output

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1769,12 +1769,7 @@ export async function build({
       if (nonDynamicSsg || isFallback) {
         outputPathData = outputPathData.replace(
           new RegExp(`${escapeStringRegexp(origRouteFileNoExt)}.json$`),
-          `${routeFileNoExt}${
-            routeFileNoExt !== origRouteFileNoExt &&
-            origRouteFileNoExt === '/index'
-              ? '/index'
-              : ''
-          }.json`
+          `${routeFileNoExt}.json`
         );
       }
 

--- a/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
@@ -427,22 +427,22 @@
     },
 
     {
-      "path": "/_next/data/testing-build-id/en-US/index.json",
+      "path": "/_next/data/testing-build-id/en-US.json",
       "status": 200,
       "mustContain": "\"locale\":\"en-US\""
     },
     {
-      "path": "/_next/data/testing-build-id/en/index.json",
+      "path": "/_next/data/testing-build-id/en.json",
       "status": 200,
       "mustContain": "\"locale\":\"en\""
     },
     {
-      "path": "/_next/data/testing-build-id/fr/index.json",
+      "path": "/_next/data/testing-build-id/fr.json",
       "status": 200,
       "mustContain": "\"locale\":\"fr\""
     },
     {
-      "path": "/_next/data/testing-build-id/nl/index.json",
+      "path": "/_next/data/testing-build-id/nl.json",
       "status": 200,
       "mustContain": "\"locale\":\"nl\""
     },

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 module.exports = function (ctx) {
   it('should revalidate content properly from /', async () => {
     const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/index.json`
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US.json`
     );
     expect(dataRes.status).toBe(200);
     await dataRes.json();
@@ -36,7 +36,7 @@ module.exports = function (ctx) {
 
   it('should revalidate content properly from /fr', async () => {
     const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/index.json`
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr.json`
     );
     expect(dataRes.status).toBe(200);
     await dataRes.json();
@@ -67,7 +67,7 @@ module.exports = function (ctx) {
 
   it('should revalidate content properly from /nl-NL', async () => {
     const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/index.json`
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL.json`
     );
     expect(dataRes.status).toBe(200);
     await dataRes.json();

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -435,22 +435,22 @@
     },
 
     {
-      "path": "/_next/data/testing-build-id/en-US/index.json",
+      "path": "/_next/data/testing-build-id/en-US.json",
       "status": 200,
       "mustContain": "\"locale\":\"en-US\""
     },
     {
-      "path": "/_next/data/testing-build-id/en/index.json",
+      "path": "/_next/data/testing-build-id/en.json",
       "status": 200,
       "mustContain": "\"locale\":\"en\""
     },
     {
-      "path": "/_next/data/testing-build-id/fr/index.json",
+      "path": "/_next/data/testing-build-id/fr.json",
       "status": 200,
       "mustContain": "\"locale\":\"fr\""
     },
     {
-      "path": "/_next/data/testing-build-id/nl/index.json",
+      "path": "/_next/data/testing-build-id/nl.json",
       "status": 200,
       "mustContain": "\"locale\":\"nl\""
     },


### PR DESCRIPTION
This ensures we use the normalized data route location for non-dynamic index SSG pages which matches the current expected location in Next.js. The tests have been updated to match the expected location. 

Closes: https://github.com/vercel/next.js/issues/19237

