### PR TITLE
[cli] Make `vc deploy` not load current "scope"

### DIFF
--- a/packages/cli/src/commands/deploy/index.js
+++ b/packages/cli/src/commands/deploy/index.js
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import { resolve, basename } from 'path';
 import { fileNameSymbol } from '@vercel/client';
-import getScope from '../../util/get-scope.ts';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
 import { readLocalConfig } from '../../util/config/files';
@@ -11,12 +10,8 @@ import { help, args } from './args';
 import deploy from './latest';
 
 export default async client => {
-  const {
-    output,
-    config: { currentTeam },
-  } = client;
+  const { output } = client;
 
-  let contextName = currentTeam || 'current user';
   let argv = null;
 
   try {
@@ -62,17 +57,6 @@ export default async client => {
     }
   }
 
-  try {
-    ({ contextName } = await getScope(client));
-  } catch (err) {
-    if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
-      output.error(err.message);
-      return 1;
-    }
-
-    throw err;
-  }
-
   if (localConfig) {
     const { version } = localConfig;
     const file = highlight(localConfig[fileNameSymbol]);
@@ -97,5 +81,5 @@ export default async client => {
     }
   }
 
-  return deploy(client, contextName, output, stats, localConfig, args);
+  return deploy(client, output, stats, localConfig, args);
 };

--- a/packages/cli/src/commands/deploy/index.js
+++ b/packages/cli/src/commands/deploy/index.js
@@ -21,12 +21,16 @@ export default async client => {
     return 1;
   }
 
+  if (argv['--help']) {
+    output.print(help());
+    return 2;
+  }
+
   if (argv._[0] === 'deploy') {
     argv._.shift();
   }
 
-  let paths = [];
-
+  let paths;
   if (argv._.length > 0) {
     // If path is relative: resolve
     // if path is absolute: clear up strange `/` etc
@@ -39,16 +43,10 @@ export default async client => {
   if (!localConfig || localConfig instanceof Error) {
     localConfig = readLocalConfig(paths[0]);
   }
-  const stats = {};
-
-  if (argv['--help']) {
-    output.print(help());
-    return 2;
-  }
 
   for (const path of paths) {
     try {
-      stats[path] = await fs.lstat(path);
+      await fs.stat(path);
     } catch (err) {
       output.error(
         `The specified file or directory "${basename(path)}" does not exist.`
@@ -81,5 +79,5 @@ export default async client => {
     }
   }
 
-  return deploy(client, output, stats, localConfig, args);
+  return deploy(client, paths, localConfig, args);
 };

--- a/packages/cli/src/commands/deploy/latest.js
+++ b/packages/cli/src/commands/deploy/latest.js
@@ -207,14 +207,7 @@ const parseEnv = env => {
   return env;
 };
 
-export default async function main(
-  client,
-  contextName,
-  output,
-  stats,
-  localConfig,
-  args
-) {
+export default async function main(client, output, stats, localConfig, args) {
   let argv = null;
 
   try {
@@ -339,6 +332,8 @@ export default async function main(
       status = 'linked';
     }
   }
+
+  const contextName = org && org.slug;
 
   // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
   // and upload the entire directory.

--- a/packages/cli/src/commands/deploy/latest.js
+++ b/packages/cli/src/commands/deploy/latest.js
@@ -207,7 +207,7 @@ const parseEnv = env => {
   return env;
 };
 
-export default async function main(client, output, stats, localConfig, args) {
+export default async function main(client, paths, localConfig, args) {
   let argv = null;
 
   try {
@@ -219,10 +219,10 @@ export default async function main(client, output, stats, localConfig, args) {
 
   const {
     apiUrl,
+    output,
     authConfig: { token },
   } = client;
   const { log, debug, error, warn } = output;
-  const paths = Object.keys(stats);
   const debugEnabled = argv['--debug'];
 
   const { isTTY } = process.stdout;


### PR DESCRIPTION
`vc deploy` doesn't care about the current "scope" that the CLI has selected, since it uses the `.vercel` directory to determine the ownerId and projectId.

Therefore, it should not be fetching the team details of the selected scope during `vc deploy`, since it's possible that the token might not have access to the current scope and returns a 403, even though that API call is unnecessary for the `vc deploy` command to complete.