### PR TITLE
[cli] Remove unnecessary `await` in Dev tests

### DIFF
--- a/packages/cli/test/dev/integration.js
+++ b/packages/cli/test/dev/integration.js
@@ -258,7 +258,7 @@ function testFixtureStdio(
       const projectJsonPath = join(cwd, '.vercel', 'project.json');
       await fs.remove(projectJsonPath);
       const gitignore = join(cwd, '.gitignore');
-      const hasGitignore = await fs.exists(gitignore);
+      const hasGitignore = await fs.pathExists(gitignore);
 
       try {
         // Run `vc link`
@@ -469,7 +469,7 @@ test('[vercel dev] `vercel.json` should be invalidated if deleted', async t => {
       t.is(body.FOO, undefined);
     }
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
     await fs.writeJSON(configPath, originalConfig);
   }
 });
@@ -569,7 +569,7 @@ test('[vercel dev] reflects changes to config and env without restart', async t 
       t.is(body.query.foo, 'boo');
     }
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
     await fs.writeJSON(configPath, originalConfig);
   }
 });
@@ -598,7 +598,7 @@ test('[vercel dev] `@vercel/node` TypeScript should be resolved by default', asy
     const body = await res.text();
     t.is(body, 'world');
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
     await fs.remove(dir);
   }
 });
@@ -848,7 +848,7 @@ test('[vercel dev] validate env var names', async t => {
 
     t.pass();
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
   }
 
   t.pass();
@@ -1431,7 +1431,7 @@ test(
 test('[vercel dev] 24-ember', async t => {
   if (shouldSkip(t, '24-ember', '>^6.14.0 || ^8.10.0 || >=9.10.0')) return;
 
-  const tester = await testFixtureStdio(
+  const tester = testFixtureStdio(
     '24-ember',
     async testPath => {
       await testPath(200, '/', /HelloWorld/m);
@@ -1539,7 +1539,7 @@ test('[vercel dev] no build matches warning', async t => {
 
     t.pass();
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
   }
 });
 
@@ -1577,7 +1577,7 @@ test('[vercel dev] render warning for empty cwd dir', async t => {
     validateResponseHeaders(t, response);
     t.is(response.status, 404);
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
   }
 });
 
@@ -1617,7 +1617,7 @@ test('[vercel dev] do not rebuild for changes in the output directory', async t 
     const text2 = await resp2.text();
     t.is(text2.trim(), 'hello second', stderr.join(''));
   } finally {
-    await dev.kill('SIGTERM');
+    dev.kill('SIGTERM');
   }
 });
 


### PR DESCRIPTION
This is the result of VS Code's "remove all unneeded await calls" formatter.