### PR TITLE
[cli] Add "Local Development" section to README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,13 +14,13 @@ Vercel is the optimal workflow for frontend teams. All-in-one: Static and Jamsta
 
 To install the latest version of Vercel CLI, visit [vercel.com/download](https://vercel.com/download) or run this command:
 
-```sh
+```bash
 npm i -g vercel
 ```
 
 To quickly start a new project, run the following commands:
 
-```
+```bash
 vercel init     # Pick an example project
 cd <PROJECT>    # Change directory to the new project
 vercel          # Deploy to the cloud
@@ -29,3 +29,31 @@ vercel          # Deploy to the cloud
 ## Documentation
 
 For details on how to use Vercel CLI, check out our [documentation](https://vercel.com/docs).
+
+## Local Development
+
+To develop Vercel CLI, first check out the source code, install dependencies, and build all packages:
+
+```bash
+git clone https://github.com/vercel/vercel.git
+cd vercel
+yarn
+yarn build
+```
+
+At this point you can make modifications to the CLI source code and test them out locally. The CLI source code is located in the `packages/cli` directory.
+
+```bash
+cd packages/cli
+```
+
+From within the `packages/cli` directory, you can use the `ts-eager` command line tool to quickly excute Vercel CLI from its TypeScript source code directly (without having to manually compile first). For example:
+
+```bash
+npx ts-eager src
+npx ts-eager src login
+npx ts-eager src switch --debug
+npx ts-eager src dev
+```
+
+When you are satisfied with your changes, make a commit and create a pull request!


### PR DESCRIPTION
Adds a section to the CLI readme explaining how to check out the source code and use `ts-eager` for local development.