### PR TITLE
[build-utils] Return "lockfileVersion" property in `scanParentDirs()` function 

### DIFF
--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -23,6 +23,7 @@ import {
   getNodeVersion,
   getSpawnOptions,
   getNodeBinPath,
+  scanParentDirs,
 } from './fs/run-user-scripts';
 import {
   getLatestNodeVersion,
@@ -68,6 +69,7 @@ export {
   debug,
   isSymbolicLink,
   getLambdaOptionsFromFunction,
+  scanParentDirs,
 };
 
 export {

--- a/packages/build-utils/test/fixtures/20-npm-7/package-lock.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "20-npm-7",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/build-utils/test/fixtures/20-npm-7/package.json
+++ b/packages/build-utils/test/fixtures/20-npm-7/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "20-npm-7",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/build-utils/test/integration.test.ts
+++ b/packages/build-utils/test/integration.test.ts
@@ -20,9 +20,13 @@ beforeAll(async () => {
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
+// Add the fixture name here, if it's only needed
+// for unit tests, and not integration tests
+const skipFixtures: string[] = ['20-npm-7'];
+
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
-  if (fixture.includes('zero-config')) {
+  if (fixture.includes('zero-config') || skipFixtures.includes(fixture)) {
     // Those have separate tests
     continue; // eslint-disable-line no-continue
   }

--- a/packages/build-utils/test/integration.test.ts
+++ b/packages/build-utils/test/integration.test.ts
@@ -20,14 +20,22 @@ beforeAll(async () => {
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
-// Add the fixture name here, if it's only needed
-// for unit tests, and not integration tests
-const skipFixtures: string[] = ['20-npm-7'];
+// Fixtures that have separate tests and should be skipped in the loop
+const skipFixtures: string[] = [
+  '01-zero-config-api',
+  '02-zero-config-api',
+  '03-zero-config-angular',
+  '04-zero-config-brunch',
+  '05-zero-config-gatsby',
+  '06-zero-config-hugo',
+  '07-zero-config-jekyll',
+  '08-zero-config-middleman',
+  '20-npm-7',
+];
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
-  if (fixture.includes('zero-config') || skipFixtures.includes(fixture)) {
-    // Those have separate tests
+  if (skipFixtures.includes(fixture)) {
     continue; // eslint-disable-line no-continue
   }
 

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -13,6 +13,7 @@ import {
   getDiscontinuedNodeVersions,
   runNpmInstall,
   runPackageJsonScript,
+  scanParentDirs,
 } from '../src';
 
 async function expectBuilderError(promise: Promise<any>, pattern: string) {
@@ -295,3 +296,26 @@ it(
   },
   ms('1m')
 );
+
+it('should return lockfileVersion 2 with npm7', async () => {
+  const packageLockJsonPath = path.join(__dirname, 'fixtures', '20-npm-7');
+  const result = await scanParentDirs(packageLockJsonPath);
+  expect(result.lockfileVersion).toEqual(2);
+});
+
+it('should not return lockfileVersion with yarn', async () => {
+  const packageLockJsonPath = path.join(__dirname, 'fixtures', '19-yarn-v2');
+  const result = await scanParentDirs(packageLockJsonPath);
+  expect(result.lockfileVersion).toEqual(undefined);
+});
+
+it('should return lockfileVersion 1 with older versions of npm', async () => {
+  const packageLockJsonPath = path.join(
+    __dirname,
+    'fixtures',
+    '08-yarn-npm/with-npm'
+  );
+  const result = await scanParentDirs(packageLockJsonPath);
+  console.log(result);
+  expect(result.lockfileVersion).toEqual(1);
+});

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -316,6 +316,5 @@ it('should return lockfileVersion 1 with older versions of npm', async () => {
     '08-yarn-npm/with-npm'
   );
   const result = await scanParentDirs(packageLockJsonPath);
-  console.log(result);
   expect(result.lockfileVersion).toEqual(1);
 });


### PR DESCRIPTION
### Related Issues
[23112](https://app.clubhouse.io/vercel/story/23112/make-scanparentdirs-function-return-the-lockfileversion-property)

#### Tests

- [* ] The code changed/added as part of this PR has been covered with tests
- [* ] All tests pass locally with `yarn test-unit`

#### Code Review

- [*] This PR has a concise title and thorough description useful to a reviewer
- [* ] Issue from task tracker has a link to this PR
