### PR TITLE
[build-utils] Move "Installing dependencies..." log to `runNpmInstall()`

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -368,6 +368,8 @@ export async function runNpmInstall(
       }
     }
 
+    const installTime = Date.now();
+    console.log('Installing dependencies...');
     debug(`Installing to ${destPath}`);
 
     const opts: SpawnOptionsExtended = { cwd: destPath, ...spawnOpts };
@@ -403,6 +405,7 @@ export async function runNpmInstall(
     }
 
     await spawnAsync(cliType, commandArgs, opts);
+    debug(`Install complete [${Date.now() - installTime}ms]`);
     return true;
   } finally {
     runNpmInstallSema.release();

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -86,7 +86,6 @@ async function downloadInstallAndBundle({
   meta,
 }: DownloadOptions) {
   const downloadedFiles = await download(files, workPath, meta);
-
   const entrypointFsDirname = join(workPath, dirname(entrypoint));
   const nodeVersion = await getNodeVersion(
     entrypointFsDirname,
@@ -95,16 +94,7 @@ async function downloadInstallAndBundle({
     meta
   );
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
-
-  if (meta.isDev) {
-    debug('Skipping dependency installation because dev mode is enabled');
-  } else {
-    const installTime = Date.now();
-    console.log('Installing dependencies...');
-    await runNpmInstall(entrypointFsDirname, [], spawnOpts, meta, nodeVersion);
-    debug(`Install complete [${Date.now() - installTime}ms]`);
-  }
-
+  await runNpmInstall(entrypointFsDirname, [], spawnOpts, meta, nodeVersion);
   const entrypointPath = downloadedFiles[entrypoint].fsPath;
   return { entrypointPath, entrypointFsDirname, nodeVersion, spawnOpts };
 }

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -105,10 +105,7 @@ export const build: BuildV2 = async ({
       console.log(`Skipping "install" command...`);
     }
   } else {
-    console.log('Installing dependencies...');
-    const installTime = Date.now();
     await runNpmInstall(entrypointFsDirname, [], spawnOpts, meta, nodeVersion);
-    debug(`Install complete [${Date.now() - installTime}ms]`);
   }
 
   if (meta.isDev) {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -407,10 +407,7 @@ export const build: BuildV2 = async ({
 
       if (!config.zeroConfig) {
         debug('Detected "builds" - not zero config');
-        printInstall();
-        const installTime = Date.now();
         await runNpmInstall(entrypointDir, [], spawnOpts, meta, nodeVersion);
-        debug(`Install complete [${Date.now() - installTime}ms]`);
         isNpmInstall = true;
       } else if (typeof installCommand === 'string') {
         if (installCommand.trim()) {
@@ -482,11 +479,7 @@ export const build: BuildV2 = async ({
           isPipInstall = true;
         }
         if (pkg) {
-          console.log('Detected package.json');
-          printInstall();
-          const installTime = Date.now();
           await runNpmInstall(entrypointDir, [], spawnOpts, meta, nodeVersion);
-          debug(`Install complete [${Date.now() - installTime}ms]`);
           isNpmInstall = true;
         }
       }


### PR DESCRIPTION
Follow-up to #7671. Since `runNpmInstall()` might now be de-duped, only print "Installing dependencies..." when the dependencies are actually being installed. This avoids printing the log message unnecessarily when the command won't actually be run, and also removes some duplication in the Builders' code.