### PR TITLE
Don't render SvelteKits port flag in the UI

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -902,7 +902,8 @@ export const frameworks = [
         placeholder: '`npm run build` or `svelte-kit build`',
       },
       devCommand: {
-        placeholder: 'svelte-kit dev --port $PORT',
+        value: 'svelte-kit dev --port $PORT',
+        placeholder: 'svelte-kit dev',
       },
       outputDirectory: {
         placeholder: 'public',


### PR DESCRIPTION
Like this, we can avoid that the dashboard will ask people to pass `--port` when running SvelteKit's Development Command.

Only `vercel dev` will make use of it.