### PR TITLE
[cli] Ignore .next/cache in `vc build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -317,6 +317,7 @@ export default async function main(client: Client) {
         '_middleware.js',
         'api/**',
         '.git/**',
+        '.next/cache/**',
       ],
       nodir: true,
       dot: true,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -397,7 +397,6 @@ export default async function main(client: Client) {
         cwd,
         OUTPUT_DIR,
         'server',
-        'pages',
         'middleware-manifest.json'
       );
       if (fs.existsSync(middlewareManifest)) {
@@ -405,7 +404,11 @@ export default async function main(client: Client) {
         Object.keys(manifest.middleware).forEach(key => {
           const files = manifest.middleware[key].files.map((f: string) => {
             if (f.startsWith('static/')) {
-              return f.replace(/^static\//gm, 'static/_next/static/');
+              const next = f.replace(/^static\//gm, 'static/_next/static/');
+              client.output.debug(
+                `Replacing file in \`middleware-manifest.json\`: ${f} => ${next}`
+              );
+              return next;
             }
 
             return f;

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -390,6 +390,33 @@ export default async function main(client: Client) {
         join(cwd, OUTPUT_DIR, 'static', '_next', 'static')
       );
 
+      // Next.js might reference files from the `static` directory in `middleware-manifest.json`.
+      // Since we move all files from `static` to `static/_next/static`, we'll need to change
+      // those references as well and update the manifest file.
+      const middlewareManifest = join(
+        cwd,
+        OUTPUT_DIR,
+        'server',
+        'pages',
+        'middleware-manifest.json'
+      );
+      if (fs.existsSync(middlewareManifest)) {
+        const manifest = await fs.readJSON(middlewareManifest);
+        Object.keys(manifest.middleware).forEach(key => {
+          const files = manifest.middleware[key].files.map((f: string) => {
+            if (f.startsWith('static/')) {
+              return f.replace(/^static\//gm, 'static/_next/static/');
+            }
+
+            return f;
+          });
+
+          manifest.middleware[key].files = files;
+        });
+
+        await fs.writeJSON(middlewareManifest, manifest);
+      }
+
       // We want to pick up directories for user-provided static files into `.`output/static`.
       // More specifically, the static directory contents would then be mounted to `output/static/static`,
       // and the public directory contents would be mounted to `output/static`. Old Next.js versions


### PR DESCRIPTION
Ignores `.next/cache` in `vc build` because it's not relevant for the `.output` directory and actually causes issue if we consider `.nft.json` files in it.

Should also improve it in combination with `vc --prebuilt` since it'll be less files to get uploaded.

Also ensures that we change references to the static directory that were made in `middleware-manifest.json`.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
