### PR TITLE
[build-utils][cli] Detect file system api usage, abort on "Exclusion Conditions"

### DIFF
--- a/packages/build-utils/src/detect-builders.ts
+++ b/packages/build-utils/src/detect-builders.ts
@@ -3,7 +3,13 @@ import { valid as validSemver } from 'semver';
 import { parse as parsePath, extname } from 'path';
 import { Route, Source } from '@vercel/routing-utils';
 import frameworkList, { Framework } from '@vercel/frameworks';
-import { PackageJson, Builder, Config, BuilderFunctions } from './types';
+import {
+  PackageJson,
+  Builder,
+  Config,
+  BuilderFunctions,
+  ProjectSettings,
+} from './types';
 import { isOfficialRuntime } from './';
 const slugToFramework = new Map<string | null, Framework>(
   frameworkList.map(f => [f.slug, f])
@@ -20,14 +26,7 @@ interface Options {
   tag?: 'canary' | 'latest' | string;
   functions?: BuilderFunctions;
   ignoreBuildScript?: boolean;
-  projectSettings?: {
-    framework?: string | null;
-    devCommand?: string | null;
-    installCommand?: string | null;
-    buildCommand?: string | null;
-    outputDirectory?: string | null;
-    createdAt?: number;
-  };
+  projectSettings?: ProjectSettings;
   cleanUrls?: boolean;
   trailingSlash?: boolean;
   featHandleMiss?: boolean;

--- a/packages/build-utils/src/detect-file-system-api.ts
+++ b/packages/build-utils/src/detect-file-system-api.ts
@@ -1,0 +1,134 @@
+import semver from 'semver';
+import { isOfficialRuntime } from './';
+import {
+  Builder,
+  BuilderFunctions,
+  Files,
+  PackageJson,
+  ProjectSettings,
+} from './types';
+
+const enableFileSystemApiFrameworks = new Set(['solidstart']);
+
+/**
+ * If the Deployment can be built with the new File System API,
+ * we'll return the new Builder here, otherwise return `null`.
+ */
+export async function detectFileSystemAPI({
+  framework,
+  files,
+  builders,
+  functions,
+  pkg,
+  projectSettings,
+  enableFlag,
+}: {
+  framework: string;
+  files: Files;
+  builders: Builder[];
+  functions: BuilderFunctions | undefined;
+  pkg: PackageJson | null | undefined;
+  projectSettings: ProjectSettings;
+  enableFlag?: boolean;
+}) {
+  const isEnabled = Boolean(
+    enableFlag ||
+      hasMiddleware(files) ||
+      hasDotOutput(files) ||
+      enableFileSystemApiFrameworks.has(framework)
+  );
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  if (
+    process.env.HUGO_VERSION ||
+    process.env.ZOLA_VERSION ||
+    process.env.GUTENBERG_VERSION ||
+    Object.values(functions || {}).some(fn => !!fn.runtime)
+  ) {
+    return null;
+  }
+
+  const deps = Object.assign({}, pkg?.dependencies, pkg?.devDependencies);
+
+  const allBuildersSupported = builders.every(
+    ({ use }) =>
+      // Some builders must use a corresponding CLI plugin
+      (isOfficialRuntime('go', use) && 'vercel-plugin-go' in deps) ||
+      (isOfficialRuntime('ruby', use) && 'vercel-plugin-ruby' in deps) ||
+      (isOfficialRuntime('python', use) && 'vercel-plugin-python' in deps) ||
+      isOfficialRuntime('node', use) ||
+      isOfficialRuntime('next', use) ||
+      isOfficialRuntime('static', use) ||
+      isOfficialRuntime('static-build', use)
+  );
+
+  if (!allBuildersSupported) {
+    return null;
+  }
+
+  if (
+    framework === 'nuxtjs' ||
+    framework === 'sveltekit' ||
+    framework === 'redwoodjs'
+  ) {
+    return null;
+  }
+
+  if (framework === 'nextjs' && !hasDotOutput(files)) {
+    // Use the old pipeline if a custom output directory was specified for Next.js
+    // because `vercel build` cannot ensure that the directory will be in the same
+    // location as `.output`, which can break imports (not just nft.json files).
+    if (projectSettings?.outputDirectory) {
+      return null;
+    }
+    const versionRange = deps['next'];
+    if (!versionRange) {
+      return null;
+    }
+
+    // TODO: We'll need to check the lockfile if one is present.
+    if (versionRange !== 'latest' && versionRange !== 'canary') {
+      const fixedVersion = semver.valid(semver.coerce(versionRange) || '');
+
+      if (!fixedVersion || !semver.gte(fixedVersion, '12.0.0')) {
+        return null;
+      }
+    }
+  }
+
+  const frontendBuilder = builders.find(
+    ({ use }) =>
+      isOfficialRuntime('next', use) ||
+      isOfficialRuntime('static', use) ||
+      isOfficialRuntime('static-build', use)
+  );
+  const config = frontendBuilder?.config || {};
+
+  // Use either `package.json` or the first file it finds.
+  const src =
+    (files['package.json'] ? 'package.json' : Object.keys(files)[0]) || '**';
+
+  return {
+    use: '@vercelruntimes/file-system-api@canary',
+    src,
+    config: {
+      ...config,
+      fileSystemAPI: true,
+      framework: config.framework || framework || null,
+      projectSettings: projectSettings,
+      hasMiddleware: hasMiddleware(files),
+      hasDotOutput: hasDotOutput(files),
+    },
+  };
+}
+
+export function hasMiddleware(files: Files) {
+  return Boolean(files['_middleware.js'] || files['_middleware.ts']);
+}
+
+export function hasDotOutput(files: Files) {
+  return Object.keys(files).some(file => file.startsWith('.output/'));
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -81,6 +81,7 @@ export {
   detectApiDirectory,
   detectApiExtensions,
 } from './detect-builders';
+export { detectFileSystemAPI } from './detect-file-system-api';
 export { detectFramework } from './detect-framework';
 export { DetectorFilesystem } from './detectors/filesystem';
 export { readConfigFile } from './fs/read-config-file';

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -29,7 +29,9 @@ export interface Config {
     | number
     | { [key: string]: string }
     | BuilderFunctions
-    | undefined;
+    | ProjectSettings
+    | undefined
+    | null;
   maxLambdaSize?: string;
   includeFiles?: string | string[];
   excludeFiles?: string | string[];
@@ -41,11 +43,12 @@ export interface Config {
   zeroConfig?: boolean;
   import?: { [key: string]: string };
   functions?: BuilderFunctions;
+  projectSettings?: ProjectSettings;
   outputDirectory?: string;
   installCommand?: string;
   buildCommand?: string;
   devCommand?: string;
-  framework?: string;
+  framework?: string | null;
   nodeVersion?: string;
 }
 

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -361,5 +361,10 @@ export interface ProjectSettings {
   installCommand?: string | null;
   buildCommand?: string | null;
   outputDirectory?: string | null;
+  rootDirectory?: string | null;
   createdAt?: number;
+  autoExposeSystemEnvs?: boolean;
+  sourceFilesOutsideRootDirectory?: boolean;
+  directoryListing?: boolean;
+  gitForkProtection?: boolean;
 }

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -351,3 +351,12 @@ export interface BuilderFunctions {
     excludeFiles?: string;
   };
 }
+
+export interface ProjectSettings {
+  framework?: string | null;
+  devCommand?: string | null;
+  installCommand?: string | null;
+  buildCommand?: string | null;
+  outputDirectory?: string | null;
+  createdAt?: number;
+}

--- a/packages/build-utils/test/unit.detect-file-system-api.test.ts
+++ b/packages/build-utils/test/unit.detect-file-system-api.test.ts
@@ -1,0 +1,396 @@
+import { detectFileSystemAPI } from '../src/detect-file-system-api';
+
+describe('Test `detectFileSystemAPI`', () => {
+  it('should error when builds in vercel.json', async () => {
+    const vercelConfig = {
+      builds: [{ use: '@vercel/node', src: 'api/**/*.js' }],
+    };
+    const files = {
+      'vercel.json': JSON.stringify(vercelConfig),
+      'api/foo.js': 'console.log("foo")',
+    };
+    const result = await detectFileSystemAPI({
+      files,
+      projectSettings: {},
+      builders: vercelConfig.builds,
+      vercelConfig,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `builds` in vercel.json. Please remove it in favor of CLI plugins.',
+    });
+  });
+
+  it('should error when functions.runtimes in vercel.json', async () => {
+    const vercelConfig = {
+      functions: {
+        'api/**/*.rs': {
+          runtime: 'vercel-rust@latest',
+        },
+      },
+    };
+    const files = {
+      'vercel.json': JSON.stringify(vercelConfig),
+      'api/foo.rs': 'println!("foo")',
+    };
+    const result = await detectFileSystemAPI({
+      files,
+      projectSettings: {},
+      builders: [],
+      vercelConfig,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `functions.runtime` in vercel.json. Please remove it in favor of CLI plugins.',
+    });
+  });
+
+  it('should error when HUGO_VERSION env var used', async () => {
+    process.env.HUGO_VERSION = 'v0.58.2';
+    const files = { 'foo.html': '<h1>Foo</h1>' };
+    const result = await detectFileSystemAPI({
+      files,
+      projectSettings: {},
+      builders: [],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason: 'Detected `HUGO_VERSION` environment variable. Please remove it.',
+    });
+    delete process.env.HUGO_VERSION;
+  });
+
+  it('should error when ZOLA_VERSION env var used', async () => {
+    process.env.ZOLA_VERSION = 'v0.0.1';
+    const files = { 'foo.html': '<h1>Foo</h1>' };
+    const result = await detectFileSystemAPI({
+      files,
+      projectSettings: {},
+      builders: [],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason: 'Detected `ZOLA_VERSION` environment variable. Please remove it.',
+    });
+    delete process.env.ZOLA_VERSION;
+  });
+
+  it('should error when GUTENBERG_VERSION env var used', async () => {
+    process.env.GUTENBERG_VERSION = 'v0.0.1';
+    const files = { 'foo.html': '<h1>Foo</h1>' };
+    const result = await detectFileSystemAPI({
+      files,
+      projectSettings: {},
+      builders: [],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `GUTENBERG_VERSION` environment variable. Please remove it.',
+    });
+    delete process.env.GUTENBERG_VERSION;
+  });
+
+  it('should error when Go detected without corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.go': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/go', src: 'api/**/*.go' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `go` Serverless Function usage without plugin `vercel-plugin-go`. Please run `npm i vercel-plugin-go`.',
+    });
+  });
+
+  it('should error when Python detected without corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.py': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/python', src: 'api/**/*.py' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `python` Serverless Function usage without plugin `vercel-plugin-python`. Please run `npm i vercel-plugin-python`.',
+    });
+  });
+
+  it('should error when Ruby detected without corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.rb': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/ruby', src: 'api/**/*.rb' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected `ruby` Serverless Function usage without plugin `vercel-plugin-ruby`. Please run `npm i vercel-plugin-ruby`.',
+    });
+  });
+
+  it('should succeed when Go detected with corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.go': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/go', src: 'api/**/*.go' }],
+      vercelConfig: null,
+      pkg: { dependencies: { 'vercel-plugin-go': '^1.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: {
+        use: '@vercelruntimes/file-system-api',
+        src: '**',
+        config: {
+          fileSystemAPI: true,
+          framework: null,
+          hasDotOutput: false,
+          hasMiddleware: false,
+          projectSettings: {},
+        },
+      },
+      reason: null,
+    });
+  });
+
+  it('should succeed when Python detected with corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.py': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/python', src: 'api/**/*.py' }],
+      vercelConfig: null,
+      pkg: { dependencies: { 'vercel-plugin-python': '^1.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: {
+        use: '@vercelruntimes/file-system-api',
+        src: '**',
+        config: {
+          fileSystemAPI: true,
+          framework: null,
+          hasDotOutput: false,
+          hasMiddleware: false,
+          projectSettings: {},
+        },
+      },
+      reason: null,
+    });
+  });
+
+  it('should succeed when Ruby detected with corresponding plugin', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.rb': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/ruby', src: 'api/**/*.rb' }],
+      vercelConfig: null,
+      pkg: { dependencies: { 'vercel-plugin-ruby': '^1.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: {
+        use: '@vercelruntimes/file-system-api',
+        src: '**',
+        config: {
+          fileSystemAPI: true,
+          framework: null,
+          hasDotOutput: false,
+          hasMiddleware: false,
+          projectSettings: {},
+        },
+      },
+      reason: null,
+    });
+  });
+
+  it('should error when framework is nuxtjs', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'nuxtjs' },
+      builders: [{ use: '@vercel/node', src: 'api/**/*.js' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected framework `nuxtjs` that only supports legacy File System API. Please contact the framework author.',
+    });
+  });
+
+  it('should error when framework is sveltekit', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'sveltekit' },
+      builders: [{ use: '@vercel/node', src: 'api/**/*.js' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected framework `sveltekit` that only supports legacy File System API. Please contact the framework author.',
+    });
+  });
+
+  it('should error when framework is redwoodjs', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'api/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'redwoodjs' },
+      builders: [{ use: '@vercel/node', src: 'api/**/*.js' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected framework `redwoodjs` that only supports legacy File System API. Please contact the framework author.',
+    });
+  });
+
+  it('should error when framework is nextjs and has output dir', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'pages/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'nextjs', outputDirectory: 'dist' },
+      builders: [{ use: '@vercel/next', src: 'package.json' }],
+      vercelConfig: null,
+      pkg: { dependencies: { next: '^12.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected Next.js with Output Directory `dist` override. Please change it back to the default.',
+    });
+  });
+
+  it('should error when framework is nextjs but missing from dependencies', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'pages/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'nextjs' },
+      builders: [{ use: '@vercel/next', src: 'package.json' }],
+      vercelConfig: null,
+      pkg: { dependencies: { 'not-next': '^12.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected Next.js in Project Settings but missing `next` package.json dependencies. Please run `npm i next`.',
+    });
+  });
+
+  it('should error when framework is nextjs but dependency is older version', async () => {
+    const result = await detectFileSystemAPI({
+      files: { 'pages/foo.js': 'console.log("foo")' },
+      projectSettings: { framework: 'nextjs' },
+      builders: [{ use: '@vercel/next', src: 'package.json' }],
+      vercelConfig: null,
+      pkg: { dependencies: { next: '^9.0.0' } },
+      tag: '',
+      enableFlag: true,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: null,
+      reason:
+        'Detected legacy Next.js version "^9.0.0" in package.json. Please run `npm i next@latest` to upgrade.',
+    });
+  });
+
+  it('should succeed when middleware detected', async () => {
+    const result = await detectFileSystemAPI({
+      files: { '_middleware.js': 'print("foo")' },
+      projectSettings: {},
+      builders: [{ use: '@vercel/static-build', src: 'package.json' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: false,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: {
+        use: '@vercelruntimes/file-system-api',
+        src: '**',
+        config: {
+          fileSystemAPI: true,
+          framework: null,
+          hasDotOutput: false,
+          hasMiddleware: true,
+          projectSettings: {},
+        },
+      },
+      reason: null,
+    });
+  });
+
+  it('should succeed when .output detected', async () => {
+    const result = await detectFileSystemAPI({
+      files: { '.output/routes-manifest.json': '{}' },
+      projectSettings: { framework: 'remix' },
+      builders: [{ use: '@vercel/static-build', src: 'package.json' }],
+      vercelConfig: null,
+      pkg: null,
+      tag: '',
+      enableFlag: false,
+    });
+    expect(result).toEqual({
+      fsApiBuilder: {
+        use: '@vercelruntimes/file-system-api',
+        src: '**',
+        config: {
+          fileSystemAPI: true,
+          framework: 'remix',
+          hasDotOutput: true,
+          hasMiddleware: false,
+          projectSettings: { framework: 'remix' },
+        },
+      },
+      reason: null,
+    });
+  });
+});

