### PR TITLE
[cli] Use `Client` instead of `LoginParams` for login

### DIFF
--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -90,8 +90,10 @@ export default class Client extends EventEmitter {
     }
 
     const headers = new Headers(opts.headers);
-    headers.set('authorization', `Bearer ${this.authConfig.token}`);
     headers.set('user-agent', ua);
+    if (this.authConfig.token) {
+      headers.set('authorization', `Bearer ${this.authConfig.token}`);
+    }
 
     let body;
     if (isJSONObject(opts.body)) {

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -1,13 +1,13 @@
 import { URL } from 'url';
-import { LoginParams } from './types';
+import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doBitbucketLogin(params: LoginParams) {
+export default function doBitbucketLogin(client: Client, ssoUserId?: string) {
   const url = new URL(
     '/api/registration/bitbucket/connect',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(params, url, 'Bitbucket');
+  return doOauthLogin(client, url, 'Bitbucket', ssoUserId);
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -13,12 +13,12 @@ export default async function doEmailLogin(
 ): Promise<number | string> {
   let securityCode;
   let verificationToken;
-  const { apiUrl, output } = client;
+  const { output } = client;
 
   output.spinner('Sending you an email');
 
   try {
-    const data = await executeLogin(apiUrl, email);
+    const data = await executeLogin(client, email);
     verificationToken = data.token;
     securityCode = data.securityCode;
   } catch (err) {

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -4,15 +4,16 @@ import highlight from '../output/highlight';
 import eraseLines from '../output/erase-lines';
 import verify from './verify';
 import executeLogin from './login';
-import { LoginParams } from './types';
+import Client from '../client';
 
 export default async function doEmailLogin(
-  params: LoginParams,
-  email: string
+  client: Client,
+  email: string,
+  ssoUserId?: string
 ): Promise<number | string> {
   let securityCode;
   let verificationToken;
-  const { apiUrl, output } = params;
+  const { apiUrl, output } = client;
 
   output.spinner('Sending you an email');
 
@@ -42,7 +43,13 @@ export default async function doEmailLogin(
   while (!token) {
     try {
       await sleep(ms('1s'));
-      token = await verify(email, verificationToken, 'Email', params);
+      token = await verify(
+        client,
+        email,
+        verificationToken,
+        'Email',
+        ssoUserId
+      );
     } catch (err) {
       if (err.message !== 'Confirmation incomplete') {
         output.error(err.message);

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -51,7 +51,7 @@ export default async function doEmailLogin(
         ssoUserId
       );
     } catch (err) {
-      if (err.message !== 'Confirmation incomplete') {
+      if (err.serverMessage !== 'Confirmation incomplete') {
         output.error(err.message);
         return 1;
       }

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -1,13 +1,13 @@
 import { URL } from 'url';
-import { LoginParams } from './types';
+import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGithubLogin(params: LoginParams) {
+export default function doGithubLogin(client: Client, ssoUserId?: string) {
   const url = new URL(
     '/api/registration/login-with-github',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(params, url, 'GitHub');
+  return doOauthLogin(client, url, 'GitHub', ssoUserId);
 }

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -1,10 +1,10 @@
 import { URL } from 'url';
-import { LoginParams } from './types';
+import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGitlabLogin(params: LoginParams) {
+export default function doGitlabLogin(client: Client, ssoUserId?: string) {
   // Can't use `apiUrl` here because this URL sets a
   // cookie that the OAuth callback URL depends on
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
-  return doOauthLogin(params, url, 'GitLab');
+  return doOauthLogin(client, url, 'GitLab', ssoUserId);
 }

--- a/packages/cli/src/util/login/login.ts
+++ b/packages/cli/src/util/login/login.ts
@@ -1,38 +1,28 @@
-import fetch from 'node-fetch';
+import Client from '../client';
 import { InvalidEmail, AccountNotFound } from '../errors-ts';
-import ua from '../ua';
 import { LoginData } from './types';
 
 export default async function login(
-  apiUrl: string,
-  email: string,
-  mode: 'login' | 'signup' = 'login'
+  client: Client,
+  email: string
 ): Promise<LoginData> {
-  const response = await fetch(`${apiUrl}/now/registration?mode=${mode}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': ua,
-    },
-    body: JSON.stringify({ email }),
-  });
-
-  const body = await response.json();
-  if (!response.ok) {
-    const { error = {} } = body;
-    if (error.code === 'not_exists') {
+  try {
+    return await client.fetch<LoginData>(`/registration?mode=login`, {
+      method: 'POST',
+      body: { email },
+    });
+  } catch (err) {
+    if (err.code === 'not_exists') {
       throw new AccountNotFound(
         email,
         `Please sign up: https://vercel.com/signup`
       );
     }
 
-    if (error.code === 'invalid_email') {
-      throw new InvalidEmail(email, error.message);
+    if (err.code === 'invalid_email') {
+      throw new InvalidEmail(email, err.message);
     }
 
-    throw new Error(`Unexpected error: ${error.message}`);
+    throw new Error(`Unexpected error: ${err.message}`);
   }
-
-  return body as LoginData;
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import open from 'open';
 import { URL } from 'url';
 import listen from 'async-listen';
-import { LoginParams } from './types';
+import Client from '../client';
 import prompt from './prompt';
 import verify from './verify';
 import highlight from '../output/highlight';
@@ -10,11 +10,12 @@ import link from '../output/link';
 import eraseLines from '../output/erase-lines';
 
 export default async function doOauthLogin(
-  params: LoginParams,
+  client: Client,
   url: URL,
-  provider: string
+  provider: string,
+  ssoUserId?: string
 ): Promise<number | string> {
-  const { output } = params;
+  const { output } = client;
 
   const server = http.createServer();
   const address = await listen(server, 0, '127.0.0.1');
@@ -89,12 +90,12 @@ export default async function doOauthLogin(
     // If an `ssoUserId` was returned, then the SAML Profile is not yet connected
     // to a Team member. Prompt the user to log in to a Vercel account now, which
     // will complete the connection to the SAML Profile.
-    const ssoUserId = query.get('ssoUserId');
-    if (ssoUserId) {
+    const ssoUserIdParam = query.get('ssoUserId');
+    if (ssoUserIdParam) {
       output.log(
         'Please log in to your Vercel account to complete SAML connection.'
       );
-      return prompt({ ...params, ssoUserId });
+      return prompt(client, undefined, ssoUserIdParam);
     }
 
     const email = query.get('email');
@@ -107,7 +108,13 @@ export default async function doOauthLogin(
     }
 
     output.spinner('Verifying authentication token');
-    const token = await verify(email, verificationToken, provider, params);
+    const token = await verify(
+      client,
+      email,
+      verificationToken,
+      provider,
+      ssoUserId
+    );
     output.success(
       `${provider} authentication complete for ${highlight(email)}`
     );

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -1,28 +1,29 @@
 import { bold } from 'chalk';
 import doSsoLogin from './sso';
 import showLoginPrompt from './prompt';
-import { LoginParams, SAMLError } from './types';
+import { SAMLError } from './types';
 import confirm from '../input/confirm';
+import Client from '../client';
 
 export default async function reauthenticate(
-  params: LoginParams,
+  client: Client,
   error: Pick<SAMLError, 'enforced' | 'scope' | 'teamId'>
 ): Promise<string | number> {
   let result: string | number = 1;
   if (error.teamId && error.enforced) {
     // If team has SAML enforced then trigger the SSO login directly
-    params.output.log(
+    client.output.log(
       `You must re-authenticate with SAML to use ${bold(error.scope)} scope.`
     );
     if (await confirm(`Log in with SAML?`, true)) {
-      result = await doSsoLogin(params, error.teamId);
+      result = await doSsoLogin(client, error.teamId);
     }
   } else {
     // Personal account, or team that does not have SAML enforced
-    params.output.log(
+    client.output.log(
       `You must re-authenticate to use ${bold(error.scope)} scope.`
     );
-    result = await showLoginPrompt(params, error);
+    result = await showLoginPrompt(client, error);
   }
   return result;
 }

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -1,9 +1,13 @@
 import { URL } from 'url';
-import { LoginParams } from './types';
+import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doSsoLogin(params: LoginParams, teamIdOrSlug: string) {
-  const url = new URL('/auth/sso', params.apiUrl);
+export default function doSsoLogin(
+  client: Client,
+  teamIdOrSlug: string,
+  ssoUserId?: string
+) {
+  const url = new URL('/auth/sso', client.apiUrl);
   url.searchParams.set('teamId', teamIdOrSlug);
-  return doOauthLogin(params, url, 'SAML Single Sign-On');
+  return doOauthLogin(client, url, 'SAML Single Sign-On', ssoUserId);
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -3,6 +3,10 @@ export interface LoginData {
   securityCode: string;
 }
 
+export interface VerifyData {
+  token: string;
+}
+
 export interface SAMLError {
   saml?: true;
   teamId: string | null;

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -1,13 +1,3 @@
-import { AuthConfig } from '../../types';
-import { Output } from '../output';
-
-export interface LoginParams {
-  authConfig: AuthConfig;
-  apiUrl: string;
-  output: Output;
-  ssoUserId?: string;
-}
-
 export interface LoginData {
   token: string;
   securityCode: string;

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -1,16 +1,19 @@
 import { URL } from 'url';
 import fetch, { Headers } from 'node-fetch';
 import ua from '../ua';
-import { LoginParams } from './types';
+import Client from '../client';
 import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
 
 export default async function verify(
+  client: Client,
   email: string,
   verificationToken: string,
   provider: string,
-  { authConfig, apiUrl, ssoUserId }: LoginParams
+  ssoUserId?: string
 ): Promise<string> {
+  const { authConfig, apiUrl } = client;
+
   const url = new URL('/registration/verify', apiUrl);
   url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -1,5 +1,4 @@
 import { URL } from 'url';
-import ua from '../ua';
 import Client from '../client';
 import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
@@ -30,8 +29,6 @@ export default async function verify(
     url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  const { token } = await client.fetch<VerifyData>(url.href, {
-    headers: { 'User-Agent': ua },
-  });
+  const { token } = await client.fetch<VerifyData>(url.href);
   return token;
 }

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -1,9 +1,9 @@
 import { URL } from 'url';
-import fetch, { Headers } from 'node-fetch';
 import ua from '../ua';
 import Client from '../client';
 import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
+import { VerifyData } from './types';
 
 export default async function verify(
   client: Client,
@@ -12,19 +12,11 @@ export default async function verify(
   provider: string,
   ssoUserId?: string
 ): Promise<string> {
-  const { authConfig, apiUrl } = client;
-
-  const url = new URL('/registration/verify', apiUrl);
+  const url = new URL('/registration/verify', client.apiUrl);
   url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);
 
-  const headers = new Headers({ 'User-Agent': ua });
-
-  if (authConfig.token) {
-    // If there is already an auth token then it will be
-    // upgraded, rather than a new token being created
-    headers.set('Authorization', `Bearer ${authConfig.token}`);
-  } else {
+  if (!client.authConfig.token) {
     // Set the "name" of the Token that will be created
     const hyphens = new RegExp('-', 'g');
     const host = hostname().replace(hyphens, ' ').replace('.local', '');
@@ -38,16 +30,8 @@ export default async function verify(
     url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  const res = await fetch(url.href, { headers });
-  const body = await res.json();
-
-  if (!res.ok) {
-    const err = new Error(
-      `Unexpected ${res.status} status code from verify API`
-    );
-    Object.assign(err, body.error);
-    throw err;
-  }
-
-  return body.token;
+  const { token } = await client.fetch<VerifyData>(url.href, {
+    headers: { 'User-Agent': ua },
+  });
+  return token;
 }

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -157,9 +157,10 @@ function mockLoginApi(req, res) {
   let { pathname = '/', query = {} } = parseUrl(url, true);
   console.log(`[mock-login-server] ${method} ${pathname}`);
   const securityCode = 'Bears Beets Battlestar Galactica';
+  res.setHeader('content-type', 'application/json');
   if (
     method === 'POST' &&
-    pathname === '/now/registration' &&
+    pathname === '/registration' &&
     query.mode === 'login'
   ) {
     res.end(JSON.stringify({ token, securityCode }));


### PR DESCRIPTION
The `LoginParams` interface had all common properties with `Client`, except for `ssoUserId`. So that property is now passed in to the login functions explicitly.

This allows us to use `client.fetch()` which simplifies the code a bit.