### PR TITLE
[cli] Expose VERCEL_REGION when `autoExposeSystemEnvs` is true

### DIFF
--- a/packages/now-cli/src/util/dev/expose-system-envs.ts
+++ b/packages/now-cli/src/util/dev/expose-system-envs.ts
@@ -10,7 +10,7 @@ export default async function exposeSystemEnvs(
 ) {
   const systemEnvs: SystemEnvs = {
     buildEnv: { VERCEL: '1', VERCEL_ENV: 'development' },
-    runEnv: { VERCEL: '1', VERCEL_ENV: 'development' },
+    runEnv: { VERCEL: '1', VERCEL_ENV: 'development', VERCEL_REGION: 'dev1' },
   };
 
   const { systemEnvValues } = await getSystemEnvValues(

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -822,6 +822,7 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     t.is(homeJson['VERCEL'], '1');
     t.is(homeJson['VERCEL_URL'], localhostNoProtocol);
     t.is(homeJson['VERCEL_ENV'], 'development');
+    t.is(homeJson['VERCEL_REGION'], undefined);
     t.is(homeJson['VERCEL_GIT_PROVIDER'], '');
     t.is(homeJson['VERCEL_GIT_REPO_SLUG'], '');
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -812,6 +812,7 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     t.is(apiJson['VERCEL'], '1');
     t.is(apiJson['VERCEL_URL'], localhostNoProtocol);
     t.is(apiJson['VERCEL_ENV'], 'development');
+    t.is(apiJson['VERCEL_REGION'], 'dev1');
     t.is(apiJson['VERCEL_GIT_PROVIDER'], '');
     t.is(apiJson['VERCEL_GIT_REPO_SLUG'], '');
 


### PR DESCRIPTION
Ref: https://app.clubhouse.io/vercel/story/15352

Automatically expose `VERCEL_REGION=dev1` to the run time when `autoExposeSystemEnvs` is set to true, to mirror the behaviour of the vercel platform.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
