### PR TITLE
[examples] Update gatsby to use @vercel/node

### DIFF
--- a/examples/gatsby/api/date.ts
+++ b/examples/gatsby/api/date.ts
@@ -1,4 +1,4 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@vercel/node';
 
 export default (_req: NowRequest, res: NowResponse) => {
   const date = new Date().toString();

--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -12,7 +12,7 @@
     "react-helmet": "^5.2.0"
   },
   "devDependencies": {
-    "@now/node": "^1.3.0"
+    "@vercel/node": "1.8.5"
   },
   "scripts": {
     "dev": "gatsby develop",

--- a/examples/gatsby/yarn.lock
+++ b/examples/gatsby/yarn.lock
@@ -1107,15 +1107,6 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@now/node@^1.3.0":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@now/node/-/node-1.7.1.tgz#764a0c6bcb24967f8014c4f73ad238c292996fe3"
-  integrity sha512-+srVKopsVTPDR3u9eOjJryZroLTrPp8XEOuIDGBdfFcJuS7qpAomctSbfyA7WNyjC0ExtUxELqBg5sAedG5+2g==
-  dependencies:
-    "@types/node" "*"
-    ts-node "8.9.1"
-    typescript "3.9.3"
-
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"
   resolved "https://registry.yarnpkg.com/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz#2e9da9d3ade9d18d013333eb408c457d04eabac0"
@@ -1408,6 +1399,15 @@
   integrity sha512-mu0xHbbMWU7RDkHawCNvHKEfDtQT0dfHPD2KXMMv9ibxp0CNdvQ00hppvf6C9j2WuPxGn2NadIjVg51vGCYr5w==
   dependencies:
     wonka "^4.0.14"
+
+"@vercel/node@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-1.8.5.tgz#2c8b9532f1bb25734a9964c52973386ed78022d4"
+  integrity sha512-1iw7FSR8Oau6vZB1MWfBnA5q2a/IqRHiSZSbt8lz0dyTF599q8pc5GcSv/TvmrYaEGzh3+N0S4cbmuMCqVlwJg==
+  dependencies:
+    "@types/node" "*"
+    ts-node "8.9.1"
+    typescript "3.9.3"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
[`@now/node`](https://www.npmjs.com/package/@now/node) is deprecated in favor of [`@vercel/node`](https://www.npmjs.com/package/@vercel/node)