### PR TITLE
[cli] check for prebuilt directory

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -181,6 +181,17 @@ export default async (client: Client) => {
     );
   }
 
+  // build `--prebuilt`
+  if (argv['--prebuilt']) {
+    const prebuiltExists = await fs.pathExists(join(path, '.vercel/output'));
+    if (!prebuiltExists) {
+      error(
+        'Option `--prebuilt` was used, but no prebuilt deploy found in ".vercel/output"'
+      );
+      return 1;
+    }
+  }
+
   // retrieve `project` and `org` from .vercel
   const link = await getLinkedProject(client, path);
 

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -186,7 +186,11 @@ export default async (client: Client) => {
     const prebuiltExists = await fs.pathExists(join(path, '.vercel/output'));
     if (!prebuiltExists) {
       error(
-        'Option `--prebuilt` was used, but no prebuilt deploy found in ".vercel/output"'
+        `The ${param(
+          '--prebuilt'
+        )} option was used, but no prebuilt deploy found in ".vercel/output". Run ${getCommandName(
+          'build'
+        )} to generate a local build.`
       );
       return 1;
     }

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -36,7 +36,7 @@ describe('deploy', () => {
     const exitCode = await deploy(client);
     expect(exitCode).toEqual(1);
     expect(client.outputBuffer).toEqual(
-      'Error! Option `--prebuilt` was used, but no prebuilt deploy found in ".vercel/output"\n'
+      'Error! The "--prebuilt" option was used, but no prebuilt deploy found in ".vercel/output". Run `vercel build` to generate a local build.\n'
     );
   });
 

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -31,6 +31,15 @@ describe('deploy', () => {
     );
   });
 
+  it('should reject deploying a directory that does not contain ".vercel/output" when `--prebuilt` is used', async () => {
+    client.setArgv('deploy', __dirname, '--prebuilt');
+    const exitCode = await deploy(client);
+    expect(exitCode).toEqual(1);
+    expect(client.outputBuffer).toEqual(
+      'Error! Option `--prebuilt` was used, but no prebuilt deploy found in ".vercel/output"\n'
+    );
+  });
+
   it('should reject deploying "version: 1"', async () => {
     client.setArgv('deploy');
     client.localConfig = {


### PR DESCRIPTION
When using `vc deploy --prebuilt`, we need to check for an actual ".vercel/output" before attempting to deploy. This PR adds a a check for that. Now...

In a directory without `.vercel/output`:

```
$ vc deploy --prebuilt
Error! Option `--prebuilt` was used, but no prebuilt deploy found in ".vercel/output"
```

In a direcotry with `.vercel/output` (where I've not linked it yet):

```
$ vc deploy --prebuilt
? Set up and deploy “~/source/vercel/examples/build-output-api/serverless-function”? [Y/n]
```

