### PR TITLE
[cli] Re-use a single `Output` instance throughout the codebase

### DIFF
--- a/packages/now-cli/src/commands/alias/index.js
+++ b/packages/now-cli/src/commands/alias/index.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 
 import { handleError } from '../../util/error';
 
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import logo from '../../util/output/logo';
@@ -92,15 +91,14 @@ export default async function main(ctx) {
     return 2;
   }
 
-  const output = createOutput({ debug: argv['--debug'] });
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
 
   switch (subcommand) {
     case 'ls':
-      return ls(ctx, argv, args, output);
+      return ls(ctx, argv, args);
     case 'rm':
-      return rm(ctx, argv, args, output);
+      return rm(ctx, argv, args);
     default:
-      return set(ctx, argv, args, output);
+      return set(ctx, argv, args);
   }
 }

--- a/packages/now-cli/src/commands/alias/ls.js
+++ b/packages/now-cli/src/commands/alias/ls.js
@@ -24,6 +24,7 @@ export default async function ls(ctx, opts, args) {
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 
@@ -48,6 +49,7 @@ export default async function ls(ctx, opts, args) {
     token,
     debug: debugEnabled,
     currentTeam,
+    output,
   });
   const lsStamp = stamp();
   let cancelWait;

--- a/packages/now-cli/src/commands/alias/ls.js
+++ b/packages/now-cli/src/commands/alias/ls.js
@@ -10,9 +10,10 @@ import strlen from '../../util/strlen.ts';
 import getCommandFlags from '../../util/get-command-flags';
 import { getCommandName } from '../../util/pkg-name.ts';
 
