### PR TITLE
[frameworks] Fix "svelte" detection and Dev Command

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -855,14 +855,14 @@ export const frameworks = [
         placeholder: '`npm run build` or `rollup -c`',
       },
       devCommand: {
-        value: 'sirv public --single --dev --port $PORT',
+        value: 'rollup -c -w',
       },
       outputDirectory: {
         value: 'public',
       },
     },
     dependency: 'sirv-cli',
-    devCommand: 'sirv public --single --dev --port $PORT',
+    devCommand: 'rollup -c -w',
     buildCommand: 'rollup -c',
     getOutputDirName: async () => 'public',
     defaultRoutes: [

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -843,6 +843,11 @@ export const frameworks = [
         {
           path: 'package.json',
           matchContent:
+            '"(dev)?(d|D)ependencies":\\s*{[^}]*"svelte":\\s*".+?"[^}]*}',
+        },
+        {
+          path: 'package.json',
+          matchContent:
             '"(dev)?(d|D)ependencies":\\s*{[^}]*"sirv-cli":\\s*".+?"[^}]*}',
         },
       ],


### PR DESCRIPTION
- We were matching any project using [sirv](https://www.npmjs.com/package/sirv) which was too broad.
- Hot reloading didn't work because default dev command was incorrect.

This PR updates the framework detection and default dev command to match the example:

https://github.com/vercel/vercel/blob/c2e7be80e869137d3dd482e017c9e65a1431225a/examples/svelte/package.json#L6