### PR TITLE
[examples] Update CRA go.mod

### DIFF
--- a/examples/create-react-app/go.mod
+++ b/examples/create-react-app/go.mod
@@ -1,3 +1,3 @@
 module example-date
 
-go 1.12
+go 1.16


### PR DESCRIPTION
The current example doesn't work with `vc dev` so this PR updates the example to put the `go.mod` in the the root directory.

I suspect this broke in #4662 which changed the logic of the normal `build()` function to a new `startDevServer()` function.