### PR TITLE
[cli][client] Printable `link` from `deployment.aliasWarning`

### DIFF
--- a/packages/cli/src/commands/deploy/latest.ts
+++ b/packages/cli/src/commands/deploy/latest.ts
@@ -117,6 +117,7 @@ const printDeploymentStatus = async (
   isClipboardEnabled: boolean,
   isFile: boolean
 ) => {
+  indications = indications || [];
   const isProdDeployment = target === 'production';
 
   if (readyState !== 'READY') {
@@ -174,23 +175,18 @@ const printDeploymentStatus = async (
     );
   }
 
-  const indent = process.stdout.isTTY ? '    ' : ''; // if using emojis
-  const newline = '\n';
-  if (aliasWarning && aliasWarning?.message) {
-    const message =
-      prependEmoji(chalk.dim(aliasWarning.message), emoji('warning')) + newline;
-    let link = '';
-    if (aliasWarning.link)
-      link =
-        indent +
-        chalk.dim(
-          `${aliasWarning.action || 'Learn More'}: ${aliasWarning.link}`
-        ) +
-        newline;
-    output.print(message + link);
+  if (aliasWarning?.message) {
+    indications.push({
+      type: 'warning',
+      payload: aliasWarning.message,
+      link: aliasWarning.link,
+      action: aliasWarning.action,
+    });
   }
 
   if (indications) {
+    const indent = process.stdout.isTTY ? '    ' : ''; // if using emojis
+    const newline = '\n';
     for (let indication of indications) {
       const message =
         prependEmoji(chalk.dim(indication.payload), emoji(indication.type)) +

--- a/packages/cli/src/commands/deploy/latest.ts
+++ b/packages/cli/src/commands/deploy/latest.ts
@@ -98,6 +98,7 @@ const printDeploymentStatus = async (
     target,
     indications,
     url: deploymentUrl,
+    aliasWarning,
   }: {
     readyState: string;
     alias: string[];
@@ -105,6 +106,12 @@ const printDeploymentStatus = async (
     target: string;
     indications: any;
     url: string;
+    aliasWarning?: {
+      code: string;
+      message: string;
+      link?: string;
+      action?: string;
+    };
   },
   deployStamp: () => string,
   isClipboardEnabled: boolean,
@@ -167,9 +174,23 @@ const printDeploymentStatus = async (
     );
   }
 
+  const indent = process.stdout.isTTY ? '    ' : ''; // if using emojis
+  const newline = '\n';
+  if (aliasWarning && aliasWarning?.message) {
+    const message =
+      prependEmoji(chalk.dim(aliasWarning.message), emoji('warning')) + newline;
+    let link = '';
+    if (aliasWarning.link)
+      link =
+        indent +
+        chalk.dim(
+          `${aliasWarning.action || 'Learn More'}: ${aliasWarning.link}`
+        ) +
+        newline;
+    output.print(message + link);
+  }
+
   if (indications) {
-    const indent = process.stdout.isTTY ? '    ' : ''; // if using emojis
-    const newline = '\n';
     for (let indication of indications) {
       const message =
         prependEmoji(chalk.dim(indication.payload), emoji(indication.type)) +

--- a/packages/cli/src/commands/deploy/latest.ts
+++ b/packages/cli/src/commands/deploy/latest.ts
@@ -13,6 +13,7 @@ import createDeploy from '../../util/deploy/create-deploy';
 import getDeploymentByIdOrHost from '../../util/deploy/get-deployment-by-id-or-host';
 import parseMeta from '../../util/parse-meta';
 import code from '../../util/output/code';
+import linkStyle from '../../util/output/link';
 import param from '../../util/output/param';
 import highlight from '../../util/output/highlight';
 import {
@@ -184,23 +185,18 @@ const printDeploymentStatus = async (
     });
   }
 
-  if (indications) {
-    const indent = process.stdout.isTTY ? '    ' : ''; // if using emojis
-    const newline = '\n';
-    for (let indication of indications) {
-      const message =
-        prependEmoji(chalk.dim(indication.payload), emoji(indication.type)) +
-        newline;
-      let link = '';
-      if (indication.link)
-        link =
-          indent +
-          chalk.dim(
-            `${indication.action || 'Learn More'}: ${indication.link}`
-          ) +
-          newline;
-      output.print(message + link);
-    }
+  const newline = '\n';
+  for (let indication of indications) {
+    const message =
+      prependEmoji(chalk.dim(indication.payload), emoji(indication.type)) +
+      newline;
+    let link = '';
+    if (indication.link)
+      link =
+        chalk.dim(
+          `${indication.action || 'Learn More'}: ${linkStyle(indication.link)}`
+        ) + newline;
+    output.print(message + link);
   }
 };
 

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -89,16 +89,6 @@ export async function* checkDeploymentStatus(
     }
 
     if (isAliasAssigned(deploymentUpdate)) {
-      if (
-        deploymentUpdate.aliasWarning &&
-        deploymentUpdate.aliasWarning.message
-      ) {
-        yield {
-          type: 'warning',
-          payload: deploymentUpdate.aliasWarning.message,
-        };
-      }
-
       debug('Deployment alias assigned');
       return yield { type: 'alias-assigned', payload: deploymentUpdate };
     }


### PR DESCRIPTION
### Related Issues

* Prints `link` property from `deployment.aliasWarning` in `vc deploy` command.
* Removes `aliasWarning` `warning` event (SEMVER MAJOR `@vercel/client` change).

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
