### PR TITLE
[now-python] Fix qs encoding in http-handler

### DIFF
--- a/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/custom.py
+++ b/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/custom.py
@@ -1,0 +1,9 @@
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import unquote
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(("path=%s" % unquote(self.path)).encode())
+        return

--- a/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/index.py
+++ b/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/index.py
@@ -1,0 +1,9 @@
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import unquote
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(("path=%s" % unquote(self.path)).encode())
+        return

--- a/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/now.json
+++ b/packages/now-python/test/fixtures/29-http-handler-url-params-encoding/now.json
@@ -1,0 +1,44 @@
+{
+  "version": 2,
+  "builds": [{ "src": "*.py", "use": "@vercel/python" }],
+  "routes": [{ "src": "/(.+)", "dest": "custom.py" }],
+  "probes": [
+    { "path": "/?hello=world", "mustContain": "path=/?hello=world" },
+    {
+      "path": "/?hello=%E4%B8%96%E7%95%8C",
+      "mustContain": "path=/?hello=世界"
+    },
+    {
+      "path": "/?hello=%E4%B8%96%20%E7%95%8C",
+      "mustContain": "path=/?hello=世 界"
+    },
+    {
+      "path": "/?hello=%E4%B8%96+%E7%95%8C",
+      "mustContain": "path=/?hello=世 界"
+    },
+    {
+      "path": "/?hello=%E4%B8%96/%E7%95%8C",
+      "mustContain": "path=/?hello=世/界"
+    },
+    {
+      "path": "/another?hello=world",
+      "mustContain": "path=/another?hello=world"
+    },
+    {
+      "path": "/another?hello=%E4%B8%96%E7%95%8C",
+      "mustContain": "path=/another?hello=世界"
+    },
+    {
+      "path": "/another?hello=%E4%B8%96%20%E7%95%8C",
+      "mustContain": "path=/another?hello=世 界"
+    },
+    {
+      "path": "/another?hello=%E4%B8%96+%E7%95%8C",
+      "mustContain": "path=/another?hello=世 界"
+    },
+    {
+      "path": "/another?hello=%E4%B8%96/%E7%95%8C",
+      "mustContain": "path=/another?hello=世/界"
+    }
+  ]
+}

--- a/packages/now-python/vc_init.py
+++ b/packages/now-python/vc_init.py
@@ -35,7 +35,7 @@ if 'handler' in __vc_variables or 'Handler' in __vc_variables:
 
     print('using HTTP Handler')
     from http.server import HTTPServer
-    from urllib.parse import unquote
+    from urllib.parse import urlparse
     import http
     import _thread
 
@@ -46,8 +46,9 @@ if 'handler' in __vc_variables or 'Handler' in __vc_variables:
         _thread.start_new_thread(server.handle_request, ())
 
         payload = json.loads(event['body'])
-        path = unquote(payload['path'])
-        path = path.replace(' ', '%20')
+        parse_result = urlparse(payload['path'])
+        query = parse_result.query.replace('%2F', '/')
+        path = ''.join([parse_result.path, '?', query]) if len(query) > 0 else parse_result.path
         headers = payload['headers']
         method = payload['method']
         encoding = payload.get('encoding')


### PR DESCRIPTION
### Issues

Fixes: error occurs when URL including special characters visited #5580 
PR: https://github.com/vercel/vercel/pull/5598
@nICEnnnnnnnLee @styfle

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR

## Description

In my application, the request succeeded when I gave the URL argument English, and crashed when I gave it Japanese.

```
$ curl "https://test2020-1z9mjtcwa.vercel.app/handler?hello=world" 

path: /handler query: {'hello': ['world']}

$ curl "https://test2020-1z9mjtcwa.vercel.app/handler?hello=%E4%B8%96%E7%95%8C"

An error occurred with this application.

NO_RESPONSE_FROM_FUNCTION
```

```
> https://vercel.com/laiso/test2020/1z9mjtcwa/functions

20:54:16:08
'ascii' codec can't encode characters in position 19-20: ordinal not in range(128): UnicodeEncodeError
Traceback (most recent call last):
  File "/var/task/now__handler__python.py", line 64, in now_handler
    conn.request(method, path, headers=headers, body=request_body)
  File "/var/lang/lib/python3.6/http/client.py", line 1287, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/var/lang/lib/python3.6/http/client.py", line 1298, in _send_request
    self.putrequest(method, url, **skips)
  File "/var/lang/lib/python3.6/http/client.py", line 1136, in putrequest
    self._output(self._encode_request(request))
  File "/var/lang/lib/python3.6/http/client.py", line 1216, in _encode_request
    return request.encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 19-20: ordinal not in range(128)
```

This issue occurs because giving a query string decoded with `unquote ()` to `HTTPConnection.request ()` will recognize it as an invalid URL encode string.

` path = unquote(payload['path'])`

but I don't really understand why `unquote()` was needed. However, it has passed existing tests to protect compatibility.

## about how to fix

First I did a print debug and looked at the raw data for the path in the payload.

When opening `/?hello=世界` in the browser, `/?hello=%E4%B8%96%E7%95%8C` was passed in the payload.
    
And I added the fixture of `29-http-handler-url-params-encoding` to see the test fails and then fixed this part.