--- a/packages/build-utils/test/unit.detect-file-system-api.test.ts
+++ b/packages/build-utils/test/unit.detect-file-system-api.test.ts
@@ -22,6 +22,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `builds` in vercel.json. Please remove it in favor of CLI plugins.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -50,6 +51,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `functions.runtime` in vercel.json. Please remove it in favor of CLI plugins.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -68,6 +70,7 @@ describe('Test `detectFileSystemAPI`', () => {
     expect(result).toEqual({
       fsApiBuilder: null,
       reason: 'Detected `HUGO_VERSION` environment variable. Please remove it.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
     delete process.env.HUGO_VERSION;
   });
@@ -87,6 +90,7 @@ describe('Test `detectFileSystemAPI`', () => {
     expect(result).toEqual({
       fsApiBuilder: null,
       reason: 'Detected `ZOLA_VERSION` environment variable. Please remove it.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
     delete process.env.ZOLA_VERSION;
   });
@@ -107,6 +111,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `GUTENBERG_VERSION` environment variable. Please remove it.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
     delete process.env.GUTENBERG_VERSION;
   });
@@ -125,6 +130,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `go` Serverless Function usage without plugin `vercel-plugin-go`. Please run `npm i vercel-plugin-go`.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -142,6 +148,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `python` Serverless Function usage without plugin `vercel-plugin-python`. Please run `npm i vercel-plugin-python`.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -159,6 +166,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected `ruby` Serverless Function usage without plugin `vercel-plugin-ruby`. Please run `npm i vercel-plugin-ruby`.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -185,6 +193,11 @@ describe('Test `detectFileSystemAPI`', () => {
         },
       },
       reason: null,
+      metadata: {
+        hasDotOutput: false,
+        hasMiddleware: false,
+        plugins: ['vercel-plugin-go'],
+      },
     });
   });
 
