### PR TITLE
[vercel-plugin-node] Use `.nft.json` files instead of directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/lib/deployment/failed-page.txt
 /public
 __pycache__
 .vercel
+.output

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "dependencies": {
-    "lerna": "3.16.4"
+    "lerna": "3.16.4",
+    "vercel-plugin-node": "https://vercel-plugin-node.vercel.app"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.28.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     ]
   },
   "dependencies": {
-    "lerna": "3.16.4",
-    "vercel-plugin-node": "https://vercel-plugin-node.vercel.app"
+    "lerna": "3.16.4"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.28.0",

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@types/node": "*",
-    "@vercel/fun": "1.0.3",
     "ts-node": "8.9.1",
     "typescript": "4.3.4"
   },
@@ -36,7 +35,7 @@
     "@types/test-listen": "1.1.0",
     "@types/yazl": "2.4.2",
     "@vercel/build-utils": "2.12.3-canary.18",
-    "@vercel/fun": "1.0.1",
+    "@vercel/fun": "1.0.3",
     "@vercel/ncc": "0.24.0",
     "@vercel/nft": "0.14.0",
     "@vercel/node-bridge": "2.1.1-canary.2",

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "27.0.2",
     "@types/node-fetch": "2",
     "@types/test-listen": "1.1.0",
+    "@types/yazl": "2.4.2",
     "@vercel/build-utils": "2.12.3-canary.18",
     "@vercel/fun": "1.0.1",
     "@vercel/ncc": "0.24.0",
@@ -47,7 +48,8 @@
     "node-fetch": "2",
     "source-map-support": "0.5.12",
     "test-listen": "1.1.0",
-    "ts-morph": "12.0.0"
+    "ts-morph": "12.0.0",
+    "yazl": "2.5.1"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@types/node": "*",
+    "@vercel/fun": "1.0.3",
     "ts-node": "8.9.1",
     "typescript": "4.3.4"
   },

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -8,7 +8,7 @@ import {
   promises as fsp,
   existsSync,
 } from 'fs';
