### PR TITLE
[build-utils] Update warning for `api` + `pages/api`

### DIFF
--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -311,7 +311,11 @@ export async function detectBuilders(
   if (frontendBuilder) {
     builders.push(frontendBuilder);
 
-    if (hasNextApiFiles && apiBuilders.length) {
+    if (
+      hasNextApiFiles &&
+      apiBuilders.length &&
+      apiBuilders.some(b => b.use === '@vercel/node')
+    ) {
       warnings.push({
         code: 'conflicting_files',
         message:

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -315,7 +315,7 @@ export async function detectBuilders(
       warnings.push({
         code: 'conflicting_files',
         message:
-          'It is not possible to use `api` and `pages/api` at the same time, please only use one option',
+          'When using Next.js, it is recommended to place Node.js Serverless Functions inside of the `pages/api` (provided by Next.js) directory instead of `api` (provided by Vercel).',
       });
     }
   }

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -311,11 +311,7 @@ export async function detectBuilders(
   if (frontendBuilder) {
     builders.push(frontendBuilder);
 
-    if (
-      hasNextApiFiles &&
-      apiBuilders.length &&
-      apiBuilders.some(b => b.use === '@vercel/node')
-    ) {
+    if (hasNextApiFiles && apiBuilders.some(b => b.use === '@vercel/node')) {
       warnings.push({
         code: 'conflicting_files',
         message:

--- a/packages/now-build-utils/src/detect-builders.ts
+++ b/packages/now-build-utils/src/detect-builders.ts
@@ -316,6 +316,8 @@ export async function detectBuilders(
         code: 'conflicting_files',
         message:
           'When using Next.js, it is recommended to place Node.js Serverless Functions inside of the `pages/api` (provided by Next.js) directory instead of `api` (provided by Vercel).',
+        link: 'https://nextjs.org/docs/api-routes/introduction',
+        action: 'Learn More',
       });
     }
   }

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -2605,6 +2605,8 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         code: 'conflicting_files',
         message:
           'When using Next.js, it is recommended to place Node.js Serverless Functions inside of the `pages/api` (provided by Next.js) directory instead of `api` (provided by Vercel).',
+        link: 'https://nextjs.org/docs/api-routes/introduction',
+        action: 'Learn More',
       },
     ]);
   }

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -2573,6 +2573,43 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
   }
 
   {
+    const files = ['api/external.js', 'pages/api/internal.js'];
+    const {
+      defaultRoutes,
+      rewriteRoutes,
+      redirectRoutes,
+      errorRoutes,
+      warnings,
+    } = await detectBuilders(files, null, {
+      featHandleMiss,
+      projectSettings: { framework: 'nextjs' },
+    });
+    expect(defaultRoutes).toStrictEqual([
+      { handle: 'miss' },
+      {
+        src: '^/api/(.+)(?:\\.(?:js))$',
+        dest: '/api/$1',
+        check: true,
+      },
+    ]);
+    expect(rewriteRoutes).toStrictEqual([
+      {
+        status: 404,
+        src: '^/api(/.*)?$',
+      },
+    ]);
+    expect(redirectRoutes).toStrictEqual([]);
+    expect(errorRoutes).toStrictEqual([]);
+    expect(warnings).toStrictEqual([
+      {
+        code: 'conflicting_files',
+        message:
+          'When using Next.js, it is recommended to place Node.js Serverless Functions inside of the `pages/api` (provided by Next.js) directory instead of `api` (provided by Vercel).',
+      },
+    ]);
+  }
+
+  {
     const files = ['public/index.html'];
 
     const { defaultRoutes } = await detectBuilders(files, null, {

--- a/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/now-build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -2574,32 +2574,27 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
 
   {
     const files = ['api/external.js', 'pages/api/internal.js'];
-    const {
-      defaultRoutes,
-      rewriteRoutes,
-      redirectRoutes,
-      errorRoutes,
-      warnings,
-    } = await detectBuilders(files, null, {
+    const { builders, warnings } = await detectBuilders(files, null, {
       featHandleMiss,
       projectSettings: { framework: 'nextjs' },
     });
-    expect(defaultRoutes).toStrictEqual([
-      { handle: 'miss' },
+    expect(builders).toStrictEqual([
       {
-        src: '^/api/(.+)(?:\\.(?:js))$',
-        dest: '/api/$1',
-        check: true,
+        config: {
+          zeroConfig: true,
+        },
+        src: 'api/external.js',
+        use: '@vercel/node',
+      },
+      {
+        config: {
+          framework: 'nextjs',
+          zeroConfig: true,
+        },
+        src: 'package.json',
+        use: '@vercel/next',
       },
     ]);
-    expect(rewriteRoutes).toStrictEqual([
-      {
-        status: 404,
-        src: '^/api(/.*)?$',
-      },
-    ]);
-    expect(redirectRoutes).toStrictEqual([]);
-    expect(errorRoutes).toStrictEqual([]);
     expect(warnings).toStrictEqual([
       {
         code: 'conflicting_files',
@@ -2609,6 +2604,32 @@ it('Test `detectRoutes` with `featHandleMiss=true`', async () => {
         action: 'Learn More',
       },
     ]);
+  }
+
+  {
+    const files = ['api/external.go', 'pages/api/internal.js'];
+    const { builders, warnings } = await detectBuilders(files, null, {
+      featHandleMiss,
+      projectSettings: { framework: 'nextjs' },
+    });
+    expect(builders).toStrictEqual([
+      {
+        config: {
+          zeroConfig: true,
+        },
+        src: 'api/external.go',
+        use: '@vercel/go',
+      },
+      {
+        config: {
+          framework: 'nextjs',
+          zeroConfig: true,
+        },
+        src: 'package.json',
+        use: '@vercel/next',
+      },
+    ]);
+    expect(warnings).toStrictEqual([]);
   }
 
   {

--- a/packages/now-cli/src/util/dev/server.ts
+++ b/packages/now-cli/src/util/dev/server.ts
@@ -589,7 +589,9 @@ export default class DevServer {
       }
 
       if (warnings && warnings.length > 0) {
-        warnings.forEach(warning => this.output.warn(warning.message));
+        warnings.forEach(warning =>
+          this.output.warn(warning.message, null, warning.link, warning.action)
+        );
       }
 
       if (builders) {


### PR DESCRIPTION
This PR updates the warning for `api` + `pages/api` to only be printed when Next.js is mixed with `@vercel/node` functions. It should not print the warning with `@vercel/go` functions for example.

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
