### PR TITLE
[cli] Add SAML Single Sign-On to `vercel login`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -147,6 +147,7 @@
     "node-fetch": "2.6.1",
     "npm-package-arg": "6.1.0",
     "nyc": "13.2.0",
+    "open": "8.0.2",
     "ora": "3.4.0",
     "pcre-to-regexp": "1.0.0",
     "pluralize": "7.0.0",

--- a/packages/cli/src/commands/teams/switch.js
+++ b/packages/cli/src/commands/teams/switch.js
@@ -41,7 +41,7 @@ export default async function ({ apiUrl, token, debug, args, config, output }) {
     user = await getUser(client);
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
-      console.error(error(err.message));
+      output.error(err.message);
       return 1;
     }
 
@@ -56,7 +56,7 @@ export default async function ({ apiUrl, token, debug, args, config, output }) {
     currentTeam = list.find(team => team.id === currentTeam);
 
     if (!currentTeam) {
-      console.error(error(`You are not a part of the current team anymore`));
+      output.error(`You are not a part of the current team anymore`);
       return 1;
     }
   }
@@ -128,6 +128,8 @@ export default async function ({ apiUrl, token, debug, args, config, output }) {
     const choice = choices.splice(index, 1)[0];
     choices.unshift(choice);
   }
+
+  output.stopSpinner();
 
   let message;
 

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -3,7 +3,6 @@ import { stringify as stringifyQuery } from 'querystring';
 import fetch from 'node-fetch';
 import sleep from '../sleep';
 import ua from '../ua';
-import ok from '../output/ok';
 import error from '../output/error';
 import highlight from '../output/highlight';
 import eraseLines from '../output/erase-lines';
@@ -79,7 +78,6 @@ export default async function doEmailLogin(
   }
 
   // Clear up `Sending email` success message
-  //output.print(eraseLines(possibleAddress ? 1 : 2));
   output.print(eraseLines(1));
 
   output.print(
@@ -109,6 +107,6 @@ export default async function doEmailLogin(
     }
   }
 
