### PR TITLE
Fixed Go, Ruby, and Python CLI Plugin output generation

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -135,7 +135,7 @@ export function convertRuntimeToPlugin(
       Object.entries(lambdaFiles).forEach(async ([relPath, file]) => {
         const newPath = join(traceDir, relPath);
 
-        if (newPath !== handlerFile) {
+        if (newPath !== handlerFilePath) {
           tracedFiles.push(relPath);
         }
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -68,8 +68,6 @@ export function convertRuntimeToPlugin(
     // before the Legacy Runtime has even started to build.
     const sourceFilesPreBuild = await getSourceFiles(workPath, ignoreFilter);
 
-    console.log(sourceFilesPreBuild);
-
     // Instead of doing another `glob` to get all the matching source files,
     // we'll filter the list of existing files down to only the ones
     // that are matching the entrypoint pattern, so we're first creating
@@ -86,7 +84,6 @@ export function convertRuntimeToPlugin(
       }
     }
 
-    console.log(entrypoints);
     const pages: { [key: string]: any } = {};
     const pluginName = packageName.replace('vercel-plugin-', '');
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -143,9 +143,12 @@ export function convertRuntimeToPlugin(
       Object.entries(lambdaFiles).forEach(async ([relPath, file]) => {
         const newPath = join(traceDir, relPath);
 
-        if (newPath !== handlerFilePath) {
-          tracedFiles.push(relPath);
+        // The handler was already moved into position above.
+        if (relPath === handlerFilePath) {
+          return;
         }
+
+        tracedFiles.push(relPath);
 
         if (file.fsPath) {
           await linkOrCopy(file.fsPath, newPath);

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -37,7 +37,8 @@ const getSourceFiles = async (workPath: string, ignoreFilter: any) => {
   // We're not passing this as an `ignore` filter to the `glob` function above,
   // so that we can re-use exactly the same `getIgnoreFilter` method that the
   // Build Step uses (literally the same code). Note that this exclusion only applies
-  // when deploying. Locally, another exclusion further below is needed.
+  // when deploying. Locally, another exclusion is needed, which is handled
+  // further below in the `convertRuntimeToPlugin` function.
   for (const file in list) {
     if (shouldIgnorePath(file, ignoreFilter, true)) {
       delete list[file];

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -126,7 +126,7 @@ export function convertRuntimeToPlugin(
 
       // Further down, we will need the filename of the Lambda handler
       // for placing it inside `server/pages/api`, but because Legacy Runtimes
-      // don't expose the that filename directly, we have to construct it
+      // don't expose the filename directly, we have to construct it
       // from the handler name, and then find the matching file further below,
       // because we don't yet know its extension here.
       const handler = output.handler;

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -120,14 +120,15 @@ export function convertRuntimeToPlugin(
         return parse(item).name === handlerFileName;
       });
 
-      if (!handlerFilePath) {
+      const handlerFileOrigin = lambdaFiles[handlerFilePath || ''].fsPath;
+
+      if (!handlerFileOrigin) {
         throw new Error(
           `Could not find a handler file. Please ensure that the list of \`files\` defined for the returned \`Lambda\` contains a file with the name ${handlerFileName} (+ any extension).`
         );
       }
 
       const entry = join(workPath, '.output', 'server', 'pages', entrypoint);
-      const handlerFileOrigin = files[handlerFilePath].fsPath;
 
       await fs.ensureDir(dirname(entry));
       await linkOrCopy(handlerFileOrigin, entry);

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -90,6 +90,11 @@ export function convertRuntimeToPlugin(
         },
       });
 
+      // Further down, we will need the filename of the Lambda handler
+      // for placing it inside `server/pages/api`, but because Legacy Runtimes
+      // don't expose the that filename directly, we have to construct it
+      // from the handler name, and then find the matching file further below,
+      // because we don't yet know its extension here.
       const handler = output.handler;
       const handlerMethod = handler.split('.').reverse()[0];
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -139,6 +139,7 @@ export function convertRuntimeToPlugin(
         '.output',
         'server',
         'pages',
+        'api',
         `${entrypoint}.nft.json`
       );
       const json = JSON.stringify({

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -90,8 +90,12 @@ export function convertRuntimeToPlugin(
         },
       });
 
+      const handler = output.handler;
+      const handlerMethod = handler.split('.').reverse()[0];
+      const handlerFile = handler.replace(`.${handlerMethod}`, '');
+
       pages[entrypoint] = {
-        handler: output.handler,
+        handler: handler,
         runtime: output.runtime,
         memory: output.memory,
         maxDuration: output.maxDuration,
@@ -114,13 +118,17 @@ export function convertRuntimeToPlugin(
 
       const entry = join(workPath, '.output', 'server', 'pages', entrypoint);
       await fs.ensureDir(dirname(entry));
-      await linkOrCopy(files[entrypoint].fsPath, entry);
+      await linkOrCopy(files[handlerFile].fsPath, entry);
 
       const tracedFiles: string[] = [];
 
       Object.entries(lambdaFiles).forEach(async ([relPath, file]) => {
         const newPath = join(traceDir, relPath);
-        tracedFiles.push(relPath);
+
+        if (newPath !== handlerFile) {
+          tracedFiles.push(relPath);
+        }
+
         if (file.fsPath) {
           await linkOrCopy(file.fsPath, newPath);
         } else if (file.type === 'FileBlob') {

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -68,8 +68,25 @@ export function convertRuntimeToPlugin(
     // before the Legacy Runtime has even started to build.
     const sourceFilesPreBuild = await getSourceFiles(workPath, ignoreFilter);
 
-    const entrypointPattern = `api/**/*${ext}`;
-    const entrypoints = await glob(entrypointPattern, { cwd: workPath });
+    console.log(sourceFilesPreBuild);
+
+    // Instead of doing another `glob` to get all the matching source files,
+    // we'll filter the list of existing files down to only the ones
+    // that are matching the entrypoint pattern, so we're first creating
+    // a clean new list to begin.
+    const entrypoints = Object.assign({}, sourceFilesPreBuild);
+
+    const entrypointMatch = new RegExp(`^api/.*${ext}$`);
+
+    // Up next, we'll strip out the files from the list of entrypoints
+    // that aren't actually considered entrypoints.
+    for (const file in entrypoints) {
+      if (!entrypointMatch.test(file)) {
+        delete entrypoints[file];
+      }
+    }
+
+    console.log(entrypoints);
     const pages: { [key: string]: any } = {};
     const pluginName = packageName.replace('vercel-plugin-', '');
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -136,7 +136,7 @@ export function convertRuntimeToPlugin(
       // Legacy Runtimes will pollute `workPath` with files like the Lambda handler,
       // so we need to clean those up. The only one we can reliably clean up without storing
       // state about what was originally present is the handler.
-      await fs.rm(handlerFileOrigin);
+      await fs.remove(handlerFileOrigin);
 
       const tracedFiles: string[] = [];
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -69,7 +69,7 @@ export function convertRuntimeToPlugin(
     const sourceFilesPreBuild = await getSourceFiles(workPath, ignoreFilter);
 
     const entrypointPattern = `api/**/*${ext}`;
-    const entrypoints = await glob(entrypointPattern, opts);
+    const entrypoints = await glob(entrypointPattern, { cwd: workPath });
     const pages: { [key: string]: any } = {};
     const pluginName = packageName.replace('vercel-plugin-', '');
 

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,0 +1,1 @@
+# handler

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,1 +1,0 @@
-# handler

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -32,16 +32,34 @@ describe('convert-runtime-to-plugin', () => {
   });
 
   it('should create correct fileystem for python', async () => {
+    const ext = '.py';
     const workPath = pythonApiWorkpath;
+    const handlerName = 'vc__handler__python';
+    const handlerFileName = handlerName + ext;
+
     const lambdaOptions = {
-      handler: 'index.handler',
+      handler: `${handlerName}.vc_handler`,
       runtime: 'python3.9',
       memory: 512,
       maxDuration: 5,
       environment: {},
     };
 
+    const writeLauncher = async () => {
+      await fs.writeFile(join(workPath, handlerFileName), '# handler');
+    };
+
+    // TODO: This should be possible to remove by re-arranging the code, but
+    // it doesn't influence the reliability of the test. It's just that this test
+    // reads files even before the build was run, so they don't yet contain a launcher,
+    // which this addition is guaranteeing. We'll just have to change reading
+    // the files at a different position.
+    await writeLauncher();
+
     const buildRuntime = async (opts: BuildOptions) => {
+      // This is the usual time at which a Legacy Runtime writes its Lambda launcher.
+      await writeLauncher();
+
       const lambda = await createLambda({
         files: opts.files,
         ...lambdaOptions,
@@ -50,15 +68,15 @@ describe('convert-runtime-to-plugin', () => {
     };
 
     const lambdaFiles = await fsToJson(workPath);
-    delete lambdaFiles['vercel.json'];
-
-    const ext = '.py';
     const packageName = 'vercel-plugin-python';
     const build = await convertRuntimeToPlugin(buildRuntime, packageName, ext);
 
     await build({ workPath });
 
     const output = await fsToJson(join(workPath, '.output'));
+
+    delete lambdaFiles['vercel.json'];
+    delete lambdaFiles['vc__handler__python.py'];
 
     expect(output).toMatchObject({
       'functions-manifest.json': expect.stringContaining('{'),
@@ -68,12 +86,12 @@ describe('convert-runtime-to-plugin', () => {
       server: {
         pages: {
           api: {
-            'index.py': expect.stringContaining('index'),
+            'index.py': expect.stringContaining('handler'),
             'index.py.nft.json': expect.stringContaining('{'),
             users: {
-              'get.py': expect.stringContaining('get'),
+              'get.py': expect.stringContaining('handler'),
               'get.py.nft.json': expect.stringContaining('{'),
-              'post.py': expect.stringContaining('post'),
+              'post.py': expect.stringContaining('handler'),
               'post.py.nft.json': expect.stringContaining('{'),
             },
           },
@@ -96,35 +114,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -137,35 +155,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -178,35 +196,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -109,35 +109,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -150,35 +150,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -191,35 +191,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],


### PR DESCRIPTION
### Related Issues

This contributes to resolving https://github.com/vercel/runtimes/issues/294 by aligning all CLI Plugins within this repo with how the File System API expects them to work, and resolves a number of bugs as part of that.

At the moment, API Routes overwrite each other's launcher files, so if you have more than one API Route per CLI Plugin, that would cause a failure when deployed. That's fixed now.

`vercel-plugin-node` wasn't yet updated, because it requires changes that are a little different and more complicated, because it requires multiple launcher files (a bridge and a launcher) per entrypoint. A PR for it will follow shortly.

Before this change, CLI Plugins would treat the entrypoint files (like `api/test.js`) as the Lambda's entrypoint file too, which is wrong, and it now has been changed to being the launcher file, with all the other files placed inside `inputs`.

![CleanShot 2021-12-02 at 17 49 35@2x](https://user-images.githubusercontent.com/6170607/144466564-02811972-a4c7-4890-9b9d-e7b95dd261d2.png)

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
