### PR TITLE
[cli] Use inspectorUrl from api

### DIFF
--- a/packages/now-cli/src/util/deploy/process-deployment.ts
+++ b/packages/now-cli/src/util/deploy/process-deployment.ts
@@ -17,29 +17,12 @@ import { prependEmoji, emoji } from '../emoji';
 
 function printInspectUrl(
   output: Output,
-  deploymentUrl: string,
-  deployStamp: () => string,
-  orgSlug: string
+  inspectorUrl: string,
+  deployStamp: () => string
 ) {
-  const url = deploymentUrl.replace('https://', '');
-
-  // example urls:
-  // lucim-fyulaijvg.now.sh
-  // s-66p6vb23x.n8.io (custom domain suffix)
-  const [sub, ...p] = url.split('.');
-  const apex = p.join('.');
-
-  const q = sub.split('-');
-  const deploymentShortId = q.pop();
-  const projectName = q.join('-');
-
-  const inspectUrl = `https://vercel.com/${orgSlug}/${projectName}/${deploymentShortId}${
-    apex !== 'now.sh' && apex !== 'vercel.app' ? `/${apex}` : ''
-  }`;
-
   output.print(
     prependEmoji(
-      `Inspect: ${chalk.bold(inspectUrl)} ${deployStamp()}`,
+      `Inspect: ${chalk.bold(inspectorUrl)} ${deployStamp()}`,
       emoji('inspect')
     ) + `\n`
   );
@@ -178,7 +161,7 @@ export default async function processDeployment({
 
         output.stopSpinner();
 
-        printInspectUrl(output, event.payload.url, deployStamp, org.slug);
+        printInspectUrl(output, event.payload.inspectorUrl, deployStamp);
 
         if (quiet) {
           process.stdout.write(`https://${event.payload.url}`);

--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -1939,6 +1939,11 @@ test('create a production deployment', async t => {
     /Setting target to production/gm,
     formatOutput(targetCall)
   );
+  t.regex(
+    targetCall.stderr,
+    /Inspect: https:\/\/vercel.com\//gm,
+    formatOutput(targetCall)
+  );
   t.regex(targetCall.stdout, /https:\/\//gm);
 
   const { host: targetHost } = new URL(targetCall.stdout);


### PR DESCRIPTION
Uses inspector url from api rather than generating one locally.

### 📋 Checklist

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
