### PR TITLE
[cli] Use vercel.app instead of now.sh for integration test

### DIFF
--- a/packages/now-cli/test/integration.js
+++ b/packages/now-cli/test/integration.js
@@ -2290,7 +2290,7 @@ test('try to revert a deployment and assign the automatic aliases', async t => {
   const { name } = JSON.parse(
     fs.readFileSync(path.join(firstDeployment, 'now.json'))
   );
-  const url = `https://${name}.user.now.sh`;
+  const url = `https://${name}.user.vercel.app`;
 
   {
     const { stdout: deploymentUrl, stderr, exitCode } = await execute([


### PR DESCRIPTION
Use vercel.app instead of now.sh for integration test

### 📋 Checklist

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
