### PR TITLE
[cli] Fix `vc projects rm` race condition

### DIFF
--- a/packages/cli/src/commands/projects.js
+++ b/packages/cli/src/commands/projects.js
@@ -187,25 +187,22 @@ async function run({ client, contextName }) {
 
     const name = args[0];
 
-    // Check the existence of the project
-    try {
-      await client.fetch(`/projects/info/${e(name)}`);
-    } catch (err) {
-      if (err.status === 404) {
-        console.error(error('No such project exists'));
-        return exit(1);
-      }
-    }
-
     const yes = await readConfirmation(name);
     if (!yes) {
       console.error(error('User abort'));
       return exit(0);
     }
 
-    await client.fetch(`/v2/projects/${name}`, {
-      method: 'DELETE',
-    });
+    try {
+      await client.fetch(`/v2/projects/${e(name)}`, {
+        method: 'DELETE',
+      });
+    } catch (err) {
+      if (err.status === 404) {
+        console.error(error('No such project exists'));
+        return exit(1);
+      }
+    }
     const elapsed = ms(new Date() - start);
     console.log(
       `${chalk.cyan('> Success!')} Project ${chalk.bold(


### PR DESCRIPTION
The call to `GET /projects/info` is used to check existence but it can cause a race condition if the project was removed before the `DELETE /v2/projects` is called.

Instead, we rely on the response from `DELETE /v2/projects` to determine if the project exists or not.

This will also allow us to remove a legacy API endpoint in the future (see related API PR)