### PR TITLE
[frameworks] Add `nuxt3` to framework detection

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1291,7 +1291,7 @@ export const frameworks = [
         {
           path: 'package.json',
           matchContent:
-            '"(dev)?(d|D)ependencies":\\s*{[^}]*"nuxt(-edge)?":\\s*".+?"[^}]*}',
+            '"(dev)?(d|D)ependencies":\\s*{[^}]*"nuxt3?(-edge)?":\\s*".+?"[^}]*}',
         },
       ],
     },


### PR DESCRIPTION
### Related Issues

Adds `nuxt3` to the framework detection.

![image](https://user-images.githubusercontent.com/16088670/136936141-eabe8907-8e4b-4fc8-a5ba-ae6c042045dd.png)

### 📋 Checklist

- [x] Add regex

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
