### PR TITLE
[static-config] Use "runtime" instead of "use"

### DIFF
--- a/packages/static-config/src/index.ts
+++ b/packages/static-config/src/index.ts
@@ -13,7 +13,7 @@ import { validate } from './validation';
 export const BaseFunctionConfigSchema = {
   type: 'object',
   properties: {
-    use: { type: 'string' },
+    runtime: { type: 'string' },
     memory: { type: 'number' },
     maxDuration: { type: 'number' },
     regions: {

--- a/packages/static-config/test/fixtures/deno.ts
+++ b/packages/static-config/test/fixtures/deno.ts
@@ -2,7 +2,7 @@ import ms from 'https://denopkg.com/TooTallNate/ms';
 import { readerFromStreamReader } from 'https://deno.land/std@0.107.0/io/streams.ts';
 
 export const config = {
-  use: 'deno',
+  runtime: 'deno',
   location: 'https://example.com/page',
 };
 

--- a/packages/static-config/test/fixtures/invalid-schema.js
+++ b/packages/static-config/test/fixtures/invalid-schema.js
@@ -1,3 +1,3 @@
 export const config = {
-  use: 0,
+  runtime: 0,
 };

--- a/packages/static-config/test/fixtures/node.js
+++ b/packages/static-config/test/fixtures/node.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 export const config = {
-  use: 'node',
+  runtime: 'nodejs',
   memory: 1024,
 };
 

--- a/packages/static-config/test/index.test.ts
+++ b/packages/static-config/test/index.test.ts
@@ -10,7 +10,7 @@ describe('getConfig()', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "memory": 1024,
-        "use": "node",
+        "runtime": "nodejs",
       }
     `);
   });
@@ -27,7 +27,7 @@ describe('getConfig()', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "location": "https://example.com/page",
-        "use": "deno",
+        "runtime": "deno",
       }
     `);
   });

--- a/packages/static-config/test/swc.test.ts
+++ b/packages/static-config/test/swc.test.ts
@@ -57,7 +57,7 @@ describe('getConfig for swc', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "memory": 1024,
-        "use": "node",
+        "runtime": "nodejs",
       }
     `);
   });
@@ -73,7 +73,7 @@ describe('getConfig for swc', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "location": "https://example.com/page",
-        "use": "deno",
+        "runtime": "deno",
       }
     `);
   });


### PR DESCRIPTION
The static configuration property name has been decided to be `runtime`.

This is a precursor for #7877.