### PR TITLE
[cli] Use `POST /projects` for `vc projects add`

### DIFF
--- a/packages/now-cli/src/commands/projects.js
+++ b/packages/now-cli/src/commands/projects.js
@@ -248,10 +248,19 @@ async function run({ client, contextName }) {
     }
 
     const [name] = args;
-    await client.fetch('/projects/ensure-project', {
-      method: 'POST',
-      body: { name },
-    });
+    try {
+      await client.fetch('/projects', {
+        method: 'POST',
+        body: { name },
+      });
+    } catch (error) {
+      if (error.status === 409) {
+        // project already exists, so we can
+        // show a success message
+      } else {
+        throw error;
+      }
+    }
     const elapsed = ms(new Date() - start);
 
     console.log(

--- a/packages/now-cli/src/commands/projects.js
+++ b/packages/now-cli/src/commands/projects.js
@@ -248,7 +248,7 @@ async function run({ client, contextName }) {
     }
 
     const [name] = args;
-    await client.fetch('/projects/ensure-project', {
+    await client.fetch('/projects', {
       method: 'POST',
       body: { name },
     });

--- a/packages/now-cli/src/commands/projects.js
+++ b/packages/now-cli/src/commands/projects.js
@@ -248,7 +248,7 @@ async function run({ client, contextName }) {
     }
 
     const [name] = args;
-    await client.fetch('/projects', {
+    await client.fetch('/projects/ensure-project', {
       method: 'POST',
       body: { name },
     });

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1029,6 +1029,41 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
   await nowEnvLsIsEmpty();
 });
 
+test('[vc projects] should create a project successfully', async t => {
+  const projectName = `vc-projects-add-${
+    Math.random().toString(36).split('.')[1]
+  }`;
+
+  const vc = execa(binaryPath, [
+    'projects',
+    'add',
+    projectName,
+    ...defaultArgs,
+  ]);
+
+  await waitForPrompt(vc, chunk =>
+    chunk.includes(`Success! Project ${projectName} added`)
+  );
+
+  const { exitCode, stderr, stdout } = await vc;
+  t.is(exitCode, 0, formatOutput({ stderr, stdout }));
+
+  // creating the same project again should succeed
+  const vc2 = execa(binaryPath, [
+    'projects',
+    'add',
+    projectName,
+    ...defaultArgs,
+  ]);
+
+  await waitForPrompt(vc2, chunk =>
+    chunk.includes(`Success! Project ${projectName} added`)
+  );
+
+  const { exitCode: exitCode2, stderr: stderr2, stdout: stdout2 } = await vc;
+  t.is(exitCode2, 0, formatOutput({ stderr2, stdout2 }));
+});
+
 test('deploy with metadata containing "=" in the value', async t => {
   const target = fixture('static-v2-meta');
 


### PR DESCRIPTION
### Related Issues

We are deprecating "ensure project" in favour of "create project".

This PR changes the `vc projects add` command to use the recommended `POST /projects` endpoint to create the project.

This also introduces a change: if the project already exists, the command was previously succeeding and will now error.

https://app.clubhouse.io/vercel/story/19627/

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
