### PR TITLE
[cli] Print timestamp for each line for multi-line log entries

### DIFF
--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -243,7 +243,7 @@ function printLogShort(log: any) {
 
   const date = new Date(log.created).toISOString();
 
-  data.split('\n').forEach((line, i) => {
+  data.split('\n').forEach(line => {
     if (
       line.includes('START RequestId:') ||
       line.includes('END RequestId:') ||
@@ -260,18 +260,9 @@ function printLogShort(log: any) {
       }
     }
 
-    if (i === 0) {
-      console.log(
-        `${chalk.dim(date)}  ${line.replace('[now-builder-debug] ', '')}`
-      );
-    } else {
-      console.log(
-        `${' '.repeat(date.length)}  ${line.replace(
-          '[now-builder-debug] ',
-          ''
-        )}`
-      );
-    }
+    console.log(
+      `${chalk.dim(date)}  ${line.replace('[now-builder-debug] ', '')}`
+    );
   });
 
   return 0;


### PR DESCRIPTION
Previously CLI was only printing the timestamp for the first line of multi-line log entries.

![CleanShot 2021-06-15 at 15 38 38@2x(1)](https://user-images.githubusercontent.com/71256/122999145-bc0a9d00-d362-11eb-9985-f5a24ea31cfa.png)

This looks strange so let's print the timestamp on every line instead.

<img width="776" alt="Screen Shot 2021-06-22 at 2 05 01 PM" src="https://user-images.githubusercontent.com/71256/122999259-e2303d00-d362-11eb-9b05-0f2a5d8c9dc3.png">
