### PR TITLE
[cli] remove deprecation warning for `vc env`

### DIFF
--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -138,13 +138,6 @@ export default async function main(client: Client) {
       case 'rm':
         return rm(client, project, argv, args, output);
       case 'pull':
-        output.warn(
-          `${getCommandName(
-            'env pull'
-          )} is deprecated and will be removed in future releases. Run ${getCommandName(
-            'pull'
-          )} instead.`
-        );
         return pull(
           client,
           project,


### PR DESCRIPTION
Removes the deprecation warning in the CLI for `vc env`. This command will have its place alongside `vc pull`.
