### PR TITLE
[cli] Allow dynamic label in `output.time()` function

### DIFF
--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -1,7 +1,5 @@
 import chalk from 'chalk';
 import boxen from 'boxen';
-import { format } from 'util';
-import { Console } from 'console';
 import renderLink from './link';
 import wait, { StopSpinner } from './wait';
 
@@ -138,20 +136,20 @@ function _createOutput({ debug: debugEnabled = false }: OutputOptions = {}) {
     }
   }
 
-  const c = {
-    _times: new Map(),
-    log(a: string, ...args: string[]) {
-      debug(format(a, ...args));
-    },
-  };
-
-  async function time(label: string, fn: Promise<any> | (() => Promise<any>)) {
+  async function time<T>(
+    label: string | ((r?: T) => string),
+    fn: Promise<T> | (() => Promise<T>)
+  ) {
     const promise = typeof fn === 'function' ? fn() : fn;
+
     if (debugEnabled) {
-      c.log(label);
-      Console.prototype.time.call(c, label);
+      const startLabel = typeof label === 'function' ? label() : label;
+      debug(startLabel);
+      const start = Date.now();
       const r = await promise;
-      Console.prototype.timeEnd.call(c, label);
+      const endLabel = typeof label === 'function' ? label(r) : label;
+      const duration = Date.now() - start;
+      debug(`${endLabel}: ${(duration / 1000).toFixed(2)}s`);
       return r;
     }
 


### PR DESCRIPTION
Updates the `output.time()` function to accept a function as the "label" parameter. When a function is passed, it will be invoked twice, once at the beginning of the promise being executed, and a second time after the promise has resolved. The second time, the return value of the promise is passed to the label function, so that the resolved value may be used to create the label.

Drops usage of Node's `console.time()` and `console.timeEnd()` since we were using it in a hacky and unnecessary way.