### PR TITLE
[cli] Disable Next.js gif test and Node.js 10 tests

### DIFF
--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [10, 12]
+        node: [12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-integration-dev.yml
+++ b/.github/workflows/test-integration-dev.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [10, 12]
+        node: [12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [10, 12]
+        node: [12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/packages/now-cli/test/dev/integration.js
+++ b/packages/now-cli/test/dev/integration.js
@@ -1692,6 +1692,9 @@ test(
       expectHeader('image/webp'),
       fetchOpts('image/webp')
     );
+    /*
+     * Disabled gif in https://github.com/vercel/next.js/pull/22253
+     * Eventually we should enable again when `next dev` supports it
     await testPath(
       200,
       toUrl('/test.gif', 64, 80),
@@ -1699,6 +1702,7 @@ test(
       expectHeader('image/webp'),
       fetchOpts('image/webp')
     );
+    */
     await testPath(
       200,
       toUrl('/test.svg', 64, 70),


### PR DESCRIPTION
These test started failing since gif has been disabled in https://github.com/vercel/next.js/pull/22253

This PR disables the test until Next.js can enable gif optimization once again.

This PR also disables Node.js 10 tests since it will reach EOL soon.