### PR TITLE
Simplify NFT output logic for CLI and CLI Plugins

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -241,7 +241,7 @@ export function convertRuntimeToPlugin(
 
             if (!fsPath) {
               throw new Error(
-                'File "${file}" is missing valid `fsPath` property'
+                `File "${file}" is missing valid \`fsPath\` property`
               );
             }
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -3,7 +3,6 @@ import { join, parse, relative, dirname, basename, extname } from 'path';
 import glob from './fs/glob';
 import { normalizePath } from './fs/normalize-path';
 import { FILES_SYMBOL, Lambda } from './lambda';
-import type FileBlob from './file-blob';
 import type { BuildOptions, Files } from './types';
 import { debug, getIgnoreFilter } from '.';
 
@@ -102,7 +101,6 @@ export function convertRuntimeToPlugin(
     await fs.ensureDir(traceDir);
 
     let newPathsRuntime: Set<string> = new Set();
-    let linkersRuntime: Array<Promise<void>> = [];
 
     const entryDir = join('.output', 'server', 'pages');
     const entryRoot = join(workPath, entryDir);
@@ -233,70 +231,28 @@ export function convertRuntimeToPlugin(
         }
       }
 
-      const tracedFiles: {
-        absolutePath: string;
-        relativePath: string;
-      }[] = [];
-
-      const linkers = Object.entries(lambdaFiles).map(
-        async ([relPath, file]) => {
-          const newPath = join(traceDir, relPath);
-
-          // The handler was already moved into position above.
-          if (relPath === handlerFileBase) {
-            return;
-          }
-
-          tracedFiles.push({ absolutePath: newPath, relativePath: relPath });
-          const { fsPath, type } = file;
-
-          if (fsPath) {
-            await fs.ensureDir(dirname(newPath));
-
-            const isNewFile = newFilesEntrypoint.includes(fsPath);
-
-            const isInsideNewDirectory = newDirectoriesEntrypoint.some(
-              dirPath => {
-                return fsPath.startsWith(dirPath);
-              }
-            );
-
-            // With this, we're making sure that files in the `workPath` that existed
-            // before the Legacy Runtime was invoked (source files) are linked from
-            // `.output` instead of copying there (the latter only happens if linking fails),
-            // which is the fastest solution. However, files that are created fresh
-            // by the Legacy Runtimes are always copied, because their link destinations
-            // are likely to be overwritten every time an entrypoint is processed by
-            // the Legacy Runtime. This is likely to overwrite the destination on subsequent
-            // runs, but that's also how `workPath` used to work originally, without
-            // the File System API (meaning that there was one `workPath` for all entrypoints).
-            if (isNewFile || isInsideNewDirectory) {
-              debug(`Copying from ${fsPath} to ${newPath}`);
-              await fs.copy(fsPath, newPath);
-            } else {
-              await linkOrCopy(fsPath, newPath);
-            }
-          } else if (type === 'FileBlob') {
-            const { data, mode } = file as FileBlob;
-            await fs.writeFile(newPath, data, { mode });
-          } else {
-            throw new Error(`Unknown file type: ${type}`);
-          }
-        }
-      );
-
-      linkersRuntime = linkersRuntime.concat(linkers);
-
       const nft = `${entry}.nft.json`;
 
       const json = JSON.stringify({
         version: 2,
-        files: tracedFiles.map(file => ({
-          input: normalizePath(relative(dirname(nft), file.absolutePath)),
-          // We'd like to place all the dependency files right next
-          // to the final launcher file inside of the Lambda.
-          output: normalizePath(file.relativePath),
-        })),
+        files: Object.keys(lambdaFiles)
+          .map(file => {
+            const { fsPath } = lambdaFiles[file];
+
+            if (!fsPath) {
+              throw new Error(
+                'File "${file}" is missing valid `fsPath` property'
+              );
+            }
+
+            // The handler was already moved into position above.
+            if (file === handlerFileBase) {
+              return;
+            }
+
+            return normalizePath(relative(dirname(nft), fsPath));
+          })
+          .filter(Boolean),
       });
 
       await fs.ensureDir(dirname(nft));
@@ -327,12 +283,6 @@ export function convertRuntimeToPlugin(
       };
     }
 
