### PR TITLE
[frameworks] Update Remix detection to check for "remix.config.js"

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -204,9 +204,7 @@ export const frameworks = [
     detectors: {
       every: [
         {
-          path: 'package.json',
-          matchContent:
-            '"(dev)?(d|D)ependencies":\\s*{[^}]*"remix":\\s*".+?"[^}]*}',
+          path: 'remix.config.js',
         },
       ],
     },


### PR DESCRIPTION
we don't encourage the "remix" magic package anymore, and anyone who doesn't have it installed will have their app framework default to "other" and cause it to 404

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
