### PR TITLE
[tests] Make test more reliable for function timeout

### DIFF
--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -2683,7 +2683,7 @@ test('deploy a Lambda with 3 seconds of maxDuration', async t => {
   const url = new URL(output.stdout);
 
   // Should time out
-  url.pathname = '/api/wait-for/4';
+  url.pathname = '/api/wait-for/5';
   const response1 = await fetch(url.href);
   t.is(
     response1.status,
@@ -2692,7 +2692,7 @@ test('deploy a Lambda with 3 seconds of maxDuration', async t => {
   );
 
   // Should not time out
-  url.pathname = '/api/wait-for/2';
+  url.pathname = '/api/wait-for/1';
   const response2 = await fetch(url.href);
   t.is(
     response2.status,


### PR DESCRIPTION
This will help flaky tests pass the first time

For example: https://github.com/vercel/vercel/runs/4268488876?check_suite_focus=true#step:11:1721