### PR TITLE
[build-utils] Make `repoRootPath` non-optional

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -82,7 +82,7 @@ export interface BuildOptions {
    * is the Git Repository Root. This is only relevant for Monorepos.
    * See https://vercel.com/blog/monorepos
    */
-  repoRootPath?: string;
+  repoRootPath: string;
 
   /**
    * An arbitrary object passed by the user in the build definition defined
@@ -123,7 +123,7 @@ export interface PrepareCacheOptions {
    * is the Git Repository Root. This is only relevant for Monorepos.
    * See https://vercel.com/blog/monorepos
    */
-  repoRootPath?: string;
+  repoRootPath: string;
 
   /**
    * An arbitrary object passed by the user in the build definition defined

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -313,7 +313,7 @@ export default async function main(client: Client): Promise<number> {
   // TODO: parallelize builds
   const buildResults: Map<Builder, BuildResult> = new Map();
   const overrides: PathOverride[] = [];
-  const repoRootPath = cwd === workPath ? undefined : cwd;
+  const repoRootPath = cwd;
   const rootPackageJsonPath = repoRootPath || workPath;
   const corepackShimDir = await initCorepack({ cwd, rootPackageJsonPath });
 

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -142,6 +142,7 @@ export async function executeBuild(
     files,
     entrypoint,
     workPath,
+    repoRootPath: workPath,
     config,
     meta: {
       isDev: true,

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1735,6 +1735,7 @@ export default class DevServer {
           entrypoint: match.entrypoint,
           workPath,
           config: match.config || {},
+          repoRootPath: this.cwd,
           meta: {
             isDev: true,
             requestPath,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -39,7 +39,7 @@ export async function downloadFilesInWorkPath({
   workPath,
   files,
   meta = {},
-}: BuildOptions) {
+}: Pick<BuildOptions, 'entrypoint' | 'workPath' | 'files' | 'meta'>) {
   debug('Downloading user files...');
   let downloadedFiles = await download(files, workPath, meta);
   if (meta.isDev) {
@@ -67,7 +67,6 @@ export const build = async ({
     files: originalFiles,
     entrypoint,
     meta,
-    config,
   });
 
   try {

--- a/packages/remix/test/build.test.ts
+++ b/packages/remix/test/build.test.ts
@@ -20,6 +20,7 @@ describe('build()', () => {
       files: {},
       entrypoint: 'package.json',
       workPath,
+      repoRootPath: workPath,
       config: {},
     });
     assert('output' in result);
@@ -36,6 +37,7 @@ describe('build()', () => {
       files: {},
       entrypoint: 'package.json',
       workPath,
+      repoRootPath: workPath,
       config: {},
     });
     const cacheNames = Object.keys(cache);


### PR DESCRIPTION
This value is always set in the Vercel build infra, so mark the type as non-optional.