### PR TITLE
[cli] Support for `next export` with `vercel build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -490,7 +490,12 @@ export default async function main(client: Client) {
         'routes-manifest.json',
         'build-manifest.json',
       ]) {
-        await smartCopy(client, join(dotNextDir, file), join(OUTPUT_DIR, file));
+        const input = join(dotNextDir, file);
+
+        if (fs.existsSync(input)) {
+          // Do not use `smartCopy`, since we want to overwrite if they already exist.
+          await fs.copyFile(input, join(OUTPUT_DIR, file));
+        }
       }
     } else if (isNextOutput) {
       // The contents of `.output/static` should be placed inside of `.output/static/_next/static`

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -449,6 +449,8 @@ export default async function main(client: Client) {
       : null;
 
     if (dotNextDir && exportStatus) {
+      client.output.debug('Found `next export` output.');
+
       const tempOutput = join(cwd, '.output___tmp');
       const outputFiles = await buildUtilsGlob(
         '**',

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -449,7 +449,7 @@ export default async function main(client: Client) {
     }
 
     // Special Next.js processing.
-    if (dotNextDir && nextExport) {
+    if (nextExport) {
       client.output.debug('Found `next export` output.');
 
       const htmlFiles = await buildUtilsGlob(
@@ -488,7 +488,7 @@ export default async function main(client: Client) {
         'routes-manifest.json',
         'build-manifest.json',
       ]) {
-        const input = join(dotNextDir, file);
+        const input = join(nextExport.dotNextDir, file);
 
         if (fs.existsSync(input)) {
           // Do not use `smartCopy`, since we want to overwrite if they already exist.
@@ -970,6 +970,7 @@ async function getNextExportStatus(dotNextDir: string | null) {
     });
 
   return {
+    dotNextDir,
     exportDetail,
     exportMarker: {
       trailingSlash: exportMarker?.hasExportPathMap

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -356,9 +356,7 @@ export default async function main(client: Client) {
     // We cannot rely on the `framework` alone, as it might be a static export,
     // and the current build might use a differnt project that's not in the settings.
     const isNextOutput = Boolean(dotNextDir);
-    const nextExport = dotNextDir
-      ? await getNextExportStatus(dotNextDir)
-      : null;
+    const nextExport = await getNextExportStatus(dotNextDir);
     const outputDir =
       isNextOutput && !nextExport ? OUTPUT_DIR : join(OUTPUT_DIR, 'static');
     const distDir =
@@ -935,7 +933,11 @@ async function resolveNftToOutput({
 /**
  * Files will only exist when `next export` was used.
  */
-async function getNextExportStatus(dotNextDir: string) {
+async function getNextExportStatus(dotNextDir: string | null) {
+  if (!dotNextDir) {
+    return null;
+  }
+
   const exportDetail: {
     success: boolean;
     outDirectory: string;


### PR DESCRIPTION
### Related Issues
Fixes https://github.com/vercel/runtimes/issues/284

This PR ensures that we'll read the specific files that `next export` creates and create the `.output` directory accordingly.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
