### PR TITLE
[cli] Show user's name in `vc switch` command

### DIFF
--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -73,8 +73,8 @@ export default async function main(client: Client, desiredSlug?: string) {
     const choices = [
       { separator: 'Personal Account' },
       {
-        name: `${user.email} (${user.username})${suffix}`,
-        value: user.email,
+        name: `${user.name || user.email} (${user.username})${suffix}`,
+        value: user.username,
         short: user.username,
         selected: personalScopeSelected,
       },

--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -112,7 +112,9 @@ export default async function main(client: Client, desiredSlug?: string) {
 
     updateCurrentTeam(config);
 
-    output.success(`Your account (${chalk.bold(desiredSlug)}) is now active!`);
+    output.success(
+      `Your account (${chalk.bold(user.username)}) is now active!`
+    );
     return 0;
   }
 


### PR DESCRIPTION
This more closely matches the Team picker on vercel.com. Will still show "email" if no "name" is defined.