### PR TITLE
[build-utils] add vercel-install

### DIFF
--- a/packages/build-utils/test/unit.get-script-name.test.ts
+++ b/packages/build-utils/test/unit.get-script-name.test.ts
@@ -7,6 +7,7 @@ describe('Test `getScriptName()`', () => {
       scripts: {
         'vercel-dev': '',
         'vercel-build': '',
+        'vercel-install': '',
         dev: '',
         build: '',
       },
@@ -19,6 +20,7 @@ describe('Test `getScriptName()`', () => {
       getScriptName(pkg, ['vercel-build', 'now-build', 'build']),
       'vercel-build'
     );
+    assert.equal(getScriptName(pkg, ['vercel-install']), 'vercel-install');
     assert.equal(getScriptName(pkg, ['dev']), 'dev');
     assert.equal(getScriptName(pkg, ['build']), 'build');
   });


### PR DESCRIPTION
### Related Issues

Adds support for prioritizing and executing a `vercel-install` command similar to the behavior of `vercel-build`

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
