### PR TITLE
[node][next] Bump nft to 0.9.5

### DIFF
--- a/packages/now-next/package.json
+++ b/packages/now-next/package.json
@@ -26,7 +26,7 @@
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.1",
-    "@vercel/nft": "0.9.4",
+    "@vercel/nft": "0.9.5",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",
     "escape-string-regexp": "2.0.0",

--- a/packages/now-node/package.json
+++ b/packages/now-node/package.json
@@ -33,7 +33,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@vercel/ncc": "0.24.0",
-    "@vercel/nft": "0.9.4",
+    "@vercel/nft": "0.9.5",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,10 +2226,10 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
   integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
 
-"@vercel/nft@0.9.4":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.9.4.tgz#43df00808e63fd1b04e7ac15898661985b48ff2c"
-  integrity sha512-vy9i2A9oZDiYgznMXHSdzgHa1sc3bHVJ42DUpRe5jcxJl0eOGgSmulVWkDkuXIeWA7cqYzN/ofb21B/le2CDNg==
+"@vercel/nft@0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.9.5.tgz#bf795944a4764ca49ca1a642f17ab32f9ac701d2"
+  integrity sha512-EhSFOYwqvH3KZyK1pKyFj/DRoCZ2KFu8sRaVaJ+KGlU4kroAWm8okeA2EtIY11+/fMX3YQkNno7kf5H4FZrDvg==
   dependencies:
     acorn "^7.1.1"
     acorn-class-fields "^0.3.2"


### PR DESCRIPTION
This PR bumps nft from version 0.9.4 to [0.9.5](https://github.com/vercel/nft/releases/tag/0.9.5).