### PR TITLE
[docs] Improve error docs for `--scope`

### DIFF
--- a/errors/scope-not-accessible.md
+++ b/errors/scope-not-accessible.md
@@ -7,4 +7,5 @@ You specified the `--scope` flag and specified the ID or slug of a team that you
 #### Possible Ways to Fix It
 
 - Make sure commands like `vercel ls` work just fine. This will ensure that your user credentials are valid. If it's not working correctly, please log in again using `vercel login`.
-- Ensure that the scope you specified using `--scope` shows up in the output of `vercel switch`. If it doesn't, you're either not part of the team (if you specified a team) or you logged into the wrong user account.
+- If you're using the `--token` flag, make sure your token is not expired. You can generate a new token on your [Settings page](https://vercel.com/account/tokens).
+- Ensure that the scope you specified using `--scope` flag shows up in the output of `vercel switch`. If it doesn't, you're either not a member of the team or you logged into the wrong user account. You can ask an owner of the team to invite you.

--- a/errors/scope-not-existent.md
+++ b/errors/scope-not-existent.md
@@ -2,10 +2,10 @@
 
 #### Why This Error Occurred
 
-You specified the `--scope` flag and specified the ID or slug of a team that does not exist or that you're not a part of. Similarly you might have specified the ID or username of user whose account you don't own.
+You specified the `--scope` flag and specified the ID or slug of a team that does not exist or that you're not a member. Similarly you might have specified the ID or username of user whose account you don't own.
 
 #### Possible Ways to Fix It
 
-If you're sure the specified team exists, please make sure that you're a part of it (ask an owner of the team to invite you). If you specified the identifier of a user, make sure you are actually the owner of this account.
-
-Otherwise, either create a team with the specified slug or ensure that the identifier is correct if you're sure that the scope exists.
+- Make sure commands like `vercel ls` work just fine. This will ensure that your user credentials are valid. If it's not working correctly, please log in again using `vercel login`.
+- If you're using the `--token` flag, make sure your token is not expired. You can generate a new token on your [Settings page](https://vercel.com/account/tokens).
+- Ensure that the scope you specified using `--scope` flag shows up in the output of `vercel switch`. If it doesn't, you're either not a member of the team or you logged into the wrong user account. You can ask an owner of the team to invite you.


### PR DESCRIPTION
Users were confused when using `--token` and `--scope` when the token expired so the docs now mention this use case.