-import path, {
+import {
   basename,
   dirname,
   extname,
@@ -517,7 +517,7 @@ export async function buildEntrypoint({
   );
 
   const pages = {
-    [path.posix.relative(pagesDir, pageOutput)]: {
+    [relative(pagesDir, pageOutput)]: {
       handler: `${getFileName(LAUNCHER_FILENAME).slice(0, -3)}.launcher`,
       runtime: nodeVersion.runtime,
     },

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -6,6 +6,7 @@ import {
   readlinkSync,
   statSync,
   promises as fsp,
+  existsSync,
 } from 'fs';
 import {
   basename,
@@ -118,9 +119,14 @@ async function downloadInstallAndBundle({
   const nodeVersion = await getNodeVersion(entrypointFsDirname);
   const spawnOpts = getSpawnOptions({}, nodeVersion);
 
-  const installTime = Date.now();
-  await runNpmInstall(entrypointFsDirname, [], spawnOpts, {}, nodeVersion);
-  debug(`Install complete [${Date.now() - installTime}ms]`);
+  // Only run when `package.json` exists.
+  if (existsSync(join(entrypointFsDirname, 'package.json'))) {
+    const installTime = Date.now();
+    await runNpmInstall(entrypointFsDirname, [], spawnOpts, {}, nodeVersion);
+    debug(`Install complete [${Date.now() - installTime}ms]`);
+  } else {
+    debug(`Skip install command for \`vercel-plugin-node\`.`);
+  }
 
   return {
     nodeVersion,

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -8,7 +8,7 @@ import {
   promises as fsp,
   existsSync,
 } from 'fs';
-import {
+import path, {
   basename,
   dirname,
   extname,
@@ -45,6 +45,7 @@ import { AbortController } from 'abort-controller';
 import { Register, register } from './typescript';
 import { pageToRoute } from './router/page-to-route';
 import { isDynamicRoute } from './router/is-dynamic';
+import crypto from 'crypto';
 
 export { shouldServe };
 export {
@@ -390,20 +391,23 @@ export async function buildEntrypoint({
   entrypoint: string;
   config: FunctionConfig;
 }) {
+  // Unique hash that will be used as directory name for `.output`.
+  const entrypointHash = crypto
+    .createHash('sha256')
+    .update(entrypoint)
+    .digest('hex');
   const outputDirPath = join(workPath, '.output');
+
   const { dir, name } = parsePath(entrypoint);
   const entrypointWithoutExt = join('/', dir, name);
-  const entrypointWithoutExtIndex = join(
-    dir,
-    name,
-    name === 'index' ? '' : 'index'
-  );
-  const outputWorkPath = join(
-    outputDirPath,
-    'server/pages',
-    entrypointWithoutExtIndex
-  );
+  const outputWorkPath = join(outputDirPath, 'inputs', entrypointHash);
+  const pagesDir = join(outputDirPath, 'server', 'pages');
+  const pageOutput = join(pagesDir, renameTStoJS(entrypoint));
+  const nftOutput = `${pageOutput}.nft.json`;
+
   await fsp.mkdir(outputWorkPath, { recursive: true });
+  await fsp.mkdir(parsePath(pageOutput).dir, { recursive: true });
+
   console.log(`Compiling "${entrypoint}" to "${outputWorkPath}"`);
 
   const shouldAddHelpers =
@@ -477,6 +481,8 @@ export async function buildEntrypoint({
     ...launcherFiles,
   };
 
+  const nftFiles: { input: string; output: string }[] = [];
+
   for (const filename of Object.keys(files)) {
     const outPath = join(outputWorkPath, filename);
     const file = files[filename];
@@ -487,10 +493,37 @@ export async function buildEntrypoint({
     const finishPromise = once(ws, 'finish');
     file.toStream().pipe(ws);
     await finishPromise;
+
+    // The `handler` will be `.output/server/pages/api/subdirectory/___vc/__launcher.launcher`
+    // or `.output/server/pages/api/___vc/__launcher.launcher`.
+    // This means everything has to be mounted to the `dirname` of the entrypoint.
+    nftFiles.push({
+      input: relative(dirname(nftOutput), outPath),
+      output: path.join(
+        '.output',
+        'server',
+        'pages',
+        dirname(entrypoint),
+        filename
+      ),
+    });
   }
 
+  await fsp.writeFile(
+    nftOutput,
+    JSON.stringify({
+      version: 1,
+      files: nftFiles,
+    })
+  );
+
+  await fsp.copyFile(
+    join(outputWorkPath, renameTStoJS(entrypoint)),
+    pageOutput
+  );
+
   const pages = {
-    [entrypointWithoutExtIndex]: {
+    [relative(pagesDir, pageOutput)]: {
       handler: `${getFileName(LAUNCHER_FILENAME).slice(0, -3)}.launcher`,
       runtime: nodeVersion.runtime,
     },

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -8,7 +8,7 @@ import {
   promises as fsp,
   existsSync,
 } from 'fs';
-import path, {
+import {
   basename,
   dirname,
   extname,
@@ -499,13 +499,7 @@ export async function buildEntrypoint({
     // This means everything has to be mounted to the `dirname` of the entrypoint.
     nftFiles.push({
       input: relative(dirname(nftOutput), outPath),
-      output: path.join(
-        '.output',
-        'server',
-        'pages',
-        dirname(entrypoint),
-        filename
-      ),
+      output: join('.output', 'server', 'pages', dirname(entrypoint), filename),
     });
   }
 

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -8,7 +8,7 @@ import {
   promises as fsp,
   existsSync,
 } from 'fs';
-import {
+import path, {
   basename,
   dirname,
   extname,
@@ -517,7 +517,7 @@ export async function buildEntrypoint({
   );
 
   const pages = {
-    [relative(pagesDir, pageOutput)]: {
+    [path.posix.relative(pagesDir, pageOutput)]: {
       handler: `${getFileName(LAUNCHER_FILENAME).slice(0, -3)}.launcher`,
       runtime: nodeVersion.runtime,
     },

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -516,8 +516,13 @@ export async function buildEntrypoint({
     pageOutput
   );
 
+  let pageKey = relative(pagesDir, pageOutput);
+  if (process.platform === 'win32') {
+    pageKey = pageKey.replace(/\\/gm, '/');
+  }
+
   const pages = {
-    [relative(pagesDir, pageOutput)]: {
+    [pageKey]: {
       handler: `${getFileName(LAUNCHER_FILENAME).slice(0, -3)}.launcher`,
       runtime: nodeVersion.runtime,
     },

--- a/packages/plugin-node/test/build.test.ts
+++ b/packages/plugin-node/test/build.test.ts
@@ -96,7 +96,7 @@ function withFixture<T>(
           });
           zip.end();
 
-          const handler = path.posix.join(
+          const handler = path.join(
             '.output/server/pages',
             path.dirname(fnKey),
             functionManifest.handler

--- a/packages/plugin-node/test/build.test.ts
+++ b/packages/plugin-node/test/build.test.ts
@@ -11,6 +11,7 @@ import {
   Headers,
 } from 'node-fetch';
 import { build } from '../src';
+import { runNpmInstall } from '@vercel/build-utils';
 
 interface TestParams {
   fixture: string;
@@ -107,6 +108,10 @@ function withFixture<T>(
         status,
         headers,
       });
+    }
+
+    if (await fsp.lstat(join(fixture, 'package.json')).catch(() => false)) {
+      await runNpmInstall(fixture);
     }
 
     await build({ workPath: fixture });

--- a/packages/plugin-node/test/build.test.ts
+++ b/packages/plugin-node/test/build.test.ts
@@ -96,7 +96,7 @@ function withFixture<T>(
           });
           zip.end();
 
-          const handler = path.join(
+          const handler = path.posix.join(
             '.output/server/pages',
             path.dirname(fnKey),
             functionManifest.handler

--- a/packages/plugin-node/test/build.test.ts
+++ b/packages/plugin-node/test/build.test.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
+import path from 'path';
 import { parse } from 'url';
 import { promises as fsp } from 'fs';
+import { ZipFile } from 'yazl';
 import { createFunction, Lambda } from '@vercel/fun';
 import {
   Request,
@@ -11,7 +12,7 @@ import {
   Headers,
 } from 'node-fetch';
 import { build } from '../src';
-import { runNpmInstall } from '@vercel/build-utils';
+import { runNpmInstall, streamToBuffer } from '@vercel/build-utils';
 
 interface TestParams {
   fixture: string;
@@ -51,40 +52,64 @@ function withFixture<T>(
   t: (props: TestParams) => Promise<T>
 ): () => Promise<T> {
   return async () => {
-    const fixture = join(__dirname, 'fixtures', name);
+    const fixture = path.join(__dirname, 'fixtures', name);
     const functions = new Map<string, Lambda>();
 
     async function fetch(r: RequestInfo, init?: RequestInit) {
       const req = new Request(r, init);
       const url = parse(req.url);
-      const pathWithIndex = join(
-        url.pathname!,
-        url.pathname!.endsWith('/index') ? '' : 'index'
-      ).substring(1);
+      const functionPath = url.pathname!.substring(1);
 
       let status = 404;
       let headers: HeadersInit = {};
       let body: string | Buffer = 'Function not found';
 
-      let fn = functions.get(pathWithIndex);
+      let fn = functions.get(functionPath);
       if (!fn) {
         const manifest = JSON.parse(
           await fsp.readFile(
-            join(fixture, '.output/functions-manifest.json'),
+            path.join(fixture, '.output/functions-manifest.json'),
             'utf8'
           )
         );
-        const functionManifest = manifest.pages[pathWithIndex];
+
+        const keyFile = `${functionPath}.js`;
+        const keyIndex = `${functionPath}/index.js`;
+        const fnKey = keyFile in manifest.pages ? keyFile : keyIndex;
+        const functionManifest = manifest.pages[fnKey];
+
         if (functionManifest) {
-          const dir = join(fixture, '.output/server/pages', pathWithIndex);
+          const entry = path.join(fixture, '.output/server/pages', fnKey);
+          const nftFile = JSON.parse(
+            await fsp.readFile(`${entry}.nft.json`, 'utf8')
+          );
+
+          const zip = new ZipFile();
+          zip.addFile(
+            path.join(fixture, '.output/server/pages', fnKey),
+            path.join('.output/server/pages', fnKey)
+          );
+
+          nftFile.files.forEach((f: { input: string; output: string }) => {
+            const input = path.join(path.dirname(entry), f.input);
+            zip.addFile(input, f.output);
+          });
+          zip.end();
+
+          const handler = path.join(
+            '.output/server/pages',
+            path.dirname(fnKey),
+            functionManifest.handler
+          );
+
           fn = await createFunction({
             Code: {
-              Directory: dir,
+              ZipFile: await streamToBuffer(zip.outputStream),
             },
-            Handler: functionManifest.handler,
+            Handler: handler,
             Runtime: functionManifest.runtime,
           });
-          functions.set(pathWithIndex, fn);
+          functions.set(functionPath, fn);
         }
       }
 
@@ -110,7 +135,9 @@ function withFixture<T>(
       });
     }
 
-    if (await fsp.lstat(join(fixture, 'package.json')).catch(() => false)) {
+    if (
+      await fsp.lstat(path.join(fixture, 'package.json')).catch(() => false)
+    ) {
       await runNpmInstall(fixture);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,7 +2537,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yazl@^2.4.1":
+"@types/yazl@2.4.2", "@types/yazl@^2.4.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.2.tgz#d5f8a4752261badbf1a36e8b49e042dc18ec84bc"
   integrity sha512-T+9JH8O2guEjXNxqmybzQ92mJUh2oCwDDMSSimZSe1P+pceZiFROZLYmcbqkzV5EUwz6VwcKXCO2S2yUpra6XQ==
@@ -12615,6 +12615,13 @@ yazl@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
   integrity sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+
+yazl@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@2", "@types/node-fetch@^2":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node-fetch@2.5.10":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
@@ -2326,14 +2334,6 @@
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
   integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
-"@types/node-fetch@^2":
-  version "2.5.12"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
-  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -2537,7 +2537,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yazl@^2.4.1":
+"@types/yazl@2.4.2", "@types/yazl@^2.4.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.2.tgz#d5f8a4752261badbf1a36e8b49e042dc18ec84bc"
   integrity sha512-T+9JH8O2guEjXNxqmybzQ92mJUh2oCwDDMSSimZSe1P+pceZiFROZLYmcbqkzV5EUwz6VwcKXCO2S2yUpra6XQ==
@@ -2780,6 +2780,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@~1.3.7:
   version "1.3.7"
@@ -5492,6 +5499,11 @@ etag@1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -8981,6 +8993,13 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@2:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
@@ -12178,15 +12197,6 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-"vercel-plugin-node@https://vercel-plugin-node.vercel.app":
-  version "1.12.2-canary.8"
-  resolved "https://vercel-plugin-node.vercel.app#b82f848267f9e75f7dda966d94401e79fa4c0eea"
-  dependencies:
-    "@types/node" "*"
-    "@vercel/fun" "1.0.3"
-    ts-node "8.9.1"
-    typescript "4.3.4"
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -12613,6 +12623,13 @@ yazl@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
   integrity sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+
+yazl@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,10 +2613,10 @@
     "@typescript-eslint/types" "4.28.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/fun@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.1.tgz#4b25f50c27bbbdca5b7e71f25ef5018701467962"
-  integrity sha512-v++KDTdKIr0357sm0AbyYk5jLmsqfUlOKhTsaN0Z/XHpk2YJHOLlGFTDzZPt+8i+ofdPG8lCfht729DHNQskJg==
+"@vercel/fun@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.3.tgz#5e5c4921a3a3a35ee129ce063e6b3f5c4b1eae48"
+  integrity sha512-9LKNosC+Sdx7ZNU7dnj7XXasHzgRkuDnz9+N6JzSVvb0v8KOZN0ky4+wn3c1B0/wF3dTn2W5nEzgmnsrVCDtkQ==
   dependencies:
     "@tootallnate/once" "2.0.0"
     async-listen "1.0.0"
@@ -2629,6 +2629,7 @@
     node-fetch "2.6.1"
     path-match "1.2.4"
     promisepipe "3.0.0"
+    semver "7.3.5"
     stat-mode "0.3.0"
     stream-to-promise "2.2.0"
     tar "4.4.18"
@@ -10665,7 +10666,7 @@ semver@6.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
   integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,14 +2307,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@2", "@types/node-fetch@^2":
-  version "2.5.12"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
-  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node-fetch@2.5.10":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
@@ -2334,6 +2326,14 @@
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
   integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node-fetch@^2":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -2537,7 +2537,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yazl@2.4.2", "@types/yazl@^2.4.1":
+"@types/yazl@^2.4.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.2.tgz#d5f8a4752261badbf1a36e8b49e042dc18ec84bc"
   integrity sha512-T+9JH8O2guEjXNxqmybzQ92mJUh2oCwDDMSSimZSe1P+pceZiFROZLYmcbqkzV5EUwz6VwcKXCO2S2yUpra6XQ==
@@ -2780,13 +2780,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-abort-controller@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 accepts@~1.3.7:
   version "1.3.7"
@@ -5499,11 +5492,6 @@ etag@1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -8993,13 +8981,6 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2, node-fetch@^2:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
-  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
@@ -9009,6 +8990,13 @@ node-fetch@2.6.1, node-fetch@^2.2.1, node-fetch@^2.3.0, node-fetch@^2.5.0, node-
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp-build@^4.2.2:
   version "4.2.3"
@@ -12190,6 +12178,15 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+"vercel-plugin-node@https://vercel-plugin-node.vercel.app":
+  version "1.12.2-canary.8"
+  resolved "https://vercel-plugin-node.vercel.app#b82f848267f9e75f7dda966d94401e79fa4c0eea"
+  dependencies:
+    "@types/node" "*"
+    "@vercel/fun" "1.0.3"
+    ts-node "8.9.1"
+    typescript "4.3.4"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -12616,13 +12613,6 @@ yazl@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
   integrity sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=
-  dependencies:
-    buffer-crc32 "~0.2.3"
-
-yazl@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
-  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 


### PR DESCRIPTION
### Related Issues

~Depends on https://github.com/vercel/fun/pull/73 for tests.~

We don't want to use directories for `pages`, as they cause issues with nesting.
This PR makes sure that we use `nft.json` files and put the related files into the `inputs` folder.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
