### PR TITLE
[cli] Make Next.js move files into .output

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -11,7 +11,7 @@ import chalk from 'chalk';
 import { SpawnOptions } from 'child_process';
 import { assert } from 'console';
 import { createHash } from 'crypto';
-import fs, { mkdirp } from 'fs-extra';
+import fs from 'fs-extra';
 import ogGlob from 'glob';
 import { isAbsolute, join, parse, relative, resolve } from 'path';
 import pluralize from 'pluralize';
@@ -388,7 +388,7 @@ export default async function main(client: Client) {
       cwd,
       absolute: true,
     });
-    await mkdirp(join(cwd, '.output', 'inputs'));
+    await fs.mkdirp(join(cwd, '.output', 'inputs'));
     for (let f of files) {
       client.output.debug(`Processing ${f}:`);
       const json = await fs.readJson(f);

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -10,18 +10,24 @@ import Sema from 'async-sema';
 import chalk from 'chalk';
 import { SpawnOptions } from 'child_process';
 import { assert } from 'console';
-import fs from 'fs-extra';
+import { createHash } from 'crypto';
+import fs, { mkdirp } from 'fs-extra';
 import ogGlob from 'glob';
-import { isAbsolute, join, relative } from 'path';
+import { isAbsolute, join, parse, relative, resolve } from 'path';
 import pluralize from 'pluralize';
 import Client from '../util/client';
+import { emoji, prependEmoji } from '../util/emoji';
 import getArgs from '../util/get-args';
 import handleError from '../util/handle-error';
+import confirm from '../util/input/confirm';
 import { isSettingValue } from '../util/is-setting-value';
 import cmd from '../util/output/cmd';
 import code from '../util/output/code';
+import { getColorForPkgName } from '../util/output/color-name-cache';
+import logo from '../util/output/logo';
 import param from '../util/output/param';
 import stamp from '../util/output/stamp';
+import cliPkgJson from '../util/pkg';
 import { getCommandName, getPkgName } from '../util/pkg-name';
 import { findFramework } from '../util/projects/find-framework';
 import { VERCEL_DIR } from '../util/projects/link';
@@ -30,11 +36,6 @@ import {
   readProjectSettings,
 } from '../util/projects/project-settings';
 import pull from './pull';
-import cliPkgJson from '../util/pkg';
-import { getColorForPkgName } from '../util/output/color-name-cache';
-import { emoji, prependEmoji } from '../util/emoji';
-import logo from '../util/output/logo';
-import confirm from '../util/input/confirm';
 
 const sema = new Sema(16, {
   capacity: 100,
@@ -311,7 +312,7 @@ export default async function main(client: Client) {
     );
     const files = await glob(join(relativeDistDir, '**'), {
       ignore: [
-        '**/node_modules/**',
+        'node_modules/**',
         '.vercel/**',
         '_middleware.ts',
         '_middleware.mts',
@@ -377,6 +378,49 @@ export default async function main(client: Client) {
         routesManifest,
         { spaces: 2 }
       );
+    }
+  }
+
+  if (framework.slug === 'nextjs') {
+    const files = await glob(join('.output', '**', '*.nft.json'), {
+      nodir: true,
+      dot: true,
+      cwd,
+      absolute: true,
+    });
+    await mkdirp(join(cwd, '.output', 'inputs'));
+    for (let f of files) {
+      client.output.debug(`Processing ${f}:`);
+      const json = await fs.readJson(f);
+      const newFilesList: Array<{ input: string; output: string }> = [];
+      for (let file of json.files) {
+        // if the resolved path is NOT in the .output directory we move in it there
+        const fullPath = resolve(
+          parse(f).dir,
+          typeof file === 'string' ? file : file.input
+        );
+        if (!resolve(fullPath).includes('.output')) {
+          const { ext } = parse(file);
+          const raw = await fs.readFile(resolve(fullPath));
+          const newFilePath = join('.output', 'inputs', hash(raw) + ext);
+          smartCopy(client, fullPath, newFilePath);
+
+          newFilesList.push({
+            input: relative(parse(f).dir, newFilePath),
+            output: file,
+          });
+        } else {
+          newFilesList.push({
+            input: file,
+            output: file,
+          });
+        }
+      }
+      // Update the .nft.json with new input and output mapping
+      await fs.writeJSON(f, {
+        ...json,
+        files: newFilesList,
+      });
     }
   }
 
@@ -551,4 +595,14 @@ async function glob(pattern: string, options: GlobOptions): Promise<string[]> {
       err ? reject(err) : resolve(files);
     });
   });
+}
+
+/**
+ * Computes a hash for the given buf.
+ *
+ * @param {Buffer} file data
+ * @return {String} hex digest
+ */
+function hash(buf: Buffer): string {
+  return createHash('sha1').update(buf).digest('hex');
 }


### PR DESCRIPTION
This effectively inlines what would be `vercel-plugin-next` into `vc build`. It scans `.output/**/*.nft.json`, resolves all of the files, and copies the ones outside of the the `.output` folder into `.outputs/inputs/[hash].[ext]` and then updates the `.nft.json` with new mapping of `input` and `output`. 

All of this work enables `vc deploy --prebuilt` to work properly with Next.js (and _only_ actually deploy `.output` directory)

This still does not solve for using Next.js < 12 with the FileSystem API. In order to do that we would need to scan `.next` and trace and resolve and copy manually. AFAIK just copying `node_modules` into `.output` won't work. We would need to move the runtime stuff into this PR

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
