### PR TITLE
[ci] Speed up GH publish skip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,21 +12,40 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - name: Check Release
+      id: check-release
+      run: |
+        tag="$(git describe --tags --exact-match 2> /dev/null || :)"
+        if [[ -z "$tag" ]];
+          then
+            echo "::set-output name=IS_RELEASE::false"
+          else
+            echo "::set-output name=IS_RELEASE::true"
+        fi
+    - name: Setup Go
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+      uses: actions/setup-go@v2
       with:
         go-version: '1.13.15'
-    - uses: actions/setup-node@v2
+    - name: Setup Node
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+      uses: actions/setup-node@v2
       with:
-        node-version: 12
-    - uses: actions/checkout@v1
+        node-version: 14
+    - name: Checkout
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+      uses: actions/checkout@v1
     - name: Install
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       run: yarn install --check-files --frozen-lockfile --network-timeout 1000000
     - name: Build
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       run: yarn build
       env:
         GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     - name: Publish
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       run: yarn publish-from-github
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v1
     - name: Check Release
       id: check-release
       run: |
@@ -32,9 +34,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 14
-    - name: Checkout
-      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
-      uses: actions/checkout@v1
     - name: Install
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       run: yarn install --check-files --frozen-lockfile --network-timeout 1000000


### PR DESCRIPTION
This is following a similar pattern to Next.js workflows so that the publish step is skipped and reduces the time it takes GH Actions to run since we don't need to build to know that it should be skipped.