### PR TITLE
[frameworks] Export `frameworks` array with `as const`

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -18,7 +18,7 @@ const isDir = async (file: string): Promise<boolean> =>
  * CLI projects.
  */
 
-export const frameworks: Framework[] = [
+export const frameworks = [
   {
     name: 'Next.js',
     slug: 'nextjs',
@@ -1548,6 +1548,7 @@ export const frameworks: Framework[] = [
     buildCommand: null,
     getOutputDirName: async () => 'public',
   },
-];
+] as const;
 
-export default frameworks;
+const def = frameworks as readonly Framework[];
+export default def;


### PR DESCRIPTION
This will be necessary for static type analysis in our API docs generator.

The default export is still typed as `Framework[]` for backwards-compat purposes, but the `frameworks` export is the statically typed array.