### PR TITLE
[cli] Replace now.sh tests with vercel.app

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2726,7 +2726,7 @@ test('fail to deploy a Lambda with a specific runtime but without a locked versi
 });
 
 test('fail to add a domain without a project', async t => {
-  const output = await execute(['domains', 'add', 'my-domain.now.sh']);
+  const output = await execute(['domains', 'add', 'my-domain.vercel.app']);
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(output.stderr, /expects two arguments/gm, formatOutput(output));
 });
@@ -2759,7 +2759,7 @@ test('change user', async t => {
 });
 
 test('assign a domain to a project', async t => {
-  const domain = `project-domain.${contextName}.now.sh`;
+  const domain = `project-domain.${contextName}.vercel.app`;
   const directory = fixture('static-deployment');
 
   const deploymentOutput = await execute([directory, '--public', '--confirm']);


### PR DESCRIPTION
Replaces now.sh references with vercel.app

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
