### PR TITLE
Don't install Ruby or Python dependencies unnecessarily

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -52,6 +52,9 @@ export function convertRuntimeToPlugin(
           includeFiles: config.includeFiles,
           excludeFiles: config.excludeFiles,
         },
+        meta: {
+          avoidTopLevelInstall: true,
+        },
       });
 
       pages[entrypoint] = {

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -58,6 +58,7 @@ export interface Meta {
   filesRemoved?: string[];
   env?: Env;
   buildEnv?: Env;
+  avoidTopLevelInstall?: boolean;
 }
 
 export interface AnalyzeOptions {

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,3 +1,4 @@
+import { relative } from 'path';
 import execa from 'execa';
 import { Meta, debug } from '@vercel/build-utils';
 
@@ -135,6 +136,19 @@ export async function installRequirementsFile({
   meta,
   args = [],
 }: InstallRequirementsFileArg) {
+  const requirementsTxtAtRoot =
+    relative(workPath, filePath) === 'requirements.txt';
+
+  // If the `requirements.txt` file is located in the Root Directory of the project and
+  // the new File System API is used (`avoidTopLevelInstall`), the Install Command
+  // will have already installed its dependencies, so we don't need to do it again.
+  if (meta.avoidTopLevelInstall && requirementsTxtAtRoot) {
+    debug(
+      `Skipping requirements file installation, already installed by Install Command`
+    );
+    return;
+  }
+
   if (
     meta.isDev &&
     (await areRequirementsInstalled(pythonPath, filePath, workPath))

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,4 +1,4 @@
-import { relative } from 'path';
+import { relative, basename } from 'path';
 import execa from 'execa';
 import { Meta, debug } from '@vercel/build-utils';
 
@@ -137,7 +137,7 @@ export async function installRequirementsFile({
   args = [],
 }: InstallRequirementsFileArg) {
   const requirementsTxtAtRoot =
-    relative(workPath, filePath) === 'requirements.txt';
+    relative(workPath, filePath) === basename(filePath);
 
   // If the `requirements.txt` file is located in the Root Directory of the project and
   // the new File System API is used (`avoidTopLevelInstall`), the Install Command

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -136,13 +136,12 @@ export async function installRequirementsFile({
   meta,
   args = [],
 }: InstallRequirementsFileArg) {
-  const requirementsTxtAtRoot =
-    relative(workPath, filePath) === basename(filePath);
+  const fileAtRoot = relative(workPath, filePath) === basename(filePath);
 
   // If the `requirements.txt` file is located in the Root Directory of the project and
   // the new File System API is used (`avoidTopLevelInstall`), the Install Command
   // will have already installed its dependencies, so we don't need to do it again.
-  if (meta.avoidTopLevelInstall && requirementsTxtAtRoot) {
+  if (meta.avoidTopLevelInstall && fileAtRoot) {
     debug(
       `Skipping requirements file installation, already installed by Install Command`
     );

--- a/packages/ruby/index.ts
+++ b/packages/ruby/index.ts
@@ -132,12 +132,12 @@ export async function build({
         'did not find a vendor directory but found a Gemfile, bundling gems...'
       );
 
-      const gemFileAtRoot = relative(workPath, gemfilePath) === gemfileName;
+      const fileAtRoot = relative(workPath, gemfilePath) === gemfileName;
 
       // If the `Gemfile` is located in the Root Directory of the project and
       // the new File System API is used (`avoidTopLevelInstall`), the Install Command
       // will have already installed its dependencies, so we don't need to do it again.
-      if (meta.avoidTopLevelInstall && gemFileAtRoot) {
+      if (meta.avoidTopLevelInstall && fileAtRoot) {
         debug('Skipping `bundle install` — already handled by Install Command');
       } else {
         // try installing. this won't work if native extesions are required.

--- a/packages/ruby/index.ts
+++ b/packages/ruby/index.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from 'path';
+import { join, dirname, relative } from 'path';
 import execa from 'execa';
 import {
   ensureDir,
@@ -85,10 +85,12 @@ export async function build({
 }: BuildOptions) {
   await download(files, workPath, meta);
   const entrypointFsDirname = join(workPath, dirname(entrypoint));
+  const gemfileName = 'Gemfile';
+
   const gemfilePath = await walkParentDirs({
     base: workPath,
     start: entrypointFsDirname,
-    filename: 'Gemfile',
+    filename: gemfileName,
   });
   const gemfileContents = gemfilePath
     ? await readFile(gemfilePath, 'utf8')
@@ -130,15 +132,24 @@ export async function build({
         'did not find a vendor directory but found a Gemfile, bundling gems...'
       );
 
-      // try installing. this won't work if native extesions are required.
-      // if that's the case, gems should be vendored locally before deploying.
-      try {
-        await bundleInstall(bundlerPath, bundleDir, gemfilePath);
-      } catch (err) {
-        debug(
-          'unable to build gems from Gemfile. vendor the gems locally with "bundle install --deployment" and retry.'
-        );
-        throw err;
+      const gemFileAtRoot = relative(workPath, gemfilePath) === gemfileName;
+
+      // If the `Gemfile` is located in the Root Directory of the project and
+      // the new File System API is used (`avoidTopLevelInstall`), the Install Command
+      // will have already installed its dependencies, so we don't need to do it again.
+      if (meta.avoidTopLevelInstall && gemFileAtRoot) {
+        debug('Skipping `bundle install` — already handled by Install Command');
+      } else {
+        // try installing. this won't work if native extesions are required.
+        // if that's the case, gems should be vendored locally before deploying.
+        try {
+          await bundleInstall(bundlerPath, bundleDir, gemfilePath);
+        } catch (err) {
+          debug(
+            'unable to build gems from Gemfile. vendor the gems locally with "bundle install --deployment" and retry.'
+          );
+          throw err;
+        }
       }
     }
   } else {

--- a/packages/ruby/install-ruby.ts
+++ b/packages/ruby/install-ruby.ts
@@ -61,6 +61,14 @@ function getRubyPath(meta: Meta, gemfileContents: string) {
 // process.env.GEM_HOME), and returns
 // the absolute path to it
 export async function installBundler(meta: Meta, gemfileContents: string) {
+  // If the new File System API is used (`avoidTopLevelInstall`), the Install Command
+  // will have already installed the dependencies, so we don't need to do it again.
+  if (meta.avoidTopLevelInstall) {
+    debug(
+      `Skipping bundler installation, already installed by Install Command`
+    );
+  }
+
   const { gemHome, rubyPath, gemPath, vendorPath, runtime } = getRubyPath(
     meta,
     gemfileContents


### PR DESCRIPTION
### Related Issues

This closes https://github.com/vercel/runtimes/issues/252.

### Notes

- The changes for `vercel-plugin-node` were already handled in [this issue](https://github.com/vercel/vercel/pull/6988).
- `vercel-plugin-go` is not touched, because the File System API doesn't natively install dependencies for Go.
- `vercel-plugin-python` continues to run `installRequirement` because the `werkzeug` and `pipfile-requirements` dependencies are only needed for API Routes, and not for all Python dependency installations in general, so the File System API doesn't install those natively.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
