### PR TITLE
[frameworks] Add static 404 route to CRA

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -926,6 +926,7 @@ export const frameworks = [
       {
         handle: 'filesystem',
       },
+      { src: '/static/(.*)', status: 404, dest: '/404.html' },
       {
         src: '/(.*)',
         headers: { 'cache-control': 's-maxage=0' },
@@ -993,6 +994,7 @@ export const frameworks = [
       {
         handle: 'filesystem',
       },
+      { src: '/static/(.*)', status: 404, dest: '/404.html' },
       {
         src: '/(.*)',
         headers: { 'cache-control': 's-maxage=0' },


### PR DESCRIPTION
Since CRA is an SPA (all routes fallback to index.html), we can't do a proper custom 404.

But we can do a custom 404 when accessing the static directory, for example `/static/foo.html`.

To handle something like `/foo`, the user needs to do a client-side routing 404 like this example: https://reactrouter.com/web/example/no-match


### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
