### PR TITLE
[cli] Use getters for `Now` props that mirror `Client`

### DIFF
--- a/packages/cli/src/commands/billing/index.js
+++ b/packages/cli/src/commands/billing/index.js
@@ -51,8 +51,6 @@ const help = () => {
 };
 
 let argv;
-let debug;
-let apiUrl;
 let subcommand;
 
 export default async client => {
@@ -65,8 +63,6 @@ export default async client => {
 
   argv._ = argv._.slice(1);
 
-  debug = argv['--debug'];
-  apiUrl = client.apiUrl;
   subcommand = argv._[0];
 
   if (argv['--help'] || !subcommand) {
@@ -76,17 +72,13 @@ export default async client => {
 
   const {
     output,
-    authConfig: { token },
     config: { currentTeam },
   } = client;
 
   const start = new Date();
   const creditCards = new NowCreditCards({
-    apiUrl,
-    token,
-    debug,
+    client,
     currentTeam,
-    output,
   });
 
   let contextName = null;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -62,11 +62,7 @@ import { Output } from '../../util/output';
 import { help } from './args';
 
 export default async (client: Client) => {
-  const {
-    apiUrl,
-    output,
-    authConfig: { token },
-  } = client;
+  const { output } = client;
 
   let argv = null;
 
@@ -157,10 +153,8 @@ export default async (client: Client) => {
     }
   }
 
-  const { log, debug, error, warn } = output;
-  const debugEnabled = argv['--debug'];
+  const { log, debug, error, warn, isTTY } = output;
 
-  const { isTTY } = process.stdout;
   const quiet = !isTTY;
 
   // check paths
@@ -437,11 +431,8 @@ export default async (client: Client) => {
 
   const currentTeam = org?.type === 'team' ? org.id : undefined;
   const now = new Now({
-    apiUrl,
-    token,
-    debug: debugEnabled,
+    client,
     currentTeam,
-    output,
   });
   let deployStamp = stamp();
   let deployment = null;

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -77,14 +77,8 @@ export default async function main(client: Client) {
     return 1;
   }
 
-  const {
-    authConfig: { token },
-    output,
-    apiUrl,
-    config,
-  } = client;
+  const { output, config } = client;
 
-  const debugEnabled = argv['--debug'];
   const { print, log, error, note, debug, spinner } = output;
 
   if (argv._.length > 2) {
@@ -126,10 +120,7 @@ export default async function main(client: Client) {
   spinner(`Fetching deployments in ${chalk.bold(contextName)}`);
 
   const now = new Now({
-    apiUrl,
-    token,
-    debug: debugEnabled,
-    output,
+    client,
     currentTeam,
   });
   const start = Date.now();

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -85,8 +85,6 @@ export default async function main(client: Client) {
   argv._ = argv._.slice(1);
 
   const {
-    apiUrl,
-    authConfig: { token },
     output,
     config: { currentTeam },
   } = client;
@@ -245,11 +243,8 @@ export default async function main(client: Client) {
   }
 
   const now = new Now({
-    apiUrl,
-    token,
-    debug: argv['--debug'],
+    client,
     currentTeam,
-    output,
   });
   const start = Date.now();
 

--- a/packages/cli/src/commands/secrets.js
+++ b/packages/cli/src/commands/secrets.js
@@ -72,8 +72,6 @@ const help = () => {
 
 // Options
 let argv;
-let debug;
-let apiUrl;
 let subcommand;
 let nextTimestamp;
 
@@ -90,8 +88,6 @@ const main = async client => {
 
   argv._ = argv._.slice(1);
 
-  debug = argv.debug;
-  apiUrl = client.apiUrl;
   subcommand = argv._[0];
   nextTimestamp = argv.next;
 
@@ -101,7 +97,6 @@ const main = async client => {
   }
 
   const {
-    authConfig: { token },
     output,
     config: { currentTeam },
   } = client;
@@ -118,7 +113,7 @@ const main = async client => {
     throw err;
   }
 
-  return run({ output, token, contextName, currentTeam, client });
+  return run({ output, contextName, currentTeam, client });
 };
 
 export default async client => {
@@ -130,8 +125,8 @@ export default async client => {
   }
 };
 
-async function run({ output, token, contextName, currentTeam, client }) {
-  const secrets = new NowSecrets({ apiUrl, token, debug, currentTeam, output });
+async function run({ output, contextName, currentTeam, client }) {
+  const secrets = new NowSecrets({ client, currentTeam });
   const args = argv._.slice(1);
   const start = Date.now();
   const { 'test-warning': testWarningFlag } = argv;

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -43,13 +43,7 @@ export default async function setupAndLink(
     projectName,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
-  const {
-    authConfig: { token },
-    localConfig,
-    apiUrl,
-    output,
-    config,
-  } = client;
+  const { localConfig, output, config } = client;
   const debug = output.isDebugEnabled();
 
   const isFile = !isDirectory(path);
@@ -153,10 +147,7 @@ export default async function setupAndLink(
 
     if (isZeroConfig) {
       const now = new Now({
-        apiUrl,
-        token,
-        debug,
-        output,
+        client,
         currentTeam: config.currentTeam,
       });
       const createArgs: CreateOptions = {


### PR DESCRIPTION
This will prevent any issues where the `Now` instance is out-of-sync with the `Client` instance, for example, during a re-auth where a new auth token is issued. Also reduces a bit of code which is nice.