### PR TITLE
[cli] Rename certain outputs in `vercel build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -513,7 +513,7 @@ export default async function main(client: Client) {
         appDir: '.',
         files: requiredServerFilesJson.files.map((i: string) => ({
           input: i.replace('.next', '.output'),
-          output: i,
+          output: i.replace('.next', '.output'),
         })),
       });
     }


### PR DESCRIPTION
### Related Issues
Follow up to https://github.com/vercel/vercel/pull/6898

The `output` path must actually not be `.next`, since it'll be `.output` for all other files.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
