### PR TITLE
[node] Add support for edge functions switchable runtime

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -394,7 +394,7 @@ export interface BuildResultV2Typical {
 export type BuildResultV2 = BuildResultV2Typical | BuildResultBuildOutput;
 
 export interface BuildResultV3 {
-  output: Lambda;
+  output: Lambda | EdgeFunction;
 }
 
 export type BuildV2 = (options: BuildOptions) => Promise<BuildResultV2>;


### PR DESCRIPTION
Add support for toggling the Serverless Function runtime from `nodejs` to `edge`.

```js
export const config = {
  runtime: 'edge'
}
```

https://linear.app/vercel/issue/BUI-30