### PR TITLE
Prevent CLI Plugins from overwriting files

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -117,6 +117,7 @@ export function convertRuntimeToPlugin(
         },
         meta: {
           avoidTopLevelInstall: true,
+          skipDownload: true,
         },
       });
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -354,7 +354,13 @@ export function convertRuntimeToPlugin(
 }
 
 async function linkOrCopy(existingPath: string, newPath: string) {
-  await fs.copyFile(existingPath, newPath);
+  try {
+    await fs.createLink(existingPath, newPath);
+  } catch (err: any) {
+    if (err.code !== 'EEXIST') {
+      await fs.copyFile(existingPath, newPath);
+    }
+  }
 }
 
 async function readJson(filePath: string): Promise<{ [key: string]: any }> {


### PR DESCRIPTION
This reverts https://github.com/vercel/vercel/pull/7138 and also fixes an issue where the contents of files would become empty because the Legacy Runtimes are calling a legacy `download()` util that is no longer relevant with the new File System API, as files don't have to explicitly be downloaded into separate builds anymore — everything runs in a single `workPath`.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
