### PR TITLE
[cli] remove deprecated message for `env pull` command

### DIFF
--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -137,13 +137,6 @@ export default async function main(client: Client) {
       case 'rm':
         return rm(client, project, argv, args, output);
       case 'pull':
-        output.warn(
-          `${getCommandName(
-            'env pull'
-          )} is deprecated and will be removed in future releases. Run ${getCommandName(
-            'pull'
-          )} instead.`
-        );
         return pull(client, project, argv, args, output);
       default:
         output.error(getInvalidSubcommand(COMMAND_CONFIG));


### PR DESCRIPTION
When running `vercel pull` it outputs a deprecated message for `vercel env pull` command.
I have removed the deprecated message which is not needed anymore.

The deprecation message is irrelevant or not needed in this context, or should be used when `vercel env pull` command is executed.

### Related Issues

> Fixes None
> Related to #7477

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
