### PR TITLE
[node] Fix `11-symlinks` integration test fixture

### DIFF
--- a/packages/node/.gitignore
+++ b/packages/node/.gitignore
@@ -1,4 +1,3 @@
 /dist
 /test/fixtures/**/types.d.ts
-/test/fixtures/11-symlinks/symlink
 !test/cache-fixtures/**

--- a/packages/node/build.js
+++ b/packages/node/build.js
@@ -21,11 +21,6 @@ async function main() {
     join(__dirname, 'test/fixtures/15-helpers/ts/types.d.ts')
   );
 
-  // Setup symlink for symlink test
-  const symlinkTarget = join(__dirname, 'test/fixtures/11-symlinks/symlink');
-  await fs.remove(symlinkTarget);
-  await fs.symlink('symlinked-asset', symlinkTarget);
-
   const mainDir = join(outDir, 'main');
   await execa(
     'ncc',

--- a/packages/node/test/fixtures/11-symlinks/index.js
+++ b/packages/node/test/fixtures/11-symlinks/index.js
@@ -1,5 +1,9 @@
 import fs from 'fs';
 
-export default function handler(req, res) {
-  res.end(fs.readFileSync(`${__dirname}/symlink`));
+export default function (req, res) {
+  const path = `${__dirname}/symlink`;
+  const data = fs.readFileSync(path, 'utf8');
+  const isSymlink = fs.lstatSync(path).isSymbolicLink();
+  const target = fs.readlinkSync(path);
+  res.json({ path, target, isSymlink, data });
 }

--- a/packages/node/test/fixtures/11-symlinks/symlink
+++ b/packages/node/test/fixtures/11-symlinks/symlink
@@ -1,0 +1,1 @@
+symlinked-asset

--- a/packages/node/test/fixtures/11-symlinks/vercel.json
+++ b/packages/node/test/fixtures/11-symlinks/vercel.json
@@ -9,7 +9,7 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "asdf"
+      "mustContain": "{\"data\":\"asdf\\n\",\"isSymlink\":true}"
     }
   ]
 }

--- a/packages/node/test/fixtures/11-symlinks/vercel.json
+++ b/packages/node/test/fixtures/11-symlinks/vercel.json
@@ -9,7 +9,7 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "{\"data\":\"asdf\\n\",\"isSymlink\":true}"
+      "mustContain": "{\"path\":\"/var/task/symlink\",\"target\":\"symlinked-asset\",\"isSymlink\":true,\"data\":\"asdf\\n\"}"
     }
   ]
 }

--- a/packages/node/test/integration.test.js
+++ b/packages/node/test/integration.test.js
@@ -1,4 +1,4 @@
-//const fs = require('fs');
+const fs = require('fs');
 const path = require('path');
 
 const {
@@ -31,8 +31,7 @@ const testsThatFailToBuild = new Map([
 ]);
 
 // eslint-disable-next-line no-restricted-syntax
-//for (const fixture of fs.readdirSync(fixturesPath)) {
-for (const fixture of ['11-symlinks']) {
+for (const fixture of fs.readdirSync(fixturesPath)) {
   const errMsg = testsThatFailToBuild.get(fixture);
   if (errMsg) {
     // eslint-disable-next-line no-loop-func

--- a/packages/node/test/integration.test.js
+++ b/packages/node/test/integration.test.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+//const fs = require('fs');
 const path = require('path');
 
 const {
@@ -31,7 +31,8 @@ const testsThatFailToBuild = new Map([
 ]);
 
 // eslint-disable-next-line no-restricted-syntax
-for (const fixture of fs.readdirSync(fixturesPath)) {
+//for (const fixture of fs.readdirSync(fixturesPath)) {
+for (const fixture of ['11-symlinks']) {
   const errMsg = testsThatFailToBuild.get(fixture);
   if (errMsg) {
     // eslint-disable-next-line no-loop-func

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -252,10 +252,12 @@ async function testDeployment(
   buildDelegate
 ) {
   logWithinTest('testDeployment', fixturePath);
+  console.log(fs.readdirSync(fixturePath));
   const globResult = await glob(`${fixturePath}/**`, {
     nodir: true,
     dot: true,
   });
+  console.log(globResult);
   const bodies = globResult.reduce((b, f) => {
     const r = path.relative(fixturePath, f);
     const stat = fs.lstatSync(f);

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -258,10 +258,18 @@ async function testDeployment(
   });
   const bodies = globResult.reduce((b, f) => {
     const r = path.relative(fixturePath, f);
-    b[r] = fs.readFileSync(f);
-    b[r][fileModeSymbol] = fs.statSync(f).mode;
+    const stat = fs.lstatSync(f);
+    let data;
+    if (stat.isSymbolicLink()) {
+      data = Buffer.from(fs.readlinkSync(f), 'utf8');
+    } else {
+      data = fs.readFileSync(f);
+    }
+    data[fileModeSymbol] = stat.mode;
+    b[r] = data;
     return b;
   }, {});
+  console.log(bodies);
 
   const randomness = Math.floor(Math.random() * 0x7fffffff)
     .toString(16)

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -252,16 +252,14 @@ async function testDeployment(
   buildDelegate
 ) {
   logWithinTest('testDeployment', fixturePath);
-  console.log(fs.readdirSync(fixturePath));
   const globResult = await glob(`${fixturePath}/**`, {
     nodir: true,
     dot: true,
   });
-  console.log(globResult);
   const bodies = globResult.reduce((b, f) => {
+    let data;
     const r = path.relative(fixturePath, f);
     const stat = fs.lstatSync(f);
-    let data;
     if (stat.isSymbolicLink()) {
       data = Buffer.from(fs.readlinkSync(f), 'utf8');
     } else {
@@ -271,7 +269,6 @@ async function testDeployment(
     b[r] = data;
     return b;
   }, {});
-  console.log(bodies);
 
   const randomness = Math.floor(Math.random() * 0x7fffffff)
     .toString(16)


### PR DESCRIPTION
The `symlink` symlink wasn't being persisted through Turbo's cache, so this test was failing. So move the symlink directly into the git repo since there's no need to create it at build-time (git can store symlinks just fine).

Additionally, the test itself was not testing that the symlink was indeed re-created as a symlink from within the lambda environment (it actually wasn't, due to the upload code not considering symlinks), so the test has been updated to test for that as well.