### PR TITLE
[cli] Use client-generated `verifyToken` during OAuth login

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "@vercel/node": "1.11.2-canary.2",
     "@vercel/python": "2.0.4",
     "@vercel/ruby": "1.2.6",
+    "uid-promise": "1.1.0",
     "update-notifier": "4.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -2,12 +2,12 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doBitbucketLogin(client: Client, ssoUserId?: string) {
+export default function doBitbucketLogin(client: Client) {
   const url = new URL(
     '/api/registration/bitbucket/connect',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(client, url, 'Bitbucket', ssoUserId);
+  return doOauthLogin(client, url, 'Bitbucket');
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -8,8 +8,7 @@ import Client from '../client';
 
 export default async function doEmailLogin(
   client: Client,
-  email: string,
-  ssoUserId?: string
+  email: string
 ): Promise<number | string> {
   let securityCode;
   let verificationToken;
@@ -43,13 +42,8 @@ export default async function doEmailLogin(
   while (!token) {
     try {
       await sleep(ms('1s'));
-      token = await verify(
-        client,
-        email,
-        verificationToken,
-        'Email',
-        ssoUserId
-      );
+      const data = await verify(client, verificationToken, 'Email');
+      token = data.token;
     } catch (err) {
       if (err.serverMessage !== 'Confirmation incomplete') {
         output.error(err.message);

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -2,12 +2,12 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGithubLogin(client: Client, ssoUserId?: string) {
+export default function doGithubLogin(client: Client) {
   const url = new URL(
     '/api/registration/login-with-github',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(client, url, 'GitHub', ssoUserId);
+  return doOauthLogin(client, url, 'GitHub');
 }

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -2,9 +2,9 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGitlabLogin(client: Client, ssoUserId?: string) {
+export default function doGitlabLogin(client: Client) {
   // Can't use `apiUrl` here because this URL sets a
   // cookie that the OAuth callback URL depends on
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
-  return doOauthLogin(client, url, 'GitLab', ssoUserId);
+  return doOauthLogin(client, url, 'GitLab');
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -1,9 +1,7 @@
-import http from 'http';
 import open from 'open';
 import { URL } from 'url';
-import listen from 'async-listen';
+import uid from 'uid-promise';
 import Client from '../client';
-import prompt from './prompt';
 import verify from './verify';
 import highlight from '../output/highlight';
 import link from '../output/link';
@@ -12,114 +10,28 @@ import eraseLines from '../output/erase-lines';
 export default async function doOauthLogin(
   client: Client,
   url: URL,
-  provider: string,
-  ssoUserId?: string
+  provider: string
 ): Promise<number | string> {
   const { output } = client;
 
-  const server = http.createServer();
-  const address = await listen(server, 0, '127.0.0.1');
-  const { port } = new URL(address);
+  const verifyToken = await uid(32);
   url.searchParams.set('mode', 'login');
-  url.searchParams.set('next', `http://localhost:${port}`);
+  url.searchParams.set('verifyToken', verifyToken);
+  //url.searchParams.set('next', `http://localhost:${port}`);
+
+  open(url.href);
 
   output.log(`Please visit the following URL in your web browser:`);
   output.log(link(url.href));
   output.spinner(`Waiting for ${provider} authentication to be completed`);
 
-  try {
-    const [query] = await Promise.all([
-      new Promise<URL['searchParams']>((resolve, reject) => {
-        server.once('request', (req, res) => {
-          // Close the HTTP connection to prevent
-          // `server.close()` from hanging
-          res.setHeader('connection', 'close');
+  // await confirmation
 
-          const query = new URL(req.url || '/', 'http://localhost')
-            .searchParams;
-          resolve(query);
+  const { email, token } = await verify(client, verifyToken, provider);
 
-          // Redirect the user's web browser back to
-          // the Vercel CLI login notification page
-          const location = new URL(
-            'https://vercel.com/notifications/cli-login-'
-          );
-          const loginError = query.get('loginError');
-          const ssoEmail = query.get('ssoEmail');
-          if (loginError) {
-            location.pathname += 'failed';
-            location.searchParams.set('loginError', loginError);
-          } else if (ssoEmail) {
-            location.pathname += 'incomplete';
-            location.searchParams.set('ssoEmail', ssoEmail);
-            const teamName = query.get('teamName');
-            const ssoType = query.get('ssoType');
-            if (teamName) {
-              location.searchParams.set('teamName', teamName);
-            }
-            if (ssoType) {
-              location.searchParams.set('ssoType', ssoType);
-            }
-          } else {
-            location.pathname += 'success';
-            const email = query.get('email');
-            if (email) {
-              location.searchParams.set('email', email);
-            }
-          }
+  output.stopSpinner();
+  output.print(eraseLines(3));
 
-          res.statusCode = 302;
-          res.setHeader('location', location.href);
-          res.end();
-        });
-        server.once('error', reject);
-      }),
-      open(url.href),
-    ]);
-
-    output.stopSpinner();
-    output.print(eraseLines(3));
-
-    const loginError = query.get('loginError');
-    if (loginError) {
-      const err = JSON.parse(loginError);
-      output.prettyError(err);
-      return 1;
-    }
-
-    // If an `ssoUserId` was returned, then the SAML Profile is not yet connected
-    // to a Team member. Prompt the user to log in to a Vercel account now, which
-    // will complete the connection to the SAML Profile.
-    const ssoUserIdParam = query.get('ssoUserId');
-    if (ssoUserIdParam) {
-      output.log(
-        'Please log in to your Vercel account to complete SAML connection.'
-      );
-      return prompt(client, undefined, ssoUserIdParam);
-    }
-
-    const email = query.get('email');
-    const verificationToken = query.get('token');
-    if (!email || !verificationToken) {
-      output.error(
-        'Verification token was not provided. Please contact support.'
-      );
-      return 1;
-    }
-
-    output.spinner('Verifying authentication token');
-    const token = await verify(
-      client,
-      email,
-      verificationToken,
-      provider,
-      ssoUserId
-    );
-    output.success(
-      `${provider} authentication complete for ${highlight(email)}`
-    );
-    return token;
-  } finally {
-    server.close();
-  }
+  output.success(`${provider} authentication complete for ${highlight(email)}`);
+  return token;
 }

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -12,8 +12,7 @@ import doBitbucketLogin from './bitbucket';
 
 export default async function prompt(
   client: Client,
-  error?: Pick<SAMLError, 'teamId'>,
-  ssoUserId?: string
+  error?: Pick<SAMLError, 'teamId'>
 ) {
   let result: number | string = 1;
 
@@ -25,9 +24,9 @@ export default async function prompt(
     { name: 'Continue with SAML Single Sign-On', value: 'sso', short: 'sso' },
   ];
 
-  if (ssoUserId || (error && !error.teamId)) {
-    // Remove SAML login option if we're connecting SAML Profile,
-    // or if this is a SAML error for a user / team without SAML
+  if (error && !error.teamId) {
+    // Remove SAML login option if this is a SAML
+    // error for a user or a team without SAML
     choices.pop();
   }
 
@@ -37,17 +36,17 @@ export default async function prompt(
   });
 
   if (choice === 'github') {
-    result = await doGithubLogin(client, ssoUserId);
+    result = await doGithubLogin(client);
   } else if (choice === 'gitlab') {
-    result = await doGitlabLogin(client, ssoUserId);
+    result = await doGitlabLogin(client);
   } else if (choice === 'bitbucket') {
-    result = await doBitbucketLogin(client, ssoUserId);
+    result = await doBitbucketLogin(client);
   } else if (choice === 'email') {
     const email = await readInput('Enter your email address');
-    result = await doEmailLogin(client, email, ssoUserId);
+    result = await doEmailLogin(client, email);
   } else if (choice === 'sso') {
     const slug = error?.teamId || (await readInput('Enter your Team slug'));
-    result = await doSsoLogin(client, slug, ssoUserId);
+    result = await doSsoLogin(client, slug);
   }
 
   return result;

--- a/packages/cli/src/util/login/sso.ts
+++ b/packages/cli/src/util/login/sso.ts
@@ -2,12 +2,8 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doSsoLogin(
-  client: Client,
-  teamIdOrSlug: string,
-  ssoUserId?: string
-) {
+export default function doSsoLogin(client: Client, teamIdOrSlug: string) {
   const url = new URL('/auth/sso', client.apiUrl);
   url.searchParams.set('teamId', teamIdOrSlug);
-  return doOauthLogin(client, url, 'SAML Single Sign-On', ssoUserId);
+  return doOauthLogin(client, url, 'SAML Single Sign-On');
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -4,6 +4,7 @@ export interface LoginData {
 }
 
 export interface VerifyData {
+  email: string;
   token: string;
 }
 

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -6,13 +6,11 @@ import { VerifyData } from './types';
 
 export default async function verify(
   client: Client,
-  email: string,
   verificationToken: string,
   provider: string,
   ssoUserId?: string
-): Promise<string> {
+): Promise<VerifyData> {
   const url = new URL('/registration/verify', client.apiUrl);
-  url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);
 
   if (!client.authConfig.token) {
@@ -29,6 +27,5 @@ export default async function verify(
     url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  const { token } = await client.fetch<VerifyData>(url.href);
-  return token;
+  return await client.fetch<VerifyData>(url.href);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10891,6 +10891,11 @@ uid-promise@1.0.0:
   resolved "https://registry.yarnpkg.com/uid-promise/-/uid-promise-1.0.0.tgz#68ef7c70a19dea4d637c7e3df2e0e548106f1a37"
   integrity sha1-aO98cKGd6k1jfH498uDlSBBvGjc=
 
+uid-promise@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/uid-promise/-/uid-promise-1.1.0.tgz#af6dee53e887834e9b0da3f705bc9d7b0d002b7c"
+  integrity sha512-8xlDRzI5YFQhoCaGvA/zZTZffX+7J916fVAnIBCVIcHlsHeXiDyrO8Kutb8zn5Azm3143hKlvmnf6eLEl9+hJQ==
+
 uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"


### PR DESCRIPTION
This PR simplifies the OAuth login logic by removing the localhost HTTP server that waits for the user to complete the OAuth login in the web browser. The localhost server technique does not work when the CLI is in fact not runnning on localhost (i.e. in headless environments such as Docker or SSH). So instead, the CLI will pre-generate the verify token that it will poll against to verify completion of the OAuth login. Once the provided `verifyToken` is "confirmed" by Vercel, then the CLI will exchange the verify token for the actual auth token.

This also removes the `ssoUserId` linking logic, since that will happen all browser-side with this change.