### PR TITLE
[next] Make sure to use outputDirectory when loading prerenderManifest

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -445,7 +445,10 @@ export async function build({
     nextVersion
   );
   const imagesManifest = await getImagesManifest(entryPath, outputDirectory);
-  const prerenderManifest = await getPrerenderManifest(entryPath);
+  const prerenderManifest = await getPrerenderManifest(
+    entryPath,
+    outputDirectory
+  );
   const headers: Route[] = [];
   const rewrites: Route[] = [];
   let redirects: Route[] = [];

--- a/packages/now-next/src/utils.ts
+++ b/packages/now-next/src/utils.ts
@@ -829,11 +829,12 @@ export async function getExportStatus(
 }
 
 export async function getPrerenderManifest(
-  entryPath: string
+  entryPath: string,
+  outputDirectory: string
 ): Promise<NextPrerenderedRoutes> {
   const pathPrerenderManifest = path.join(
     entryPath,
-    '.next',
+    outputDirectory,
     'prerender-manifest.json'
   );
 

--- a/packages/now-next/test/fixtures/24-custom-output-dir/next.config.js
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/next.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   distDir: 'the-output-directory',
-  target: 'serverless',
+  generateBuildId() {
+    return 'testing-build-id';
+  },
 };

--- a/packages/now-next/test/fixtures/24-custom-output-dir/now.json
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/now.json
@@ -14,6 +14,26 @@
       "path": "/",
       "status": 200,
       "mustContain": "hello world"
+    },
+    {
+      "path": "/ssg/first",
+      "status": 200,
+      "mustContain": "first"
+    },
+    {
+      "path": "/ssg/second",
+      "status": 200,
+      "mustContain": "Loading..."
+    },
+    {
+      "path": "/_next/data/testing-build-id/ssg/second.json",
+      "status": 200,
+      "mustContain": "\"slug\":\"second\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/ssg/third.json",
+      "status": 200,
+      "mustContain": "\"slug\":\"third\""
     }
   ]
 }

--- a/packages/now-next/test/fixtures/24-custom-output-dir/pages/ssg/[slug].js
+++ b/packages/now-next/test/fixtures/24-custom-output-dir/pages/ssg/[slug].js
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      params,
+      hello: 'world',
+    },
+  };
+};
+
+export const getStaticPaths = () => {
+  return {
+    paths: [{ params: { slug: 'first' } }],
+    fallback: true,
+  };
+};
+
+export default function Page(props) {
+  const router = useRouter();
+
+  if (router.isFallback) {
+    return 'Loading...';
+  }
+
+  return (
+    <>
+      <p>slug: {props.params?.slug}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  );
+}


### PR DESCRIPTION
This makes sure we load the `prerender-manifest` the same way we load the `routes-manifest`
 
x-ref: https://github.com/vercel/next.js/issues/19621
