### PR TITLE
Use correct Lambda handler for CLI Plugins

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -307,8 +307,8 @@ export function convertRuntimeToPlugin(
 
       const apiRouteHandler = `${parse(entry).name}.${handlerMethod}`;
 
-      // Add an entry that will later on be added to `functions-manifest.json`
-      // that is placed inside of the `.output` directory.
+      // Add an entry that will later on be added to the `functions-manifest.json`
+      // file that is placed inside of the `.output` directory.
       pages[entrypoint] = {
         handler: apiRouteHandler,
         runtime: output.runtime,

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -98,9 +98,13 @@ describe('convert-runtime-to-plugin', () => {
     expect(funcManifest).toMatchObject({
       version: 1,
       pages: {
-        'api/index.py': lambdaOptions,
-        'api/users/get.py': lambdaOptions,
-        'api/users/post.py': { ...lambdaOptions, memory: 512 },
+        'api/index.py': { ...lambdaOptions, handler: 'index.vc_handler' },
+        'api/users/get.py': { ...lambdaOptions, handler: 'get.vc_handler' },
+        'api/users/post.py': {
+          ...lambdaOptions,
+          handler: 'post.vc_handler',
+          memory: 512,
+        },
       },
     });
 


### PR DESCRIPTION
As mentioned in [this Slack message](https://vercel.slack.com/archives/C02DB4T5D2A/p1638538063434600?thread_ts=1638533559.423900&cid=C02DB4T5D2A), the `handler` property for every API Route created by Legacy Runtimes should match the files present inside `.output/server/pages/api` in order for them to work.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
