### PR TITLE
[cli] Fix swapped error messages in `executeBuild`

### DIFF
--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -217,13 +217,13 @@ export async function executeBuild(
 
     if (output.maxDuration) {
       throw new Error(
-        'The result of "builder.build()" must not contain `memory`'
+        'The result of "builder.build()" must not contain `maxDuration`'
       );
     }
 
     if (output.memory) {
       throw new Error(
-        'The result of "builder.build()" must not contain `maxDuration`'
+        'The result of "builder.build()" must not contain `memory`'
       );
     }
 


### PR DESCRIPTION
This fixes two error messages which appear, based on the if-conditions to which they're respectively attached,
 to have been swapped.

### Related Issues

None, because this is a tiny change, but I can make one if you'd like me to.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR (not sure what to do with this one)
