### PR TITLE
[cli] Bump chalk and change "update available" color

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,7 +113,7 @@
     "async-sema": "2.1.4",
     "ava": "2.2.0",
     "bytes": "3.0.0",
-    "chalk": "2.4.2",
+    "chalk": "4.1.0",
     "chokidar": "3.3.1",
     "clipboardy": "2.1.0",
     "codecov": "3.7.1",

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -136,7 +136,7 @@ const main = async () => {
     const { latest } = notifier.update;
     console.log(
       info(
-        `${chalk.black(chalk.bgCyan('UPDATE AVAILABLE'))} ` +
+        `${chalk.black.bgCyan('UPDATE AVAILABLE')} ` +
           `Run ${cmd(
             await getUpdateCommand()
           )} to install ${getTitleName()} CLI ${latest}`

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -136,7 +136,7 @@ const main = async () => {
     const { latest } = notifier.update;
     console.log(
       info(
-        `${chalk.bgRed('UPDATE AVAILABLE')} ` +
+        `${chalk.black(chalk.bgCyan('UPDATE AVAILABLE'))} ` +
           `Run ${cmd(
             await getUpdateCommand()
           )} to install ${getTitleName()} CLI ${latest}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3233,7 +3233,15 @@ chalk@2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==


### PR DESCRIPTION
- Bump `chalk` to latest version https://github.com/chalk/chalk/releases
- Use black text instead of white text
- Use cyan background instead of red background


### Before
![before](https://user-images.githubusercontent.com/229881/114088378-f3e56680-9882-11eb-90e9-e628d4c1a397.png)

### After
![after](https://user-images.githubusercontent.com/229881/114088526-19727000-9883-11eb-870f-b8b7d45e7cc2.png)

