### PR TITLE
[cli] Fix `vc build` with nested app dir

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -298,6 +298,9 @@ export default async function main(client: Client) {
     }
   }
 
+  // Required for Next.js to produce the correct `.nft.json` files.
+  spawnOpts.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = baseDir;
+
   // Yarn v2 PnP mode may be activated, so force
   // "node-modules" linker style
   const env = {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -621,16 +621,18 @@ export default async function main(client: Client) {
         ...requiredServerFilesJson,
         appDir: '.',
         files: requiredServerFilesJson.files.map((i: string) => {
-          const originalPath = join(dirname(distDir), i);
+          const originalPath = join(requiredServerFilesJson.appDir, i);
           const relPath = join(OUTPUT_DIR, relative(distDir, originalPath));
 
           const absolutePath = join(cwd, relPath);
           const output = relative(baseDir, absolutePath);
 
-          return {
-            input: relPath,
-            output,
-          };
+          return relPath === output
+            ? relPath
+            : {
+                input: relPath,
+                output,
+              };
         }),
       });
     }


### PR DESCRIPTION
### Related Issues
We'll have to use `appDir` instead of `distDir`, because the paths are relative to it.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
