### PR TITLE
[routing-utils] Update routes schema

### DIFF
--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -151,20 +151,7 @@ export const routesSchema = {
             },
           },
           middleware: {
-            type: 'object',
-            required: ['id', 'type'],
-            additionalProperties: false,
-            properties: {
-              id: {
-                type: 'string',
-                maxLength: 256,
-              },
-              type: {
-                type: 'string',
-                maxLength: 32,
-                enum: ['v8-worker'],
-              },
-            },
+            type: 'number',
           },
           has: hasSchema,
         },

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -36,10 +36,7 @@ export type Source = {
     redirect?: Record<string, string>;
     cookie?: string;
   };
-  middleware?: {
-    id: string;
-    type: 'v8-worker';
-  };
+  middleware?: number;
 };
 
 export type Handler = {

--- a/packages/routing-utils/test/index.spec.js
+++ b/packages/routing-utils/test/index.spec.js
@@ -60,10 +60,7 @@ describe('normalizeRoutes', () => {
       },
       {
         src: '^/.*$',
-        middleware: {
-          id: '1',
-          type: 'v8-worker',
-        },
+        middleware: 0,
       },
       { handle: 'filesystem' },
       { src: '^/(?<slug>[^/]+)$', dest: 'blog?slug=$slug' },

--- a/packages/routing-utils/test/merge.spec.js
+++ b/packages/routing-utils/test/merge.spec.js
@@ -489,10 +489,7 @@ test('mergeRoutes ensure beforeFiles comes after redirects (check)', () => {
         },
         {
           src: '^/.*$',
-          middleware: {
-            id: '1',
-            type: 'v8-worker',
-          },
+          middleware: 0,
         },
         {
           handle: 'filesystem',
@@ -517,10 +514,7 @@ test('mergeRoutes ensure beforeFiles comes after redirects (check)', () => {
     },
     {
       src: '^/.*$',
-      middleware: {
-        id: '1',
-        type: 'v8-worker',
-      },
+      middleware: 0,
     },
     { handle: 'filesystem' },
     { src: '^/404$', dest: '/404', status: 404, check: true },


### PR DESCRIPTION
Updates the `routes` schema and type with the correct type as #6860 was setting an old shape. Now it should be just an index since details are stored somewhere else.

### Related Issues

NA

### 📋 Checklist

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
