### PR TITLE
[tests] Skip broken go test

### DIFF
--- a/packages/go/test/test.js
+++ b/packages/go/test/test.js
@@ -21,10 +21,15 @@ beforeAll(async () => {
   console.log('builderUrl', builderUrl);
 });
 
+const skipFixtures = ['08-include-files'];
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
+  if (skipFixtures.includes(fixture)) {
+    console.log(`Skipping test fixture ${fixture}`);
+    continue;
+  }
   // eslint-disable-next-line no-loop-func
   it(`should build ${fixture}`, async () => {
     await expect(


### PR DESCRIPTION
This test was added several years ago, before the monorepo in https://github.com/vercel/vercel/pull/2812 but it was never working correctly due to the way zero config behaves differently than the test with `builds` in vercel.json

We can fix it in a follow up PR