@@ -211,6 +224,11 @@ describe('Test `detectFileSystemAPI`', () => {
         },
       },
       reason: null,
+      metadata: {
+        hasDotOutput: false,
+        hasMiddleware: false,
+        plugins: ['vercel-plugin-python'],
+      },
     });
   });
 
@@ -237,6 +255,11 @@ describe('Test `detectFileSystemAPI`', () => {
         },
       },
       reason: null,
+      metadata: {
+        hasDotOutput: false,
+        hasMiddleware: false,
+        plugins: ['vercel-plugin-ruby'],
+      },
     });
   });
 
@@ -254,6 +277,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected framework `nuxtjs` that only supports legacy File System API. Please contact the framework author.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -271,6 +295,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected framework `sveltekit` that only supports legacy File System API. Please contact the framework author.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -288,6 +313,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected framework `redwoodjs` that only supports legacy File System API. Please contact the framework author.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -305,6 +331,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected Next.js with Output Directory `dist` override. Please change it back to the default.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -322,6 +349,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected Next.js in Project Settings but missing `next` package.json dependencies. Please run `npm i next`.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -339,6 +367,7 @@ describe('Test `detectFileSystemAPI`', () => {
       fsApiBuilder: null,
       reason:
         'Detected legacy Next.js version "^9.0.0" in package.json. Please run `npm i next@latest` to upgrade.',
+      metadata: { hasDotOutput: false, hasMiddleware: false, plugins: [] },
     });
   });
 
