### PR TITLE
[cli] Support `--project` flag in `vc link` command

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -242,7 +242,6 @@ export default async (client: Client) => {
     });
 
     const projectOrNewProjectName = await inputProject(
-      output,
       client,
       org,
       detectedProjectName,

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -36,17 +36,11 @@ export default async function dev(
   ]);
 
   if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_DEV_CMD) {
-    const autoConfirm = opts['--confirm'] || false;
-    const forceDelete = false;
-
-    link = await setupAndLink(
-      client,
-      cwd,
-      forceDelete,
-      autoConfirm,
-      'link',
-      'Set up and develop'
-    );
+    link = await setupAndLink(client, cwd, {
+      autoConfirm: opts['--confirm'],
+      successEmoji: 'link',
+      setupMsg: 'Set up and develop',
+    });
 
     if (link.status === 'not_linked') {
       // User aborted project linking questions

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -59,7 +59,6 @@ export default async function main(client: Client) {
     forceDelete: true,
     autoConfirm: argv['--confirm'],
     projectName: argv['--project'],
-    scope: argv['--scope'],
     successEmoji: 'success',
     setupMsg: 'Set up',
   });

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -22,6 +22,9 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    -p ${chalk.bold.underline('NAME')}, --project=${chalk.bold.underline(
+    'NAME'
+  )}        Project name
     --confirm                      Confirm default options and skip questions
 
   ${chalk.dim('Examples:')}

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import Client from '../../util/client';
 import getArgs from '../../util/get-args';
-import getSubcommand from '../../util/get-subcommand';
-import handleError from '../../util/handle-error';
 import logo from '../../util/output/logo';
 import { getPkgName } from '../../util/pkg-name';
 import setupAndLink from '../../util/link/setup-and-link';
@@ -44,40 +42,27 @@ const help = () => {
 `);
 };
 
-const COMMAND_CONFIG = {
-  // No subcommands yet
-};
-
 export default async function main(client: Client) {
-  let argv;
-
-  try {
-    argv = getArgs(client.argv.slice(2), {
-      '--confirm': Boolean,
-    });
-  } catch (error) {
-    handleError(error);
-    return 1;
-  }
+  const argv = getArgs(client.argv.slice(2), {
+    '--confirm': Boolean,
+    '--project': String,
+    '-p': '--project',
+  });
 
   if (argv['--help']) {
     help();
     return 2;
   }
 
-  const { args } = getSubcommand(argv._.slice(1), COMMAND_CONFIG);
-  const path = args[0] || process.cwd();
-  const autoConfirm = argv['--confirm'] || false;
-  const forceDelete = true;
-
-  const link = await setupAndLink(
-    client,
-    path,
-    forceDelete,
-    autoConfirm,
-    'success',
-    'Set up'
-  );
+  const cwd = argv._[1] || process.cwd();
+  const link = await setupAndLink(client, cwd, {
+    forceDelete: true,
+    autoConfirm: argv['--confirm'],
+    projectName: argv['--project'],
+    scope: argv['--scope'],
+    successEmoji: 'success',
+    setupMsg: 'Set up',
+  });
 
   if (link.status === 'error') {
     return link.exitCode;

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -4,17 +4,16 @@ import confirm from './confirm';
 import getProjectByIdOrName from '../projects/get-project-by-id-or-name';
 import chalk from 'chalk';
 import { ProjectNotFound } from '../../util/errors-ts';
-import { Output } from '../output';
 import { Project, Org } from '../../types';
 import slugify from '@sindresorhus/slugify';
 
 export default async function inputProject(
-  output: Output,
   client: Client,
   org: Org,
   detectedProjectName: string,
   autoConfirm: boolean
 ): Promise<Project | string> {
+  const { output } = client;
   const slugifiedName = slugify(detectedProjectName);
 
   // attempt to auto-detect a project to link

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -9,7 +9,8 @@ type Choice = { name: string; value: Org };
 export default async function selectOrg(
   client: Client,
   question: string,
-  autoConfirm?: boolean
+  autoConfirm?: boolean,
+  scope?: string
 ): Promise<Org> {
   require('./patch-inquirer');
   const {
@@ -36,6 +37,18 @@ export default async function selectOrg(
       value: { type: 'team', id: team.id, slug: team.slug },
     })),
   ];
+
+  // If an explicit `scope` was provided then
+  // try to match the correct `org` choince
+  if (scope) {
+    const choice = choices.find(
+      ({ value }) => value.id === scope || value.slug === scope
+    );
+    if (!choice) {
+      throw new Error('bad');
+    }
+    return choice.value;
+  }
 
   const defaultOrgIndex = teams.findIndex(team => team.id === currentTeam) + 1;
 

--- a/packages/cli/src/util/input/select-org.ts
+++ b/packages/cli/src/util/input/select-org.ts
@@ -9,8 +9,7 @@ type Choice = { name: string; value: Org };
 export default async function selectOrg(
   client: Client,
   question: string,
-  autoConfirm?: boolean,
-  scope?: string
+  autoConfirm?: boolean
 ): Promise<Org> {
   require('./patch-inquirer');
   const {
@@ -37,18 +36,6 @@ export default async function selectOrg(
       value: { type: 'team', id: team.id, slug: team.slug },
     })),
   ];
-
-  // If an explicit `scope` was provided then
-  // try to match the correct `org` choince
-  if (scope) {
-    const choice = choices.find(
-      ({ value }) => value.id === scope || value.slug === scope
-    );
-    if (!choice) {
-      throw new Error('bad');
-    }
-    return choice.value;
-  }
 
   const defaultOrgIndex = teams.findIndex(team => team.id === currentTeam) + 1;
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -107,7 +107,6 @@ export default async function setupAndLink(
   const detectedProjectName = projectName || basename(path);
 
   const projectOrNewProjectName = await inputProject(
-    output,
     client,
     org,
     detectedProjectName,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -25,13 +25,26 @@ import { EmojiLabel } from '../emoji';
 import createDeploy from '../deploy/create-deploy';
 import Now from '../index';
 
+export interface SetupAndLinkOptions {
+  forceDelete?: boolean;
+  autoConfirm?: boolean;
+  successEmoji: EmojiLabel;
+  setupMsg: string;
+  scope?: string;
+  projectName?: string;
+}
+
 export default async function setupAndLink(
   client: Client,
   path: string,
-  forceDelete: boolean,
-  autoConfirm: boolean,
-  successEmoji: EmojiLabel,
-  setupMsg: string
+  {
+    forceDelete = false,
+    autoConfirm = false,
+    successEmoji,
+    setupMsg,
+    scope,
+    projectName,
+  }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const {
     authConfig: { token },
@@ -79,7 +92,8 @@ export default async function setupAndLink(
     org = await selectOrg(
       client,
       'Which scope should contain your project?',
-      autoConfirm
+      autoConfirm,
+      scope
     );
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {
@@ -90,7 +104,7 @@ export default async function setupAndLink(
     throw err;
   }
 
-  const detectedProjectName = basename(path);
+  const detectedProjectName = projectName || basename(path);
 
   const projectOrNewProjectName = await inputProject(
     output,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -30,7 +30,6 @@ export interface SetupAndLinkOptions {
   autoConfirm?: boolean;
   successEmoji: EmojiLabel;
   setupMsg: string;
-  scope?: string;
   projectName?: string;
 }
 
@@ -42,7 +41,6 @@ export default async function setupAndLink(
     autoConfirm = false,
     successEmoji,
     setupMsg,
-    scope,
     projectName,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
@@ -92,8 +90,7 @@ export default async function setupAndLink(
     org = await selectOrg(
       client,
       'Which scope should contain your project?',
-      autoConfirm,
-      scope
+      autoConfirm
     );
   } catch (err) {
     if (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED') {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -3643,3 +3643,19 @@ test('[vc dev] should send the platform proxy request headers to frontend dev se
     process.kill(dev.pid, 'SIGTERM');
   }
 });
+
+test('[vc link] should support the `--project` flag', async t => {
+  const projectName = 'link-project-flag';
+  const directory = fixture('static-deployment');
+
+  const [user, output] = await Promise.all([
+    fetchTokenInformation(token),
+    execute(['link', '--confirm', '--project', projectName, directory]),
+  ]);
+
+  t.is(output.exitCode, 0, formatOutput(output));
+  t.true(
+    output.stderr.includes(`Linked to ${user.username}/${projectName}`),
+    formatOutput(output)
+  );
+});


### PR DESCRIPTION
To make setting up local dev README instructions easier for new users being introduced to a Vercel project, support flags to make the `vc link` command be non-interactive, in the case where the project name does not match the name of the directory where the code is located:

```
$ vc link --scope acme --project docs
```

Related to https://github.com/vercel/front/pull/10732.