### PR TITLE
[cli] Fix `vc logout` command when using Team scope

### DIFF
--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import logo from '../util/output/logo';
-// @ts-ignore
 import { handleError } from '../util/error';
 import { writeToConfigFile, writeToAuthConfigFile } from '../util/config/files';
 import getArgs from '../util/get-args';
@@ -62,6 +61,7 @@ export default async function main(client: Client): Promise<number> {
   try {
     await client.fetch(`/v3/user/tokens/current`, {
       method: 'DELETE',
+      useCurrentTeam: false,
     });
   } catch (err) {
     if (err.status === 403) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -16,7 +16,7 @@ export interface JSONObject {
 }
 
 export interface AuthConfig {
-  token: string;
+  token?: string;
   skipWrite?: boolean;
 }
 


### PR DESCRIPTION
Fixes logout command not working when switched to a Team scope:

```
$ vc login
$ vc switch $some_team
$ vc logout
Failed during logout
```