### PR TITLE
[build-utils] Add `repoRootPath` to `PrepareCacheOptions`

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -119,10 +119,11 @@ export interface PrepareCacheOptions {
   workPath: string;
 
   /**
-   * A writable temporary directory where you can build a cache to use for
-   * the next run.
+   * The "Root Directory" is assigned to the `workPath` so the `repoRootPath`
+   * is the Git Repository Root. This is only relevant for Monorepos.
+   * See https://vercel.com/blog/monorepos
    */
-  cachePath: string;
+  repoRootPath?: string;
 
   /**
    * An arbitrary object passed by the user in the build definition defined


### PR DESCRIPTION
`repoRootPath` is provided to the `prepareCache()` function and is the same value as provided to the `build()` function.

Also remove `cachePath` since it's no longer used.