### PR TITLE
[build-utils] Fix warning for package.json engines

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -220,9 +220,9 @@ export async function getNodeVersion(
   config: Config = {},
   meta: Meta = {}
 ): Promise<NodeVersion> {
+  const latest = getLatestNodeVersion();
   if (meta && meta.isDev) {
     // Use the system-installed version of `node` in PATH for `vercel dev`
-    const latest = getLatestNodeVersion();
     return { ...latest, runtime: 'nodejs' };
   }
   const { packageJson } = await scanParentDirs(destPath, true);
@@ -242,6 +242,14 @@ export async function getNodeVersion(
     } else if (coerce(node)?.raw === node && !meta.isDev) {
       console.warn(
         `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` with major.minor.patch, but only major Node.js Version can be selected. Learn More: http://vercel.link/node-version`
+      );
+    } else if (
+      validRange(node) &&
+      intersects(`${latest.major + 1}.x`, node) &&
+      !meta.isDev
+    ) {
+      console.warn(
+        `Warning: Detected "engines": { "node": "${node}" } in your \`package.json\` that will automatically upgrade when a new major Node.js Version is released. Learn More: http://vercel.link/node-version`
       );
     }
     nodeVersion = node;

--- a/packages/build-utils/test/pkg-engine-node-exact/package.json
+++ b/packages/build-utils/test/pkg-engine-node-exact/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "engines": {
+    "node": "16.14.0"
+  }
+}

--- a/packages/build-utils/test/pkg-engine-node-greaterthan/package.json
+++ b/packages/build-utils/test/pkg-engine-node-greaterthan/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -291,6 +291,20 @@ it('should warn when package.json engines is exact version', async () => {
   ]);
 });
 
+it('should warn when package.json engines is greater than', async () => {
+  expect(
+    await getNodeVersion(
+      path.join(__dirname, 'pkg-engine-node-greaterthan'),
+      undefined,
+      {},
+      {}
+    )
+  ).toHaveProperty('range', '16.x');
+  expect(warningMessages).toStrictEqual([
+    'Warning: Detected "engines": { "node": ">=16" } in your `package.json` that will automatically upgrade when a new major Node.js Version is released. Learn More: http://vercel.link/node-version',
+  ]);
+});
+
 it('should not warn when package.json engines matches project setting from config', async () => {
   expect(
     await getNodeVersion(

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -277,12 +277,46 @@ it('should prefer package.json engines over project setting from config and warn
   ]);
 });
 
+it('should warn when package.json engines is exact version', async () => {
+  expect(
+    await getNodeVersion(
+      path.join(__dirname, 'pkg-engine-node-exact'),
+      undefined,
+      {},
+      {}
+    )
+  ).toHaveProperty('range', '16.x');
+  expect(warningMessages).toStrictEqual([
+    'Warning: Detected "engines": { "node": "16.14.0" } in your `package.json` with major.minor.patch, but only major Node.js Version can be selected. Learn More: http://vercel.link/node-version',
+  ]);
+});
+
 it('should not warn when package.json engines matches project setting from config', async () => {
   expect(
     await getNodeVersion(
       path.join(__dirname, 'pkg-engine-node'),
       undefined,
+      { nodeVersion: '14' },
+      {}
+    )
+  ).toHaveProperty('range', '14.x');
+  expect(warningMessages).toStrictEqual([]);
+
+  expect(
+    await getNodeVersion(
+      path.join(__dirname, 'pkg-engine-node'),
+      undefined,
       { nodeVersion: '14.x' },
+      {}
+    )
+  ).toHaveProperty('range', '14.x');
+  expect(warningMessages).toStrictEqual([]);
+
+  expect(
+    await getNodeVersion(
+      path.join(__dirname, 'pkg-engine-node'),
+      undefined,
+      { nodeVersion: '<15' },
       {}
     )
   ).toHaveProperty('range', '14.x');


### PR DESCRIPTION
This PR updates the way we handle warning for engines.node in `package.json`.

- should not warn when the engines version satisfies the project settings (previously it was an exact match)
- should warn when engines version is exact instead of range since it cannot be satisfied exactly
- should warn when engines version is greater than since it might introduce breaking changes for a future node.js version