### PR TITLE
[cli] Use updated SSO auth URL for login

### DIFF
--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -19,7 +19,7 @@ export default async function doSsoLogin(
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
   const server = http.createServer();
-  const address = await listen(server);
+  const address = await listen(server, 0, '127.0.0.1');
   const { port } = new URL(address);
 
   try {

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -23,7 +23,7 @@ export default async function doSsoLogin(
   const { port } = new URL(address);
 
   try {
-    const url = new URL('/registration/sso/auth', apiUrl);
+    const url = new URL('/auth/sso', apiUrl);
     url.searchParams.append('mode', 'login');
     url.searchParams.append('next', `http://localhost:${port}`);
     url.searchParams.append('teamId', teamIdOrSlug);


### PR DESCRIPTION
The `/registration` prefix is no longer necessary.