### PR TITLE
[build-utils] Remove `now-next` and `now-static-build` tests

### DIFF
--- a/packages/now-build-utils/test/integration.test.js
+++ b/packages/now-build-utils/test/integration.test.js
@@ -39,7 +39,7 @@ for (const fixture of fs.readdirSync(fixturesPath)) {
 
 // few foreign tests
 
-const buildersToTestWith = ['now-next', 'now-node', 'now-static-build'];
+const buildersToTestWith = ['now-node'];
 
 // eslint-disable-next-line no-restricted-syntax
 for (const builder of buildersToTestWith) {


### PR DESCRIPTION
These directories are no longer in this repository, so the tests were failing.