### PR TITLE
[routing-utils] Ensure headers with only has items are replaced correctly

### DIFF
--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -112,7 +112,7 @@ export function convertHeaders(headers: Header[]): Route[] {
     });
 
     h.headers.forEach(({ key, value }) => {
-      if (namedSegments.length > 0) {
+      if (namedSegments.length > 0 || hasSegments.length > 0) {
         if (key.includes(':')) {
           key = safelyCompile(key, indexes);
         }

--- a/packages/routing-utils/test/superstatic.spec.js
+++ b/packages/routing-utils/test/superstatic.spec.js
@@ -938,6 +938,22 @@ test('convertHeaders', () => {
         },
       ],
     },
+    {
+      source: '/(.*)',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value:
+            "frame-ancestors 'self' https://test-app.vercel.app https://:shop;",
+        },
+      ],
+      has: [
+        {
+          type: 'query',
+          key: 'shop',
+        },
+      ],
+    },
   ]);
 
   const expected = [
@@ -1040,6 +1056,20 @@ test('convertHeaders', () => {
         'x-$d': 'd',
       },
     },
+    {
+      continue: true,
+      has: [
+        {
+          key: 'shop',
+          type: 'query',
+        },
+      ],
+      headers: {
+        'Content-Security-Policy':
+          "frame-ancestors 'self' https://test-app.vercel.app https://$shop;",
+      },
+      src: '^(?:\\/(.*))$',
+    },
   ];
 
   deepEqual(actual, expected);
@@ -1051,6 +1081,7 @@ test('convertHeaders', () => {
     ['/like/params/first', '/like/params/second'],
     ['/hello/world'],
     ['/hello/world'],
+    ['/hello'],
   ];
 
   const mustNotMatch = [
@@ -1060,6 +1091,7 @@ test('convertHeaders', () => {
     ['/non-match', '/like/params', '/like/params/'],
     ['/hellooo'],
     ['/hellooo'],
+    [],
   ];
 
   assertRegexMatches(actual, mustMatch, mustNotMatch);


### PR DESCRIPTION
This ensures we replace header values correctly when no named segments are used and only has items are used. 

### Related Issues

Fixes: https://vercel.slack.com/archives/CHTTGQYQ4/p1631023974185700

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
