### PR TITLE
Make links in `vc ls` clickable

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -95,7 +95,7 @@ export default async function main(client: Client) {
   }
 
   const meta = parseMeta(argv['--meta']);
-  const { currentTeam, includeScheme } = config;
+  const { currentTeam } = config;
 
   let contextName = null;
 
@@ -227,7 +227,7 @@ export default async function main(client: Client) {
           .map(dep => [
             [
               getProjectName(dep),
-              chalk.bold((includeScheme ? 'https://' : '') + dep.url),
+              chalk.bold('https://' + dep.url),
               stateString(dep.state),
               chalk.gray(ms(Date.now() - dep.createdAt)),
               dep.creator.username,


### PR DESCRIPTION
Currently, URLs in the `vc ls` command are not clickable, which makes them a lot less useful to me. It seems like this was intentionally prevented at some point; however, I (admittedly with no context about the history of this command) think this behavior should be enabled by default.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
