### PR TITLE
[build-utils] Add `_experimental_` prefix to exported experimental functions

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -53,7 +53,7 @@ const getSourceFiles = async (workPath: string, ignoreFilter: any) => {
  * @param packageName - the name of the package, for example `vercel-plugin-python`
  * @param ext - the file extension, for example `.py`
  */
-export function convertRuntimeToPlugin(
+export function _experimental_convertRuntimeToPlugin(
   buildRuntime: (options: BuildOptions) => Promise<{ output: Lambda }>,
   packageName: string,
   ext: string
@@ -287,7 +287,7 @@ export function convertRuntimeToPlugin(
 
     // Add any Serverless Functions that were exposed by the Legacy Runtime
     // to the `functions-manifest.json` file provided in `.output`.
-    await updateFunctionsManifest({ workPath, pages });
+    await _experimental_updateFunctionsManifest({ workPath, pages });
   };
 }
 
@@ -307,7 +307,7 @@ async function readJson(filePath: string): Promise<{ [key: string]: any }> {
  * If `.output/functions-manifest.json` exists, append to the pages
  * property. Otherwise write a new file.
  */
-export async function updateFunctionsManifest({
+export async function _experimental_updateFunctionsManifest({
   workPath,
   pages,
 }: {
@@ -335,7 +335,7 @@ export async function updateFunctionsManifest({
  * Append routes to the `routes-manifest.json` file.
  * If the file does not exist, it will be created.
  */
-export async function updateRoutesManifest({
+export async function _experimental_updateRoutesManifest({
   workPath,
   redirects,
   rewrites,

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import FileBlob from './file-blob';
 import FileFsRef from './file-fs-ref';
 import FileRef from './file-ref';
@@ -87,9 +86,9 @@ export { DetectorFilesystem } from './detectors/filesystem';
 export { readConfigFile } from './fs/read-config-file';
 export { normalizePath } from './fs/normalize-path';
 export {
-  convertRuntimeToPlugin,
-  updateFunctionsManifest,
-  updateRoutesManifest,
+  _experimental_convertRuntimeToPlugin,
+  _experimental_updateFunctionsManifest,
+  _experimental_updateRoutesManifest,
 } from './convert-runtime-to-plugin';
 
 export * from './schemas';
@@ -135,12 +134,4 @@ export const getPlatformEnv = (name: string): string | undefined => {
     return v;
   }
   return n;
-};
-
-/**
- * Helper function for generating file or directories names in `.output/inputs`
- * for dependencies of files provided to the File System API.
- */
-export const getInputHash = (source: Buffer | string): string => {
-  return createHash('sha1').update(source).digest('hex');
 };

--- a/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
+++ b/packages/build-utils/test/unit.convert-runtime-to-plugin.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import fs from 'fs-extra';
 import { BuildOptions, createLambda, FileFsRef } from '../src';
-import { convertRuntimeToPlugin } from '../src/convert-runtime-to-plugin';
+import { _experimental_convertRuntimeToPlugin } from '../src/convert-runtime-to-plugin';
 
 async function fsToJson(dir: string, output: Record<string, any> = {}) {
   const files = await fs.readdir(dir);
@@ -63,7 +63,11 @@ describe('convert-runtime-to-plugin', () => {
     };
 
     const packageName = 'vercel-plugin-python';
-    const build = await convertRuntimeToPlugin(buildRuntime, packageName, ext);
+    const build = await _experimental_convertRuntimeToPlugin(
+      buildRuntime,
+      packageName,
+      ext
+    );
 
     await build({ workPath });
 

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -5,7 +5,7 @@ import { promises as fsp } from 'fs';
 import { IncomingMessage, ServerResponse } from 'http';
 import libGlob from 'glob';
 import Proxy from 'http-proxy';
-import { updateFunctionsManifest } from '@vercel/build-utils';
+import { _experimental_updateFunctionsManifest } from '@vercel/build-utils';
 
 import { run } from './websandbox';
 import type { FetchEventResult } from './websandbox/types';
@@ -110,7 +110,7 @@ export async function build({ workPath }: { workPath: string }) {
     sortingIndex: 1,
   };
 
-  await updateFunctionsManifest({ workPath, pages });
+  await _experimental_updateFunctionsManifest({ workPath, pages });
 }
 
 const stringifyQuery = (req: IncomingMessage, query: ParsedUrlQuery) => {

--- a/packages/plugin-go/src/index.ts
+++ b/packages/plugin-go/src/index.ts
@@ -1,6 +1,10 @@
-import { convertRuntimeToPlugin } from '@vercel/build-utils';
+import { _experimental_convertRuntimeToPlugin } from '@vercel/build-utils';
 import * as go from '@vercel/go';
 
-export const build = convertRuntimeToPlugin(go.build, 'vercel-plugin-go', '.go');
+export const build = _experimental_convertRuntimeToPlugin(
+  go.build,
+  'vercel-plugin-go',
+  '.go'
+);
 
 export const startDevServer = go.startDevServer;

--- a/packages/plugin-node/src/index.ts
+++ b/packages/plugin-node/src/index.ts
@@ -1,4 +1,5 @@
 import { fork, spawn } from 'child_process';
+import { createHash } from 'crypto';
 import {
   createWriteStream,
   readFileSync,
@@ -35,12 +36,11 @@ import {
   debug,
   isSymbolicLink,
   runNpmInstall,
-  updateFunctionsManifest,
-  updateRoutesManifest,
+  _experimental_updateFunctionsManifest,
+  _experimental_updateRoutesManifest,
   walkParentDirs,
   normalizePath,
   runPackageJsonScript,
-  getInputHash,
 } from '@vercel/build-utils';
 import { FromSchema } from 'json-schema-to-ts';
 import { getConfig, BaseFunctionConfigSchema } from '@vercel/static-config';
@@ -428,7 +428,8 @@ export async function buildEntrypoint({
   installedPaths?: Set<string>;
 }) {
   // Unique hash that will be used as directory name for `.output`.
-  const entrypointHash = 'api-routes-node-' + getInputHash(entrypoint);
+  const entrypointHash =
+    'api-routes-node-' + createHash('sha1').update(entrypoint).digest('hex');
   const outputDirPath = join(workPath, '.output');
 
   const { dir, name } = parsePath(entrypoint);
@@ -548,12 +549,12 @@ export async function buildEntrypoint({
       runtime: nodeVersion.runtime,
     },
   };
-  await updateFunctionsManifest({ workPath, pages });
+  await _experimental_updateFunctionsManifest({ workPath, pages });
 
   // Update the `routes-mainifest.json` file with the wildcard route
   // when the entrypoint is dynamic (i.e. `/api/[id].ts`).
   if (isDynamicRoute(entrypointWithoutExt)) {
-    await updateRoutesManifest({
+    await _experimental_updateRoutesManifest({
       workPath,
       dynamicRoutes: [pageToRoute(entrypointWithoutExt)],
     });

--- a/packages/plugin-python/src/index.ts
+++ b/packages/plugin-python/src/index.ts
@@ -1,6 +1,10 @@
-import { convertRuntimeToPlugin } from '@vercel/build-utils';
+import { _experimental_convertRuntimeToPlugin } from '@vercel/build-utils';
 import * as python from '@vercel/python';
 
-export const build = convertRuntimeToPlugin(python.build, 'vercel-plugin-python', '.py');
+export const build = _experimental_convertRuntimeToPlugin(
+  python.build,
+  'vercel-plugin-python',
+  '.py'
+);
 
 //export const startDevServer = python.startDevServer;

--- a/packages/plugin-ruby/src/index.ts
+++ b/packages/plugin-ruby/src/index.ts
@@ -1,6 +1,10 @@
-import { convertRuntimeToPlugin } from '@vercel/build-utils';
+import { _experimental_convertRuntimeToPlugin } from '@vercel/build-utils';
 import * as ruby from '@vercel/ruby';
 
-export const build = convertRuntimeToPlugin(ruby.build, 'vercel-plugin-ruby', '.rb');
+export const build = _experimental_convertRuntimeToPlugin(
+  ruby.build,
+  'vercel-plugin-ruby',
+  '.rb'
+);
 
 //export const startDevServer = ruby.startDevServer;


### PR DESCRIPTION
We don't want users to rely on these experimental functions yet so let's prefix with `_experimental_`.

In the future, we might want to consider creating a new package, specifically for CLI plugins to depend on. That way, `@vercel/build-utils` can be used for legacy builders/runtimes and newer CLI plugins can get a fresh start.