### PR TITLE
[cli] Print login URL to terminal

### DIFF
--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -42,7 +42,7 @@ export default async function doEmailLogin(
   while (!token) {
     try {
       await sleep(ms('1s'));
-      token = await verify(email, verificationToken, params);
+      token = await verify(email, verificationToken, 'Email', params);
     } catch (err) {
       if (err.message !== 'Confirmation incomplete') {
         output.error(err.message);

--- a/packages/cli/src/util/login/login.ts
+++ b/packages/cli/src/util/login/login.ts
@@ -1,8 +1,6 @@
 import fetch from 'node-fetch';
-import { hostname } from 'os';
 import { InvalidEmail, AccountNotFound } from '../errors-ts';
 import ua from '../ua';
-import { getTitleName } from '../pkg-name';
 import { LoginData } from './types';
 
 export default async function login(
@@ -10,20 +8,13 @@ export default async function login(
   email: string,
   mode: 'login' | 'signup' = 'login'
 ): Promise<LoginData> {
-  const hyphens = new RegExp('-', 'g');
-  const host = hostname().replace(hyphens, ' ').replace('.local', '');
-  const tokenName = `${getTitleName()} CLI on ${host}`;
-
   const response = await fetch(`${apiUrl}/now/registration?mode=${mode}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': ua,
     },
-    body: JSON.stringify({
-      tokenName,
-      email,
-    }),
+    body: JSON.stringify({ email }),
   });
 
   const body = await response.json();

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -2,22 +2,37 @@ import { URL } from 'url';
 import fetch, { Headers } from 'node-fetch';
 import ua from '../ua';
 import { LoginParams } from './types';
+import { hostname } from 'os';
+import { getTitleName } from '../pkg-name';
 
 export default async function verify(
   email: string,
   verificationToken: string,
+  provider: string,
   { authConfig, apiUrl, ssoUserId }: LoginParams
 ): Promise<string> {
   const url = new URL('/registration/verify', apiUrl);
   url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);
-  if (ssoUserId) {
-    url.searchParams.set('ssoUserId', ssoUserId);
-  }
 
   const headers = new Headers({ 'User-Agent': ua });
+
   if (authConfig.token) {
+    // If there is already an auth token then it will be
+    // upgraded, rather than a new token being created
     headers.set('Authorization', `Bearer ${authConfig.token}`);
+  } else {
+    // Set the "name" of the Token that will be created
+    const hyphens = new RegExp('-', 'g');
+    const host = hostname().replace(hyphens, ' ').replace('.local', '');
+    const tokenName = `${getTitleName()} CLI on ${host} via ${provider}`;
+    url.searchParams.set('tokenName', tokenName);
+  }
+
+  // If `ssoUserId` is defined then this verification
+  // will complete the SAML two-step login connection
+  if (ssoUserId) {
+    url.searchParams.set('ssoUserId', ssoUserId);
   }
 
   const res = await fetch(url.href, { headers });


### PR DESCRIPTION
In some cases (i.e. when SSH'd to a remote machine) the `open` command will not work reliably. So we need to print the URL to the user as a fallback for those cases when the web browser is not automatically opened.

This also moves where `tokenName` is specified to be in the "verify" endpoint, so that it does not need to be part of the URL that gets printed to the user.

<img width="738" alt="Screen Shot 2021-06-07 at 2 12 47 PM" src="https://user-images.githubusercontent.com/71256/121089239-b5452d00-c79b-11eb-85b2-0e45b817dff0.png">
