### PR TITLE
[cli] Make `Output` class a singleton and have reusable `Spinner`

### DIFF
--- a/packages/now-cli/src/commands/alias/rm.js
+++ b/packages/now-cli/src/commands/alias/rm.js
@@ -39,7 +39,6 @@ export default async function rm(ctx, opts, args, output) {
     throw err;
   }
 
-  // $FlowFixMe
   const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
   const [aliasOrId] = args;
 

--- a/packages/now-cli/src/commands/deploy/index.js
+++ b/packages/now-cli/src/commands/deploy/index.js
@@ -3,7 +3,6 @@ import { resolve, basename } from 'path';
 import { fileNameSymbol } from '@vercel/client';
 import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
-import createOutput from '../../util/output';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
 import { readLocalConfig } from '../../util/config/files';
@@ -15,6 +14,7 @@ import deploy from './latest';
 export default async ctx => {
   const {
     authConfig,
+    output,
     config: { currentTeam },
     apiUrl,
   } = ctx;
@@ -48,7 +48,6 @@ export default async ctx => {
     localConfig = readLocalConfig(paths[0]);
   }
   const debugEnabled = argv['--debug'];
-  const output = createOutput({ debug: debugEnabled });
   const stats = {};
 
   if (argv['--help']) {
@@ -74,6 +73,7 @@ export default async ctx => {
       apiUrl,
       token: authConfig.token,
       currentTeam,
+      output,
       debug: debugEnabled,
     });
     try {

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -233,8 +233,7 @@ export default async function main(
   const paths = Object.keys(stats);
   const debugEnabled = argv['--debug'];
 
-  // $FlowFixMe
-  const isTTY = process.stdout.isTTY;
+  const { isTTY } = process.stdout;
   const quiet = !isTTY;
 
   // check paths

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -346,6 +346,7 @@ const main = async argv_ => {
 
   // the context object to supply to the providers or the commands
   const ctx = {
+    output,
     config,
     authConfig,
     localConfig,

--- a/packages/now-cli/src/types.ts
+++ b/packages/now-cli/src/types.ts
@@ -1,4 +1,5 @@
 import { NowConfig } from './util/dev/types';
+import { Output } from './util/output';
 
 export type ThenArg<T> = T extends Promise<infer U> ? U : T;
 
@@ -8,6 +9,7 @@ export interface NowContext {
   authConfig: {
     token: string;
   };
+  output: Output;
   config: {
     currentTeam: string;
     updateChannel: string;

--- a/packages/now-cli/src/util/index.js
+++ b/packages/now-cli/src/util/index.js
@@ -23,6 +23,7 @@ export default class Now extends EventEmitter {
     forceNew = false,
     withCache = false,
     debug = false,
+    output = createOutput({ debug }),
   }) {
     super();
 
@@ -30,7 +31,7 @@ export default class Now extends EventEmitter {
     this._debug = debug;
     this._forceNew = forceNew;
     this._withCache = withCache;
-    this._output = createOutput({ debug });
+    this._output = output;
     this._apiUrl = apiUrl;
     this._onRetry = this._onRetry.bind(this);
     this.currentTeam = currentTeam;

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -3,7 +3,7 @@ import boxen from 'boxen';
 import { format } from 'util';
 import { Console } from 'console';
 import renderLink from './link';
-import wait from './wait';
+import wait, { StopSpinner } from './wait';
 
 export type Output = ReturnType<typeof createOutput>;
 
@@ -94,15 +94,17 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
-  function spinner(message: string, delay: number = 300) {
+  function spinner(message: string, delay: number = 300): StopSpinner {
     if (debugEnabled) {
       debug(`Spinner invoked (${message}) with a ${delay}ms delay`);
       let isEnded = false;
-      return () => {
+      const stop = (() => {
         if (isEnded) return;
         isEnded = true;
         debug(`Spinner ended (${message})`);
-      };
+      }) as StopSpinner;
+      stop.text = message;
+      return stop;
     }
 
     return wait(message, delay);

--- a/packages/now-cli/src/util/output/create-output.ts
+++ b/packages/now-cli/src/util/output/create-output.ts
@@ -5,14 +5,31 @@ import { Console } from 'console';
 import renderLink from './link';
 import wait, { StopSpinner } from './wait';
 
-export type Output = ReturnType<typeof createOutput>;
+export type Output = ReturnType<typeof _createOutput>;
 
-export default function createOutput({ debug: debugEnabled = false } = {}) {
+export interface OutputOptions {
+  debug?: boolean;
+}
+
+// Singleton
+let instance: Output | null = null;
+
+export default function createOutput(opts?: OutputOptions) {
+  if (!instance) {
+    instance = _createOutput(opts);
+  }
+  return instance;
+}
+
+function _createOutput({ debug: debugEnabled = false }: OutputOptions = {}) {
+  let spinner: StopSpinner | null = null;
+
   function isDebugEnabled() {
     return debugEnabled;
   }
 
   function print(str: string) {
+    stopSpinner();
     process.stderr.write(str);
   }
 
@@ -94,7 +111,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     }
   }
 
-  function spinner(message: string, delay: number = 300): StopSpinner {
+  function setSpinner(message: string, delay: number = 300): StopSpinner {
     if (debugEnabled) {
       debug(`Spinner invoked (${message}) with a ${delay}ms delay`);
       let isEnded = false;
@@ -107,7 +124,19 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
       return stop;
     }
 
-    return wait(message, delay);
+    if (spinner) {
+      spinner.text = message;
+    } else {
+      spinner = wait(message, delay);
+    }
+    return spinner;
+  }
+
+  function stopSpinner() {
+    if (spinner) {
+      spinner();
+      spinner = null;
+    }
   }
 
   const c = {
@@ -143,6 +172,7 @@ export default function createOutput({ debug: debugEnabled = false } = {}) {
     dim,
     time,
     note,
-    spinner,
+    spinner: setSpinner,
+    stopSpinner,
   };
 }

--- a/packages/now-cli/src/util/output/index.ts
+++ b/packages/now-cli/src/util/output/index.ts
@@ -1,1 +1,2 @@
 export { default, Output } from './create-output';
+export { StopSpinner } from './wait';

--- a/packages/now-cli/src/util/output/wait.ts
+++ b/packages/now-cli/src/util/output/wait.ts
@@ -2,28 +2,50 @@ import ora from 'ora';
 import chalk from 'chalk';
 import eraseLines from './erase-lines';
 
-export default function wait(msg: string, delay: number = 300, _ora = ora) {
-  let spinner: ReturnType<typeof _ora>;
-  let running = false;
+export interface StopSpinner {
+  (): void;
+  text: string;
+}
 
-  const planned = setTimeout(() => {
+export default function wait(
+  msg: string,
+  delay: number = 300,
+  _ora = ora
+): StopSpinner {
+  let spinner: ReturnType<typeof _ora> | null = null;
+
+  const timeout = setTimeout(() => {
     spinner = _ora(chalk.gray(msg));
     spinner.color = 'gray';
     spinner.start();
-    running = true;
   }, delay);
 
-  const cancel = () => {
-    clearTimeout(planned);
-    if (running) {
+  const stop = () => {
+    clearTimeout(timeout);
+    if (spinner) {
       spinner.stop();
+      spinner = null;
       process.stderr.write(eraseLines(1));
-      running = false;
     }
-    process.removeListener('nowExit', cancel);
   };
 
+  stop.text = msg;
+
+  // Allow `text` property to update the text while the spinner is in action
+  Object.defineProperty(stop, 'text', {
+    get() {
+      return msg;
+    },
+
+    set(v: string) {
+      msg = v;
+      if (spinner) {
+        spinner.text = chalk.gray(v);
+      }
+    },
+  });
+
   // @ts-ignore
-  process.on('nowExit', cancel);
-  return cancel;
+  process.once('nowExit', stop);
+  return stop;
 }


### PR DESCRIPTION
This is a refactor of the `ora` Spinner usage to make the preferred usage be via the `output.spinner()` and `output.stopSpinner()` functions.

* The `Output` instance has a local spinner instance that can be updated via multiple calls to `output.spinner()`.
* `output.print()` and friends call `output.stopSpinner()` implicitly, so `output.stopSpinner()` doesn't need to be called unless it is desired to immediately remove the spinner before rendering the next text.
* Because there's meant to be a shared `spinner` for the `output` instance, it means that the same `output` instance needs to be used throughout the CLI lifecycle. Therefore, the `createOutput()` function now returns a singleton so that it's guaranteed to be the same instance.

https://user-images.githubusercontent.com/71256/105009979-0670a200-59f0-11eb-9853-232f92eae536.mov

https://user-images.githubusercontent.com/71256/105010034-17211800-59f0-11eb-918d-b15f457e9640.mov

In the "before" video above, note how there's a brief second where the spinner is cleared, but the deployment URL has not yet been printed. In the "after" video, this is fixed and the spinner is only cleared once the CLI is ready to render the deployment URL.