### PR TITLE
[build-utils] Inherit `process.env` when `runPackageJsonScript()` is invoking yarn

### DIFF
--- a/packages/now-build-utils/src/fs/run-user-scripts.ts
+++ b/packages/now-build-utils/src/fs/run-user-scripts.ts
@@ -403,7 +403,7 @@ export async function runPackageJsonScript(
     });
   } else {
     // Yarn v2 PnP mode may be activated, so force "node-modules" linker style
-    const env: typeof process.env = { ...spawnOpts?.env };
+    const env: typeof process.env = { ...process.env, ...spawnOpts?.env };
     if (!env.YARN_NODE_LINKER) {
       env.YARN_NODE_LINKER = 'node-modules';
     }

--- a/packages/now-build-utils/test/fixtures/19-yarn-v2/.gitignore
+++ b/packages/now-build-utils/test/fixtures/19-yarn-v2/.gitignore
@@ -1,3 +1,4 @@
+/env.txt
 /node_modules/
 /public/build/
 

--- a/packages/now-build-utils/test/fixtures/19-yarn-v2/package.json
+++ b/packages/now-build-utils/test/fixtures/19-yarn-v2/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public",
+    "env": "echo \"$PATH\" > env.txt"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^12.0.0",

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -8,6 +8,7 @@ const {
   getNodeVersion,
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
+  runNpmInstall,
   runPackageJsonScript,
 } = require('../dist');
 
@@ -259,6 +260,7 @@ it('should support require by path for legacy builders', () => {
 
 it('should have correct $PATH when running `runPackageJsonScript()` with yarn', async () => {
   const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
+  await runNpmInstall(fixture);
   await runPackageJsonScript(fixture, 'env');
 
   // `yarn` was failing with ENOENT before, so as long as the

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -267,4 +267,4 @@ it('should have correct $PATH when running `runPackageJsonScript()` with yarn', 
   // script was invoked at all is enough to verify the fix
   const out = await fs.readFile(path.join(fixture, 'env.txt'), 'utf8');
   expect(out.trim()).toBeTruthy();
-});
+}, 10000);

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -267,4 +267,4 @@ it('should have correct $PATH when running `runPackageJsonScript()` with yarn', 
   // script was invoked at all is enough to verify the fix
   const out = await fs.readFile(path.join(fixture, 'env.txt'), 'utf8');
   expect(out.trim()).toBeTruthy();
-}, 10000);
+}, 20000);

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -8,6 +8,7 @@ const {
   getNodeVersion,
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
+  runPackageJsonScript,
 } = require('../dist');
 
 async function expectBuilderError(promise, pattern) {
@@ -254,4 +255,14 @@ it('should support require by path for legacy builders', () => {
   expect(FileFsRef2).toBe(index.FileFsRef);
   expect(FileRef2).toBe(index.FileRef);
   expect(Lambda2).toBe(index.Lambda);
+});
+
+it('should have correct $PATH when running `runPackageJsonScript()` with yarn', async () => {
+  const fixture = path.join(__dirname, 'fixtures/19-yarn-v2');
+  await runPackageJsonScript(fixture, 'env');
+
+  // `yarn` was failing with ENOENT before, so as long as the
+  // script was invoked at all is enough to verify the fix
+  const out = await fs.readFile(path.join(fixture, 'env.txt'), 'utf8');
+  expect(out.trim()).toBeTruthy();
 });

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -1,3 +1,4 @@
+const ms = require('ms');
 const path = require('path');
 const fs = require('fs-extra');
 const assert = require('assert').strict;
@@ -258,13 +259,17 @@ it('should support require by path for legacy builders', () => {
   expect(Lambda2).toBe(index.Lambda);
 });
 
-it('should have correct $PATH when running `runPackageJsonScript()` with yarn', async () => {
-  const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
-  await runNpmInstall(fixture);
-  await runPackageJsonScript(fixture, 'env');
+it(
+  'should have correct $PATH when running `runPackageJsonScript()` with yarn',
+  async () => {
+    const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
+    await runNpmInstall(fixture);
+    await runPackageJsonScript(fixture, 'env');
 
-  // `yarn` was failing with ENOENT before, so as long as the
-  // script was invoked at all is enough to verify the fix
-  const out = await fs.readFile(path.join(fixture, 'env.txt'), 'utf8');
-  expect(out.trim()).toBeTruthy();
-}, 20000);
+    // `yarn` was failing with ENOENT before, so as long as the
+    // script was invoked at all is enough to verify the fix
+    const out = await fs.readFile(path.join(fixture, 'env.txt'), 'utf8');
+    expect(out.trim()).toBeTruthy();
+  },
+  ms('1m')
+);

--- a/packages/now-build-utils/test/unit.test.js
+++ b/packages/now-build-utils/test/unit.test.js
@@ -258,7 +258,7 @@ it('should support require by path for legacy builders', () => {
 });
 
 it('should have correct $PATH when running `runPackageJsonScript()` with yarn', async () => {
-  const fixture = path.join(__dirname, 'fixtures/19-yarn-v2');
+  const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
   await runPackageJsonScript(fixture, 'env');
 
   // `yarn` was failing with ENOENT before, so as long as the


### PR DESCRIPTION
This is a more proper fix for #5825.

Closes #5825.