### PR TITLE
[api] Fix `GET /api/examples/list` output

### DIFF
--- a/api/_lib/examples/summary.ts
+++ b/api/_lib/examples/summary.ts
@@ -15,5 +15,6 @@ export function summary(source: string) {
 
   return readdirSync(source, { withFileTypes: true })
     .filter(d => !isDotFile(d.name))
-    .filter(d => d.isDirectory());
+    .filter(d => d.isDirectory())
+    .map(d => d.name);
 }

--- a/api/_lib/examples/summary.ts
+++ b/api/_lib/examples/summary.ts
@@ -8,7 +8,7 @@ const exists = (path: string) => existsSync(path);
 const isDotFile = (name: string) => name.startsWith('.');
 const isDirectory = (path: string) => lstatSync(path).isDirectory();
 
-export function summary(source: string) {
+export function summary(source: string): string[] {
   if (!exists(source) || !isDirectory(source)) {
     return [];
   }


### PR DESCRIPTION
A regression from #6554 caused the return value to contain a nested object with a `name` property for the `name` key of the response in the list.