### PR TITLE
[cli] Fix `cleanUrls: true` when using an output directory

### DIFF
--- a/packages/now-cli/src/util/dev/builder.ts
+++ b/packages/now-cli/src/util/dev/builder.ts
@@ -280,7 +280,6 @@ export async function executeBuild(
       path = extensionless;
     }
 
-    delete output[path];
     output[path] = value;
   });
 
@@ -402,7 +401,7 @@ export async function getBuildMatches(
   const builds = nowConfig.builds || [{ src: '**', use: '@vercel/static' }];
 
   for (const buildConfig of builds) {
-    let { src = '**', use } = buildConfig;
+    let { src = '**', use, config = {} } = buildConfig;
 
     if (!use) {
       continue;
@@ -437,6 +436,15 @@ export async function getBuildMatches(
 
     for (const file of files) {
       src = relative(cwd, file);
+
+      // Remove the output directory prefix
+      if (config.zeroConfig && config.outputDirectory) {
+        const outputMatch = config.outputDirectory + '/';
+        if (src.startsWith(outputMatch)) {
+          src = src.slice(outputMatch.length);
+        }
+      }
+
       const builderWithPkg = await getBuilder(use, output);
       matches.push({
         ...buildConfig,

--- a/packages/now-cli/src/util/dev/static-builder.ts
+++ b/packages/now-cli/src/util/dev/static-builder.ts
@@ -13,37 +13,30 @@ export function build({
   entrypoint,
   config: { zeroConfig, outputDirectory },
 }: BuildOptions): BuildResult {
-  let path = entrypoint;
-
-  // Add the output directory prefix
-  if (zeroConfig && outputDirectory) {
-    path = `${outputDirectory}/${path}`;
-  }
-
-  const output = {
-    [entrypoint]: files[path] as FileFsRef,
+  const path =
+    zeroConfig && outputDirectory
+      ? `${outputDirectory}/${entrypoint}`
+      : entrypoint;
+  return {
+    output: {
+      [entrypoint]: files[path] as FileFsRef,
+    },
+    routes: [],
+    watch: [path],
   };
-  const watch = [path];
-
-  return { output, routes: [], watch };
 }
 
-export function shouldServe(opts: ShouldServeOptions) {
+export function shouldServe(_opts: ShouldServeOptions) {
+  const opts = { ..._opts };
   let {
-    entrypoint,
-    requestPath,
     config: { zeroConfig, outputDirectory },
   } = opts;
 
   // Add the output directory prefix
   if (zeroConfig && outputDirectory) {
-    entrypoint = `${outputDirectory}/${entrypoint}`;
-    requestPath = `${outputDirectory}/${requestPath}`;
+    opts.entrypoint = `${outputDirectory}/${opts.entrypoint}`;
+    opts.requestPath = `${outputDirectory}/${opts.requestPath}`;
   }
 
-  return defaultShouldServe({
-    ...opts,
-    entrypoint,
-    requestPath,
-  });
+  return defaultShouldServe(opts);
 }

--- a/packages/now-cli/src/util/dev/static-builder.ts
+++ b/packages/now-cli/src/util/dev/static-builder.ts
@@ -1,7 +1,7 @@
-import { basename, extname, join } from 'path';
 import {
   FileFsRef,
   BuildOptions,
+  shouldServe as defaultShouldServe,
   ShouldServeOptions,
 } from '@vercel/build-utils';
 import { BuildResult } from './types';
@@ -11,50 +11,39 @@ export const version = 2;
 export function build({
   files,
   entrypoint,
-  config,
+  config: { zeroConfig, outputDirectory },
 }: BuildOptions): BuildResult {
   let path = entrypoint;
-  const outputDir = config.zeroConfig ? config.outputDirectory : '';
-  const outputMatch = outputDir + '/';
-  if (outputDir && path.startsWith(outputMatch)) {
-    // static output files are moved to the root directory
-    path = path.slice(outputMatch.length);
+
+  // Add the output directory prefix
+  if (zeroConfig && outputDirectory) {
+    path = `${outputDirectory}/${path}`;
   }
+
   const output = {
-    [path]: files[entrypoint] as FileFsRef,
+    [entrypoint]: files[path] as FileFsRef,
   };
   const watch = [path];
 
   return { output, routes: [], watch };
 }
 
-export function shouldServe({
-  entrypoint,
-  files,
-  requestPath,
-  config = {},
-}: ShouldServeOptions) {
-  let outputPrefix = '';
-  const outputDir = config.zeroConfig ? config.outputDirectory : '';
-  const outputMatch = outputDir + '/';
-  if (outputDir && entrypoint.startsWith(outputMatch)) {
-    // static output files are moved to the root directory
-    entrypoint = entrypoint.slice(outputMatch.length);
-    outputPrefix = outputMatch;
-  }
-  const isMatch = (f: string) => entrypoint === f && outputPrefix + f in files;
+export function shouldServe(opts: ShouldServeOptions) {
+  let {
+    entrypoint,
+    requestPath,
+    config: { zeroConfig, outputDirectory },
+  } = opts;
 
-  if (isIndex(entrypoint)) {
-    const indexPath = join(requestPath, basename(entrypoint));
-    if (isMatch(indexPath)) {
-      return true;
-    }
+  // Add the output directory prefix
+  if (zeroConfig && outputDirectory) {
+    entrypoint = `${outputDirectory}/${entrypoint}`;
+    requestPath = `${outputDirectory}/${requestPath}`;
   }
-  return isMatch(requestPath);
-}
 
-function isIndex(path: string): boolean {
-  const ext = extname(path);
-  const name = basename(path, ext);
-  return name === 'index';
+  return defaultShouldServe({
+    ...opts,
+    entrypoint,
+    requestPath,
+  });
 }

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/.gitignore
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+!public

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/about.html
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/about.html
@@ -1,0 +1,1 @@
+About Page

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/index.html
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/index.html
@@ -1,0 +1,1 @@
+Index Page

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/style.css
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/style.css
@@ -1,0 +1,1 @@
+body { color: green }

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/sub/another.html
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/sub/another.html
@@ -1,0 +1,1 @@
+Sub Another Page

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/sub/index.html
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/public/sub/index.html
@@ -1,0 +1,1 @@
+Sub Index Page

--- a/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/vercel.json
+++ b/packages/now-cli/test/dev/fixtures/test-clean-urls-with-output-directory/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "cleanUrls": true,
+  "trailingSlash": false
+}

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -919,6 +919,32 @@ test(
 );
 
 test(
+  '[vercel dev] test cleanUrls serve correct content when using `outputDirectory`',
+  testFixtureStdio('test-clean-urls-with-output-directory', async testPath => {
+    await testPath(200, '/', 'Index Page');
+    await testPath(200, '/about', 'About Page');
+    await testPath(200, '/sub', 'Sub Index Page');
+    await testPath(200, '/sub/another', 'Sub Another Page');
+    await testPath(200, '/style.css', 'body { color: green }');
+    await testPath(308, '/index.html', 'Redirecting to / (308)', {
+      Location: '/',
+    });
+    await testPath(308, '/about.html', 'Redirecting to /about (308)', {
+      Location: '/about',
+    });
+    await testPath(308, '/sub/index.html', 'Redirecting to /sub (308)', {
+      Location: '/sub',
+    });
+    await testPath(
+      308,
+      '/sub/another.html',
+      'Redirecting to /sub/another (308)',
+      { Location: '/sub/another' }
+    );
+  })
+);
+
+test(
   '[vercel dev] should serve custom 404 when `cleanUrls: true`',
   testFixtureStdio('test-clean-urls-custom-404', async testPath => {
     await testPath(200, '/', 'This is the home page');


### PR DESCRIPTION
This is essentially a refactor of the `@vercel/static` builder that simplifies the code a lot and fixes a bug where `cleanUrls: true` was not working correctly when using an `outputDirectory`.