### PR TITLE
[cli] Update `14-svelte-node` fixture to run "dev" command

### DIFF
--- a/packages/cli/test/dev/fixtures/14-svelte-node/package.json
+++ b/packages/cli/test/dev/fixtures/14-svelte-node/package.json
@@ -18,6 +18,6 @@
     "build": "rollup -c",
     "autobuild": "rollup -c -w",
     "start": "sirv public --single --port $PORT",
-    "start:dev": "sirv public --single --dev --port $PORT"
+    "dev": "sirv public --single --dev --port $PORT"
   }
 }


### PR DESCRIPTION
These `vc dev` tests need a more thorough investigation in order for `vc dev` to invoke the "Dev Command" from the project settings directly, rather then relying on `@vercel/static-build` to do it. But in the meantime, this is a quick band-aid fix for this test fixture.