### PR TITLE
Fixed middleware tests

### DIFF
--- a/packages/middleware/test/__snapshots__/build.test.ts.snap
+++ b/packages/middleware/test/__snapshots__/build.test.ts.snap
@@ -15,6 +15,6 @@ Object {
       "sortingIndex": 1,
     },
   },
-  "version": 1,
+  "version": 2,
 }
 `;


### PR DESCRIPTION
This fixes a problem with the `vercel-plugin-middleware` tests introduced in https://github.com/vercel/vercel/pull/7143.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
