### PR TITLE
[tests] update fixture path

### DIFF
--- a/packages/cli/test/unit/util/projects/get-vercel-directory.test.ts
+++ b/packages/cli/test/unit/util/projects/get-vercel-directory.test.ts
@@ -1,7 +1,8 @@
 import { basename, join } from 'path';
 import { getVercelDirectory } from '../../../../src/util/projects/link';
 
-const fixture = (name: string) => join(__dirname, '../../fixtures/unit', name);
+const fixture = (name: string) =>
+  join(__dirname, '../../../fixtures/unit', name);
 
 describe('getVercelDirectory', () => {
   it('should return ".vercel"', () => {

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -8,7 +8,8 @@ import { useUser } from '../../../mocks/user';
 
 type UnPromisify<T> = T extends Promise<infer U> ? U : T;
 
-const fixture = (name: string) => join(__dirname, '../../fixtures/unit', name);
+const fixture = (name: string) =>
+  join(__dirname, '../../../fixtures/unit', name);
 
 describe('getLinkedProject', () => {
   it('should fail to return a link when token is missing', async () => {


### PR DESCRIPTION
It looks like the fixture location was shifted and these references to it were not updated. The crashing `dev` tests were hiding these failures.

