### PR TITLE
[examples] Add missing semi to "solidstart" vite config

### DIFF
--- a/examples/solidstart/vite.config.js
+++ b/examples/solidstart/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import solid from "solid-start";
-import vercel from "solid-start-vercel"
+import vercel from "solid-start-vercel";
 
 export default defineConfig({
-  plugins: [solid({ adapter: vercel() })]
+  plugins: [solid({ adapter: vercel() })],
 });


### PR DESCRIPTION
Ran `prettier` on this file due to missing semicolon.