### PR TITLE
[build-utils] Add regions to lambda options

### DIFF
--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -20,6 +20,7 @@ interface LambdaOptions {
   maxDuration?: number;
   environment: Environment;
   allowQuery?: string[];
+  regions?: string[];
 }
 
 interface CreateLambdaOptions {
@@ -30,6 +31,7 @@ interface CreateLambdaOptions {
   maxDuration?: number;
   environment?: Environment;
   allowQuery?: string[];
+  regions?: string[];
 }
 
 interface GetLambdaOptionsFromFunctionOptions {
@@ -46,6 +48,7 @@ export class Lambda {
   public maxDuration?: number;
   public environment: Environment;
   public allowQuery?: string[];
+  public regions?: string[];
 
   constructor({
     zipBuffer,
@@ -55,6 +58,7 @@ export class Lambda {
     memory,
     environment,
     allowQuery,
+    regions,
   }: LambdaOptions) {
     this.type = 'Lambda';
     this.zipBuffer = zipBuffer;
@@ -64,6 +68,7 @@ export class Lambda {
     this.maxDuration = maxDuration;
     this.environment = environment;
     this.allowQuery = allowQuery;
+    this.regions = regions;
   }
 }
 
@@ -78,6 +83,7 @@ export async function createLambda({
   maxDuration,
   environment = {},
   allowQuery,
+  regions,
 }: CreateLambdaOptions): Promise<Lambda> {
   assert(typeof files === 'object', '"files" must be an object');
   assert(typeof handler === 'string', '"handler" is not a string');
@@ -100,6 +106,14 @@ export async function createLambda({
     );
   }
 
+  if (regions !== undefined) {
+    assert(Array.isArray(regions), '"regions" is not an Array');
+    assert(
+      regions.every(r => typeof r === 'string'),
+      '"regions" is not a string Array'
+    );
+  }
+
   await sema.acquire();
 
   try {
@@ -111,6 +125,7 @@ export async function createLambda({
       memory,
       maxDuration,
       environment,
+      regions,
     });
   } finally {
     sema.release();


### PR DESCRIPTION
This is required for being able to specify regions in functions config in the File System API

### Related Issues

> Related to https://github.com/vercel/runtimes/issues/157

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
