### PR TITLE
[build-utils] Invoke npm 7 when lockfile version 2 is detected

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "node build",
     "test-unit": "jest --env node --verbose --runInBand --bail test/unit.*test.*",
-    "test-integration-once": "jest --env node --verbose --runInBand --bail test/integration.test.ts",
+    "test-integration-once": "VERCEL_DEBUG=1 jest --env node --verbose --runInBand --bail test/integration.test.ts",
     "prepublishOnly": "node build"
   },
   "devDependencies": {

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "node build",
     "test-unit": "jest --env node --verbose --runInBand --bail test/unit.*test.*",
-    "test-integration-once": "VERCEL_DEBUG=1 jest --env node --verbose --runInBand --bail test/integration.test.ts",
+    "test-integration-once": "jest --env node --verbose --runInBand --bail test/integration.test.ts",
     "prepublishOnly": "node build"
   },
   "devDependencies": {

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -329,9 +329,9 @@ export async function runNpmInstall(
       .filter(a => a !== '--prefer-offline')
       .concat(['install', '--no-audit', '--unsafe-perm']);
 
-    if (lockfileVersion === 2) {
+    if (typeof lockfileVersion === 'number' && lockfileVersion >= 2) {
       // Ensure that npm 7 is at the beginning of the `$PATH`
-      env.PATH = `/node16/bin:${env.PATH}`;
+      env.PATH = `/node16/bin-npm7:${env.PATH}`;
     }
   } else {
     opts.prettyCommand = 'yarn install';
@@ -376,9 +376,9 @@ export async function runPackageJsonScript(
   if (cliType === 'npm') {
     opts.prettyCommand = `npm run ${scriptName}`;
 
-    if (lockfileVersion === 2) {
+    if (typeof lockfileVersion === 'number' && lockfileVersion >= 2) {
       // Ensure that npm 7 is at the beginning of the `$PATH`
-      env.PATH = `/node16/bin:${env.PATH}`;
+      env.PATH = `/node16/bin-npm7:${env.PATH}`;
     }
   } else {
     opts.prettyCommand = `yarn run ${scriptName}`;

--- a/packages/build-utils/test/fixtures/20-npm-7/package-lock.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/package-lock.json
@@ -5,8 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
-      "license": "ISC"
+      "version": "1.0.0"
     }
   }
 }

--- a/packages/build-utils/test/fixtures/20-npm-7/package.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/package.json
@@ -1,12 +1,7 @@
 {
   "name": "20-npm-7",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+    "build": "mkdir -p public && (printf \"npm version: \" && npm -v) > public/index.txt"
+  }
 }

--- a/packages/build-utils/test/fixtures/20-npm-7/vercel.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
   "builds": [{ "src": "package.json", "use": "@vercel/static-build" }],
-  "build": { "env": { "VERCEL_DEBUG": "1" } },
   "probes": [{ "path": "/", "mustContain": "npm version: 7" }]
 }

--- a/packages/build-utils/test/fixtures/20-npm-7/vercel.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/vercel.json
@@ -1,4 +1,4 @@
 {
   "version": 2,
-  "probes": [{ "path": "/", "mustContain": "npm version: 7" }]
+  "build": { "env": { "VERCEL_DEBUG": "1" } }
 }

--- a/packages/build-utils/test/fixtures/20-npm-7/vercel.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "probes": [{ "path": "/", "mustContain": "npm version: 7" }]
+}

--- a/packages/build-utils/test/fixtures/20-npm-7/vercel.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/vercel.json
@@ -1,4 +1,5 @@
 {
   "version": 2,
-  "build": { "env": { "VERCEL_DEBUG": "1" } }
+  "build": { "env": { "VERCEL_DEBUG": "1" } },
+  "probes": [{ "path": "/", "mustContain": "npm version: 7" }]
 }

--- a/packages/build-utils/test/fixtures/20-npm-7/vercel.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/static-build" }],
   "build": { "env": { "VERCEL_DEBUG": "1" } },
   "probes": [{ "path": "/", "mustContain": "npm version: 7" }]
 }

--- a/packages/build-utils/test/integration.test.ts
+++ b/packages/build-utils/test/integration.test.ts
@@ -30,7 +30,6 @@ const skipFixtures: string[] = [
   '06-zero-config-hugo',
   '07-zero-config-jekyll',
   '08-zero-config-middleman',
-  '20-npm-7',
 ];
 
 // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
As the title suggests, this PR makes it such that npm 7 will be invoked when there is a `package-lock.json` file with `lockfileVersion` 2 or greater, by prepending the the `$PATH` a directory within the build container where npm 7 is located.

The test fixture `20-npm-7` is also enabled for E2E testing, to ensure that the proper npm version is enabled in the production build.