### PR TITLE
[cli] Add auto renew prompt to domains buy

### DIFF
--- a/packages/now-cli/src/util/domains/purchase-domain.ts
+++ b/packages/now-cli/src/util/domains/purchase-domain.ts
@@ -12,11 +12,12 @@ type Response = {
 export default async function purchaseDomain(
   client: Client,
   name: string,
-  expectedPrice: number
+  expectedPrice: number,
+  renew: boolean = true
 ) {
   try {
     return await client.fetch<Response>(`/v3/domains/buy`, {
-      body: { name, expectedPrice },
+      body: { name, expectedPrice, renew },
       method: 'POST',
     });
   } catch (error) {

--- a/packages/now-cli/src/util/input/prompt-bool.ts
+++ b/packages/now-cli/src/util/input/prompt-bool.ts
@@ -23,7 +23,7 @@ export default async function promptBool(label: string, options: Options = {}) {
     trailing = '',
   } = options;
 
-  return new Promise(resolve => {
+  return new Promise<boolean>(resolve => {
     const isRaw = Boolean(stdin && stdin.isRaw);
 
     if (stdin) {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1349,7 +1349,7 @@ test('try to purchase a domain', async t => {
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
-    ['domains', 'buy', `test001.space`],
+    ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
     {
       reject: false,
       input: stream,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1337,11 +1337,8 @@ test('try to purchase a domain', async t => {
   }
 
   const stream = new Readable();
-  stream.push('y\n');
-  stream.push('y\n');
-  stream.push(null);
 
-  const { stderr, stdout, exitCode } = await execa(
+  const execaP = execa(
     binaryPath,
     ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
     {
@@ -1349,6 +1346,12 @@ test('try to purchase a domain', async t => {
       input: stream,
     }
   );
+
+  stream.push('y\n');
+  stream.push('y\n');
+  stream.push(null);
+
+  const { stderr, stdout, exitCode } = await execaP;
 
   console.log(stderr);
   console.log(stdout);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { URL, parse as parseUrl } from 'url';
 import test from 'ava';
 import semVer from 'semver';
-import { Writable } from 'stream';
+import { Readable } from 'stream';
 import { homedir } from 'os';
 import _execa from 'execa';
 import XDGAppPaths from 'xdg-app-paths';
@@ -1336,12 +1336,10 @@ test('try to purchase a domain', async t => {
     return;
   }
 
-  const stream = new Writable();
-  stream.pipe = dest => {
-    dest.write('y');
-    dest.write('y');
-    return dest;
-  };
+  const stream = new Readable();
+stream.push('y\n');
+stream.push('y\n');
+stream.push(null);
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1347,8 +1347,8 @@ test('try to purchase a domain', async t => {
     }
   );
 
-  stream.push('y\n');
-  stream.push('y\n');
+  stream.push('y');
+  stream.push('y');
   stream.push(null);
 
   const { stderr, stdout, exitCode } = await execaP;

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1340,7 +1340,7 @@ test('try to purchase a domain', async t => {
     ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
     {
       reject: false,
-      input: 'y',
+      input: 'y\ny',
     }
   );
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { URL, parse as parseUrl } from 'url';
 import test from 'ava';
 import semVer from 'semver';
+import { Writable } from 'stream';
 import { homedir } from 'os';
 import _execa from 'execa';
 import XDGAppPaths from 'xdg-app-paths';
@@ -1335,12 +1336,19 @@ test('try to purchase a domain', async t => {
     return;
   }
 
+  const stream = new Writable();
+  stream.pipe = dest => {
+    dest.write('y');
+    dest.write('y');
+    return dest;
+  };
+
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
     ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
     {
       reject: false,
-      input: 'y\ny',
+      input: stream,
     }
   );
 

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1337,6 +1337,7 @@ test('try to purchase a domain', async t => {
   }
 
   const stream = new Readable();
+  stream._read = () => {};
 
   const execaP = execa(
     binaryPath,
@@ -1347,14 +1348,17 @@ test('try to purchase a domain', async t => {
     }
   );
 
+  await sleep(ms('1s'));
   stream.push('y');
+  await sleep(ms('1s'));
   stream.push('y');
+  await sleep(ms('1s'));
   stream.push(null);
 
   const { stderr, stdout, exitCode } = await execaP;
 
-  console.log(stderr);
   console.log(stdout);
+  console.log(stderr);
   console.log(exitCode);
 
   t.is(exitCode, 1);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1352,13 +1352,12 @@ test('try to purchase a domain', async t => {
   stream.push('y');
   await sleep(ms('1s'));
   stream.push('y');
-  await sleep(ms('1s'));
   stream.push(null);
 
   const { stderr, stdout, exitCode } = await execaP;
 
-  console.log(stdout);
   console.log(stderr);
+  console.log(stdout);
   console.log(exitCode);
 
   t.is(exitCode, 1);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1339,22 +1339,22 @@ test('try to purchase a domain', async t => {
   const stream = new Readable();
   stream._read = () => {};
 
-  const execaP = execa(
+  setTimeout(async () => {
+    await sleep(ms('1s'));
+    stream.push('y');
+    await sleep(ms('1s'));
+    stream.push('y');
+    stream.push(null);
+  }, ms('1s'));
+
+  const { stderr, stdout, exitCode } = await execa(
     binaryPath,
-    ['domains', 'buy', `${session}-test.org`, ...defaultArgs],
+    ['domains', 'buy', `test001.space`],
     {
       reject: false,
       input: stream,
     }
   );
-
-  await sleep(ms('1s'));
-  stream.push('y');
-  await sleep(ms('1s'));
-  stream.push('y');
-  stream.push(null);
-
-  const { stderr, stdout, exitCode } = await execaP;
 
   console.log(stderr);
   console.log(stdout);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1337,9 +1337,9 @@ test('try to purchase a domain', async t => {
   }
 
   const stream = new Readable();
-stream.push('y\n');
-stream.push('y\n');
-stream.push(null);
+  stream.push('y\n');
+  stream.push('y\n');
+  stream.push(null);
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,


### PR DESCRIPTION
Add auto renew prompt to `domains buy`

```diff
 > The domain "example.com" is available to buy under <username>!
 > Buy now for $20 (1yr)? [y|N] 
+ > Auto renew yearly for $20? [Y|n] 
```

### 📋 Checklist

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
