### PR TITLE
[cli] Fix `vc init` spinner

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -83,6 +83,7 @@ async function fetchExampleList(client: Client) {
   const url = `${EXAMPLE_API}/v2/list.json`;
 
   const body = await client.fetch<Example[]>(url);
+  client.output.stopSpinner();
   return body;
 }
 


### PR DESCRIPTION
The spinner was started but never stopped.

This PR adds the explicit stop once the response is parsed, instead of waiting for the implicit stop once writing to stdout.