### PR TITLE
[next] share cache between `nft` runs

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1089,19 +1089,25 @@ export async function build({
         console.time(tracingLabel);
       }
 
+      const nftCache = Object.create(null);
+
       const {
         fileList: apiFileList,
         reasons: apiReasons,
       } = await nodeFileTrace(apiPages, {
         base: baseDir,
         processCwd: entryPath,
+        cache: nftCache,
       });
+
+      debug(`node-file-trace result for api routes: ${apiFileList}`);
 
       const { fileList, reasons: nonApiReasons } = await nodeFileTrace(
         nonApiPages,
         {
           base: baseDir,
           processCwd: entryPath,
+          cache: nftCache,
         }
       );
 


### PR DESCRIPTION
This should result in faster Lambda tracing, as it avoids duplicate work.

This is a performance optimization that doesn't need additional tests. The existing tests should catch if this introduces a bug.

---

### Related Issues

N/A

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
