### PR TITLE
[cli] Fix error usage before defined

### DIFF
--- a/packages/cli/src/commands/teams.js
+++ b/packages/cli/src/commands/teams.js
@@ -116,7 +116,7 @@ const main = async client => {
     }
     case 'add':
     case 'create': {
-      exitCode = await add(client, argv, teams);
+      exitCode = await add(client, teams);
       break;
     }
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -6,7 +6,7 @@ try {
   process.cwd();
 } catch (e) {
   if (e && e.message && e.message.includes('uv_cwd')) {
-    console.error(error('The current working directory does not exist.'));
+    console.error('Error! The current working directory does not exist.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
This PR fixes a couple regressions from #6016:

- Using `error` before its imported. [See index.js](https://github.com/vercel/vercel/pull/6016/files#diff-032eb615f83c504bbb0ec2dfae005b7cea1748c905270acfffe6be0ee3fef7acL3)
- Passing the incorrect params to `add()`. [See add.js](https://github.com/vercel/vercel/pull/6016/files#diff-ee72a76cd216b786bc71a05d76a1b3c760a73248e5b8363ec2f83dd1d46b63d7R39)

We should eventually move these files to TS to catch these types of bugs.