### PR TITLE
[cli] Set `tokenName` query param for Git provider login methods

### DIFF
--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -2,9 +2,11 @@ import http from 'http';
 import open from 'open';
 import { URL } from 'url';
 import listen from 'async-listen';
+import { hostname } from 'os';
 import { LoginParams } from './types';
 import prompt from './prompt';
 import verify from './verify';
+import { getTitleName } from '../pkg-name';
 import highlight from '../output/highlight';
 
 export default async function doOauthLogin(
@@ -23,6 +25,12 @@ export default async function doOauthLogin(
   const { port } = new URL(address);
   url.searchParams.append('mode', 'login');
   url.searchParams.append('next', `http://localhost:${port}`);
+
+  // Append token name param
+  const hyphens = new RegExp('-', 'g');
+  const host = hostname().replace(hyphens, ' ').replace('.local', '');
+  const tokenName = `${getTitleName()} CLI on ${host}`;
+  url.searchParams.append('tokenName', tokenName);
 
   try {
     const [query] = await Promise.all([

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -29,7 +29,7 @@ export default async function doOauthLogin(
   // Append token name param
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
-  const tokenName = `${getTitleName()} CLI on ${host}`;
+  const tokenName = `${getTitleName()} CLI on ${host} via ${provider}`;
   url.searchParams.append('tokenName', tokenName);
 
   try {

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,17 +1,9 @@
 import { URL } from 'url';
-import { hostname } from 'os';
-import { getTitleName } from '../pkg-name';
 import { LoginParams } from './types';
 import doOauthLogin from './oauth';
 
 export default function doSsoLogin(teamIdOrSlug: string, params: LoginParams) {
-  const hyphens = new RegExp('-', 'g');
-  const host = hostname().replace(hyphens, ' ').replace('.local', '');
-  const tokenName = `${getTitleName()} CLI on ${host}`;
-
   const url = new URL('/auth/sso', params.apiUrl);
   url.searchParams.append('teamId', teamIdOrSlug);
-  url.searchParams.append('tokenName', tokenName);
-
   return doOauthLogin(url, 'SAML Single Sign-On', params);
 }


### PR DESCRIPTION
We're not currently setting the `tokenName` when logging in via a Git provider, so the name becomes the default "Website" one which is confusing / incorrect.