### PR TITLE
[now-cli] Remove code which removes auto-generated secrets

### DIFF
--- a/packages/now-cli/src/util/env/remove-env-record.ts
+++ b/packages/now-cli/src/util/env/remove-env-record.ts
@@ -1,6 +1,6 @@
 import { Output } from '../output';
 import Client from '../client';
-import { ProjectEnvTarget, Secret, ProjectEnvVariableV5 } from '../../types';
+import { ProjectEnvTarget, ProjectEnvVariableV5 } from '../../types';
 
 export default async function removeEnvRecord(
   output: Output,
@@ -18,32 +18,7 @@ export default async function removeEnvRecord(
     envName
   )}${qs}`;
 
-  const env = await client.fetch<ProjectEnvVariableV5>(urlProject, {
+  await client.fetch<ProjectEnvVariableV5>(urlProject, {
     method: 'DELETE',
   });
-
-  if (env && env.value) {
-    const idOrName = env.value.startsWith('@') ? env.value.slice(1) : env.value;
-    const urlSecret = `/v2/now/secrets/${idOrName}`;
-    let secret: Secret | undefined;
-
-    try {
-      secret = await client.fetch<Secret>(urlSecret);
-    } catch (error) {
-      if (error && error.status === 404) {
-        // User likely deleted the secret before the env var, so we can still report success
-        output.debug(
-          `Skipped ${env.key} because secret ${idOrName} was already deleted`
-        );
-        return;
-      }
-      throw error;
-    }
-
-    // Since integrations add global secrets, we must only delete if the secret was
-    // specifically added to this project
-    if (secret && secret.projectId === projectId) {
-      await client.fetch<Secret>(urlSecret, { method: 'DELETE' });
-    }
-  }
 }


### PR DESCRIPTION
This PR removes the code which deletes the auto-generated secret in the function which removes an env var. We are not creating a secret when creating an env var anymore, so there's no need for that code.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
