### PR TITLE
[cli] Switch from hardlinks to symlinks in vc build

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -669,7 +669,16 @@ export async function runPackageJsonScript(
 
 async function linkOrCopy(existingPath: string, newPath: string) {
   try {
-    await fs.createLink(existingPath, newPath);
+    if (
+      newPath.endsWith('.nft.json') ||
+      newPath.endsWith('middleware-manifest.json')
+    ) {
+      await fs.copy(existingPath, newPath, {
+        overwrite: true,
+      });
+    } else {
+      await fs.createSymlink(existingPath, newPath, 'file');
+    }
   } catch (err: any) {
     // eslint-disable-line
     // If a hard link to the same file already exists
@@ -678,7 +687,9 @@ async function linkOrCopy(existingPath: string, newPath: string) {
     // In some VERY rare cases (1 in a thousand), hard-link creation fails on Windows.
     // In that case, we just fall back to copying.
     // This issue is reproducible with "pnpm add @material-ui/icons@4.9.1"
-    await fs.copyFile(existingPath, newPath);
+    await fs.copy(existingPath, newPath, {
+      overwrite: true,
+    });
   }
 }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -668,28 +668,15 @@ export async function runPackageJsonScript(
 }
 
 async function linkOrCopy(existingPath: string, newPath: string) {
-  try {
-    if (
-      newPath.endsWith('.nft.json') ||
-      newPath.endsWith('middleware-manifest.json')
-    ) {
-      await fs.copy(existingPath, newPath, {
-        overwrite: true,
-      });
-    } else {
-      await fs.createSymlink(existingPath, newPath, 'file');
-    }
-  } catch (err: any) {
-    // eslint-disable-line
-    // If a hard link to the same file already exists
-    // then trying to copy it will make an empty file from it.
-    if (err['code'] === 'EEXIST') return;
-    // In some VERY rare cases (1 in a thousand), hard-link creation fails on Windows.
-    // In that case, we just fall back to copying.
-    // This issue is reproducible with "pnpm add @material-ui/icons@4.9.1"
+  if (
+    newPath.endsWith('.nft.json') ||
+    newPath.endsWith('middleware-manifest.json')
+  ) {
     await fs.copy(existingPath, newPath, {
       overwrite: true,
     });
+  } else {
+    await fs.createSymlink(existingPath, newPath, 'file');
   }
 }
 


### PR DESCRIPTION
- Safelist manipulated .nft.json and middleware-manifest.json files so that they are always copied. This ensures that .next directory is never altered by `vc build`
- Switch from `fs.createLink` to `fs.createSymlink`

When removing calling build plugins: `fs.createSymlink` was ~2x faster when copying 70k files. 

<img width="634" alt="CleanShot 2021-11-18 at 10 55 22@2x" src="https://user-images.githubusercontent.com/4060187/142451194-ffc8c102-4e41-4f37-a6f4-8b059f6bed3c.png">

With build plugins, symlink is roughly 30%-40% faster.

### Related Issues

> Fixes #6975, #267

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
