### PR TITLE
[routing-utils] Fix host segment replacing

### DIFF
--- a/packages/routing-utils/test/superstatic.spec.js
+++ b/packages/routing-utils/test/superstatic.spec.js
@@ -474,6 +474,7 @@ test('convertRewrites', () => {
   const actual = convertRewrites([
     { source: '/some/old/path', destination: '/some/new/path' },
     { source: '/proxy/(.*)', destination: 'https://www.firebase.com' },
+    { source: '/proxy/(.*)', destination: 'https://www.firebase.com/' },
     {
       source: '/proxy-regex/([a-zA-Z]{1,})',
       destination: 'https://firebase.com/$1',
@@ -582,6 +583,11 @@ test('convertRewrites', () => {
 
   const expected = [
     { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', check: true },
+    {
+      src: '^\\/proxy(?:\\/(.*))$',
+      dest: 'https://www.firebase.com/',
+      check: true,
+    },
     {
       src: '^\\/proxy(?:\\/(.*))$',
       dest: 'https://www.firebase.com/',
@@ -729,6 +735,7 @@ test('convertRewrites', () => {
   const mustMatch = [
     ['/some/old/path'],
     ['/proxy/one', '/proxy/two'],
+    ['/proxy/one', '/proxy/two'],
     ['/proxy-regex/admin', '/proxy-regex/anotherAdmin'],
     ['/proxy-port/admin', '/proxy-port/anotherAdmin'],
     ['/projects/one/edit', '/projects/two/edit'],
@@ -752,6 +759,7 @@ test('convertRewrites', () => {
 
   const mustNotMatch = [
     ['/nope'],
+    ['/prox', '/proxyed/two'],
     ['/prox', '/proxyed/two'],
     ['/proxy-regex/user/1', '/proxy-regex/another/1'],
     ['/proxy-port/user/1', '/proxy-port/another/1'],

--- a/packages/routing-utils/test/superstatic.spec.js
+++ b/packages/routing-utils/test/superstatic.spec.js
@@ -147,6 +147,11 @@ test('convertCleanUrls false', () => {
 
 test('convertRedirects', () => {
   const actual = convertRedirects([
+    {
+      source: '/(.*)',
+      has: [{ type: 'host', value: '(?<subdomain>.*)-test.vercel.app' }],
+      destination: 'https://:subdomain.example.com/some-path/end?a=b',
+    },
     { source: '/some/old/path', destination: '/some/new/path' },
     { source: '/next(\\.js)?', destination: 'https://nextjs.org' },
     {
@@ -256,6 +261,19 @@ test('convertRedirects', () => {
   ]);
 
   const expected = [
+    {
+      has: [
+        {
+          type: 'host',
+          value: '(?<subdomain>.*)-test.vercel.app',
+        },
+      ],
+      headers: {
+        Location: 'https://$subdomain.example.com/some-path/end?a=b',
+      },
+      src: '^(?:\\/(.*))$',
+      status: 308,
+    },
     {
       src: '^\\/some\\/old\\/path$',
       headers: { Location: '/some/new/path' },
@@ -406,6 +424,7 @@ test('convertRedirects', () => {
   deepEqual(actual, expected);
 
   const mustMatch = [
+    ['/hello'],
     ['/some/old/path'],
     ['/next', '/next.js'],
     ['/proxy/one', '/proxy/2', '/proxy/-', '/proxy/dir/sub'],
@@ -427,6 +446,7 @@ test('convertRedirects', () => {
   ];
 
   const mustNotMatch = [
+    [],
     ['/nope'],
     ['/nextAjs', '/nextjs'],
     ['/prox', '/proxyed/two'],
@@ -564,7 +584,7 @@ test('convertRewrites', () => {
     { src: '^\\/some\\/old\\/path$', dest: '/some/new/path', check: true },
     {
       src: '^\\/proxy(?:\\/(.*))$',
-      dest: 'https://www.firebase.com',
+      dest: 'https://www.firebase.com/',
       check: true,
     },
     {


### PR DESCRIPTION
This fixes segments inside of the host of the destination failing to parse with `url.parse` due to the unexpected colon by escaping the colon for segments and then unescaping them after we have parsed the URL. 

### Related Issues

Fixes: https://vercel.slack.com/archives/CLDDX2Y0G/p1631496861015500

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