-export default async function ls(ctx, opts, args, output) {
+export default async function ls(ctx, opts, args) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/alias/rm.js
+++ b/packages/now-cli/src/commands/alias/rm.js
@@ -12,9 +12,10 @@ import { isValidName } from '../../util/is-valid-name';
 import findAliasByAliasOrId from '../../util/alias/find-alias-by-alias-or-id';
 import { getCommandName } from '../../util/pkg-name.ts';
 
-export default async function rm(ctx, opts, args, output) {
+export default async function rm(ctx, opts, args) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/alias/rm.js
+++ b/packages/now-cli/src/commands/alias/rm.js
@@ -26,6 +26,7 @@ export default async function rm(ctx, opts, args) {
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 
@@ -40,7 +41,13 @@ export default async function rm(ctx, opts, args) {
     throw err;
   }
 
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
+  const now = new Now({
+    apiUrl,
+    token,
+    debug: debugEnabled,
+    currentTeam,
+    output,
+  });
   const [aliasOrId] = args;
 
   if (args.length !== 1) {

--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -29,11 +29,11 @@ type Options = {
 export default async function set(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
     localConfig,
   } = ctx;

--- a/packages/now-cli/src/commands/alias/set.ts
+++ b/packages/now-cli/src/commands/alias/set.ts
@@ -49,6 +49,7 @@ export default async function set(
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
 
   let user: User;

--- a/packages/now-cli/src/commands/billing/index.js
+++ b/packages/now-cli/src/commands/billing/index.js
@@ -108,8 +108,14 @@ function buildInquirerChoices(cards) {
 
 async function run({ token, output, config: { currentTeam } }) {
   const start = new Date();
-  const creditCards = new NowCreditCards({ apiUrl, token, debug, currentTeam });
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const creditCards = new NowCreditCards({
+    apiUrl,
+    token,
+    debug,
+    currentTeam,
+    output,
+  });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/billing/index.js
+++ b/packages/now-cli/src/commands/billing/index.js
@@ -14,7 +14,6 @@ import addBilling from './add';
 import exit from '../../util/exit';
 import Client from '../../util/client.ts';
 import getScope from '../../util/get-scope.ts';
-import createOutput from '../../util/output';
 import { getPkgName } from '../../util/pkg-name.ts';
 
 const help = () => {
@@ -90,8 +89,9 @@ function buildInquirerChoices(cards) {
     const _default =
       source.id === cards.defaultSource ? ` ${chalk.bold('(default)')}` : '';
     const id = `${chalk.cyan(`ID: ${source.id}`)}${_default}`;
-    const number = `${chalk.gray('#### ').repeat(3)}${source.last4 ||
-      source.card.last4}`;
+    const number = `${chalk.gray('#### ').repeat(3)}${
+      source.last4 || source.card.last4
+    }`;
     const str = [
       id,
       indent(source.name || source.owner.name, 2),
@@ -106,10 +106,9 @@ function buildInquirerChoices(cards) {
   });
 }
 
-async function run({ token, config: { currentTeam } }) {
+async function run({ token, output, config: { currentTeam } }) {
   const start = new Date();
   const creditCards = new NowCreditCards({ apiUrl, token, debug, currentTeam });
-  const output = createOutput({ debug });
   const client = new Client({ apiUrl, token, currentTeam, debug });
   let contextName = null;
 
@@ -147,8 +146,9 @@ async function run({ token, config: { currentTeam } }) {
           const id = `${chalk.gray('-')} ${chalk.cyan(
             `ID: ${source.id}`
           )}${_default}`;
-          const number = `${chalk.gray('#### ').repeat(3)}${source.last4 ||
-            source.card.last4}`;
+          const number = `${chalk.gray('#### ').repeat(3)}${
+            source.last4 || source.card.last4
+          }`;
 
           return [
             id,
@@ -231,8 +231,9 @@ async function run({ token, config: { currentTeam } }) {
         const elapsed = ms(new Date() - start);
         console.log(
           success(
-            `${card.brand || card.card.brand} ending in ${card.last4 ||
-              card.card.last4} is now the default ${chalk.gray(`[${elapsed}]`)}`
+            `${card.brand || card.card.brand} ending in ${
+              card.last4 || card.card.last4
+            } is now the default ${chalk.gray(`[${elapsed}]`)}`
           )
         );
       } else {
@@ -301,9 +302,9 @@ async function run({ token, config: { currentTeam } }) {
         const deletedCard = cards.sources.find(card => card.id === cardId);
         const remainingCards = cards.sources.filter(card => card.id !== cardId);
 
-        let text = `${deletedCard.brand ||
-          deletedCard.card.brand} ending in ${deletedCard.last4 ||
-          deletedCard.card.last4} was deleted`;
+        let text = `${deletedCard.brand || deletedCard.card.brand} ending in ${
+          deletedCard.last4 || deletedCard.card.last4
+        } was deleted`;
         //  ${chalk.gray(`[${elapsed}]`)}
 
         if (cardId === cards.defaultSource) {
@@ -317,11 +318,11 @@ async function run({ token, config: { currentTeam } }) {
               card => card.id === cards.defaultCardId
             );
 
-            text += `\n${newDefaultCard.brand ||
-              newDefaultCard.card.brand} ending in ${newDefaultCard.last4 ||
-              newDefaultCard.card.last4} in now default for ${chalk.bold(
-              contextName
-            )}`;
+            text += `\n${
+              newDefaultCard.brand || newDefaultCard.card.brand
+            } ending in ${
+              newDefaultCard.last4 || newDefaultCard.card.last4
+            } in now default for ${chalk.bold(contextName)}`;
           }
         }
 

--- a/packages/now-cli/src/commands/certs/add.ts
+++ b/packages/now-cli/src/commands/certs/add.ts
@@ -8,7 +8,6 @@ import stamp from '../../util/output/stamp';
 import createCertFromFile from '../../util/certs/create-cert-from-file';
 import createCertForCns from '../../util/certs/create-cert-for-cns';
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import { getCommandName } from '../../util/pkg-name';
 
 interface Options {
@@ -22,11 +21,11 @@ interface Options {
 async function add(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ): Promise<number> {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;
@@ -71,7 +70,7 @@ async function add(
   }
 
   if (crtPath || keyPath || caPath) {
-    if (args.length !== 0 || (!crtPath || !keyPath || !caPath)) {
+    if (args.length !== 0 || !crtPath || !keyPath || !caPath) {
       output.error(
         `Invalid number of arguments to create a custom certificate entry. Usage:`
       );

--- a/packages/now-cli/src/commands/certs/add.ts
+++ b/packages/now-cli/src/commands/certs/add.ts
@@ -48,6 +48,7 @@ async function add(
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
 
   try {
@@ -61,7 +62,13 @@ async function add(
     throw err;
   }
 
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
+  const now = new Now({
+    apiUrl,
+    token,
+    debug: debugEnabled,
+    currentTeam,
+    output,
+  });
 
   if (overwite) {
     output.error('Overwrite option is deprecated');

--- a/packages/now-cli/src/commands/certs/index.ts
+++ b/packages/now-cli/src/commands/certs/index.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 // @ts-ignore
 import { handleError } from '../../util/error';
 
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import logo from '../../util/output/logo';
@@ -104,17 +103,17 @@ export default async function main(ctx: NowContext) {
     return 0;
   }
 
-  const output = createOutput({ debug: argv['--debug'] });
+  const { output } = ctx;
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
   switch (subcommand) {
     case 'issue':
-      return issue(ctx, argv, args, output);
+      return issue(ctx, argv, args);
     case 'ls':
-      return ls(ctx, argv, args, output);
+      return ls(ctx, argv, args);
     case 'rm':
-      return rm(ctx, argv, args, output);
+      return rm(ctx, argv, args);
     case 'add':
-      return add(ctx, argv, args, output);
+      return add(ctx, argv, args);
     case 'renew':
       output.error('Renewing certificates is deprecated, issue a new one.');
       return 1;

--- a/packages/now-cli/src/commands/certs/issue.ts
+++ b/packages/now-cli/src/commands/certs/issue.ts
@@ -28,11 +28,11 @@ type Options = {
 export default async function issue(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/certs/issue.ts
+++ b/packages/now-cli/src/commands/certs/issue.ts
@@ -55,6 +55,7 @@ export default async function issue(
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 

--- a/packages/now-cli/src/commands/certs/ls.ts
+++ b/packages/now-cli/src/commands/certs/ls.ts
@@ -8,7 +8,6 @@ import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
 import getCerts from '../../util/certs/get-certs';
 import strlen from '../../util/strlen';
-import { Output } from '../../util/output';
 import { NowContext, Cert } from '../../types';
 import getCommandFlags from '../../util/get-command-flags';
 import { getCommandName } from '../../util/pkg-name';
@@ -21,11 +20,11 @@ interface Options {
 async function ls(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ): Promise<number> {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/certs/ls.ts
+++ b/packages/now-cli/src/commands/certs/ls.ts
@@ -30,7 +30,7 @@ async function ls(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const { '--debug': debug, '--next': nextTimestamp } = opts;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {
@@ -47,7 +47,7 @@ async function ls(
     output.error('Please provide a number for flag --next');
     return 1;
   }
-  const now = new Now({ apiUrl, token, debug, currentTeam });
+  const now = new Now({ apiUrl, token, debug, currentTeam, output });
   const lsStamp = stamp();
 
   if (args.length !== 0) {

--- a/packages/now-cli/src/commands/certs/rm.ts
+++ b/packages/now-cli/src/commands/certs/rm.ts
@@ -28,7 +28,7 @@ async function rm(ctx: NowContext, opts: Options, args: string[]) {
   const { apiUrl } = ctx;
   const rmStamp = stamp();
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
 
   let contextName = null;
 

--- a/packages/now-cli/src/commands/certs/rm.ts
+++ b/packages/now-cli/src/commands/certs/rm.ts
@@ -18,14 +18,10 @@ type Options = {
   '--debug': boolean;
 };
 
-async function rm(
-  ctx: NowContext,
-  opts: Options,
-  args: string[],
-  output: Output
-) {
+async function rm(ctx: NowContext, opts: Options, args: string[]) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/deploy/latest.js
+++ b/packages/now-cli/src/commands/deploy/latest.js
@@ -262,6 +262,7 @@ export default async function main(
     apiUrl: ctx.apiUrl,
     token: ctx.authConfig.token,
     debug: debugEnabled,
+    output,
   });
 
   // retrieve `project` and `org` from .vercel
@@ -644,6 +645,7 @@ export default async function main(
           token: ctx.authConfig.token,
           currentTeam: org.id,
           debug: debugEnabled,
+          output,
         }),
         err.meta.domain,
         contextName
@@ -726,6 +728,7 @@ export default async function main(
       token: ctx.authConfig.token,
       currentTeam: org.type === 'team' ? org.id : null,
       debug: debugEnabled,
+      output,
     }),
     deployment,
     deployStamp,

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -49,7 +49,6 @@ export default async function dev(
 
     link = await setupAndLink(
       ctx,
-      output,
       cwd,
       forceDelete,
       autoConfirm,

--- a/packages/now-cli/src/commands/dev/dev.ts
+++ b/packages/now-cli/src/commands/dev/dev.ts
@@ -2,7 +2,6 @@ import { resolve, join } from 'path';
 
 import DevServer from '../../util/dev/server';
 import parseListen from '../../util/dev/parse-listen';
-import { Output } from '../../util/output';
 import { NowContext, ProjectEnvVariable } from '../../types';
 import Client from '../../util/client';
 import { getLinkedProject } from '../../util/projects/link';
@@ -22,9 +21,9 @@ type Options = {
 export default async function dev(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
+  const { output } = ctx;
   const [dir = '.'] = args;
   let cwd = resolve(dir);
   const listen = parseListen(opts['--listen'] || '3000');
@@ -35,6 +34,7 @@ export default async function dev(
     token: ctx.authConfig.token,
     currentTeam: ctx.config.currentTeam,
     debug,
+    output,
   });
 
   // retrieve dev command

--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -117,7 +117,7 @@ export default async function main(ctx: NowContext) {
   }
 
   try {
-    return await dev(ctx, argv, args, output);
+    return await dev(ctx, argv, args);
   } catch (err) {
     if (err.code === 'ENOTFOUND') {
       // Error message will look like the following:

--- a/packages/now-cli/src/commands/dev/index.ts
+++ b/packages/now-cli/src/commands/dev/index.ts
@@ -7,7 +7,6 @@ import getSubcommand from '../../util/get-subcommand';
 import { NowContext } from '../../types';
 import { NowError } from '../../util/now-error';
 import handleError from '../../util/handle-error';
-import createOutput from '../../util/output/create-output';
 import logo from '../../util/output/logo';
 import cmd from '../../util/output/cmd';
 import highlight from '../../util/output/highlight';
@@ -51,7 +50,7 @@ const help = () => {
 export default async function main(ctx: NowContext) {
   let argv;
   let args;
-  let output;
+  const { output } = ctx;
 
   try {
     argv = getArgs(ctx.argv.slice(2), {
@@ -63,9 +62,7 @@ export default async function main(ctx: NowContext) {
       '--port': Number,
       '-p': '--port',
     });
-    const debug = argv['--debug'];
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
-    output = createOutput({ debug });
 
     if ('--port' in argv) {
       output.warn('`--port` is deprecated, please use `--listen` instead');

--- a/packages/now-cli/src/commands/dns/add.ts
+++ b/packages/now-cli/src/commands/dns/add.ts
@@ -24,14 +24,14 @@ export default async function add(
   args: string[]
 ) {
   const {
+    apiUrl,
     authConfig: { token },
     output,
     config,
   } = ctx;
   const { currentTeam } = config;
-  const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/dns/add.ts
+++ b/packages/now-cli/src/commands/dns/add.ts
@@ -6,7 +6,6 @@ import {
   DNSInvalidType,
 } from '../../util/errors-ts';
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import addDNSRecord from '../../util/dns/add-dns-record';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
@@ -22,11 +21,11 @@ type Options = {
 export default async function add(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/dns/import.ts
+++ b/packages/now-cli/src/commands/dns/import.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
 import { DomainNotFound, InvalidDomain } from '../../util/errors-ts';
@@ -15,11 +14,11 @@ type Options = {
 export default async function add(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/dns/import.ts
+++ b/packages/now-cli/src/commands/dns/import.ts
@@ -17,14 +17,14 @@ export default async function add(
   args: string[]
 ) {
   const {
+    apiUrl,
     authConfig: { token },
     output,
     config,
   } = ctx;
   const { currentTeam } = config;
-  const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/dns/index.ts
+++ b/packages/now-cli/src/commands/dns/index.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { NowContext } from '../../types';
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import handleError from '../../util/handle-error';
@@ -112,16 +111,15 @@ export default async function main(ctx: NowContext) {
     return 2;
   }
 
-  const output = createOutput({ debug: argv['--debug'] });
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
   switch (subcommand) {
     case 'add':
-      return add(ctx, argv, args, output);
+      return add(ctx, argv, args);
     case 'import':
-      return importZone(ctx, argv, args, output);
+      return importZone(ctx, argv, args);
     case 'rm':
-      return rm(ctx, argv, args, output);
+      return rm(ctx, argv, args);
     default:
-      return ls(ctx, argv, args, output);
+      return ls(ctx, argv, args);
   }
 }

--- a/packages/now-cli/src/commands/dns/ls.ts
+++ b/packages/now-cli/src/commands/dns/ls.ts
@@ -24,14 +24,14 @@ export default async function ls(
   args: string[]
 ) {
   const {
+    apiUrl,
     authConfig: { token },
     output,
     config,
   } = ctx;
   const { currentTeam } = config;
-  const { apiUrl } = ctx;
   const { '--debug': debug, '--next': nextTimestamp } = opts;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/dns/ls.ts
+++ b/packages/now-cli/src/commands/dns/ls.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import ms from 'ms';
-import { Output } from '../../util/output';
 import { DomainNotFound } from '../../util/errors-ts';
 import { DNSRecord, NowContext } from '../../types';
 import Client from '../../util/client';
@@ -22,11 +21,11 @@ type Options = {
 export default async function ls(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/dns/rm.ts
+++ b/packages/now-cli/src/commands/dns/rm.ts
@@ -17,11 +17,11 @@ type Options = {
 export default async function rm(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;
@@ -100,12 +100,7 @@ function readConfirmation(
     process.stdin
       .on('data', d => {
         process.stdin.pause();
-        resolve(
-          d
-            .toString()
-            .trim()
-            .toLowerCase() === 'y'
-        );
+        resolve(d.toString().trim().toLowerCase() === 'y');
       })
       .resume();
   });

--- a/packages/now-cli/src/commands/dns/rm.ts
+++ b/packages/now-cli/src/commands/dns/rm.ts
@@ -20,14 +20,14 @@ export default async function rm(
   args: string[]
 ) {
   const {
+    apiUrl,
     authConfig: { token },
     output,
     config,
   } = ctx;
   const { currentTeam } = config;
-  const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
 
   try {
     await getScope(client);

--- a/packages/now-cli/src/commands/domains/add.ts
+++ b/packages/now-cli/src/commands/domains/add.ts
@@ -34,7 +34,7 @@ export default async function add(
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
   const force = opts['--force'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/domains/add.ts
+++ b/packages/now-cli/src/commands/domains/add.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
 import formatNSTable from '../../util/format-ns-table';
@@ -24,11 +23,11 @@ type Options = {
 export default async function add(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/buy.ts
+++ b/packages/now-cli/src/commands/domains/buy.ts
@@ -30,7 +30,7 @@ export default async function buy(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/domains/buy.ts
+++ b/packages/now-cli/src/commands/domains/buy.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import psl from 'psl';
 
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
 import getDomainPrice from '../../util/domains/get-domain-price';
@@ -21,11 +20,11 @@ type Options = {
 export default async function buy(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/index.ts
+++ b/packages/now-cli/src/commands/domains/index.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { NowContext } from '../../types';
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import handleError from '../../util/handle-error';
@@ -106,24 +105,23 @@ export default async function main(ctx: NowContext) {
     return 2;
   }
 
-  const output = createOutput({ debug: argv['--debug'] });
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
   switch (subcommand) {
     case 'add':
-      return add(ctx, argv, args, output);
+      return add(ctx, argv, args);
     case 'inspect':
-      return inspect(ctx, argv, args, output);
+      return inspect(ctx, argv, args);
     case 'move':
-      return move(ctx, argv, args, output);
+      return move(ctx, argv, args);
     case 'buy':
-      return buy(ctx, argv, args, output);
+      return buy(ctx, argv, args);
     case 'rm':
-      return rm(ctx, argv, args, output);
+      return rm(ctx, argv, args);
     case 'transferIn':
-      return transferIn(ctx, argv, args, output);
+      return transferIn(ctx, argv, args);
     case 'verify':
-      return verify(ctx, argv, args, output);
+      return verify(ctx, argv, args);
     default:
-      return ls(ctx, argv, args, output);
+      return ls(ctx, argv, args);
   }
 }

--- a/packages/now-cli/src/commands/domains/inspect.ts
+++ b/packages/now-cli/src/commands/domains/inspect.ts
@@ -34,7 +34,7 @@ export default async function inspect(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
 
   let contextName = null;
 

--- a/packages/now-cli/src/commands/domains/inspect.ts
+++ b/packages/now-cli/src/commands/domains/inspect.ts
@@ -24,11 +24,11 @@ type Options = {
 export default async function inspect(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/ls.ts
+++ b/packages/now-cli/src/commands/domains/ls.ts
@@ -7,7 +7,6 @@ import Client from '../../util/client';
 import getDomains from '../../util/domains/get-domains';
 import getScope from '../../util/get-scope';
 import stamp from '../../util/output/stamp';
-import { Output } from '../../util/output';
 import formatTable from '../../util/format-table';
 import { formatDateWithoutTime } from '../../util/format-date';
 import { Domain, NowContext } from '../../types';
@@ -24,11 +23,11 @@ type Options = {
 export default async function ls(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/ls.ts
+++ b/packages/now-cli/src/commands/domains/ls.ts
@@ -33,7 +33,7 @@ export default async function ls(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const { '--debug': debug, '--next': nextTimestamp } = opts;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   if (typeof nextTimestamp !== undefined && Number.isNaN(nextTimestamp)) {

--- a/packages/now-cli/src/commands/domains/move.ts
+++ b/packages/now-cli/src/commands/domains/move.ts
@@ -34,7 +34,7 @@ export default async function move(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
   let user = null;
 

--- a/packages/now-cli/src/commands/domains/move.ts
+++ b/packages/now-cli/src/commands/domains/move.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import plural from 'pluralize';
 
 import { NowContext, User, Team } from '../../types';
-import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
@@ -25,11 +24,11 @@ type Options = {
 export default async function move(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/rm.ts
+++ b/packages/now-cli/src/commands/domains/rm.ts
@@ -26,11 +26,11 @@ type Options = {
 export default async function rm(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/rm.ts
+++ b/packages/now-cli/src/commands/domains/rm.ts
@@ -36,7 +36,7 @@ export default async function rm(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   const [domainName] = args;
   let contextName = null;
 

--- a/packages/now-cli/src/commands/domains/transfer-in.ts
+++ b/packages/now-cli/src/commands/domains/transfer-in.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import * as ERRORS from '../../util/errors-ts';
 import Client from '../../util/client';
 import getScope from '../../util/get-scope';
@@ -24,11 +23,11 @@ type Options = {
 export default async function transferIn(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;

--- a/packages/now-cli/src/commands/domains/transfer-in.ts
+++ b/packages/now-cli/src/commands/domains/transfer-in.ts
@@ -33,7 +33,7 @@ export default async function transferIn(
   const { currentTeam } = config;
   const { apiUrl } = ctx;
   const debug = opts['--debug'];
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/commands/domains/verify.ts
+++ b/packages/now-cli/src/commands/domains/verify.ts
@@ -1,13 +1,11 @@
 import { NowContext } from '../../types';
-import { Output } from '../../util/output';
 import { NowBuildError } from '@vercel/build-utils';
 import { getCommandName } from '../../util/pkg-name';
 
 export default async function verify(
-  _ctx: NowContext,
+  { output }: NowContext,
   _opts: {},
-  args: string[],
-  output: Output
+  args: string[]
 ) {
   const [domainName] = args;
 

--- a/packages/now-cli/src/commands/env/index.ts
+++ b/packages/now-cli/src/commands/env/index.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { NowContext } from '../../types';
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
@@ -109,14 +108,14 @@ export default async function main(ctx: NowContext) {
   }
 
   const debug = argv['--debug'];
-  const output = createOutput({ debug });
   const { subcommand, args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
   const {
     authConfig: { token },
+    apiUrl,
+    output,
     config,
   } = ctx;
   const { currentTeam } = config;
-  const { apiUrl } = ctx;
   const client = new Client({ apiUrl, token, currentTeam, debug });
   const link = await getLinkedProject(output, client);
   if (link.status === 'error') {

--- a/packages/now-cli/src/commands/env/index.ts
+++ b/packages/now-cli/src/commands/env/index.ts
@@ -116,7 +116,7 @@ export default async function main(ctx: NowContext) {
     config,
   } = ctx;
   const { currentTeam } = config;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   const link = await getLinkedProject(output, client);
   if (link.status === 'error') {
     return link.exitCode;

--- a/packages/now-cli/src/commands/init/index.ts
+++ b/packages/now-cli/src/commands/init/index.ts
@@ -4,7 +4,6 @@ import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import { NowContext } from '../../types';
 import handleError from '../../util/handle-error';
-import createOutput from '../../util/output/create-output';
 import logo from '../../util/output/logo';
 import error from '../../util/output/error';
 import init from './init';
@@ -47,7 +46,6 @@ const help = () => {
 export default async function main(ctx: NowContext) {
   let argv;
   let args;
-  let output;
 
   try {
     argv = getArgs(ctx.argv.slice(2), {
@@ -55,7 +53,6 @@ export default async function main(ctx: NowContext) {
       '-f': Boolean,
     });
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
-    output = createOutput({ debug: argv['--debug'] });
   } catch (err) {
     handleError(err);
     return 1;
@@ -67,15 +64,15 @@ export default async function main(ctx: NowContext) {
   }
 
   if (argv._.length > 3) {
-    output.error('Too much arguments.');
+    ctx.output.error('Too much arguments.');
     return 1;
   }
 
   try {
-    return await init(ctx, argv, args, output);
+    return await init(ctx, argv, args);
   } catch (err) {
     console.log(error(err.message));
-    output.debug(err.stack);
+    ctx.output.debug(err.stack);
     return 1;
   }
 }

--- a/packages/now-cli/src/commands/init/init.ts
+++ b/packages/now-cli/src/commands/init/init.ts
@@ -34,9 +34,9 @@ const EXAMPLE_API = 'https://now-example-files.zeit.sh';
 export default async function init(
   ctx: NowContext,
   opts: Options,
-  args: string[],
-  output: Output
+  args: string[]
 ) {
+  const { output } = ctx;
   const [name, dir] = args;
   const force = opts['-f'] || opts['--force'];
 

--- a/packages/now-cli/src/commands/inspect.js
+++ b/packages/now-cli/src/commands/inspect.js
@@ -58,7 +58,12 @@ export default async function main(ctx) {
     return 2;
   }
 
-  const { apiUrl, output } = ctx;
+  const {
+    apiUrl,
+    output,
+    authConfig: { token },
+    config,
+  } = ctx;
   const debugEnabled = argv['--debug'];
   const { print, log, error } = output;
 
@@ -71,16 +76,13 @@ export default async function main(ctx) {
     return 1;
   }
 
-  const {
-    authConfig: { token },
-    config,
-  } = ctx;
   const { currentTeam } = config;
   const client = new Client({
     apiUrl,
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 
@@ -95,7 +97,13 @@ export default async function main(ctx) {
     throw err;
   }
 
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
+  const now = new Now({
+    apiUrl,
+    token,
+    debug: debugEnabled,
+    currentTeam,
+    output,
+  });
 
   // resolve the deployment, since we might have been given an alias
   const depFetchStart = Date.now();

--- a/packages/now-cli/src/commands/inspect.js
+++ b/packages/now-cli/src/commands/inspect.js
@@ -3,7 +3,6 @@ import getArgs from '../util/get-args';
 import buildsList from '../util/output/builds';
 import routesList from '../util/output/routes';
 import indent from '../util/output/indent';
-import createOutput from '../util/output';
 import Now from '../util';
 import logo from '../util/output/logo';
 import elapsed from '../util/output/elapsed.ts';
@@ -59,9 +58,8 @@ export default async function main(ctx) {
     return 2;
   }
 
-  const apiUrl = ctx.apiUrl;
+  const { apiUrl, output } = ctx;
   const debugEnabled = argv['--debug'];
-  const output = createOutput({ debug: debugEnabled });
   const { print, log, error } = output;
 
   // extract the first parameter
@@ -90,7 +88,7 @@ export default async function main(ctx) {
     ({ contextName } = await getScope(client));
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
-      output.error(err.message);
+      error(err.message);
       return 1;
     }
 
@@ -101,14 +99,13 @@ export default async function main(ctx) {
 
   // resolve the deployment, since we might have been given an alias
   const depFetchStart = Date.now();
-  const cancelWait = output.spinner(
+  output.spinner(
     `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(contextName)}`
   );
 
   try {
     deployment = await now.findDeployment(deploymentIdOrHost);
   } catch (err) {
-    cancelWait();
     if (err.status === 404) {
       error(
         `Failed to find deployment "${deploymentIdOrHost}" in ${chalk.bold(
@@ -136,7 +133,6 @@ export default async function main(ctx) {
       ? await now.fetch(`/v1/now/deployments/${id}/builds`)
       : { builds: [] };
 
-  cancelWait();
   log(
     `Fetched deployment "${url}" in ${chalk.bold(contextName)} ${elapsed(
       Date.now() - depFetchStart

--- a/packages/now-cli/src/commands/link/index.ts
+++ b/packages/now-cli/src/commands/link/index.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import { NowContext } from '../../types';
-import createOutput from '../../util/output';
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import handleError from '../../util/handle-error';
@@ -66,8 +65,6 @@ export default async function main(ctx: NowContext) {
     return 2;
   }
 
-  const debug = argv['--debug'];
-  const output = createOutput({ debug });
   const { args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
   const path = args[0] || process.cwd();
   const autoConfirm = argv['--confirm'];
@@ -75,7 +72,6 @@ export default async function main(ctx: NowContext) {
 
   const link = await setupAndLink(
     ctx,
-    output,
     path,
     forceDelete,
     autoConfirm,

--- a/packages/now-cli/src/commands/list.js
+++ b/packages/now-cli/src/commands/list.js
@@ -3,7 +3,6 @@ import ms from 'ms';
 import table from 'text-table';
 import Now from '../util';
 import getArgs from '../util/get-args';
-import createOutput from '../util/output';
 import { handleError } from '../util/error';
 import cmd from '../util/output/cmd.ts';
 import logo from '../util/output/logo';
@@ -78,11 +77,15 @@ export default async function main(ctx) {
     return 1;
   }
 
-  const debugEnabled = argv['--debug'];
+  const {
+    authConfig: { token },
+    output,
+    apiUrl,
+    config,
+  } = ctx;
 
-  const { print, log, error, note, debug } = createOutput({
-    debug: debugEnabled,
-  });
+  const debugEnabled = argv['--debug'];
+  const { print, log, error, note, debug } = output;
 
   if (argv._.length > 2) {
     error(`${getCommandName('ls [app]')} accepts at most one argument`);
@@ -92,24 +95,19 @@ export default async function main(ctx) {
   let app = argv._[1];
   let host = null;
 
-  const apiUrl = ctx.apiUrl;
-
   if (argv['--help']) {
     help();
     return 0;
   }
 
   const meta = parseMeta(argv['--meta']);
-  const {
-    authConfig: { token },
-    config,
-  } = ctx;
   const { currentTeam, includeScheme } = config;
   const client = new Client({
     apiUrl,
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 
@@ -135,7 +133,13 @@ export default async function main(ctx) {
     `Fetching deployments in ${chalk.bold(contextName)}`
   );
 
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
+  const now = new Now({
+    apiUrl,
+    token,
+    debug: debugEnabled,
+    output,
+    currentTeam,
+  });
   const start = new Date();
 
   if (app && !isValidName(app)) {

--- a/packages/now-cli/src/commands/login.js
+++ b/packages/now-cli/src/commands/login.js
@@ -140,7 +140,7 @@ const login = async ctx => {
     await exit(0);
   }
 
-  const { apiUrl, output } = ctx.apiUrl;
+  const { apiUrl, output } = ctx;
 
   argv._ = argv._.slice(1);
 

--- a/packages/now-cli/src/commands/login.js
+++ b/packages/now-cli/src/commands/login.js
@@ -146,7 +146,6 @@ const login = async ctx => {
 
   let email;
   let emailIsValid = false;
-  let stopSpinner;
 
   const possibleAddress = argv._[0];
 
@@ -194,8 +193,7 @@ const login = async ctx => {
     verificationToken = data.token;
     securityCode = data.securityCode;
   } catch (err) {
-    stopSpinner();
-    console.log(error(err.message));
+    output.error(err.message);
     return 1;
   }
 
@@ -225,8 +223,7 @@ const login = async ctx => {
         // /now/registraton is currently returning plain text in that case
         // we just wait for the user to click on the link
       } else {
-        stopSpinner();
-        console.log(err.message);
+        output.error(err.message);
         return 1;
       }
     }

--- a/packages/now-cli/src/commands/login.js
+++ b/packages/now-cli/src/commands/login.js
@@ -19,7 +19,6 @@ import getGlobalPathConfig from '../util/config/global-path';
 import hp from '../util/humanize-path';
 import logo from '../util/output/logo';
 import exit from '../util/exit';
-import createOutput from '../util/output';
 import executeLogin from '../util/login/login.ts';
 import { prependEmoji, emoji } from '../util/emoji';
 import { getCommandName, getPkgName } from '../util/pkg-name.ts';
@@ -141,12 +140,10 @@ const login = async ctx => {
     await exit(0);
   }
 
-  const debugEnabled = argv['--debug'];
-  const output = createOutput({ debug: debugEnabled });
+  const { apiUrl, output } = ctx.apiUrl;
 
   argv._ = argv._.slice(1);
 
-  const apiUrl = ctx.apiUrl;
   let email;
   let emailIsValid = false;
   let stopSpinner;
@@ -190,7 +187,7 @@ const login = async ctx => {
   let verificationToken;
   let securityCode;
 
-  stopSpinner = output.spinner('Sending you an email');
+  output.spinner('Sending you an email');
 
   try {
     const data = await executeLogin(apiUrl, email);
@@ -202,7 +199,7 @@ const login = async ctx => {
     return 1;
   }
 
-  stopSpinner();
+  output.stopSpinner();
 
   // Clear up `Sending email` success message
   process.stdout.write(eraseLines(possibleAddress ? 1 : 2));
@@ -215,7 +212,7 @@ const login = async ctx => {
     )}.\n`
   );
 
-  stopSpinner = output.spinner('Waiting for your confirmation');
+  output.spinner('Waiting for your confirmation');
 
   let token;
 
@@ -235,7 +232,7 @@ const login = async ctx => {
     }
   }
 
-  stopSpinner();
+  output.stopSpinner();
   console.log(ok('Email confirmed'));
 
   // There's no need to save the user since we always

--- a/packages/now-cli/src/commands/logout.ts
+++ b/packages/now-cli/src/commands/logout.ts
@@ -11,7 +11,7 @@ import {
 } from '../util/config/files';
 import getArgs from '../util/get-args';
 import { NowContext } from '../types';
-import createOutput, { Output } from '../util/output';
+import { Output } from '../util/output';
 import { getPkgName } from '../util/pkg-name';
 
 const help = () => {
@@ -54,9 +54,7 @@ export default async function main(ctx: NowContext): Promise<number> {
     return 2;
   }
 
-  const debugEnabled = argv['--debug'];
-  const output = createOutput({ debug: debugEnabled });
-  return logout(ctx.apiUrl, output);
+  return logout(ctx.apiUrl, ctx.output);
 }
 
 const logout = async (apiUrl: string, output: Output) => {

--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -128,12 +128,13 @@ export default async function main(ctx) {
   outputMode = argv.output in logPrinters ? argv.output : 'short';
 
   const { currentTeam } = config;
-  const now = new Now({ apiUrl, token, debug, currentTeam });
+  const now = new Now({ apiUrl, token, debug, currentTeam, output });
   const client = new Client({
     apiUrl,
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 

--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -85,7 +85,6 @@ export default async function main(ctx) {
     return 2;
   }
 
-  const debugEnabled = argv.debug;
   const {
     authConfig: { token },
     apiUrl,
@@ -133,7 +132,7 @@ export default async function main(ctx) {
     apiUrl,
     token,
     currentTeam,
-    debug: debugEnabled,
+    debug,
     output,
   });
   let contextName = null;

--- a/packages/now-cli/src/commands/logs.js
+++ b/packages/now-cli/src/commands/logs.js
@@ -1,7 +1,6 @@
 import mri from 'mri';
 import chalk from 'chalk';
 import Now from '../util';
-import createOutput from '../util/output';
 import logo from '../util/output/logo';
 import elapsed from '../util/output/elapsed.ts';
 import { maybeURL, normalizeURL } from '../util/url';
@@ -59,7 +58,6 @@ export default async function main(ctx) {
   let deploymentIdOrURL;
 
   let debug;
-  let apiUrl;
   let head;
   let limit;
   let follow;
@@ -88,7 +86,12 @@ export default async function main(ctx) {
   }
 
   const debugEnabled = argv.debug;
-  const output = createOutput({ debug: debugEnabled });
+  const {
+    authConfig: { token },
+    apiUrl,
+    output,
+    config,
+  } = ctx;
 
   try {
     since = argv.since ? toTimestamp(argv.since) : 0;
@@ -117,7 +120,6 @@ export default async function main(ctx) {
   }
 
   debug = argv.debug;
-  apiUrl = ctx.apiUrl;
 
   head = argv.head;
   limit = typeof argv.n === 'number' ? argv.n : 100;
@@ -125,10 +127,6 @@ export default async function main(ctx) {
   if (follow) until = 0;
   outputMode = argv.output in logPrinters ? argv.output : 'short';
 
-  const {
-    authConfig: { token },
-    config,
-  } = ctx;
   const { currentTeam } = config;
   const now = new Now({ apiUrl, token, debug, currentTeam });
   const client = new Client({
@@ -206,6 +204,7 @@ export default async function main(ctx) {
     quiet: false,
     debug,
     findOpts: findOpts1,
+    output,
   });
 
   const printedEventIds = new Set();
@@ -232,6 +231,7 @@ export default async function main(ctx) {
       quiet: false,
       debug,
       findOpts: findOpts2,
+      output,
     });
   }
 

--- a/packages/now-cli/src/commands/projects.js
+++ b/packages/now-cli/src/commands/projects.js
@@ -8,7 +8,6 @@ import exit from '../util/exit';
 import Client from '../util/client.ts';
 import logo from '../util/output/logo';
 import getScope from '../util/get-scope';
-import createOutput from '../util/output';
 import getCommandFlags from '../util/get-command-flags';
 import wait from '../util/output/wait';
 import { getPkgName, getCommandName } from '../util/pkg-name.ts';
@@ -76,13 +75,12 @@ const main = async ctx => {
     return exit(2);
   }
 
-  const output = createOutput({ debug });
-
   const {
     authConfig: { token },
     config: { currentTeam },
+    output,
   } = ctx;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
 
   let contextName = null;
 
@@ -288,12 +286,7 @@ function readConfirmation(projectName) {
     process.stdin
       .on('data', d => {
         process.stdin.pause();
-        resolve(
-          d
-            .toString()
-            .trim()
-            .toLowerCase() === 'y'
-        );
+        resolve(d.toString().trim().toLowerCase() === 'y');
       })
       .resume();
   });

--- a/packages/now-cli/src/commands/remove.js
+++ b/packages/now-cli/src/commands/remove.js
@@ -5,7 +5,6 @@ import plural from 'pluralize';
 import table from 'text-table';
 import Now from '../util';
 import getAliases from '../util/alias/get-aliases';
-import createOutput from '../util/output';
 import logo from '../util/output/logo';
 import elapsed from '../util/output/elapsed.ts';
 import { normalizeURL } from '../util/url';
@@ -79,12 +78,11 @@ export default async function main(ctx) {
 
   argv._ = argv._.slice(1);
 
-  const apiUrl = ctx.apiUrl;
+  const { apiUrl, output } = ctx;
   const hard = argv.hard || false;
   const skipConfirmation = argv.yes || false;
   const ids = argv._;
   const debugEnabled = argv.debug;
-  const output = createOutput({ debug: debugEnabled });
   const { success, error, log } = output;
 
   if (argv.help || ids[0] === 'help') {
@@ -235,11 +233,9 @@ export default async function main(ctx) {
   }
 
   if (!skipConfirmation) {
-    const confirmation = (await readConfirmation(
-      deployments,
-      projects,
-      output
-    )).toLowerCase();
+    const confirmation = (
+      await readConfirmation(deployments, projects, output)
+    ).toLowerCase();
 
     if (confirmation !== 'y' && confirmation !== 'yes') {
       output.log('Aborted');

--- a/packages/now-cli/src/commands/remove.js
+++ b/packages/now-cli/src/commands/remove.js
@@ -78,7 +78,12 @@ export default async function main(ctx) {
 
   argv._ = argv._.slice(1);
 
-  const { apiUrl, output } = ctx;
+  const {
+    apiUrl,
+    authConfig: { token },
+    output,
+    config,
+  } = ctx;
   const hard = argv.hard || false;
   const skipConfirmation = argv.yes || false;
   const ids = argv._;
@@ -105,16 +110,13 @@ export default async function main(ctx) {
     return 1;
   }
 
-  const {
-    authConfig: { token },
-    config,
-  } = ctx;
   const { currentTeam } = config;
   const client = new Client({
     apiUrl,
     token,
     currentTeam,
     debug: debugEnabled,
+    output,
   });
   let contextName = null;
 
@@ -244,7 +246,13 @@ export default async function main(ctx) {
     }
   }
 
-  const now = new Now({ apiUrl, token, debug: debugEnabled, currentTeam });
+  const now = new Now({
+    apiUrl,
+    token,
+    debug: debugEnabled,
+    currentTeam,
+    output,
+  });
   const start = new Date();
 
   await Promise.all([

--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -106,7 +106,7 @@ const main = async ctx => {
     output,
     config: { currentTeam },
   } = ctx;
-  const client = new Client({ apiUrl, token, currentTeam, debug });
+  const client = new Client({ apiUrl, token, currentTeam, debug, output });
   let contextName = null;
 
   try {
@@ -138,7 +138,7 @@ export default async ctx => {
 };
 
 async function run({ output, token, contextName, currentTeam, ctx }) {
-  const secrets = new NowSecrets({ apiUrl, token, debug, currentTeam });
+  const secrets = new NowSecrets({ apiUrl, token, debug, currentTeam, output });
   const args = argv._.slice(1);
   const start = Date.now();
 

--- a/packages/now-cli/src/commands/secrets.js
+++ b/packages/now-cli/src/commands/secrets.js
@@ -9,7 +9,6 @@ import exit from '../util/exit';
 import logo from '../util/output/logo';
 import Client from '../util/client.ts';
 import getScope from '../util/get-scope.ts';
-import createOutput from '../util/output';
 import confirm from '../util/input/confirm';
 import getCommandFlags from '../util/get-command-flags';
 import getPrefixedFlags from '../util/get-prefixed-flags';
@@ -104,9 +103,9 @@ const main = async ctx => {
 
   const {
     authConfig: { token },
+    output,
     config: { currentTeam },
   } = ctx;
-  const output = createOutput({ debug });
   const client = new Client({ apiUrl, token, currentTeam, debug });
   let contextName = null;
 

--- a/packages/now-cli/src/commands/teams.js
+++ b/packages/now-cli/src/commands/teams.js
@@ -52,7 +52,7 @@ const help = () => {
   ${chalk.gray('–')} Invite new members (interactively)
 
       ${chalk.cyan(`$ ${getPkgName()} teams invite`)}
-  
+
   ${chalk.gray('–')} Paginate results, where ${chalk.dim(
     '`1584722256178`'
   )} is the time in milliseconds since the UNIX epoch.
@@ -97,10 +97,11 @@ const main = async ctx => {
 
   const {
     authConfig: { token },
+    output,
     config,
   } = ctx;
 
-  return run({ token, config });
+  return run({ token, config, output });
 };
 
 export default async ctx => {
@@ -112,7 +113,7 @@ export default async ctx => {
   }
 };
 
-async function run({ token, config }) {
+async function run({ token, config, output }) {
   const { currentTeam } = config;
   const teams = new NowTeams({ apiUrl, token, debug, currentTeam });
   const args = argv._;
@@ -126,6 +127,7 @@ async function run({ token, config }) {
         config,
         apiUrl,
         token,
+        output,
         argv,
       });
       break;
@@ -154,6 +156,7 @@ async function run({ token, config }) {
         config,
         apiUrl,
         token,
+        output,
       });
       break;
     }

--- a/packages/now-cli/src/commands/teams/invite.js
+++ b/packages/now-cli/src/commands/teams/invite.js
@@ -14,7 +14,6 @@ import success from '../../util/output/success';
 import getUser from '../../util/get-user.ts';
 import Client from '../../util/client.ts';
 import { getCommandName } from '../../util/pkg-name.ts';
-import createOutput from '../../util/output';
 
 const validateEmail = data => regexEmail.test(data.trim()) || data.length === 0;
 
@@ -65,8 +64,8 @@ export default async function ({
   noopMsg = 'No changes made',
   apiUrl,
   token,
+  output,
 } = {}) {
-  const output = createOutput();
   const { currentTeam: currentTeamId } = config;
 
   const stopSpinner = wait('Fetching teams');

--- a/packages/now-cli/src/commands/teams/invite.js
+++ b/packages/now-cli/src/commands/teams/invite.js
@@ -76,7 +76,7 @@ export default async function ({
   stopSpinner();
 
   const stopUserSpinner = wait('Fetching user information');
-  const client = new Client({ apiUrl, token });
+  const client = new Client({ apiUrl, token, output });
   let user;
   try {
     user = await getUser(client);

--- a/packages/now-cli/src/commands/teams/list.js
+++ b/packages/now-cli/src/commands/teams/list.js
@@ -8,7 +8,6 @@ import info from '../../util/output/info';
 import error from '../../util/output/error';
 import chars from '../../util/output/chars';
 import table from '../../util/output/table';
-import createOutput from '../../util/output';
 import getUser from '../../util/get-user.ts';
 import Client from '../../util/client.ts';
 import getPrefixedFlags from '../../util/get-prefixed-flags';
@@ -16,9 +15,8 @@ import { getPkgName } from '../../util/pkg-name.ts';
 import getCommandFlags from '../../util/get-command-flags';
 import cmd from '../../util/output/cmd.ts';
 
-export default async function({ teams, config, apiUrl, token, argv }) {
+export default async function ({ teams, config, apiUrl, token, output, argv }) {
   const { next } = argv;
-  const output = createOutput({ debug: argv['--debug'] });
 
   if (typeof next !== 'undefined' && !Number.isInteger(next)) {
     output.error('Please provide a number for flag --next');

--- a/packages/now-cli/src/commands/teams/list.js
+++ b/packages/now-cli/src/commands/teams/list.js
@@ -34,7 +34,7 @@ export default async function ({ teams, config, apiUrl, token, output, argv }) {
   stopSpinner();
 
   const stopUserSpinner = wait('Fetching user information');
-  const client = new Client({ apiUrl, token, currentTeam });
+  const client = new Client({ apiUrl, token, currentTeam, output });
   let user;
   try {
     user = await getUser(client);

--- a/packages/now-cli/src/commands/teams/switch.js
+++ b/packages/now-cli/src/commands/teams/switch.js
@@ -24,22 +24,21 @@ const updateCurrentTeam = (config, newTeam) => {
   writeToConfigFile(config);
 };
 
-export default async function({ apiUrl, token, debug, args, config }) {
-  let stopSpinner = wait('Fetching teams');
+export default async function ({ apiUrl, token, debug, args, config, output }) {
+  let stopSpinner;
+  output.spinner('Fetching teams');
 
   // We're loading the teams here without `currentTeam`, so that
   // people can use `vercel switch` in the case that their
   // current team was deleted.
-  const teams = new NowTeams({ apiUrl, token, debug });
+  const teams = new NowTeams({ apiUrl, token, debug, output });
   const list = (await teams.ls()).teams;
 
   let { currentTeam } = config;
   const accountIsCurrent = !currentTeam;
 
-  stopSpinner();
-
-  const stopUserSpinner = wait('Fetching user information');
-  const client = new Client({ apiUrl, token });
+  output.spinner('Fetching user information');
+  const client = new Client({ apiUrl, token, output });
   let user;
   try {
     user = await getUser(client);
@@ -51,8 +50,6 @@ export default async function({ apiUrl, token, debug, args, config }) {
 
     throw err;
   }
-
-  stopUserSpinner();
 
   if (accountIsCurrent) {
     currentTeam = {

--- a/packages/now-cli/src/commands/update.ts
+++ b/packages/now-cli/src/commands/update.ts
@@ -5,7 +5,6 @@ import logo from '../util/output/logo';
 import handleError from '../util/handle-error';
 import getArgs from '../util/get-args';
 import { NowContext } from '../types';
-import createOutput from '../util/output';
 import getUpdateCommand from '../util/get-update-command';
 import { getPkgName, getTitleName } from '../util/pkg-name';
 
@@ -35,6 +34,7 @@ const help = () => {
 
 export default async function main(ctx: NowContext): Promise<number> {
   let argv;
+  const { output } = ctx;
 
   try {
     argv = getArgs(ctx.argv.slice(2), {
@@ -55,8 +55,6 @@ export default async function main(ctx: NowContext): Promise<number> {
     return 2;
   }
 
-  const debugEnabled = argv['--debug'];
-  const output = createOutput({ debug: debugEnabled });
   output.log(
     `Please run ${cmd(
       await getUpdateCommand()

--- a/packages/now-cli/src/commands/whoami.js
+++ b/packages/now-cli/src/commands/whoami.js
@@ -4,7 +4,6 @@ import logo from '../util/output/logo';
 import { handleError } from '../util/error';
 import Client from '../util/client.ts';
 import getScope from '../util/get-scope.ts';
-import createOutput from '../util/output';
 import { getPkgName } from '../util/pkg-name.ts';
 
 const help = () => {
@@ -55,10 +54,10 @@ const main = async ctx => {
   const debug = argv['--debug'];
   const {
     authConfig: { token },
+    output,
     apiUrl,
   } = ctx;
-  const output = createOutput({ debug });
-  const client = new Client({ apiUrl, token, debug });
+  const client = new Client({ apiUrl, token, debug, output });
   let contextName = null;
 
   try {

--- a/packages/now-cli/src/index.js
+++ b/packages/now-cli/src/index.js
@@ -537,7 +537,7 @@ const main = async argv_ => {
     !(targetCommand === 'teams' && argv._[3] !== 'invite')
   ) {
     let user = null;
-    const client = new Client({ apiUrl, token });
+    const client = new Client({ apiUrl, token, output });
 
     try {
       user = await getUser(client);

--- a/packages/now-cli/src/util/client.ts
+++ b/packages/now-cli/src/util/client.ts
@@ -33,6 +33,7 @@ export default class Client extends EventEmitter {
     forceNew = false,
     withCache = false,
     debug = false,
+    output = createOutput({ debug }),
   }: {
     apiUrl: string;
     token: string;
@@ -40,13 +41,14 @@ export default class Client extends EventEmitter {
     forceNew?: boolean;
     withCache?: boolean;
     debug?: boolean;
+    output?: Output;
   }) {
     super();
     this._token = token;
     this._debug = debug;
     this._forceNew = forceNew;
     this._withCache = withCache;
-    this._output = createOutput({ debug });
+    this._output = output;
     this._apiUrl = apiUrl;
     this._onRetry = this._onRetry.bind(this);
     this.currentTeam = currentTeam;

--- a/packages/now-cli/src/util/events.js
+++ b/packages/now-cli/src/util/events.js
@@ -7,16 +7,21 @@ import { eraseLines } from 'ansi-escapes';
 import jsonlines from 'jsonlines';
 import retry from 'async-retry';
 
-// Utilities
-import createOutput from './output';
-
 async function printEvents(
   now,
   deploymentIdOrURL,
   currentTeam = null,
-  { mode, onOpen = () => {}, onEvent, quiet, debugEnabled, findOpts } = {}
+  {
+    mode,
+    onOpen = () => {},
+    onEvent,
+    quiet,
+    debugEnabled,
+    findOpts,
+    output,
+  } = {}
 ) {
-  const { log, debug } = createOutput({ debug: debugEnabled });
+  const { log, debug } = output;
 
   let onOpenCalled = false;
   function callOnOpenOnce() {

--- a/packages/now-cli/src/util/link/setup-and-link.ts
+++ b/packages/now-cli/src/util/link/setup-and-link.ts
@@ -47,6 +47,7 @@ export default async function setupAndLink(
     token,
     currentTeam: config.currentTeam,
     debug,
+    output,
   });
 
   const isFile = !isDirectory(path);
@@ -160,6 +161,7 @@ export default async function setupAndLink(
         apiUrl,
         token,
         debug,
+        output,
         currentTeam: client.currentTeam,
       });
       const createArgs: any = {

--- a/packages/now-cli/src/util/link/setup-and-link.ts
+++ b/packages/now-cli/src/util/link/setup-and-link.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import { remove } from 'fs-extra';
 import { NowContext, ProjectLinkResult, ProjectSettings } from '../../types';
 import { NowConfig } from '../dev/types';
-import { Output } from '../output';
 import {
   getLinkedProject,
   linkFolderToProject,
@@ -30,7 +29,6 @@ import Now from '../index';
 
 export default async function setupAndLink(
   ctx: NowContext,
-  output: Output,
   path: string,
   forceDelete: boolean,
   autoConfirm: boolean,
@@ -39,9 +37,10 @@ export default async function setupAndLink(
 ): Promise<ProjectLinkResult> {
   const {
     authConfig: { token },
+    apiUrl,
+    output,
     config,
   } = ctx;
-  const { apiUrl } = ctx;
   const debug = output.isDebugEnabled();
   const client = new Client({
     apiUrl,

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1174,10 +1174,9 @@ test('login with unregistered user', async t => {
   const goal = `Error! Please sign up: https://vercel.com/signup`;
   const lines = stderr.trim().split('\n');
   const last = lines[lines.length - 1];
-  console.error({ last, goal });
 
   t.is(exitCode, 1);
-  t.is(last, goal);
+  t.true(last.includes(goal));
 });
 
 test('ignore files specified in .nowignore', async t => {

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1172,7 +1172,7 @@ test('login with unregistered user', async t => {
   console.log(exitCode);
 
   const goal = `Error! Please sign up: https://vercel.com/signup`;
-  const lines = stdout.trim().split('\n');
+  const lines = stderr.trim().split('\n');
   const last = lines[lines.length - 1];
 
   t.is(exitCode, 1);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1174,6 +1174,7 @@ test('login with unregistered user', async t => {
   const goal = `Error! Please sign up: https://vercel.com/signup`;
   const lines = stderr.trim().split('\n');
   const last = lines[lines.length - 1];
+  console.error({ last, goal });
 
   t.is(exitCode, 1);
   t.is(last, goal);
@@ -1250,10 +1251,10 @@ test('list the scopes', async t => {
 
   t.is(exitCode, 0);
 
-  const include = `✔ ${contextName}     ${email}`;
+  const include = new RegExp(`✔ ${contextName}\\s+${email}`);
 
   t.true(
-    stdout.includes(include),
+    include.test(stdout),
     `Expected: ${include}\n\nReceived instead:\n${stdout}\n${stderr}`
   );
 });


### PR DESCRIPTION
Previously every command implementation was invoking `createOutput()` individually, causing multiple instances of `Output` to be created, which was unnecessary, and causes issues with the shared `spinner` instance introduced by #5717.

Now, the `Output` instance created in `src/index.js` is passed down to the sub-command being executed and therefore re-used.