### PR TITLE
[cli] Hard-code `VERCEL: 1` env var for "vc build"

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -159,7 +159,8 @@ export default async function main(client: Client): Promise<number> {
     output.log(`Loaded env from "${relative(cwd, envPath)}"`);
   }
 
-  // Some build processes use this env var to platform detect Vercel
+  // Some build processes use these env vars to platform detect Vercel
+  process.env.VERCEL = '1';
   process.env.NOW_BUILDER = '1';
 
   const workPath = join(cwd, project.settings.rootDirectory || '.');


### PR DESCRIPTION
This env var should normally come from the `.env` file that is created from `vc pull`, but let's just be extra sure and hard-code it directly in to `vc build` command as well.

SvelteKit `adapter-vercel` depends on this env var being set for its detection logic.