### PR TITLE
[next] Fix _next/data resolving priority with afterFiles

### DIFF
--- a/packages/next/test/fixtures/00-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-middleware/middleware.js
@@ -200,15 +200,15 @@ export function middleware(request) {
   }
 
   if (pathname.startsWith('/home')) {
-    if (!request.cookies.bucket) {
+    if (!request.cookies.get('bucket')) {
       const bucket = Math.random() >= 0.5 ? 'a' : 'b';
       url.pathname = `/home/${bucket}`;
       const response = NextResponse.rewrite(url);
-      response.cookie('bucket', bucket);
+      response.cookies.set('bucket', bucket);
       return response;
     }
 
-    url.pathname = `/home/${request.cookies.bucket}`;
+    url.pathname = `/home/${request.cookies.get('bucket')}`;
     return NextResponse.rewrite(url);
   }
 

--- a/packages/next/test/fixtures/00-middleware/next.config.js
+++ b/packages/next/test/fixtures/00-middleware/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
   redirects() {
     return [
       {
@@ -14,6 +17,12 @@ module.exports = {
         {
           source: '/rewrite-before-files',
           destination: '/somewhere',
+        },
+      ],
+      afterFiles: [
+        {
+          source: '/after-file-rewrite',
+          destination: '/about',
         },
       ],
     };

--- a/packages/next/test/fixtures/00-middleware/next.config.js
+++ b/packages/next/test/fixtures/00-middleware/next.config.js
@@ -24,6 +24,14 @@ module.exports = {
           source: '/after-file-rewrite',
           destination: '/about',
         },
+        {
+          source: '/after-file-rewrite-auto-static',
+          destination: '/home/a',
+        },
+        {
+          source: '/after-file-rewrite-auto-static-dynamic',
+          destination: '/dynamic/first',
+        },
       ],
     };
   },

--- a/packages/next/test/fixtures/00-middleware/pages/about.js
+++ b/packages/next/test/fixtures/00-middleware/pages/about.js
@@ -12,5 +12,6 @@ export const getServerSideProps = ({ query }) => ({
   props: {
     middleware: query.middleware || '',
     message: query.message || '',
+    page: 'about',
   },
 });

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -28,6 +28,19 @@
       "fetchOptions": {
         "redirect": "manual"
       }
+    },
+    {
+      "path": "/after-file-rewrite",
+      "status": 200,
+      "mustContain": "About Page"
+    },
+    {
+      "path": "/_next/data/testing-build-id/after-file-rewrite.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": "1"
+      },
+      "mustContain": "page\":\"about\""
     }
   ]
 }

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -41,6 +41,17 @@
         "x-nextjs-data": "1"
       },
       "mustContain": "page\":\"about\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/after-file-rewrite-auto-static-dynamic.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": "1"
+      },
+      "responseHeaders": {
+        "x-nextjs-matched-path": "/dynamic/first"
+      },
+      "mustContain": "{}"
     }
   ]
 }


### PR DESCRIPTION
### Related Issues

This ensures we only use `overrides` when in the phase before `filesystem` as it causes `afterFiles` rewrites to come before the `_next/data` resolving when used after the `filesystem` check. 

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
