### PR TITLE
Renamed `runtime` to `use` in static JS config

### DIFF
--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -401,9 +401,9 @@ export async function build({ workPath }: { workPath: string }) {
       getConfig(project, absEntrypoint, FunctionConfigSchema) || {};
 
     // No config exported means "node", but if there is a config
-    // and "runtime" is defined, but it is not "node" then don't
+    // and "use" is defined, but it is not "node" then don't
     // compile this file.
-    if (config.runtime && config.runtime !== 'node') {
+    if (config.use && config.use !== 'node') {
       continue;
     }
 

--- a/packages/static-config/src/index.ts
+++ b/packages/static-config/src/index.ts
@@ -15,7 +15,7 @@ const ajv = new Ajv();
 export const BaseFunctionConfigSchema = {
   type: 'object',
   properties: {
-    runtime: { type: 'string' },
+    use: { type: 'string' },
     memory: { type: 'number' },
     maxDuration: { type: 'number' },
     regions: {

--- a/packages/static-config/test/fixtures/deno.ts
+++ b/packages/static-config/test/fixtures/deno.ts
@@ -2,7 +2,7 @@ import ms from 'https://denopkg.com/TooTallNate/ms';
 import { readerFromStreamReader } from 'https://deno.land/std@0.107.0/io/streams.ts';
 
 export const config = {
-  runtime: 'deno',
+  use: 'deno',
   location: 'https://example.com/page',
 };
 

--- a/packages/static-config/test/fixtures/invalid-schema.js
+++ b/packages/static-config/test/fixtures/invalid-schema.js
@@ -1,3 +1,3 @@
 export const config = {
-  runtime: 0,
+  use: 0,
 };

--- a/packages/static-config/test/fixtures/node.js
+++ b/packages/static-config/test/fixtures/node.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 export const config = {
-  runtime: 'node',
+  use: 'node',
   memory: 1024,
 };
 

--- a/packages/static-config/test/index.test.ts
+++ b/packages/static-config/test/index.test.ts
@@ -10,7 +10,7 @@ describe('getConfig()', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "memory": 1024,
-        "runtime": "node",
+        "use": "node",
       }
     `);
   });
@@ -27,7 +27,7 @@ describe('getConfig()', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "location": "https://example.com/page",
-        "runtime": "deno",
+        "use": "deno",
       }
     `);
   });


### PR DESCRIPTION
### Related Issues

This applies what was mentioned in https://github.com/vercel/runtimes/issues/288#issuecomment-984101750.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
