### PR TITLE
[next] Ensure 404 is static with _app.GIP and 404 GSP

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1831,7 +1831,11 @@ export async function build({
           });
         }
 
-        if (!canUsePreviewMode) {
+        // If revalidate isn't enabled we force the /404 route to be static
+        // to match next start behavior otherwise getStaticProps would be
+        // recalled for each 404 URL path since Prerender is cached based
+        // on the URL path
+        if (!canUsePreviewMode || (hasPages404 && routeKey === '/404')) {
           htmlFsRef.contentType = htmlContentType;
           prerenders[outputPathPage] = htmlFsRef;
           prerenders[outputPathData] = jsonFsRef;

--- a/packages/now-next/test/integration/gip-gsp-404/next.config.js
+++ b/packages/now-next/test/integration/gip-gsp-404/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/now-next/test/integration/gip-gsp-404/now.json
+++ b/packages/now-next/test/integration/gip-gsp-404/now.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}

--- a/packages/now-next/test/integration/gip-gsp-404/package.json
+++ b/packages/now-next/test/integration/gip-gsp-404/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/now-next/test/integration/gip-gsp-404/pages/404.js
+++ b/packages/now-next/test/integration/gip-gsp-404/pages/404.js
@@ -1,0 +1,18 @@
+export default function MyApp(props) {
+  return (
+    <>
+      <p>static 404</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export const getStaticProps = () => {
+  console.log('/404 getStaticProps');
+  return {
+    props: {
+      random: Math.random(),
+      is404: true,
+    },
+  };
+};

--- a/packages/now-next/test/integration/gip-gsp-404/pages/_app.js
+++ b/packages/now-next/test/integration/gip-gsp-404/pages/_app.js
@@ -1,0 +1,13 @@
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+MyApp.getInitialProps = () => {
+  console.log('App.getInitialProps');
+  return {
+    random: Math.random(),
+    hello: 'world',
+  };
+};
+
+export default MyApp;

--- a/packages/now-next/test/integration/gip-gsp-404/pages/api/hello.js
+++ b/packages/now-next/test/integration/gip-gsp-404/pages/api/hello.js
@@ -1,0 +1,6 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  res.statusCode = 200;
+  res.json({ name: 'John Doe' });
+};

--- a/packages/now-next/test/integration/gip-gsp-404/pages/index.js
+++ b/packages/now-next/test/integration/gip-gsp-404/pages/index.js
@@ -1,0 +1,62 @@
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Create Next App</title>
+      </Head>
+
+      <main className={styles.main}>
+        <h1 className={styles.title}>
+          Welcome to <a href="https://nextjs.org">Next.js!</a>
+        </h1>
+
+        <p className={styles.description}>
+          Get started by editing{' '}
+          <code className={styles.code}>pages/index.js</code>
+        </p>
+
+        <div className={styles.grid}>
+          <a href="https://nextjs.org/docs" className={styles.card}>
+            <h3>Documentation &rarr;</h3>
+            <p>Find in-depth information about Next.js features and API.</p>
+          </a>
+
+          <a href="https://nextjs.org/learn" className={styles.card}>
+            <h3>Learn &rarr;</h3>
+            <p>Learn about Next.js in an interactive course with quizzes!</p>
+          </a>
+
+          <a
+            href="https://github.com/vercel/next.js/tree/master/examples"
+            className={styles.card}
+          >
+            <h3>Examples &rarr;</h3>
+            <p>Discover and deploy boilerplate example Next.js projects.</p>
+          </a>
+
+          <a
+            href="https://vercel.com/import?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+            className={styles.card}
+          >
+            <h3>Deploy &rarr;</h3>
+            <p>
+              Instantly deploy your Next.js site to a public URL with Vercel.
+            </p>
+          </a>
+        </div>
+      </main>
+
+      <footer className={styles.footer}>
+        <a
+          href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Powered by{' '}
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -35,6 +35,37 @@ it(
 );
 
 it(
+  'Should build the gip-gsp-404 example',
+  async () => {
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(path.join(__dirname, 'gip-gsp-404'));
+    expect(output.goodbye).not.toBeDefined();
+    expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
+    expect(output['404']).toBeDefined();
+    expect(output['404'].type).toBe('FileFsRef');
+    expect(output['_next/data/testing-build-id/404.json']).toBeDefined();
+    expect(output['_next/data/testing-build-id/404.json'].type).toBe(
+      'FileFsRef'
+    );
+    const filePaths = Object.keys(output);
+    const serverlessError = filePaths.some(filePath =>
+      filePath.match(/_error/)
+    );
+    const hasUnderScoreAppStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_app-.*\.js$/)
+    );
+    const hasUnderScoreErrorStaticFile = filePaths.some(filePath =>
+      filePath.match(/static.*\/pages\/_error-.*\.js$/)
+    );
+    expect(hasUnderScoreAppStaticFile).toBeTruthy();
+    expect(hasUnderScoreErrorStaticFile).toBeTruthy();
+    expect(serverlessError).toBeTruthy();
+  },
+  FOUR_MINUTES
+);
+
+it(
   'Should not deploy preview lambdas for static site',
   async () => {
     const {


### PR DESCRIPTION
This ensures when generating a static 404 using `getStaticProps` in `/404.js` that the resulting file isn't a `Prerender` output unless `revalidate` is used otherwise the `/404.js` `getStaticProps` will be unexpectedly called during runtime for each 404 path. 
 
### Related Issues

Fixes: https://github.com/vercel/next.js/issues/19849

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
