### PR TITLE
[frameworks] Add cachePattern to API response

### DIFF
--- a/api/frameworks.ts
+++ b/api/frameworks.ts
@@ -14,7 +14,6 @@ const frameworks = (_frameworks as Framework[])
       sort: undefined,
       dependency: undefined,
       defaultRoutes: undefined,
-      cachePattern: undefined,
       devCommand: undefined,
       buildCommand: undefined,
     };


### PR DESCRIPTION
We want to start showing `cachePattern` in the documentation for each framework.