### PR TITLE
[tests] Add `vc build` integration test

### DIFF
--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -426,6 +426,20 @@ module.exports = async function prepare(session, binaryPath) {
         projectId: 'QmRoBYhejkkmssotLZr8tWgewPdPcjYucYUNERFbhJrRNi',
       }),
     },
+    'vc-build-static-build': {
+      '.vercel/project.json': JSON.stringify({
+        orgId: '.',
+        projectId: '.',
+        settings: {
+          framework: null,
+        },
+      }),
+      'package.json': JSON.stringify({
+        scripts: {
+          build: 'mkdir -p public && echo hi > public/index.txt',
+        },
+      }),
+    },
   };
 
   for (const [typeName, needed] of Object.entries(spec)) {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -3782,3 +3782,30 @@ test('[vc link] should support the `--project` flag', async t => {
     formatOutput(output)
   );
 });
+
+test('[vc build] should build project with `@vercel/static-build`', async t => {
+  const directory = fixture('vc-build-static-build');
+  const output = await execute(['build'], { cwd: directory });
+  t.is(output.exitCode, 0);
+  t.true(output.stderr.includes('Build Completed in .vercel/output'));
+
+  t.is(
+    await fs.readFile(
+      path.join(directory, '.vercel/output/static/index.txt'),
+      'utf8'
+    ),
+    'hi\n'
+  );
+
+  const config = await fs.readJSON(
+    path.join(directory, '.vercel/output/config.json')
+  );
+  t.is(config.version, 3);
+
+  const builds = await fs.readJSON(
+    path.join(directory, '.vercel/output/builds.json')
+  );
+  t.is(builds.target, 'preview');
+  t.is(builds.builds[0].src, 'package.json');
+  t.is(builds.builds[0].use, '@vercel/static-build');
+});

--- a/test/lib/deployment/log.js
+++ b/test/lib/deployment/log.js
@@ -13,7 +13,7 @@ const dateFormat = new Intl.DateTimeFormat('en-us', {
 
 function logWithinTest(...inputs) {
   const { testPath, currentTestName } =
-    typeof expect === 'undefined' ? expect.getState() : {};
+    typeof expect !== 'undefined' ? expect.getState() : {};
 
   const messages = [
     dateFormat.format(new Date()),


### PR DESCRIPTION
Adds a `vc build` integration test to ensure the ncc'd CLI works as expected to supplement the unit tests from #7869.