### PR TITLE
[cli] Don't pass `teamId` query param to `/verify` token endpoint

### DIFF
--- a/packages/cli/src/util/login/verify.ts
+++ b/packages/cli/src/util/login/verify.ts
@@ -31,5 +31,5 @@ export default function verify(
     url.searchParams.set('ssoUserId', ssoUserId);
   }
 
-  return client.fetch<LoginResultSuccess>(url.href);
+  return client.fetch<LoginResultSuccess>(url.href, { useCurrentTeam: false });
 }


### PR DESCRIPTION
Fixes an issue where the token would not be properly upgraded while a Team scope was currently active, causing a new auth token to be issued and lose the previous access scope(s).