### PR TITLE
[client] Drop "/now" prefix from API endpoints

### DIFF
--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -4,17 +4,18 @@ import { nodeFetch, zeitFetch } from './fetch';
 import { join, sep, relative, posix } from 'path';
 import { URL } from 'url';
 import ignore from 'ignore';
-type Ignore = ReturnType<typeof ignore>;
 import { pkgVersion } from '../pkg';
 import { NowBuildError } from '@vercel/build-utils';
-import { VercelClientOptions, DeploymentOptions, NowConfig } from '../types';
+import { VercelClientOptions, DeploymentOptions, VercelConfig } from '../types';
 import { Sema } from 'async-sema';
 import { readFile } from 'fs-extra';
 import readdir from './readdir-recursive';
 
+type Ignore = ReturnType<typeof ignore>;
+
 const semaphore = new Sema(10);
 
-export const API_FILES = '/v2/now/files';
+export const API_FILES = '/v2/files';
 
 const EVENTS_ARRAY = [
   // File events
@@ -49,13 +50,15 @@ export function getApiDeploymentsUrl(
   metadata?: Pick<DeploymentOptions, 'builds' | 'functions'>
 ) {
   if (metadata && metadata.builds && !metadata.functions) {
-    return '/v10/now/deployments';
+    return '/v10/deployments';
   }
 
-  return '/v13/now/deployments';
+  return '/v13/deployments';
 }
 
-export async function parseVercelConfig(filePath?: string): Promise<NowConfig> {
+export async function parseVercelConfig(
+  filePath?: string
+): Promise<VercelConfig> {
   if (!filePath) {
     return {};
   }


### PR DESCRIPTION
This prefix is not necessary for the API endpoints so remove.

Also updated a reference of `NowConfig` to use `VercelConfig` instead.