### PR TITLE
[node] Bump nft to 0.14.0

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,7 +33,7 @@
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
     "@vercel/ncc": "0.31.1",
-    "@vercel/nft": "0.13.1",
+    "@vercel/nft": "0.14.0",
     "@vercel/node-bridge": "2.1.1-canary.1",
     "content-type": "1.0.4",
     "cookie": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,14 +2498,15 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.31.1.tgz#9346c7e59326f5eeac75c0286e47df94c2d6d8f7"
   integrity sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==
 
-"@vercel/nft@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.13.1.tgz#98df07e04620069ba63fff92af490c5842a2f31f"
-  integrity sha512-7pBTfSkwhhcPAeGVsFml5YX7LCZgtocP+zTAknnRK2u/RsV3GGqOD5yw7CtbgTpfjY8NfXWzwoxF1zOUEVsbww==
+"@vercel/nft@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.14.0.tgz#e9a6c33508881837ede68d59763fa1dc9fab7cbb"
+  integrity sha512-E3fVM+/ZygEs4AS9Wyx/ZyzpvjGMs20E0IfuqGgixUIj0Xnebl0260WqVvKLVuw/Z9oK4ZwoC+n/6JIMWivpfw==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.5"
     acorn "^8.3.0"
     acorn-class-fields "^1.0.0"
+    acorn-private-class-elements "^1.0.0"
     acorn-static-class-features "^1.0.0"
     bindings "^1.4.0"
     estree-walker "^0.6.1"


### PR DESCRIPTION
This PR bumps `@vercel/nft` to version [0.14.0](https://github.com/vercel/nft/releases/tag/0.14.0).