### PR TITLE
[go] Fix analyze ignore list

### DIFF
--- a/packages/now-go/util/analyze.go
+++ b/packages/now-go/util/analyze.go
@@ -18,7 +18,7 @@ import (
 var ignoredFoldersRegex []*regexp.Regexp
 
 func init() {
-	ignoredFolders := []string{"vendor", "testdata", ".now"}
+	ignoredFolders := []string{"vendor", "testdata", ".now", ".vercel"}
 
 	// Build the regex that matches if a path contains the respective ignored folder
 	// The pattern will look like: (.*/)?vendor/.*, which matches every path that contains a vendor folder


### PR DESCRIPTION
A regression was introduced in #5873 that caused the analyze step to parse Go's internal source files (eg `golang/test/bombad.go`) instead of only parsing the user's source code (eg `api/users.go`).

This resulted in the error:

```
Failed to parse AST for "api/users.go"
Error: Command failed: /vercel/1ab928d537d26157/.build-utils/.builder/node_modules/@vercel/go/dist/analyze -modpath=/vercel/workpath1 /vercel/workpath1/api/users.go
2021/02/26 14:26:42 Could not parse Go file "/vercel/workpath1/.vercel/cache/golang/test/bombad.go"
```
