### PR TITLE
[tests] increase test timeout; it has been failing recently

### DIFF
--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -10,7 +10,7 @@ import {
 import vercelNextPkg from '@vercel/next/package.json';
 import vercelNodePkg from '@vercel/node/package.json';
 
-jest.setTimeout(ms('20 seconds'));
+jest.setTimeout(ms('30 seconds'));
 
 describe('importBuilders()', () => {
   it('should import built-in Builders', async () => {


### PR DESCRIPTION
Increase test timeout for the `import-builder` tests because they've been timing out recently.

```
● importBuilders() › should import 3rd party Builders
  thrown: "Exceeded timeout of 20000 ms for a test.
  Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
    at test/unit/util/test/unit/util/build/import-builders.test.ts:30:3
    at Object.<anonymous> (test/unit/util/test/unit/util/build/import-builders.test.ts:15:1)
```

Example: https://github.com/vercel/vercel/runs/6716357010?check_suite_focus=true