### PR TITLE
[build-utils] Fix unit tests from `@vercel/frameworks` type change

### DIFF
--- a/packages/now-build-utils/src/detect-framework.ts
+++ b/packages/now-build-utils/src/detect-framework.ts
@@ -3,7 +3,7 @@ import { DetectorFilesystem } from './detectors/filesystem';
 
 export interface DetectFrameworkOptions {
   fs: DetectorFilesystem;
-  frameworkList: Framework[];
+  frameworkList: readonly Framework[];
 }
 
 async function matches(fs: DetectorFilesystem, framework: Framework) {


### PR DESCRIPTION
Fixes TypeScript error:

```
test/unit.framework-detector.test.ts:52:40 - error TS4104: The type 'readonly Framework[]' is 'readonly' and cannot be assigned to the mutable type 'Framework[]'.

52     expect(await detectFramework({ fs, frameworkList })).toBe(null);
                                          ~~~~~~~~~~~~~
```