### PR TITLE
[build-utils] Add a few more files to `.npmignore`

### DIFF
--- a/packages/build-utils/.npmignore
+++ b/packages/build-utils/.npmignore
@@ -1,3 +1,6 @@
 /src
 /test
+/tsconfig.json
+/.turbo
+/jest.config.js
 tmp


### PR DESCRIPTION
These files don't need to be in the published npm package, so added them to the npm ignore file.