### PR TITLE
[go] Ignore Go test files

### DIFF
--- a/packages/now-go/util/analyze.go
+++ b/packages/now-go/util/analyze.go
@@ -48,7 +48,7 @@ func parse(fileName string) *ast.File {
 // ensure we only working with interest go file(s)
 func visit(files *[]string) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
-		itf, err := filepath.Match("*test.go", path)
+		itf, err := filepath.Match("*test.go", info.Name())
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
I encountered a problem with `vercel dev` in my repository where my test files in `/api` were being incorrectly picked up to be used as serverless functions. This caused my endpoint to fail with the following ouput (captured using `--debug`):
```sh
Error! Command failed: /home/[user]/.config/yarn/global/node_modules/@vercel/go/dist/analyze -modpath=/home/[user]/Development/project api/handler.go
2021/02/26 17:21:43 Rel: can't make api/handler_test.go relative to /home/[user]/Development/project
```
The source of the error is the `visit` function in `packages/now-go/utils/analyze.go`, which incorrectly uses `filepath.Match()` to weed out test files.

I couldn't quite figure out how to add a test case for this, please let me know how and I'll do it!
### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
