### PR TITLE
[routing-utils] Ensure beforeFiles rewrites come after redirects when continuing

### DIFF
--- a/packages/routing-utils/src/merge.ts
+++ b/packages/routing-utils/src/merge.ts
@@ -39,7 +39,7 @@ function getCheckAndContinue(
       );
     } else if (route.check) {
       checks.push(route);
-    } else if (route.continue) {
+    } else if (route.continue && !route.override) {
       continues.push(route);
     } else {
       others.push(route);

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -104,6 +104,9 @@ export const routesSchema = {
           continue: {
             type: 'boolean',
           },
+          override: {
+            type: 'boolean',
+          },
           check: {
             type: 'boolean',
           },

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -27,6 +27,7 @@ export type Source = {
   headers?: { [name: string]: string };
   methods?: string[];
   continue?: boolean;
+  override?: boolean;
   check?: boolean;
   important?: boolean;
   status?: number;

--- a/packages/routing-utils/test/merge.spec.js
+++ b/packages/routing-utils/test/merge.spec.js
@@ -419,3 +419,50 @@ test('mergeRoutes ensure `handle: error` comes last', () => {
   ];
   deepStrictEqual(actual, expected);
 });
+
+test('mergeRoutes ensure beforeFiles comes after redirects', () => {
+  const userRoutes = [];
+  const builds = [
+    {
+      use: '@vercel/next',
+      entrypoint: 'package.json',
+      routes: [
+        {
+          src: '^/home$',
+          status: 301,
+          headers: {
+            Location: '/',
+          },
+        },
+        {
+          src: '^/hello$',
+          dest: '/somewhere',
+          continue: true,
+          override: true,
+        },
+        {
+          handle: 'filesystem',
+        },
+        {
+          src: '^/404$',
+          dest: '/404',
+          status: 404,
+          check: true,
+        },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { src: '^/home$', status: 301, headers: { Location: '/' } },
+    {
+      src: '^/hello$',
+      dest: '/somewhere',
+      continue: true,
+      override: true,
+    },
+    { handle: 'filesystem' },
+    { src: '^/404$', dest: '/404', status: 404, check: true },
+  ];
+  deepStrictEqual(actual, expected);
+});


### PR DESCRIPTION
This adds a new `override: true` field for routes to allow us to ensure `beforeFiles` rewrites are sorted after redirects when merging as currently they are moved above redirects due to them using `continue: true`

### Related Issues

x-ref: https://vercel.slack.com/archives/C01224Q5M99/p1622035710050800
x-ref: https://vercel.slack.com/archives/C01L9USB5FS/p1622014909006200

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
