### PR TITLE
[examples] fixed vercel deploy link

### DIFF
--- a/examples/dojo/README.md
+++ b/examples/dojo/README.md
@@ -6,7 +6,7 @@ This directory is a brief example of a [Dojo](https://dojo.io) site that can be 
 
 Deploy your own Dojo project with Vercel.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/vercel/tree/main/dojo&template=dojo)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/vercel/tree/main/examples/dojo&template=dojo)
 
 ### How We Created This Example
 


### PR DESCRIPTION
I tried to deploy from the button link, but it failed with `Cannot use simple-git on a directory that does not exist.`. It looks like the link wasn't using the right `repository-url` param.

The new url works for me.