### PR TITLE
Set `ENABLE_FILE_SYSTEM_API=1` in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -46,5 +46,10 @@
         }
       ]
     }
-  ]
+  ],
+  "build": {
+    "env": {
+      "ENABLE_FILE_SYSTEM_API": "1"
+    }
+  }
 }


### PR DESCRIPTION
Temporarily set this in `vercel.json` since the current way the Vercel deployment is structured requires it to be set.

Can remove this once #7599 is merged.