### PR TITLE
[cli] Remove timestamp based lookback in `vc bisect --help`

### DIFF
--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -56,10 +56,6 @@ const help = () => {
 
       ${chalk.cyan(`$ ${pkgName} bisect --bad example-310pce9i0.vercel.app`)}
 
-  ${chalk.gray('–')} Bisect specifying a deployment that was working 3 days ago
-
-      ${chalk.cyan(`$ ${pkgName} bisect --good 3d`)}
-
   ${chalk.gray('–')} Automated bisect with a run script
 
       ${chalk.cyan(`$ ${pkgName} bisect --run ./test.sh`)}
@@ -201,7 +197,11 @@ export default async function main(client: Client): Promise<number> {
 
   if (badDeployment.target !== goodDeployment.target) {
     output.error(
-      `Bad deployment target "${badDeployment.target || 'preview'}" does not match good deployment target "${goodDeployment.target || 'preview'}"`
+      `Bad deployment target "${
+        badDeployment.target || 'preview'
+      }" does not match good deployment target "${
+        goodDeployment.target || 'preview'
+      }"`
     );
     return 1;
   }


### PR DESCRIPTION
Looking up a deployment via timestamp is not implemented in the `vc bisect` command, so remove it from the `--help` output.