### PR TITLE
[cli] Update test for animated gif bypass

### DIFF
--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1706,12 +1706,13 @@ test(
       expectHeader('image/svg+xml'),
       fetchOpts('image/webp')
     );
+    // animated gif should bypass: serve as-is
     await testPath(
       200,
       toUrl('/animated.gif', 64, 60),
       null,
       expectHeader('image/gif'),
-      fetchOpts('image/gif')
+      fetchOpts('image/webp')
     );
   })
 );


### PR DESCRIPTION
Animated gif should bypass (serve as-is).

This is to avoid the time it takes to optimize animated images which can sometimes take minutes.

It also matches how `next dev` works so we want to stay consistent (this tests both dev and a deployment).

