### PR TITLE
[cli] Add `outputBuffer` getter and mutable `isTTY` for tests

### DIFF
--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -20,15 +20,13 @@ export class Output {
   private debugEnabled: boolean;
   private spinnerMessage: string;
   private _spinner: StopSpinner | null;
+  isTTY: boolean;
 
   constructor({ debug: debugEnabled = false }: OutputOptions = {}) {
     this.debugEnabled = debugEnabled;
     this.spinnerMessage = '';
     this._spinner = null;
-  }
-
-  get isTTY() {
-    return process.stdout.isTTY;
+    this.isTTY = process.stdout.isTTY || false;
   }
 
   isDebugEnabled = () => {

--- a/packages/cli/test/commands/inspect.test.ts
+++ b/packages/cli/test/commands/inspect.test.ts
@@ -23,7 +23,7 @@ describe('inspect', () => {
     client.setArgv('inspect', 'bad.com');
     const exitCode = await inspect(client);
     expect(exitCode).toEqual(1);
-    expect(client.mockOutput.mock.calls[0][0]).toEqual(
+    expect(client.outputBuffer).toEqual(
       `Error! Failed to find deployment "bad.com" in ${user.username}\n`
     );
   });

--- a/packages/cli/test/commands/login.test.ts
+++ b/packages/cli/test/commands/login.test.ts
@@ -6,11 +6,8 @@ describe('login', () => {
     client.setArgv('login', '--token', 'foo');
     const exitCode = await login(client);
     expect(exitCode).toEqual(2);
-    expect(client.mockOutput.mock.calls.length).toEqual(1);
-    expect(
-      client.mockOutput.mock.calls[0][0].includes(
-        '`--token` may not be used with the "login" command'
-      )
-    ).toEqual(true);
+    expect(client.outputBuffer).toEqual(
+      'Error! `--token` may not be used with the "login" command\n'
+    );
   });
 });

--- a/packages/cli/test/commands/whoami.test.ts
+++ b/packages/cli/test/commands/whoami.test.ts
@@ -14,7 +14,14 @@ describe('whoami', () => {
     const user = useUser();
     const exitCode = await whoami(client);
     expect(exitCode).toEqual(0);
-    expect(client.mockOutput.mock.calls.length).toEqual(1);
-    expect(client.mockOutput.mock.calls[0][0]).toEqual(`${user.username}\n`);
+    expect(client.outputBuffer).toEqual(`> ${user.username}\n`);
+  });
+
+  it('should print only the Vercel username when output is not a TTY', async () => {
+    const user = useUser();
+    client.output.isTTY = false;
+    const exitCode = await whoami(client);
+    expect(exitCode).toEqual(0);
+    expect(client.outputBuffer).toEqual(`${user.username}\n`);
   });
 });

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -69,6 +69,12 @@ export class MockClient extends Client {
     this.output.spinner = () => {};
 
     this.scenario = Router();
+
+    this.output.isTTY = true;
+  }
+
+  get outputBuffer() {
+    return this.mockOutput.mock.calls.map(c => c[0]).join('');
   }
 
   async startMockServer() {


### PR DESCRIPTION
These changes related to CLI tests arer originally from #6652, but pulled out to be merged separately.

- `outputBuffer` is a simpler way of asserting tests against the CLI output instead of working directly withe Jest mock function.
- `output.isTTY` is also now mutable, so that we can write tests for both cases when the output is different based on TTY-ness (for example, see the updated `vc whoami` tests in this PR).