### PR TITLE
[test] Skip `runPackageJsonScript()` on windows and macOS

### DIFF
--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -285,6 +285,14 @@ it('should support require by path for legacy builders', () => {
 it(
   'should have correct $PATH when running `runPackageJsonScript()` with yarn',
   async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+    if (process.platform === 'darwin') {
+      console.log('Skipping test on macOS');
+      return;
+    }
     const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
     await runNpmInstall(fixture);
     await runPackageJsonScript(fixture, 'env');


### PR DESCRIPTION
This test is flaky on windows and macOS but its never actually run on those OS's so there is no need to test it there.

https://github.com/vercel/vercel/runs/4478211743?check_suite_focus=true

https://github.com/vercel/vercel/runs/4478211767?check_suite_focus=true