### PR TITLE
Make Python CLI Plugin work

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -183,8 +183,13 @@ export function convertRuntimeToPlugin(
         let handlerContent = await fs.readFile(fsPath, encoding);
 
         const importPaths = [
-          // This is the full entrypoint path, like `./api/test.py`
-          `./${entrypoint}`,
+          // This is the full entrypoint path, like `./api/test.py`. In our tests
+          // Python didn't support importing from a parent directory without using different
+          // code in the launcher that registers it as a location for modules and then changing
+          // the importing syntax, but continuing to import it like before seems to work. If
+          // other languages need this, we should consider excluding Python explicitly.
+          // `./${entrypoint}`,
+
           // This is the entrypoint path without extension, like `api/test`
           entrypoint.slice(0, -ext.length),
         ];

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,4 +1,3 @@
-import { relative, basename } from 'path';
 import execa from 'execa';
 import { Meta, debug } from '@vercel/build-utils';
 
@@ -136,17 +135,10 @@ export async function installRequirementsFile({
   meta,
   args = [],
 }: InstallRequirementsFileArg) {
-  const fileAtRoot = relative(workPath, filePath) === basename(filePath);
-
-  // If the `requirements.txt` file is located in the Root Directory of the project and
-  // the new File System API is used (`avoidTopLevelInstall`), the Install Command
-  // will have already installed its dependencies, so we don't need to do it again.
-  if (meta.avoidTopLevelInstall && fileAtRoot) {
-    debug(
-      `Skipping requirements file installation, already installed by Install Command`
-    );
-    return;
-  }
+  // The Vercel platform already handles `requirements.txt` for frontend projects,
+  // but the installation logic there is different, because it seems to install all
+  // of the dependencies globally, whereas, for this Runtime, we want it to happen only
+  // locally, so we'll run a separate installation.
 
   if (
     meta.isDev &&


### PR DESCRIPTION
As you can see in [this Deployment](https://vercel.com/curated-tests/api-routes-python/EEfL8dJPUwe7r5LegjqioU9P3gQZ/functions), the Python CLI Plugin currently fails at runtime.

The first error is that importing the user-defined request handler from a parent directory doesn't work, but continuing to use the previous relative path (like `./api/test.py`) seems to work, so that's fixed in this PR.

The second error (which is the one you can see now) is that it can't find any local dependencies, which is because we were relying on the dependencies installed by the "Install Command" for the frontend, but those are global, so not available to Python API Routes. That's also fixed in this PR.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
