### PR TITLE
[cli] Upgrade token scopes in `vc switch` command

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -12,7 +12,6 @@ import { getCommandName, getPkgName } from '../util/pkg-name';
 import getGlobalPathConfig from '../util/config/global-path';
 import { writeToAuthConfigFile, writeToConfigFile } from '../util/config/files';
 import Client from '../util/client';
-import { LoginParams } from '../util/login/types';
 
 const help = () => {
   console.log(`
@@ -46,7 +45,7 @@ const help = () => {
 
 export default async function login(client: Client): Promise<number> {
   let argv;
-  const { apiUrl, output } = client;
+  const { output } = client;
 
   try {
     argv = getArgs(client.argv.slice(2));
@@ -68,18 +67,17 @@ export default async function login(client: Client): Promise<number> {
   const input = argv._[1];
 
   let result: number | string = 1;
-  const params: LoginParams = { output, apiUrl };
 
   if (input) {
     // Email or Team slug was provided via command line
     if (validateEmail(input)) {
-      result = await doEmailLogin(params, input);
+      result = await doEmailLogin(client, input);
     } else {
-      result = await doSsoLogin(params, input);
+      result = await doSsoLogin(client, input);
     }
   } else {
     // Interactive mode
-    result = await prompt(params);
+    result = await prompt(client);
   }
 
   // The login function failed, so it returned an exit code

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -23,14 +23,14 @@ export default async function doOauthLogin(
   const server = http.createServer();
   const address = await listen(server, 0, '127.0.0.1');
   const { port } = new URL(address);
-  url.searchParams.append('mode', 'login');
-  url.searchParams.append('next', `http://localhost:${port}`);
+  url.searchParams.set('mode', 'login');
+  url.searchParams.set('next', `http://localhost:${port}`);
 
   // Append token name param
   const hyphens = new RegExp('-', 'g');
   const host = hostname().replace(hyphens, ' ').replace('.local', '');
   const tokenName = `${getTitleName()} CLI on ${host} via ${provider}`;
-  url.searchParams.append('tokenName', tokenName);
+  url.searchParams.set('tokenName', tokenName);
 
   try {
     const [query] = await Promise.all([

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -4,6 +4,6 @@ import doOauthLogin from './oauth';
 
 export default function doSsoLogin(params: LoginParams, teamIdOrSlug: string) {
   const url = new URL('/auth/sso', params.apiUrl);
-  url.searchParams.append('teamId', teamIdOrSlug);
+  url.searchParams.set('teamId', teamIdOrSlug);
   return doOauthLogin(params, url, 'SAML Single Sign-On');
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -1,6 +1,8 @@
+import { AuthConfig } from '../../types';
 import { Output } from '../output';
 
 export interface LoginParams {
+  authConfig: AuthConfig;
   apiUrl: string;
   output: Output;
   ssoUserId?: string;

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -1,24 +1,26 @@
 import { URL } from 'url';
-import fetch from 'node-fetch';
+import fetch, { Headers } from 'node-fetch';
 import ua from '../ua';
 import { LoginParams } from './types';
 
 export default async function verify(
   email: string,
   verificationToken: string,
-  { apiUrl, ssoUserId }: LoginParams
+  { authConfig, apiUrl, ssoUserId }: LoginParams
 ): Promise<string> {
   const url = new URL('/registration/verify', apiUrl);
-  url.searchParams.append('email', email);
-  url.searchParams.append('token', verificationToken);
+  url.searchParams.set('email', email);
+  url.searchParams.set('token', verificationToken);
   if (ssoUserId) {
-    url.searchParams.append('ssoUserId', ssoUserId);
+    url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  const res = await fetch(url.href, {
-    headers: { 'User-Agent': ua },
-  });
+  const headers = new Headers({ 'User-Agent': ua });
+  if (authConfig.token) {
+    headers.set('Authorization', `Bearer ${authConfig.token}`);
+  }
 
+  const res = await fetch(url.href, { headers });
   const body = await res.json();
 
   if (!res.ok) {


### PR DESCRIPTION
Pass the `Authorization` request header to the verify endpoint so that the current auth token will be upgraded with the new scope.

[ch22273]