### PR TITLE
[build-utils] framework can be null as default

### DIFF
--- a/packages/build-utils/src/detect-builders.ts
+++ b/packages/build-utils/src/detect-builders.ts
@@ -474,7 +474,7 @@ function detectFrontBuilder(
 
   if (
     pkg &&
-    (framework === undefined || createdAt < Date.parse('2020-03-01'))
+    (!framework || createdAt < Date.parse('2020-03-01'))
   ) {
     const deps: PackageJson['dependencies'] = {
       ...pkg.dependencies,


### PR DESCRIPTION
### Related Issues

> Fixes #1
> Related to #2

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
