### PR TITLE
[next] Update to skip middleware for on-demand revalidate

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -797,6 +797,7 @@ export async function serverBuild({
     outputDirectory,
     routesManifest,
     isCorrectMiddlewareOrder,
+    prerenderBypassToken: prerenderManifest.bypassToken || '',
   });
 
   const isNextDataServerResolving =

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2142,9 +2142,11 @@ export async function getMiddlewareBundle({
   outputDirectory,
   routesManifest,
   isCorrectMiddlewareOrder,
+  prerenderBypassToken,
 }: {
   entryPath: string;
   outputDirectory: string;
+  prerenderBypassToken: string;
   routesManifest: RoutesManifest;
   isCorrectMiddlewareOrder: boolean;
 }) {
@@ -2268,6 +2270,13 @@ export async function getMiddlewareBundle({
       const route: Route = {
         continue: true,
         src: worker.routeSrc,
+        missing: [
+          {
+            type: 'header',
+            key: 'x-prerender-revalidate',
+            value: prerenderBypassToken,
+          },
+        ],
       };
 
       if (worker.type === 'function') {

--- a/packages/next/test/integration/middleware.test.ts
+++ b/packages/next/test/integration/middleware.test.ts
@@ -105,6 +105,14 @@ function sharedTests(ctx: Context) {
     const routes = ctx.buildResult.routes.filter(
       route => 'middleware' in route || 'middlewarePath' in route
     );
+    expect(
+      routes.every(
+        route =>
+          route.missing[0].type === 'header' &&
+          route.missing[0].key === 'x-prerender-revalidate' &&
+          route.missing[0].value.length > 0
+      )
+    ).toBeTruthy();
     expect(routes.length).toBeGreaterThan(0);
   });
 }


### PR DESCRIPTION
As discussed, this updates to skip middleware for on-demand revalidate requests as the middleware should not be necessary here and could prevent the request from revalidating successfully inadvertently. 

### Related Issues

x-ref: https://github.com/vercel/next.js/pull/37734

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
