### PR TITLE
[node-bridge] Move `launcher.ts` to `@vercel/node-bridge`

### DIFF
--- a/packages/now-node-bridge/.gitignore
+++ b/packages/now-node-bridge/.gitignore
@@ -1,1 +1,2 @@
 /bridge.*
+/launcher.*

--- a/packages/now-node-bridge/src/launcher.ts
+++ b/packages/now-node-bridge/src/launcher.ts
@@ -41,7 +41,7 @@ export function getNowLauncher({
   helpersPath,
   shouldAddHelpers = false,
 }: LauncherConfiguration) {
-  return function(): Bridge {
+  return function (): Bridge {
     let bridge = new Bridge();
     let isServerListening = false;
 
@@ -133,7 +133,7 @@ export function getAwsLauncher({
   }
 
   // @ts-ignore
-  return function(e, context, callback) {
+  return function (e, context, callback) {
     const { path, method: httpMethod, body, headers } = JSON.parse(e.body);
     const { query } = parse(path, true);
     const queryStringParameters: { [i: string]: string } = {};

--- a/packages/now-node/.gitignore
+++ b/packages/now-node/.gitignore
@@ -1,4 +1,5 @@
 /dist
 /src/bridge.ts
+/src/launcher.ts
 /test/fixtures/**/types.d.ts
 /test/fixtures/11-symlinks/symlink

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -1,29 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
-bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
+# Copy shared dependencies
+bridge_dir="$(dirname $(pwd))/now-node-bridge"
+cp -v "$bridge_dir/src/bridge.ts" "$bridge_dir/src/launcher.ts" src
 
-cp -v "$bridge_defs" src
+# Start fresh
+rm -rf dist
 
-# build ts files
+# Build TypeScript files
 tsc
 
-# todo: improve
-# copy type file for ts test
+# TODO: improve
+# Copy type file for ts test
 cp dist/types.d.ts test/fixtures/15-helpers/ts/types.d.ts
 # setup symlink for symlink test
 ln -sf symlinked-asset test/fixtures/11-symlinks/symlink
 
-# use types.d.ts as the main types export
-mv dist/types.d.ts dist/index.d.ts
+# Use types.d.ts as the main types export
+mv dist/types.d.ts dist/types
+mv dist/types dist/index.d.ts
 
-# bundle helpers.ts with ncc
+# Bundle helpers.ts with ncc
 rm dist/helpers.js
 ncc build src/helpers.ts -e @vercel/build-utils -e @now/build-utils -o dist/helpers
 mv dist/helpers/index.js dist/helpers.js
 rm -rf dist/helpers
 
-# build source-map-support/register for source maps
+# Build source-map-support/register for source maps
 ncc build ../../node_modules/source-map-support/register -e @vercel/build-utils -e @now/build-utils -o dist/source-map-support
 mv dist/source-map-support/index.js dist/source-map-support.js
 rm -rf dist/source-map-support

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -15,8 +15,7 @@ cp dist/types.d.ts test/fixtures/15-helpers/ts/types.d.ts
 ln -sf symlinked-asset test/fixtures/11-symlinks/symlink
 
 # use types.d.ts as the main types export
-mv dist/types.d.ts dist/types
-mv dist/types dist/index.d.ts
+mv dist/types.d.ts dist/index.d.ts
 
 # bundle helpers.ts with ncc
 rm dist/helpers.js

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -16,7 +16,6 @@ ln -sf symlinked-asset test/fixtures/11-symlinks/symlink
 
 # use types.d.ts as the main types export
 mv dist/types.d.ts dist/types
-rm dist/*.d.ts
 mv dist/types dist/index.d.ts
 
 # bundle helpers.ts with ncc

--- a/packages/now-node/build.sh
+++ b/packages/now-node/build.sh
@@ -19,6 +19,7 @@ ln -sf symlinked-asset test/fixtures/11-symlinks/symlink
 
 # Use types.d.ts as the main types export
 mv dist/types.d.ts dist/types
+rm dist/*.d.ts
 mv dist/types dist/index.d.ts
 
 # Bundle helpers.ts with ncc

--- a/packages/now-static-build/build.sh
+++ b/packages/now-static-build/build.sh
@@ -2,15 +2,13 @@
 set -euo pipefail
 
 # Copy shared dependencies
-bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
-launcher_defs="$(dirname $(pwd))/now-node/src/launcher.ts"
-
-cp -v "$bridge_defs" src
-cp -v "$launcher_defs" src
+bridge_dir="$(dirname $(pwd))/now-node-bridge"
+cp -v "$bridge_dir/src/bridge.ts" "$bridge_dir/src/launcher.ts" src
 
 # Start fresh
 rm -rf dist
 
+# Build TypeScript files
 tsc
 
 # Build with `ncc`

--- a/packages/redwood/build.sh
+++ b/packages/redwood/build.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 
 # Copy shared dependencies
-bridge_defs="$(dirname $(pwd))/now-node-bridge/src/bridge.ts"
-launcher_defs="$(dirname $(pwd))/now-node/src/launcher.ts"
-
-cp -v "$bridge_defs" src
-cp -v "$launcher_defs" src
+bridge_dir="$(dirname $(pwd))/now-node-bridge"
+cp -v "$bridge_dir/src/bridge.ts" "$bridge_dir/src/launcher.ts" src
 
 # Start fresh
 rm -rf dist
 
-## Build ts files
+# Build TypeScript files
 tsc
-
-# Build with `ncc`
-#ncc build src/index.ts -e @vercel/build-utils -e @now/build-utils -o dist


### PR DESCRIPTION
The `launcher.ts` file is more closely aligned to the node bridge package, as it's used by other runtimes as well.