### PR TITLE
[node-bridge] Publish `launcher.*` files to npm

### DIFF
--- a/packages/now-node-bridge/package.json
+++ b/packages/now-node-bridge/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "bridge.*",
+    "launcher.*",
     "index.js"
   ],
   "scripts": {


### PR DESCRIPTION
So that npm consumers can have access to these files.