### PR TITLE
[cli][build-utils] Change type to handle builds without a `src` property

### DIFF
--- a/packages/now-build-utils/src/types.ts
+++ b/packages/now-build-utils/src/types.ts
@@ -336,7 +336,7 @@ export interface NodeVersion {
 
 export interface Builder {
   use: string;
-  src: string;
+  src?: string;
   config?: Config;
 }
 

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -182,7 +182,7 @@ describe('Test `detectBuilders`', () => {
 
     const { builders } = await detectBuilders(files);
     expect(builders!.length).toBe(7);
-    expect(builders!.some(b => b.src.endsWith('_test.go'))).toBe(false);
+    expect(builders!.some(b => b.src!.endsWith('_test.go'))).toBe(false);
   });
 
   it('just public', async () => {
@@ -1341,7 +1341,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
       featHandleMiss,
     });
     expect(builders!.length).toBe(7);
-    expect(builders!.some(b => b.src.endsWith('_test.go'))).toBe(false);
+    expect(builders!.some(b => b.src!.endsWith('_test.go'))).toBe(false);
     expect(errorRoutes!.length).toBe(1);
     expect((errorRoutes![0] as Source).status).toBe(404);
   });

--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -402,7 +402,7 @@ export async function getBuildMatches(
   const builds = nowConfig.builds || [{ src: '**', use: '@vercel/static' }];
 
   for (const buildConfig of builds) {
-    let { src, use } = buildConfig;
+    let { src = '**', use } = buildConfig;
 
     if (!use) {
       continue;

--- a/packages/now-cli/src/util/dev/types.ts
+++ b/packages/now-cli/src/util/dev/types.ts
@@ -50,6 +50,7 @@ export interface EnvConfigs {
 
 export interface BuildMatch extends BuildConfig {
   entrypoint: string;
+  src: string;
   builderWithPkg: BuilderWithPackage;
   buildOutput: BuilderOutputs;
   buildResults: Map<string | null, BuildResult>;

--- a/packages/now-cli/test/dev/fixtures/missing-src-property/.gitignore
+++ b/packages/now-cli/test/dev/fixtures/missing-src-property/.gitignore
@@ -1,0 +1,4 @@
+package.json
+yarn.lock
+.now
+.vercel

--- a/packages/now-cli/test/dev/fixtures/missing-src-property/index.txt
+++ b/packages/now-cli/test/dev/fixtures/missing-src-property/index.txt
@@ -1,0 +1,1 @@
+hello:index.txt

--- a/packages/now-cli/test/dev/fixtures/missing-src-property/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/missing-src-property/vercel.json
@@ -1,0 +1,7 @@
+{
+  "builds": [
+    {
+      "use": "@vercel/static"
+    }
+  ]
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1756,3 +1756,11 @@ test(
     });
   })
 );
+
+test(
+  '[vercel dev] Do not fail if `src` is missing',
+  testFixtureStdio('missing-src-property', async testPath => {
+    await testPath(200, '/', /hello:index.txt/m);
+    await testPath(404, '/i-do-not-exist');
+  })
+);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1734,9 +1734,10 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid request: should NOT have additional property `builder`.'
+      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
     )
   );
+  t.true(stderr.includes('https://vercel.com/docs/configuration'));
 });
 
 test('try to create a builds deployments with wrong vercel.json', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1734,10 +1734,9 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
+      'Error! Invalid request: should NOT have additional property `builder`.'
     )
   );
-  t.true(stderr.includes('https://vercel.com/docs/configuration'));
 });
 
 test('try to create a builds deployments with wrong vercel.json', async t => {


### PR DESCRIPTION
### Related Issues

[The schema for builds](https://github.com/vercel/vercel/blob/3f76fefde6bef7833b45cb52796f6a17819697ea/packages/now-build-utils/src/schemas.ts#L46) doesn't mark `src` as required, this PR updates the type to match the schema.

As a result `vc dev` was updated to fall back to `**` in case `src` is not defined, as we do in production.