### PR TITLE
Adjust import statements inside Runtime launchers

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -228,6 +228,8 @@ export function convertRuntimeToPlugin(
 
             handlerContent = replaceAt(
               handlerContent,
+              // We'd like to add one character to the index, to consider
+              // that the import path is wrapped in quotes.
               match.index + 1,
               path,
               join(locationPrefix, path)

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -202,7 +202,7 @@ export function convertRuntimeToPlugin(
           // This is the full entrypoint path, like `./api/test.py`
           `./${entrypoint}`,
           // This is the entrypoint path without extension, like `api/test`
-          entrypoint.replace(ext, ''),
+          entrypoint.slice(0, -ext.length),
         ];
 
         // Generate a list of regular expressions that we can use for

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -236,7 +236,9 @@ export function convertRuntimeToPlugin(
               newPath
             );
 
-            debug(`Replaced "${oldPath}" inside "${entry}" with "${newPath}"`);
+            debug(
+              `Replaced "${oldPath}" inside "${entry}" with "${newPath}" to ensure correct import of user-provided request handler`
+            );
 
             replacedMatch = match;
           }

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -191,6 +191,9 @@ export function convertRuntimeToPlugin(
       if (handlerHasImport) {
         const { fsPath } = handlerFile;
         const encoding = 'utf-8';
+
+        // This is the true location of the user-provided request handler in the
+        // source files, so that's what we will use as a import path in the launcher.
         const newLocationPrefix = relative(entry, outputPath);
         const newLocation = join(newLocationPrefix, entrypoint);
 

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -192,16 +192,12 @@ export function convertRuntimeToPlugin(
       if (handlerHasImport) {
         const encoding = 'utf-8';
         const handlerContent = await fs.readFile(handlerFile.fsPath, encoding);
-        const extLessEntry = entrypoint.replace(ext, '');
 
         const importPaths = [
           // This is the full entrypoint path, like `./api/test.py`
-          // eslint-disable-next-line no-useless-escape
           `./${entrypoint}`,
           // This is the entrypoint path without extension, like `api/test`
-          extLessEntry,
-          // This is the entrypoint path in module syntax, like `api.test`
-          extLessEntry.replace(/\//g, '.'),
+          entrypoint.replace(ext, ''),
         ];
 
         // Generate a list of regular expressions that we can use for

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -220,7 +220,8 @@ export function convertRuntimeToPlugin(
 
           for (const match of matches) {
             // The import path without quotes
-            const path = match[0].substr(1, match[0].length - 1);
+            const oldPath = match[0].substr(1, match[0].length - 1);
+            const newPath = join(locationPrefix, oldPath);
 
             if (!match.index) {
               throw new Error('Missing `index` for match');
@@ -231,9 +232,11 @@ export function convertRuntimeToPlugin(
               // We'd like to add one character to the index, to consider
               // that the import path is wrapped in quotes.
               match.index + 1,
-              path,
-              join(locationPrefix, path)
+              oldPath,
+              newPath
             );
+
+            debug(`Replaced "${oldPath}" inside "${entry}" with "${newPath}"`);
 
             replacedMatch = match;
           }

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -86,10 +86,10 @@ export function convertRuntimeToPlugin(
 
     const pages: { [key: string]: any } = {};
     const pluginName = packageName.replace('vercel-plugin-', '');
+    const outputPath = join(workPath, '.output');
 
     const traceDir = join(
-      workPath,
-      `.output`,
+      outputPath,
       `inputs`,
       // Legacy Runtimes can only provide API Routes, so that's
       // why we can use this prefix for all of them. Here, we have to
@@ -102,8 +102,7 @@ export function convertRuntimeToPlugin(
 
     let newPathsRuntime: Set<string> = new Set();
 
-    const entryDir = join('.output', 'server', 'pages');
-    const entryRoot = join(workPath, entryDir);
+    const entryRoot = join(outputPath, 'server', 'pages');
 
     for (const entrypoint of Object.keys(entrypoints)) {
       const { output } = await buildRuntime({
@@ -192,6 +191,8 @@ export function convertRuntimeToPlugin(
       if (handlerHasImport) {
         const { fsPath } = handlerFile;
         const encoding = 'utf-8';
+        const newLocationPrefix = relative(entry, outputPath);
+        const newLocation = join(newLocationPrefix, entrypoint);
 
         let handlerContent = await fs.readFile(fsPath, encoding);
 
@@ -220,7 +221,7 @@ export function convertRuntimeToPlugin(
               handlerContent,
               match.index,
               match[0],
-              'test'
+              newLocation
             );
 
             replacedMatch = match;

--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -193,7 +193,7 @@ export function convertRuntimeToPlugin(
         const encoding = 'utf-8';
 
         // This is the true directory of the user-provided request handler in the
-        // source files, so that's what we will use as a import path in the launcher.
+        // source files, so that's what we will use as an import path in the launcher.
         const locationPrefix = relative(entry, outputPath);
 
         let handlerContent = await fs.readFile(fsPath, encoding);


### PR DESCRIPTION
This contributes to https://github.com/vercel/runtimes/issues/294 by ensuring that every launcher file used with an interpreted language like Ruby or Python imports the user-provided request handler from the source files, instead of expecting it to be copied right next to the launcher inside `.output`.

The path is already located in the respective NFT files, so all that was left is replacing the import statements inside the laucher files to load the user-provided request handler from the source files instead of `.output`.

#### Examples

**Python:**

![CleanShot 2021-12-07 at 14 37 13@2x](https://user-images.githubusercontent.com/6170607/145039974-30d2d78e-fea5-4a55-a042-25ef2c532bc6.png)

**Ruby:**

![CleanShot 2021-12-07 at 14 37 56@2x](https://user-images.githubusercontent.com/6170607/145039990-bb86de0d-e45a-428e-bb32-8bed552edd1e.png)

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
