### PR TITLE
[cli] Add "outDir" to `tsconfig.json`

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["esnext"],
     "resolveJsonModule": true,
     "sourceMap": true,
+    "outDir": "./dist",
     "typeRoots": ["./@types", "./node_modules/@types"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Fixes TypeScript errors:

<img width="932" alt="Screen Shot 2021-08-09 at 12 56 34 AM" src="https://user-images.githubusercontent.com/71256/128675400-86fa1cc0-c3ed-4136-8481-35ed7cd8485e.png">

The value doesn't really matter anyways, since we use `ncc` to compile the CLI, not `tsc`.