### PR TITLE
[tests] Increase CI duration

### DIFF
--- a/.github/workflows/test-integration-dev.yml
+++ b/.github/workflows/test-integration-dev.yml
@@ -11,12 +11,12 @@ on:
 jobs:
   test:
     name: Dev
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [12]
+        node: [14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-go@v2

--- a/.github/workflows/test-integration-dev.yml
+++ b/.github/workflows/test-integration-dev.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [14]
+        node: [12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Seems like macOS sometimes exceeds 60 min so this bumps the timeout.

The build can be between 3 minutes and 5 minutes. The tests can be between 45 minutes and 55 minutes.