### PR TITLE
Fix check: true beforeFiles order

### DIFF
--- a/packages/routing-utils/src/merge.ts
+++ b/packages/routing-utils/src/merge.ts
@@ -37,7 +37,7 @@ function getCheckAndContinue(
           route
         )}`
       );
-    } else if (route.check) {
+    } else if (route.check && !route.override) {
       checks.push(route);
     } else if (route.continue && !route.override) {
       continues.push(route);

--- a/packages/routing-utils/test/merge.spec.js
+++ b/packages/routing-utils/test/merge.spec.js
@@ -420,7 +420,7 @@ test('mergeRoutes ensure `handle: error` comes last', () => {
   deepStrictEqual(actual, expected);
 });
 
-test('mergeRoutes ensure beforeFiles comes after redirects', () => {
+test('mergeRoutes ensure beforeFiles comes after redirects (continue)', () => {
   const userRoutes = [];
   const builds = [
     {
@@ -459,6 +459,53 @@ test('mergeRoutes ensure beforeFiles comes after redirects', () => {
       src: '^/hello$',
       dest: '/somewhere',
       continue: true,
+      override: true,
+    },
+    { handle: 'filesystem' },
+    { src: '^/404$', dest: '/404', status: 404, check: true },
+  ];
+  deepStrictEqual(actual, expected);
+});
+
+test('mergeRoutes ensure beforeFiles comes after redirects (check)', () => {
+  const userRoutes = [];
+  const builds = [
+    {
+      use: '@vercel/next',
+      entrypoint: 'package.json',
+      routes: [
+        {
+          src: '^/home$',
+          status: 301,
+          headers: {
+            Location: '/',
+          },
+        },
+        {
+          src: '^/hello$',
+          dest: '/somewhere',
+          check: true,
+          override: true,
+        },
+        {
+          handle: 'filesystem',
+        },
+        {
+          src: '^/404$',
+          dest: '/404',
+          status: 404,
+          check: true,
+        },
+      ],
+    },
+  ];
+  const actual = mergeRoutes({ userRoutes, builds });
+  const expected = [
+    { src: '^/home$', status: 301, headers: { Location: '/' } },
+    {
+      src: '^/hello$',
+      dest: '/somewhere',
+      check: true,
       override: true,
     },
     { handle: 'filesystem' },


### PR DESCRIPTION
This ensures we don't sort redirects after `check: true` beforeFiles rewrites which are used on older Next.js versions

### Related Issues

x-ref: https://github.com/vercel/vercel/pull/6289

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
