### PR TITLE
[frameworks] Fix Parcel default output directory to dist

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1946,7 +1946,7 @@ export const frameworks = [
         value: 'parcel',
       },
       outputDirectory: {
-        value: 'dist'
+        value: 'dist',
       },
     },
     dependency: 'parcel',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1978,6 +1978,7 @@ export const frameworks = [
       },
       outputDirectory: {
         placeholder: 'dist',
+        value: 'dist'
       },
     },
     dependency: 'parcel',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1977,7 +1977,6 @@ export const frameworks = [
         placeholder: 'parcel',
       },
       outputDirectory: {
-        placeholder: 'dist',
         value: 'dist'
       },
     },


### PR DESCRIPTION
### Related Issues

The Parcel template via the Project Creating Flow returns a build error because the default output directory for the Parcel **Framework Preset** is searching for `public` instead of `dist`. The default behavior of Parcel's CLI I believe is `dist`.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
