### PR TITLE
Make middleware plugin output code in strict mode

### DIFF
--- a/packages/cli/test/fixtures/unit/edge-middleware-strict/_middleware.ts
+++ b/packages/cli/test/fixtures/unit/edge-middleware-strict/_middleware.ts
@@ -2,5 +2,5 @@ export default function (req) {
   const isStrict = (function () {
     return !this;
   })();
-  return new Response('is strict mode? (next.js) ' + (isStrict ? 'yes' : 'no'));
+  return new Response('is strict mode? ' + (isStrict ? 'yes' : 'no'));
 }

--- a/packages/cli/test/fixtures/unit/edge-middleware-strict/_middleware.ts
+++ b/packages/cli/test/fixtures/unit/edge-middleware-strict/_middleware.ts
@@ -1,0 +1,6 @@
+export default function (req) {
+  const isStrict = (function () {
+    return !this;
+  })();
+  return new Response('is strict mode? (next.js) ' + (isStrict ? 'yes' : 'no'));
+}

--- a/packages/cli/test/util/dev/server.test.ts
+++ b/packages/cli/test/util/dev/server.test.ts
@@ -385,4 +385,13 @@ describe('DevServer', () => {
       );
     })
   );
+
+  it(
+    'should run middleware in strict mode',
+    testFixture('edge-middleware-strict', async server => {
+      const response = await fetch(`${server.address}/index.html`);
+      const body = await response.text();
+      expect(body).toStrictEqual('is strict mode? (next.js) yes');
+    })
+  );
 });

--- a/packages/cli/test/util/dev/server.test.ts
+++ b/packages/cli/test/util/dev/server.test.ts
@@ -391,7 +391,7 @@ describe('DevServer', () => {
     testFixture('edge-middleware-strict', async server => {
       const response = await fetch(`${server.address}/index.html`);
       const body = await response.text();
-      expect(body).toStrictEqual('is strict mode? (next.js) yes');
+      expect(body).toStrictEqual('is strict mode? yes');
     })
   );
 });

