### PR TITLE
[api] Use the new File System API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "description": "API for the vercel/vercel repo",
   "main": "index.js",
   "scripts": {
-    "vercel-build": "yarn --cwd .. && node ../utils/run.js build all"
+    "vercel-build": "node ../utils/run.js build all"
   },
   "dependencies": {
     "@sentry/node": "5.11.1",


### PR DESCRIPTION
Since the yarn dependencies are already installed from the "Install Command" during build, installing again here is not necessary