### PR TITLE
[tests] Fix turbo cache invalidation for GH Actions `RUNNER_OS`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "baseBranch": "origin/main",
   "globalDependencies": ["$RUNNER_OS"],
+  "baseBranch": "origin/main",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "globalDependencies": ["$RUNNER_OS"],
   "baseBranch": "origin/main",
+  "globalDependencies": ["$RUNNER_OS"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "baseBranch": "origin/main",
+  "globalDependencies": ["$RUNNER_OS"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This PR fixes an issue where turbo was caching the result regardless of OS by adding the env var `RUNNER_OS` to the cache key.

https://docs.github.com/en/actions/learn-github-actions/environment-variables#detecting-the-operating-system