### PR TITLE
[node] Move `@vercel/node-bridge` to dependencies

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@types/node": "*",
+    "@vercel/node-bridge": "2.1.2-canary.0",
     "ts-node": "8.9.1",
     "typescript": "4.3.4"
   },
@@ -34,7 +35,6 @@
     "@vercel/build-utils": "2.14.1-canary.3",
     "@vercel/ncc": "0.24.0",
     "@vercel/nft": "0.17.5",
-    "@vercel/node-bridge": "2.1.2-canary.0",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",


### PR DESCRIPTION
Fixes issue introduced by #7436 when using `vc dev`. Since the dev-server script now imports `@vercel/node-bridge` directly, instead of copying the relevant files into the package, the bridge needs to be a regular dependency otherwise the import will fail.

```
Error: Cannot find module '@vercel/node-bridge/launcher.js'
Require stack:
- /usr/local/lib/node_modules/vercel/node_modules/@vercel/node/dist/dev-server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/vercel/node_modules/@vercel/node/dist/dev-server.js:79:23)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
Error! `node api/hello.js` failed with exit code 1
```