### PR TITLE
[next] Ensure middleware route comes before beforeFiles rewrites

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1025,6 +1025,8 @@ export async function serverBuild({
 
       ...redirects,
 
+      ...middleware.staticRoutes,
+
       ...beforeFilesRewrites,
 
       // Make sure to 404 for the /404 path itself
@@ -1066,8 +1068,6 @@ export async function serverBuild({
               continue: true,
             },
           ]),
-
-      ...middleware.staticRoutes,
 
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2142,10 +2142,12 @@ export async function getMiddlewareBundle({
   entryPath,
   outputDirectory,
   routesManifest,
+  isCorrectMiddlewareOrder,
 }: {
   entryPath: string;
   outputDirectory: string;
   routesManifest: RoutesManifest;
+  isCorrectMiddlewareOrder: boolean;
 }) {
   const middlewareManifest = await getMiddlewareManifest(
     entryPath,
@@ -2247,12 +2249,15 @@ export async function getMiddlewareBundle({
       const edgeFile = worker.edgeFunction.name;
       worker.edgeFunction.name = edgeFile.replace(/^pages\//, '');
       source.edgeFunctions[edgeFile] = worker.edgeFunction;
-      const route = {
+      const route: Source = {
         continue: true,
-        override: true,
         middlewarePath: edgeFile,
         src: worker.routeSrc,
       };
+
+      if (isCorrectMiddlewareOrder) {
+        route.override = true;
+      }
 
       if (routesManifest.version > 3 && isDynamicRoute(worker.page)) {
         source.dynamicRouteMap.set(worker.page, route);

--- a/packages/next/test/fixtures/00-middleware-nested/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-nested/vercel.json
@@ -6,7 +6,7 @@
       "path": "/redirect-me",
       "status": 307,
       "responseHeaders": {
-        "Location": "/from-next-config/"
+        "Location": "/from-middleware/"
       },
       "fetchOptions": {
         "redirect": "manual"

--- a/packages/next/test/fixtures/00-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-middleware/middleware.js
@@ -47,6 +47,11 @@ export function middleware(request) {
     return;
   }
 
+  if (url.pathname === '/somewhere') {
+    url.pathname = '/from-middleware';
+    return NextResponse.redirect(url);
+  }
+
   if (url.pathname === '/logs') {
     console.clear();
     for (let i = 0; i < 3; i++) console.count();

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -11,6 +11,13 @@
       "fetchOptions": {
         "redirect": "manual"
       }
+    },
+    {
+      "path": "/rewrite-before-files",
+      "status": 404,
+      "fetchOptions": {
+        "redirect": "manual"
+      }
     }
   ]
 }

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -18,6 +18,16 @@
       "fetchOptions": {
         "redirect": "manual"
       }
+    },
+    {
+      "path": "/somewhere",
+      "status": 307,
+      "responseHeaders": {
+        "Location": "/from-middleware/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
     }
   ]
 }

--- a/packages/next/test/integration/middleware.test.ts
+++ b/packages/next/test/integration/middleware.test.ts
@@ -45,7 +45,7 @@ describe('Middleware simple project', () => {
     expect(typeof beforeFilesIndex).toBe('number');
     expect(redirectIndex).toBeLessThan(middlewareIndex);
     expect(redirectIndex).toBeLessThan(beforeFilesIndex);
-    expect(beforeFilesIndex).toBeLessThan(middlewareIndex);
+    expect(middlewareIndex).toBeLessThan(beforeFilesIndex);
     expect(middlewareIndex).toBeLessThan(handleFileSystemIndex);
   });
 


### PR DESCRIPTION
This ensures `beforeFiles` rewrites come after middleware as there can be a conflict with redirects in middleware if they aren't expecting rewrites to modify the original path. 

### Related Issues

x-ref: https://github.com/vercel/vercel/pull/7847
x-ref: [slack thread](https://github.com/vercel/vercel/pull/7847)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
