### PR TITLE
Bundle middleware deps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,9 +48,7 @@
     "@vercel/node": "1.12.2-canary.4",
     "@vercel/python": "2.0.6-canary.4",
     "@vercel/ruby": "1.2.8-canary.3",
-    "update-notifier": "4.1.0",
-    "vercel-plugin-middleware": "0.0.0-canary.4",
-    "vercel-plugin-node": "1.12.2-plugin.6"
+    "update-notifier": "4.1.0"
   },
   "devDependencies": {
     "@next/env": "11.1.2",
@@ -166,6 +164,8 @@
     "typescript": "4.3.4",
     "universal-analytics": "0.4.20",
     "utility-types": "2.1.0",
+    "vercel-plugin-middleware": "0.0.0-canary.4",
+    "vercel-plugin-node": "1.12.2-plugin.6",
     "which": "2.0.2",
     "write-json-file": "2.2.0",
     "xdg-app-paths": "5.1.0"

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -49,16 +49,7 @@ async function main() {
 
   // Do the initial `ncc` build
   console.log();
-  const args = [
-    'ncc',
-    'build',
-    '--external',
-    'update-notifier',
-    '--external',
-    'vercel-plugin-node',
-    '--external',
-    'vercel-plugin-middleware',
-  ];
+  const args = ['ncc', 'build', '--external', 'update-notifier'];
   if (isDev) {
     args.push('--source-map');
   }

--- a/packages/middleware/build.js
+++ b/packages/middleware/build.js
@@ -4,14 +4,17 @@ const execa = require('execa');
 const { join } = require('path');
 
 async function main() {
+  const srcDir = join(__dirname, 'src');
   const outDir = join(__dirname, 'dist');
 
   // Start fresh
   await fs.remove(outDir);
 
-  await execa('tsc', [], {
-    stdio: 'inherit',
-  });
+  await execa(
+    'ncc',
+    ['build', join(srcDir, 'index.ts'), '-o', outDir, '--external', 'esbuild'],
+    { stdio: 'inherit' }
+  );
 
   await fs.copyFile(
     join(__dirname, 'src/entries.js'),

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -17,21 +17,8 @@
   "files": [
     "dist"
   ],
-  "dependencies": {
-    "@peculiar/webcrypto": "1.2.0",
-    "cookie": "0.4.1",
-    "esbuild": "0.13.10",
-    "formdata-node": "4.3.1",
-    "globby": "9",
-    "http-proxy": "1.18.1",
-    "node-fetch": "^2",
-    "querystring": "0.2.1",
-    "ua-parser-js": "1.0.2",
-    "url": "0.11.0",
-    "uuid": "8.3.2",
-    "web-streams-polyfill": "3.1.1"
-  },
   "devDependencies": {
+    "@peculiar/webcrypto": "1.2.0",
     "@types/cookie": "0.4.1",
     "@types/glob": "7.2.0",
     "@types/http-proxy": "1.17.7",
@@ -40,7 +27,17 @@
     "@types/node-fetch": "^2",
     "@types/ua-parser-js": "0.7.36",
     "@types/uuid": "8.3.1",
-    "@vercel/ncc": "0.24.0"
+    "@vercel/ncc": "0.24.0",
+    "cookie": "0.4.1",
+    "esbuild": "0.13.10",
+    "formdata-node": "4.3.1",
+    "globby": "9",
+    "http-proxy": "1.18.1",
+    "node-fetch": "^2",
+    "ua-parser-js": "1.0.2",
+    "url": "0.11.0",
+    "uuid": "8.3.2",
+    "web-streams-polyfill": "3.1.1"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -31,7 +31,7 @@
     "cookie": "0.4.1",
     "esbuild": "0.13.10",
     "formdata-node": "4.3.1",
-    "globby": "9",
+    "glob": "7.2.0",
     "http-proxy": "1.18.1",
     "node-fetch": "^2",
     "ua-parser-js": "1.0.2",

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -1,8 +1,9 @@
-import globby from 'globby';
+import util from 'util';
 import { extname, join, basename } from 'path';
 import * as esbuild from 'esbuild';
 import { promises as fsp } from 'fs';
 import { IncomingMessage, ServerResponse } from 'http';
+import libGlob from 'glob';
 import Proxy from 'http-proxy';
 
 import { run } from './websandbox';
@@ -16,6 +17,7 @@ import {
 } from 'url';
 import { toNodeHeaders } from './websandbox/utils';
 
+const glob = util.promisify(libGlob);
 const SUPPORTED_EXTENSIONS = ['.js', '.ts'];
 
 // File name of the `entries.js` file that gets copied into the
@@ -26,7 +28,7 @@ async function getMiddlewareFile(workingDirectory: string) {
   // Only the root-level `_middleware.*` files are considered.
   // For more granular routing, the Project's Framework (i.e. Next.js)
   // middleware support should be used.
-  const middlewareFiles = await globby(join(workingDirectory, '_middleware.*'));
+  const middlewareFiles = await glob(join(workingDirectory, '_middleware.*'));
 
   if (middlewareFiles.length === 0) {
     // No middleware file at the root of the project, so bail...

--- a/yarn.lock
+++ b/yarn.lock
@@ -9990,11 +9990,6 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystring@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
-  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
-
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6278,6 +6278,18 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -6328,20 +6340,6 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@9, globby@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
-
 globby@^10.0.1:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
@@ -6378,6 +6376,20 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
+  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^1.0.2"
+    dir-glob "^2.2.2"
+    fast-glob "^2.2.6"
+    glob "^7.1.3"
+    ignore "^4.0.3"
+    pify "^4.0.1"
+    slash "^2.0.0"
 
 got@^9.6.0:
   version "9.6.0"


### PR DESCRIPTION
### Related Issues

This PR is meant to address 2 issues.

The first is unbundled dependencies in the middleware-plugin (fixed by using ncc vs tsc for building, and by unmarking the plugins as external).

The second is deprecation warnings on install, fixed by replacing globby with glob, and removing the external querystring lib in favor of the node built in.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
