### PR TITLE
chore(node): remove `typescript` dependency

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -38,8 +38,7 @@
     "edge-runtime": "1.0.1",
     "exit-hook": "2.2.1",
     "node-fetch": "2.6.1",
-    "ts-node": "8.9.1",
-    "typescript": "4.3.4"
+    "ts-node": "8.9.1"
   },
   "devDependencies": {
     "@babel/core": "7.5.0",
@@ -57,6 +56,15 @@
     "cookie": "0.4.0",
     "etag": "1.8.1",
     "source-map-support": "0.5.12",
-    "test-listen": "1.1.0"
+    "test-listen": "1.1.0",
+    "typescript": "4.3.4"
+  },
+  "peerDependencies": {
+    "typescript": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -1,4 +1,4 @@
-import _ts from 'typescript';
+import type _ts from 'typescript';
 import { NowBuildError } from '@vercel/build-utils';
 import { relative, basename, resolve, dirname } from 'path';
 


### PR DESCRIPTION
`typescript` is only used as a type or as bin when doing a type check.

Since type checks aren't necessary when using normal Node, we can move `typescript` to an optional peerDependency.

---

BREAKING CHANGE: `typescript` isn't a dependency anymore