### PR TITLE
[cli] replace deprecated `--no-install` option of `npx` with `--no`

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -2156,7 +2156,7 @@ export default class DevServer {
       .catch(() => false);
 
     if (isNpxAvailable) {
-      command = `npx --no-install ${command}`;
+      command = `npx --no ${command}`;
     } else {
       const isYarnAvailable = await which('yarn')
         .then(() => true)


### PR DESCRIPTION
Quoting from [npm docs](https://docs.npmjs.com/cli/v8/commands/npx#:~:text=The-,%2D%2Dno%2Dinstall,-option%20is%20deprecated):

> The `--no-install` option is deprecated, and will be converted to `--no`.

### Related Issues

N/A

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