@@ -365,6 +394,7 @@ describe('Test `detectFileSystemAPI`', () => {
         },
       },
       reason: null,
+      metadata: { hasDotOutput: false, hasMiddleware: true, plugins: [] },
     });
   });
 
@@ -391,6 +421,7 @@ describe('Test `detectFileSystemAPI`', () => {
         },
       },
       reason: null,
+      metadata: { hasDotOutput: true, hasMiddleware: false, plugins: [] },
     });
   });
 });

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -192,7 +192,7 @@ export default async (client: Client) => {
 
   let newProjectName = null;
   let rootDirectory = project ? project.rootDirectory : null;
-  let sourceFilesOutsideRootDirectory = true;
+  let sourceFilesOutsideRootDirectory: boolean | undefined = true;
 
   if (status === 'not_linked') {
     const shouldStartSetup =

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,5 @@
+export type ProjectSettings = import('@vercel/build-utils').ProjectSettings;
+
 export type Primitive =
   | bigint
   | boolean
@@ -239,16 +241,6 @@ export interface ProjectEnvVariable {
   gitBranch?: string;
 }
 
-export interface ProjectSettings {
-  framework?: string | null;
-  devCommand?: string | null;
-  buildCommand?: string | null;
-  outputDirectory?: string | null;
-  rootDirectory?: string | null;
-  autoExposeSystemEnvs?: boolean;
-  directoryListing?: boolean;
-}
-
 export interface Project extends ProjectSettings {
   id: string;
   name: string;
@@ -260,8 +252,6 @@ export interface Project extends ProjectSettings {
   framework?: string | null;
   rootDirectory?: string | null;
   latestDeployments?: Partial<Deployment>[];
-  autoExposeSystemEnvs?: boolean;
-  sourceFilesOutsideRootDirectory: boolean;
 }
 
 export interface Org {

--- a/packages/cli/src/util/config/read-config.ts
+++ b/packages/cli/src/util/config/read-config.ts
@@ -6,14 +6,14 @@ import getLocalConfigPath from './local-path';
 
 export default async function readConfig(dir: string) {
   const pkgFilePath = getLocalConfigPath(join(process.cwd(), dir));
-  const result = await readJSONFile(pkgFilePath);
+  const result = await readJSONFile<VercelConfig>(pkgFilePath);
 
   if (result instanceof CantParseJSONFile) {
     return result;
   }
 
   if (result) {
-    return result as VercelConfig;
+    return result;
   }
 
   return null;

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -600,7 +600,7 @@ export default class DevServer {
         );
       }
 
-      const detectResult = await detectFileSystemAPI({
+      const { reason, metadata } = await detectFileSystemAPI({
         files,
         builders: builders || [],
         projectSettings: projectSettings || this.projectSettings || {},
@@ -610,8 +610,20 @@ export default class DevServer {
         enableFlag: true,
       });
 
-      if (detectResult.reason) {
-        this.output.warn('Unable to use latest API: ' + detectResult.reason);
+      if (reason) {
+        if (metadata.hasMiddleware) {
+          this.output.error(
+            `Detected middleware usage which requires the latest API. ${reason}`
+          );
+          await this.exit();
+        } else if (metadata.plugins.length > 0) {
+          this.output.error(
+            `Detected CLI plugins which requires the latest API. ${reason}`
+          );
+          await this.exit();
+        } else {
+          this.output.warn(`Unable to use latest API. ${reason}`);
+        }
       }
 
       if (builders) {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -40,6 +40,7 @@ import {
   detectApiExtensions,
   spawnCommand,
   isOfficialRuntime,
+  detectFileSystemAPI,
 } from '@vercel/build-utils';
 import frameworkList from '@vercel/frameworks';
 
@@ -597,6 +598,20 @@ export default class DevServer {
         warnings.forEach(warning =>
           this.output.warn(warning.message, null, warning.link, warning.action)
         );
+      }
+
+      const detectResult = await detectFileSystemAPI({
+        files,
+        builders: builders || [],
+        projectSettings: projectSettings || this.projectSettings || {},
+        vercelConfig,
+        pkg,
+        tag: '',
+        enableFlag: true,
+      });
+
+      if (detectResult.reason) {
+        this.output.warn('Unable to use latest API: ' + detectResult.reason);
       }
 
       if (builders) {

--- a/packages/cli/src/util/get-config.ts
+++ b/packages/cli/src/util/get-config.ts
@@ -39,12 +39,12 @@ export default async function getConfig(
     output.debug(
       `Found config in provided --local-config path ${localFilePath}`
     );
-    const localConfig = await readJSONFile(localFilePath);
+    const localConfig = await readJSONFile<VercelConfig>(localFilePath);
     if (localConfig instanceof CantParseJSONFile) {
       return localConfig;
     }
     if (localConfig !== null) {
-      config = localConfig as VercelConfig;
+      config = localConfig;
       config[fileNameSymbol] = configFile;
       return config;
     }
@@ -54,8 +54,8 @@ export default async function getConfig(
   const vercelFilePath = path.resolve(localPath, 'vercel.json');
   const nowFilePath = path.resolve(localPath, 'now.json');
   const [vercelConfig, nowConfig] = await Promise.all([
-    readJSONFile(vercelFilePath),
-    readJSONFile(nowFilePath),
+    readJSONFile<VercelConfig>(vercelFilePath),
+    readJSONFile<VercelConfig>(nowFilePath),
   ]);
   if (vercelConfig instanceof CantParseJSONFile) {
     return vercelConfig;
@@ -68,13 +68,13 @@ export default async function getConfig(
   }
   if (vercelConfig !== null) {
     output.debug(`Found config in file "${vercelFilePath}"`);
-    config = vercelConfig as VercelConfig;
+    config = vercelConfig;
     config[fileNameSymbol] = 'vercel.json';
     return config;
   }
   if (nowConfig !== null) {
     output.debug(`Found config in file "${nowFilePath}"`);
-    config = nowConfig as VercelConfig;
+    config = nowConfig;
     config[fileNameSymbol] = 'now.json';
     return config;
   }

--- a/packages/cli/src/util/read-json-file.ts
+++ b/packages/cli/src/util/read-json-file.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 import { CantParseJSONFile } from './errors-ts';
 
-export default async function readJSONFile(
+export default async function readJSONFile<T>(
   file: string
-): Promise<Object | null | CantParseJSONFile> {
+): Promise<T | null | CantParseJSONFile> {
   const content = await readFileSafe(file);
   if (content === null) {
     return content;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,4 +1,8 @@
-import { Builder, BuilderFunctions } from '@vercel/build-utils';
+import {
+  Builder,
+  BuilderFunctions,
+  ProjectSettings,
+} from '@vercel/build-utils';
 import { Header, Route, Redirect, Rewrite } from '@vercel/routing-utils';
 
 export { DeploymentEventType } from './utils';
@@ -124,12 +128,7 @@ export interface VercelConfig {
   scope?: string;
   alias?: string | string[];
   regions?: string[];
-  projectSettings?: {
-    devCommand?: string | null;
-    buildCommand?: string | null;
-    outputDirectory?: string | null;
-    framework?: string | null;
-  };
+  projectSettings?: ProjectSettings;
 }
 
 /**
@@ -155,9 +154,5 @@ export interface DeploymentOptions {
   name?: string;
   public?: boolean;
   meta?: Dictionary<string>;
-  projectSettings?: {
-    devCommand?: string | null;
-    buildCommand?: string | null;
-    outputDirectory?: string | null;
-  };
+  projectSettings?: ProjectSettings;
 }


### PR DESCRIPTION
This adds the "Exclusion Conditions" to `@vercel/build-utils`.

If detected:

- Throw and error during `vercel build`
- Print a warning during `vercel dev`

This PR also cleans up TS types for `ProjectSettings` and moves the interface to `@vercel/build-utils`.

Fixes https://github.com/vercel/runtimes/issues/238