### PR TITLE
[cli] Update "open" to v8.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -148,7 +148,7 @@
     "node-fetch": "2.6.1",
     "npm-package-arg": "6.1.0",
     "nyc": "13.2.0",
-    "open": "8.0.2",
+    "open": "8.2.0",
     "ora": "3.4.0",
     "pcre-to-regexp": "1.0.0",
     "pluralize": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,10 +8293,10 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.0.2.tgz#8c3e95cce93ba2fc8d99968ee8bfefecdb50b84f"
-  integrity sha512-NV5QmWJrTaNBLHABJyrb+nd5dXI5zfea/suWawBhkHzAbVhLLiJdrqMgxMypGK9Eznp2Ltoh7SAVkQ3XAucX7Q==
+open@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.2.0.tgz#d6a4788b00009a9d60df471ecb89842a15fdcfc1"
+  integrity sha512-O8uInONB4asyY3qUcEytpgwxQG3O0fJ/hlssoUHsBboOIRVZzT6Wq+Rwj5nffbeUhOdMjpXeISpDDzHCMRDuOQ==
   dependencies:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"


### PR DESCRIPTION
Fixes an issue where the bundled `xdg-open` script would not be used.

![CleanShot 2021-06-10 at 15 35 11@2x](https://user-images.githubusercontent.com/71256/121619476-8807b180-ca1d-11eb-9a58-bfffb8a5bb87.png)
