### PR TITLE
[cli] Remove broken `vc downgrade` command

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -10,7 +10,6 @@ export default new Map([
   ['dns', 'dns'],
   ['domain', 'domains'],
   ['domains', 'domains'],
-  ['downgrade', 'upgrade'],
   ['env', 'env'],
   ['help', 'help'],
   ['init', 'init'],


### PR DESCRIPTION
It maps to an "upgrade" command, which does not exist.

Fixes:

```
$ vc downgrade
Vercel CLI 23.1.2
Error! Cannot find module './upgrade'
```