### PR TITLE
[python] Fix installRequirement to use explicit version

### DIFF
--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -86,6 +86,7 @@ export const build = async ({
 
   await installRequirement({
     dependency: 'werkzeug',
+    version: '1.0.1',
     workPath,
     meta,
   });
@@ -109,6 +110,7 @@ export const build = async ({
     const tempDir = await getWriteableDirectory();
     await installRequirement({
       dependency: 'pipfile-requirements',
+      version: '0.3.0',
       workPath: tempDir,
       meta,
       args: ['--no-warn-script-location'],

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -94,6 +94,7 @@ async function pipInstall(workPath: string, args: string[]) {
 
 interface InstallRequirementArg {
   dependency: string;
+  version: string;
   workPath: string;
   meta: Meta;
   args?: string[];
@@ -101,6 +102,7 @@ interface InstallRequirementArg {
 
 export async function installRequirement({
   dependency,
+  version,
   workPath,
   meta,
   args = [],
@@ -111,7 +113,8 @@ export async function installRequirement({
     );
     return;
   }
-  await pipInstall(workPath, [dependency, ...args]);
+  const exact = `${dependency}==${version}`;
+  await pipInstall(workPath, [exact, ...args]);
 }
 
 interface InstallRequirementsFileArg {

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -61,33 +61,21 @@ async function pipInstall(workPath: string, args: string[]) {
   // distutils.errors.DistutilsOptionError: can't combine user with
   // prefix, exec_prefix/home, or install_(plat)base
   process.env.PIP_USER = '0';
-  debug(
-    `Running "pip install --disable-pip-version-check --target ${target} --upgrade ${args.join(
-      ' '
-    )}"...`
-  );
+  const cmdArgs = [
+    'install',
+    '--disable-pip-version-check',
+    '--target',
+    target,
+    ...args,
+  ];
+  debug(`Running "pip3 ${cmdArgs.join(' ')}"...`);
   try {
-    await execa(
-      pipPath,
-      [
-        'install',
-        '--disable-pip-version-check',
-        '--target',
-        target,
-        '--upgrade',
-        ...args,
-      ],
-      {
-        cwd: workPath,
-        stdio: 'pipe',
-      }
-    );
+    await execa(pipPath, cmdArgs, {
+      cwd: workPath,
+      stdio: 'pipe',
+    });
   } catch (err) {
-    console.log(
-      `Failed to run "pip install --disable-pip-version-check --target ${target} --upgrade ${args.join(
-        ' '
-      )}"...`
-    );
+    console.log(`Failed to run "pip3 ${cmdArgs.join(' ')}"`);
     throw err;
   }
 }


### PR DESCRIPTION
This PR pins the exact version of dependencies to avoid breaking changes.

- [Werkzeug](https://pypi.org/project/Werkzeug/#history)
- [pipfile-requirements](https://pypi.org/project/pipfile-requirements/#history)