### PR TITLE
[build-utils] De-couple zip file creation from `Lambda` class

### DIFF
--- a/packages/build-utils/src/convert-runtime-to-plugin.ts
+++ b/packages/build-utils/src/convert-runtime-to-plugin.ts
@@ -2,8 +2,8 @@ import fs from 'fs-extra';
 import { join, parse, relative, dirname, basename, extname } from 'path';
 import glob from './fs/glob';
 import { normalizePath } from './fs/normalize-path';
-import { FILES_SYMBOL, Lambda } from './lambda';
-import type { BuildOptions, Files } from './types';
+import { Lambda } from './lambda';
+import type { BuildOptions } from './types';
 import { debug, getIgnoreFilter } from '.';
 
 // `.output` was already created by the Build Command, so we have
@@ -116,8 +116,7 @@ export function _experimental_convertRuntimeToPlugin(
         },
       });
 
-      // @ts-ignore This symbol is a private API
-      const lambdaFiles: Files = output[FILES_SYMBOL];
+      const lambdaFiles = output.files;
 
       // When deploying, the `files` that are passed to the Legacy Runtimes already
       // have certain files that are ignored stripped, but locally, that list of

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -39,7 +39,7 @@ export class Lambda {
   public allowQuery?: string[];
   public regions?: string[];
   /**
-   * @deprecated
+   * @deprecated Use `await lambda.createZip()` instead.
    */
   public zipBuffer?: Buffer;
 

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -13,17 +13,6 @@ interface Environment {
 }
 
 interface LambdaOptions {
-  zipBuffer: Buffer;
-  handler: string;
-  runtime: string;
-  memory?: number;
-  maxDuration?: number;
-  environment: Environment;
-  allowQuery?: string[];
-  regions?: string[];
-}
-
-interface CreateLambdaOptions {
   files: Files;
   handler: string;
   runtime: string;
@@ -39,11 +28,9 @@ interface GetLambdaOptionsFromFunctionOptions {
   config?: Pick<Config, 'functions'>;
 }
 
-export const FILES_SYMBOL = Symbol('files');
-
 export class Lambda {
   public type: 'Lambda';
-  public zipBuffer: Buffer;
+  public files: Files;
   public handler: string;
   public runtime: string;
   public memory?: number;
@@ -51,19 +38,51 @@ export class Lambda {
   public environment: Environment;
   public allowQuery?: string[];
   public regions?: string[];
+  /**
+   * @deprecated
+   */
+  public zipBuffer?: Buffer;
 
   constructor({
-    zipBuffer,
+    files,
     handler,
     runtime,
     maxDuration,
     memory,
-    environment,
+    environment = {},
     allowQuery,
     regions,
   }: LambdaOptions) {
+    assert(typeof files === 'object', '"files" must be an object');
+    assert(typeof handler === 'string', '"handler" is not a string');
+    assert(typeof runtime === 'string', '"runtime" is not a string');
+    assert(typeof environment === 'object', '"environment" is not an object');
+
+    if (memory !== undefined) {
+      assert(typeof memory === 'number', '"memory" is not a number');
+    }
+
+    if (maxDuration !== undefined) {
+      assert(typeof maxDuration === 'number', '"maxDuration" is not a number');
+    }
+
+    if (allowQuery !== undefined) {
+      assert(Array.isArray(allowQuery), '"allowQuery" is not an Array');
+      assert(
+        allowQuery.every(q => typeof q === 'string'),
+        '"allowQuery" is not a string Array'
+      );
+    }
+
+    if (regions !== undefined) {
+      assert(Array.isArray(regions), '"regions" is not an Array');
+      assert(
+        regions.every(r => typeof r === 'string'),
+        '"regions" is not a string Array'
+      );
+    }
     this.type = 'Lambda';
-    this.zipBuffer = zipBuffer;
+    this.files = files;
     this.handler = handler;
     this.runtime = runtime;
     this.memory = memory;
@@ -72,69 +91,34 @@ export class Lambda {
     this.allowQuery = allowQuery;
     this.regions = regions;
   }
+
+  async createZip(): Promise<Buffer> {
+    let { zipBuffer } = this;
+    if (!zipBuffer) {
+      await sema.acquire();
+      try {
+        zipBuffer = await createZip(this.files);
+      } finally {
+        sema.release();
+      }
+    }
+    return zipBuffer;
+  }
 }
 
 const sema = new Sema(10);
 const mtime = new Date(1540000000000);
 
-export async function createLambda({
-  files,
-  handler,
-  runtime,
-  memory,
-  maxDuration,
-  environment = {},
-  allowQuery,
-  regions,
-}: CreateLambdaOptions): Promise<Lambda> {
-  assert(typeof files === 'object', '"files" must be an object');
-  assert(typeof handler === 'string', '"handler" is not a string');
-  assert(typeof runtime === 'string', '"runtime" is not a string');
-  assert(typeof environment === 'object', '"environment" is not an object');
+/**
+ * @deprecated Use `new Lambda()` instead.
+ */
+export async function createLambda(opts: LambdaOptions): Promise<Lambda> {
+  const lambda = new Lambda(opts);
 
-  if (memory !== undefined) {
-    assert(typeof memory === 'number', '"memory" is not a number');
-  }
+  // backwards compat
+  lambda.zipBuffer = await lambda.createZip();
 
-  if (maxDuration !== undefined) {
-    assert(typeof maxDuration === 'number', '"maxDuration" is not a number');
-  }
-
-  if (allowQuery !== undefined) {
-    assert(Array.isArray(allowQuery), '"allowQuery" is not an Array');
-    assert(
-      allowQuery.every(q => typeof q === 'string'),
-      '"allowQuery" is not a string Array'
-    );
-  }
-
-  if (regions !== undefined) {
-    assert(Array.isArray(regions), '"regions" is not an Array');
-    assert(
-      regions.every(r => typeof r === 'string'),
-      '"regions" is not a string Array'
-    );
-  }
-
-  await sema.acquire();
-
-  try {
-    const zipBuffer = await createZip(files);
-    const lambda = new Lambda({
-      zipBuffer,
-      handler,
-      runtime,
-      memory,
-      maxDuration,
-      environment,
-      regions,
-    });
-    // @ts-ignore This symbol is a private API
-    lambda[FILES_SYMBOL] = files;
-    return lambda;
-  } finally {
-    sema.release();
-  }
+  return lambda;
 }
 
 export async function createZip(files: Files): Promise<Buffer> {
@@ -177,7 +161,7 @@ export async function getLambdaOptionsFromFunction({
 }: GetLambdaOptionsFromFunctionOptions): Promise<
   Pick<LambdaOptions, 'memory' | 'maxDuration'>
 > {
-  if (config && config.functions) {
+  if (config?.functions) {
     for (const [pattern, fn] of Object.entries(config.functions)) {
       if (sourceFile === pattern || minimatch(sourceFile, pattern)) {
         return {

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -288,7 +288,7 @@ export async function executeBuild(
   // subclass type instances.
   for (const name of Object.keys(output)) {
     const obj = output[name] as File;
-    let lambda: Lambda;
+    let lambda: BuiltLambda;
     let fileRef: FileFsRef;
     let fileBlob: FileBlob;
     switch (obj.type) {
@@ -302,7 +302,7 @@ export async function executeBuild(
         output[name] = fileBlob;
         break;
       case 'Lambda':
-        lambda = Object.assign(Object.create(Lambda.prototype), obj) as Lambda;
+        lambda = Object.assign(Object.create(Lambda.prototype), obj);
         // Convert the JSON-ified Buffer object back into an actual Buffer
         lambda.zipBuffer = Buffer.from((obj as any).zipBuffer.data);
         output[name] = lambda;

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -35,6 +35,7 @@ import {
   BuildResultV3,
   BuilderOutputs,
   EnvConfigs,
+  BuiltLambda,
 } from './types';
 import { normalizeRoutes } from '@vercel/routing-utils';
 import getUpdateCommand from '../get-update-command';

--- a/packages/cli/src/util/dev/types.ts
+++ b/packages/cli/src/util/dev/types.ts
@@ -66,6 +66,7 @@ export interface BuilderInputs {
 }
 
 export interface BuiltLambda extends Lambda {
+  zipBuffer: Buffer;
   fn?: FunLambda;
 }
 


### PR DESCRIPTION
Makes the `Lambda` class itself just a reference of the files that are needed to produce a zip file, and adds a `createZip()` function that does the actual zip file creation. This will allow the zip file creation to be done in the Vercel build container instead of directly in the Builder itself.

* Adds `files` property to `Lambda` class
* Adds `createZip()` function to `Lambda` class
* Deprecates the `createLambda()` function (`new Lambda()` should be used instead)
* Deprecates the `zipBuffer` property (only populated when `createLambda()` is used)
* Removes the private `FILES_SYMBOL` symbol, since `files` is the same thing