### PR TITLE
[build-utils] Preserve symlinks for `FileRef` and `FileBlob` types in `download()`

### DIFF
--- a/packages/build-utils/src/file-blob.ts
+++ b/packages/build-utils/src/file-blob.ts
@@ -48,6 +48,10 @@ export default class FileBlob implements FileBase {
     return new FileBlob({ mode, contentType, data });
   }
 
+  async toStreamAsync(): Promise<NodeJS.ReadableStream> {
+    return this.toStream();
+  }
+
   toStream(): NodeJS.ReadableStream {
     return intoStream(this.data);
   }

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -26,7 +26,7 @@ async function prepareSymlinkTarget(
     return target;
   }
 
-  if (file.type === 'FileRef') {
+  if (file.type === 'FileRef' || file.type === 'FileBlob') {
     const targetPathBufferPromise = await streamToBuffer(
       await file.toStreamAsync()
     );
@@ -37,7 +37,9 @@ async function prepareSymlinkTarget(
     return targetPathBuffer.toString('utf8');
   }
 
-  throw new Error('some error'); // TODO
+  throw new Error(
+    `file.type "${(file as any).type}" not supported for symlink`
+  );
 }
 
 async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -14,6 +14,7 @@ import {
   runNpmInstall,
   runPackageJsonScript,
   scanParentDirs,
+  FileBlob,
 } from '../src';
 
 async function expectBuilderError(promise: Promise<any>, pattern: string) {
@@ -76,7 +77,30 @@ it('should re-create FileRef symlinks properly', async () => {
     console.log('Skipping test on windows');
     return;
   }
-  const files = await glob('**', path.join(__dirname, 'symlinks'));
+
+  const files = {
+    'a.txt': new FileBlob({
+      mode: 33188,
+      contentType: undefined,
+      data: 'some text',
+    }),
+    'dir/b.txt': new FileBlob({
+      mode: 33188,
+      contentType: undefined,
+      data: 'b text',
+    }),
+    'link-dir': new FileBlob({
+      mode: 41453,
+      contentType: undefined,
+      data: 'dir',
+    }),
+    'link.txt': new FileBlob({
+      mode: 41453,
+      contentType: undefined,
+      data: 'a.txt',
+    }),
+  };
+
   assert.equal(Object.keys(files).length, 4);
 
   const outDir = path.join(__dirname, 'symlinks-out');

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -70,6 +70,14 @@ it('should re-create FileFsRef symlinks properly', async () => {
   assert(linkStat.isSymbolicLink());
   assert(linkDirStat.isSymbolicLink());
   assert(aStat.isFile());
+
+  const [linkDirContents, linkTextContents] = await Promise.all([
+    readlink(path.join(outDir, 'link-dir')),
+    readlink(path.join(outDir, 'link.txt')),
+  ]);
+
+  strictEqual(linkDirContents, 'dir');
+  strictEqual(linkTextContents, './a.txt');
 });
 
 it('should re-create FileBlob symlinks properly', async () => {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -47,7 +47,31 @@ afterEach(() => {
   console.warn = originalConsoleWarn;
 });
 
-it('should re-create symlinks properly', async () => {
+it('should re-create FileFsRef symlinks properly', async () => {
+  if (process.platform === 'win32') {
+    console.log('Skipping test on windows');
+    return;
+  }
+  const files = await glob('**', path.join(__dirname, 'symlinks'));
+  assert.equal(Object.keys(files).length, 4);
+
+  const outDir = path.join(__dirname, 'symlinks-out');
+  await fs.remove(outDir);
+
+  const files2 = await download(files, outDir);
+  assert.equal(Object.keys(files2).length, 4);
+
+  const [linkStat, linkDirStat, aStat] = await Promise.all([
+    fs.lstat(path.join(outDir, 'link.txt')),
+    fs.lstat(path.join(outDir, 'link-dir')),
+    fs.lstat(path.join(outDir, 'a.txt')),
+  ]);
+  assert(linkStat.isSymbolicLink());
+  assert(linkDirStat.isSymbolicLink());
+  assert(aStat.isFile());
+});
+
+it('should re-create FileRef symlinks properly', async () => {
   if (process.platform === 'win32') {
     console.log('Skipping test on windows');
     return;

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -72,7 +72,7 @@ it('should re-create FileFsRef symlinks properly', async () => {
   assert(aStat.isFile());
 });
 
-it('should re-create FileRef symlinks properly', async () => {
+it('should re-create FileBlob symlinks properly', async () => {
   if (process.platform === 'win32') {
     console.log('Skipping test on windows');
     return;


### PR DESCRIPTION
Ensure we preserve symlinks for `FileRef` and `FileBlob` files in the build-utils `download()` function.

---

Card: https://linear.app/vercel/issue/BUI-23/preserve-symlinks-in-vc-deploy