### PR TITLE
[cli] Add request counter to `--debug` logs

### DIFF
--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -149,7 +149,9 @@ function _createOutput({ debug: debugEnabled = false }: OutputOptions = {}) {
       const r = await promise;
       const endLabel = typeof label === 'function' ? label(r) : label;
       const duration = Date.now() - start;
-      debug(`${endLabel}: ${(duration / 1000).toFixed(2)}s`);
+      const durationPretty =
+        duration < 1000 ? `${duration}ms` : `${(duration / 1000).toFixed(2)}s`;
+      debug(`${endLabel} ${chalk.gray(`[${durationPretty}]`)}`);
       return r;
     }
 


### PR DESCRIPTION
Follow up to #6508. Adds a request "counter" that increments for every API request, matching how `front` does it.

Also tweaks the `output.time()` output a bit by rendering the timestamp in gray, and with `[]` brackets. If the time diff is < 1000ms then the full milliseconds will be printed intstead of the seconds.

<img width="710" alt="Screen Shot 2021-07-22 at 2 45 39 PM" src="https://user-images.githubusercontent.com/71256/126713843-db70ed9c-4752-4ca9-8f54-313c4cb44914.png">
