### PR TITLE
[routing-utils] Ensure header key value casing is normalized

### DIFF
--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -187,6 +187,10 @@ function collectHasSegments(has?: HasField) {
   const hasSegments = new Set<string>();
 
   for (const hasItem of has || []) {
+    if ('key' in hasItem && hasItem.type === 'header') {
+      hasItem.key = hasItem.key.toLowerCase();
+    }
+
     if (!hasItem.value && 'key' in hasItem) {
       hasSegments.add(hasItem.key);
     }

--- a/packages/routing-utils/test/superstatic.spec.js
+++ b/packages/routing-utils/test/superstatic.spec.js
@@ -247,7 +247,7 @@ test('convertRedirects', () => {
         },
         {
           type: 'header',
-          key: 'x-pathname',
+          key: 'X-Pathname',
           value: '(?<another>hello|world)',
         },
       ],
@@ -549,7 +549,7 @@ test('convertRewrites', () => {
         },
         {
           type: 'header',
-          key: 'x-pathname',
+          key: 'X-Pathname',
           value: '(?<another>hello|world)',
         },
       ],
@@ -893,7 +893,7 @@ test('convertHeaders', () => {
         },
         {
           type: 'header',
-          key: 'x-pathname',
+          key: 'X-Pathname',
           value: '(?<another>hello|world)',
         },
       ],


### PR DESCRIPTION
This ensures we normalize header `key` values in `has` items to be lower-case as the proxy currently only matches against the lower-case variant. Updated superstatic tests to ensure the header key is normalized correctly. 

### Related Issues

[related thread](https://vercel.slack.com/archives/C01N3RWTE5V/p1621937306006400)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
