### PR TITLE
[next] Use `substring()` instead of `substr()`

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -855,7 +855,7 @@ export async function serverBuild({
           currentRouteSrc = starterRouteSrc;
         }
         // add to existing route src if src length limit isn't reached
-        currentRouteSrc = `${currentRouteSrc.substr(
+        currentRouteSrc = `${currentRouteSrc.substring(
           0,
           currentRouteSrc.length - 1
         )}${

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -445,7 +445,7 @@ export function localizeDynamicRoutes(
       const isApiRoute =
         pathnameNoPrefix === '/api' || pathnameNoPrefix?.startsWith('/api/');
       const isAutoExport =
-        staticPages[addLocaleOrDefault(pathname!, routesManifest).substr(1)];
+        staticPages[addLocaleOrDefault(pathname!, routesManifest).substring(1)];
 
       const isLocalePrefixed =
         isFallback || isBlocking || isAutoExport || isServerMode;


### PR DESCRIPTION
Fixes linting warnings, i.e.:

> packages/next/src/server-build.ts#L858
>
> substr() is deprecated, use slice() or substring() instead