### PR TITLE
[cli] Remove boxen for warnings

### DIFF
--- a/packages/cli/src/commands/domains/inspect.ts
+++ b/packages/cli/src/commands/domains/inspect.ts
@@ -150,17 +150,7 @@ export default async function inspect(
       `This Domain is not configured properly. To configure it you should either:`,
       null,
       null,
-      null,
-      {
-        boxen: {
-          margin: {
-            left: 2,
-            right: 0,
-            bottom: 0,
-            top: 0,
-          },
-        },
-      }
+      null
     );
     output.print(
       `  ${chalk.grey('a)')} ` +

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import boxen from 'boxen';
 import renderLink from './link';
 import wait, { StopSpinner } from './wait';
 import { Writable } from 'stream';
@@ -51,28 +50,15 @@ export class Output {
     str: string,
     slug: string | null = null,
     link: string | null = null,
-    action: string | null = 'Learn More',
-    options?: {
-      boxen?: boxen.Options;
-    }
+    action: string | null = 'Learn More'
   ) => {
     const details = slug ? `https://err.sh/vercel/${slug}` : link;
 
     this.print(
-      boxen(
-        chalk.bold.yellow('WARN! ') +
+      chalk.yellow(
+        chalk.bold('WARN! ') +
           str +
-          (details ? `\n${action}: ${renderLink(details)}` : ''),
-        {
-          padding: {
-            top: 0,
-            bottom: 0,
-            left: 1,
-            right: 1,
-          },
-          borderColor: 'yellow',
-          ...options?.boxen,
-        }
+          (details ? `\n${action}: ${renderLink(details)}` : '')
       )
     );
     this.print('\n');


### PR DESCRIPTION
This never worked correctly and its too verbose. Lets remove boxen in favor of yellow text.

## Before

<img width="1432" alt="before" src="https://user-images.githubusercontent.com/229881/173138338-1cd1c81c-f294-4752-a08f-f80466fbd21c.png" />

## After

<img width="1432" alt="after" src="https://user-images.githubusercontent.com/229881/173138813-f9ff4de1-5bb7-4b60-8609-6abdd0e86fa0.png">


