### PR TITLE
[cli] Fix `vc logs -o raw` and add test

### DIFF
--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -324,7 +324,7 @@ function printLogRaw(log) {
 
   if (log.object) {
     console.log(log.object);
-  } else {
+  } else if (typeof log.text === 'string') {
     console.log(
       log.text
         .replace(/\n$/, '')

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1566,7 +1566,7 @@ test('ensure we render a warning for deployments with no files', async t => {
   t.is(res.status, 404);
 });
 
-test('output logs of a 2.0 deployment', async t => {
+test('output logs with "short" output', async t => {
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
     ['logs', context.deployment, ...defaultArgs],
@@ -1583,13 +1583,21 @@ test('output logs of a 2.0 deployment', async t => {
     stderr.includes(`Fetched deployment "${context.deployment}"`),
     formatOutput({ stderr, stdout })
   );
+
+  // "short" format includes timestamps
+  t.truthy(
+    stdout.match(
+      /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
+    )
+  );
+
   t.is(exitCode, 0);
 });
 
-test('output logs of a 2.0 deployment without annotate', async t => {
+test('output logs with "raw" output', async t => {
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
-    ['logs', context.deployment, ...defaultArgs],
+    ['logs', context.deployment, ...defaultArgs, '--output', 'raw'],
     {
       reject: false,
     }
@@ -1599,12 +1607,19 @@ test('output logs of a 2.0 deployment without annotate', async t => {
   console.log(stdout);
   console.log(exitCode);
 
-  t.true(!stderr.includes('[now-builder-debug]'));
-  t.true(!stderr.includes('START RequestId'));
-  t.true(!stderr.includes('END RequestId'));
-  t.true(!stderr.includes('REPORT RequestId'));
-  t.true(!stderr.includes('Init Duration'));
-  t.true(!stderr.includes('XRAY TraceId'));
+  t.true(
+    stderr.includes(`Fetched deployment "${context.deployment}"`),
+    formatOutput({ stderr, stdout })
+  );
+
+  // "raw" format does not include timestamps
+  t.is(
+    null,
+    stdout.match(
+      /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
+    )
+  );
+
   t.is(exitCode, 0);
 });
 


### PR DESCRIPTION
There are events (i.e. with `type: "deployment-event"`) that do not
contain a `text` property, so check that it's a string before invoking
`.replace()` on it.

Fixes this stack trace:

```
Error! An unexpected error occurred in logs: TypeError: Cannot read property 'replace' of undefined
    at Object.printLogRaw [as raw] (/home/me/nextjs-site/node_modules/vercel/dist/index.js:203803:10)
    at printEvent (/home/me/nextjs-site/node_modules/vercel/dist/index.js:203688:35)
    at Array.forEach (<anonymous>)
    at main (/home/me/nextjs-site/node_modules/vercel/dist/index.js:203690:31)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at main (/home/me/nextjs-site/node_modules/vercel/dist/index.js:207173:16)
```

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR