### PR TITLE
[cli] Formatting fixes for `startDevServer()` and npm error messages

### DIFF
--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import execa from 'execa';
 import semver from 'semver';
 import npa from 'npm-package-arg';
@@ -261,7 +262,9 @@ async function npmInstall(
       throw new NowBuildError({
         message:
           (result as any).code === 'ENOENT'
-            ? '`npm` is not installed'
+            ? `Command not found: ${chalk.cyan(
+                'npm'
+              )}\nPlease ensure that ${chalk.cyan('npm')} is properly installed`
             : 'Failed to install `vercel dev` dependencies',
         code: 'NPM_INSTALL_ERROR',
         link: 'https://vercel.link/npm-install-failed-dev',

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -887,7 +887,7 @@ export default class DevServer {
         })
         .catch(err => {
           this.updateBuildersPromise = null;
-          this.output.error(`Failed to update builders: ${err.message}`);
+          this.output.prettyError(err);
           this.output.debug(err.stack);
         });
     }, ms('30s'));
@@ -1341,7 +1341,7 @@ export default class DevServer {
     routes: Route[] | undefined = nowConfig.routes,
     callLevel: number = 0
   ) => {
-    const { debug, log, error } = this.output;
+    const { debug } = this.output;
 
     // If there is a double-slash present in the URL,
     // then perform a redirect to make it "clean".
@@ -1683,17 +1683,15 @@ export default class DevServer {
         // server process exited before sending the port information message
         // (missing dependency at runtime, for example).
         if (err.code === 'ENOENT') {
-          log(
-            `${chalk.red('Error:')} Command not found: ${chalk.cyan(
-              err.path,
-              ...err.spawnargs
-            )}`,
-            chalk.red
-          );
-          log(`Please ensure that ${cmd(err.path)} is properly installed`);
-        } else {
-          error(`Failed to start "${builderPkg.name}" dev server: ${err}`);
+          err.message = `Command not found: ${chalk.cyan(
+            err.path,
+            ...err.spawnargs
+          )}\nPlease ensure that ${cmd(err.path)} is properly installed`;
+          err.link = 'https://vercel.link/command-not-found';
         }
+
+        this.output.prettyError(err);
+
         await this.sendError(
           req,
           res,


### PR DESCRIPTION
 * Adds error link when `startDevServer()` throws ENOENT
 * Make `npm` not installed error formatting consistent with `startDevServer()` version
 * Fixes "double error message printing" for non-ENOENT `startDevServer()` errors, as seen in the screenshots below

### Before

![Clipboard 2021-10-01 at 4 12 43 PM](https://user-images.githubusercontent.com/71256/104254887-afd1f980-542c-11eb-8318-b166dbf3b893.png)

### After

<img width="583" alt="Screen Shot 2021-01-11 at 4 21 10 PM" src="https://user-images.githubusercontent.com/71256/104254954-d09a4f00-542c-11eb-9407-52a9b02ab2ff.png">
