### PR TITLE
[tests] Update 502 to 504 for Serverless Function timeout

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2674,7 +2674,7 @@ test('deploy a Lambda with 3 seconds of maxDuration', async t => {
   ]);
 
   t.is(response1.status, 200, url);
-  t.is(response2.status, 502, url);
+  t.is(response2.status, 504, url);
 });
 
 test('fail to deploy a Lambda with an incorrect value for maxDuration', async t => {


### PR DESCRIPTION
We now return a 504 for lambda timeouts

### Related Issues

Related to https://github.com/vercel/now-proxy/pull/1970

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
