### PR TITLE
Fixed Legacy Runtime output generation

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -185,7 +185,7 @@ export function convertRuntimeToPlugin(
 
       // Generate a list of directories and files that weren't present
       // before the entrypoint was processed by the Legacy Runtime, so
-      // that we can perform a cleanup later. We need to device into files
+      // that we can perform a cleanup later. We need to divide into files
       // and directories because only cleaning up files might leave empty
       // directories, and listing directories separately also speeds up the
       // build because we can just delete them, which wipes all of their nested
@@ -327,7 +327,7 @@ export function convertRuntimeToPlugin(
     // Once all the entrypoints have been processed, we'd like to
     // remove all the files from `workPath` that originally weren't present
     // before the Legacy Runtime began running, because the `workPath`
-    // is nowadays the directorry in which the user keeps their source code, since
+    // is nowadays the directory in which the user keeps their source code, since
     // we're no longer running separate parallel builds for every Legacy Runtime.
     await Promise.all(toRemove);
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -203,10 +203,6 @@ export function convertRuntimeToPlugin(
             return dirname(filePath).startsWith(dirPath);
           });
 
-          console.log(`New Dir: ${isNewDir}`);
-          console.log(path);
-          console.log(dirPath);
-
           // Check out the list of tracked directories that were
           // newly added and see if one of them contains the path
           // we're looking at.

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -101,7 +101,7 @@ export function convertRuntimeToPlugin(
 
     await fs.ensureDir(traceDir);
 
-    let newFilesRuntime: Set<string> = new Set();
+    let newPathsRuntime: Set<string> = new Set();
     let linkersRuntime: Array<Promise<void>> = [];
 
     for (const entrypoint of Object.keys(entrypoints)) {
@@ -176,14 +176,14 @@ export function convertRuntimeToPlugin(
       await fs.ensureDir(dirname(entry));
       await linkOrCopy(handlerFileOrigin, entry);
 
-      const newFilesEntrypoint: Set<string> = new Set();
+      const newPathsEntrypoint: Set<string> = new Set();
 
       // You can find more details about this at the point where the
       // `sourceFilesAfterBuild` is created originally.
       for (const file in sourceFilesAfterBuild) {
         if (!sourceFilesPreBuild[file]) {
           const path = sourceFilesAfterBuild[file].fsPath;
-          newFilesEntrypoint.add(path);
+          newPathsEntrypoint.add(path);
         }
       }
 
@@ -216,7 +216,7 @@ export function convertRuntimeToPlugin(
             // the Legacy Runtime. This is likely to overwrite the destination on subsequent
             // runs, but that's also how `workPath` used to work originally, without
             // the File System API (meaning that there was one `workPath` for all entrypoints).
-            if (newFilesEntrypoint.has(fsPath)) {
+            if (newPathsEntrypoint.has(fsPath)) {
               debug(`Copying from ${fsPath} to ${newPath}`);
               await fs.copyFile(fsPath, newPath);
             } else {
@@ -255,7 +255,7 @@ export function convertRuntimeToPlugin(
       // Extend the list of files that were created by the Legacy Runtime
       // with the list of files that were created for the entrypoint
       // that was just processed above.
-      newFilesRuntime = new Set([...newFilesRuntime, ...newFilesEntrypoint]);
+      newPathsRuntime = new Set([...newPathsRuntime, ...newPathsEntrypoint]);
     }
 
     // Instead of of waiting for all of the linking to be done for every
@@ -266,7 +266,7 @@ export function convertRuntimeToPlugin(
 
     // A list of all the files that were created by the Legacy Runtime,
     // which we'd like to remove from the File System.
-    const toRemove = Array.from(newFilesRuntime).map(file => fs.remove(file));
+    const toRemove = Array.from(newPathsRuntime).map(file => fs.remove(file));
 
     // Once all the entrypoints have been processed, we'd like to
     // remove all the files from `workPath` that originally weren't present

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -205,6 +205,8 @@ export function convertRuntimeToPlugin(
           const { fsPath, type } = file;
 
           if (fsPath) {
+            await fs.ensureDir(dirname(newPath));
+
             // With this, we're making sure that files in the `workPath` that existed
             // before the Legacy Runtime was invoked (source files) are linked from
             // `.output` instead of copying there (the latter only happens if linking fails),


### PR DESCRIPTION
As you can see in [this Deployment](https://vercel.com/curated-tests/api-routes-python/CMy1HBhNULg8U7f7ZXiMGmTcTg5k), the utility wrapped around Legacy Runtimes to convert them into CLI Plugins previously had an issue where dependencies of Serverless Functions would not be available.

This error was caused by the functionality within the utility that automatically cleans up the `workPath` after the Legacy Runtime has handled the build, so that the user's working directory won't remain polluted, and only `.output` is the result that remains at the end.

The changes in this PR ensure that the `workPath` remains clean, but the files that the Legacy Runtimes temporarily create in that directory are still made available in the final `.output` result.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
