### PR TITLE
[tests] bump node version to 14

### DIFF
--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [12]
+        node: [14]
     runs-on: ${{ matrix.os }}
     env:
       TURBO_REMOTE_ONLY: true


### PR DESCRIPTION
Update `test-integration` to use `node@14` as an incremental step to get everything node-related up to version `14`.