-  output.log(ok('Email confirmed'));
+  output.success('Email confirmed');
   return token;
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -1,0 +1,145 @@
+import ms from 'ms';
+import chalk from 'chalk';
+import { stringify as stringifyQuery } from 'querystring';
+import fetch from 'node-fetch';
+import sleep from '../sleep';
+import ua from '../ua';
+import hp from '../humanize-path';
+import { getCommandName } from '../pkg-name';
+import ok from '../output/ok';
+import error from '../output/error';
+import highlight from '../output/highlight';
+import eraseLines from '../output/erase-lines';
+import { prependEmoji, emoji } from '../emoji';
+import { writeToAuthConfigFile, writeToConfigFile } from '../config/files';
+import getGlobalPathConfig from '../config/global-path';
+import executeLogin from './login';
+import { LoginParams } from './types';
+
+async function verify(
+  email: string,
+  verificationToken: string,
+  { apiUrl, output }: LoginParams
+) {
+  const query = {
+    email,
+    token: verificationToken,
+  };
+
+  output.debug('GET /now/registration/verify');
+
+  let res;
+
+  try {
+    res = await fetch(
+      `${apiUrl}/now/registration/verify?${stringifyQuery(query)}`,
+      {
+        headers: { 'User-Agent': ua },
+      }
+    );
+  } catch (err) {
+    output.debug(`error fetching /now/registration/verify: ${err.stack}`);
+
+    throw new Error(
+      error(
+        `An unexpected error occurred while trying to verify your login: ${err.message}`
+      )
+    );
+  }
+
+  output.debug('parsing response from GET /now/registration/verify');
+  let body;
+
+  try {
+    body = await res.json();
+  } catch (err) {
+    output.debug(
+      `error parsing the response from /now/registration/verify: ${err.stack}`
+    );
+    throw new Error(
+      error(
+        `An unexpected error occurred while trying to verify your login: ${err.message}`
+      )
+    );
+  }
+
+  return body.token;
+}
+
+export default async function doEmailLogin(
+  email: string,
+  { apiUrl, output, ctx }: LoginParams
+) {
+  let securityCode;
+  let verificationToken;
+
+  output.spinner('Sending you an email');
+
+  try {
+    const data = await executeLogin(apiUrl, email);
+    verificationToken = data.token;
+    securityCode = data.securityCode;
+  } catch (err) {
+    output.error(err.message);
+    return 1;
+  }
+
+  // Clear up `Sending email` success message
+  //output.print(eraseLines(possibleAddress ? 1 : 2));
+  output.print(eraseLines(1));
+
+  output.print(
+    `We sent an email to ${highlight(
+      email
+    )}. Please follow the steps provided inside it and make sure the security code matches ${highlight(
+      securityCode
+    )}.\n`
+  );
+
+  output.spinner('Waiting for your confirmation');
+
+  let token;
+
+  while (!token) {
+    try {
+      await sleep(ms('1s'));
+      token = await verify(email, verificationToken, { apiUrl, output, ctx });
+    } catch (err) {
+      if (/invalid json response body/.test(err.message)) {
+        // /now/registraton is currently returning plain text in that case
+        // we just wait for the user to click on the link
+      } else {
+        output.error(err.message);
+        return 1;
+      }
+    }
+  }
+
+  output.log(ok('Email confirmed'));
+
+  // There's no need to save the user since we always
+  // pull the user data fresh from the server.
+  ctx.authConfig.token = token;
+
+  // New user, so we can't keep the team
+  delete ctx.config.currentTeam;
+
+  writeToAuthConfigFile(ctx.authConfig);
+  writeToConfigFile(ctx.config);
+
+  output.debug(`Saved credentials in "${hp(getGlobalPathConfig())}"`);
+
+  console.log(
+    `${chalk.cyan('Congratulations!')} ` +
+      `You are now logged in. In order to deploy something, run ${getCommandName()}.`
+  );
+
+  output.print(
+    `${prependEmoji(
+      `Connect your Git Repositories to deploy every branch push automatically (https://vercel.link/git).`,
+      emoji('tip')
+    )}\n`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/login/login.ts
+++ b/packages/cli/src/util/login/login.ts
@@ -14,7 +14,7 @@ export default async function login(
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
-  const response = await fetch(`${apiUrl}/registration?mode=${mode}`, {
+  const response = await fetch(`${apiUrl}/now/registration?mode=${mode}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/cli/src/util/login/login.ts
+++ b/packages/cli/src/util/login/login.ts
@@ -14,7 +14,7 @@ export default async function login(
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
-  const response = await fetch(`${apiUrl}/now/registration?mode=${mode}`, {
+  const response = await fetch(`${apiUrl}/registration?mode=${mode}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/cli/src/util/login/login.ts
+++ b/packages/cli/src/util/login/login.ts
@@ -3,11 +3,7 @@ import { hostname } from 'os';
 import { InvalidEmail, AccountNotFound } from '../errors-ts';
 import ua from '../ua';
 import { getTitleName } from '../pkg-name';
-
-type LoginData = {
-  token: string;
-  securityCode: string;
-};
+import { LoginData } from './types';
 
 export default async function login(
   apiUrl: string,

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -9,10 +9,10 @@ import { getTitleName } from '../pkg-name';
 import { LoginParams } from './types';
 
 export default async function doSsoLogin(
-  slug: string,
+  teamIdOrSlug: string,
   { apiUrl, output }: LoginParams
 ): Promise<number | string> {
-  output.print(`Logging in to team "${slug}"`);
+  output.print(`Logging in to team "${teamIdOrSlug}"`);
 
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
@@ -26,7 +26,7 @@ export default async function doSsoLogin(
     const url = new URL('/registration/sso/auth', apiUrl);
     url.searchParams.append('mode', 'login');
     url.searchParams.append('next', `http://localhost:${port}`);
-    url.searchParams.append('slug', slug);
+    url.searchParams.append('teamId', teamIdOrSlug);
     url.searchParams.append('tokenName', tokenName);
 
     output.spinner(
@@ -88,7 +88,7 @@ export default async function doSsoLogin(
     }
 
     output.success(
-      `Successfully logged in to "${slug}" team as ${chalk.bold(
+      `Successfully logged in to "${teamIdOrSlug}" team as ${chalk.bold(
         username || email
       )}`
     );

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import open from 'open';
+import chalk from 'chalk';
 import fetch from 'node-fetch';
 import { hostname } from 'os';
 import { URL, URLSearchParams } from 'url';
@@ -62,6 +63,7 @@ export default async function doSsoLogin(
     }
 
     const email = query.get('email');
+    const username = query.get('username');
     const verificationToken = query.get('token');
     if (!email || !verificationToken) {
       output.error(
@@ -74,10 +76,8 @@ export default async function doSsoLogin(
     const verifyUrl = new URL('/registration/verify', apiUrl);
     verifyUrl.searchParams.append('email', email);
     verifyUrl.searchParams.append('token', verificationToken);
-    verifyUrl.searchParams.append('t', String(Date.now()));
 
     const verifyRes = await fetch(verifyUrl.href);
-    output.log('got it');
 
     if (!verifyRes.ok) {
       output.error(
@@ -87,6 +87,11 @@ export default async function doSsoLogin(
       return 1;
     }
 
+    output.success(
+      `Successfully logged in to "${slug}" team as ${chalk.bold(
+        username || email
+      )}`
+    );
     const body = await verifyRes.json();
     return body.token;
   } finally {

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -52,8 +52,7 @@ export default async function doSsoLogin(
       open(url.href),
     ]);
 
-    const rawQuery = req.url!.slice(req.url!.indexOf('?') + 1);
-    const query = new URLSearchParams(rawQuery);
+    const query = new URL(req.url || '/', 'http://localhost').searchParams;
 
     const loginError = query.get('loginError');
     if (loginError) {

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,0 +1,69 @@
+import http from 'http';
+import open from 'open';
+import { hostname } from 'os';
+import { URL, URLSearchParams } from 'url';
+import listen from 'async-listen';
+import { getTitleName } from '../pkg-name';
+import { LoginParams } from './types';
+
+export default async function doSsoLogin(
+  slug: string,
+  { apiUrl, output }: LoginParams
+): Promise<number> {
+  output.print(`Logging in to team "${slug}"`);
+
+  const hyphens = new RegExp('-', 'g');
+  const host = hostname().replace(hyphens, ' ').replace('.local', '');
+  const tokenName = `${getTitleName()} CLI on ${host}`;
+
+  const server = http.createServer();
+  const address = await listen(server);
+  const { port } = new URL(address);
+
+  try {
+    const url = new URL('/registration/sso/auth', apiUrl);
+    url.searchParams.append('mode', 'login');
+    url.searchParams.append('next', `http://localhost:${port}`);
+    url.searchParams.append('slug', slug);
+    url.searchParams.append('tokenName', tokenName);
+
+    output.spinner(
+      'Please complete the SAML Single Sign-On authentication in your web browser'
+    );
+    const [req] = await Promise.all([
+      new Promise<http.IncomingMessage>((resolve, reject) => {
+        server.once('request', (req, res) => {
+          resolve(req);
+
+          // Redirect the user's web browser back
+          // to the Vercel email confirmation page
+          res.statusCode = 302;
+          // TODO: maybe a dedicated page for CLI login success?
+          res.setHeader(
+            'location',
+            'https://vercel.com/notifications/email-confirmed'
+          );
+          res.end();
+        });
+        server.once('error', reject);
+      }),
+      open(url.href),
+    ]);
+
+    const rawQuery = req.url!.slice(req.url!.indexOf('?') + 1);
+    const query = new URLSearchParams(rawQuery);
+
+    const loginError = query.get('loginError');
+    if (loginError) {
+      const err = JSON.parse(loginError);
+      output.error(err.message);
+      return 1;
+    }
+
+    console.log({ query, headers: req.headers });
+  } finally {
+    server.close();
+  }
+
+  return 0;
+}

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import open from 'open';
-import chalk from 'chalk';
 import fetch from 'node-fetch';
 import { hostname } from 'os';
 import { URL, URLSearchParams } from 'url';
@@ -63,7 +62,6 @@ export default async function doSsoLogin(
     }
 
     const email = query.get('email');
-    const username = query.get('username');
     const verificationToken = query.get('token');
     if (!email || !verificationToken) {
       output.error(
@@ -87,16 +85,10 @@ export default async function doSsoLogin(
       return 1;
     }
 
-    output.success(
-      `Successfully logged in to "${teamIdOrSlug}" team as ${chalk.bold(
-        username || email
-      )}`
-    );
+    output.success(`SAML authentication complete`);
     const body = await verifyRes.json();
     return body.token;
   } finally {
     server.close();
   }
-
-  return 0;
 }

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -3,7 +3,7 @@ import open from 'open';
 import chalk from 'chalk';
 import fetch from 'node-fetch';
 import { hostname } from 'os';
-import { URL, URLSearchParams } from 'url';
+import { URL } from 'url';
 import listen from 'async-listen';
 import { getTitleName } from '../pkg-name';
 import { LoginParams } from './types';

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -1,0 +1,13 @@
+import { Output } from '../output';
+import { NowContext } from '../../types';
+
+export interface LoginParams {
+  apiUrl: string;
+  output: Output;
+  ctx: NowContext;
+}
+
+export interface LoginData {
+  token: string;
+  securityCode: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4034,6 +4034,11 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -6047,6 +6052,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
 is-error@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843"
@@ -6302,6 +6312,13 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 is-yarn-global@^0.3.0:
   version "0.3.0"
@@ -8221,6 +8238,15 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.0.2.tgz#8c3e95cce93ba2fc8d99968ee8bfefecdb50b84f"
+  integrity sha512-NV5QmWJrTaNBLHABJyrb+nd5dXI5zfea/suWawBhkHzAbVhLLiJdrqMgxMypGK9Eznp2Ltoh7SAVkQ3XAucX7Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
Refactors the `vercel login` command to be more modular and adds SAML Single Sign-On functionality, where the user's web browser is automatically opened to the identity provider's authentication page, before finally being redirected back to a server that CLI is running on localhost in order to retrieve the final auth token.