### PR TITLE
[build-utils] Use `File` type for `Prerender` fallback

### DIFF
--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -1,12 +1,10 @@
-import FileBlob from './file-blob';
-import FileFsRef from './file-fs-ref';
-import FileRef from './file-ref';
+import { File } from './types';
 import { Lambda } from './lambda';
 
 interface PrerenderOptions {
   expiration: number | false;
   lambda: Lambda;
-  fallback: FileBlob | FileFsRef | FileRef | null;
+  fallback: File | null;
   group?: number;
   bypassToken?: string | null /* optional to be non-breaking change */;
   allowQuery?: string[];
@@ -16,7 +14,7 @@ export class Prerender {
   public type: 'Prerender';
   public expiration: number | false;
   public lambda: Lambda;
-  public fallback: FileBlob | FileFsRef | FileRef | null;
+  public fallback: File | null;
   public group?: number;
   public bypassToken: string | null;
   public allowQuery?: string[];


### PR DESCRIPTION
Tiny follow-up to #7530 since we can now use this union type to express the same group of File implementation types.