### PR TITLE
[build-utils] Use `File` instead of `FileBase` for builder output type

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -360,7 +360,7 @@ export interface BuildResultV2 {
   routes?: any[];
   images?: Images;
   output: {
-    [key: string]: FileBase | Lambda | Prerender | EdgeFunction;
+    [key: string]: File | Lambda | Prerender | EdgeFunction;
   };
   wildcard?: Array<{
     domain: string;


### PR DESCRIPTION
This allows for the individual `File` subtypes to be properly narrowed.