### PR TITLE
[middleware] Fix dependencies

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -30,7 +30,7 @@
     "@types/node-fetch": "^2",
     "@types/ua-parser-js": "0.7.36",
     "@types/uuid": "8.3.1",
-    "@vercel/build-utils": "2.12.3-canary.30",
+    "@vercel/build-utils": "2.12.3-canary.32",
     "@vercel/ncc": "0.24.0",
     "cookie": "0.4.1",
     "formdata-node": "4.3.1",


### PR DESCRIPTION
This fixes an issue where `yarn.lock` was being regenerated due to incorrect version