### PR TITLE
[cli] Fix update command to favor npm

### DIFF
--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -1,11 +1,9 @@
 import { Stats } from 'fs';
 import { sep, dirname, join, resolve } from 'path';
-import { readJSON, lstat, readlink, readFile, realpath } from 'fs-extra';
+import { lstat, readlink, readFile, realpath } from 'fs-extra';
 import { isCanary } from './is-canary';
 import { getPkgName } from './pkg-name';
 
-// `npm` tacks a bunch of extra properties on the `package.json` file,
-// so check for one of them to determine yarn vs. npm.
 async function isYarn(): Promise<boolean> {
   let s: Stats;
   let binPath = process.argv[1];
@@ -20,8 +18,12 @@ async function isYarn(): Promise<boolean> {
     }
   }
   const pkgPath = join(dirname(binPath), '..', 'package.json');
-  const pkg = await readJSON(pkgPath).catch(() => ({}));
-  return !('_id' in pkg);
+  /*
+   * Generally, pkgPath looks like:
+   * "/Users/username/.config/yarn/global/node_modules/vercel/package.json"
+   * "/usr/local/share/.config/yarn/global/node_modules/vercel/package.json"
+   */
+  return pkgPath.includes(join('yarn', 'global'));
 }
 
 async function getConfigPrefix() {

--- a/packages/cli/test/util/get-update-command.test.ts
+++ b/packages/cli/test/util/get-update-command.test.ts
@@ -5,7 +5,7 @@ describe('getUpdateCommand', () => {
   it('should detect update command', async () => {
     const updateCommand = await getUpdateCommand();
     expect(updateCommand).toEqual(
-      `npm i -g vercel@${isCanary() ? 'canary' : 'latest'}`
+      `npm i vercel@${isCanary() ? 'canary' : 'latest'}`
     );
   });
 });

--- a/packages/cli/test/util/get-update-command.test.ts
+++ b/packages/cli/test/util/get-update-command.test.ts
@@ -5,7 +5,7 @@ describe('getUpdateCommand', () => {
   it('should detect update command', async () => {
     const updateCommand = await getUpdateCommand();
     expect(updateCommand).toEqual(
-      `yarn add vercel@${isCanary() ? 'canary' : 'latest'}`
+      `npm i -g vercel@${isCanary() ? 'canary' : 'latest'}`
     );
   });
 });


### PR DESCRIPTION
This PR fixes an issue where the wrong update command is show for npm 7 or npm 8.

This will favor npm if we can't be certain `vercel` was previously installed with yarn.