### PR TITLE
[cli] Fix `vc login` hanging for a few seconds before exiting

### DIFF
--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -30,6 +30,10 @@ export default async function doOauthLogin(
     const [query] = await Promise.all([
       new Promise<URL['searchParams']>((resolve, reject) => {
         server.once('request', (req, res) => {
+          // Close the HTTP connection to prevent
+          // `server.close()` from hanging
+          res.setHeader('connection', 'close');
+
           const query = new URL(req.url || '/', 'http://localhost')
             .searchParams;
           resolve(query);


### PR DESCRIPTION
Closing keep-alive HTTP connections was causing the `server.close()` call to take a few seconds before completing, so set the `Connection: close` response header in order to make the connections close immediately, so that `server.close()` is fast.