### PR TITLE
[client] Don't consider `rootDirectory` for --prebuilt buildFileTree()

### DIFF
--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { DeploymentFile } from './hashes';
 import { FetchOptions } from '@zeit/fetch';
 import { nodeFetch, zeitFetch } from './fetch';
-import { join, sep, relative, posix } from 'path';
+import { join, sep, relative } from 'path';
 import { URL } from 'url';
 import ignore from 'ignore';
 type Ignore = ReturnType<typeof ignore>;
@@ -85,13 +85,12 @@ export async function buildFileTree(
   {
     isDirectory,
     prebuilt,
-    rootDirectory,
-  }: Pick<VercelClientOptions, 'isDirectory' | 'prebuilt' | 'rootDirectory'>,
+  }: Pick<VercelClientOptions, 'isDirectory' | 'prebuilt'>,
   debug: Debug
 ): Promise<{ fileList: string[]; ignoreList: string[] }> {
   const ignoreList: string[] = [];
   let fileList: string[];
-  let { ig, ignores } = await getVercelIgnore(path, prebuilt, rootDirectory);
+  let { ig, ignores } = await getVercelIgnore(path, prebuilt);
 
   debug(`Found ${ignores.length} rules in .vercelignore`);
   debug('Building file tree...');
@@ -123,14 +122,13 @@ export async function buildFileTree(
 
 export async function getVercelIgnore(
   cwd: string | string[],
-  prebuilt?: boolean,
-  rootDirectory?: string
+  prebuilt?: boolean
 ): Promise<{ ig: Ignore; ignores: string[] }> {
   const ig = ignore();
   let ignores: string[];
 
   if (prebuilt) {
-    const outputDir = posix.join(rootDirectory || '', '.vercel/output');
+    const outputDir = '.vercel/output';
     ignores = ['*'];
     const parts = outputDir.split('/');
     parts.forEach((_, i) => {

--- a/packages/client/tests/unit.utils.test.ts
+++ b/packages/client/tests/unit.utils.test.ts
@@ -127,49 +127,4 @@ describe('buildFileTree()', () => {
       normalizeWindowsPaths(ignoreList).sort()
     );
   });
-
-  it('should find root files but ignore all .output files when prebuilt=false and rootDirectory=root', async () => {
-    const cwd = fixture('file-system-api-root-directory');
-    const { fileList, ignoreList } = await buildFileTree(
-      cwd,
-      { isDirectory: true, prebuilt: false, rootDirectory: 'root' },
-      noop
-    );
-
-    const expectedFileList = toAbsolutePaths(cwd, [
-      'foo.txt',
-      'root/bar.txt',
-      'someother/bar.txt',
-    ]);
-    expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
-      normalizeWindowsPaths(fileList).sort()
-    );
-
-    const expectedIgnoreList = ['root/.vercel', 'someother/.vercel'];
-    expect(normalizeWindowsPaths(expectedIgnoreList).sort()).toEqual(
-      normalizeWindowsPaths(ignoreList).sort()
-    );
-  });
-
-  it('should find root/.output files but ignore other files when prebuilt=true and rootDirectory=root', async () => {
-    const cwd = fixture('file-system-api-root-directory');
-    const { fileList, ignoreList } = await buildFileTree(
-      cwd,
-      { isDirectory: true, prebuilt: true, rootDirectory: 'root' },
-      noop
-    );
-
-    const expectedFileList = toAbsolutePaths(cwd, [
-      'root/.vercel/output/static/baz.txt',
-      'root/.vercel/output/static/sub/qux.txt',
-    ]);
-    expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
-      normalizeWindowsPaths(fileList).sort()
-    );
-
-    const expectedIgnoreList = ['foo.txt', 'root/bar.txt', 'someother'];
-    expect(normalizeWindowsPaths(expectedIgnoreList).sort()).toEqual(
-      normalizeWindowsPaths(ignoreList).sort()
-    );
-  });
 });


### PR DESCRIPTION
`vc build` outputs to the root-level `.vercel` directory, so no need to consider `rootDirectory` of the Project Settings when collecting this file list.