### PR TITLE
[tests] improve error message when a deploy fails

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -88,7 +88,9 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
     const { readyState } = deployment;
     if (readyState === 'ERROR') {
       logWithinTest('state is ERROR, throwing');
-      const error = new Error(`State of https://${deploymentUrl} is ERROR`);
+      const error = new Error(
+        `State of https://${deploymentUrl} is ERROR: ${deployment.errorMessage}`
+      );
       error.deployment = deployment;
       throw error;
     }


### PR DESCRIPTION
When a deploy fails in a test, you typically only see the `State of https://${deploymentUrl} is ERROR` message, not what caused the deploy to fail.

This PR adds the source error message directly to the one that's logged out, removing a step when debugging.