### PR TITLE
[next] Fix normalizing for _next/data/index.json route with middleware

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -909,7 +909,7 @@ export async function serverBuild({
           // normalize "/index" from "/_next/data/index.json" to -> just "/"
           // as matches a rewrite sources will expect just "/"
           {
-            src: path.join('^', entryDirectory, '/index'),
+            src: path.join('^/', entryDirectory, '/index'),
             has: [
               {
                 type: 'header',
@@ -925,6 +925,24 @@ export async function serverBuild({
   const denormalizeNextDataRoute = (isOverride = false) => {
     return isNextDataServerResolving
       ? [
+          {
+            src: path.join('^/', entryDirectory, '$'),
+            has: [
+              {
+                type: 'header',
+                key: 'x-nextjs-data',
+              },
+            ],
+            dest: `${path.join(
+              '/',
+              entryDirectory,
+              '/_next/data/',
+              buildId,
+              '/index.json'
+            )}`,
+            continue: true,
+            ...(isOverride ? { override: true } : {}),
+          },
           {
             src: path.join('^/', entryDirectory, '((?!_next/).*)$'),
             has: [

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -917,6 +917,8 @@ export async function serverBuild({
               },
             ],
             dest: path.join('/', entryDirectory),
+            ...(isOverride ? { override: true } : {}),
+            continue: true,
           },
         ]
       : [];

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -906,6 +906,18 @@ export async function serverBuild({
               },
             ],
           },
+          // normalize "/index" from "/_next/data/index.json" to -> just "/"
+          // as matches a rewrite sources will expect just "/"
+          {
+            src: path.join('^', entryDirectory, '/index'),
+            has: [
+              {
+                type: 'header',
+                key: 'x-nextjs-data',
+              },
+            ],
+            dest: path.join('/', entryDirectory),
+          },
         ]
       : [];
   };


### PR DESCRIPTION
This ensures we correctly normalize `/_next/data/build-id/index.json` -> `/` so that the middleware matcher is able to match correctly with having to manually handle the `/index` case. 

Tests have been added in the Next.js e2e suite here https://github.com/vercel/next.js/pull/37961

x-ref: https://github.com/vercel/next.js/issues/37804#issuecomment-1161907235

### Related Issues

x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1655946788395279?thread_ts=1655942747.319429&cid=C0289CGVAR2)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
