### PR TITLE
[all] Revert to `@vercel/ncc@0.24.0`

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -31,7 +31,7 @@
     "@types/semver": "6.0.0",
     "@types/yazl": "^2.4.1",
     "@vercel/frameworks": "0.5.1-canary.5",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "aggregate-error": "3.0.1",
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -31,7 +31,7 @@
     "@types/semver": "6.0.0",
     "@types/yazl": "^2.4.1",
     "@vercel/frameworks": "0.5.1-canary.5",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "aggregate-error": "3.0.1",
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "@types/which": "1.3.2",
     "@types/write-json-file": "2.2.1",
     "@vercel/frameworks": "0.5.1-canary.5",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "@zeit/fun": "0.11.2",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.12.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "@types/which": "1.3.2",
     "@types/write-json-file": "2.2.1",
     "@vercel/frameworks": "0.5.1-canary.5",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "@zeit/fun": "0.11.2",
     "@zeit/source-map-support": "0.6.2",
     "ajv": "6.12.2",

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -50,7 +50,13 @@ async function main() {
   // Do the initial `ncc` build
   console.log();
   const src = join(dirRoot, 'src/index.ts');
-  const args = ['ncc', 'build', '--external', 'update-notifier'];
+  const args = [
+    'ncc',
+    'build',
+    '--no-asset-builds',
+    '--external',
+    'update-notifier',
+  ];
   if (isDev) {
     args.push('--source-map');
   }

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -49,19 +49,12 @@ async function main() {
 
   // Do the initial `ncc` build
   console.log();
-  const src = join(dirRoot, 'src/index.ts');
-  const args = [
-    'ncc',
-    'build',
-    '--no-asset-builds',
-    '--external',
-    'update-notifier',
-  ];
+  const args = ['ncc', 'build', '--external', 'update-notifier'];
   if (isDev) {
     args.push('--source-map');
   }
-  args.push(src);
-  await execa('yarn', args, { stdio: 'inherit' });
+  args.push('src/index.ts');
+  await execa('yarn', args, { stdio: 'inherit', cwd: dirRoot });
 
   // `ncc` has some issues with `@zeit/fun`'s runtime files:
   //   - Executable bits on the `bootstrap` files appear to be lost:

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -24,7 +24,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "^4.0.0",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "async-retry": "1.3.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -24,7 +24,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "^4.0.0",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "async-retry": "1.3.1",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,7 +32,7 @@
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "@vercel/nft": "0.14.0",
     "@vercel/node-bridge": "2.1.1-canary.1",
     "content-type": "1.0.4",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,7 +32,7 @@
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
     "@types/test-listen": "1.1.0",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "@vercel/nft": "0.14.0",
     "@vercel/node-bridge": "2.1.1-canary.1",
     "content-type": "1.0.4",

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/execa": "^0.9.0",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "execa": "^1.0.0",
     "typescript": "4.3.4"
   }

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/execa": "^0.9.0",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "execa": "^1.0.0",
     "typescript": "4.3.4"
   }

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/fs-extra": "8.0.0",
     "@types/semver": "6.0.0",
-    "@vercel/ncc": "0.31.1",
+    "@vercel/ncc": "0.26.2",
     "execa": "2.0.4",
     "fs-extra": "^7.0.1",
     "semver": "6.1.1",

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/fs-extra": "8.0.0",
     "@types/semver": "6.0.0",
-    "@vercel/ncc": "0.26.2",
+    "@vercel/ncc": "0.24.0",
     "execa": "2.0.4",
     "fs-extra": "^7.0.1",
     "semver": "6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,11 +2498,6 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.26.2.tgz#d0799374eb8618e48cc0841c82793b5b670c9219"
   integrity sha512-qdajZzkGn62Ry+v7bmTSd7Qza2BVjEBuCcGpxCV5Y+ANa6d//BzByMkODmYQAhAXOg6kiAgVpbnfsd/At3PWQA==
 
-"@vercel/ncc@0.31.1":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.31.1.tgz#9346c7e59326f5eeac75c0286e47df94c2d6d8f7"
-  integrity sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==
-
 "@vercel/nft@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.14.0.tgz#e9a6c33508881837ede68d59763fa1dc9fab7cbb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@
     "@typescript-eslint/types" "4.28.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/ncc@0.26.2":
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.26.2.tgz#d0799374eb8618e48cc0841c82793b5b670c9219"
-  integrity sha512-qdajZzkGn62Ry+v7bmTSd7Qza2BVjEBuCcGpxCV5Y+ANa6d//BzByMkODmYQAhAXOg6kiAgVpbnfsd/At3PWQA==
+"@vercel/ncc@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
+  integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
 
 "@vercel/nft@0.14.0":
   version "0.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,6 +2493,11 @@
     "@typescript-eslint/types" "4.28.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/ncc@0.26.2":
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.26.2.tgz#d0799374eb8618e48cc0841c82793b5b670c9219"
+  integrity sha512-qdajZzkGn62Ry+v7bmTSd7Qza2BVjEBuCcGpxCV5Y+ANa6d//BzByMkODmYQAhAXOg6kiAgVpbnfsd/At3PWQA==
+
 "@vercel/ncc@0.31.1":
   version "0.31.1"
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.31.1.tgz#9346c7e59326f5eeac75c0286e47df94c2d6d8f7"


### PR DESCRIPTION
Reverted #6605 and #6700 which was causing problems when updating the API