### PR TITLE
Filter CLI Plugin output

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -13,10 +13,18 @@ import { getIgnoreFilter } from '.';
 // Builders/Runtimes didn't have `vercel.json` or `now.json`.
 const ignoredPaths = ['.output', '.vercel', 'vercel.json', 'now.json'];
 
-const shouldIgnorePath = (file: string, ignoreFilter: any) => {
+const shouldIgnorePath = (
+  file: string,
+  ignoreFilter: any,
+  ignoreFile: boolean
+) => {
   const isNative = ignoredPaths.some(item => {
     return file.startsWith(item);
   });
+
+  if (!ignoreFile) {
+    return isNative;
+  }
 
   return isNative || ignoreFilter(file);
 };
@@ -46,7 +54,7 @@ export function convertRuntimeToPlugin(
     // Build Step uses (literally the same code). Note that this exclusion only applies
     // when deploying. Locally, another exclusion further below is needed.
     for (const file in files) {
-      if (shouldIgnorePath(file, ignoreFilter)) {
+      if (shouldIgnorePath(file, ignoreFilter, true)) {
         delete files[file];
       }
     }
@@ -99,7 +107,7 @@ export function convertRuntimeToPlugin(
       // files isn't used by the Legacy Runtimes, so we need to apply the filters
       // to the outputs that they are returning instead.
       for (const file in lambdaFiles) {
-        if (shouldIgnorePath(file, ignoreFilter)) {
+        if (shouldIgnorePath(file, ignoreFilter, false)) {
           delete files[file];
         }
       }

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -7,6 +7,20 @@ import type FileBlob from './file-blob';
 import type { BuildOptions, Files } from './types';
 import { getIgnoreFilter } from '.';
 
+// `.output` was already created by the Build Command, so we have
+// to ensure its contents don't get bundled into the Lambda. Similarily,
+// we don't want to bundle anything from `.vercel` either. Lastly,
+// Builders/Runtimes didn't have `vercel.json` or `now.json`.
+const ignoredPaths = ['.output', '.vercel', 'vercel.json', 'now.json'];
+
+const shouldIgnorePath = (file: string, ignoreFilter: any) => {
+  const isNative = ignoredPaths.some(item => {
+    return file.startsWith(item);
+  });
+
+  return isNative || ignoreFilter(file);
+};
+
 /**
  * Convert legacy Runtime to a Plugin.
  * @param buildRuntime - a legacy build() function from a Runtime
@@ -23,25 +37,16 @@ export function convertRuntimeToPlugin(
     const opts = { cwd: workPath };
     const files = await glob('**', opts);
 
-    // `.output` was already created by the Build Command, so we have
-    // to ensure its contents don't get bundled into the Lambda. Similarily,
-    // we don't want to bundle anything from `.vercel` either. Lastly,
-    // Builders/Runtimes didn't have `vercel.json` or `now.json`.
-    const ignoredPaths = ['.output', '.vercel', 'vercel.json', 'now.json'];
-
     // We also don't want to provide any files to Runtimes that were ignored
     // through `.vercelignore` or `.nowignore`, because the Build Step does the same.
     const ignoreFilter = await getIgnoreFilter(workPath);
 
     // We're not passing this as an `ignore` filter to the `glob` function above,
     // so that we can re-use exactly the same `getIgnoreFilter` method that the
-    // Build Step uses (literally the same code).
+    // Build Step uses (literally the same code). Note that this exclusion only applies
+    // when deploying. Locally, another exclusion further below is needed.
     for (const file in files) {
-      const isNative = ignoredPaths.some(item => {
-        return file.startsWith(item);
-      });
-
-      if (isNative || ignoreFilter(file)) {
+      if (shouldIgnorePath(file, ignoreFilter)) {
         delete files[file];
       }
     }
@@ -88,6 +93,16 @@ export function convertRuntimeToPlugin(
 
       // @ts-ignore This symbol is a private API
       const lambdaFiles: Files = output[FILES_SYMBOL];
+
+      // When deploying, the `files` that are passed to the Legacy Runtimes already
+      // have certain files that are ignored stripped, but locally, that list of
+      // files isn't used by the Legacy Runtimes, so we need to apply the filters
+      // to the outputs that they are returning instead.
+      for (const file in lambdaFiles) {
+        if (shouldIgnorePath(file, ignoreFilter)) {
+          delete files[file];
+        }
+      }
 
       const entry = join(workPath, '.output', 'server', 'pages', entrypoint);
       await fs.ensureDir(dirname(entry));


### PR DESCRIPTION
### Related Issues

This change completes https://github.com/vercel/vercel/pull/7088.

We were already filtering the list of files that get passed to Legacy Runtimes, but since that list of files is only used when deploying (locally it just uses whatever exists on the file system), we have to apply the same filtering to the output too.

`vercel-plugin-node` doesn't have this problem, because it only includes what it has traced, whereas `vercel-plugin-go`, `vercel-plugin-ruby`, and `vercel-plugin-python` just need to include everything because they're not tracing.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
