### PR TITLE
Correctly position dependencies for CLI Plugins

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -104,6 +104,9 @@ export function convertRuntimeToPlugin(
     let newPathsRuntime: Set<string> = new Set();
     let linkersRuntime: Array<Promise<void>> = [];
 
+    const entryDir = join('.output', 'server', 'pages');
+    const entryRoot = join(workPath, entryDir);
+
     for (const entrypoint of Object.keys(entrypoints)) {
       const { output } = await buildRuntime({
         files: sourceFilesPreBuild,
@@ -166,7 +169,6 @@ export function convertRuntimeToPlugin(
 
       const handlerExtName = extname(handlerFile.fsPath);
 
-      const entryRoot = join(workPath, '.output', 'server', 'pages');
       const entryBase = basename(entrypoint).replace(ext, handlerExtName);
       const entryPath = join(dirname(entrypoint), entryBase);
       const entry = join(entryRoot, entryPath);
@@ -290,7 +292,9 @@ export function convertRuntimeToPlugin(
         version: 1,
         files: tracedFiles.map(file => ({
           input: normalizePath(relative(dirname(nft), file.absolutePath)),
-          output: normalizePath(file.relativePath),
+          // We'd like to place all the dependency files right next
+          // to the final launcher file inside of the Lambda.
+          output: normalizePath(join(entryDir, 'api', file.relativePath)),
         })),
       });
 

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,0 +1,1 @@
+# handler

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,1 +1,0 @@
-# handler

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -114,35 +114,35 @@ describe('convert-runtime-to-plugin', () => {
       files: [
         {
           input: `../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
+          output: '.output/server/pages/api/api/db/[id].py',
         },
         {
           input: `../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
+          output: '.output/server/pages/api/api/index.py',
         },
         {
           input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
+          output: '.output/server/pages/api/api/project/[aid]/[bid]/index.py',
         },
         {
           input: `../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
+          output: '.output/server/pages/api/api/users/get.py',
         },
         {
           input: `../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
+          output: '.output/server/pages/api/api/users/post.py',
         },
         {
           input: `../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
+          output: '.output/server/pages/api/file.txt',
         },
         {
           input: `../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
+          output: '.output/server/pages/api/util/date.py',
         },
         {
           input: `../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
+          output: '.output/server/pages/api/util/math.py',
         },
       ],
     });
@@ -155,35 +155,35 @@ describe('convert-runtime-to-plugin', () => {
       files: [
         {
           input: `../../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
+          output: '.output/server/pages/api/api/db/[id].py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
+          output: '.output/server/pages/api/api/index.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
+          output: '.output/server/pages/api/api/project/[aid]/[bid]/index.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
+          output: '.output/server/pages/api/api/users/get.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
+          output: '.output/server/pages/api/api/users/post.py',
         },
         {
           input: `../../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
+          output: '.output/server/pages/api/file.txt',
         },
         {
           input: `../../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
+          output: '.output/server/pages/api/util/date.py',
         },
         {
           input: `../../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
+          output: '.output/server/pages/api/util/math.py',
         },
       ],
     });
@@ -196,35 +196,35 @@ describe('convert-runtime-to-plugin', () => {
       files: [
         {
           input: `../../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
+          output: '.output/server/pages/api/api/db/[id].py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
+          output: '.output/server/pages/api/api/index.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
+          output: '.output/server/pages/api/api/project/[aid]/[bid]/index.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
+          output: '.output/server/pages/api/api/users/get.py',
         },
         {
           input: `../../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
+          output: '.output/server/pages/api/api/users/post.py',
         },
         {
           input: `../../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
+          output: '.output/server/pages/api/file.txt',
         },
         {
           input: `../../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
+          output: '.output/server/pages/api/util/date.py',
         },
         {
           input: `../../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
+          output: '.output/server/pages/api/util/math.py',
         },
       ],
     });


### PR DESCRIPTION
Previously, CLI Plugins would try to mount the user-provided request handler (e.g. `api/test.rb`) at the same position inside the Lambda at which the launcher was located (e.g. `api/test.rb`), which would cause the launcher to be overwritten.

With this change, all the destination mounting points for NFT input files are becoming relative to the `.output/server/pages/api` directory instead of `.output/server/pages`, so they should no longer overwrite the launcher, and instead be loaded from the launcher, like normal.

This PR might have two problems:

- If imports in Ruby/Python/etc are relative to `cwd` and not the file from which the import is executed (which I doubt), this would fail.
- We might have to replace `api` with the exact sub folder of the API Route within `.output/server/pages/api` if the current change doesn't yet work for nested paths. Although that also means repeating all of the other dependencies (not just the user-provided request handler) in a different location for every single API Route.

The two above will be tested after this PR was merged, as there currently isn't a way to test `vercel-plugin-go`, `vercel-plugin-python`, and `vercel-plugin-ruby` without publishing a canary, because they don't bundle `@vercel/build-utils`, which was the package that was just updated.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
