### PR TITLE
[cli] trim env file path output

### DIFF
--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -48,7 +48,8 @@ export default async function pull(
   environment: ProjectEnvTarget,
   opts: Partial<Options>,
   args: string[],
-  output: Output
+  output: Output,
+  cwd: string = process.cwd()
 ) {
   if (args.length > 1) {
     output.error(
@@ -59,7 +60,7 @@ export default async function pull(
 
   // handle relative or absolute filename
   const [filename = '.env'] = args;
-  const fullPath = resolve(filename);
+  const fullPath = resolve(cwd, filename);
   const skipConfirmation = opts['--yes'];
 
   const head = tryReadHeadSync(fullPath, Buffer.byteLength(CONTENTS_PREFIX));

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -127,8 +127,9 @@ async function pullAllEnvFiles(
     project,
     environment,
     argv,
-    [join(cwd, '.vercel', environmentFile)],
-    client.output
+    [join('.vercel', environmentFile)],
+    client.output,
+    cwd
   );
 }
 


### PR DESCRIPTION
The log lines for what files were written when running `vc pull` were inconsistent. One was a full path, the other was a relative path. This PR makes them both relative.

Before:

```
$  vc pull
✅  Created /Users/nrajlich/nextjs/.vercel/.env.development.local file [103ms]
✅  Downloaded project settings to .vercel/project.json [0ms]
```

After:

```
$  vc pull
Overwriting existing .vercel/.env.development.local file
Downloading Development Environment Variables for Project vercel-demo-nextjs
✅  Updated .vercel/.env.development.local file [1s]
✅  Downloaded project settings to .vercel/project.json [0ms]
```