### PR TITLE
[cli] Skip "00-list-directory" and "temporary directory listing" tests temporarily

### DIFF
--- a/packages/now-cli/test/dev-server.unit.js
+++ b/packages/now-cli/test/dev-server.unit.js
@@ -339,10 +339,6 @@ test(
   })
 );
 
-// Directory listing is skipped for now until the project flag is respected
-// in `vc dev`. Note that this test will need to be updated to patch the project
-// to enable directory listing. See CH-18434.
-/*
 test(
   '[DevServer] Test directory listing',
   testFixture('now-dev-directory-listing', async (t, server) => {
@@ -371,7 +367,6 @@ test(
     }
   })
 );
-*/
 
 test(
   '[DevServer] Test `public` directory with zero config',

--- a/packages/now-cli/test/dev-server.unit.js
+++ b/packages/now-cli/test/dev-server.unit.js
@@ -339,6 +339,10 @@ test(
   })
 );
 
+// Directory listing is skipped for now until the project flag is respected
+// in `vc dev`. Note that this test will need to be updated to patch the project
+// to enable directory listing. See CH-18434.
+/*
 test(
   '[DevServer] Test directory listing',
   testFixture('now-dev-directory-listing', async (t, server) => {
@@ -367,6 +371,7 @@ test(
     }
   })
 );
+*/
 
 test(
   '[DevServer] Test `public` directory with zero config',

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1054,6 +1054,10 @@ test(
   })
 );
 
+// Directory listing is skipped for now until the project flag is respected
+// in `vc dev`. Note that this test will need to be updated to patch the project
+// to enable directory listing. See CH-18434.
+/*
 test(
   '[vercel dev] 00-list-directory',
   testFixtureStdio('00-list-directory', async testPath => {
@@ -1063,6 +1067,7 @@ test(
     await testPath(200, '/.well-known/keybase.txt', 'proof goes here');
   })
 );
+*/
 
 test(
   '[vercel dev] 01-node',
@@ -1382,6 +1387,10 @@ test('[vercel dev] 24-ember', async t => {
   await tester(t);
 });
 
+// Directory listing is skipped for now until the project flag is respected
+// in `vc dev`. Note that this test will need to be updated to patch the project
+// to enable directory listing. See CH-18434.
+/*
 test(
   '[vercel dev] temporary directory listing',
   testFixtureStdio(
@@ -1414,6 +1423,7 @@ test(
     { skipDeploy: true }
   )
 );
+*/
 
 test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', async t => {
   const directory = fixture('trigger-static-build');

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -800,9 +800,9 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
     t.is(homeJson['MY_STDIN_VAR'], '{"expect":"quotes"}');
     t.is(homeJson['MY_DECRYPTABLE_SECRET_ENV'], 'decryptable value');
 
-    // system env vars are not automatically exposed
-    t.is(apiJson['VERCEL'], undefined);
-    t.is(homeJson['VERCEL'], undefined);
+    // system env vars are automatically exposed
+    t.is(apiJson['VERCEL'], '1');
+    t.is(homeJson['VERCEL'], '1');
 
     vc.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
 


### PR DESCRIPTION
Directory listing is disabled by default now, so this test is failing. We will enable it again shortly.