### PR TITLE
[frameworks] Add `defaultVersion` field

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1385,7 +1385,7 @@ export const frameworks = [
 
       return (config && config.publishDir) || 'public';
     },
-    defaultVersion: 'v0.58.2',
+    defaultVersion: '0.58.2',
   },
   {
     name: 'Jekyll',
@@ -1524,7 +1524,7 @@ export const frameworks = [
     devCommand: 'zola serve --port $PORT',
     buildCommand: 'zola build',
     getOutputDirName: async () => 'public',
-    defaultVersion: 'v0.13.0',
+    defaultVersion: '0.13.0',
   },
   {
     name: 'Other',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1385,6 +1385,7 @@ export const frameworks = [
 
       return (config && config.publishDir) || 'public';
     },
+    defaultVersion: 'v0.58.2',
   },
   {
     name: 'Jekyll',
@@ -1523,6 +1524,7 @@ export const frameworks = [
     devCommand: 'zola serve --port $PORT',
     buildCommand: 'zola build',
     getOutputDirName: async () => 'public',
+    defaultVersion: 'v0.13.0',
   },
   {
     name: 'Other',

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -173,7 +173,7 @@ export interface Framework {
   /**
    * The default version of the framework command that is available within the
    * build image. Usually an environment variable can be set to override this.
-   * @example "v0.13.0"
+   * @example "0.13.0"
    */
   defaultVersion?: string;
 }

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -170,4 +170,10 @@ export interface Framework {
    * @example "next dev"
    */
   devCommand: string | null;
+  /**
+   * The default version of the framework command that is available within the
+   * build image. Usually an environment variable can be set to override this.
+   * @example "v0.13.0"
+   */
+  defaultVersion?: string;
 }


### PR DESCRIPTION
This will be used on the docs page to render the default version that is included in the build image.