### PR TITLE
[cli] Fix `vc logout` retry

### DIFF
--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import fetch from 'node-fetch';
 import logo from '../util/output/logo';
 // @ts-ignore
 import { handleError } from '../util/error';
@@ -48,10 +47,9 @@ export default async function main(client: Client): Promise<number> {
     return 2;
   }
 
-  const { authConfig, config, apiUrl, output } = client;
-  const { token } = authConfig;
+  const { authConfig, config, output } = client;
 
-  if (!token) {
+  if (!authConfig.token) {
     output.note(
       `Not currently logged in, so ${getCommandName('logout')} did nothing`
     );
@@ -59,6 +57,21 @@ export default async function main(client: Client): Promise<number> {
   }
 
   output.spinner('Logging out…', 200);
+  let exitCode = 0;
+
+  try {
+    await client.fetch(`/v3/user/tokens/current`, {
+      method: 'DELETE',
+    });
+  } catch (err) {
+    if (err.status === 403) {
+      output.debug('Token is invalid so it cannot be revoked');
+    } else if (err.status !== 200) {
+      output.error('Failed to revoke token');
+      output.debug(err?.message ?? '');
+      exitCode = 1;
+    }
+  }
 
   delete config.currentTeam;
 
@@ -76,25 +89,10 @@ export default async function main(client: Client): Promise<number> {
     output.debug('Configuration has been deleted');
   } catch (err) {
     output.error(`Couldn't remove config while logging out`);
-    return 1;
-  }
-
-  const res = await fetch(`${apiUrl}/v3/user/tokens/current`, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (res.status === 403) {
-    output.debug('Token is invalid so it cannot be revoked');
-  } else if (res.status !== 200) {
-    const err = await res.json();
-    output.error('Failed to revoke token');
-    output.debug(err ? err.message : '');
-    return 1;
+    output.debug(err?.message ?? '');
+    exitCode = 1;
   }
 
   output.log('Logged out!');
-  return 0;
+  return exitCode;
 }

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -67,7 +67,6 @@ export default async function main(client: Client): Promise<number> {
     if (err.status === 403) {
       output.debug('Token is invalid so it cannot be revoked');
     } else if (err.status !== 200) {
-      output.error('Failed to revoke token');
       output.debug(err?.message ?? '');
       exitCode = 1;
     }
@@ -88,11 +87,15 @@ export default async function main(client: Client): Promise<number> {
     writeToAuthConfigFile(authConfig);
     output.debug('Configuration has been deleted');
   } catch (err) {
-    output.error(`Couldn't remove config while logging out`);
     output.debug(err?.message ?? '');
     exitCode = 1;
   }
 
-  output.log('Logged out!');
+  if (exitCode === 0) {
+    output.log('Logged out!');
+  } else {
+    output.error(`Failed during logout`);
+  }
+
   return exitCode;
 }


### PR DESCRIPTION
This PR fixes flaky networks like GH Actions https://github.com/vercel/vercel/runs/2658182610#step:11:213

We moved the API call before the config file write so that we can utilize `client.fetch()` which already does retry.