### PR TITLE
Remove --cwd option from build in favor of existing patterns.

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -44,7 +44,7 @@ const sema = new Sema(16, {
 
 const help = () => {
   return console.log(`
-  ${chalk.bold(`${logo} ${getPkgName()} build`)}
+  ${chalk.bold(`${logo} ${getPkgName()} build [path]`)}
 
  ${chalk.dim('Options:')}
 
@@ -55,7 +55,6 @@ const help = () => {
     -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
     'DIR'
   )}    Path to the global ${'`.vercel`'} directory
-    --cwd [path]                   The current working directory
     -d, --debug                    Debug mode [off]
     -y, --yes                      Skip the confirmation prompt
 
@@ -86,7 +85,6 @@ export default async function main(client: Client) {
   try {
     argv = getArgs(client.argv.slice(2), {
       '--debug': Boolean,
-      '--cwd': String,
     });
   } catch (err) {
     handleError(err);
@@ -98,7 +96,7 @@ export default async function main(client: Client) {
     return 2;
   }
 
-  let cwd = argv['--cwd'] || process.cwd();
+  let cwd = argv._[1] || process.cwd();
 
   let project = await readProjectSettings(join(cwd, VERCEL_DIR));
   // If there are no project settings, only then do we pull them down


### PR DESCRIPTION
### Related Issues

I noticed while working on `vc dev` that the vc build command expects a `--cwd` flag for setting the working directory. Other commands already exist that expect it to be the final argument passed to the command.  This is especially apparent when `vc build` runs `vc pull` as it passes along the same options.

This change consolidates the apis to be the same.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
