### PR TITLE
[client] Remove single file deployment root path `/` route

### DIFF
--- a/packages/client/src/deploy.ts
+++ b/packages/client/src/deploy.ts
@@ -126,27 +126,6 @@ export async function* deploy(
     }
   }
 
-  if (
-    files.size === 1 &&
-    deploymentOptions.builds === undefined &&
-    deploymentOptions.routes === undefined &&
-    deploymentOptions.cleanUrls === undefined &&
-    deploymentOptions.rewrites === undefined &&
-    deploymentOptions.redirects === undefined &&
-    deploymentOptions.headers === undefined &&
-    deploymentOptions.trailingSlash === undefined
-  ) {
-    debug(`Assigning '/' route for single file deployment`);
-    const filePath = Array.from(files.values())[0].names[0];
-
-    deploymentOptions.routes = [
-      {
-        src: '/',
-        dest: `/${filePath.split('/').pop()}`,
-      },
-    ];
-  }
-
   if (!deploymentOptions.name) {
     deploymentOptions.name =
       clientOptions.defaultName || getDefaultName(files, clientOptions);


### PR DESCRIPTION
This is strange behavior, and also inconsistent compared to how a Git deployment is created. Let's remove it.