### PR TITLE
[examples] Add `vercel.json` file back to "remix" template for now

### DIFF
--- a/examples/remix/vercel.json
+++ b/examples/remix/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "ENABLE_FILE_SYSTEM_API": "1"
+    }
+  }
+}


### PR DESCRIPTION
This file was removed prematurely in #7831.