-    // Instead of of waiting for all of the linking to be done for every
-    // entrypoint before processing the next one, we immediately handle all
-    // of them one after the other, while then waiting for the linking
-    // to finish right here, before we clean up newly created files below.
-    await Promise.all(linkersRuntime);
-
     // A list of all the files that were created by the Legacy Runtime,
     // which we'd like to remove from the File System.
     const toRemove = Array.from(newPathsRuntime).map(path => {
@@ -351,16 +301,6 @@ export function convertRuntimeToPlugin(
     // to the `functions-manifest.json` file provided in `.output`.
     await updateFunctionsManifest({ workPath, pages });
   };
-}
-
-async function linkOrCopy(existingPath: string, newPath: string) {
-  try {
-    await fs.createLink(existingPath, newPath);
-  } catch (err: any) {
-    if (err.code !== 'EEXIST') {
-      await fs.copyFile(existingPath, newPath);
-    }
-  }
 }
 
 async function readJson(filePath: string): Promise<{ [key: string]: any }> {

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,0 +1,1 @@
+# handler

--- a/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
+++ b/packages/build-utils/test/convert-runtime/python-api/vc__handler__python.py
@@ -1,1 +1,0 @@
-# handler

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -62,7 +62,6 @@ describe('convert-runtime-to-plugin', () => {
       return { output: lambda };
     };
 
-    const lambdaFiles = await fsToJson(workPath);
     const packageName = 'vercel-plugin-python';
     const build = await convertRuntimeToPlugin(buildRuntime, packageName, ext);
 
@@ -70,14 +69,8 @@ describe('convert-runtime-to-plugin', () => {
 
     const output = await fsToJson(join(workPath, '.output'));
 
-    delete lambdaFiles['vercel.json'];
-    delete lambdaFiles['vc__handler__python.py'];
-
     expect(output).toMatchObject({
       'functions-manifest.json': expect.stringContaining('{'),
-      inputs: {
-        'api-routes-python': lambdaFiles,
-      },
       server: {
         pages: {
           api: {
@@ -112,38 +105,14 @@ describe('convert-runtime-to-plugin', () => {
     expect(indexJson).toMatchObject({
       version: 2,
       files: [
-        {
-          input: `../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
-        },
-        {
-          input: `../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
-        },
-        {
-          input: `../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
-        },
+        '../../../../api/db/[id].py',
+        '../../../../api/index.py',
+        '../../../../api/project/[aid]/[bid]/index.py',
+        '../../../../api/users/get.py',
+        '../../../../api/users/post.py',
+        '../../../../file.txt',
+        '../../../../util/date.py',
+        '../../../../util/math.py',
       ],
     });
 
@@ -153,38 +122,14 @@ describe('convert-runtime-to-plugin', () => {
     expect(getJson).toMatchObject({
       version: 2,
       files: [
-        {
-          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
-        },
+        '../../../../../api/db/[id].py',
+        '../../../../../api/index.py',
+        '../../../../../api/project/[aid]/[bid]/index.py',
+        '../../../../../api/users/get.py',
+        '../../../../../api/users/post.py',
+        '../../../../../file.txt',
+        '../../../../../util/date.py',
+        '../../../../../util/math.py',
       ],
     });
 
@@ -194,38 +139,14 @@ describe('convert-runtime-to-plugin', () => {
     expect(postJson).toMatchObject({
       version: 2,
       files: [
-        {
-          input: `../../../../inputs/api-routes-python/api/db/[id].py`,
-          output: 'api/db/[id].py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/index.py`,
-          output: 'api/index.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/project/[aid]/[bid]/index.py`,
-          output: 'api/project/[aid]/[bid]/index.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/users/get.py`,
-          output: 'api/users/get.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/api/users/post.py`,
-          output: 'api/users/post.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/file.txt`,
-          output: 'file.txt',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/util/date.py`,
-          output: 'util/date.py',
-        },
-        {
-          input: `../../../../inputs/api-routes-python/util/math.py`,
-          output: 'util/math.py',
-        },
+        '../../../../../api/db/[id].py',
+        '../../../../../api/index.py',
+        '../../../../../api/project/[aid]/[bid]/index.py',
+        '../../../../../api/users/get.py',
+        '../../../../../api/users/post.py',
+        '../../../../../file.txt',
+        '../../../../../util/date.py',
+        '../../../../../util/math.py',
       ],
     });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -668,15 +668,7 @@ export default async function main(client: Client) {
             const originalPath = join(requiredServerFilesJson.appDir, i);
             const relPath = join(OUTPUT_DIR, relative(distDir, originalPath));
 
-            const absolutePath = join(cwd, relPath);
-            const output = relative(baseDir, absolutePath);
-
-            return relPath === output
-              ? relPath
-              : {
-                  input: relPath,
-                  output,
-                };
+            return relPath;
           }),
         });
       }


### PR DESCRIPTION
This change contributes to https://github.com/vercel/runtimes/issues/294 by leaving the resolving of source files to the File System API, instead of copying or linking files around to place them inside `.output` unnecessarily.

This fixes https://github.com/vercel/runtimes/issues/280.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
