### PR TITLE
[python] Remove imports from werkzeug._compat

### DIFF
--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -88,10 +88,11 @@ elif 'app' in __vc_variables:
         from werkzeug.wrappers import Response
 
         string_types = (str,)
+
         def to_bytes(x, charset=sys.getdefaultencoding(), errors="strict"):
             if x is None:
                 return None
-            if isinstance(x, (bytes, bytearray, memoryview)):  # noqa
+            if isinstance(x, (bytes, bytearray, memoryview)):
                 return bytes(x)
             if isinstance(x, str):
                 return x.encode(charset, errors)

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -98,9 +98,9 @@ elif 'app' in __vc_variables:
             raise TypeError("Expected bytes")
 
         def wsgi_encoding_dance(s, charset="utf-8", errors="replace"):
-            if isinstance(s, bytes):
-                return s
-            return s.encode(charset, errors)
+            if isinstance(s, str):
+                s = s.encode(charset)
+            return s.decode("latin1", errors)
         
         def vc_handler(event, context):
             payload = json.loads(event['body'])

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -82,14 +82,26 @@ elif 'app' in __vc_variables:
         not inspect.iscoroutinefunction(__vc_module.app.__call__)
     ):
         print('using Web Server Gateway Interface (WSGI)')
+        from io import BytesIO
         from urllib.parse import urlparse
-        from werkzeug._compat import BytesIO
-        from werkzeug._compat import string_types
-        from werkzeug._compat import to_bytes
-        from werkzeug._compat import wsgi_encoding_dance
         from werkzeug.datastructures import Headers
         from werkzeug.wrappers import Response
 
+        string_types = (str,)
+        def to_bytes(x, charset=sys.getdefaultencoding(), errors="strict"):
+            if x is None:
+                return None
+            if isinstance(x, (bytes, bytearray, memoryview)):  # noqa
+                return bytes(x)
+            if isinstance(x, str):
+                return x.encode(charset, errors)
+            raise TypeError("Expected bytes")
+
+        def wsgi_encoding_dance(s, charset="utf-8", errors="replace"):
+            if isinstance(s, bytes):
+                return s
+            return s.encode(charset, errors)
+        
         def vc_handler(event, context):
             payload = json.loads(event['body'])
 


### PR DESCRIPTION
werkzeug._compat was removed in 2.0, this PR removes the need to import from it and inlines couple of functions 
This removes the need for pinning werkzeug ( #6272 ) and allows users to use the latest version

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
