### PR TITLE
[next] Ensure basePath is matched correctly for _next/data resolving

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -914,7 +914,7 @@ export async function serverBuild({
     return isNextDataServerResolving
       ? [
           {
-            src: '^/((?!_next/).*)$',
+            src: path.join('^/', entryDirectory, '((?!_next/).*)$'),
             has: [
               {
                 type: 'header',


### PR DESCRIPTION
This ensures we correctly match `basePath` for the `_next/data` resolving routes. The tests in the below referenced PR already cover this change so no new fixtures have been added here as they would rely on those changes landing first. 

### Related Issues

x-ref: https://github.com/vercel/next.js/pull/37854

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
