### PR TITLE
[build-utils] Make Builder `routes` output optional

### DIFF
--- a/packages/build-utils/src/detect-builders.ts
+++ b/packages/build-utils/src/detect-builders.ts
@@ -67,8 +67,7 @@ function getPublicBuilder(
       typeof builder.src === 'string' &&
       isOfficialRuntime('static', builder.use) &&
       /^.*\/\*\*\/\*$/.test(builder.src) &&
-      builder.config &&
-      builder.config.zeroConfig === true
+      builder.config?.zeroConfig === true
     ) {
       return builder as Builder & { src: string };
     }

--- a/packages/build-utils/src/fs/glob.ts
+++ b/packages/build-utils/src/fs/glob.ts
@@ -46,8 +46,8 @@ export default async function glob(
   const files = await vanillaGlob(pattern, options);
 
   for (const relativePath of files) {
-    const fsPath = normalizePath(path.join(options.cwd!, relativePath));
-    let stat: Stats = options.statCache![fsPath] as Stats;
+    const fsPath = normalizePath(path.join(options.cwd, relativePath));
+    let stat: Stats = options.statCache[fsPath] as Stats;
     assert(
       stat,
       `statCache does not contain value for ${relativePath} (resolved to ${fsPath})`

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -394,7 +394,7 @@ export interface Images {
 
 export interface BuildResultV2 {
   // TODO: use proper `Route` type from `routing-utils` (perhaps move types to a common package)
-  routes: any[];
+  routes?: any[];
   images?: Images;
   output: {
     [key: string]: File | Lambda;


### PR DESCRIPTION
Mark the `routes` property on BuilderResultV2 as optional, since not all Builders need to return routes.

Also a couple other random unrelated TypeScript usage fixes/optimizations.