### PR TITLE
[cli] Make `vc whoami` not require team context

### DIFF
--- a/packages/cli/src/commands/whoami.js
+++ b/packages/cli/src/commands/whoami.js
@@ -51,7 +51,7 @@ const main = async client => {
   let contextName = null;
 
   try {
-    ({ contextName } = await getScope(client));
+    ({ contextName } = await getScope(client, { getTeam: false }));
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
       output.error(err.message);

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -4,12 +4,19 @@ import getTeamById from './get-team-by-id';
 import { TeamDeleted } from './errors-ts';
 import { Team } from '../types';
 
-export default async function getScope(client: Client) {
+interface GetScopeOptions {
+  getTeam?: boolean;
+}
+
+export default async function getScope(
+  client: Client,
+  opts: GetScopeOptions = {}
+) {
   const user = await getUser(client);
   let contextName = user.username || user.email;
   let team: Team | null = null;
 
-  if (client.config.currentTeam) {
+  if (client.config.currentTeam && opts.getTeam !== false) {
     team = await getTeamById(client, client.config.currentTeam);
 
     if (!team) {


### PR DESCRIPTION
### Related Issues

If the user is signed in to a team with SAML enforced, but the current token is not a SAML token, then `getScope()` will fail.

So this PR adds the option to opt-out of team information in `getScope()`, and uses that new option in `vc whoami` since it doesn't require team information.