### PR TITLE
[cli][client] Drop support for Node.js 10

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "dependencies": {
     "@vercel/build-utils": "2.10.2-canary.4",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,12 +2,13 @@
   "compilerOptions": {
     "strict": true,
     "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "module": "CommonJS",
-    "target": "ES2018",
+    "module": "commonjs",
+    "target": "es2019",
     "esModuleInterop": true,
     "allowJs": true,
-    "lib": ["ES2018"],
+    "lib": ["esnext"],
     "resolveJsonModule": true,
     "sourceMap": true,
     "typeRoots": ["./@types", "./node_modules/@types"]

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,9 @@
     "test-integration-once": "jest --verbose --runInBand --bail tests/create-deployment.test.ts tests/create-legacy-deployment.test.ts tests/paths.test.ts",
     "test-unit": "jest --verbose --runInBand --bail tests/unit.*test.*"
   },
+  "engines": {
+    "node": ">= 12"
+  },
   "devDependencies": {
     "@types/async-retry": "1.4.1",
     "@types/fs-extra": "7.0.0",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["ES2018"],
-    "module": "CommonJS",
+    "lib": ["esnext"],
+    "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist",
     "strictNullChecks": true,
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "target": "ES2018"
+    "target": "es2019"
   },
   "include": ["./src"]
 }

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -30,13 +30,11 @@ const requireTypescript = (p: string): TypescriptModule => {
 
 let ts: TypescriptModule | null = null;
 
-// Assume Node 10 as the lowest common denominator
-let target = 'ES2018';
+// Assume Node.js 12 as the lowest common denominator
+let target = 'ES2019';
 const nodeMajor = Number(process.versions.node.split('.')[0]);
 if (nodeMajor >= 14) {
   target = 'ES2020';
-} else if (nodeMajor >= 12) {
-  target = 'ES2019';
 }
 
 // Use the project's version of Typescript if available and supports `target`


### PR DESCRIPTION
Node.js 10 is about to reach EOL so we can drop CLI support in the next major release. We'll support 12+ going forward.

Node.js 12 needs `es2019` because it doesn't support the `es2020` features of optional chaining and nullish coalescing as seen from the [compatibility table](https://kangax.github.io/compat-table/es2016plus/#node12_11).