### PR TITLE
[build-utils] Update "yazl" dependency

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -29,7 +29,7 @@
     "@types/multistream": "2.1.1",
     "@types/node-fetch": "^2.1.6",
     "@types/semver": "6.0.0",
-    "@types/yazl": "^2.4.1",
+    "@types/yazl": "2.4.2",
     "@vercel/frameworks": "0.7.2-canary.1",
     "@vercel/ncc": "0.24.0",
     "aggregate-error": "3.0.1",
@@ -47,6 +47,6 @@
     "node-fetch": "2.6.1",
     "semver": "6.1.1",
     "typescript": "4.3.4",
-    "yazl": "2.4.3"
+    "yazl": "2.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2628,7 +2628,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yazl@^2.4.1":
+"@types/yazl@2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.2.tgz#d5f8a4752261badbf1a36e8b49e042dc18ec84bc"
   integrity sha512-T+9JH8O2guEjXNxqmybzQ92mJUh2oCwDDMSSimZSe1P+pceZiFROZLYmcbqkzV5EUwz6VwcKXCO2S2yUpra6XQ==
@@ -12123,10 +12123,10 @@ yauzl@^2.9.1:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yazl@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
-  integrity sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=
+yazl@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 


### PR DESCRIPTION
The older version of "yazl" was using `new Buffer()` which causes deprecation warnings to be printed. The latest version avoids that.