### PR TITLE
[cli] Fix `vercel login` command

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,12 +1,8 @@
-import { fileNameSymbol } from '@vercel/client';
-
 export interface AuthConfig {
-  [fileNameSymbol]?: string;
   token: string;
 }
 
 export interface GlobalConfig {
-  [fileNameSymbol]?: string;
   currentTeam?: string;
   collectMetrics?: boolean;
   api?: string;

--- a/packages/cli/src/util/config/files.ts
+++ b/packages/cli/src/util/config/files.ts
@@ -16,19 +16,15 @@ const CONFIG_FILE_PATH = join(VERCEL_DIR, 'config.json');
 const AUTH_CONFIG_FILE_PATH = join(VERCEL_DIR, 'auth.json');
 
 // reads "global config" file atomically
-export const readConfigFile = (fileName = CONFIG_FILE_PATH): GlobalConfig => {
-  const config = loadJSON.sync(fileName);
-  config[fileNameSymbol] = fileName;
+export const readConfigFile = (): GlobalConfig => {
+  const config = loadJSON.sync(CONFIG_FILE_PATH);
   return config;
 };
 
 // writes whatever's in `stuff` to "global config" file, atomically
 export const writeToConfigFile = (stuff: GlobalConfig): void => {
-  const fileName = stuff[fileNameSymbol];
-  if (!fileName) return;
-
   try {
-    return writeJSON.sync(fileName, stuff, { indent: 2 });
+    return writeJSON.sync(CONFIG_FILE_PATH, stuff, { indent: 2 });
   } catch (err) {
     if (err.code === 'EPERM') {
       console.error(
@@ -55,21 +51,15 @@ export const writeToConfigFile = (stuff: GlobalConfig): void => {
 };
 
 // reads "auth config" file atomically
-export const readAuthConfigFile = (
-  fileName = AUTH_CONFIG_FILE_PATH
-): AuthConfig => {
-  const config = loadJSON.sync(fileName);
-  config[fileNameSymbol] = fileName;
+export const readAuthConfigFile = (): AuthConfig => {
+  const config = loadJSON.sync(AUTH_CONFIG_FILE_PATH);
   return config;
 };
 
 // writes whatever's in `stuff` to "auth config" file, atomically
 export const writeToAuthConfigFile = (stuff: AuthConfig) => {
-  const fileName = stuff[fileNameSymbol];
-  if (!fileName) return;
-
   try {
-    return writeJSON.sync(fileName, stuff, {
+    return writeJSON.sync(AUTH_CONFIG_FILE_PATH, stuff, {
       indent: 2,
       mode: 0o600,
     });

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -295,6 +295,7 @@ test('default command should prompt login with empty auth.json', async t => {
 test('login', async t => {
   t.timeout(ms('1m'));
 
+  await fs.remove(getConfigAuthPath());
   const loginOutput = await execa(binaryPath, [
     'login',
     email,


### PR DESCRIPTION
Fixes a bug where users run `vc login` but the auth file is not persisted, thus they're not really logged in.

The problem was introduced in #6053 because of the assumption that we must read the file before writing. But we don't read the file for `vc login` command so the symbol is never assigned. Since there is no symbol, the file does not write.

This PR reverts the behavior to use a gobal variable for the file path instead of relying on a symbol.

The test was also updated to ensure we don't regress, previously it was checking for a file that already existed.