### PR TITLE
[client] Fix duplicate files when analyzing `nft.json`

### DIFF
--- a/packages/client/src/utils/hashes.ts
+++ b/packages/client/src/utils/hashes.ts
@@ -58,7 +58,9 @@ export async function hashes(
       const entry = map.get(h);
 
       if (entry) {
-        entry.names.push(name);
+        if (entry.names[0] !== name) {
+          entry.names.push(name);
+        }
       } else {
         map.set(h, { names: [name], data, mode });
       }

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -266,39 +266,31 @@ export const prepareFiles = (
   files: Map<string, DeploymentFile>,
   clientOptions: VercelClientOptions
 ): PreparedFile[] => {
-  const preparedFiles = [...files.keys()].reduce(
-    (acc: PreparedFile[], sha: string): PreparedFile[] => {
-      const next = [...acc];
+  const preparedFiles: PreparedFile[] = [];
+  for (const [sha, file] of files) {
+    for (const name of file.names) {
+      let fileName: string;
 
-      const file = files.get(sha) as DeploymentFile;
-
-      for (const name of file.names) {
-        let fileName: string;
-
-        if (clientOptions.isDirectory) {
-          // Directory
-          fileName =
-            typeof clientOptions.path === 'string'
-              ? relative(clientOptions.path, name)
-              : name;
-        } else {
-          // Array of files or single file
-          const segments = name.split(sep);
-          fileName = segments[segments.length - 1];
-        }
-
-        next.push({
-          file: isWin ? fileName.replace(/\\/g, '/') : fileName,
-          size: file.data.byteLength || file.data.length,
-          mode: file.mode,
-          sha,
-        });
+      if (clientOptions.isDirectory) {
+        // Directory
+        fileName =
+          typeof clientOptions.path === 'string'
+            ? relative(clientOptions.path, name)
+            : name;
+      } else {
+        // Array of files or single file
+        const segments = name.split(sep);
+        fileName = segments[segments.length - 1];
       }
 
-      return next;
-    },
-    []
-  );
+      preparedFiles.push({
+        file: isWin ? fileName.replace(/\\/g, '/') : fileName,
+        size: file.data.byteLength || file.data.length,
+        mode: file.mode,
+        sha,
+      });
+    }
+  }
 
   return preparedFiles;
 };


### PR DESCRIPTION
This PR fixes a regression from #7144 where a duplicate file was added if `nft.json` referenced an existing file.

I also refactored the prepared files logic to avoid cloning the array in every loop iteration.

Review [without whitespace](https://github.com/vercel/vercel/pull/7150/files?diff=split&w=1) will make it easier to understand.

- Related to https://github.com/vercel/runtimes/issues/304