### PR TITLE
[cli] Ensure `.vercel` directory is created in `vc pull`

### DIFF
--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
-import { closeSync, openSync, promises, readSync } from 'fs';
+import { outputFile } from 'fs-extra';
+import { closeSync, openSync, readSync } from 'fs';
 import { resolve } from 'path';
 import { Project, ProjectEnvTarget } from '../../types';
 import Client from '../../util/client';
@@ -12,7 +13,6 @@ import { Output } from '../../util/output';
 import param from '../../util/output/param';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
-const { writeFile } = promises;
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -111,7 +111,7 @@ export default async function pull(
       .join('\n') +
     '\n';
 
-  await writeFile(fullPath, contents, 'utf8');
+  await outputFile(fullPath, contents, 'utf8');
 
   output.print(
     `${prependEmoji(

--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs-extra';
+import { outputJSON } from 'fs-extra';
 import { Org, Project, ProjectLink } from '../../types';
 import { getLinkFromDir, VERCEL_DIR, VERCEL_DIR_PROJECT } from './link';
 import { join } from 'path';
@@ -22,21 +22,22 @@ export async function writeProjectSettings(
   project: Project,
   org: Org
 ) {
-  return await writeFile(
-    join(cwd, VERCEL_DIR, VERCEL_DIR_PROJECT),
-    JSON.stringify({
-      projectId: project.id,
-      orgId: org.id,
-      settings: {
-        buildCommand: project.buildCommand,
-        devCommand: project.devCommand,
-        outputDirectory: project.outputDirectory,
-        directoryListing: project.directoryListing,
-        rootDirectory: project.rootDirectory,
-        framework: project.framework,
-      },
-    })
-  );
+  const data = {
+    projectId: project.id,
+    orgId: org.id,
+    settings: {
+      buildCommand: project.buildCommand,
+      devCommand: project.devCommand,
+      outputDirectory: project.outputDirectory,
+      directoryListing: project.directoryListing,
+      rootDirectory: project.rootDirectory,
+      framework: project.framework,
+    },
+  };
+  const path = join(cwd, VERCEL_DIR, VERCEL_DIR_PROJECT);
+  return await outputJSON(path, data, {
+    spaces: 2,
+  });
 }
 
 export async function readProjectSettings(cwd: string) {

--- a/packages/cli/test/commands/pull.test.ts
+++ b/packages/cli/test/commands/pull.test.ts
@@ -28,6 +28,39 @@ describe('pull', () => {
     expect(devFileHasDevEnv).toBeTruthy();
   });
 
+  it('should handle pulling with env vars', async () => {
+    try {
+      process.env.VERCEL_PROJECT_ID = 'vercel-pull-next';
+      process.env.VERCEL_ORG_ID = 'team_dummy';
+
+      const cwd = setupFixture('vercel-pull-next');
+
+      // Remove the `.vercel` dir to ensure that the `pull`
+      // command creates a new one based on env vars
+      await fs.remove(path.join(cwd, '.vercel'));
+
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-pull-next',
+        name: 'vercel-pull-next',
+      });
+      client.setArgv('pull', '--yes', cwd);
+      const exitCode = await pull(client);
+      expect(exitCode, client.outputBuffer).toEqual(0);
+
+      const rawDevEnv = await fs.readFile(
+        path.join(cwd, '.vercel', '.env.development.local')
+      );
+      const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
+      expect(devFileHasDevEnv).toBeTruthy();
+    } finally {
+      delete process.env.VERCEL_PROJECT_ID;
+      delete process.env.VERCEL_ORG_ID;
+    }
+  });
+
   it('should handle --environment=preview flag', async () => {
     const cwd = setupFixture('vercel-pull-next');
     useUser();

--- a/packages/cli/test/commands/pull.test.ts
+++ b/packages/cli/test/commands/pull.test.ts
@@ -28,7 +28,7 @@ describe('pull', () => {
     expect(devFileHasDevEnv).toBeTruthy();
   });
 
-  it('should handle pulling with env vars', async () => {
+  it('should handle pulling with env vars (headless mode)', async () => {
     try {
       process.env.VERCEL_PROJECT_ID = 'vercel-pull-next';
       process.env.VERCEL_ORG_ID = 'team_dummy';
@@ -46,15 +46,18 @@ describe('pull', () => {
         id: 'vercel-pull-next',
         name: 'vercel-pull-next',
       });
-      client.setArgv('pull', '--yes', cwd);
+      client.setArgv('pull', cwd);
       const exitCode = await pull(client);
       expect(exitCode, client.outputBuffer).toEqual(0);
 
-      const rawDevEnv = await fs.readFile(
-        path.join(cwd, '.vercel', '.env.development.local')
-      );
-      const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
-      expect(devFileHasDevEnv).toBeTruthy();
+      const config = await fs.readJSON(path.join(cwd, '.vercel/project.json'));
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "orgId": "team_dummy",
+          "projectId": "vercel-pull-next",
+          "settings": Object {},
+        }
+      `);
     } finally {
       delete process.env.VERCEL_PROJECT_ID;
       delete process.env.VERCEL_ORG_ID;

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -152,6 +152,7 @@ export function useProject(project: Partial<Project> = defaultProject) {
     if (typeof target === 'string') {
       const targetEnvs = envs.filter(env => env.target.includes(target));
       res.json({ envs: targetEnvs });
+      return;
     }
 
     res.json({ envs });


### PR DESCRIPTION
When the `.vercel` directory does not exist and the env vars (`VERCEL_PROJECT_ID`/`VERCEL_ORG_ID`) are used for project linking, the `vercel pull` command was throwing an error:

```
$ VERCEL_PROJECT_ID=xxxxxxxx VERCEL_ORG_ID=xxxxxxxxxx vercel pull
Vercel CLI 24.1.1-canary.3 — https://vercel.com/feedback
Downloading "development" Environment Variables for Project t
Error! ENOENT: no such file or directory, open '/Code/t/.vercel/.env.development.local'
```