### PR TITLE
Make "vercel dev" work with Ionic Angular projects

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -682,14 +682,14 @@ export const frameworks = [
         placeholder: '`npm run build` or `ng build`',
       },
       devCommand: {
-        value: 'ng serve',
+        value: 'ng serve --port $PORT',
       },
       outputDirectory: {
         value: 'www',
       },
     },
     dependency: '@ionic/angular',
-    devCommand: 'ng serve',
+    devCommand: 'ng serve --port $PORT',
     buildCommand: 'ng build',
     getOutputDirName: async () => 'www',
     defaultRoutes: [


### PR DESCRIPTION
When testing Vercel's serverless functions feature locally in an Ionic Angular project, the `vercel dev` command runs `ng serve`. The Angular project runs/serves correctly but the API located in the same project does not run at all.

To fix this, the dev command should have `--port $PORT` appended, just like the Vercel CLI uses for regular Angular projects (Ionic Angular projects are, in fact, just Angular projects).


### Related Issues

> Fixes #1
> Related to #2

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [X] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
