### PR TITLE
[ruby] Show error when Ruby 2.5.x detected

### DIFF
--- a/packages/ruby/install-ruby.ts
+++ b/packages/ruby/install-ruby.ts
@@ -55,7 +55,7 @@ function getRubyPath(meta: Meta, gemfileContents: string) {
       if (isDiscontinued(selection)) {
         const latest = getLatestRubyVersion();
         const intro = `Found \`Gemfile\` with discontinued Ruby version: \`${line}.\``;
-        const hint = `Please set \`ruby "~> ${latest.range}"\` in your \`Gemfile\` to use Ruby ${latest.major}.`;
+        const hint = `Please set \`ruby "~> ${latest.range}"\` in your \`Gemfile\` to use Ruby ${latest.range}.`;
         const upstream =
           'This change is the result of a decision made by an upstream infrastructure provider (AWS).';
         throw new NowBuildError({

--- a/packages/ruby/install-ruby.ts
+++ b/packages/ruby/install-ruby.ts
@@ -9,11 +9,22 @@ interface RubyVersion extends NodeVersion {
 
 const allOptions: RubyVersion[] = [
   { major: 2, minor: 7, range: '2.7.x', runtime: 'ruby2.7' },
-  { major: 2, minor: 5, range: '2.5.x', runtime: 'ruby2.5' },
+  {
+    major: 2,
+    minor: 5,
+    range: '2.5.x',
+    runtime: 'ruby2.5',
+    discontinueDate: new Date('2021-11-30'),
+  },
 ];
 
 function getLatestRubyVersion(): RubyVersion {
   return allOptions[0];
+}
+
+function isDiscontinued({ discontinueDate }: RubyVersion): boolean {
+  const today = Date.now();
+  return discontinueDate !== undefined && discontinueDate.getTime() <= today;
 }
 
 function getRubyPath(meta: Meta, gemfileContents: string) {
@@ -37,8 +48,20 @@ function getRubyPath(meta: Meta, gemfileContents: string) {
       if (!found) {
         throw new NowBuildError({
           code: 'RUBY_INVALID_VERSION',
-          message: 'Found `Gemfile` with invalid Ruby version: `' + line + '`.',
-          link: 'https://vercel.com/docs/runtimes#official-runtimes/ruby/ruby-version',
+          message: `Found \`Gemfile\` with invalid Ruby version: \`${line}.\``,
+          link: 'http://vercel.link/ruby-version',
+        });
+      }
+      if (isDiscontinued(selection)) {
+        const latest = getLatestRubyVersion();
+        const intro = `Found \`Gemfile\` with discontinued Ruby version: \`${line}.\``;
+        const hint = `Please set \`ruby "~> ${latest.range}"\` in your \`Gemfile\` to use Ruby ${latest.major}.`;
+        const upstream =
+          'This change is the result of a decision made by an upstream infrastructure provider (AWS).';
+        throw new NowBuildError({
+          code: 'RUBY_DISCONTINUED_VERSION',
+          link: 'http://vercel.link/ruby-version',
+          message: `${intro} ${hint} ${upstream}`,
         });
       }
     }

--- a/packages/ruby/test/fixtures/02-cowsay-vendored/now.json
+++ b/packages/ruby/test/fixtures/02-cowsay-vendored/now.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
   "builds": [{ "src": "index.rb", "use": "@vercel/ruby" }],
-  "build": { "env": { "RUBY_VERSION": "2.7.x" } },
   "probes": [{ "path": "/", "mustContain": "gem:RANDOMNESS_PLACEHOLDER" }]
 }

--- a/packages/ruby/test/fixtures/04-cowsay-vendored-nested/now.json
+++ b/packages/ruby/test/fixtures/04-cowsay-vendored-nested/now.json
@@ -1,7 +1,6 @@
 {
   "version": 2,
   "builds": [{ "src": "project/index.rb", "use": "@vercel/ruby" }],
-  "build": { "env": { "RUBY_VERSION": "2.7.x" } },
   "probes": [
     { "path": "/project/", "mustContain": "gem:RANDOMNESS_PLACEHOLDER" }
   ]

--- a/packages/ruby/test/fixtures/05-sinatra/now.json
+++ b/packages/ruby/test/fixtures/05-sinatra/now.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
   "builds": [{ "src": "index.ru", "use": "@vercel/ruby" }],
-  "build": { "env": { "RUBY_VERSION": "2.7.x" } },
   "probes": [{ "path": "/", "mustContain": "gem:RANDOMNESS_PLACEHOLDER" }]
 }

--- a/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile
+++ b/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 2.5.x"
+
+gem "cowsay", "~> 0.3.0"

--- a/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile.lock
+++ b/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cowsay (0.3.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  cowsay (~> 0.3.0)
+
+RUBY VERSION
+   ruby 2.5.5p157
+
+BUNDLED WITH
+   2.2.22

--- a/packages/ruby/test/fixtures/11-version-2-5-error/index.rb
+++ b/packages/ruby/test/fixtures/11-version-2-5-error/index.rb
@@ -1,0 +1,9 @@
+require 'cowsay'
+
+Handler = Proc.new do |req, res|
+  name = req.query['name'] || 'World'
+
+  res.status = 200
+  res['Content-Type'] = 'text/text; charset=utf-8'
+  res.body = Cowsay.say("Hello #{name}", 'cow')
+end

--- a/packages/ruby/test/fixtures/11-version-2-5-error/vercel.json
+++ b/packages/ruby/test/fixtures/11-version-2-5-error/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.rb", "use": "@vercel/ruby" }]
+}

--- a/packages/ruby/test/test.js
+++ b/packages/ruby/test/test.js
@@ -23,8 +23,32 @@ beforeAll(async () => {
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
+const testsThatFailToBuild = new Map([
+  [
+    '11-version-2-5-error',
+    'Found `Gemfile` with discontinued Ruby version: `ruby "~> 2.5.x".` Please set `ruby "~> 2.7.x"` in your `Gemfile` to use Ruby 2.7.x. This change is the result of a decision made by an upstream infrastructure provider (AWS).',
+  ],
+]);
+
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
+  const errMsg = testsThatFailToBuild.get(fixture);
+  if (errMsg) {
+    // eslint-disable-next-line no-loop-func
+    it(`should fail to build ${fixture}`, async () => {
+      try {
+        await testDeployment(
+          { builderUrl, buildUtilsUrl },
+          path.join(fixturesPath, fixture)
+        );
+      } catch (err) {
+        expect(err).toBeTruthy();
+        expect(err.deployment).toBeTruthy();
+        expect(err.deployment.errorMessage).toBe(errMsg);
+      }
+    });
+    continue; //eslint-disable-line
+  }
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(


### PR DESCRIPTION
This will show a better error message when Ruby 2.5.x is detected and explain how to upgrade.