### PR TITLE
Corrected input paths for CLI Plugins

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -222,7 +222,7 @@ export function convertRuntimeToPlugin(
       const json = JSON.stringify({
         version: 1,
         files: tracedFiles.map(file => ({
-          input: normalizePath(relative(nft, file.absolutePath)),
+          input: normalizePath(relative(dirname(nft), file.absolutePath)),
           output: normalizePath(file.relativePath),
         })),
       });

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -87,22 +87,18 @@ export function convertRuntimeToPlugin(
 
     const pages: { [key: string]: any } = {};
     const pluginName = packageName.replace('vercel-plugin-', '');
-    const outputPath = join(workPath, '.output');
 
-    // Legacy Runtimes can only provide API Routes, so that's
-    // why we can use this prefix for all of them. Here, we have to
-    // make sure to not use a cryptic hash name, because people
-    // need to be able to easily inspect the output.
-    const inputPath = join('inputs', `api-routes-${pluginName}`);
+    const traceDir = join(
+      workPath,
+      `.output`,
+      `inputs`,
+      // Legacy Runtimes can only provide API Routes, so that's
+      // why we can use this prefix for all of them. Here, we have to
+      // make sure to not use a cryptic hash name, because people
+      // need to be able to easily inspect the output.
+      `api-routes-${pluginName}`
+    );
 
-    // This is where any dependencies of the Lambdas exposed by
-    // the Legacy Runtime will be placed, so that the platform can
-    // automatically do smart bundling and make multiple API Routes
-    // use the same files if they need to, without actually duplicating
-    // the files on the disk.
-    const traceDir = join(outputPath, inputPath);
-
-    // The directory doesn't yet exist, so we'll create it.
     await fs.ensureDir(traceDir);
 
     for (const entrypoint of Object.keys(entrypoints)) {
@@ -225,16 +221,10 @@ export function convertRuntimeToPlugin(
 
       const json = JSON.stringify({
         version: 1,
-        files: tracedFiles.map(file => {
-          const { absolutePath, relativePath } = file;
-          const climbHigher = relative(absolutePath, outputPath);
-          const climbLower = join(climbHigher, inputPath, relativePath);
-
-          return {
-            input: normalizePath(climbLower),
-            output: normalizePath(relativePath),
-          };
-        }),
+        files: tracedFiles.map(file => ({
+          input: normalizePath(relative(nft, file.absolutePath)),
+          output: normalizePath(file.relativePath),
+        })),
       });
 
       await fs.ensureDir(dirname(nft));

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,0 +1,1 @@
+# handler

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,1 +1,0 @@
-# handler

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -109,35 +109,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -150,35 +150,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -191,35 +191,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -109,35 +109,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -150,35 +150,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],
@@ -191,35 +191,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -109,6 +109,47 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
+          input: `../../../inputs/api-routes-python/api/db/[id].py`,
+          output: 'api/db/[id].py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/api/index.py`,
+          output: 'api/index.py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          output: 'api/project/[aid]/[bid]/index.py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/api/users/get.py`,
+          output: 'api/users/get.py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/api/users/post.py`,
+          output: 'api/users/post.py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/file.txt`,
+          output: 'file.txt',
+        },
+        {
+          input: `../../../inputs/api-routes-python/util/date.py`,
+          output: 'util/date.py',
+        },
+        {
+          input: `../../../inputs/api-routes-python/util/math.py`,
+          output: 'util/math.py',
+        },
+      ],
+    });
+
+    const getJson = JSON.parse(
+      output.server.pages.api.users['get.py.nft.json']
+    );
+    expect(getJson).toMatchObject({
+      version: 1,
+      files: [
+        {
           input: `../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
@@ -143,47 +184,6 @@ describe('convert-runtime-to-plugin', () => {
       ],
     });
 
-    const getJson = JSON.parse(
-      output.server.pages.api.users['get.py.nft.json']
-    );
-    expect(getJson).toMatchObject({
-      version: 1,
-      files: [
-        {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
-        },
-        {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
-        },
-      ],
-    });
-
     const postJson = JSON.parse(
       output.server.pages.api.users['post.py.nft.json']
     );
@@ -191,35 +191,35 @@ describe('convert-runtime-to-plugin', () => {
       version: 1,
       files: [
         {
-          input: `../../../../../inputs/api-routes-python/api/db/[id].py`,
+          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
           output: 'api/db/[id].py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/index.py`,
+          input: `../../../../inputs/api-routes-python/api/index.py`,
           output: 'api/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
+          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
           output: 'api/project/[aid]/[bid]/index.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/get.py`,
+          input: `../../../../inputs/api-routes-python/api/users/get.py`,
           output: 'api/users/get.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/api/users/post.py`,
+          input: `../../../../inputs/api-routes-python/api/users/post.py`,
           output: 'api/users/post.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/file.txt`,
+          input: `../../../../inputs/api-routes-python/file.txt`,
           output: 'file.txt',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/date.py`,
+          input: `../../../../inputs/api-routes-python/util/date.py`,
           output: 'util/date.py',
         },
         {
-          input: `../../../../../inputs/api-routes-python/util/math.py`,
+          input: `../../../../inputs/api-routes-python/util/math.py`,
           output: 'util/math.py',
         },
       ],


### PR DESCRIPTION
As shown in [this Deployment](https://vercel.com/curated-tests/api-routes-ruby/3i72LgistyFXERzif5eb1yWf3EBZ) (which is using the latest canary), the paths within the NFT files are still one level too far up.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
