### PR TITLE
Replace regex lexer with minimal regex for named groups

### DIFF
--- a/packages/routing-utils/package.json
+++ b/packages/routing-utils/package.json
@@ -20,8 +20,7 @@
     "test-unit": "jest --env node --verbose --runInBand --bail"
   },
   "dependencies": {
-    "path-to-regexp": "6.1.0",
-    "regexr": "https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337"
+    "path-to-regexp": "6.1.0"
   },
   "devDependencies": {
     "@types/node": "12.12.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9205,10 +9205,6 @@ regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
-"regexr@https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337":
-  version "3.8.0"
-  resolved "https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337"
-
 registry-auth-token@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.1.1.tgz#40a33be1e82539460f94328b0f7f0f84c16d9479"


### PR DESCRIPTION
This removes the regex lexer in favor of a minimal regex to gather the named groups which we can expand on to handle edge cases as we catch them. Initially this only supports the `(?<hello>)` syntax if other syntaxes like `(?'another')` pop up we can add support for them as well. 

### Related Issues

x-ref: https://github.com/vercel/vercel/pull/5919

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
