### PR TITLE
[cli] Add "out-of-band" mode to `vc login`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -136,6 +136,7 @@
     "glob": "7.1.2",
     "http-proxy": "1.18.1",
     "inquirer": "7.0.4",
+    "is-docker": "2.2.1",
     "is-port-reachable": "3.0.0",
     "is-url": "1.2.2",
     "jaro-winkler": "0.2.8",

--- a/packages/cli/src/util/login/bitbucket.ts
+++ b/packages/cli/src/util/login/bitbucket.ts
@@ -2,12 +2,16 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doBitbucketLogin(client: Client, ssoUserId?: string) {
+export default function doBitbucketLogin(
+  client: Client,
+  outOfBand?: boolean,
+  ssoUserId?: string
+) {
   const url = new URL(
     '/api/registration/bitbucket/connect',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(client, url, 'Bitbucket', ssoUserId);
+  return doOauthLogin(client, url, 'Bitbucket', outOfBand, ssoUserId);
 }

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -46,8 +46,8 @@ export default async function doEmailLogin(
       await sleep(ms('1s'));
       result = await verify(
         client,
-        email,
         verificationToken,
+        email,
         'Email',
         ssoUserId
       );

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -40,11 +40,11 @@ export default async function doEmailLogin(
 
   output.spinner('Waiting for your confirmation');
 
-  let token = '';
-  while (!token) {
+  let result;
+  while (!result) {
     try {
       await sleep(ms('1s'));
-      token = await verify(
+      result = await verify(
         client,
         email,
         verificationToken,
@@ -60,5 +60,5 @@ export default async function doEmailLogin(
   }
 
   output.success(`Email authentication complete for ${email}`);
-  return { token };
+  return result;
 }

--- a/packages/cli/src/util/login/github.ts
+++ b/packages/cli/src/util/login/github.ts
@@ -2,12 +2,16 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGithubLogin(client: Client, ssoUserId?: string) {
+export default function doGithubLogin(
+  client: Client,
+  outOfBand?: boolean,
+  ssoUserId?: string
+) {
   const url = new URL(
     '/api/registration/login-with-github',
     // Can't use `apiUrl` here because this URL sets a
     // cookie that the OAuth callback URL depends on
     'https://vercel.com'
   );
-  return doOauthLogin(client, url, 'GitHub', ssoUserId);
+  return doOauthLogin(client, url, 'GitHub', outOfBand, ssoUserId);
 }

--- a/packages/cli/src/util/login/gitlab.ts
+++ b/packages/cli/src/util/login/gitlab.ts
@@ -2,9 +2,13 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doGitlabLogin(client: Client, ssoUserId?: string) {
+export default function doGitlabLogin(
+  client: Client,
+  outOfBand?: boolean,
+  ssoUserId?: string
+) {
   // Can't use `apiUrl` here because this URL sets a
   // cookie that the OAuth callback URL depends on
   const url = new URL('/api/registration/gitlab/connect', 'https://vercel.com');
-  return doOauthLogin(client, url, 'GitLab', ssoUserId);
+  return doOauthLogin(client, url, 'GitLab', outOfBand, ssoUserId);
 }

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -35,8 +35,8 @@ export default async function doOauthLogin(
     output.spinner('Verifying authentication token');
     result = await verify(
       client,
-      'nate@vercel.com',
       result.verificationToken,
+      undefined,
       provider,
       ssoUserId
     );

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -168,7 +168,7 @@ async function getVerificationTokenOutOfBand(client: Client, url: URL) {
   const { output } = client;
   url.searchParams.set(
     'next',
-    `http://localhost:3000/notifications/cli-login-oob`
+    `https://vercel.com/notifications/cli-login-oob`
   );
   output.log(`Please visit the following URL in your web browser:`);
   output.log(link(url.href));

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -166,7 +166,6 @@ async function getVerificationTokenOutOfBand(client: Client, url: URL) {
     'next',
     `http://localhost:3000/notifications/cli-login-oob`
   );
-
   output.log(`Please visit the following URL in your web browser:`);
   output.log(link(url.href));
   output.print('\n');
@@ -174,7 +173,7 @@ async function getVerificationTokenOutOfBand(client: Client, url: URL) {
     `After login is complete, enter the verification code printed in your browser.`
   );
   const verificationToken = await readInput('Verification code:');
-
+  output.print(eraseLines(6));
   return { verificationToken };
 }
 

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -158,7 +158,11 @@ async function getVerificationTokenInBand(
 }
 
 /**
+ * Get the verification token "out-of-band" by presenting the login URL
+ * to the user and directing them to visit the URL in their web browser.
  *
+ * A prompt is rendered asking for the verification token that is
+ * provided to them in the callback URL after the login is successful.
  */
 async function getVerificationTokenOutOfBand(client: Client, url: URL) {
   const { output } = client;

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -54,7 +54,7 @@ export default async function prompt(
   return result;
 }
 
-export async function readInput(message: string) {
+export async function readInput(message: string): Promise<string> {
   let input;
 
   while (!input) {

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -1,5 +1,5 @@
 import { bold } from 'chalk';
-import doSsoLogin from './sso';
+import doSamlLogin from './saml';
 import showLoginPrompt from './prompt';
 import { LoginResult, SAMLError } from './types';
 import confirm from '../input/confirm';
@@ -15,7 +15,7 @@ export default async function reauthenticate(
       `You must re-authenticate with SAML to use ${bold(error.scope)} scope.`
     );
     if (await confirm(`Log in with SAML?`, true)) {
-      return doSsoLogin(client, error.teamId);
+      return doSamlLogin(client, error.teamId);
     }
   } else {
     // Personal account, or team that does not have SAML enforced

--- a/packages/cli/src/util/login/saml.ts
+++ b/packages/cli/src/util/login/saml.ts
@@ -2,12 +2,13 @@ import { URL } from 'url';
 import Client from '../client';
 import doOauthLogin from './oauth';
 
-export default function doSsoLogin(
+export default function doSamlLogin(
   client: Client,
   teamIdOrSlug: string,
+  outOfBand?: boolean,
   ssoUserId?: string
 ) {
   const url = new URL('/auth/sso', client.apiUrl);
   url.searchParams.set('teamId', teamIdOrSlug);
-  return doOauthLogin(client, url, 'SAML Single Sign-On', ssoUserId);
+  return doOauthLogin(client, url, 'SAML Single Sign-On', outOfBand, ssoUserId);
 }

--- a/packages/cli/src/util/login/types.ts
+++ b/packages/cli/src/util/login/types.ts
@@ -7,11 +7,8 @@ export type LoginResult = number | LoginResultSuccess;
 
 export interface LoginResultSuccess {
   token: string;
-  teamId?: string | null;
-}
-
-export interface VerifyData {
-  token: string;
+  email: string;
+  teamId?: string;
 }
 
 export interface SAMLError {

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -6,14 +6,16 @@ import { LoginResultSuccess } from './types';
 
 export default function verify(
   client: Client,
-  email: string,
   verificationToken: string,
+  email: string | undefined,
   provider: string,
   ssoUserId?: string
 ) {
   const url = new URL('/registration/verify', client.apiUrl);
-  url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);
+  if (email) {
+    url.searchParams.set('email', email);
+  }
 
   if (!client.authConfig.token) {
     // Set the "name" of the Token that will be created

--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -2,15 +2,15 @@ import { URL } from 'url';
 import Client from '../client';
 import { hostname } from 'os';
 import { getTitleName } from '../pkg-name';
-import { VerifyData } from './types';
+import { LoginResultSuccess } from './types';
 
-export default async function verify(
+export default function verify(
   client: Client,
   email: string,
   verificationToken: string,
   provider: string,
   ssoUserId?: string
-): Promise<string> {
+) {
   const url = new URL('/registration/verify', client.apiUrl);
   url.searchParams.set('email', email);
   url.searchParams.set('token', verificationToken);
@@ -29,6 +29,5 @@ export default async function verify(
     url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  const { token } = await client.fetch<VerifyData>(url.href);
-  return token;
+  return client.fetch<LoginResultSuccess>(url.href);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6157,10 +6157,10 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
-is-docker@^2.0.0, is-docker@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+is-docker@2.2.1, is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-error@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
Adds an "out-of-band" login mode to the `vc login` command, for use in headless environments like inside a Docker container or an SSH session. In these situations, spawning a localhost HTTP server won't work, because the HTTP server will not be accessible to the web browser that is doing the authentication.

In "out-of-band" mode, the login URL is simply presented to the user, and they must visit the login URL in their web browser and complete the authentication. The callback URL is a page on front that shows the verification token to the user and instructs them to copy + paste the token back into the CLI, at which point the login can complete.

Docker/SSH sessions are attempted to be automatically detected, and "out-of-band" mode is enabled implicitly. But there is also an `--oob` flag in case that detection logic were to fail (or if you'd like to run OOB mode locally).

This PR also adds shortcut flags for the Git provider login mechanisms, i.e. `vc login --github`.


https://user-images.githubusercontent.com/71256/125129304-1f5f3380-e0b4-11eb-8139-d1109811bd86.mov

