### PR TITLE
[next] Add handle: resource to ensure 404 page

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -718,6 +718,8 @@ export async function build({
         // with that routing section
         ...rewrites,
 
+        // make sure 404 page is used when a directory is matched without
+        // an index page
         { handle: 'resource' },
         { src: path.join('/', entryDirectory, '.*'), status: 404 },
 
@@ -2243,6 +2245,8 @@ export async function build({
       // with that routing section
       ...rewrites,
 
+      // make sure 404 page is used when a directory is matched without
+      // an index page
       { handle: 'resource' },
       { src: path.join('/', entryDirectory, '.*'), status: 404 },
 

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -718,6 +718,9 @@ export async function build({
         // with that routing section
         ...rewrites,
 
+        { handle: 'resource' },
+        { src: path.join('/', entryDirectory, '.*'), status: 404 },
+
         // We need to make sure to 404 for /_next after handle: miss since
         // handle: miss is called before rewrites and to prevent rewriting
         // /_next
@@ -2016,7 +2019,6 @@ export async function build({
   const { i18n } = routesManifest || {};
 
   const trailingSlashRedirects: Route[] = [];
-  let trailingSlash = false;
 
   redirects = redirects.filter(_redir => {
     const redir = _redir as Source;
@@ -2032,9 +2034,6 @@ export async function build({
     if (redir.status === 308 && (location === '/$1' || location === '/$1/')) {
       // we set continue here to prevent the redirect from
       // moving underneath i18n routes
-      if (location === '/$1/') {
-        trailingSlash = true;
-      }
       redir.continue = true;
       trailingSlashRedirects.push(redir);
       return false;
@@ -2081,13 +2080,6 @@ export async function build({
       - Builder rewrites
     */
     routes: [
-      ...(trailingSlash
-        ? [
-            {
-              src: '^/\\.well-known(?:/.*)?$',
-            },
-          ]
-        : []),
       // force trailingSlashRedirect to the very top so it doesn't
       // conflict with i18n routes that don't have or don't have the
       // trailing slash
@@ -2250,6 +2242,9 @@ export async function build({
       // These need to come before handle: miss or else they are grouped
       // with that routing section
       ...rewrites,
+
+      { handle: 'resource' },
+      { src: path.join('/', entryDirectory, '.*'), status: 404 },
 
       // We need to make sure to 404 for /_next after handle: miss since
       // handle: miss is called before rewrites and to prevent rewriting /_next

--- a/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support-no-locale-detection/now.json
@@ -345,17 +345,21 @@
       "mustContain": "slug\":\"first\""
     },
 
-    // TODO: update when directory listing is disabled
-    // and these are proper 404s
     {
       "path": "/en/not-found",
-      "status": 200,
-      "mustContain": "Index of"
+      "status": 404
+    },
+    {
+      "path": "/en/not-found",
+      "mustContain": "lang=\"en\""
     },
     {
       "path": "/nl/not-found",
-      "status": 200,
-      "mustContain": "Index of"
+      "status": 404
+    },
+    {
+      "path": "/nl/not-found",
+      "mustContain": "lang=\"nl\""
     },
     {
       "path": "/en-US/not-found",

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
@@ -20,7 +20,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('en-US');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/`);
     expect(res2.status).toBe(200);
@@ -48,7 +48,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('fr');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr`);
     expect(res2.status).toBe(200);
@@ -76,7 +76,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('nl-NL');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL`);
     expect(res2.status).toBe(200);
@@ -95,7 +95,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/second`);
     expect(res.status).toBe(200);
@@ -107,7 +107,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('en-US');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/second`);
     expect(res2.status).toBe(200);
@@ -126,7 +126,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/fr/second`);
     expect(res.status).toBe(200);
@@ -138,7 +138,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('fr');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr/second`);
     expect(res2.status).toBe(200);
@@ -157,7 +157,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL/second`);
     expect(res.status).toBe(200);
@@ -169,7 +169,7 @@ module.exports = function (ctx) {
     expect($('#router-locale').text()).toBe('nl-NL');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL/second`);
     expect(res2.status).toBe(200);

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
@@ -4,13 +4,6 @@ const cheerio = require('cheerio');
 
 module.exports = function (ctx) {
   it('should revalidate content properly from /', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
     const res = await fetch(`${ctx.deploymentUrl}/`);
     expect(res.status).toBe(200);
 
@@ -32,13 +25,6 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /fr', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
     const res = await fetch(`${ctx.deploymentUrl}/fr`);
     expect(res.status).toBe(200);
 
@@ -60,13 +46,6 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /nl-NL', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/index.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL`);
     expect(res.status).toBe(200);
 
@@ -88,15 +67,6 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /second', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/en-US/second.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
-    await new Promise(resolve => setTimeout(resolve, 4000));
-
     const res = await fetch(`${ctx.deploymentUrl}/second`);
     expect(res.status).toBe(200);
 
@@ -119,15 +89,6 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /fr/second', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/fr/second.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
-    await new Promise(resolve => setTimeout(resolve, 4000));
-
     const res = await fetch(`${ctx.deploymentUrl}/fr/second`);
     expect(res.status).toBe(200);
 
@@ -150,15 +111,6 @@ module.exports = function (ctx) {
   });
 
   it('should revalidate content properly from /nl-NL/second', async () => {
-    // we have to hit the _next/data URL first
-    const dataRes = await fetch(
-      `${ctx.deploymentUrl}/_next/data/testing-build-id/nl-NL/second.json`
-    );
-    expect(dataRes.status).toBe(200);
-    await dataRes.json();
-
-    await new Promise(resolve => setTimeout(resolve, 4000));
-
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL/second`);
     expect(res.status).toBe(200);
 

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -10,7 +10,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/`);
     expect(res.status).toBe(200);
@@ -22,7 +22,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/`);
     expect(res2.status).toBe(200);
@@ -41,7 +41,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/fr`);
     expect(res.status).toBe(200);
@@ -53,7 +53,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr`);
     expect(res2.status).toBe(200);
@@ -72,7 +72,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL`);
     expect(res.status).toBe(200);
@@ -84,7 +84,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({});
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL`);
     expect(res2.status).toBe(200);
@@ -104,7 +104,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/gsp/fallback/first`);
     expect(res.status).toBe(200);
@@ -118,7 +118,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/gsp/fallback/first`);
     expect(res2.status).toBe(200);
@@ -139,7 +139,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/first`);
     expect(res.status).toBe(200);
@@ -153,7 +153,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/first`);
     expect(res2.status).toBe(200);
@@ -174,7 +174,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/first`);
     expect(res.status).toBe(200);
@@ -188,7 +188,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/first`);
     expect(res2.status).toBe(200);
@@ -212,7 +212,7 @@ module.exports = function (ctx) {
     const initRes = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
     expect(initRes.status).toBe(200);
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
     expect(res.status).toBe(200);
@@ -226,7 +226,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/gsp/fallback/new-page`);
     expect(res2.status).toBe(200);
@@ -246,7 +246,7 @@ module.exports = function (ctx) {
     );
     expect(dataRes.status).toBe(200);
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/new-page`);
     expect(res.status).toBe(200);
@@ -260,7 +260,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/fallback/new-page`);
     expect(res2.status).toBe(200);
@@ -278,7 +278,7 @@ module.exports = function (ctx) {
     );
     expect(dataRes.status).toBe(200);
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/nl-NL/gsp/fallback/new-page`);
     expect(res.status).toBe(200);
@@ -292,7 +292,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'new-page' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/nl-NL/gsp/fallback/new-page`
@@ -314,7 +314,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/gsp/no-fallback/first`);
     expect(res.status).toBe(200);
@@ -327,7 +327,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/gsp/no-fallback/first`);
     expect(res2.status).toBe(200);
@@ -347,7 +347,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/fr/gsp/no-fallback/first`);
     expect(res.status).toBe(200);
@@ -360,7 +360,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'first' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/fr/gsp/no-fallback/first`);
     expect(res2.status).toBe(200);
@@ -380,7 +380,7 @@ module.exports = function (ctx) {
     expect(dataRes.status).toBe(200);
     await dataRes.json();
 
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(
       `${ctx.deploymentUrl}/nl-NL/gsp/no-fallback/second`
@@ -395,7 +395,7 @@ module.exports = function (ctx) {
     expect(JSON.parse($('#router-query').text())).toEqual({ slug: 'second' });
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/nl-NL/gsp/no-fallback/second`

--- a/packages/now-next/test/fixtures/00-i18n-support/now.json
+++ b/packages/now-next/test/fixtures/00-i18n-support/now.json
@@ -353,17 +353,21 @@
       "mustContain": "slug\":\"first\""
     },
 
-    // TODO: update when directory listing is disabled
-    // and these are proper 404s
     {
       "path": "/en/not-found",
-      "status": 200,
-      "mustContain": "Index of"
+      "status": 404
+    },
+    {
+      "path": "/en/not-found",
+      "mustContain": "lang=\"en\""
     },
     {
       "path": "/nl/not-found",
-      "status": 200,
-      "mustContain": "Index of"
+      "status": 404
+    },
+    {
+      "path": "/nl/not-found",
+      "mustContain": "lang=\"nl\""
     },
     {
       "path": "/en-US/not-found",

--- a/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
+++ b/packages/now-next/test/fixtures/00-root-optional-revalidate/additional.js
@@ -18,7 +18,7 @@ module.exports = function (ctx) {
     const props = await getProps('/', { params: {} });
     expect(props.params).toEqual({});
 
-    await waitFor(2000);
+    await waitFor(4000);
     await getProps('/');
 
     const newProps = await getProps('/', { params: {} });
@@ -30,7 +30,7 @@ module.exports = function (ctx) {
     const props = await getProps('/a');
     expect(props.params).toEqual({ slug: ['a'] });
 
-    await waitFor(2000);
+    await waitFor(4000);
     await getProps('/a');
 
     const newProps = await getProps('/a');
@@ -42,7 +42,7 @@ module.exports = function (ctx) {
     const props = await getProps('/hello/world');
     expect(props.params).toEqual({ slug: ['hello', 'world'] });
 
-    await waitFor(2000);
+    await waitFor(4000);
     await getProps('/hello/world');
 
     const newProps = await getProps('/hello/world');

--- a/packages/now-next/test/fixtures/22-ssg-v2/additional.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/additional.js
@@ -13,7 +13,7 @@ module.exports = function (ctx) {
     expect($('#hello').text()).toBe('hello: world');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/another`);
     expect(res2.status).toBe(200);
@@ -34,7 +34,7 @@ module.exports = function (ctx) {
     expect($('#post').text()).toBe('Post: post-123');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/blog/post-123`);
     expect(res2.status).toBe(200);
@@ -56,7 +56,7 @@ module.exports = function (ctx) {
     expect($('#comment').text()).toBe('Comment: comment-321');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/blog/post-123/comment-321`);
     expect(res2.status).toBe(200);
@@ -82,7 +82,7 @@ module.exports = function (ctx) {
     expect(isNaN(initialRandom)).toBe(false);
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/_next/data/testing-build-id/another.json`
@@ -111,7 +111,7 @@ module.exports = function (ctx) {
     expect(isNaN(initialRandom)).toBe(false);
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/_next/data/testing-build-id/blog/post-123.json`
@@ -141,7 +141,7 @@ module.exports = function (ctx) {
     expect(isNaN(initialRandom)).toBe(false);
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/_next/data/testing-build-id/blog/post-123/comment-321.json`

--- a/packages/now-next/test/fixtures/31-blocking-fallback/additional.js
+++ b/packages/now-next/test/fixtures/31-blocking-fallback/additional.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 module.exports = function (ctx) {
   it('should revalidate content properly from dynamic pathname', async () => {
     // wait for revalidation to expire
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(`${ctx.deploymentUrl}/regenerated/blue`);
     expect(res.status).toBe(200);
@@ -15,7 +15,7 @@ module.exports = function (ctx) {
     expect($('#slug').text()).toBe('blue');
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(`${ctx.deploymentUrl}/regenerated/blue`);
     expect(res2.status).toBe(200);
@@ -27,7 +27,7 @@ module.exports = function (ctx) {
 
   it('should revalidate content properly from /_next/data dynamic pathname', async () => {
     // wait for revalidation to expire
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res = await fetch(
       `${ctx.deploymentUrl}/_next/data/testing-build-id/regenerated/blue.json`
@@ -40,7 +40,7 @@ module.exports = function (ctx) {
     expect(isNaN(initialTime)).toBe(false);
 
     // wait for revalidation to occur
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 4000));
 
     const res2 = await fetch(
       `${ctx.deploymentUrl}/_next/data/testing-build-id/regenerated/blue.json`


### PR DESCRIPTION
This adds `handle: resource` to ensure the 404 page is shown instead of a directory listing when there isn't an index route for an output directory. This also removes the `.well-known` route added in https://github.com/vercel/vercel/pull/5447 in favor of adding it in Next.js itself here https://github.com/vercel/next.js/pull/19364 and revalidate tests wait times are increased in this PR due to [this thread](https://vercel.slack.com/archives/C9MMK4674/p1605821738156200)

x-ref: https://github.com/vercel/next.js/pull/19364
Fixes: https://github.com/vercel/next.js/issues/16555
Fixes: https://github.com/vercel/next.js/issues/16552


