### PR TITLE
[build-utils] Allow `EdgeFunction` as a valid output type for version 3 Builders

### DIFF
--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -428,7 +428,7 @@ export interface BuildResultV2Typical {
 export type BuildResultV2 = BuildResultV2Typical | BuildResultBuildOutput;
 
 export interface BuildResultV3 {
-  output: Lambda;
+  output: Lambda | EdgeFunction;
 }
 
 export type BuildV2 = (options: BuildOptions) => Promise<BuildResultV2>;


### PR DESCRIPTION
A version 3 Builder is allowed to output an `EdgeFunction` output type. This already is handled correctly by the Vercel build infrastructure.