### PR TITLE
Use pip --upgrade when installing python function dependencies

### DIFF
--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -86,6 +86,10 @@ interface InstallRequirementArg {
   args?: string[];
 }
 
+// note that any internal dependency that vc_init.py requires that's installed
+// with this function can get overriden by a newer version from requirements.txt,
+// so vc_init should do runtime version checks to be compatible with any recent
+// version of its dependencies
 export async function installRequirement({
   dependency,
   version,
@@ -120,5 +124,5 @@ export async function installRequirementsFile({
     debug(`Skipping requirements file installation, already installed`);
     return;
   }
-  await pipInstall(workPath, ['-r', filePath, ...args]);
+  await pipInstall(workPath, ['--upgrade', '-r', filePath, ...args]);
 }

--- a/packages/python/test/fixtures/29-flask2/api/werkzeug_version.py
+++ b/packages/python/test/fixtures/29-flask2/api/werkzeug_version.py
@@ -1,0 +1,11 @@
+import werkzeug
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def main(path):
+    return werkzeug.__version__
+
+if __name__ == '__main__':
+    app.run(debug=True, port=8002)

--- a/packages/python/test/fixtures/29-flask2/requirements.txt
+++ b/packages/python/test/fixtures/29-flask2/requirements.txt
@@ -1,0 +1,2 @@
+flask==2.0.1
+werkzeug==2.0.1

--- a/packages/python/test/fixtures/29-flask2/vercel.json
+++ b/packages/python/test/fixtures/29-flask2/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/*.py", "use": "@vercel/python" }],
+  "probes": [
+    {
+      "path": "/api/werkzeug_version.py",
+      "mustContain": "2.0.1"
+    }
+  ]
+}


### PR DESCRIPTION
Passes `--upgrade` to `pip install -r` so that werkzeug 2.0 can be installed if that's a dependency of the function.

### Related Issues

> Related to https://github.com/vercel/vercel/pull/6272#issuecomment-913226139

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

<!-- - [ ] The code changed/added as part of this PR has been covered with tests -->
<!-- - [ ] All tests pass locally with `yarn test-unit` -->

I don't think there's a good way to test this, but let me know if I'm wrong - it seems like the fixture tests just check that the runtime can build them.

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
<!-- - [ ] Issue from task tracker has a link to this PR -->
