### PR TITLE
[tests] skip flakey test

### DIFF
--- a/packages/cli/test/util/dev/server.test.ts
+++ b/packages/cli/test/util/dev/server.test.ts
@@ -171,6 +171,12 @@ describe('DevServer', () => {
   it(
     'should support default builds and routes',
     testFixture('now-dev-default-builds-and-routes', async server => {
+      if (process.platform === 'darwin') {
+        // this test very often fails on Mac OS only due to timeouts
+        console.log('Skipping test on macOS');
+        return;
+      }
+
       let podId: string;
 
       let res = await fetch(`${server.address}/`);

--- a/packages/cli/test/util/dev/server.test.ts
+++ b/packages/cli/test/util/dev/server.test.ts
@@ -126,6 +126,12 @@ describe('DevServer', () => {
   it(
     'should maintain query when builder defines routes',
     testFixture('now-dev-next', async server => {
+      if (process.platform === 'darwin') {
+        // this test very often fails on Mac OS only due to timeouts
+        console.log('Skipping test on macOS');
+        return;
+      }
+
       const res = await fetch(`${server.address}/something?url-param=a`);
       validateResponseHeaders(res);
 


### PR DESCRIPTION
Skips two flakey tests on Mac OS only. The error often looks like:

<img width="1453" alt="Screen Shot 2022-05-09 at 2 26 52 PM" src="https://user-images.githubusercontent.com/41545/167483088-49498f69-5470-4c1a-98f5-96ca811b838b.png">

Created internal tracking card to dig deeper. Skipping this for now will unclog other work.
