### PR TITLE
[node] Skip TS compile for `.d.ts` assets

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -187,7 +187,10 @@ async function compile(
         if (cached === null) return null;
         try {
           let source: string | Buffer = readFileSync(fsPath);
-          if (fsPath.endsWith('.ts') || fsPath.endsWith('.tsx')) {
+          if (
+            (fsPath.endsWith('.ts') && !fsPath.endsWith('.d.ts')) ||
+            fsPath.endsWith('.tsx')
+          ) {
             source = compileTypeScript(fsPath, source.toString());
           }
           const { mode } = lstatSync(fsPath);

--- a/packages/node/test/fixtures/05-ts-declaration-asset/index.ts
+++ b/packages/node/test/fixtures/05-ts-declaration-asset/index.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+
+const filePath = join(__dirname, 'test.d.ts');
+const fileContent = readFileSync(filePath, 'utf8');
+
+export default function handler(_req: any, res: any) {
+  res.end(fileContent);
+}

--- a/packages/node/test/fixtures/05-ts-declaration-asset/package.json
+++ b/packages/node/test/fixtures/05-ts-declaration-asset/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@types/node": "^16.0.0"
+  }
+}

--- a/packages/node/test/fixtures/05-ts-declaration-asset/test.d.ts
+++ b/packages/node/test/fixtures/05-ts-declaration-asset/test.d.ts
@@ -1,0 +1,3 @@
+declare namespace Test {
+  // example .d.ts file
+}

--- a/packages/node/test/fixtures/05-ts-declaration-asset/vercel.json
+++ b/packages/node/test/fixtures/05-ts-declaration-asset/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [{ "src": "index.ts", "use": "@vercel/node" }],
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "declare namespace Test"
+    }
+  ]
+}

--- a/packages/node/test/integration.test.js
+++ b/packages/node/test/integration.test.js
@@ -32,9 +32,6 @@ const testsThatFailToBuild = new Map([
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
-  if (fixture != '05-ts-declaration-asset') {
-    continue;
-  }
   const errMsg = testsThatFailToBuild.get(fixture);
   if (errMsg) {
     // eslint-disable-next-line no-loop-func

--- a/packages/node/test/integration.test.js
+++ b/packages/node/test/integration.test.js
@@ -32,6 +32,9 @@ const testsThatFailToBuild = new Map([
 
 // eslint-disable-next-line no-restricted-syntax
 for (const fixture of fs.readdirSync(fixturesPath)) {
+  if (fixture != '05-ts-declaration-asset') {
+    continue;
+  }
   const errMsg = testsThatFailToBuild.get(fixture);
   if (errMsg) {
     // eslint-disable-next-line no-loop-func


### PR DESCRIPTION
Fixes an issue where `.d.ts` assets were incorrectly being compiled after a fix to nft in https://github.com/vercel/nft/pull/289

- [Repro Steps](https://github.com/cheapsteak/repro-vercel-cli-build-dts-error)
- [Incident](https://app.kintaba.com/incident/755531679765890512)
- [Slack](https://vercel.slack.com/archives/C03JNHA844R/p1654334373086879)


```
Error! An unexpected error occurred in build: TypeError: Unable to require `.d.ts` file.
This is usually the result of a faulty configuration or import. Make sure there is a `.js`, `.json` or another executable extension and loader (attached before `ts-node`) available alongside `test.d.ts`.
    at getOutputTypeCheck (node_modules/@vercel/node/dist/index.js:104574:27)
    at compile (node_modules/@vercel/node/dist/index.js:104645:109)
    at compileTypeScript (node_modules/@vercel/node/dist/index.js:104059:31)
    at Job.readFile (node_modules/@vercel/node/dist/index.js:104085:30)
    at Job.emitDependency (node_modules/@vercel/node/dist/index.js:61748:39)
    at node_modules/@vercel/node/dist/index.js:61762:21
    at async Promise.all (index 0)
    at Job.emitDependency (node_modules/@vercel/node/dist/index.js:61757:9)
    at async Promise.all (index 0)
    at Object.nodeFileTrace (node_modules/@vercel/node/dist/index.js:61499:5)
```

<img src="https://user-images.githubusercontent.com/229881/172055403-d2edfe1d-3a60-459f-bf40-506fea1d1ca4.png" height=500 />
