### PR TITLE
[cli] Use `output.spinner()` instead of `wait()`

### DIFF
--- a/packages/cli/src/commands/domains/inspect.ts
+++ b/packages/cli/src/commands/domains/inspect.ts
@@ -13,7 +13,6 @@ import getDomainPrice from '../../util/domains/get-domain-price';
 import { getCommandName } from '../../util/pkg-name';
 import { getDomainConfig } from '../../util/domains/get-domain-config';
 import code from '../../util/output/code';
-import wait from '../../util/output/wait';
 import { getDomainRegistrar } from '../../util/domains/get-domain-registrar';
 
 type Options = {};
@@ -59,7 +58,7 @@ export default async function inspect(
 
   output.debug(`Fetching domain info`);
 
-  const cancelWait = wait(
+  output.spinner(
     `Fetching Domain ${domainName} under ${chalk.bold(contextName)}`
   );
 
@@ -68,9 +67,6 @@ export default async function inspect(
     client,
     contextName,
     domainName,
-    cancelWait,
-  }).finally(() => {
-    cancelWait();
   });
 
   if (typeof information === 'number') {
@@ -207,13 +203,11 @@ async function fetchInformation({
   client,
   contextName,
   domainName,
-  cancelWait,
 }: {
   output: Output;
   client: Client;
   contextName: string;
   domainName: string;
-  cancelWait: () => void;
 }) {
   const [domain, renewalPrice] = await Promise.all([
     getDomainByName(client, contextName, domainName, { ignoreWait: true }),
@@ -223,13 +217,11 @@ async function fetchInformation({
   ]);
 
   if (domain instanceof DomainNotFound) {
-    cancelWait();
     output.prettyError(domain);
     return 1;
   }
 
   if (domain instanceof DomainPermissionDenied) {
-    cancelWait();
     output.prettyError(domain);
     output.log(`Run ${getCommandName(`domains ls`)} to see your domains.`);
     return 1;
@@ -238,7 +230,6 @@ async function fetchInformation({
   const projects = await findProjectsForDomain(client, domainName);
 
   if (projects instanceof Error) {
-    cancelWait();
     output.prettyError(projects);
     return 1;
   }

--- a/packages/cli/src/commands/domains/ls.ts
+++ b/packages/cli/src/commands/domains/ls.ts
@@ -2,7 +2,6 @@ import ms from 'ms';
 import chalk from 'chalk';
 import plural from 'pluralize';
 
-import wait from '../../util/output/wait';
 import Client from '../../util/client';
 import getDomains from '../../util/domains/get-domains';
 import getScope from '../../util/get-scope';
@@ -55,14 +54,9 @@ export default async function ls(
     return 1;
   }
 
-  const cancelWait = wait(`Fetching Domains under ${chalk.bold(contextName)}`);
+  output.spinner(`Fetching Domains under ${chalk.bold(contextName)}`);
 
-  const { domains, pagination } = await getDomains(
-    client,
-    nextTimestamp
-  ).finally(() => {
-    cancelWait();
-  });
+  const { domains, pagination } = await getDomains(client, nextTimestamp);
 
   output.log(
     `${plural('Domain', domains.length, true)} found under ${chalk.bold(

--- a/packages/cli/src/commands/projects.js
+++ b/packages/cli/src/commands/projects.js
@@ -8,7 +8,6 @@ import exit from '../util/exit';
 import logo from '../util/output/logo';
 import getScope from '../util/get-scope';
 import getCommandFlags from '../util/get-command-flags';
-import wait from '../util/output/wait';
 import { getPkgName, getCommandName } from '../util/pkg-name.ts';
 
 const e = encodeURIComponent;
@@ -118,7 +117,9 @@ async function run({ client, contextName }) {
       return exit(2);
     }
 
-    const stopSpinner = wait(`Fetching projects in ${chalk.bold(contextName)}`);
+    const stopSpinner = client.output.spinner(
+      `Fetching projects in ${chalk.bold(contextName)}`
+    );
 
     let projectsUrl = '/v4/projects/?limit=20';
 

--- a/packages/cli/src/commands/projects.js
+++ b/packages/cli/src/commands/projects.js
@@ -102,6 +102,7 @@ export default async client => {
 };
 
 async function run({ client, contextName }) {
+  const { output } = client;
   const args = argv._.slice(1);
   const start = Date.now();
 
@@ -117,9 +118,7 @@ async function run({ client, contextName }) {
       return exit(2);
     }
 
-    const stopSpinner = client.output.spinner(
-      `Fetching projects in ${chalk.bold(contextName)}`
-    );
+    output.spinner(`Fetching projects in ${chalk.bold(contextName)}`);
 
     let projectsUrl = '/v4/projects/?limit=20';
 
@@ -132,7 +131,7 @@ async function run({ client, contextName }) {
       method: 'GET',
     });
 
-    stopSpinner();
+    output.stopSpinner();
 
     const elapsed = ms(new Date() - start);
 

--- a/packages/cli/src/commands/teams/list.js
+++ b/packages/cli/src/commands/teams/list.js
@@ -1,11 +1,3 @@
-// Packages
-import chalk from 'chalk';
-
-// Utilities
-import wait from '../../util/output/wait';
-
-import info from '../../util/output/info';
-import error from '../../util/output/error';
 import chars from '../../util/output/chars';
 import table from '../../util/output/table';
 import getUser from '../../util/get-user.ts';
@@ -23,7 +15,7 @@ export default async function list(client, argv, teams) {
     return 1;
   }
 
-  const stopSpinner = wait('Fetching teams');
+  output.spinner('Fetching teams');
   const { teams: list, pagination } = await teams.ls({
     next,
     apiVersion: 2,
@@ -31,22 +23,18 @@ export default async function list(client, argv, teams) {
   let { currentTeam } = config;
   const accountIsCurrent = !currentTeam;
 
-  stopSpinner();
-
-  const stopUserSpinner = wait('Fetching user information');
+  output.spinner('Fetching user information');
   let user;
   try {
     user = await getUser(client);
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
-      console.error(error(err.message));
+      output.error(err.message);
       return 1;
     }
 
     throw err;
   }
-
-  stopUserSpinner();
 
   if (accountIsCurrent) {
     currentTeam = {
@@ -79,12 +67,12 @@ export default async function list(client, argv, teams) {
   const count = teamList.length;
   if (!count) {
     // Maybe should not happen
-    console.error(error(`No team found`));
+    output.error(`No teams found`);
     return 1;
   }
 
-  info(`${chalk.bold(count)} team${count > 1 ? 's' : ''} found`);
-  console.log();
+  output.stopSpinner();
+  console.log(); // empty line
 
   table(
     ['', 'id', 'email / name'],

--- a/packages/cli/src/util/certs/create-cert-from-file.ts
+++ b/packages/cli/src/util/certs/create-cert-from-file.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import wait from '../output/wait';
 import Client from '../client';
 import { Cert } from '../../types';
 
@@ -10,7 +9,7 @@ export default async function createCertFromFile(
   certPath: string,
   caPath: string
 ) {
-  const cancelWait = wait('Adding your custom certificate');
+  client.output.spinner('Adding your custom certificate');
 
   try {
     const cert = readFileSync(resolve(certPath), 'utf8');
@@ -36,7 +35,5 @@ export default async function createCertFromFile(
     }
 
     throw error;
-  } finally {
-    cancelWait();
   }
 }

--- a/packages/cli/src/util/certs/finish-cert-order.ts
+++ b/packages/cli/src/util/certs/finish-cert-order.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import { Cert } from '../../types';
 import * as ERRORS from '../errors-ts';
 import Client from '../client';
-import wait from '../output/wait';
 import mapCertError from './map-cert-error';
 
 export default async function startCertOrder(
@@ -11,7 +10,7 @@ export default async function startCertOrder(
   cns: string[],
   context: string // eslint-disable-line
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Issuing a certificate for ${chalk.bold(cns.join(', '))}`
   );
   try {
@@ -22,10 +21,8 @@ export default async function startCertOrder(
         domains: cns,
       },
     });
-    cancelWait();
     return cert;
   } catch (error) {
-    cancelWait();
     if (error.code === 'cert_order_not_found') {
       return new ERRORS.CertOrderNotFound(cns);
     }

--- a/packages/cli/src/util/certs/start-cert-order.ts
+++ b/packages/cli/src/util/certs/start-cert-order.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import wait from '../output/wait';
 import Client from '../client';
 
 export type CertificateChallenge = {
@@ -24,23 +23,17 @@ export default async function startCertOrder(
   cns: string[],
   contextName: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Starting certificate issuance for ${chalk.bold(
       cns.join(', ')
     )} under ${chalk.bold(contextName)}`
   );
-  try {
-    const order = await client.fetch<CertificateOrder>('/v3/now/certs', {
-      method: 'PATCH',
-      body: {
-        op: 'startOrder',
-        domains: cns
-      }
-    });
-    cancelWait();
-    return order;
-  } catch (error) {
-    cancelWait();
-    throw error;
-  }
+  const order = await client.fetch<CertificateOrder>('/v3/now/certs', {
+    method: 'PATCH',
+    body: {
+      op: 'startOrder',
+      domains: cns,
+    },
+  });
+  return order;
 }

--- a/packages/cli/src/util/dns/get-dns-records.ts
+++ b/packages/cli/src/util/dns/get-dns-records.ts
@@ -4,7 +4,6 @@ import { Output } from '../output';
 import Client from '../client';
 import getDomainDNSRecords from './get-domain-dns-records';
 import getDomains from '../domains/get-domains';
-import wait from '../output/wait';
 import chalk from 'chalk';
 
 export type DomainRecordsItem = {
@@ -60,11 +59,7 @@ async function getDomainNames(
   contextName: string,
   next?: number
 ) {
-  const cancelWait = wait(`Fetching domains under ${chalk.bold(contextName)}`);
-  try {
-    const { domains, pagination } = await getDomains(client, next);
-    return { domainNames: domains.map(domain => domain.name), pagination };
-  } finally {
-    cancelWait();
-  }
+  client.output.spinner(`Fetching domains under ${chalk.bold(contextName)}`);
+  const { domains, pagination } = await getDomains(client, next);
+  return { domainNames: domains.map(domain => domain.name), pagination };
 }

--- a/packages/cli/src/util/dns/import-zonefile.ts
+++ b/packages/cli/src/util/dns/import-zonefile.ts
@@ -4,7 +4,6 @@ import { resolve } from 'path';
 import { Response } from 'node-fetch';
 import { DomainNotFound, InvalidDomain } from '../errors-ts';
 import Client from '../client';
-import wait from '../output/wait';
 
 type JSONResponse = {
   recordIds: string[];
@@ -16,7 +15,7 @@ export default async function importZonefile(
   domain: string,
   zonefilePath: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Importing Zone file for domain ${domain} under ${chalk.bold(contextName)}`
   );
   const zonefile = readFileSync(resolve(zonefilePath), 'utf8');
@@ -33,10 +32,8 @@ export default async function importZonefile(
     );
 
     const { recordIds } = (await res.json()) as JSONResponse;
-    cancelWait();
     return recordIds;
   } catch (error) {
-    cancelWait();
     if (error.code === 'not_found') {
       return new DomainNotFound(domain, contextName);
     }

--- a/packages/cli/src/util/domains/add-domain.ts
+++ b/packages/cli/src/util/domains/add-domain.ts
@@ -3,7 +3,6 @@ import retry from 'async-retry';
 import { DomainAlreadyExists, InvalidDomain } from '../errors-ts';
 import { Domain } from '../../types';
 import Client from '../client';
-import wait from '../output/wait';
 
 type Response = {
   domain: Domain;
@@ -14,17 +13,11 @@ export default async function addDomain(
   domain: string,
   contextName: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Adding domain ${domain} under ${chalk.bold(contextName)}`
   );
-  try {
-    const addedDomain = await performAddRequest(client, domain);
-    cancelWait();
-    return addedDomain;
-  } catch (error) {
-    cancelWait();
-    throw error;
-  }
+  const addedDomain = await performAddRequest(client, domain);
+  return addedDomain;
 }
 
 async function performAddRequest(client: Client, domainName: string) {

--- a/packages/cli/src/util/domains/get-domain-by-name.ts
+++ b/packages/cli/src/util/domains/get-domain-by-name.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import Client from '../client';
-import wait from '../output/wait';
 import { Domain } from '../../types';
 import { DomainPermissionDenied, DomainNotFound } from '../errors-ts';
 
@@ -16,14 +15,15 @@ export default async function getDomainByName(
     ignoreWait?: boolean;
   } = {}
 ) {
-  const cancelWait = options.ignoreWait
-    ? null
-    : wait(`Fetching domain ${domainName} under ${chalk.bold(contextName)}`);
+  if (!options.ignoreWait) {
+    client.output.spinner(
+      `Fetching domain ${domainName} under ${chalk.bold(contextName)}`
+    );
+  }
   try {
     const { domain } = await client.fetch<Response>(
       `/v4/domains/${encodeURIComponent(domainName)}`
     );
-
     return domain;
   } catch (error) {
     if (error.status === 404) {
@@ -35,7 +35,5 @@ export default async function getDomainByName(
     }
 
     throw error;
-  } finally {
-    cancelWait?.();
   }
 }

--- a/packages/cli/src/util/domains/get-domain.ts
+++ b/packages/cli/src/util/domains/get-domain.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import Client from '../client';
-import wait from '../output/wait';
 import { Domain } from '../../types';
 
 type Response = {
@@ -12,7 +11,7 @@ export async function getDomain(
   contextName: string,
   domainName: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Fetching domain ${domainName} under ${chalk.bold(contextName)}`
   );
   try {
@@ -27,7 +26,5 @@ export async function getDomain(
     }
 
     throw error;
-  } finally {
-    cancelWait();
   }
 }

--- a/packages/cli/src/util/domains/verify-domain.ts
+++ b/packages/cli/src/util/domains/verify-domain.ts
@@ -3,22 +3,19 @@ import retry from 'async-retry';
 import { Domain } from '../../types';
 import * as ERRORS from '../errors-ts';
 import Client from '../client';
-import wait from '../output/wait';
 
 export default async function verifyDomain(
   client: Client,
   domainName: string,
   contextName: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Verifying domain ${domainName} under ${chalk.bold(contextName)}`
   );
   try {
     const { domain } = await performVerifyDomain(client, domainName);
-    cancelWait();
     return domain;
   } catch (error) {
-    cancelWait();
     if (error.code === 'verification_failed') {
       return new ERRORS.DomainVerificationFailed({
         purchased: false,

--- a/packages/cli/src/util/projects/add-domain-to-project.ts
+++ b/packages/cli/src/util/projects/add-domain-to-project.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import Client from '../client';
-import wait from '../output/wait';
 import { ProjectAliasTarget } from '../../types';
 
 export async function addDomainToProject(
@@ -8,7 +7,7 @@ export async function addDomainToProject(
   projectNameOrId: string,
   domain: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Adding domain ${domain} to project ${chalk.bold(projectNameOrId)}`
   );
   try {
@@ -40,7 +39,5 @@ export async function addDomainToProject(
     }
 
     throw err;
-  } finally {
-    cancelWait();
   }
 }

--- a/packages/cli/src/util/projects/remove-domain-from-project.ts
+++ b/packages/cli/src/util/projects/remove-domain-from-project.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import Client from '../client';
-import wait from '../output/wait';
 import { ProjectAliasTarget } from '../../types';
 
 export async function removeDomainFromProject(
@@ -8,7 +7,7 @@ export async function removeDomainFromProject(
   projectNameOrId: string,
   domain: string
 ) {
-  const cancelWait = wait(
+  client.output.spinner(
     `Removing domain ${domain} from project ${chalk.bold(projectNameOrId)}`
   );
   try {
@@ -28,7 +27,5 @@ export async function removeDomainFromProject(
     }
 
     throw err;
-  } finally {
-    cancelWait();
   }
 }


### PR DESCRIPTION
Replaces `wait()` usage with `output.spinner()`, which gets properly cleaned up by subsequent `output` logging functions.

Fixes for example this bug in the `vercel projects ls` command:

<img width="600" src="https://user-images.githubusercontent.com/71256/123872987-a6f5b700-d8ea-11eb-9229-30f9032f5419.gif" />
