### PR TITLE
[cli] Fix tracing for `vc build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -63,7 +63,7 @@ const help = () => {
   ${chalk.gray('–')} Build the project
 
     ${chalk.cyan(`$ ${getPkgName()} build`)}
-    ${chalk.cyan(`$ ${getPkgName()} build --cwd ./path-to-project`)}    
+    ${chalk.cyan(`$ ${getPkgName()} build --cwd ./path-to-project`)}
 `);
 };
 
@@ -397,24 +397,25 @@ export default async function main(client: Client) {
       const json = await fs.readJson(f);
       const newFilesList: Array<{ input: string; output: string }> = [];
       for (let fileEntity of json.files) {
-        const file =
+        const relativeInput =
           typeof fileEntity === 'string' ? fileEntity : fileEntity.input;
+        const fullInput = resolve(join(parse(f).dir, relativeInput));
+
         // if the resolved path is NOT in the .output directory we move in it there
-        const fullPath = resolve(parse(f).dir);
-        if (!resolve(fullPath).includes(OUTPUT_DIR)) {
-          const { ext } = parse(file);
-          const raw = await fs.readFile(resolve(fullPath));
+        if (!fullInput.includes(OUTPUT_DIR)) {
+          const { ext } = parse(fullInput);
+          const raw = await fs.readFile(fullInput);
           const newFilePath = join(OUTPUT_DIR, 'inputs', hash(raw) + ext);
-          smartCopy(client, fullPath, newFilePath);
+          smartCopy(client, fullInput, newFilePath);
 
           newFilesList.push({
             input: relative(parse(f).dir, newFilePath),
-            output: file,
+            output: relative(cwd, fullInput),
           });
         } else {
           newFilesList.push({
-            input: file,
-            output: file,
+            input: relativeInput,
+            output: relative(cwd, fullInput),
           });
         }
       }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -395,9 +395,9 @@ export default async function main(client: Client) {
     for (let f of files) {
       client.output.debug(`Processing ${f}:`);
       const json = await fs.readJson(f);
-      const newFilesList: Array<{ input: string; output: string }> = [];
+      const newFilesList: (string | { input: string; output: string })[] = [];
       for (let fileEntity of json.files) {
-        const relativeInput =
+        const relativeInput: string =
           typeof fileEntity === 'string' ? fileEntity : fileEntity.input;
         const fullInput = resolve(join(parse(f).dir, relativeInput));
 
@@ -413,10 +413,7 @@ export default async function main(client: Client) {
             output: relative(cwd, fullInput),
           });
         } else {
-          newFilesList.push({
-            input: relativeInput,
-            output: relative(cwd, fullInput),
-          });
+          newFilesList.push(relativeInput);
         }
       }
       // Update the .nft.json with new input and output mapping


### PR DESCRIPTION
### Related Issues
Ensures the `input` and `output` path are correct for `vercel build` in `.nft.json` files.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
