### PR TITLE
[cli] Re-trigger SSO auth when a SAML error is encountered

### DIFF
--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -3,16 +3,10 @@ import fetch from 'node-fetch';
 import logo from '../util/output/logo';
 // @ts-ignore
 import { handleError } from '../util/error';
-import {
-  readConfigFile,
-  writeToConfigFile,
-  readAuthConfigFile,
-  writeToAuthConfigFile,
-} from '../util/config/files';
+import { writeToConfigFile, writeToAuthConfigFile } from '../util/config/files';
 import getArgs from '../util/get-args';
 import Client from '../util/client';
-import { Output } from '../util/output';
-import { getPkgName } from '../util/pkg-name';
+import { getCommandName, getPkgName } from '../util/pkg-name';
 
 const help = () => {
   console.log(`
@@ -54,29 +48,31 @@ export default async function main(client: Client): Promise<number> {
     return 2;
   }
 
-  return logout(client.apiUrl, client.output);
-}
+  const { authConfig, config, apiUrl, output } = client;
+  const { token } = authConfig;
 
-const logout = async (apiUrl: string, output: Output) => {
+  if (!token) {
+    output.note(
+      `Not currently logged in, so ${getCommandName('logout')} did nothing`
+    );
+    return 0;
+  }
+
   output.spinner('Logging out…', 200);
 
-  const configContent = readConfigFile();
-  const authContent = readAuthConfigFile();
-  const { token } = authContent;
-
-  delete configContent.currentTeam;
+  delete config.currentTeam;
 
   // The new user might have completely different teams, so
   // we should wipe the order.
-  if (configContent.desktop) {
-    delete configContent.desktop.teamOrder;
+  if (config.desktop) {
+    delete config.desktop.teamOrder;
   }
 
-  delete authContent.token;
+  delete authConfig.token;
 
   try {
-    writeToConfigFile(configContent);
-    writeToAuthConfigFile(authContent);
+    writeToConfigFile(config);
+    writeToAuthConfigFile(authConfig);
     output.debug('Configuration has been deleted');
   } catch (err) {
     output.error(`Couldn't remove config while logging out`);
@@ -101,4 +97,4 @@ const logout = async (apiUrl: string, output: Output) => {
 
   output.log('Logged out!');
   return 0;
-};
+}

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -62,9 +62,7 @@ const logout = async (apiUrl: string, output: Output) => {
 
   const configContent = readConfigFile();
   const authContent = readAuthConfigFile();
-
-  // Copy the content
-  const token = `${authContent.token}`;
+  const { token } = authContent;
 
   delete configContent.currentTeam;
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -278,7 +278,7 @@ const main = async () => {
 
   let authConfig = null;
 
-  const subcommandsWithoutToken = ['login', 'help', 'init', 'update'];
+  const subcommandsWithoutToken = ['login', 'logout', 'help', 'init', 'update'];
 
   if (authConfigExists) {
     try {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -484,7 +484,7 @@ const main = async () => {
       return 1;
     }
 
-    client.authConfig.token = token;
+    client.authConfig = { token };
 
     // Don't use team from config if `--token` was set
     if (client.config && client.config.currentTeam) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,14 +1,21 @@
-export type ThenArg<T> = T extends Promise<infer U> ? U : T;
+import { fileNameSymbol } from '@vercel/client';
 
 export interface AuthConfig {
+  [fileNameSymbol]?: string;
   token: string;
 }
 
 export interface GlobalConfig {
+  [fileNameSymbol]?: string;
   currentTeam?: string;
-  updateChannel?: string;
   collectMetrics?: boolean;
   api?: string;
+
+  // TODO: legacy - remove
+  updateChannel?: string;
+  desktop?: {
+    teamOrder: any;
+  };
 }
 
 type Billing = {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -9,6 +9,8 @@ import ua from './ua';
 import printIndications from './print-indications';
 import { AuthConfig, GlobalConfig } from '../types';
 import { NowConfig } from './dev/types';
+import doSsoLogin from './login/sso';
+import { writeToAuthConfigFile } from './config/files';
 
 export interface FetchOptions {
   body?: NodeJS.ReadableStream | object | string;
@@ -107,6 +109,22 @@ export default class Client extends EventEmitter {
 
       if (!res.ok) {
         const error = await responseError(res);
+
+        if (error.saml && error.teamId) {
+          // If a SAML error is encountered then we re-trigger the SAML
+          // authentication flow for the team specified in the error.
+          const result = await doSsoLogin(error.teamId, this);
+
+          if (typeof result === 'number') {
+            this.output.prettyError(error);
+            process.exit(1);
+            return;
+          }
+
+          this.authConfig.token = result;
+          writeToAuthConfigFile(this.authConfig);
+          throw error;
+        }
 
         if (res.status >= 400 && res.status < 500) {
           return bail(error);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -123,10 +123,8 @@ export default class Client extends EventEmitter {
 
           this.authConfig.token = result;
           writeToAuthConfigFile(this.authConfig);
-          throw error;
-        }
-
-        if (res.status >= 400 && res.status < 500) {
+        } else if (res.status >= 400 && res.status < 500) {
+          // Any other 4xx should bail without retrying
           return bail(error);
         }
 

--- a/packages/cli/src/util/config/files.ts
+++ b/packages/cli/src/util/config/files.ts
@@ -9,18 +9,26 @@ import { NowError } from '../now-error';
 import error from '../output/error';
 import highlight from '../output/highlight';
 import { NowConfig } from '../dev/types';
+import { AuthConfig, GlobalConfig } from '../../types';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const CONFIG_FILE_PATH = join(VERCEL_DIR, 'config.json');
 const AUTH_CONFIG_FILE_PATH = join(VERCEL_DIR, 'auth.json');
 
-// reads `CONFIG_FILE_PATH` atomically
-export const readConfigFile = () => loadJSON.sync(CONFIG_FILE_PATH);
+// reads "global config" file atomically
+export const readConfigFile = (fileName = CONFIG_FILE_PATH): GlobalConfig => {
+  const config = loadJSON.sync(fileName);
+  config[fileNameSymbol] = fileName;
+  return config;
+};
 
-// writes whatever's in `stuff` to `CONFIG_FILE_PATH`, atomically
-export const writeToConfigFile = (stuff: object) => {
+// writes whatever's in `stuff` to "global config" file, atomically
+export const writeToConfigFile = (stuff: GlobalConfig): void => {
+  const fileName = stuff[fileNameSymbol];
+  if (!fileName) return;
+
   try {
-    return writeJSON.sync(CONFIG_FILE_PATH, stuff, { indent: 2 });
+    return writeJSON.sync(fileName, stuff, { indent: 2 });
   } catch (err) {
     if (err.code === 'EPERM') {
       console.error(
@@ -46,13 +54,22 @@ export const writeToConfigFile = (stuff: object) => {
   }
 };
 
-// reads `AUTH_CONFIG_FILE_PATH` atomically
-export const readAuthConfigFile = () => loadJSON.sync(AUTH_CONFIG_FILE_PATH);
+// reads "auth config" file atomically
+export const readAuthConfigFile = (
+  fileName = AUTH_CONFIG_FILE_PATH
+): AuthConfig => {
+  const config = loadJSON.sync(fileName);
+  config[fileNameSymbol] = fileName;
+  return config;
+};
 
-// writes whatever's in `stuff` to `AUTH_CONFIG_FILE_PATH`, atomically
-export const writeToAuthConfigFile = (stuff: object) => {
+// writes whatever's in `stuff` to "auth config" file, atomically
+export const writeToAuthConfigFile = (stuff: AuthConfig) => {
+  const fileName = stuff[fileNameSymbol];
+  if (!fileName) return;
+
   try {
-    return writeJSON.sync(AUTH_CONFIG_FILE_PATH, stuff, {
+    return writeJSON.sync(fileName, stuff, {
       indent: 2,
       mode: 0o600,
     });


### PR DESCRIPTION
When the API returns a `saml: true` error, CLI will re-trigger the SSO auth browser window so that the user can sign into their identity provider again. Once the new token is received, it is saved to the `auth.json` file (unless the token was specified via `--token`) for future use.