### PR TITLE
[cli] Set current scope to proper team after SSO login

### DIFF
--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -165,7 +165,7 @@ export default class Client extends EventEmitter {
       process.exit(1);
     }
 
-    this.authConfig.token = result;
+    this.authConfig.token = result.token;
     writeToAuthConfigFile(this.authConfig);
   });
 

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -5,12 +5,13 @@ import eraseLines from '../output/erase-lines';
 import verify from './verify';
 import executeLogin from './login';
 import Client from '../client';
+import { LoginResult } from './types';
 
 export default async function doEmailLogin(
   client: Client,
   email: string,
   ssoUserId?: string
-): Promise<number | string> {
+): Promise<LoginResult> {
   let securityCode;
   let verificationToken;
   const { output } = client;
@@ -59,5 +60,5 @@ export default async function doEmailLogin(
   }
 
   output.success(`Email authentication complete for ${email}`);
-  return token;
+  return { token };
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -8,13 +8,14 @@ import verify from './verify';
 import highlight from '../output/highlight';
 import link from '../output/link';
 import eraseLines from '../output/erase-lines';
+import { LoginResult } from './types';
 
 export default async function doOauthLogin(
   client: Client,
   url: URL,
   provider: string,
   ssoUserId?: string
-): Promise<number | string> {
+): Promise<LoginResult> {
   const { output } = client;
 
   const server = http.createServer();
@@ -100,6 +101,7 @@ export default async function doOauthLogin(
 
     const email = query.get('email');
     const verificationToken = query.get('token');
+    const teamId = query.get('teamId');
     if (!email || !verificationToken) {
       output.error(
         'Verification token was not provided. Please contact support.'
@@ -118,7 +120,7 @@ export default async function doOauthLogin(
     output.success(
       `${provider} authentication complete for ${highlight(email)}`
     );
-    return token;
+    return { token, teamId };
   } finally {
     server.close();
   }

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -3,7 +3,7 @@ import Client from '../client';
 import error from '../output/error';
 import listInput from '../input/list';
 import { getCommandName } from '../pkg-name';
-import { SAMLError } from './types';
+import { LoginResult, SAMLError } from './types';
 import doSsoLogin from './sso';
 import doEmailLogin from './email';
 import doGithubLogin from './github';
@@ -15,7 +15,7 @@ export default async function prompt(
   error?: Pick<SAMLError, 'teamId'>,
   ssoUserId?: string
 ) {
-  let result: number | string = 1;
+  let result: LoginResult = 1;
 
   const choices = [
     { name: 'Continue with GitHub', value: 'github', short: 'github' },

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -1,29 +1,28 @@
 import { bold } from 'chalk';
 import doSsoLogin from './sso';
 import showLoginPrompt from './prompt';
-import { SAMLError } from './types';
+import { LoginResult, SAMLError } from './types';
 import confirm from '../input/confirm';
 import Client from '../client';
 
 export default async function reauthenticate(
   client: Client,
   error: Pick<SAMLError, 'enforced' | 'scope' | 'teamId'>
-): Promise<string | number> {
-  let result: string | number = 1;
+): Promise<LoginResult> {
   if (error.teamId && error.enforced) {
     // If team has SAML enforced then trigger the SSO login directly
     client.output.log(
       `You must re-authenticate with SAML to use ${bold(error.scope)} scope.`
     );
     if (await confirm(`Log in with SAML?`, true)) {
-      result = await doSsoLogin(client, error.teamId);
+      return doSsoLogin(client, error.teamId);
     }
   } else {
     // Personal account, or team that does not have SAML enforced
     client.output.log(
       `You must re-authenticate to use ${bold(error.scope)} scope.`
     );
-    result = await showLoginPrompt(client, error);
+    return showLoginPrompt(client, error);
   }
-  return result;
+  return 1;
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -3,6 +3,13 @@ export interface LoginData {
   securityCode: string;
 }
 
+export type LoginResult = number | LoginResultSuccess;
+
+export interface LoginResultSuccess {
+  token: string;
+  teamId?: string | null;
+}
+
 export interface VerifyData {
   token: string;
 }


### PR DESCRIPTION
When logging in via SAML SSO, set the current scope to the team that the SSO belongs to. Otherwise the user's personal scope is selected, and if the auth token only has access to that team then the personal scope is not accessible.