### PR TITLE
[build-utils] Add warning for experimental Node.js

### DIFF
--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -44,10 +44,6 @@ export async function getSupportedNodeVersion(
 ): Promise<NodeVersion> {
   let selection: NodeVersion = getLatestNodeVersion();
 
-  if (process.env.ENABLE_EXPERIMENTAL_NODE16 === '1') {
-    return { major: 16, range: '16.x', runtime: 'nodejs16.x' };
-  }
-
   if (engineRange) {
     const found =
       validRange(engineRange) &&

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -222,6 +222,12 @@ export async function getNodeVersion(
     const latest = getLatestNodeVersion();
     return { ...latest, runtime: 'nodejs' };
   }
+  if (process.env.ENABLE_EXPERIMENTAL_NODE16 === '1') {
+    console.warn(
+      'Warning: Using experimental Node.js 16.x due to ENABLE_EXPERIMENTAL_NODE16=1'
+    );
+    return { major: 16, range: '16.x', runtime: 'nodejs16.x' };
+  }
   const { packageJson } = await scanParentDirs(destPath, true);
   let { nodeVersion } = config;
   let isAuto = true;

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -282,7 +282,9 @@ it('should select nodejs16.x with ENABLE_EXPERIMENTAL_NODE16', async () => {
   const result = await getNodeVersion('/tmp', undefined, {}, {});
   delete process.env.ENABLE_EXPERIMENTAL_NODE16;
   expect(result).toEqual({ major: 16, range: '16.x', runtime: 'nodejs16.x' });
-  expect(warningMessages).toStrictEqual([]);
+  expect(warningMessages).toStrictEqual([
+    'Warning: Using experimental Node.js 16.x due to ENABLE_EXPERIMENTAL_NODE16=1',
+  ]);
 });
 
 it('should get latest node version', async () => {


### PR DESCRIPTION
Follow up to #7489 so that we don't print package.json engines warning but we do print experimental warning.