### PR TITLE
[cli] Fix resolving of config paths

### DIFF
--- a/packages/cli/src/util/config/global-path.ts
+++ b/packages/cli/src/util/config/global-path.ts
@@ -18,12 +18,8 @@ export const isDirectory = (path: string): boolean => {
 const getGlobalPathConfig = (): string => {
   let customPath: string | undefined;
 
-  try {
-    const argv = getArgs(process.argv.slice(2), {});
-    customPath = argv['--global-config'];
-  } catch (_error) {
-    // args are optional so consume error
-  }
+  const argv = getArgs(process.argv.slice(2), {}, { permissive: true });
+  customPath = argv['--global-config'];
 
   const vercelDirectories = XDGAppPaths('com.vercel.cli').dataDirs();
 

--- a/packages/cli/src/util/config/local-path.ts
+++ b/packages/cli/src/util/config/local-path.ts
@@ -7,12 +7,8 @@ import getArgs from '../../util/get-args';
 export default function getLocalPathConfig(prefix: string) {
   let customPath: string | undefined;
 
-  try {
-    const argv = getArgs(process.argv.slice(2), {});
-    customPath = argv['--local-config'];
-  } catch (_error) {
-    // args are optional so consume error
-  }
+  const argv = getArgs(process.argv.slice(2), {}, { permissive: true });
+  customPath = argv['--local-config'];
 
   // If `--local-config` flag was specified, then that takes priority
   if (customPath) {


### PR DESCRIPTION
This PR fixes functions for resolving local and global config paths. The issue was that `--local-config` resp. `--global-config` arguments were silently ignored when other than common args were also used  (e.g. `--confirm`). It caused that CLI integration tests were failing locally.

### Related Issues

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
