### PR TITLE
[cli] Fix pathing for passthrough urls on vite

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1621,7 +1621,7 @@ export default class DevServer {
         delete origUrl.search;
         origUrl.pathname = dest;
         Object.assign(origUrl.query, uri_args);
-        req.url = url.format(origUrl);
+        req.url = origUrl.path;
         return proxyPass(req, res, upstream, this, nowRequestId, false);
       }
 


### PR DESCRIPTION
I am not sure if the node `url.format` is necessary, but it was breaking here. Transformed paths of style `/src/test.svg?import` to `/src/test.svg?import=`, which is a breaking url modification for vite

I have requested that vite is modified to handle these query params better in the future. Not sure how y'all feel about using this fix for now https://twitter.com/t3dotgg/status/1404287709393276936

### Related Issues

> Fixes https://github.com/vercel/vercel/discussions/6356 , https://github.com/vercel/vercel/discussions/6145 , https://github.com/vitejs/vite/issues/3781

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
