### PR TITLE
[cli] Fix NFT output path for monorepos

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -696,6 +696,10 @@ async function resolveNftToOutput({
       const newFilePath = join(outputDir, 'inputs', hash(raw) + ext);
       smartCopy(client, fullInput, newFilePath);
 
+      // We have to use `baseDir` instead of `cwd`, because we want to
+      // mount everything from there (especially `node_modules`).
+      // This is important for NPM Workspaces where `node_modules` is not
+      // in the directory of the workspace.
       const output = relative(baseDir, fullInput).replace('.output', '.next');
 
       newFilesList.push({

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -511,10 +511,15 @@ export default async function main(client: Client) {
       await fs.writeJSON(requiredServerFilesPath, {
         ...requiredServerFilesJson,
         appDir: '.',
-        files: requiredServerFilesJson.files.map((i: string) => ({
-          input: i.replace('.next', '.output'),
-          output: i.replace('.next', '.output'),
-        })),
+        files: requiredServerFilesJson.files.map((i: string) => {
+          const absolutePath = join(cwd, i.replace('.next', '.output'));
+          const output = relative(baseDir, absolutePath);
+
+          return {
+            input: i.replace('.next', '.output'),
+            output,
+          };
+        }),
       });
     }
   }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -693,9 +693,16 @@ async function resolveNftToOutput({
       const newFilePath = join(outputDir, 'inputs', hash(raw) + ext);
       smartCopy(client, fullInput, newFilePath);
 
+      let output = relative(cwd, fullInput).replace('.output', '.next');
+      if (/^[./]*\/node_modules\//gm.test(output)) {
+        // NPM Workspaces put `node_modules` in the root of the workspace,
+        // so we'll put them in the root `node_modules` of `output`.
+        output = output.replace(/^[./]*\/node_modules\//gm, 'node_modules/');
+      }
+
       newFilesList.push({
         input: relative(parse(nftFileName).dir, newFilePath),
-        output: relative(cwd, fullInput).replace('.output', '.next'),
+        output,
       });
     } else {
       newFilesList.push(relativeInput);


### PR DESCRIPTION
Ensures that we use the `baseDir` instead of `cwd` as relative path for the `output` in the `nft.json` files.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
