### PR TITLE
[cli] Set proper `currentTeam` in `vc deploy`

### DIFF
--- a/packages/cli/src/commands/deploy/latest.js
+++ b/packages/cli/src/commands/deploy/latest.js
@@ -333,7 +333,15 @@ export default async function main(client, paths, localConfig, args) {
     }
   }
 
-  const contextName = org && org.slug;
+  // At this point `org` should be populated
+  if (!org) {
+    throw new Error(`"org" is not defined`);
+  }
+
+  // Set the `contextName` and `currentTeam` as specified by the
+  // Project Settings, so that API calls happen with the proper scope
+  const contextName = org.slug;
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
   // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
   // and upload the entire directory.


### PR DESCRIPTION
Fixes an edge case bug when the user has a current scope that is different than the owner of the project that is being deployed.

When this was the case, the API call to get the certs for a domain at the end of the `vc deploy` command was using the incorrect `teamId`, potentially causing a 403 error (when the current auth token does not have access to the selected scope).