### PR TITLE
[python] Upgrade python 3.9

### DIFF
--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -163,7 +163,7 @@ export const build = async ({
   await writeFile(join(workPath, `${handlerPyFilename}.py`), handlerPyContents);
 
   // Use the system-installed version of `python3` when running via `vercel dev`
-  const runtime = meta.isDev ? 'python3' : 'python3.6';
+  const runtime = meta.isDev ? 'python3' : 'python3.9';
 
   const globOptions: GlobOptions = {
     cwd: workPath,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -22,6 +22,7 @@ async function pipenvConvert(cmd: string, srcDir: string) {
     const out = await execa.stdout(cmd, [], {
       cwd: srcDir,
     });
+    debug('Contents of requirements.txt is: ' + out);
     fs.writeFileSync(join(srcDir, 'requirements.txt'), out);
   } catch (err) {
     console.log('Failed to run "pipfile2req"');

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -67,14 +67,14 @@ async function pipInstall(workPath: string, args: string[]) {
     target,
     ...args,
   ];
-  debug(`Running "pip3 ${cmdArgs.join(' ')}"...`);
+  const pretty = `${pipPath} ${cmdArgs.join(' ')}`;
+  debug(`Running "${pretty}"...`);
   try {
     await execa(pipPath, cmdArgs, {
       cwd: workPath,
-      stdio: 'pipe',
     });
   } catch (err) {
-    console.log(`Failed to run "pip3 ${cmdArgs.join(' ')}"`);
+    console.log(`Failed to run "${pretty}"`);
     throw err;
   }
 }

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,6 +1,7 @@
 import execa from 'execa';
 import { Meta, debug } from '@vercel/build-utils';
 const pipPath = 'pip3.9';
+const pythonPath = 'python3.9';
 
 const makeDependencyCheckCode = (dependency: string) => `
 from importlib import util
@@ -12,7 +13,7 @@ print(spec.origin)
 async function isInstalled(dependency: string, cwd: string) {
   try {
     const { stdout } = await execa(
-      'python3',
+      pythonPath,
       ['-c', makeDependencyCheckCode(dependency)],
       {
         stdio: 'pipe',
@@ -36,7 +37,7 @@ pkg_resources.require(dependencies)
 async function areRequirementsInstalled(requirementsPath: string, cwd: string) {
   try {
     await execa(
-      'python3',
+      pythonPath,
       ['-c', makeRequirementsCheckCode(requirementsPath)],
       {
         stdio: 'pipe',

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,6 +1,6 @@
 import execa from 'execa';
 import { Meta, debug } from '@vercel/build-utils';
-const pipPath = 'pip3';
+const pipPath = 'pip3.9';
 
 const makeDependencyCheckCode = (dependency: string) => `
 from importlib import util

--- a/packages/python/tsconfig.json
+++ b/packages/python/tsconfig.json
@@ -13,6 +13,6 @@
     "outDir": "dist",
     "types": ["node"],
     "strict": true,
-    "target": "esnext"
+    "target": "es2018"
   }
 }

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -20,7 +20,12 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
         (path.extname(n) === '.sh' ? 0o100755 : 0o100644),
     }));
 
-  const { FORCE_BUILD_IN_REGION, NOW_DEBUG, VERCEL_DEBUG } = process.env;
+  const {
+    FORCE_BUILD_IN_REGION,
+    NOW_DEBUG,
+    VERCEL_DEBUG,
+    VERCEL_BUILDER_DEBUG,
+  } = process.env;
   const nowJson = JSON.parse(bodies['vercel.json'] || bodies['now.json']);
 
   const nowDeployPayload = {
@@ -34,6 +39,7 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
         FORCE_BUILD_IN_REGION,
         NOW_DEBUG,
         VERCEL_DEBUG,
+        VERCEL_BUILDER_DEBUG,
       },
     },
     name: 'test2020',


### PR DESCRIPTION
This PR adds support for python 3.9 and uses it as the default version.

If a Pipfile is detected and it requires python 3.6, then it will continue using 3.6 (although it will reach EOL in a few months).

```
[requires]
python_version = "3.6"
```

- Fixes #2979 
- Fixes #5486 
- Fixes #2839 