### PR TITLE
[node] Add `Vercel` prefixed TypeScript types

### DIFF
--- a/packages/now-node/src/types.ts
+++ b/packages/now-node/src/types.ts
@@ -1,20 +1,31 @@
 import { ServerResponse, IncomingMessage } from 'http';
 
-export type NowRequestCookies = { [key: string]: string };
-export type NowRequestQuery = { [key: string]: string | string[] };
+export type VercelRequestCookies = { [key: string]: string };
+export type VercelRequestQuery = { [key: string]: string | string[] };
+export type VercelRequestBody = any;
+
+export type VercelRequest = IncomingMessage & {
+  query: VercelRequestQuery;
+  cookies: VercelRequestCookies;
+  body: VercelRequestBody;
+};
+
+export type VercelResponse = ServerResponse & {
+  send: (body: any) => VercelResponse;
+  json: (jsonBody: any) => VercelResponse;
+  status: (statusCode: number) => VercelResponse;
+  redirect: (statusOrUrl: string | number, url?: string) => VercelResponse;
+};
+
+export type VercelApiHandler = (
+  req: VercelRequest,
+  res: VercelResponse
+) => void;
+
+// Backwards-compat
+export type NowRequestCookies = VercelRequestCookies;
+export type NowRequestQuery = VercelRequestQuery;
 export type NowRequestBody = any;
-
-export type NowRequest = IncomingMessage & {
-  query: NowRequestQuery;
-  cookies: NowRequestCookies;
-  body: NowRequestBody;
-};
-
-export type NowResponse = ServerResponse & {
-  send: (body: any) => NowResponse;
-  json: (jsonBody: any) => NowResponse;
-  status: (statusCode: number) => NowResponse;
-  redirect: (statusOrUrl: string | number, url?: string) => NowResponse;
-};
-
-export type NowApiHandler = (req: NowRequest, res: NowResponse) => void;
+export type NowRequest = VercelRequest;
+export type NowResponse = VercelResponse;
+export type NowApiHandler = VercelApiHandler;

--- a/packages/now-node/test/fixtures/15-helpers/now.json
+++ b/packages/now-node/test/fixtures/15-helpers/now.json
@@ -3,6 +3,7 @@
   "builds": [
     { "src": "index.js", "use": "@vercel/node" },
     { "src": "ts/index.ts", "use": "@vercel/node" },
+    { "src": "ts-legacy/index.ts", "use": "@vercel/node" },
     { "src": "micro-compat/index.js", "use": "@vercel/node" },
     {
       "src": "no-helpers/index.js",
@@ -39,6 +40,10 @@
     {
       "path": "/ts",
       "mustContain": "hello:RANDOMNESS_PLACEHOLDER"
+    },
+    {
+      "path": "/ts-legacy",
+      "mustContain": "hello legacy:RANDOMNESS_PLACEHOLDER"
     },
     {
       "path": "/micro-compat",

--- a/packages/now-node/test/fixtures/15-helpers/ts-legacy/handler.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts-legacy/handler.ts
@@ -1,0 +1,8 @@
+import { NowApiHandler } from './types';
+
+const listener: NowApiHandler = (req, res) => {
+  res.status(200);
+  res.send('hello:RANDOMNESS_PLACEHOLDER');
+};
+
+export default listener;

--- a/packages/now-node/test/fixtures/15-helpers/ts-legacy/handler.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts-legacy/handler.ts
@@ -2,7 +2,7 @@ import { NowApiHandler } from './types';
 
 const listener: NowApiHandler = (req, res) => {
   res.status(200);
-  res.send('hello:RANDOMNESS_PLACEHOLDER');
+  res.send('hello legacy:RANDOMNESS_PLACEHOLDER');
 };
 
 export default listener;

--- a/packages/now-node/test/fixtures/15-helpers/ts-legacy/index.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts-legacy/index.ts
@@ -1,0 +1,6 @@
+import { NowRequest, NowResponse } from './types';
+
+export default function listener(req: NowRequest, res: NowResponse) {
+  res.status(200);
+  res.send('hello legacy:RANDOMNESS_PLACEHOLDER');
+}

--- a/packages/now-node/test/fixtures/15-helpers/ts-legacy/tsconfig.json
+++ b/packages/now-node/test/fixtures/15-helpers/ts-legacy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "lib": ["esnext"],
+    "target": "esnext",
+    "module": "commonjs"
+  },
+  "include": ["index.ts"]
+}

--- a/packages/now-node/test/fixtures/15-helpers/ts-legacy/tsconfig.json
+++ b/packages/now-node/test/fixtures/15-helpers/ts-legacy/tsconfig.json
@@ -7,5 +7,5 @@
     "target": "esnext",
     "module": "commonjs"
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "handler.ts"]
 }

--- a/packages/now-node/test/fixtures/15-helpers/ts/handler.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts/handler.ts
@@ -1,6 +1,6 @@
-import { NowApiHandler } from './types';
+import { VercelApiHandler } from './types';
 
-const listener: NowApiHandler = (req, res) => {
+const listener: VercelApiHandler = (req, res) => {
   res.status(200);
   res.send('hello:RANDOMNESS_PLACEHOLDER');
 };

--- a/packages/now-node/test/fixtures/15-helpers/ts/index.ts
+++ b/packages/now-node/test/fixtures/15-helpers/ts/index.ts
@@ -1,6 +1,6 @@
-import { NowRequest, NowResponse } from './types';
+import { VercelRequest, VercelResponse } from './types';
 
-export default function listener(req: NowRequest, res: NowResponse) {
+export default function listener(req: VercelRequest, res: VercelResponse) {
   res.status(200);
   res.send('hello:RANDOMNESS_PLACEHOLDER');
 }

--- a/packages/now-node/test/fixtures/15-helpers/ts/tsconfig.json
+++ b/packages/now-node/test/fixtures/15-helpers/ts/tsconfig.json
@@ -7,5 +7,5 @@
     "target": "esnext",
     "module": "commonjs"
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "handler.ts"]
 }

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
@@ -1,7 +1,7 @@
-import { NowRequest, NowResponse } from '@now/node';
+import { VercelRequest, VercelResponse } from '@now/node';
 import { hello } from './dep';
 
-export default function(req: NowRequest, res: NowResponse) {
+export default function (req: VercelRequest, res: VercelResponse) {
   if (req) {
     res.end(hello.toString());
   } else {

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/index.ts
@@ -1,7 +1,7 @@
-import { VercelRequest, VercelResponse } from '@now/node';
+import { NowRequest, NowResponse } from '@now/node';
 import { hello } from './dep';
 
-export default function (req: VercelRequest, res: VercelResponse) {
+export default function (req: NowRequest, res: NowResponse) {
   if (req) {
     res.end(hello.toString());
   } else {

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "devDependencies": {
-    "@vercel/node": "*",
+    "@now/node": "*",
     "typescript": "3.5.3"
   }
 }

--- a/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
+++ b/packages/now-node/test/fixtures/18-nested-tsconfig/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "devDependencies": {
-    "@now/node": "*",
+    "@vercel/node": "*",
     "typescript": "3.5.3"
   }
 }


### PR DESCRIPTION
The `Now` prefixed types remain as aliases for backwards-compat purposes.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer