### PR TITLE
[cli] Add SAML reauthentication logic when using different scope

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,7 @@
     "@types/mri": "1.1.0",
     "@types/ms": "0.7.30",
     "@types/node": "11.11.0",
-    "@types/node-fetch": "2.1.4",
+    "@types/node-fetch": "2.5.10",
     "@types/npm-package-arg": "6.1.0",
     "@types/pluralize": "0.0.29",
     "@types/progress": "2.0.3",

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -73,9 +73,9 @@ export default async function login(client: Client): Promise<number> {
   if (input) {
     // Email or Team slug was provided via command line
     if (validateEmail(input)) {
-      result = await doEmailLogin(input, params);
+      result = await doEmailLogin(params, input);
     } else {
-      result = await doSsoLogin(input, params);
+      result = await doSsoLogin(params, input);
     }
   } else {
     // Interactive mode

--- a/packages/cli/src/commands/remove.js
+++ b/packages/cli/src/commands/remove.js
@@ -115,8 +115,6 @@ export default async function main(client) {
   try {
     ({ contextName } = await getScope(client));
   } catch (err) {
-    client.close();
-
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
       output.error(err.message);
       return 1;
@@ -210,7 +208,6 @@ export default async function main(client) {
           .map(id => chalk.bold(`"${id}"`))
           .join(', ')}. Run ${getCommandName('ls')} to list.`
     );
-    client.close();
     return 1;
   }
 
@@ -233,7 +230,6 @@ export default async function main(client) {
 
     if (confirmation !== 'y' && confirmation !== 'yes') {
       output.log('Aborted');
-      client.close();
       return 1;
     }
   }
@@ -265,7 +261,6 @@ export default async function main(client) {
     console.log(`${chalk.gray('-')} ${chalk.bold(project.name)}`);
   });
 
-  client.close();
   return 0;
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,20 @@
+export type Primitive =
+  | bigint
+  | boolean
+  | null
+  | number
+  | string
+  | symbol
+  | undefined;
+
+export type JSONArray = JSONValue[];
+
+export type JSONValue = Primitive | JSONObject | JSONArray;
+
+export interface JSONObject {
+  [key: string]: JSONValue;
+}
+
 export interface AuthConfig {
   token: string;
   skipWrite?: boolean;

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -121,7 +121,6 @@ export default class Client extends EventEmitter {
 
       if (!res.ok) {
         const error = await responseError(res);
-        console.log(error);
 
         if (isSAMLError(error)) {
           // A SAML error means the token is expired, or is not

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -5,19 +5,14 @@ import { VercelConfig } from '@vercel/client';
 import retry, { RetryFunction, Options as RetryOptions } from 'async-retry';
 import fetch, { BodyInit, Headers, RequestInit, Response } from 'node-fetch';
 import ua from './ua';
-import { APIError } from './errors-ts';
 import { Output } from './output/create-output';
 import responseError from './response-error';
 import printIndications from './print-indications';
 import reauthenticate from './login/reauthenticate';
+import { SAMLError } from './login/types';
 import { writeToAuthConfigFile } from './config/files';
 import { AuthConfig, GlobalConfig, JSONObject } from '../types';
 import { sharedPromise } from './promise';
-
-interface SAMLError extends APIError {
-  saml: true;
-  teamId: string | null;
-}
 
 const isSAMLError = (v: any): v is SAMLError => {
   return v && v.saml;
@@ -153,7 +148,7 @@ export default class Client extends EventEmitter {
     this: Client,
     error: SAMLError
   ) {
-    const result = await reauthenticate(this, error.teamId);
+    const result = await reauthenticate(this, error);
 
     if (typeof result === 'number') {
       this.output.prettyError(error);

--- a/packages/cli/src/util/deploy/get-deployments-by-project-id.ts
+++ b/packages/cli/src/util/deploy/get-deployments-by-project-id.ts
@@ -39,7 +39,9 @@ export default async function getDeploymentsByProjectId(
     query.set('from', options.from.toString());
   }
 
-  const { deployments } = await client.fetch<Response>(`/v4/now/deployments?${query}`);
+  const { deployments } = await client.fetch<Response>(
+    `/v4/now/deployments?${query}`
+  );
   total += deployments.length;
 
   if (options.max && total >= options.max) {
@@ -49,15 +51,15 @@ export default async function getDeploymentsByProjectId(
   if (options.continue && deployments.length === limit) {
     const nextFrom = deployments[deployments.length - 1].created;
     const nextOptions = Object.assign({}, options, { from: nextFrom });
-    deployments.push(...(await getDeploymentsByProjectId(client, projectId, nextOptions, total)));
+    deployments.push(
+      ...(await getDeploymentsByProjectId(
+        client,
+        projectId,
+        nextOptions,
+        total
+      ))
+    );
   }
 
   return deployments;
-}
-
-export async function getAllDeploymentsByProjectId(
-  client: Client,
-  projectId: string
-) {
-  return getDeploymentsByProjectId(client, projectId, { from: null, limit: 100, continue: true });
 }

--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -6,15 +6,12 @@ export default async function confirm(
 ): Promise<boolean> {
   require('./patch-inquirer');
 
-  const name = `${Date.now()}`;
-
   const answers = await inquirer.prompt({
     type: 'confirm',
-    name,
+    name: 'value',
     message,
     default: preferred,
   });
 
-  const answer = answers[name] as boolean;
-  return answer;
+  return answers.value;
 }

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -9,5 +9,5 @@ export default function doBitbucketLogin(params: LoginParams) {
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(url, 'Bitbucket', params);
+  return doOauthLogin(params, url, 'Bitbucket');
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -7,8 +7,8 @@ import executeLogin from './login';
 import { LoginParams } from './types';
 
 export default async function doEmailLogin(
-  email: string,
-  params: LoginParams
+  params: LoginParams,
+  email: string
 ): Promise<number | string> {
   let securityCode;
   let verificationToken;

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -9,5 +9,5 @@ export default function doGithubLogin(params: LoginParams) {
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(url, 'GitHub', params);
+  return doOauthLogin(params, url, 'GitHub');
 }

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -6,5 +6,5 @@ export default function doGitlabLogin(params: LoginParams) {
   // Can't use `apiUrl` here because this URL sets a
   // cookie that the OAuth callback URL depends on
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
-  return doOauthLogin(url, 'GitLab', params);
+  return doOauthLogin(params, url, 'GitLab');
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -10,9 +10,9 @@ import { getTitleName } from '../pkg-name';
 import highlight from '../output/highlight';
 
 export default async function doOauthLogin(
+  params: LoginParams,
   url: URL,
-  provider: string,
-  params: LoginParams
+  provider: string
 ): Promise<number | string> {
   const { output } = params;
 

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -9,7 +9,14 @@ import doGithubLogin from './github';
 import doGitlabLogin from './gitlab';
 import doBitbucketLogin from './bitbucket';
 
-export default async function prompt(params: LoginParams) {
+interface PromptOptions {
+  showSso?: boolean;
+}
+
+export default async function prompt(
+  params: LoginParams,
+  { showSso }: PromptOptions = {}
+) {
   let result: number | string = 1;
 
   const choices = [
@@ -17,10 +24,10 @@ export default async function prompt(params: LoginParams) {
     { name: 'Continue with GitLab', value: 'gitlab', short: 'gitlab' },
     { name: 'Continue with Bitbucket', value: 'bitbucket', short: 'bitbucket' },
     { name: 'Continue with Email', value: 'email', short: 'email' },
-    { name: 'Continue with SAML Single Sign-On', value: 'saml', short: 'saml' },
+    { name: 'Continue with SAML Single Sign-On', value: 'sso', short: 'sso' },
   ];
 
-  if (params.ssoUserId) {
+  if (showSso === false || params.ssoUserId) {
     // Remove SAML login option if we're connecting SAML Profile
     choices.pop();
   }
@@ -38,10 +45,10 @@ export default async function prompt(params: LoginParams) {
     result = await doBitbucketLogin(params);
   } else if (choice === 'email') {
     const email = await readInput('Enter your email address');
-    result = await doEmailLogin(email, params);
-  } else if (choice === 'saml') {
+    result = await doEmailLogin(params, email);
+  } else if (choice === 'sso') {
     const slug = await readInput('Enter your Team slug');
-    result = await doSsoLogin(slug, params);
+    result = await doSsoLogin(params, slug);
   }
 
   return result;

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -22,7 +22,7 @@ export default async function prompt(params: LoginParams, error?: SAMLError) {
 
   if (params.ssoUserId || (error && !error.teamId)) {
     // Remove SAML login option if we're connecting SAML Profile,
-    // or if this is a SAML error for a Team/User without SAML
+    // or if this is a SAML error for a user / team without SAML
     choices.pop();
   }
 

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -1,23 +1,30 @@
 import confirm from '../input/confirm';
+import highlight from '../output/highlight';
 import doSsoLogin from './sso';
 import showLoginPrompt from './prompt';
-import { LoginParams } from './types';
+import { LoginParams, SAMLError } from './types';
 
 export default async function reauthenticate(
   params: LoginParams,
-  teamId: string | null
+  error: SAMLError
 ): Promise<string | number> {
   let result: string | number = 1;
-  if (teamId) {
-    // If `teamId` is defined then trigger the SAML login flow
-    params.output.log(`You must re-authenticate with SAML.`);
+  if (error.teamId && error.enforced) {
+    // If team has SAML enforced then trigger the SSO login directly
+    params.output.log(
+      `You must re-authenticate with SAML to use ${highlight(
+        error.scope
+      )} scope.`
+    );
     if (await confirm(`Log in with SAML?`, true)) {
-      result = await doSsoLogin(params, teamId);
+      result = await doSsoLogin(params, error.teamId);
     }
   } else {
-    // Personal account, or team that does not have SAML enabled
-    params.output.log(`You must re-authenticate.`);
-    result = await showLoginPrompt(params, { showSso: false });
+    // Personal account, or team that does not have SAML enforced
+    params.output.log(
+      `You must re-authenticate to use ${highlight(error.scope)} scope.`
+    );
+    result = await showLoginPrompt(params, error);
   }
   return result;
 }

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -1,0 +1,23 @@
+import confirm from '../input/confirm';
+import doSsoLogin from './sso';
+import showLoginPrompt from './prompt';
+import { LoginParams } from './types';
+
+export default async function reauthenticate(
+  params: LoginParams,
+  teamId: string | null
+): Promise<string | number> {
+  let result: string | number = 1;
+  if (teamId) {
+    // If `teamId` is defined then trigger the SAML login flow
+    params.output.log(`You must re-authenticate with SAML.`);
+    if (await confirm(`Log in with SAML?`, true)) {
+      result = await doSsoLogin(params, teamId);
+    }
+  } else {
+    // Personal account, or team that does not have SAML enabled
+    params.output.log(`You must re-authenticate.`);
+    result = await showLoginPrompt(params, { showSso: false });
+  }
+  return result;
+}

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -4,7 +4,7 @@ import { getTitleName } from '../pkg-name';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
-export default function doSsoLogin(teamIdOrSlug: string, params: LoginParams) {
+export default function doSsoLogin(params: LoginParams, teamIdOrSlug: string) {
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host}`;

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -5,5 +5,5 @@ import doOauthLogin from './oauth';
 export default function doSsoLogin(params: LoginParams, teamIdOrSlug: string) {
   const url = new URL('/auth/sso', params.apiUrl);
   url.searchParams.append('teamId', teamIdOrSlug);
-  return doOauthLogin(url, 'SAML Single Sign-On', params);
+  return doOauthLogin(params, url, 'SAML Single Sign-On');
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -1,4 +1,5 @@
 import { Output } from '../output';
+import { APIError } from '../errors-ts';
 
 export interface LoginParams {
   apiUrl: string;
@@ -9,4 +10,11 @@ export interface LoginParams {
 export interface LoginData {
   token: string;
   securityCode: string;
+}
+
+export interface SAMLError extends APIError {
+  saml: true;
+  teamId: string | null;
+  scope: string;
+  enforced: boolean;
 }

--- a/packages/cli/src/util/promise.ts
+++ b/packages/cli/src/util/promise.ts
@@ -1,0 +1,24 @@
+/**
+ * Wraps a function such that only one in-flight invocation is active at a time.
+ *
+ * That is, if the returned function is invoked more that one time before the
+ * promise returned from the initial invocation resolves, then the same promise
+ * is returned for subsequent invocations.
+ *
+ * Once the promise has resolved, the next invocation of the returned function
+ * will re-invoke the original function again.
+ */
+export function sharedPromise<P extends any[], V, T>(
+  fn: (this: T, ...args: P) => Promise<V>
+) {
+  let promise: Promise<V> | null = null;
+  return function (this: T, ...args: P) {
+    if (!promise) {
+      promise = fn.apply(this, args);
+      promise.finally(() => {
+        promise = null;
+      });
+    }
+    return promise;
+  };
+}

--- a/packages/cli/src/util/to-host.ts
+++ b/packages/cli/src/util/to-host.ts
@@ -7,9 +7,9 @@ import { parse } from 'url';
  * google.com => google.com
  */
 
-function toHost(url: string) {
+function toHost(url: string): string {
   if (/^https?:\/\//.test(url)) {
-    return parse(url).host;
+    return parse(url).host!;
   }
 
   // Remove any path if present

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -2275,7 +2275,6 @@ test('`vercel rm` removes a deployment', async t => {
       reject: false,
     }
   );
-  console.log({ stdout });
 
   const { host } = new URL(stdout);
   const { exitCode, stdout: stdoutRemove } = await execute([
@@ -2283,7 +2282,6 @@ test('`vercel rm` removes a deployment', async t => {
     host,
     '--yes',
   ]);
-  console.log({ exitCode, stdoutRemove });
 
   t.truthy(stdoutRemove.includes(host));
   t.is(exitCode, 0);

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -2275,6 +2275,7 @@ test('`vercel rm` removes a deployment', async t => {
       reject: false,
     }
   );
+  console.log({ stdout });
 
   const { host } = new URL(stdout);
   const { exitCode, stdout: stdoutRemove } = await execute([
@@ -2282,6 +2283,7 @@ test('`vercel rm` removes a deployment', async t => {
     host,
     '--yes',
   ]);
+  console.log({ exitCode, stdoutRemove });
 
   t.truthy(stdoutRemove.includes(host));
   t.is(exitCode, 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1860,12 +1860,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.4.tgz#093d1beae11541aef25999d70aa09286fd025b1a"
-  integrity sha512-tR1ekaXUGpmzOcDXWU9BW73YfA2/VW1DF1FH+wlJ82BbCSnWTbdX+JkqWQXWKIGsFPnPsYadbXfNgz28g+ccWg==
+"@types/node-fetch@2.5.10":
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
+  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
   dependencies:
     "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node-fetch@2.5.4":
   version "2.5.4"


### PR DESCRIPTION
When the API returns a SAML error, then show the proper reauthentication prompt depending on the scope being requested:

Team with SAML enforced, shows only SSO login option:

<img width="476" alt="Screen Shot 2021-05-24 at 1 50 29 PM" src="https://user-images.githubusercontent.com/71256/119406131-31694c00-bc97-11eb-858a-52e5fe7052d1.png">

Team with SAML enabled, but not enforced, prompts with all login methods:

<img width="352" alt="Screen Shot 2021-05-24 at 1 50 36 PM" src="https://user-images.githubusercontent.com/71256/119406134-3201e280-bc97-11eb-9166-60fbfec47ee0.png">

Team without SAML enabled, or User scope, shows prompt with SSO option removed:

<img width="366" alt="Screen Shot 2021-05-24 at 1 50 44 PM" src="https://user-images.githubusercontent.com/71256/119406137-3201e280-bc97-11eb-8c5c-b88eb9983500.png">

[ch21964]