### PR TITLE
[build-utils] Add env var ENABLE_EXPERIMENTAL_NODE16

### DIFF
--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -44,6 +44,10 @@ export async function getSupportedNodeVersion(
 ): Promise<NodeVersion> {
   let selection: NodeVersion = getLatestNodeVersion();
 
+  if (process.env.ENABLE_EXPERIMENTAL_NODE16 === '1') {
+    return { major: 16, range: '16.x', runtime: 'nodejs16.x' };
+  }
+
   if (engineRange) {
     const found =
       validRange(engineRange) &&

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -209,6 +209,14 @@ it('should not warn when package.json engines matches project setting from confi
   expect(warningMessages).toStrictEqual([]);
 });
 
+it('should select nodejs16.x with ENABLE_EXPERIMENTAL_NODE16', async () => {
+  process.env.ENABLE_EXPERIMENTAL_NODE16 = '1';
+  const result = await getNodeVersion('/tmp', undefined, {}, {});
+  delete process.env.ENABLE_EXPERIMENTAL_NODE16;
+  expect(result).toEqual({ major: 16, range: '16.x', runtime: 'nodejs16.x' });
+  expect(warningMessages).toStrictEqual([]);
+});
+
 it('should get latest node version', async () => {
   expect(getLatestNodeVersion()).toHaveProperty('major', 14);
 });


### PR DESCRIPTION
This PR uses an environment variable since this feature is not available to all accounts yet.