### PR TITLE
[cli] Respect the `directoryListing` Project setting in `vc dev`

### DIFF
--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -231,6 +231,7 @@ export interface ProjectSettings {
   outputDirectory?: string | null;
   rootDirectory?: string | null;
   autoExposeSystemEnvs?: boolean;
+  directoryListing?: boolean;
 }
 
 export interface Project extends ProjectSettings {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -651,7 +651,7 @@ export default class DevServer {
       const cloudEnv = exposeSystemEnvs(
         this.projectEnvs || [],
         this.systemEnvValues || [],
-        this.projectSettings && this.projectSettings.autoExposeSystemEnvs,
+        this.projectSettings?.autoExposeSystemEnvs,
         new URL(this.address).host
       );
 
@@ -668,7 +668,7 @@ export default class DevServer {
     // mirror how VERCEL_REGION is injected in prod/preview
     // only inject in `runEnvs`, because `allEnvs` is exposed to dev command
     // and should not contain VERCEL_REGION
-    if (this.projectSettings && this.projectSettings.autoExposeSystemEnvs) {
+    if (this.projectSettings?.autoExposeSystemEnvs) {
       runEnv['VERCEL_REGION'] = 'dev1';
     }
 
@@ -1904,6 +1904,12 @@ export default class DevServer {
     requestPath: string,
     nowRequestId: string
   ): boolean {
+    // If the "directory listing" feature is disabled in the
+    // Project's settings, then don't render the directory listing
+    if (this.projectSettings?.directoryListing === false) {
+      return false;
+    }
+
     let prefix = requestPath;
     if (prefix.length > 0 && !prefix.endsWith('/')) {
       prefix += '/';

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -232,7 +232,7 @@ async function testFixture(directory, opts = {}, args = []) {
 function testFixtureStdio(
   directory,
   fn,
-  { expectedCode = 0, skipDeploy, isExample } = {}
+  { expectedCode = 0, skipDeploy, isExample, projectSettings } = {}
 ) {
   return async t => {
     const nodeMajor = Number(process.versions.node.split('.')[0]);
@@ -249,24 +249,51 @@ function testFixtureStdio(
 
     // Deploy fixture and link project
     if (!skipDeploy) {
-      const project = join(cwd, '.vercel', 'project.json');
-      if (await fs.exists(project)) {
-        await fs.unlink(project);
-      }
+      const projectJsonPath = join(cwd, '.vercel', 'project.json');
+      await fs.remove(projectJsonPath);
       const gitignore = join(cwd, '.gitignore');
-      const gitignoreOrig = await fs.exists(gitignore);
-      let { stdout, stderr, exitCode } = await execa(
-        binaryPath,
-        ['-t', token, '--confirm', '--public', '--no-clipboard', '--debug'],
-        { cwd, reject: false }
-      );
-      console.log({ stdout, stderr, exitCode });
-      if (!gitignoreOrig && (await fs.exists(gitignore))) {
-        await fs.unlink(gitignore);
-      }
-      t.is(exitCode, expectedCode);
-      if (expectedCode === 0) {
-        deploymentUrl = new URL(stdout).host;
+      const hasGitignore = await fs.exists(gitignore);
+
+      try {
+        // Run `vc link`
+        const { exitCode: linkExitCode } = await execa(
+          binaryPath,
+          ['-t', token, 'link', '--confirm'],
+          { cwd, stdio: 'inherit', reject: false }
+        );
+        t.is(linkExitCode, 0);
+
+        // Patch the project with any non-default properties
+        if (projectSettings) {
+          const { projectId } = await fs.readJson(projectJsonPath);
+          const res = await fetch(
+            `https://api.vercel.com/v2/projects/${projectId}`,
+            {
+              method: 'PATCH',
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+              body: JSON.stringify(projectSettings),
+            }
+          );
+          t.is(res.status, 200);
+        }
+
+        // Run `vc deploy`
+        let { exitCode, stdout } = await execa(
+          binaryPath,
+          ['-t', token, 'deploy', '--public', '--no-clipboard', '--debug'],
+          { cwd, stdio: ['ignore', 'pipe', 'inherit'], reject: false }
+        );
+        console.log({ exitCode, stdout });
+        t.is(exitCode, expectedCode);
+        if (expectedCode === 0) {
+          deploymentUrl = new URL(stdout).host;
+        }
+      } finally {
+        if (!hasGitignore) {
+          await fs.remove(gitignore);
+        }
       }
     }
 
@@ -622,14 +649,6 @@ test(
     });
   })
 );
-/*
-test(
-  '[vercel dev] displays directory listing after miss',
-  testFixtureStdio('handle-miss-display-dir-list', async (testPath) => {
-    await testPath(404, '/post', /one.html/m);
-  })
-);
-*/
 
 test(
   '[vercel dev] does not display directory listing after 404',
@@ -1054,20 +1073,19 @@ test(
   })
 );
 
-// Directory listing is skipped for now until the project flag is respected
-// in `vc dev`. Note that this test will need to be updated to patch the project
-// to enable directory listing. See CH-18434.
-/*
 test(
   '[vercel dev] 00-list-directory',
-  testFixtureStdio('00-list-directory', async testPath => {
-    await testPath(200, '/', /Files within/m);
-    await testPath(200, '/', /test[0-3]\.txt/m);
-    await testPath(200, '/', /\.well-known/m);
-    await testPath(200, '/.well-known/keybase.txt', 'proof goes here');
-  })
+  testFixtureStdio(
+    '00-list-directory',
+    async testPath => {
+      await testPath(200, '/', /Files within/m);
+      await testPath(200, '/', /test[0-3]\.txt/m);
+      await testPath(200, '/', /\.well-known/m);
+      await testPath(200, '/.well-known/keybase.txt', 'proof goes here');
+    },
+    { projectSettings: { directoryListing: true } }
+  )
 );
-*/
 
 test(
   '[vercel dev] 01-node',
@@ -1387,10 +1405,6 @@ test('[vercel dev] 24-ember', async t => {
   await tester(t);
 });
 
-// Directory listing is skipped for now until the project flag is respected
-// in `vc dev`. Note that this test will need to be updated to patch the project
-// to enable directory listing. See CH-18434.
-/*
 test(
   '[vercel dev] temporary directory listing',
   testFixtureStdio(
@@ -1423,7 +1437,6 @@ test(
     { skipDeploy: true }
   )
 );
-*/
 
 test('[vercel dev] add a `package.json` to trigger `@vercel/static-build`', async t => {
   const directory = fixture('trigger-static-build');


### PR DESCRIPTION
Implements the ["Directory Listing" Project setting](https://vercel.com/changelog/listing-the-content-of-directories-can-now-be-toggled) in `vercel dev`.

The Dev integration test file has been updated to allow specifying custom Project settings that will be `PATCH`'d to the project document before running `vc deploy` / `vc dev`.