### PR TITLE
Fix "undefined" DNS record types when running "dns rm"

### DIFF
--- a/packages/cli/src/commands/dns/rm.ts
+++ b/packages/cli/src/commands/dns/rm.ts
@@ -103,7 +103,7 @@ function getDeleteTableRow(domainName: string, record: DNSRecord) {
   return [
     record.id,
     chalk.bold(
-      `${recordName} ${record.type} ${record.value} ${record.mxPriority || ''}`
+      `${recordName} ${record.recordType} ${record.value} ${record.mxPriority || ''}`
     ),
     chalk.gray(
       `${ms(Date.now() - new Date(Number(record.createdAt)).getTime())} ago`


### PR DESCRIPTION
I noticed `vercel dns rm [recordID]` was showing `undefined` each time where the DNS Record Type should display:
<img width="970" alt="Screen Shot 2021-11-08 at 10 13 31 PM" src="https://user-images.githubusercontent.com/2448782/140859486-1993496f-1d40-4b38-bf9c-d3142fe3677f.png">

Did some digging and it _appears_ Vercel API v5 renames the `type` property of a DNS Record to `recordType`, so made a quick change to reflect that.

(`vercel dns ls [domain]` still uses API v4, so it still works as expected.)

Let me know if I should create an Issue!

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
