### PR TITLE
Temporarily remove CLI Plugin linking

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -353,13 +353,7 @@ export function convertRuntimeToPlugin(
 }
 
 async function linkOrCopy(existingPath: string, newPath: string) {
-  try {
-    await fs.createLink(existingPath, newPath);
-  } catch (err: any) {
-    if (err.code !== 'EEXIST') {
-      await fs.copyFile(existingPath, newPath);
-    }
-  }
+  await fs.copyFile(existingPath, newPath);
 }
 
 async function readJson(filePath: string): Promise<{ [key: string]: any }> {


### PR DESCRIPTION
This temporarily removes the creation of hard links for CLI Plugins while we're debugging something.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
