### PR TITLE
[cli] Remove legacy example from vc ls --help

### DIFF
--- a/packages/now-cli/src/commands/list.js
+++ b/packages/now-cli/src/commands/list.js
@@ -51,12 +51,6 @@ const help = () => {
 
     ${chalk.cyan(`$ ${getPkgName()} ls my-app`)}
 
-  ${chalk.gray(
-    '–'
-  )} List all deployments and all instances for the app ${chalk.dim('`my-app`')}
-
-    ${chalk.cyan(`$ ${getPkgName()} ls my-app --all`)}
-
   ${chalk.gray('–')} Filter deployments by metadata
 
     ${chalk.cyan(`$ ${getPkgName()} ls -m key1=value1 -m key2=value2`)}


### PR DESCRIPTION
`vc ls --help` was still listing an example using `--all` which was removed with Now 1.0 in PR #5011.

This PR removes that legacy example.