### PR TITLE
[next] Fix priority for notFound preview routes

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1017,15 +1017,15 @@ export async function serverBuild({
           ]
         : []),
 
-      // ensure prerender's for notFound: true static routes
-      // have 404 status code when not in preview mode
-      ...notFoundPreviewRoutes,
-
       ...headers,
 
       ...redirects,
 
       ...beforeFilesRewrites,
+
+      // ensure prerender's for notFound: true static routes
+      // have 404 status code when not in preview mode
+      ...notFoundPreviewRoutes,
 
       // Make sure to 404 for the /404 path itself
       ...(i18n

--- a/packages/next/test/fixtures/00-server-build/next.config.js
+++ b/packages/next/test/fixtures/00-server-build/next.config.js
@@ -5,4 +5,13 @@ module.exports = {
   experimental: {
     nftTracing: true,
   },
+  redirects() {
+    return [
+      {
+        source: '/build-time-not-found/:path*',
+        destination: '/somewhere-else',
+        permanent: false,
+      },
+    ];
+  },
 };

--- a/packages/next/test/fixtures/00-server-build/pages/build-time-not-found/[slug].js
+++ b/packages/next/test/fixtures/00-server-build/pages/build-time-not-found/[slug].js
@@ -1,0 +1,30 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>build-time-not-found</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/build-time-not-found/first', '/build-time-not-found/second'],
+    fallback: 'blocking',
+  };
+}
+
+export function getStaticProps({ params }) {
+  console.log('getStaticProps', params);
+  if (params.slug === 'first') {
+    return {
+      notFound: true,
+    };
+  }
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  };
+}

--- a/packages/next/test/fixtures/00-server-build/vercel.json
+++ b/packages/next/test/fixtures/00-server-build/vercel.json
@@ -32,6 +32,26 @@
       "mustContain": "index page"
     },
     {
+      "path": "/build-time-not-found/first",
+      "status": 307,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
+      "path": "/build-time-not-found/second",
+      "status": 307,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "location": "//somewhere-else/"
+      }
+    },
+    {
       "path": "/static",
       "status": 200,
       "mustContain": "static page"


### PR DESCRIPTION
This ensures the route used to ensure the 404 status for build-time `notFound: true` paths comes after `redirects` since the not found preview routes are equivalent to a filesystem output so should come after. Also adds a regression test. 

### Related Issues

Fixes: [slack thread](https://vercel.slack.com/archives/CP0GBT0MC/p1653696081084459)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
