### PR TITLE
[test] Add next image bmp test

### DIFF
--- a/packages/cli/test/dev/fixtures/30-next-image-optimization/package.json
+++ b/packages/cli/test/dev/fixtures/30-next-image-optimization/package.json
@@ -5,7 +5,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "latest",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   }

--- a/packages/cli/test/dev/fixtures/30-next-image-optimization/vercel.json
+++ b/packages/cli/test/dev/fixtures/30-next-image-optimization/vercel.json
@@ -1,8 +1,0 @@
-{
-  "version": 2,
-  "build": {
-    "env": {
-      "FORCE_BUILDER_TAG": "canary"
-    }
-  }
-}

--- a/packages/cli/test/dev/integration.js
+++ b/packages/cli/test/dev/integration.js
@@ -1710,19 +1710,20 @@ test(
       expectHeader('image/svg+xml'),
       fetchOpts('image/webp')
     );
+    // bmp should bypass: serve as-is
+    await testPath(
+      200,
+      toUrl('/test.bmp', 64, 50),
+      null,
+      expectHeader('image/bmp'),
+      fetchOpts('image/webp')
+    );
     // animated gif should bypass: serve as-is
     await testPath(
       200,
       toUrl('/animated.gif', 64, 60),
       null,
       expectHeader('image/gif'),
-      fetchOpts('image/webp')
-    ); // bmp should bypass: serve as-is
-    await testPath(
-      200,
-      toUrl('/animated.bmp', 64, 50),
-      null,
-      expectHeader('image/bmp'),
       fetchOpts('image/webp')
     );
   })

--- a/packages/cli/test/dev/integration.js
+++ b/packages/cli/test/dev/integration.js
@@ -1717,6 +1717,13 @@ test(
       null,
       expectHeader('image/gif'),
       fetchOpts('image/webp')
+    ); // bmp should bypass: serve as-is
+    await testPath(
+      200,
+      toUrl('/animated.bmp', 64, 50),
+      null,
+      expectHeader('image/bmp'),
+      fetchOpts('image/webp')
     );
   })
 );


### PR DESCRIPTION
This was fixed in proxy PR 1963 so we can add a test here to confirm `next dev` and the deployment work the same way.