### PR TITLE
[cli] Refactor `vc login` command

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -6,7 +6,7 @@ import handleError from '../util/handle-error';
 import logo from '../util/output/logo';
 import prompt from '../util/login/prompt';
 import doSsoLogin from '../util/login/sso';
-import doEmailLogin from '../util/login//email';
+import doEmailLogin from '../util/login/email';
 import { prependEmoji, emoji } from '../util/emoji';
 import { getCommandName, getPkgName } from '../util/pkg-name';
 import getGlobalPathConfig from '../util/config/global-path';

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -44,14 +44,6 @@ const help = () => {
 `);
 };
 
-function isValidSlug(slug: string) {
-  return (
-    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug) &&
-    slug.length >= 1 &&
-    slug.length <= 48
-  );
-}
-
 export default async function login(client: Client): Promise<number> {
   let argv;
   const { apiUrl, output } = client;
@@ -82,12 +74,8 @@ export default async function login(client: Client): Promise<number> {
     // Email or Team slug was provided via command line
     if (validateEmail(input)) {
       result = await doEmailLogin(input, params);
-    } else if (isValidSlug(input)) {
-      result = await doSsoLogin(input, params);
     } else {
-      output.error(`Invalid input: "${input}"`);
-      output.log(`Please enter a valid email address or team slug`);
-      return 2;
+      result = await doSsoLogin(input, params);
     }
   } else {
     // Interactive mode

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -1,0 +1,30 @@
+import { URL } from 'url';
+import highlight from '../output/highlight';
+import { LoginParams } from './types';
+import doOauthLogin from './oauth';
+
+export default async function doBitbucketLogin(
+  params: LoginParams
+): Promise<number | string> {
+  const { output } = params;
+
+  const url = new URL(
+    '/api/registration/bitbucket/connect',
+    'https://vercel.com'
+  );
+  url.searchParams.append('mode', 'login');
+
+  output.spinner(
+    'Please complete the Bitbucket authentication in your web browser'
+  );
+
+  const result = await doOauthLogin(url, params);
+
+  if (typeof result !== 'number') {
+    output.success(
+      `Bitbucket authentication complete for ${highlight('email')}`
+    );
+  }
+
+  return result;
+}

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -5,6 +5,8 @@ import doOauthLogin from './oauth';
 export default function doBitbucketLogin(params: LoginParams) {
   const url = new URL(
     '/api/registration/bitbucket/connect',
+    // Can't use `apiUrl` here because this URL sets a
+    // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
   return doOauthLogin(url, 'Bitbucket', params);

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -1,30 +1,11 @@
 import { URL } from 'url';
-import highlight from '../output/highlight';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
-export default async function doBitbucketLogin(
-  params: LoginParams
-): Promise<number | string> {
-  const { output } = params;
-
+export default function doBitbucketLogin(params: LoginParams) {
   const url = new URL(
     '/api/registration/bitbucket/connect',
     'https://vercel.com'
   );
-  url.searchParams.append('mode', 'login');
-
-  output.spinner(
-    'Please complete the Bitbucket authentication in your web browser'
-  );
-
-  const result = await doOauthLogin(url, params);
-
-  if (typeof result !== 'number') {
-    output.success(
-      `Bitbucket authentication complete for ${highlight('email')}`
-    );
-  }
-
-  return result;
+  return doOauthLogin(url, 'Bitbucket', params);
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -51,6 +51,6 @@ export default async function doEmailLogin(
     }
   }
 
-  output.success('Email confirmed');
+  output.success(`Email authentication complete for ${email}`);
   return token;
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -1,70 +1,18 @@
 import ms from 'ms';
-import { stringify as stringifyQuery } from 'querystring';
-import fetch from 'node-fetch';
 import sleep from '../sleep';
-import ua from '../ua';
-import error from '../output/error';
 import highlight from '../output/highlight';
 import eraseLines from '../output/erase-lines';
+import verify from './verify';
 import executeLogin from './login';
 import { LoginParams } from './types';
 
-async function verify(
-  email: string,
-  verificationToken: string,
-  { apiUrl, output }: LoginParams
-): Promise<string> {
-  const query = {
-    email,
-    token: verificationToken,
-  };
-
-  output.debug('GET /now/registration/verify');
-
-  let res;
-
-  try {
-    res = await fetch(
-      `${apiUrl}/now/registration/verify?${stringifyQuery(query)}`,
-      {
-        headers: { 'User-Agent': ua },
-      }
-    );
-  } catch (err) {
-    output.debug(`error fetching /now/registration/verify: ${err.stack}`);
-
-    throw new Error(
-      error(
-        `An unexpected error occurred while trying to verify your login: ${err.message}`
-      )
-    );
-  }
-
-  output.debug('parsing response from GET /now/registration/verify');
-  let body;
-
-  try {
-    body = await res.json();
-  } catch (err) {
-    output.debug(
-      `error parsing the response from /now/registration/verify: ${err.stack}`
-    );
-    throw new Error(
-      error(
-        `An unexpected error occurred while trying to verify your login: ${err.message}`
-      )
-    );
-  }
-
-  return body.token;
-}
-
 export default async function doEmailLogin(
   email: string,
-  { apiUrl, output }: LoginParams
+  params: LoginParams
 ): Promise<number | string> {
   let securityCode;
   let verificationToken;
+  const { apiUrl, output } = params;
 
   output.spinner('Sending you an email');
 
@@ -91,16 +39,12 @@ export default async function doEmailLogin(
   output.spinner('Waiting for your confirmation');
 
   let token = '';
-
   while (!token) {
     try {
       await sleep(ms('1s'));
-      token = await verify(email, verificationToken, { apiUrl, output });
+      token = await verify(email, verificationToken, params);
     } catch (err) {
-      if (/invalid json response body/.test(err.message)) {
-        // /now/registraton is currently returning plain text in that case
-        // we just wait for the user to click on the link
-      } else {
+      if (err.message !== 'Confirmation incomplete') {
         output.error(err.message);
         return 1;
       }

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -1,28 +1,11 @@
 import { URL } from 'url';
-import highlight from '../output/highlight';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
-export default async function doGithubLogin(
-  params: LoginParams
-): Promise<number | string> {
-  const { output } = params;
-
+export default function doGithubLogin(params: LoginParams) {
   const url = new URL(
     '/api/registration/login-with-github',
     'https://vercel.com'
   );
-  url.searchParams.append('mode', 'login');
-
-  output.spinner(
-    'Please complete the GitHub authentication in your web browser'
-  );
-
-  const result = await doOauthLogin(url, params);
-
-  if (typeof result !== 'number') {
-    output.success(`GitHub authentication complete for ${highlight('email')}`);
-  }
-
-  return result;
+  return doOauthLogin(url, 'GitHub', params);
 }

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -1,0 +1,28 @@
+import { URL } from 'url';
+import highlight from '../output/highlight';
+import { LoginParams } from './types';
+import doOauthLogin from './oauth';
+
+export default async function doGithubLogin(
+  params: LoginParams
+): Promise<number | string> {
+  const { output } = params;
+
+  const url = new URL(
+    '/api/registration/login-with-github',
+    'https://vercel.com'
+  );
+  url.searchParams.append('mode', 'login');
+
+  output.spinner(
+    'Please complete the GitHub authentication in your web browser'
+  );
+
+  const result = await doOauthLogin(url, params);
+
+  if (typeof result !== 'number') {
+    output.success(`GitHub authentication complete for ${highlight('email')}`);
+  }
+
+  return result;
+}

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -5,6 +5,8 @@ import doOauthLogin from './oauth';
 export default function doGithubLogin(params: LoginParams) {
   const url = new URL(
     '/api/registration/login-with-github',
+    // Can't use `apiUrl` here because this URL sets a
+    // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
   return doOauthLogin(url, 'GitHub', params);

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -1,25 +1,8 @@
 import { URL } from 'url';
-import highlight from '../output/highlight';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
-export default async function doGitlabLogin(
-  params: LoginParams
-): Promise<number | string> {
-  const { output } = params;
-
+export default function doGitlabLogin(params: LoginParams) {
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
-  url.searchParams.append('mode', 'login');
-
-  output.spinner(
-    'Please complete the GitLab authentication in your web browser'
-  );
-
-  const result = await doOauthLogin(url, params);
-
-  if (typeof result !== 'number') {
-    output.success(`GitLab authentication complete for ${highlight('email')}`);
-  }
-
-  return result;
+  return doOauthLogin(url, 'GitLab', params);
 }

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -1,0 +1,25 @@
+import { URL } from 'url';
+import highlight from '../output/highlight';
+import { LoginParams } from './types';
+import doOauthLogin from './oauth';
+
+export default async function doGitlabLogin(
+  params: LoginParams
+): Promise<number | string> {
+  const { output } = params;
+
+  const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
+  url.searchParams.append('mode', 'login');
+
+  output.spinner(
+    'Please complete the GitLab authentication in your web browser'
+  );
+
+  const result = await doOauthLogin(url, params);
+
+  if (typeof result !== 'number') {
+    output.success(`GitLab authentication complete for ${highlight('email')}`);
+  }
+
+  return result;
+}

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -3,6 +3,8 @@ import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
 export default function doGitlabLogin(params: LoginParams) {
+  // Can't use `apiUrl` here because this URL sets a
+  // cookie that the OAuth callback URL depends on
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
   return doOauthLogin(url, 'GitLab', params);
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -5,16 +5,23 @@ import listen from 'async-listen';
 import { LoginParams } from './types';
 import prompt from './prompt';
 import verify from './verify';
+import highlight from '../output/highlight';
 
 export default async function doOauthLogin(
   url: URL,
+  provider: string,
   params: LoginParams
 ): Promise<number | string> {
   const { output } = params;
 
+  output.spinner(
+    `Please complete the ${provider} authentication in your web browser`
+  );
+
   const server = http.createServer();
   const address = await listen(server, 0, '127.0.0.1');
   const { port } = new URL(address);
+  url.searchParams.append('mode', 'login');
   url.searchParams.append('next', `http://localhost:${port}`);
 
   try {
@@ -94,6 +101,9 @@ export default async function doOauthLogin(
 
     output.spinner('Verifying authentication token');
     const token = await verify(email, verificationToken, params);
+    output.success(
+      `${provider} authentication complete for ${highlight(email)}`
+    );
     return token;
   } finally {
     server.close();

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -77,8 +77,6 @@ export default async function doOauthLogin(
       return 1;
     }
 
-    //console.log(query);
-
     // If an `ssoUserId` was returned, then the SAML Profile is not yet connected
     // to a Team member. Prompt the user to log in to a Vercel account now, which
     // will complete the connection to the SAML Profile.

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -1,0 +1,101 @@
+import http from 'http';
+import open from 'open';
+import { URL } from 'url';
+import listen from 'async-listen';
+import { LoginParams } from './types';
+import prompt from './prompt';
+import verify from './verify';
+
+export default async function doOauthLogin(
+  url: URL,
+  params: LoginParams
+): Promise<number | string> {
+  const { output } = params;
+
+  const server = http.createServer();
+  const address = await listen(server, 0, '127.0.0.1');
+  const { port } = new URL(address);
+  url.searchParams.append('next', `http://localhost:${port}`);
+
+  try {
+    const [query] = await Promise.all([
+      new Promise<URL['searchParams']>((resolve, reject) => {
+        server.once('request', (req, res) => {
+          const query = new URL(req.url || '/', 'http://localhost')
+            .searchParams;
+          resolve(query);
+
+          // Redirect the user's web browser back to
+          // the Vercel CLI login notification page
+          const location = new URL(
+            'https://vercel.com/notifications/cli-login-'
+          );
+          const loginError = query.get('loginError');
+          const ssoEmail = query.get('ssoEmail');
+          if (loginError) {
+            location.pathname += 'failed';
+            location.searchParams.set('loginError', loginError);
+          } else if (ssoEmail) {
+            location.pathname += 'incomplete';
+            location.searchParams.set('ssoEmail', ssoEmail);
+            const teamName = query.get('teamName');
+            const ssoType = query.get('ssoType');
+            if (teamName) {
+              location.searchParams.set('teamName', teamName);
+            }
+            if (ssoType) {
+              location.searchParams.set('ssoType', ssoType);
+            }
+          } else {
+            location.pathname += 'success';
+            const email = query.get('email');
+            if (email) {
+              location.searchParams.set('email', email);
+            }
+          }
+
+          res.statusCode = 302;
+          res.setHeader('location', location.href);
+          res.end();
+        });
+        server.once('error', reject);
+      }),
+      open(url.href),
+    ]);
+
+    const loginError = query.get('loginError');
+    if (loginError) {
+      const err = JSON.parse(loginError);
+      output.prettyError(err);
+      return 1;
+    }
+
+    //console.log(query);
+
+    // If an `ssoUserId` was returned, then the SAML Profile is not yet connected
+    // to a Team member. Prompt the user to log in to a Vercel account now, which
+    // will complete the connection to the SAML Profile.
+    const ssoUserId = query.get('ssoUserId');
+    if (ssoUserId) {
+      output.log(
+        'Please log in to your Vercel account to complete SAML connection.'
+      );
+      return prompt({ ...params, ssoUserId });
+    }
+
+    const email = query.get('email');
+    const verificationToken = query.get('token');
+    if (!email || !verificationToken) {
+      output.error(
+        'Verification token was not provided. Please contact support.'
+      );
+      return 1;
+    }
+
+    output.spinner('Verifying authentication token');
+    const token = await verify(email, verificationToken, params);
+    return token;
+  } finally {
+    server.close();
+  }
+}

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -2,9 +2,12 @@ import inquirer from 'inquirer';
 import error from '../output/error';
 import listInput from '../input/list';
 import { getCommandName } from '../pkg-name';
+import { LoginParams } from './types';
 import doSsoLogin from './sso';
 import doEmailLogin from './email';
-import { LoginParams } from './types';
+import doGithubLogin from './github';
+import doGitlabLogin from './gitlab';
+import doBitbucketLogin from './bitbucket';
 
 export default async function prompt(params: LoginParams) {
   let result: number | string = 1;
@@ -29,8 +32,11 @@ export default async function prompt(params: LoginParams) {
   });
 
   if (choice === 'github') {
+    result = await doGithubLogin(params);
   } else if (choice === 'gitlab') {
+    result = await doGitlabLogin(params);
   } else if (choice === 'bitbucket') {
+    result = await doBitbucketLogin(params);
   } else if (choice === 'email') {
     const email = await readInput('Enter your email address');
     result = await doEmailLogin(email, params);

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -1,0 +1,72 @@
+import inquirer from 'inquirer';
+import error from '../output/error';
+import listInput from '../input/list';
+import { getCommandName } from '../pkg-name';
+import doSsoLogin from './sso';
+import doEmailLogin from './email';
+import { LoginParams } from './types';
+
+export default async function prompt(params: LoginParams) {
+  let result: number | string = 1;
+
+  const choices = [
+    { name: 'Continue with GitHub', value: 'github', short: 'github' },
+    { name: 'Continue with GitLab', value: 'gitlab', short: 'gitlab' },
+    { name: 'Continue with Bitbucket', value: 'bitbucket', short: 'bitbucket' },
+    { name: 'Continue with Email', value: 'email', short: 'email' },
+    { name: 'Continue with SAML Single Sign-On', value: 'saml', short: 'saml' },
+  ];
+
+  if (params.ssoUserId) {
+    // Remove SAML login option if we're connecting SAML Profile
+    choices.pop();
+  }
+
+  const choice = await listInput({
+    message: 'Log in to Vercel',
+    separator: false,
+    choices,
+  });
+
+  if (choice === 'github') {
+  } else if (choice === 'gitlab') {
+  } else if (choice === 'bitbucket') {
+  } else if (choice === 'email') {
+    const email = await readInput('Enter your email address');
+    result = await doEmailLogin(email, params);
+  } else if (choice === 'saml') {
+    const slug = await readInput('Enter your Team slug');
+    result = await doSsoLogin(slug, params);
+  }
+
+  return result;
+}
+
+async function readInput(message: string) {
+  let input;
+
+  while (!input) {
+    try {
+      const { val } = await inquirer.prompt({
+        type: 'input',
+        name: 'val',
+        message,
+      });
+      input = val;
+    } catch (err) {
+      console.log(); // \n
+
+      if (err.isTtyError) {
+        throw new Error(
+          error(
+            `Interactive mode not supported – please run ${getCommandName(
+              `login you@domain.com`
+            )}`
+          )
+        );
+      }
+    }
+  }
+
+  return input;
+}

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,34 +1,19 @@
 import { URL } from 'url';
 import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
-import highlight from '../output/highlight';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
-export default async function doSsoLogin(
-  teamIdOrSlug: string,
-  params: LoginParams
-): Promise<number | string> {
-  const { apiUrl, output } = params;
+export default function doSsoLogin(teamIdOrSlug: string, params: LoginParams) {
+  const { apiUrl } = params;
 
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
   const url = new URL('/auth/sso', apiUrl);
-  url.searchParams.append('mode', 'login');
   url.searchParams.append('teamId', teamIdOrSlug);
   url.searchParams.append('tokenName', tokenName);
 
-  output.spinner(
-    'Please complete the SAML Single Sign-On authentication in your web browser'
-  );
-
-  const result = await doOauthLogin(url, params);
-
-  if (typeof result !== 'number') {
-    output.success(`SAML authentication complete for ${highlight('email')}`);
-  }
-
-  return result;
+  return doOauthLogin(url, 'SAML Single Sign-On', params);
 }

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,118 +1,34 @@
-import http from 'http';
-import open from 'open';
-import { hostname } from 'os';
 import { URL } from 'url';
-import listen from 'async-listen';
+import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
 import highlight from '../output/highlight';
 import { LoginParams } from './types';
-import prompt from './prompt';
-import verify from './verify';
+import doOauthLogin from './oauth';
 
 export default async function doSsoLogin(
   teamIdOrSlug: string,
   params: LoginParams
 ): Promise<number | string> {
   const { apiUrl, output } = params;
-  output.print(`Logging in to team "${teamIdOrSlug}"`);
 
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
-  const server = http.createServer();
-  const address = await listen(server, 0, '127.0.0.1');
-  const { port } = new URL(address);
+  const url = new URL('/auth/sso', apiUrl);
+  url.searchParams.append('mode', 'login');
+  url.searchParams.append('teamId', teamIdOrSlug);
+  url.searchParams.append('tokenName', tokenName);
 
-  try {
-    const url = new URL('/auth/sso', apiUrl);
-    url.searchParams.append('mode', 'login');
-    url.searchParams.append('next', `http://localhost:${port}`);
-    url.searchParams.append('teamId', teamIdOrSlug);
-    url.searchParams.append('tokenName', tokenName);
+  output.spinner(
+    'Please complete the SAML Single Sign-On authentication in your web browser'
+  );
 
-    output.spinner(
-      'Please complete the SAML Single Sign-On authentication in your web browser'
-    );
-    const [query] = await Promise.all([
-      new Promise<URL['searchParams']>((resolve, reject) => {
-        server.once('request', (req, res) => {
-          const query = new URL(req.url || '/', 'http://localhost')
-            .searchParams;
-          resolve(query);
+  const result = await doOauthLogin(url, params);
 
-          // Redirect the user's web browser back to
-          // the Vercel CLI login notification page
-          const location = new URL(
-            'https://vercel.com/notifications/cli-login-'
-          );
-          const loginError = query.get('loginError');
-          const ssoEmail = query.get('ssoEmail');
-          if (loginError) {
-            location.pathname += 'failed';
-            location.searchParams.set('loginError', loginError);
-          } else if (ssoEmail) {
-            location.pathname += 'incomplete';
-            location.searchParams.set('ssoEmail', ssoEmail);
-            const teamName = query.get('teamName');
-            const ssoType = query.get('ssoType');
-            if (teamName) {
-              location.searchParams.set('teamName', teamName);
-            }
-            if (ssoType) {
-              location.searchParams.set('ssoType', ssoType);
-            }
-          } else {
-            location.pathname += 'success';
-            const email = query.get('email');
-            if (email) {
-              location.searchParams.set('email', email);
-            }
-          }
-
-          res.statusCode = 302;
-          res.setHeader('location', location.href);
-          res.end();
-        });
-        server.once('error', reject);
-      }),
-      open(url.href),
-    ]);
-
-    const loginError = query.get('loginError');
-    if (loginError) {
-      const err = JSON.parse(loginError);
-      output.prettyError(err);
-      return 1;
-    }
-
-    //console.log(query);
-
-    // If an `ssoUserId` was returned, then the SAML Profile is not yet connected
-    // to a Team member. Prompt the user to log in to a Vercel account now, which
-    // will complete the connection to the SAML Profile.
-    const ssoUserId = query.get('ssoUserId');
-    if (ssoUserId) {
-      output.log(
-        'Please log in to your Vercel account to complete SAML connection.'
-      );
-      return prompt({ ...params, ssoUserId });
-    }
-
-    const email = query.get('email');
-    const verificationToken = query.get('token');
-    if (!email || !verificationToken) {
-      output.error(
-        'Verification token was not provided. Please contact support.'
-      );
-      return 1;
-    }
-
-    output.spinner('Verifying authentication token');
-    const token = await verify(email, verificationToken, params);
-    output.success(`SAML authentication complete for ${highlight(email)}`);
-    return token;
-  } finally {
-    server.close();
+  if (typeof result !== 'number') {
+    output.success(`SAML authentication complete for ${highlight('email')}`);
   }
+
+  return result;
 }

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -5,13 +5,11 @@ import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
 export default function doSsoLogin(teamIdOrSlug: string, params: LoginParams) {
-  const { apiUrl } = params;
-
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;
 
-  const url = new URL('/auth/sso', apiUrl);
+  const url = new URL('/auth/sso', params.apiUrl);
   url.searchParams.append('teamId', teamIdOrSlug);
   url.searchParams.append('tokenName', tokenName);
 

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -3,6 +3,7 @@ import { Output } from '../output';
 export interface LoginParams {
   apiUrl: string;
   output: Output;
+  ssoUserId?: string;
 }
 
 export interface LoginData {

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -1,0 +1,33 @@
+import { URL } from 'url';
+import fetch from 'node-fetch';
+import ua from '../ua';
+import { LoginParams } from './types';
+
+export default async function verify(
+  email: string,
+  verificationToken: string,
+  { apiUrl, ssoUserId }: LoginParams
+): Promise<string> {
+  const url = new URL('/registration/verify', apiUrl);
+  url.searchParams.append('email', email);
+  url.searchParams.append('token', verificationToken);
+  if (ssoUserId) {
+    url.searchParams.append('ssoUserId', ssoUserId);
+  }
+
+  const res = await fetch(url.href, {
+    headers: { 'User-Agent': ua },
+  });
+
+  const body = await res.json();
+
+  if (!res.ok) {
+    const err = new Error(
+      `Unexpected ${res.status} status code from verify API`
+    );
+    Object.assign(err, body.error);
+    throw err;
+  }
+
+  return body.token;
+}

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -165,7 +165,7 @@ function mockLoginApi(req, res) {
     res.end(JSON.stringify({ token, securityCode }));
   } else if (
     method === 'GET' &&
-    pathname === '/now/registration/verify' &&
+    pathname === '/registration/verify' &&
     query.email === email
   ) {
     res.end(JSON.stringify({ token }));


### PR DESCRIPTION
Refactors the CLI `vc login` command with the following features:

* Adds GitHub, GitLab and Bitbucket as login options
* Uses a "list" input to select which login method to use (same list as `vc init`)
* Support connecting SAML Profile to Vercel user during login

<img width="289" alt="Screen Shot 2021-05-05 at 11 02 06 AM" src="https://user-images.githubusercontent.com/71256/117188539-02e00b80-ad92-11eb-88e6-c2ad1da2bdbf.png">
<img width="471" alt="Screen Shot 2021-05-05 at 11 03 13 AM" src="https://user-images.githubusercontent.com/71256/117188544-04113880-ad92-11eb-844c-b83b0c7dee71.png">
<img width="505" alt="Screen Shot 2021-05-05 at 11 03 51 AM" src="https://user-images.githubusercontent.com/71256/117188546-04113880-ad92-11eb-86d9-10456bde6fed.png">