--- a/packages/middleware/src/entries.js
+++ b/packages/middleware/src/entries.js
@@ -1,4 +1,4 @@
-import * as middleware from './_middleware';
+import * as middleware from './_temp_middleware';
 _ENTRIES = typeof _ENTRIES === 'undefined' ? {} : _ENTRIES;
 _ENTRIES['middleware_pages/_middleware'] = {
   default: async function (ev) {

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -22,7 +22,8 @@ const SUPPORTED_EXTENSIONS = ['.js', '.ts'];
 
 // File name of the `entries.js` file that gets copied into the
 // project directory. Use a name that is unlikely to conflict.
-const ENTRIES_NAME = '___vc_entries.js';
+const TMP_ENTRIES_NAME = '.output/server/pages/___vc_entries.js';
+const TMP_MIDDLEWARE_BUNDLE = '.output/server/pages/_temp_middleware.js';
 
 async function getMiddlewareFile(workingDirectory: string) {
   // Only the root-level `_middleware.*` files are considered.
@@ -52,17 +53,36 @@ async function getMiddlewareFile(workingDirectory: string) {
 }
 
 export async function build({ workPath }: { workPath: string }) {
-  const entriesPath = join(workPath, ENTRIES_NAME);
+  const entriesPath = join(workPath, TMP_ENTRIES_NAME);
+  const transientFilePath = join(workPath, TMP_MIDDLEWARE_BUNDLE);
   const middlewareFile = await getMiddlewareFile(workPath);
   if (!middlewareFile) return;
 
   console.log('Compiling middleware file: %j', middlewareFile);
 
-  // Create `_ENTRIES` wrapper
-  await fsp.copyFile(join(__dirname, 'entries.js'), entriesPath);
-
-  // Build
+  /**
+   * Two builds happen here, because esbuild doesn't offer a way to add a banner
+   * to individual input files, and the entries wrapper relies on running in
+   * non-strict mode to access the ENTRIES global.
+   *
+   * To work around this, we bundle the middleware directly and add
+   * 'use strict'; to make the entire bundle run in strict mode. We then bundle
+   * a second time, adding the global ENTRIES wrapper and preserving the
+   * 'use strict' for the entire scope of the original bundle.
+   */
   try {
+    await esbuild.build({
+      entryPoints: [middlewareFile],
+      bundle: true,
+      absWorkingDir: workPath,
+      outfile: transientFilePath,
+      banner: {
+        js: '"use strict";',
+      },
+      format: 'cjs',
+    });
+    // Create `_ENTRIES` wrapper
+    await fsp.copyFile(join(__dirname, 'entries.js'), entriesPath);
     await esbuild.build({
       entryPoints: [entriesPath],
       bundle: true,
@@ -70,6 +90,7 @@ export async function build({ workPath }: { workPath: string }) {
       outfile: join(workPath, '.output/server/pages/_middleware.js'),
     });
   } finally {
+    await fsp.unlink(transientFilePath);
     await fsp.unlink(entriesPath);
   }
 

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -23,8 +23,8 @@ const SUPPORTED_EXTENSIONS = ['.js', '.ts'];
 
 // File name of the `entries.js` file that gets copied into the
 // project directory. Use a name that is unlikely to conflict.
-const TMP_ENTRIES_NAME = '.output/server/pages/___vc_entries.js';
-const TMP_MIDDLEWARE_BUNDLE = '.output/server/pages/_temp_middleware.js';
+const TMP_ENTRIES_NAME = '.output/inputs/middleware/___vc_entries.js';
+const TMP_MIDDLEWARE_BUNDLE = '.output/inputs/middleware/_temp_middleware.js';
 
 async function getMiddlewareFile(workingDirectory: string) {
   // Only the root-level `_middleware.*` files are considered.

--- a/packages/middleware/src/websandbox/sandbox/sandbox.ts
+++ b/packages/middleware/src/websandbox/sandbox/sandbox.ts
@@ -114,6 +114,7 @@ export async function run(params: {
     const content = readFileSync(params.path, 'utf-8');
     const esBuildResult = esbuild.transformSync(content, {
       format: 'cjs',
+      banner: '"use strict";',
     });
     const x = vm.runInNewContext(m.wrap(esBuildResult.code), cache.sandbox, {
       filename: params.path,
@@ -163,6 +164,7 @@ function sandboxRequire(referrer: string, specifier: string) {
 
   const transformOptions: esbuild.TransformOptions = {
     format: 'cjs',
+    banner: '"use strict";',
   };
   if (extname(resolved) === '.json') {
     transformOptions.loader = 'json';

--- a/packages/middleware/test/build.test.ts
+++ b/packages/middleware/test/build.test.ts
@@ -11,7 +11,7 @@ const setupFixture = async (fixture: string) => {
 
   const functionsManifest = JSON.parse(
     await fsp.readFile(
-      join(fixturePath, '.output/server/functions-manifest.json'),
+      join(fixturePath, '.output/functions-manifest.json'),
       'utf8'
     )
   );

--- a/packages/middleware/test/build.test.ts
+++ b/packages/middleware/test/build.test.ts
@@ -62,7 +62,7 @@ describe('build()', () => {
     ).toEqual('1');
   });
 
-  it('should create a middlware that runs in strict mode', async () => {
+  it('should create a middleware that runs in strict mode', async () => {
     const { middleware } = await setupFixture('use-strict');
     const response = await middleware({
       request: {},

--- a/packages/middleware/test/build.test.ts
+++ b/packages/middleware/test/build.test.ts
@@ -68,8 +68,6 @@ describe('build()', () => {
     const response = await middleware({
       request: {},
     });
-    expect(String(response.response.body)).toEqual(
-      'is strict mode? (next.js) yes'
-    );
+    expect(String(response.response.body)).toEqual('is strict mode? yes');
   });
 });

--- a/packages/middleware/test/build.test.ts
+++ b/packages/middleware/test/build.test.ts
@@ -3,6 +3,30 @@ import { promises as fsp } from 'fs';
 import { build } from '../src';
 import { Response } from 'node-fetch';
 
+const setupFixture = async (fixture: string) => {
+  const fixturePath = join(__dirname, `fixtures/${fixture}`);
+  await build({
+    workPath: fixturePath,
+  });
+
+  const middlewareManifest = JSON.parse(
+    await fsp.readFile(
+      join(fixturePath, '.output/server/middleware-manifest.json'),
+      'utf8'
+    )
+  );
+
+  const outputFile = join(fixturePath, '.output/server/pages/_middleware.js');
+  expect(await fsp.stat(outputFile)).toBeTruthy();
+  require(outputFile);
+  //@ts-ignore
+  const middleware = global._ENTRIES['middleware_pages/_middleware'].default;
+  return {
+    middleware,
+    middlewareManifest,
+  };
+};
+
 describe('build()', () => {
   beforeEach(() => {
     //@ts-ignore
@@ -15,25 +39,8 @@ describe('build()', () => {
     delete global._ENTRIES;
   });
   it('should build simple middleware', async () => {
-    const fixture = join(__dirname, 'fixtures/simple');
-    await build({
-      workPath: fixture,
-    });
-
-    const middlewareManifest = JSON.parse(
-      await fsp.readFile(
-        join(fixture, '.output/server/middleware-manifest.json'),
-        'utf8'
-      )
-    );
+    const { middlewareManifest, middleware } = await setupFixture('simple');
     expect(middlewareManifest).toMatchSnapshot();
-
-    const outputFile = join(fixture, '.output/server/pages/_middleware.js');
-    expect(await fsp.stat(outputFile)).toBeTruthy();
-
-    require(outputFile);
-    //@ts-ignore
-    const middleware = global._ENTRIES['middleware_pages/_middleware'].default;
     expect(typeof middleware).toStrictEqual('function');
     const handledResponse = await middleware({
       request: {
@@ -53,5 +60,15 @@ describe('build()', () => {
     expect(
       (unhandledResponse.response as Response).headers.get('x-middleware-next')
     ).toEqual('1');
+  });
+
+  it('should create a middlware that runs in strict mode', async () => {
+    const { middleware } = await setupFixture('use-strict');
+    const response = await middleware({
+      request: {},
+    });
+    expect(String(response.response.body)).toEqual(
+      'is strict mode? (next.js) yes'
+    );
   });
 });

--- a/packages/middleware/test/fixtures/use-strict/_middleware.js
+++ b/packages/middleware/test/fixtures/use-strict/_middleware.js
@@ -2,5 +2,5 @@ export default function (req) {
   const isStrict = (function () {
     return !this;
   })();
-  return new Response('is strict mode? (next.js) ' + (isStrict ? 'yes' : 'no'));
+  return new Response('is strict mode? ' + (isStrict ? 'yes' : 'no'));
 }

--- a/packages/middleware/test/fixtures/use-strict/_middleware.js
+++ b/packages/middleware/test/fixtures/use-strict/_middleware.js
@@ -1,0 +1,6 @@
+export default function (req) {
+  const isStrict = (function () {
+    return !this;
+  })();
+  return new Response('is strict mode? (next.js) ' + (isStrict ? 'yes' : 'no'));
+}


### PR DESCRIPTION
### Related Issues

This updates the output middleware to run in strict mode. Added related dev/middleware build tests to ensure no regressions. I've also built and deployed a small test project locally.

Fixes https://github.com/vercel/runtimes/issues/289

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
