### PR TITLE
[tests] Update `ts-jest` to v28.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "npm-package-arg": "6.1.0",
     "prettier": "2.6.2",
     "ts-eager": "2.0.2",
-    "ts-jest": "28.0.0-next.1",
+    "ts-jest": "28.0.5",
     "turbo": "1.2.14"
   },
   "scripts": {

--- a/packages/build-utils/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/build-utils/test/unit.builds-and-routes-detector.test.ts
@@ -2245,13 +2245,9 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('no package.json + no build + root-level "middleware.ts"', async () => {
     const files = ['middleware.ts', 'index.html', 'web/middleware.js'];
-    const { builders, defaultRoutes, errors } = await detectBuilders(
-      files,
-      null,
-      {
-        featHandleMiss,
-      }
-    );
+    const { builders, errors } = await detectBuilders(files, null, {
+      featHandleMiss,
+    });
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('middleware.ts');
     expect(builders![0].config?.middleware).toEqual(true);
@@ -2259,7 +2255,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders![1].src).toBe('!{api/**,package.json,middleware.[jt]s}');
     expect(builders!.length).toBe(2);
     expect(errors).toBe(null);
-    console.log(defaultRoutes);
   });
 
   it('should not add middleware builder when "nextjs" framework is selected', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8416,13 +8416,6 @@ json5@2.1.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@2.x:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^2.1.0, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -12307,19 +12300,19 @@ ts-eager@2.0.2:
     esbuild "^0.11.20"
     source-map-support "^0.5.19"
 
-ts-jest@28.0.0-next.1:
-  version "28.0.0-next.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.0-next.1.tgz#b9961b0220d797a09ffc98d93caa73879794b122"
-  integrity sha512-rhxVFSOOcJLCjGvh/RXmvz0fSpnQrB0PjiC3JL25oNeuHH/bC3BVlanLg9AtPm/AnW3l0JCBfgACm2xAT9DPxw==
+ts-jest@28.0.5:
+  version "28.0.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.5.tgz#31776f768fba6dfc8c061d488840ed0c8eeac8b9"
+  integrity sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
     jest-util "^28.0.0"
-    json5 "2.x"
+    json5 "^2.2.1"
     lodash.memoize "4.x"
     make-error "1.x"
     semver "7.x"
-    yargs-parser "^20.x"
+    yargs-parser "^21.0.1"
 
 ts-morph@12.0.0:
   version "12.0.0"
@@ -13166,12 +13159,7 @@ yargs-parser@^18.1.3:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.x:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==


### PR DESCRIPTION
Gets rid of the annoying ts-jest update warning:

```
ts-jest[ts-jest-transformer] (WARN) Use 'ts-jest' entry point in v28 will resolve in refactored transformer. If you wish to use legacy transformer, please adjust your Jest 'transform' config. For example:
     module.exports = {
        transform: {
           '^.+\\.tsx?$': 'ts-jest/legacy'
        }
     }
```