### PR TITLE
[build-utils] streamline File types for better type narrowing

### DIFF
--- a/packages/build-utils/src/file-blob.ts
+++ b/packages/build-utils/src/file-blob.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import intoStream from 'into-stream';
-import { File } from './types';
+import { FileBase } from './types';
 
 interface FileBlobOptions {
   mode?: number;
@@ -14,7 +14,7 @@ interface FromStreamOptions {
   stream: NodeJS.ReadableStream;
 }
 
-export default class FileBlob implements File {
+export default class FileBlob implements FileBase {
   public type: 'FileBlob';
   public mode: number;
   public data: string | Buffer;

--- a/packages/build-utils/src/file-fs-ref.ts
+++ b/packages/build-utils/src/file-fs-ref.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import multiStream from 'multistream';
 import path from 'path';
 import Sema from 'async-sema';
-import { File } from './types';
+import { FileBase } from './types';
 
 const semaToPreventEMFILE = new Sema(20);
 
@@ -20,7 +20,7 @@ interface FromStreamOptions {
   fsPath: string;
 }
 
-class FileFsRef implements File {
+class FileFsRef implements FileBase {
   public type: 'FileFsRef';
   public mode: number;
   public fsPath: string;

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import multiStream from 'multistream';
 import retry from 'async-retry';
 import Sema from 'async-sema';
-import { File } from './types';
+import { FileBase } from './types';
 
 interface FileRefOptions {
   mode?: number;
@@ -23,7 +23,7 @@ class BailableError extends Error {
   }
 }
 
-export default class FileRef implements File {
+export default class FileRef implements FileBase {
   public type: 'FileRef';
   public mode: number;
   public digest: string;

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -19,7 +19,7 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
   const { mode } = file;
   if (mode && isSymbolicLink(mode) && file.type === 'FileFsRef') {
     const [target] = await Promise.all([
-      readlink((file as FileFsRef).fsPath),
+      readlink(file.fsPath),
       mkdirp(path.dirname(fsPath)),
     ]);
     await symlink(target, fsPath);

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -1,5 +1,6 @@
 import type FileRef from './file-ref';
 import type FileFsRef from './file-fs-ref';
+import type FileBlob from './file-blob';
 import type { Lambda } from './lambda';
 import type { Prerender } from './prerender';
 import type { EdgeFunction } from './edge-function';
@@ -8,16 +9,13 @@ export interface Env {
   [name: string]: string | undefined;
 }
 
-export interface File {
+export type File = FileRef | FileFsRef | FileBlob;
+export interface FileBase {
   type: string;
   mode: number;
   contentType?: string;
   toStream: () => NodeJS.ReadableStream;
   toStreamAsync?: () => Promise<NodeJS.ReadableStream>;
-  /**
-   * The absolute path to the file in the filesystem
-   */
-  fsPath?: string;
 }
 
 export interface Files {
@@ -399,7 +397,7 @@ export interface BuildResultV2 {
   routes?: any[];
   images?: Images;
   output: {
-    [key: string]: File | Lambda | Prerender | EdgeFunction;
+    [key: string]: FileBase | Lambda | Prerender | EdgeFunction;
   };
   wildcard?: Array<{
     domain: string;

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -288,7 +288,7 @@ export async function executeBuild(
   // Convert the JSON-ified output map back into their corresponding `File`
   // subclass type instances.
   for (const name of Object.keys(output)) {
-    const obj = output[name] as File;
+    const obj = output[name] as File | Lambda;
     let lambda: BuiltLambda;
     let fileRef: FileFsRef;
     let fileBlob: FileBlob;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -238,7 +238,7 @@ async function compile(
         entry = new FileBlob({ data: source, mode });
       }
     }
-    if (isSymbolicLink(entry.mode) && entry.fsPath) {
+    if (isSymbolicLink(entry.mode) && entry.type === 'FileFsRef') {
       // ensure the symlink target is added to the file list
       const symlinkTarget = relative(
         baseDir,


### PR DESCRIPTION
When narrowing a type based on `File`, the typescript compiler can't tell what the options are for `type`, which results in not narrowing.

Example:

```
if (file.type === 'FileFsRef') {
  file; // still a "File"
}
```

After this PR, we get narrowed `File` types:

```
if (file.type === 'FileFsRef') {
  file; // now a FileFsRef
}
```
