### PR TITLE
[static-build] Don't fail CRA builds on warnings

### DIFF
--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -389,12 +389,9 @@ export const build: BuildV2 = async ({
     */
     if (framework && framework.slug === 'create-react-app') {
       if (!spawnOpts.env) {
-        spawnOpts.env = {
-          CI: 'false',
-        };
-      } else {
-        spawnOpts.env.CI = 'false';
+        spawnOpts.env = {};
       }
+      spawnOpts.env.CI = 'false';
     }
 
     if (meta.isDev) {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -378,6 +378,25 @@ export const build: BuildV2 = async ({
     );
     const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
+    /* Don't fail the build on warnings from Create React App.
+    Node.js will load 'false' as a string, not a boolean, so it's truthy still.
+    This is to ensure we don't accidentally break other packages that check
+    if process.env.CI is true somewhere.
+    
+    https://github.com/facebook/create-react-app/issues/2453
+    https://github.com/facebook/create-react-app/pull/2501
+    https://github.com/vercel/community/discussions/30
+    */
+    if (framework && framework.slug === 'create-react-app') {
+      if (!spawnOpts.env) {
+        spawnOpts.env = {
+          CI: 'false',
+        };
+      } else {
+        spawnOpts.env.CI = 'false';
+      }
+    }
+
     if (meta.isDev) {
       debug('Skipping dependency installation because dev mode is enabled');
     } else {

--- a/packages/static-build/test/fixtures/12-create-react-app/package.json
+++ b/packages/static-build/test/fixtures/12-create-react-app/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "CI=false react-scripts build",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Don't fail the build on warnings from Create React App. Node.js will load 'false' as a string, not a boolean, so it's truthy still. This is to ensure we don't accidentally break other packages that check if process.env.CI is true somewhere.
    
- https://github.com/facebook/create-react-app/issues/2453
- https://github.com/facebook/create-react-app/pull/2501
- https://github.com/vercel/community/discussions/30