### PR TITLE
[cli] update `vc env pull --help`

### DIFF
--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -46,7 +46,7 @@ const help = () => {
     '–'
   )} Pull all Development Environment Variables down from the cloud
 
-      ${chalk.cyan(`$ ${getPkgName()} env pull`)}
+      ${chalk.cyan(`$ ${getPkgName()} env pull <file>`)}
       ${chalk.cyan(`$ ${getPkgName()} env pull .env.development.local`)}
 
   ${chalk.gray('–')} Add a new variable to multiple Environments

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -46,8 +46,8 @@ const help = () => {
     '–'
   )} Pull all Development Environment Variables down from the cloud
 
-      ${chalk.cyan(`$ ${getPkgName()} env env pull`)}
-      ${chalk.cyan(`$ ${getPkgName()} env env pull .env.development.local`)}
+      ${chalk.cyan(`$ ${getPkgName()} env pull`)}
+      ${chalk.cyan(`$ ${getPkgName()} env pull .env.development.local`)}
 
   ${chalk.gray('–')} Add a new variable to multiple Environments
 

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -42,6 +42,13 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
+  ${chalk.gray(
+    '–'
+  )} Pull all Development Environment Variables down from the cloud
+
+      ${chalk.cyan(`$ ${getPkgName()} env env pull`)}
+      ${chalk.cyan(`$ ${getPkgName()} env env pull .env.development.local`)}
+
   ${chalk.gray('–')} Add a new variable to multiple Environments
 
       ${chalk.cyan(`$ ${getPkgName()} env add <name>`)}

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -42,18 +42,29 @@ const help = () => {
 
   ${chalk.dim('Examples:')}
 
-  ${chalk.gray('–')} Pull the latest Project Settings from the cloud
+  ${chalk.gray(
+    '–'
+  )} Pull the latest Environment Variables and Project Settings from the cloud
+    and stores them in \`.vercel/.env.\${target}.local\` and \`.vercel/project.json\` respectively.
 
     ${chalk.cyan(`$ ${getPkgName()} pull`)}
     ${chalk.cyan(`$ ${getPkgName()} pull ./path-to-project`)}
-    ${chalk.cyan(`$ ${getPkgName()} pull --env .env.local`)}
-    ${chalk.cyan(`$ ${getPkgName()} pull ./path-to-project --env .env.local`)}
 
-  ${chalk.gray('–')} Pull specific environment's Project Settings from the cloud
+  ${chalk.gray('–')} Pull for a specific environment
 
     ${chalk.cyan(
       `$ ${getPkgName()} pull --environment=${getEnvTargetPlaceholder()}`
     )}
+
+  ${chalk.gray(
+    '–'
+  )} Pull the latest Environment Variables to a specific file. (Deprecated)
+    ${chalk.gray(
+      'If you want to download environment variables to a specific file, use `vercel env pull` instead.'
+    )}
+
+    ${chalk.cyan(`$ ${getPkgName()} pull --env .env.local`)}
+    ${chalk.cyan(`$ ${getPkgName()} pull ./path-to-project --env .env.local`)}
 `);
 };
 

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -25,7 +25,7 @@ import {
 
 const help = () => {
   return console.log(`
-  ${chalk.bold(`${logo} ${getPkgName()} pull`)} [path]
+  ${chalk.bold(`${logo} ${getPkgName()} pull`)} [project-path]
 
  ${chalk.dim('Options:')}
 
@@ -57,21 +57,14 @@ const help = () => {
     )}
 
   ${chalk.gray(
-    '–'
-  )} Pull the latest Environment Variables to a specific file. (Deprecated)
-    ${chalk.gray(
-      'If you want to download environment variables to a specific file, use `vercel env pull` instead.'
-    )}
-
-    ${chalk.cyan(`$ ${getPkgName()} pull --env .env.local`)}
-    ${chalk.cyan(`$ ${getPkgName()} pull ./path-to-project --env .env.local`)}
+    'If you want to download environment variables to a specific file, use `vercel env pull` instead.'
+  )}
 `);
 };
 
 function processArgs(client: Client) {
   return getArgs(client.argv.slice(2), {
     '--yes': Boolean,
-    '--env': String, // deprecated
     '--environment': String,
     '--debug': Boolean,
     '-d': '--debug',

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -10,7 +10,7 @@ import {
 import vercelNextPkg from '@vercel/next/package.json';
 import vercelNodePkg from '@vercel/node/package.json';
 
-jest.setTimeout(ms('20 seconds'));
+jest.setTimeout(ms('30 seconds'));
 
 describe('importBuilders()', () => {
   it('should import built-in Builders', async () => {


### PR DESCRIPTION
Updated `vercel pull --help` to make it clearer what it does and when to use `vercel env pull`.

### Related Issues

> Related to https://github.com/vercel/front/pull/14123

---

`vercel pull --help`:

<img width="915" alt="Screen Shot 2022-06-02 at 4 08 45 PM" src="https://user-images.githubusercontent.com/41545/171739741-01ac3b0f-c164-467c-a29f-907e603ed7fc.png">

---

`vercel env --help`:

<img width="1178" alt="Screen Shot 2022-06-02 at 4 18 13 PM" src="https://user-images.githubusercontent.com/41545/171740067-1bd1bc41-ad13-4acc-a5bc-fc540a011c47.png">
