### PR TITLE
[tests] Remove un-needed use of secret for team as it mangles logs

### DIFF
--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TURBO_REMOTE_ONLY: true
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: vercel
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     steps:
       - uses: actions/setup-go@v2

--- a/.github/workflows/test-integration-dev.yml
+++ b/.github/workflows/test-integration-dev.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TURBO_REMOTE_ONLY: true
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: vercel
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     steps:
       - uses: actions/setup-go@v2

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TURBO_REMOTE_ONLY: true
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: vercel
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     steps:
       - uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ needs.setup.outputs['tests'] != '[]' }}
     env:
       TURBO_REMOTE_ONLY: true
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: vercel
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     needs:
       - setup


### PR DESCRIPTION
### Related Issues

This removes the secret for turbo team as it filters anywhere vercel is printed in the logs and it doesn't really need to be secret. 

x-ref: https://github.com/vercel/vercel/runs/6496893033?check_suite_focus=true

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
