### PR TITLE
[node] Add missing dependencies for `dev-server.ts`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@types/node": "*",
-    "@vercel/ncc": "0.34.0",
+    "@vercel/ncc": "0.24.0",
     "@vercel/node-bridge": "3.0.0",
     "@vercel/static-config": "2.0.1",
     "edge-runtime": "1.0.1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,6 +33,10 @@
     "@types/node": "*",
     "@vercel/ncc": "0.34.0",
     "@vercel/node-bridge": "3.0.0",
+    "@vercel/static-config": "2.0.1",
+    "edge-runtime": "1.0.1",
+    "exit-hook": "2.2.1",
+    "node-fetch": "2.6.1",
     "ts-node": "8.9.1",
     "typescript": "4.3.4"
   },
@@ -48,14 +52,10 @@
     "@types/node-fetch": "^2.6.1",
     "@types/test-listen": "1.1.0",
     "@vercel/build-utils": "4.1.1-canary.1",
-    "@vercel/ncc": "0.24.0",
     "@vercel/nft": "0.19.1",
-    "@vercel/static-config": "2.0.1",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
-    "edge-runtime": "1.0.1",
     "etag": "1.8.1",
-    "node-fetch": "2.6.1",
     "source-map-support": "0.5.12",
     "test-listen": "1.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3039,11 +3039,6 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
   integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
 
-"@vercel/ncc@0.34.0":
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.34.0.tgz#d0139528320e46670d949c82967044a8f66db054"
-  integrity sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==
-
 "@vercel/nft@0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.19.1.tgz#dcd3c20d7ef14d2050244e7d5edcfecc7303dd46"


### PR DESCRIPTION
Some new imports were introduced recently but are missing from the `"dependencies"` object, so they were missing when the package was installed from the npm registry.