### PR TITLE
[node][go] Fix order of exit code in `startDevServer()` error reason

### DIFF
--- a/packages/now-go/index.ts
+++ b/packages/now-go/index.ts
@@ -581,7 +581,7 @@ Learn more: https://vercel.com/docs/runtimes#official-runtimes/go`
   } else if (Array.isArray(result)) {
     // Got "exit" event from child process
     const [exitCode, signal] = result;
-    const reason = signal ? `${signal} signal` : `${exitCode} exit code`;
+    const reason = signal ? `"${signal}" signal` : `exit code ${exitCode}`;
     throw new Error(`\`go run ${entrypointWithExt}\` failed with ${reason}`);
   } else {
     throw new Error(`Unexpected result type: ${typeof result}`);

--- a/packages/now-node/src/index.ts
+++ b/packages/now-node/src/index.ts
@@ -471,7 +471,7 @@ export async function startDevServer(
   } else {
     // Got "exit" event from child process
     const [exitCode, signal] = result;
-    const reason = signal ? `${signal} signal` : `${exitCode} exit code`;
+    const reason = signal ? `"${signal}" signal` : `exit code ${exitCode}`;
     throw new Error(`\`node ${entrypoint}\` failed with ${reason}`);
   }
 }


### PR DESCRIPTION
### Before

<img width="439" alt="Screen Shot 2021-01-12 at 3 14 56 PM" src="https://user-images.githubusercontent.com/71256/104386221-90e56d00-54e9-11eb-9f48-2a25fdaf3e03.png">


### After

<img width="437" alt="Screen Shot 2021-01-12 at 3 17 14 PM" src="https://user-images.githubusercontent.com/71256/104386241-993da800-54e9-11eb-9b20-00c70e4f13fd.png">
