### PR TITLE
[cli] Use `@vercel/fetch-retry` in CLI integration tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -91,6 +91,7 @@
     "@types/which": "1.3.2",
     "@types/write-json-file": "2.2.1",
     "@vercel/client": "10.2.3-canary.51",
+    "@vercel/fetch-retry": "5.0.3",
     "@vercel/frameworks": "0.5.1-canary.20",
     "@vercel/ncc": "0.24.0",
     "@vercel/nft": "0.17.0",

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -35,7 +35,7 @@ function fetchOverride(url) {
   const parsed = parseUrl(url);
   const { host } = parsed;
   //parsed.host = '54.153.119.80';
-  parsed.host = '13.52.246.114';
+  parsed.host = '54.193.60.54';
   const ipUrl = format(parsed);
   console.log({ url, ipUrl });
   return fetch(ipUrl, {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -35,7 +35,7 @@ function fetchOverride(url) {
   const parsed = parseUrl(url);
   const { host } = parsed;
   //parsed.host = '54.153.119.80';
-  parsed.host = '54.193.60.54';
+  parsed.host = '54.193.13.231';
   const ipUrl = format(parsed);
   console.log({ url, ipUrl });
   return fetch(ipUrl, {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -34,7 +34,8 @@ function execa(file, args, options) {
 function fetchOverride(url) {
   const parsed = parseUrl(url);
   const { host } = parsed;
-  parsed.host = '54.153.119.80';
+  //parsed.host = '54.153.119.80';
+  parsed.host = '13.52.246.114';
   const ipUrl = format(parsed);
   console.log({ url, ipUrl });
   return fetch(ipUrl, {
@@ -721,14 +722,14 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
 
     const apiUrl = `https://${host}/api/get-env`;
     console.log({ apiUrl });
-    const apiRes = await fetch(apiUrl);
+    const apiRes = await fetchOverride(apiUrl);
     t.is(apiRes.status, 200, formatOutput({ stderr, stdout }));
     const apiJson = await apiRes.json();
     t.is(apiJson['MY_NEW_ENV_VAR'], 'my plaintext value');
 
     const homeUrl = `https://${host}`;
     console.log({ homeUrl });
-    const homeRes = await fetch(homeUrl);
+    const homeRes = await fetchOverride(homeUrl);
     t.is(homeRes.status, 200, formatOutput({ stderr, stdout }));
     const homeJson = await homeRes.json();
     t.is(homeJson['MY_NEW_ENV_VAR'], 'my plaintext value');
@@ -1132,7 +1133,7 @@ test('should add secret with hyphen prefix', async t => {
     formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
   );
   const { host } = new URL(targetCall.stdout);
-  const response = await fetch(`https://${host}`);
+  const response = await fetchOverride(`https://${host}`);
   t.is(
     response.status,
     200,

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -7,7 +7,7 @@ import { Readable } from 'stream';
 import { homedir } from 'os';
 import _execa from 'execa';
 import XDGAppPaths from 'xdg-app-paths';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import tmp from 'tmp-promise';
 import retry from 'async-retry';
 import createFetchRetry from '@vercel/fetch-retry';
@@ -25,7 +25,7 @@ import pkg from '../package';
 import prepareFixtures from './helpers/prepare';
 import { fetchTokenWithRetry } from '../../../test/lib/deployment/now-deploy';
 
-const fetchRetry = createFetchRetry(fetch);
+const fetch = createFetchRetry(nodeFetch);
 
 // log command when running `execa`
 function execa(file, args, options) {
@@ -421,18 +421,18 @@ test('deploy using --local-config flag v2', async t => {
   const { host } = new URL(stdout);
   t.regex(host, /secondary/gm, `Expected "secondary" but received "${host}"`);
 
-  const testRes = await fetchRetry(`https://${host}/test-${contextName}.html`);
+  const testRes = await fetch(`https://${host}/test-${contextName}.html`);
   const testText = await testRes.text();
   t.is(testText, '<h1>hello test</h1>');
 
-  const anotherTestRes = await fetchRetry(`https://${host}/another-test`);
+  const anotherTestRes = await fetch(`https://${host}/another-test`);
   const anotherTestText = await anotherTestRes.text();
   t.is(anotherTestText, testText);
 
-  const mainRes = await fetchRetry(`https://${host}/main-${contextName}.html`);
+  const mainRes = await fetch(`https://${host}/main-${contextName}.html`);
   t.is(mainRes.status, 404, 'Should not deploy/build main now.json');
 
-  const anotherMainRes = await fetchRetry(`https://${host}/another-main`);
+  const anotherMainRes = await fetch(`https://${host}/another-main`);
   t.is(anotherMainRes.status, 404, 'Should not deploy/build main now.json');
 });
 
@@ -460,11 +460,11 @@ test('deploy using --local-config flag above target', async t => {
 
   const { host } = new URL(stdout);
 
-  const testRes = await fetchRetry(`https://${host}/index.html`);
+  const testRes = await fetch(`https://${host}/index.html`);
   const testText = await testRes.text();
   t.is(testText, '<h1>hello index</h1>');
 
-  const anotherTestRes = await fetchRetry(`https://${host}/another.html`);
+  const anotherTestRes = await fetch(`https://${host}/another.html`);
   const anotherTestText = await anotherTestRes.text();
   t.is(anotherTestText, '<h1>hello another</h1>');
 
@@ -708,14 +708,14 @@ test('Deploy `api-env` fixture and test `vercel env` command', async t => {
 
     const apiUrl = `https://${host}/api/get-env`;
     console.log({ apiUrl });
-    const apiRes = await fetchRetry(apiUrl);
+    const apiRes = await fetch(apiUrl);
     t.is(apiRes.status, 200, formatOutput({ stderr, stdout }));
     const apiJson = await apiRes.json();
     t.is(apiJson['MY_NEW_ENV_VAR'], 'my plaintext value');
 
     const homeUrl = `https://${host}`;
     console.log({ homeUrl });
-    const homeRes = await fetchRetry(homeUrl);
+    const homeRes = await fetch(homeUrl);
     t.is(homeRes.status, 200, formatOutput({ stderr, stdout }));
     const homeJson = await homeRes.json();
     t.is(homeJson['MY_NEW_ENV_VAR'], 'my plaintext value');
@@ -1119,7 +1119,7 @@ test('should add secret with hyphen prefix', async t => {
     formatOutput({ stderr: targetCall.stderr, stdout: targetCall.stdout })
   );
   const { host } = new URL(targetCall.stdout);
-  const response = await fetchRetry(`https://${host}`);
+  const response = await fetch(`https://${host}`);
   t.is(
     response.status,
     200,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,14 @@
     "@typescript-eslint/types" "4.28.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/fetch-retry@5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@vercel/fetch-retry/-/fetch-retry-5.0.3.tgz#cce5d23f6e64f6f525c24e2ac7c78f65d6c5b1f4"
+  integrity sha512-DIIoBY92r+sQ6iHSf5WjKiYvkdsDIMPWKYATlE0KcUAj2RV6SZK9UWpUzBRKsofXqedOqpVjrI0IE6AWL7JRtg==
+  dependencies:
+    async-retry "^1.3.1"
+    debug "^3.1.0"
+
 "@vercel/fun@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.3.tgz#5e5c4921a3a3a35ee129ce063e6b3f5c4b1eae48"


### PR DESCRIPTION
These integration tests have started consistently failing with `ECONNRESET` errors and after some debugging it's been difficult to point the finger at anything related to Vercel infrastructure. So possibly it's related to GitHub actions infra changes, but either way retrying seems to help.