### PR TITLE
[client] Use a Set to prevent duplicates in `hashes()` function

### DIFF
--- a/packages/client/src/utils/hashes.ts
+++ b/packages/client/src/utils/hashes.ts
@@ -58,9 +58,9 @@ export async function hashes(
       const entry = map.get(h);
 
       if (entry) {
-        if (entry.names[0] !== name) {
-          entry.names.push(name);
-        }
+        const names = new Set(entry.names);
+        names.add(name);
+        entry.names = [...names];
       } else {
         map.set(h, { names: [name], data, mode });
       }


### PR DESCRIPTION
Follow-up to #7150 to use a Set instead of assuming the conflicting entry is at index 0, which is not always the case.