### PR TITLE
[next][build-utils] Update to re-use build result type from build-utils

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -352,11 +352,41 @@ export interface BuilderV3 {
 
 type ImageFormat = 'image/avif' | 'image/webp';
 
+export type RemotePattern = {
+  /**
+   * Must be `http` or `https`.
+   */
+  protocol?: 'http' | 'https';
+
+  /**
+   * Can be literal or wildcard.
+   * Single `*` matches a single subdomain.
+   * Double `**` matches any number of subdomains.
+   */
+  hostname: string;
+
+  /**
+   * Can be literal port such as `8080` or empty string
+   * meaning no port.
+   */
+  port?: string;
+
+  /**
+   * Can be literal or wildcard.
+   * Single `*` matches a single path segment.
+   * Double `**` matches any number of path segments.
+   */
+  pathname?: string;
+};
+
 export interface Images {
   domains: string[];
+  remotePatterns?: RemotePattern[];
   sizes: number[];
   minimumCacheTTL?: number;
   formats?: ImageFormat[];
+  dangerouslyAllowSVG?: boolean;
+  contentSecurityPolicy?: string;
 }
 
 /**

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,5 +1,4 @@
 import {
-  File,
   FileBlob,
   FileFsRef,
   Files,
@@ -22,7 +21,7 @@ import {
   BuildV2,
   PrepareCache,
   NodejsLambda,
-  EdgeFunction,
+  BuildResultV2Typical as BuildResult,
 } from '@vercel/build-utils';
 import { Handler, Route, Source } from '@vercel/routing-utils';
 import {
@@ -32,7 +31,6 @@ import {
 } from '@vercel/routing-utils/dist/superstatic';
 import { nodeFileTrace } from '@vercel/nft';
 import { Sema } from 'async-sema';
-import { ChildProcess } from 'child_process';
 // escape-string-regexp version must match Next.js version
 import escapeStringRegexp from 'escape-string-regexp';
 import findUp from 'find-up';
@@ -179,66 +177,6 @@ function isLegacyNext(nextVersion: string) {
 
   return true;
 }
-
-export interface BuildResult {
-  routes: Route[];
-  images?: {
-    domains: string[];
-    remotePatterns?: RemotePattern[];
-    sizes: number[];
-    minimumCacheTTL?: number;
-    formats?: ImageFormat[];
-    dangerouslyAllowSVG?: boolean;
-    contentSecurityPolicy?: string;
-  };
-  middleware?: {
-    buffer: Buffer;
-    env: string[];
-    format: 'module' | 'service-worker';
-    name: string;
-    sourcemap?: string;
-    wasmBindings?: { name: string; filePath: string }[];
-    type: 'v8-worker';
-  }[];
-  output: {
-    [key: string]: File | Lambda | EdgeFunction | FileFsRef | Prerender;
-  };
-  wildcard?: Array<{
-    domain: string;
-    value: string;
-  }>;
-  watch?: string[];
-  childProcesses: ChildProcess[];
-}
-
-export type RemotePattern = {
-  /**
-   * Must be `http` or `https`.
-   */
-  protocol?: 'http' | 'https';
-
-  /**
-   * Can be literal or wildcard.
-   * Single `*` matches a single subdomain.
-   * Double `**` matches any number of subdomains.
-   */
-  hostname: string;
-
-  /**
-   * Can be literal port such as `8080` or empty string
-   * meaning no port.
-   */
-  port?: string;
-
-  /**
-   * Can be literal or wildcard.
-   * Single `*` matches a single path segment.
-   * Double `**` matches any number of path segments.
-   */
-  pathname?: string;
-};
-
-type ImageFormat = 'image/avif' | 'image/webp';
 
 export const build: BuildV2 = async ({
   files,
@@ -978,8 +916,6 @@ export const build: BuildV2 = async ({
             ]
           : []),
       ],
-      watch: [],
-      childProcesses: [],
     };
   }
 
@@ -2594,8 +2530,6 @@ export const build: BuildV2 = async ({
                 ]),
           ]),
     ],
-    watch: [],
-    childProcesses: [],
   };
 };
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -12,9 +12,10 @@ import {
   debug,
   glob,
   Files,
+  BuildResultV2Typical as BuildResult,
 } from '@vercel/build-utils';
 import { Handler, Route, Source } from '@vercel/routing-utils';
-import { BuildResult, MAX_AGE_ONE_YEAR } from '.';
+import { MAX_AGE_ONE_YEAR } from '.';
 import {
   NextRequiredServerFilesManifest,
   NextImagesManifest,
@@ -1281,7 +1282,5 @@ export async function serverBuild({
             },
           ]),
     ],
-    watch: [],
-    childProcesses: [],
   };
 }


### PR DESCRIPTION
### Related Issues

We were previously using a custom type in Next.js for the build result although there is an existing type for this in the build-utils package which we can centralize around. 

x-ref: https://github.com/vercel/vercel/pull/7854#issuecomment-1133934764

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
