### PR TITLE
Add optional screenshot urls to frameworks

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -60,6 +60,8 @@ export const frameworks = [
     slug: 'nextjs',
     demo: 'https://nextjs-template.vercel.app',
     logo: 'https://raw.githubusercontent.com/vercel/vercel/main/packages/frameworks/logos/next.svg',
+    screenshot:
+      'https://assets.vercel.com/image/upload/v1647366075/front/import/nextjs.png',
     tagline:
       'Next.js makes you productive with React instantly — whether you want to build static or dynamic sites.',
     description: 'A Next.js app and a Serverless Function API.',
@@ -1100,6 +1102,8 @@ export const frameworks = [
     slug: 'sveltekit',
     demo: 'https://sveltekit-template.vercel.app',
     logo: 'https://raw.githubusercontent.com/vercel/vercel/main/packages/frameworks/logos/svelte.svg',
+    screenshot:
+      'https://assets.vercel.com/image/upload/v1647366075/front/import/sveltekit.png',
     tagline:
       'SvelteKit is a framework for building web applications of all sizes.',
     description: 'A SvelteKit app optimized Edge-first.',
@@ -1625,6 +1629,8 @@ export const frameworks = [
     slug: 'nuxtjs',
     demo: 'https://nuxtjs-template.vercel.app',
     logo: 'https://raw.githubusercontent.com/vercel/vercel/main/packages/frameworks/logos/nuxt.svg',
+    screenshot:
+      'https://assets.vercel.com/image/upload/v1647366075/front/import/nuxtjs.png',
     tagline:
       'Nuxt.js is the web comprehensive framework that lets you dream big with Vue.js.',
     description: 'A Nuxt.js app, bootstrapped with create-nuxt-app.',

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -61,6 +61,11 @@ export interface Framework {
    */
   logo: string;
   /**
+   * A URL to the logo of a screenshot of the framework
+   * @example "https://assets.vercel.com/image/upload/v1647366075/front/import/nuxtjs.png"
+   */
+  screenshot?: string;
+  /**
    * A URL to a deployed example of the framework
    * @example "https://nextjs.now-examples.vercel.app"
    */


### PR DESCRIPTION
### Related Issues
In order to load `/new` faster and to ensure that screenshot fetching doesn't fail, this adds an optional screenshot property to the `/api/frameworks` response (and the `Framework` type).

https://github.com/vercel/front/issues/12834

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
