### PR TITLE
[cli] Use `cmd()` formatting for "npm not installed" message

### DIFF
--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -264,7 +264,7 @@ async function npmInstall(
           (result as any).code === 'ENOENT'
             ? `Command not found: ${chalk.cyan(
                 'npm'
-              )}\nPlease ensure that ${chalk.cyan('npm')} is properly installed`
+              )}\nPlease ensure that ${cmd('npm')} is properly installed`
             : 'Failed to install `vercel dev` dependencies',
         code: 'NPM_INSTALL_ERROR',
         link: 'https://vercel.link/npm-install-failed-dev',

--- a/packages/now-cli/src/util/dev/builder-cache.ts
+++ b/packages/now-cli/src/util/dev/builder-cache.ts
@@ -9,9 +9,10 @@ import { mkdirp, readJSON, writeJSON } from 'fs-extra';
 import { NowBuildError, PackageJson } from '@vercel/build-utils';
 import cliPkg from '../pkg';
 
-import { NoBuilderCacheError } from '../errors-ts';
+import cmd from '../output/cmd';
 import { Output } from '../output';
 import { getDistTag } from '../get-dist-tag';
+import { NoBuilderCacheError } from '../errors-ts';
 
 import * as staticBuilder from './static-builder';
 import { BuilderWithPackage } from './types';


### PR DESCRIPTION
For consistency with the `startDevServer()` ENOENT error message.