### PR TITLE
[tests] Install Go in GH Actions Workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,13 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.13.15'
+    - uses: actions/setup-node@v2
       with:
         node-version: 12
+    - uses: actions/checkout@v1
     - name: Install
       run: yarn install --check-files --frozen-lockfile --network-timeout 1000000
     - name: Build

--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -19,6 +19,12 @@ jobs:
         node: [12]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.15'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 100
@@ -28,9 +34,6 @@ jobs:
       - run: git diff origin/master...HEAD --name-only
       - run: yarn install --network-timeout 1000000
       - run: yarn run build
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
       - run: yarn test-integration-cli --clean false
         env:
           VERCEL_TEAM_TOKEN: ${{ secrets.VERCEL_TEAM_TOKEN }}

--- a/.github/workflows/test-integration-dev.yml
+++ b/.github/workflows/test-integration-dev.yml
@@ -19,6 +19,12 @@ jobs:
         node: [12]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.15'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 100
@@ -31,9 +37,6 @@ jobs:
         run: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.56.0/hugo_0.56.0_macOS-64bit.tar.gz && tar -xzf hugo_0.56.0_macOS-64bit.tar.gz && mv ./hugo packages/now-cli/test/dev/fixtures/08-hugo/
       - run: yarn install --network-timeout 1000000
       - run: yarn run build
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
       - run: yarn test-integration-dev --clean false
         env:
           VERCEL_TEAM_TOKEN: ${{ secrets.VERCEL_TEAM_TOKEN }}

--- a/.github/workflows/test-integration-once.yml
+++ b/.github/workflows/test-integration-once.yml
@@ -14,6 +14,12 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.15'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
       - uses: actions/checkout@v2
         with:
           fetch-depth: 100

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -19,6 +19,12 @@ jobs:
         node: [12]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.13.15'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 100
@@ -26,9 +32,6 @@ jobs:
       - run: git fetch origin master --depth=100
       - run: git fetch origin ${{ github.ref }} --depth=100
       - run: git diff origin/master...HEAD --name-only
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
       - run: yarn install --network-timeout 1000000
       - run: yarn run build
       - run: yarn run lint


### PR DESCRIPTION
We need to make CI explicit about the lowest common denominator for Go Version like we do with the Node.js Version.

This will add about 10 seconds to CI which is negligible to the 8 min+ CI currently.