### PR TITLE
[cli] Fix in-flight re-login when there are no existing credentials

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -430,12 +430,16 @@ const main = async () => {
         return result;
       }
 
+      if (result.teamId) {
+        // SSO login, so set the current scope to the appropriate Team
+        client.config.currentTeam = result.teamId;
+      } else {
+        delete client.config.currentTeam;
+      }
+
       // When `result` is a string it's the user's authentication token.
       // It needs to be saved to the configuration file.
-      client.authConfig.token = result;
-
-      // New user, so we can't keep the team
-      delete client.config.currentTeam;
+      client.authConfig.token = result.token;
 
       configFiles.writeToAuthConfigFile(client.authConfig);
       configFiles.writeToConfigFile(client.config);


### PR DESCRIPTION
This logic broke because the `doLoginPrompt()` return value changed in #6415 (we really need to convert this `src/index.js` file to TypeScript).