### PR TITLE
[cli] Remove "now" from variable names in `vc dev`

### DIFF
--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -96,7 +96,7 @@ async function createBuildProcess(
 }
 
 export async function executeBuild(
-  nowConfig: VercelConfig,
+  vercelConfig: VercelConfig,
   devServer: DevServer,
   files: BuilderInputs,
   match: BuildMatch,
@@ -263,7 +263,7 @@ export async function executeBuild(
   }
 
   const { output } = result;
-  const { cleanUrls } = nowConfig;
+  const { cleanUrls } = vercelConfig;
 
   // Mimic fmeta-util and perform file renaming
   Object.entries(output).forEach(([path, value]) => {
@@ -359,7 +359,7 @@ export async function executeBuild(
           MemorySize: asset.memory || 3008,
           Environment: {
             Variables: {
-              ...nowConfig.env,
+              ...vercelConfig.env,
               ...asset.environment,
               ...envConfigs.runEnv,
             },
@@ -383,7 +383,7 @@ export async function executeBuild(
 }
 
 export async function getBuildMatches(
-  nowConfig: VercelConfig,
+  vercelConfig: VercelConfig,
   cwd: string,
   output: Output,
   devServer: DevServer,
@@ -398,7 +398,7 @@ export async function getBuildMatches(
   }
 
   const noMatches: Builder[] = [];
-  const builds = nowConfig.builds || [{ src: '**', use: '@vercel/static' }];
+  const builds = vercelConfig.builds || [{ src: '**', use: '@vercel/static' }];
 
   for (const buildConfig of builds) {
     let { src = '**', use, config = {} } = buildConfig;

--- a/packages/cli/src/util/dev/router.ts
+++ b/packages/cli/src/util/dev/router.ts
@@ -50,7 +50,7 @@ export async function devRouter(
   reqMethod?: string,
   routes?: Route[],
   devServer?: DevServer,
-  nowConfig?: VercelConfig,
+  vercelConfig?: VercelConfig,
   previousHeaders?: HttpHeadersConfig,
   missRoutes?: Route[],
   phase?: HandleValue | null
@@ -124,14 +124,14 @@ export async function devRouter(
         if (
           routeConfig.check &&
           devServer &&
-          nowConfig &&
+          vercelConfig &&
           phase !== 'hit' &&
           !isDestUrl
         ) {
           const { pathname = '/' } = url.parse(destPath);
           const hasDestFile = await devServer.hasFilesystem(
             pathname,
-            nowConfig
+            vercelConfig
           );
 
           if (!hasDestFile) {
@@ -144,7 +144,7 @@ export async function devRouter(
                 reqMethod,
                 missRoutes,
                 devServer,
-                nowConfig,
+                vercelConfig,
                 combinedHeaders,
                 [],
                 'miss'

--- a/packages/cli/src/util/dev/templates/error.jst
+++ b/packages/cli/src/util/dev/templates/error.jst
@@ -4,6 +4,6 @@
     {{? it.error_code }}
     <span class="devinfo-line">Code: <code>{{! it.error_code }}</code></span>
     {{?}}
-    <span class="devinfo-line">ID: <code>{{! it.now_id }}</code>
+    <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
   </p>
 </main>

--- a/packages/cli/src/util/dev/templates/error.tsdef
+++ b/packages/cli/src/util/dev/templates/error.tsdef
@@ -2,5 +2,5 @@ interface Inputs {
   http_status_code: number;
   http_status_description: string;
   error_code?: string;
-  now_id: string;
+  request_id: string;
 }

--- a/packages/cli/src/util/dev/templates/error_404.jst
+++ b/packages/cli/src/util/dev/templates/error_404.jst
@@ -4,6 +4,6 @@
     {{? it.error_code }}
     <span class="devinfo-line">Code: <code>{{! it.error_code }}</code></span>
     {{?}}
-    <span class="devinfo-line">ID: <code>{{! it.now_id }}</code>
+    <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
   </p>
 </main>

--- a/packages/cli/src/util/dev/templates/error_404.tsdef
+++ b/packages/cli/src/util/dev/templates/error_404.tsdef
@@ -5,5 +5,5 @@ interface Inputs {
   http_status_code: number;
   http_status_description: string;
   error_code?: string;
-  now_id: string;
+  request_id: string;
 }

--- a/packages/cli/src/util/dev/templates/error_502.jst
+++ b/packages/cli/src/util/dev/templates/error_502.jst
@@ -38,7 +38,7 @@
     {{? it.error_code }}
     <span class="devinfo-line">Code: <code>{{! it.error_code }}</code></span>
     {{?}}
-    <span class="devinfo-line">ID: <code>{{! it.now_id }}</code>
+    <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
   </p>
   {{? it.app_error }}
   <p>

--- a/packages/cli/src/util/dev/templates/error_502.tsdef
+++ b/packages/cli/src/util/dev/templates/error_502.tsdef
@@ -5,5 +5,5 @@ interface Inputs {
   http_status_code: number;
   http_status_description: string;
   error_code?: string;
-  now_id: string;
+  request_id: string;
 }


### PR DESCRIPTION
Renames the variables that contain "now" in the name to "vercel" or drops the name completely. Just some house-keeping, should be functionally no changes.