### PR TITLE
[frameworks] Add test case to ensure all "demo" URLs are public Vercel deployments

### DIFF
--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -19,6 +19,7 @@
     "@types/jest": "24.0.22",
     "@types/js-yaml": "3.12.1",
     "@types/node": "12.0.4",
+    "@types/node-fetch": "2.5.8",
     "@vercel/routing-utils": "1.9.2",
     "ajv": "6.12.2",
     "jest": "24.9.0",

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -215,7 +215,11 @@ describe('frameworks', () => {
         .map(async f => {
           const url = new URL(f.demo!);
           const deployment = await getDeployment(url.hostname);
-          assert.equal(deployment.public, true, `adsf`);
+          assert.equal(
+            deployment.public,
+            true,
+            `Demo URL ${f.demo} is not "public"`
+          );
         })
     );
   });

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -3,6 +3,8 @@ import assert from 'assert';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { isString } from 'util';
+import fetch from 'node-fetch';
+import { URL, URLSearchParams } from 'url';
 import frameworkList from '../src/frameworks';
 
 const SchemaFrameworkDetectionItem = {
@@ -138,6 +140,16 @@ const Schema = {
   },
 };
 
+async function getDeployment(host: string) {
+  const query = new URLSearchParams();
+  query.set('url', host);
+  const res = await fetch(
+    `https://api.vercel.com/v11/deployments/get?${query}`
+  );
+  const body = await res.json();
+  return body;
+}
+
 describe('frameworks', () => {
   it('ensure there is an example for every framework', async () => {
     const root = join(__dirname, '..', '..', '..');
@@ -194,5 +206,17 @@ describe('frameworks', () => {
         slugs.add(slug);
       }
     }
+  });
+
+  it('ensure all demo URLs are "public"', async () => {
+    await Promise.all(
+      frameworkList
+        .filter(f => typeof f.demo === 'string')
+        .map(async f => {
+          const url = new URL(f.demo!);
+          const deployment = await getDeployment(url.hostname);
+          assert.equal(deployment.public, true, `adsf`);
+        })
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,6 +1858,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node-fetch@^2.1.6", "@types/node-fetch@^2.3.0":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"


### PR DESCRIPTION
All demo URLs must be public for the template import flow, so this test case ensures that we don't accidentally publish a demo URL that is not public.