### PR TITLE
[cli] Fix SAML usage with `--token`

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -484,7 +484,7 @@ const main = async () => {
       return 1;
     }
 
-    client.authConfig = { token };
+    client.authConfig = { token, skipWrite: true };
 
     // Don't use team from config if `--token` was set
     if (client.config && client.config.currentTeam) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,5 +1,6 @@
 export interface AuthConfig {
   token: string;
+  skipWrite?: boolean;
 }
 
 export interface GlobalConfig {

--- a/packages/cli/src/util/config/files.ts
+++ b/packages/cli/src/util/config/files.ts
@@ -56,10 +56,12 @@ export const readAuthConfigFile = (): AuthConfig => {
   return config;
 };
 
-// writes whatever's in `stuff` to "auth config" file, atomically
-export const writeToAuthConfigFile = (stuff: AuthConfig) => {
+export const writeToAuthConfigFile = (authConfig: AuthConfig) => {
+  if (authConfig.skipWrite) {
+    return;
+  }
   try {
-    return writeJSON.sync(AUTH_CONFIG_FILE_PATH, stuff, {
+    return writeJSON.sync(AUTH_CONFIG_FILE_PATH, authConfig, {
       indent: 2,
       mode: 0o600,
     });


### PR DESCRIPTION
Follow up to #6138:

SAML will periodically write the auth.json file but it shouldn't write the file if the `--token` flag was provided.