### PR TITLE
[node] Remove `mkdirp-promise` dependency

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,7 +51,6 @@
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",
-    "mkdirp-promise": "5.0.1",
     "node-fetch": "2.6.1",
     "source-map-support": "0.5.12",
     "test-listen": "1.1.0"

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -16,8 +16,6 @@ import {
   sep,
   parse as parsePath,
 } from 'path';
-// @ts-ignore - `@types/mkdirp-promise` is broken
-import mkdirp from 'mkdirp-promise';
 import once from '@tootallnate/once';
 import { nodeFileTrace } from '@vercel/nft';
 import {
@@ -472,7 +470,7 @@ async function doTypeCheck(
 
   try {
     const json = JSON.stringify(tsconfig, null, '\t');
-    await mkdirp(entrypointCacheDir);
+    await fsp.mkdir(entrypointCacheDir, { recursive: true });
     await fsp.writeFile(tsconfigPath, json, { flag: 'wx' });
   } catch (err) {
     // Don't throw if the file already exists

--- a/yarn.lock
+++ b/yarn.lock
@@ -9093,7 +9093,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp-promise@5.0.1, mkdirp-promise@^5.0.1:
+mkdirp-promise@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz#e9b8f68e552c68a9c1713b84883f7a1dd039b8a1"
   integrity sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=


### PR DESCRIPTION
There's no need to use this module since Node.js has `recursive: true` since Node v10.