### PR TITLE
Fixed Lambda handler for compiled languages

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -146,6 +146,7 @@ export function convertRuntimeToPlugin(
       const { handler } = output;
       const handlerMethod = handler.split('.').reverse()[0];
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');
+      const handlerFileBase = handlerFileName + ext;
 
       // For compiled languages, the launcher file for the Lambda generated
       // by the Legacy Runtime matches the `handler` defined for it, but for
@@ -153,12 +154,12 @@ export function convertRuntimeToPlugin(
       // without an extension, plus the name of the method inside of that file
       // that should be invoked, so we have to construct the file path explicitly.
       if (!handlerFile) {
-        handlerFile = lambdaFiles[join(workPath, handlerFileName, ext)];
+        handlerFile = lambdaFiles[join(workPath, handlerFileBase)];
       }
 
       if (!handlerFile || !handlerFile.fsPath) {
         throw new Error(
-          `Could not find a handler file. Please ensure that the list of \`files\` defined for the returned \`Lambda\` contains a file with the name ${handlerFileName} (+ any extension).`
+          `Could not find a handler file. Please ensure that \`files\` for the returned \`Lambda\` contains an \`FileFsRef\` named "${handlerFileBase}" with a valid \`fsPath\`.`
         );
       }
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -148,6 +148,7 @@ export function convertRuntimeToPlugin(
       const { handler } = output;
       const handlerMethod = handler.split('.').reverse()[0];
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');
+      const handlerExtName = extname(handlerFileName);
 
       // For compiled languages, the launcher file for the Lambda generated
       // by the Legacy Runtime matches the `handler` defined for it, but for
@@ -170,7 +171,7 @@ export function convertRuntimeToPlugin(
 
       const entryRoot = join(workPath, '.output', 'server', 'pages');
       const entryDir = dirname(entrypoint);
-      const entryBase = basename(entrypoint).replace(ext, extname(handler));
+      const entryBase = basename(entrypoint).replace(ext, handlerExtName);
       const entry = join(entryRoot, entryDir, entryBase);
 
       // We never want to link here, only copy, because the launcher

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -307,7 +307,7 @@ export function convertRuntimeToPlugin(
 
       // Add an entry that will later on be added to the `functions-manifest.json`
       // file that is placed inside of the `.output` directory.
-      pages[entryPath] = {
+      pages[normalizePath(entryPath)] = {
         // Because the underlying file used as a handler was placed
         // inside `.output/server/pages/api`, it no longer has the name it originally
         // had and is now named after the API Route that it's responsible for,

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -169,8 +169,9 @@ export function convertRuntimeToPlugin(
       }
 
       const entryRoot = join(workPath, '.output', 'server', 'pages');
+      const entryDir = dirname(entrypoint);
       const entryBase = basename(entrypoint).replace(ext, extname(handler));
-      const entry = join(entryRoot, dirname(entrypoint), entryBase);
+      const entry = join(entryRoot, entryDir, entryBase);
 
       // We never want to link here, only copy, because the launcher
       // file often has the same name for every entrypoint, which means that
@@ -315,7 +316,7 @@ export function convertRuntimeToPlugin(
 
       // Add an entry that will later on be added to the `functions-manifest.json`
       // file that is placed inside of the `.output` directory.
-      pages[entrypoint] = {
+      pages[join(entryDir, entryBase)] = {
         // Because the underlying file used as a handler was placed
         // inside `.output/server/pages/api`, it no longer has the name it originally
         // had and is now named after the API Route that it's responsible for,

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -287,13 +287,7 @@ export function convertRuntimeToPlugin(
 
       linkersRuntime = linkersRuntime.concat(linkers);
 
-      const nft = join(
-        workPath,
-        '.output',
-        'server',
-        'pages',
-        `${entrypoint}.nft.json`
-      );
+      const nft = `${entry}.nft.json`;
 
       const json = JSON.stringify({
         version: 1,

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -141,7 +141,7 @@ export function convertRuntimeToPlugin(
         }
       }
 
-      let handlerFile = lambdaFiles[join(workPath, output.handler)];
+      let handlerFile = lambdaFiles[output.handler];
 
       const { handler } = output;
       const handlerMethod = handler.split('.').pop();
@@ -154,7 +154,7 @@ export function convertRuntimeToPlugin(
       // without an extension, plus the name of the method inside of that file
       // that should be invoked, so we have to construct the file path explicitly.
       if (!handlerFile) {
-        handlerFile = lambdaFiles[join(workPath, handlerFileBase)];
+        handlerFile = lambdaFiles[handlerFileBase];
       }
 
       if (!handlerFile || !handlerFile.fsPath) {

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -146,7 +146,7 @@ export function convertRuntimeToPlugin(
       });
 
       const { handler } = output;
-      const handlerMethod = handler.split('.').reverse()[0];
+      const handlerMethod = handler.split('.').pop();
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');
 
       // For compiled languages, the launcher file for the Lambda generated

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -148,7 +148,6 @@ export function convertRuntimeToPlugin(
       const { handler } = output;
       const handlerMethod = handler.split('.').reverse()[0];
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');
-      const handlerExtName = extname(handlerFileName);
 
       // For compiled languages, the launcher file for the Lambda generated
       // by the Legacy Runtime matches the `handler` defined for it, but for
@@ -162,6 +161,7 @@ export function convertRuntimeToPlugin(
       }
 
       const handlerFileOrigin = lambdaFiles[handlerFilePath || ''].fsPath;
+      const handlerExtName = extname(handlerFilePath || '');
 
       if (!handlerFileOrigin) {
         throw new Error(

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -141,12 +141,12 @@ export function convertRuntimeToPlugin(
         }
       }
 
-      let handlerFile = lambdaFiles[output.handler];
+      let handlerFileBase = output.handler;
+      let handlerFile = lambdaFiles[handlerFileBase];
 
       const { handler } = output;
       const handlerMethod = handler.split('.').pop();
       const handlerFileName = handler.replace(`.${handlerMethod}`, '');
-      const handlerFileBase = handlerFileName + ext;
 
       // For compiled languages, the launcher file for the Lambda generated
       // by the Legacy Runtime matches the `handler` defined for it, but for
@@ -154,6 +154,7 @@ export function convertRuntimeToPlugin(
       // without an extension, plus the name of the method inside of that file
       // that should be invoked, so we have to construct the file path explicitly.
       if (!handlerFile) {
+        handlerFileBase = handlerFileName + ext;
         handlerFile = lambdaFiles[handlerFileBase];
       }
 
@@ -239,7 +240,7 @@ export function convertRuntimeToPlugin(
           const newPath = join(traceDir, relPath);
 
           // The handler was already moved into position above.
-          if (relPath === entryPath) {
+          if (relPath === handlerFileBase) {
             return;
           }
 


### PR DESCRIPTION
Interpreted languages deployed to AWS Lambda use the following format for the `handler` of a Lambda:

```
<file-name-without-extension>.<method-name>
```

Compiled languages, on the other hand, use this format:

```
<file-name>
```

The latter previously wasn't supported at all, but after this change, it will be.

The logic does not rely on actually knowing whether a compiled or interpreted language is used. Instead, it just checks if the `handler` exists as-is on the file system, and if it does, it's considered a compiled language. If that's not the case, the first format is assumed and used instead.

After this change, the error shown on the "Errors" tab of [this Deployment](https://vercel.com/curated-tests/api-routes-go/HofQuEBJSr4Zb8DnnjypsZCVHqCV/functions) should disappear.

It works with `vercel-plugin-go`, `vercel-plugin-ruby`, and `vercel-plugin-python`.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
