### PR TITLE
[cli] Pass the `output` object to `vercel switch` command

### DIFF
--- a/packages/now-cli/src/commands/teams.js
+++ b/packages/now-cli/src/commands/teams.js
@@ -140,6 +140,7 @@ async function run({ token, config, output }) {
         apiUrl,
         token,
         debug,
+        output,
       });
       break;
     }


### PR DESCRIPTION
Fixes error: `Cannot read property 'spinner' of undefined`