### PR TITLE
[next][node] Bump `@vercel/nft` to 0.19.1

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -46,7 +46,7 @@
     "@types/text-table": "0.2.1",
     "@types/webpack-sources": "3.2.0",
     "@vercel/build-utils": "3.1.1-canary.0",
-    "@vercel/nft": "0.19.0",
+    "@vercel/nft": "0.19.1",
     "@vercel/routing-utils": "1.13.3",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -47,7 +47,7 @@
     "@types/test-listen": "1.1.0",
     "@vercel/build-utils": "3.1.1-canary.0",
     "@vercel/ncc": "0.24.0",
-    "@vercel/nft": "0.19.0",
+    "@vercel/nft": "0.19.1",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "node build.js"
   },
   "dependencies": {
-    "@vercel/nft": "0.19.0",
+    "@vercel/nft": "0.19.1",
     "@vercel/routing-utils": "1.13.3",
     "semver": "6.1.1"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "@remix-run/vercel": "1.4.3",
-    "@vercel/nft": "0.19.0"
+    "@vercel/nft": "0.19.1"
   },
   "devDependencies": {
     "@types/jest": "27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,10 +2925,10 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
   integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
 
-"@vercel/nft@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.19.0.tgz#56f2a17e0685b5c052158aafec3a9f31552de5b4"
-  integrity sha512-diHIP3/OHq/4wSkS4JJ7LqY6NAQOpCr83vpNZuKqx2PV7zrhwUH8CZ9QCu0SHkZh3LYaV0zcbGusVxTNw3DMvA==
+"@vercel/nft@0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.19.1.tgz#dcd3c20d7ef14d2050244e7d5edcfecc7303dd46"
+  integrity sha512-klR5oN7S3WJsZz0r6Xsq7o8YlFEyU3/00VmlpZzIPVFzKfbcEjXo/sVR5lQBUqNKuOzhcbxaFtzW9aOyHjmPYA==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.5"
     acorn "^8.6.0"


### PR DESCRIPTION
Bump `@vercel/nft` to 0.19.1 https://github.com/vercel/nft/releases/tag/0.19.1