### PR TITLE
[next] Ensure 404 route is correct for GSP/GIP 404

### DIFF
--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -2417,7 +2417,9 @@ export async function build({
                         ...(static404Page
                           ? {}
                           : {
-                              'x-nextjs-page': page404Path,
+                              headers: {
+                                'x-nextjs-page': page404Path,
+                              },
                             }),
                       }
                     : {

--- a/packages/now-next/src/index.ts
+++ b/packages/now-next/src/index.ts
@@ -1037,7 +1037,7 @@ export async function build({
 
       if (
         initialRevalidate === false &&
-        !canUsePreviewMode &&
+        (!canUsePreviewMode || (hasPages404 && routeKey === '/404')) &&
         !prerenderManifest.fallbackRoutes[route] &&
         !prerenderManifest.blockingFallbackRoutes[route]
       ) {
@@ -2414,9 +2414,11 @@ export async function build({
                         ),
 
                         status: 404,
-                        headers: {
-                          'x-nextjs-page': page404Path,
-                        },
+                        ...(static404Page
+                          ? {}
+                          : {
+                              'x-nextjs-page': page404Path,
+                            }),
                       }
                     : {
                         src: path.join('/', entryDirectory, '.*'),

--- a/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support-root-catchall/additional.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-const fetch = require('node-fetch');
 const cheerio = require('cheerio');
 const { check, waitFor } = require('../../utils');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 async function checkForChange(url, initialValue, hardError) {
   return check(

--- a/packages/now-next/test/fixtures/00-i18n-support/additional.js
+++ b/packages/now-next/test/fixtures/00-i18n-support/additional.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-const fetch = require('node-fetch');
 const cheerio = require('cheerio');
 const { check, waitFor } = require('../../utils');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 async function checkForChange(url, initialValue, hardError) {
   return check(

--- a/packages/now-next/test/fixtures/22-ssg-v2/additional.js
+++ b/packages/now-next/test/fixtures/22-ssg-v2/additional.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-const fetch = require('node-fetch');
 const cheerio = require('cheerio');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 module.exports = function (ctx) {
   it('should revalidate content properly from pathname', async () => {

--- a/packages/now-next/test/fixtures/27-preview-mode/additional.js
+++ b/packages/now-next/test/fixtures/27-preview-mode/additional.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 const cheerio = require('cheerio');
-const fetch = require('node-fetch');
 const setCookieParser = require('set-cookie-parser');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 module.exports = function (ctx) {
   let previewCookie;

--- a/packages/now-next/test/fixtures/31-blocking-fallback/additional.js
+++ b/packages/now-next/test/fixtures/31-blocking-fallback/additional.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-const fetch = require('node-fetch');
 const cheerio = require('cheerio');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 module.exports = function (ctx) {
   it('should revalidate content properly from dynamic pathname', async () => {

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -37,9 +37,21 @@ it(
 it(
   'Should build the gip-gsp-404 example',
   async () => {
-    const {
-      buildResult: { output },
-    } = await runBuildLambda(path.join(__dirname, 'gip-gsp-404'));
+    const { buildResult } = await runBuildLambda(
+      path.join(__dirname, 'gip-gsp-404')
+    );
+    const { output, routes } = buildResult;
+
+    let handleErrorIdx = -1;
+
+    (routes || []).some((route, idx) => {
+      if (route.handle === 'error') {
+        handleErrorIdx = idx;
+        return true;
+      }
+    });
+    expect(routes[handleErrorIdx + 1].dest).toBe('/404');
+    expect(routes[handleErrorIdx + 1].headers).toBe(undefined);
     expect(output.goodbye).not.toBeDefined();
     expect(output.__NEXT_PAGE_LAMBDA_0).toBeDefined();
     expect(output['404']).toBeDefined();

--- a/packages/now-next/test/integration/index.test.js
+++ b/packages/now-next/test/integration/index.test.js
@@ -42,14 +42,7 @@ it(
     );
     const { output, routes } = buildResult;
 
-    let handleErrorIdx = -1;
-
-    (routes || []).some((route, idx) => {
-      if (route.handle === 'error') {
-        handleErrorIdx = idx;
-        return true;
-      }
-    });
+    const handleErrorIdx = (routes || []).findIndex(r => r.handle === 'error')
     expect(routes[handleErrorIdx + 1].dest).toBe('/404');
     expect(routes[handleErrorIdx + 1].headers).toBe(undefined);
     expect(output.goodbye).not.toBeDefined();


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/vercel/pull/5618 ensuring the 404 route is pointing to the static 404 output correctly when `_app.gip` and getStaticProps in `/404.js` is used

### Related Issues

Fixes: https://github.com/vercel/next.js/issues/19849

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
