### PR TITLE
[cli] Render an error page when middleware explodes.

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1421,6 +1421,16 @@ export default class DevServer {
     const middlewareResult = await runDevMiddleware(req, res, this.cwd);
 
     if (middlewareResult) {
+      if (middlewareResult.error) {
+        this.sendError(
+          req,
+          res,
+          requestId,
+          'EDGE_FUNCTION_INVOCATION_FAILED',
+          500
+        );
+        return;
+      }
       if (middlewareResult.finished) {
         return;
       }

--- a/packages/cli/test/fixtures/unit/edge-middleware-error/_middleware.js
+++ b/packages/cli/test/fixtures/unit/edge-middleware-error/_middleware.js
@@ -1,0 +1,3 @@
+export default () => {
+  throw new Error('asdf');
+};

--- a/packages/cli/test/util/dev/server.test.ts
+++ b/packages/cli/test/util/dev/server.test.ts
@@ -363,4 +363,15 @@ describe('DevServer', () => {
       expect(body).toStrictEqual('response');
     })
   );
+
+  it(
+    'should render an error page when the middleware throws',
+    testFixture('edge-middleware-error', async server => {
+      const response = await fetch(`${server.address}/index.html`);
+      const body = await response.text();
+      expect(body).toStrictEqual(
+        'A server error has occurred\n\nEDGE_FUNCTION_INVOCATION_FAILED\n'
+      );
+    })
+  );
 });

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -127,17 +127,8 @@ async function runMiddlewareCatchAll(
       parsed: parseUrl(req.url!, true),
     });
   } catch (err) {
-    // if (isError(err) && err.code === 'ENOENT') {
-    //   await this.render404(req, res, parsed)
-    //   return { finished: true }
-    // }
-
-    // const error = isError(err) ? err : new Error(err + '')
-    // console.error(error)
-    // TODO - pretty sure we'll need this.
-    // res.statusCode = 500;
-    // this.sendError(req, res, requestId, 'error in middleware', 500);
-    return { finished: true };
+    console.error(err);
+    return { finished: true, error: err };
   }
 
   if (result === null) {


### PR DESCRIPTION
### Related Issues

This adds error handling for middleware in `vc dev`

Local looks a little different than production:
Local
![image](https://user-images.githubusercontent.com/4172067/139951848-efa08a88-aeee-446f-8319-35c8bb0b1d75.png)

Production
![image](https://user-images.githubusercontent.com/4172067/139951580-33a4ad0f-18a5-4aa1-bfb0-5e1da646a4b8.png)


### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
