### PR TITLE
[tests] Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,26 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
-*                                        @TooTallNate
-/.github/workflows                       @AndyBitz @styfle
-/packages/frameworks                     @AndyBitz
-/packages/cli/src/commands/build         @TooTallNate @styfle @AndyBitz @gdborton @jaredpalmer
-/packages/cli/src/commands/dev           @TooTallNate @styfle @AndyBitz
-/packages/cli/src/util/dev               @TooTallNate @styfle @AndyBitz
+*                                        @TooTallNate @EndangeredMassa @styfle
+/.github/workflows                       @TooTallNate @EndangeredMassa @styfle @ijjk
+/packages/frameworks                     @TooTallNate @EndangeredMassa @styfle @AndyBitz
 /packages/cli/src/commands/domains       @javivelasco @mglagola @anatrajkovska
 /packages/cli/src/commands/certs         @javivelasco @mglagola @anatrajkovska
 /packages/cli/src/commands/env           @styfle @lucleray
-/packages/client                         @styfle @TooTallNate
-/packages/build-utils                    @styfle @AndyBitz @TooTallNate
+/packages/client                         @TooTallNate @EndangeredMassa @styfle
+/packages/build-utils                    @TooTallNate @EndangeredMassa @styfle @AndyBitz
 /packages/middleware                     @gdborton @javivelasco
-/packages/node                           @styfle @TooTallNate @lucleray
-/packages/node-bridge                    @styfle @TooTallNate @lucleray
-/packages/next                           @Timer @ijjk
-/packages/go                             @styfle @TooTallNate
-/packages/python                         @styfle @TooTallNate
-/packages/ruby                           @styfle @TooTallNate
-/packages/static-build                   @styfle @AndyBitz
-/packages/routing-utils                  @styfle @dav-is @ijjk
-/examples                                @mcsdevv
+/packages/node                           @TooTallNate @EndangeredMassa @styfle
+/packages/node-bridge                    @TooTallNate @EndangeredMassa @styfle @ijjk
+/packages/next                           @TooTallNate @ijjk
+/packages/go                             @TooTallNate @EndangeredMassa @styfle
+/packages/python                         @TooTallNate @EndangeredMassa @styfle
+/packages/ruby                           @TooTallNate @EndangeredMassa @styfle
+/packages/static-build                   @TooTallNate @EndangeredMassa @styfle @AndyBitz
+/packages/routing-utils                  @TooTallNate @EndangeredMassa @styfle @ijjk
+/examples                                @leerob
 /examples/create-react-app               @Timer
-/examples/nextjs                         @timneutkens @Timer
-/examples/hugo                           @mcsdevv @styfle
-/examples/jekyll                         @mcsdevv @styfle
-/examples/zola                           @mcsdevv @styfle
+/examples/nextjs                         @timneutkens @ijjk @styfle
+/examples/hugo                           @styfle
+/examples/jekyll                         @styfle
+/examples/zola                           @styfle


### PR DESCRIPTION
- In addition to @TooTallNate, add @EndangeredMassa and @styfle to wildcard
- Remove @mcsdevv in favor of @leerob for examples
- Remove dav-is from `@vercel/routing-utils`
- Add @ijjk and @styfle to next.js example
- Add @ijjk to github actions and remove @AndyBitz 
- Add @TooTallNate to `@vercel/next`
- Remove @gdborton and @jaredpalmer from vc build
- Add @EndangeredMassa to most other files