### PR TITLE
[node] Use `require()` when source is TypeScript in `vc dev`

### DIFF
--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -26,6 +26,7 @@ ${
 const entrypointPath = ${JSON.stringify(entrypointPath)};
 const shouldAddHelpers = ${JSON.stringify(shouldAddHelpers)};
 const helpersPath = ${JSON.stringify(helpersPath)};
+const useRequire = false;
 
 const func = (${getVercelLauncher(config).toString()})();
 exports.launcher = func.launcher;`;

--- a/packages/node-bridge/types.ts
+++ b/packages/node-bridge/types.ts
@@ -35,4 +35,5 @@ export type LauncherConfiguration = {
   shouldAddHelpers?: boolean;
   shouldAddSourcemapSupport?: boolean;
   awsLambdaHandler?: string;
+  useRequire?: boolean;
 };

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -13,6 +13,8 @@ import { register } from 'ts-node';
 
 type TypescriptModule = typeof import('typescript');
 
+let useRequire = false;
+
 if (!process.env.VERCEL_DEV_IS_ESM) {
   const resolveTypescript = (p: string): string => {
     try {
@@ -79,6 +81,8 @@ if (!process.env.VERCEL_DEV_IS_ESM) {
     project: tsconfig || undefined, // Resolve `tsconfig.json` from entrypoint dir
     transpileOnly: true,
   });
+
+  useRequire = true;
 }
 
 import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
@@ -115,6 +119,7 @@ async function main() {
     entrypointPath: join(process.cwd(), entrypoint!),
     helpersPath: './helpers.js',
     shouldAddHelpers,
+    useRequire,
   });
   bridge = launcher();
 


### PR DESCRIPTION
`vc dev` currently doesn't work when the Node.js entrypoint is TypeScript:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/nrajlich/n/api/index.ts
```

This is due to the recent ESM related change where the `require()` call in launcher.js was changed to `import()`. This makes ts-node fail since [`require.extensions` is not respected](https://nodejs.org/api/esm.html#esm_no_require_extensions) by Node.js when in ESM mode.

Interestingly, `vc dev` _does_ work from within the vercel monorepo, but not when installed globally from npm. After some investigating, I discovered that this was because ts-node was compiling the launcher.js file when inside the monorepo (causing the problematic `import()` to be compiled into `require()`), but was ignoring the launcher.js file when installed globally. This was due to ts-node's default setting of ignoring files within `node_modules`, which ends up being true for launcher.js when installed globally.

So this solution makes it so that launcher.js still does explicitly use `require()` when `vc dev` has ts-node registered.