### PR TITLE
[build-utils] Allow `Prerender` type in BuildV2 `output`

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1,6 +1,7 @@
 import FileRef from './file-ref';
 import FileFsRef from './file-fs-ref';
 import { Lambda } from './lambda';
+import { Prerender } from './prerender';
 
 export interface Env {
   [name: string]: string | undefined;
@@ -397,7 +398,7 @@ export interface BuildResultV2 {
   routes?: any[];
   images?: Images;
   output: {
-    [key: string]: File | Lambda;
+    [key: string]: File | Lambda | Prerender;
   };
   wildcard?: Array<{
     domain: string;


### PR DESCRIPTION
This is a supported output type but was missing in the TypeScript type.