### PR TITLE
[frameworks] Use `@vercel/remix` Builder for "remix" preset

### DIFF
--- a/examples/remix/vercel.json
+++ b/examples/remix/vercel.json
@@ -1,7 +1,0 @@
-{
-  "build": {
-    "env": {
-      "ENABLE_FILE_SYSTEM_API": "1"
-    }
-  }
-}

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -202,6 +202,8 @@ export const frameworks = [
     description: 'A new Remix app — the result of running `npx create-remix`.',
     website: 'https://remix.run',
     sort: 6,
+    useRuntime: { src: 'package.json', use: '@vercel/remix' },
+    ignoreRuntimes: ['@vercel/node'],
     detectors: {
       every: [
         {
@@ -227,39 +229,6 @@ export const frameworks = [
     },
     dependency: 'remix',
     getOutputDirName: async () => 'public',
-    defaultRoutes: [
-      {
-        src: '^/build/(.*)$',
-        headers: { 'cache-control': 'public, max-age=31536000, immutable' },
-        continue: true,
-      },
-      {
-        handle: 'filesystem',
-      },
-      {
-        src: '/(.*)',
-        dest: '/api',
-      },
-    ],
-    defaultRewrites: [
-      {
-        source: '/(.*)',
-        regex: '/(.*)',
-        destination: '/api',
-      },
-    ],
-    defaultHeaders: [
-      {
-        source: '/build/(.*)',
-        regex: '/build/(.*)',
-        headers: [
-          {
-            key: 'cache-control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-    ],
   },
   {
     name: 'Astro',


### PR DESCRIPTION
Specify the `useRuntimes` property for the "remix" framework to use the `@vercel/remix` Builder.

The `ENABLE_FILE_SYSTEM_API` env var is no longer necessary so the `vercel.json` file from the Remix template has also been deleted.