### PR TITLE
[next] Update error for internal missing page

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1950,11 +1950,23 @@ export const build: BuildV2 = async ({
 
                   if (!currentPage) {
                     console.error(
-                      "Failed to find matching page for", {toRender, header: req.headers['x-nextjs-page'], url: req.url }, "in lambda"
-                    )
-                    console.error('pages in lambda', Object.keys(pages))
-                    res.statusCode = 500
-                    return res.end('internal server error')
+                      "pages in lambda:",
+                      Object.keys(pages),
+                      "page header received:",
+                      req.headers["x-nextjs-page"]
+                    );
+                    throw new Error(
+                      "Failed to find matching page in lambda for: " +
+                        JSON.stringify(
+                          {
+                            toRender,
+                            url: req.url,
+                            header: req.headers["x-nextjs-page"],
+                          },
+                          null,
+                          2
+                        )
+                    );
                   }
 
                   const mod = currentPage()


### PR DESCRIPTION
This updates the error shown for older Next.js versions when we fail to resolve the page internally and ensures we properly crash the lambda so that the configured error page shows properly. 

### Related Issues

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1655409935219589)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
