### PR TITLE
Properly publish CLI Plugins

### DIFF
--- a/packages/plugin-go/package.json
+++ b/packages/plugin-go/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "name": "vercel-plugin-go",
   "version": "1.0.0-canary.13",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "license": "MIT",
   "files": [
     "dist"

--- a/packages/plugin-python/package.json
+++ b/packages/plugin-python/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "name": "vercel-plugin-python",
   "version": "1.0.0-canary.14",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "license": "MIT",
   "files": [
     "dist"

--- a/packages/plugin-ruby/package.json
+++ b/packages/plugin-ruby/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "name": "vercel-plugin-ruby",
   "version": "1.0.0-canary.12",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
After https://github.com/vercel/vercel/pull/7088, `dist` now contains `package.json`, which made `tsc` move `index.js` a level deeper, effectively breaking the `main` property of all of the affected CLI Plugins.

This change makes them work again. 

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
