### PR TITLE
[tests] Remove ava `compileEnhancements` property from package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
     "scripts/preinstall.js"
   ],
   "ava": {
-    "compileEnhancements": false,
     "extensions": [
       "ts"
     ],


### PR DESCRIPTION
VS Code was complaining about this property, so I guess it's not doing anything:

> Property `compileEnhancements` is not allowed.