### PR TITLE
[cli] Change `vc build` to use stdout

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -169,15 +169,15 @@ export default async function main(client: Client) {
 
   const buildState = { ...project.settings };
 
-  client.output.log(`Retrieved Project Settings:`);
-  client.output.print(
-    chalk.dim(`  - ${chalk.bold(`Framework Preset:`)} ${framework.name}\n`)
+  console.log(`Retrieved Project Settings:`);
+  console.log(
+    chalk.dim(`  - ${chalk.bold(`Framework Preset:`)} ${framework.name}`)
   );
 
   for (let field of fields) {
     const defaults = (framework.settings as any)[field.value];
     if (defaults) {
-      client.output.print(
+      console.log(
         chalk.dim(
           `  - ${chalk.bold(`${field.name}:`)} ${`${
             project.settings[field.value]
@@ -185,7 +185,7 @@ export default async function main(client: Client) {
               : isSettingValue(defaults)
               ? defaults.value
               : chalk.italic(`${defaults.placeholder}`)
-          }`}\n`
+          }`}`
         )
       );
     }
@@ -201,14 +201,14 @@ export default async function main(client: Client) {
   }
 
   if (loadedEnvFiles.length > 0) {
-    client.output.log(
+    console.log(
       `Loaded Environment Variables from ${loadedEnvFiles.length} ${pluralize(
         'file',
         loadedEnvFiles.length
       )}:`
     );
     for (let envFile of loadedEnvFiles) {
-      client.output.print(chalk.dim(`  - ${envFile.path}\n`));
+      console.log(chalk.dim(`  - ${envFile.path}`));
     }
   }
 
@@ -239,7 +239,7 @@ export default async function main(client: Client) {
   };
 
   if (plugins?.pluginCount && plugins?.pluginCount > 0) {
-    client.output.log(
+    console.log(
       `Loaded ${plugins.pluginCount} CLI ${pluralize(
         'Plugin',
         plugins.pluginCount
@@ -247,7 +247,7 @@ export default async function main(client: Client) {
     );
     // preBuild Plugins
     if (plugins.preBuildPlugins.length > 0) {
-      client.output.log(
+      console.log(
         `Running ${plugins.pluginCount} CLI ${pluralize(
           'Plugin',
           plugins.pluginCount
@@ -286,7 +286,7 @@ export default async function main(client: Client) {
   fs.removeSync(join(cwd, OUTPUT_DIR));
 
   if (typeof buildState.buildCommand === 'string') {
-    client.output.log(`Running Build Command: ${cmd(buildState.buildCommand)}`);
+    console.log(`Running Build Command: ${cmd(buildState.buildCommand)}`);
     await execCommand(buildState.buildCommand, {
       ...spawnOpts,
       // Yarn v2 PnP mode may be activated, so force
@@ -352,7 +352,7 @@ export default async function main(client: Client) {
       )
     );
     client.output.stopSpinner();
-    client.output.log(
+    console.log(
       `Copied ${files.length.toLocaleString()} files from ${param(
         distDir
       )} to ${param(outputDir)} ${copyStamp()}`
@@ -573,7 +573,7 @@ export default async function main(client: Client) {
 
   // Build Plugins
   if (plugins?.buildPlugins && plugins.buildPlugins.length > 0) {
-    client.output.log(
+    console.log(
       `Running ${plugins.pluginCount} CLI ${pluralize(
         'Plugin',
         plugins.pluginCount
@@ -608,13 +608,13 @@ export default async function main(client: Client) {
     }
   }
 
-  client.output.print(
+  console.log(
     `${prependEmoji(
       `Build Completed in ${chalk.bold(OUTPUT_DIR)} ${chalk.gray(
         buildStamp()
       )}`,
       emoji('success')
-    )}\n`
+    )}`
   );
 
   return 0;
@@ -660,9 +660,9 @@ export async function runPackageJsonScript(
     }
   }
 
-  client.output.log(`Running Build Command: ${cmd(opts.prettyCommand)}\n`);
+  console.log(`Running Build Command: ${cmd(opts.prettyCommand)}\n`);
   await spawnAsync(cliType, ['run', scriptName], opts);
-  client.output.print('\n'); // give it some room
+  console.log(); // give it some room
   client.output.debug(`Script complete [${Date.now() - runScriptTime}ms]`);
   return true;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -160,24 +160,26 @@ const main = async () => {
   //  * a path to deploy (as in: `vercel path/`)
   //  * a subcommand (as in: `vercel ls`)
   const targetOrSubcommand = argv._[2];
+  const isBuildOrDev =
+    targetOrSubcommand === 'build' || targetOrSubcommand === 'dev';
 
-  output.print(
-    `${chalk.grey(
-      `${getTitleName()} CLI ${pkg.version}${
-        targetOrSubcommand === 'dev'
-          ? ' dev (beta)'
-          : targetOrSubcommand === 'build'
-          ? ' build (beta)'
-          : ''
-      }${
-        isCanary ||
-        targetOrSubcommand === 'dev' ||
-        targetOrSubcommand === 'build'
-          ? ' — https://vercel.com/feedback'
-          : ''
-      }`
-    )}\n`
-  );
+  if (isBuildOrDev) {
+    console.log(
+      `${chalk.grey(
+        `${getTitleName()} CLI ${
+          pkg.version
+        } ${targetOrSubcommand} (beta) — https://vercel.com/feedback`
+      )}`
+    );
+  } else {
+    output.print(
+      `${chalk.grey(
+        `${getTitleName()} CLI ${pkg.version}${
+          isCanary ? ' — https://vercel.com/feedback' : ''
+        }`
+      )}\n`
+    );
+  }
 
   // Handle `--version` directly
   if (!targetOrSubcommand && argv['--version']) {


### PR DESCRIPTION
Since `output.log()` and `output.print()` go to stderr, the logs looked confusing

![image](https://user-images.githubusercontent.com/229881/141841268-5cff816a-8eab-44f0-962f-cc46a70ce64c.png)

This PR changes the `vc build` output to use stdout instead of stderr.

- Fixes https://github.com/vercel/runtimes/issues/243