### PR TITLE
[next] Update max size warning to handle initial layer better

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1529,7 +1529,7 @@ export const build: BuildV2 = async ({
         pageTraces,
         compressedPages,
         tracedPseudoLayer?.pseudoLayer || {},
-        0,
+        { pseudoLayer: {}, pseudoLayerBytes: 0 },
         0,
         lambdaCompressedByteLimit,
         // internal pages are already referenced in traces for serverless
@@ -1545,7 +1545,7 @@ export const build: BuildV2 = async ({
         pageTraces,
         compressedPages,
         tracedPseudoLayer?.pseudoLayer || {},
-        0,
+        { pseudoLayer: {}, pseudoLayerBytes: 0 },
         0,
         lambdaCompressedByteLimit,
         []

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -425,11 +425,8 @@ export async function serverBuild({
     const uncompressedInitialSize = Object.keys(
       initialPseudoLayer.pseudoLayer
     ).reduce((prev, cur) => {
-      return (
-        prev +
-          (initialPseudoLayer.pseudoLayer[cur] as PseudoFile)
-            .uncompressedSize || 0
-      );
+      const file = initialPseudoLayer.pseudoLayer[cur] as PseudoFile;
+      return prev + file.uncompressedSize || 0;
     }, 0);
 
     debug(
@@ -611,13 +608,6 @@ export async function serverBuild({
       }, {})
     );
 
-    const initialPseudoLayerSize = Object.keys(
-      initialPseudoLayer.pseudoLayer
-    ).reduce((prev, cur) => {
-      const file = initialPseudoLayer.pseudoLayer[cur] as PseudoFile;
-      return prev + file.uncompressedSize || 0;
-    }, 0);
-
     const pageExtensions = requiredServerFilesManifest.config?.pageExtensions;
 
     const pageLambdaGroups = await getPageLambdaGroups(
@@ -628,9 +618,9 @@ export async function serverBuild({
       pageTraces,
       compressedPages,
       tracedPseudoLayer.pseudoLayer,
-      initialPseudoLayer.pseudoLayerBytes,
-      initialPseudoLayerSize,
+      initialPseudoLayer,
       lambdaCompressedByteLimit,
+      uncompressedInitialSize,
       internalPages,
       pageExtensions
     );
@@ -643,8 +633,8 @@ export async function serverBuild({
       pageTraces,
       compressedPages,
       tracedPseudoLayer.pseudoLayer,
-      initialPseudoLayer.pseudoLayerBytes,
-      initialPseudoLayerSize,
+      initialPseudoLayer,
+      uncompressedInitialSize,
       lambdaCompressedByteLimit,
       internalPages
     );
@@ -682,7 +672,6 @@ export async function serverBuild({
       const lambda = await createLambdaFromPseudoLayers({
         files: launcherFiles,
         layers: [
-          initialPseudoLayer.pseudoLayer,
           group.pseudoLayer,
           [...group.pages, ...internalPages].reduce((prev, page) => {
             const pageFileName = path.normalize(

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1289,8 +1289,8 @@ export async function getPageLambdaGroups(
     [page: string]: PseudoFile;
   },
   tracedPseudoLayer: PseudoLayer,
-  initialPseudoLayerSize: number,
-  initialPseudoLayerUncompressedSize: number,
+  initialPseudoLayer: PseudoLayerResult,
+  initialPseudoLayerUncompressed: number,
   lambdaCompressedByteLimit: number,
   internalPages: string[],
   pageExtensions?: string[]
@@ -1341,10 +1341,10 @@ export async function getPageLambdaGroups(
         }
 
         const underUncompressedLimit =
-          newTracedFilesUncompressedSize + initialPseudoLayerUncompressedSize <
+          newTracedFilesUncompressedSize <
           MAX_UNCOMPRESSED_LAMBDA_SIZE - LAMBDA_RESERVED_UNCOMPRESSED_SIZE;
         const underCompressedLimit =
-          newTracedFilesSize + initialPseudoLayerSize <
+          newTracedFilesSize <
           lambdaCompressedByteLimit - LAMBDA_RESERVED_COMPRESSED_SIZE;
 
         return underUncompressedLimit && underCompressedLimit;
@@ -1359,9 +1359,9 @@ export async function getPageLambdaGroups(
         pages: [page],
         ...opts,
         isPrerenders: isPrerenderRoute,
-        pseudoLayerBytes: 0,
-        pseudoLayerUncompressedBytes: 0,
-        pseudoLayer: {},
+        pseudoLayerBytes: initialPseudoLayer.pseudoLayerBytes,
+        pseudoLayerUncompressedBytes: initialPseudoLayerUncompressed,
+        pseudoLayer: Object.assign({}, initialPseudoLayer.pseudoLayer),
       };
       groups.push(newGroup);
       matchingGroup = newGroup;

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -802,3 +802,36 @@ it('Should provide lambda info when limit is hit for internal pages (server buil
   expect(logs).toMatch(/public\/big-image-1\.jpg/);
   expect(logs).toMatch(/public\/big-image-2\.jpg/);
 });
+
+it('Should provide lambda info when limit is hit (uncompressed)', async () => {
+  let logs = '';
+
+  const origLog = console.log;
+
+  console.log = function (...args) {
+    logs += args.join(' ');
+    origLog(...args);
+  };
+
+  try {
+    await runBuildLambda(
+      path.join(__dirname, 'test-limit-exceeded-404-static-files')
+    );
+  } catch (err) {
+    console.error(err);
+  }
+  console.log = origLog;
+
+  expect(logs).toContain(
+    'Max serverless function size was exceeded for 1 function'
+  );
+  expect(logs).toContain(
+    'Max serverless function size of 50 MB compressed or 250 MB uncompressed reached'
+  );
+  expect(logs).toContain(`Serverless Function's page: api/hello.js`);
+  expect(logs).toMatch(
+    /Large Dependencies.*?Uncompressed size.*?Compressed size/
+  );
+  expect(logs).toMatch(/data\.txt/);
+  expect(logs).toMatch(/\.next\/server\/pages/);
+});

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -715,7 +715,7 @@ it('Should provide lambda info when limit is hit (server build)', async () => {
   console.log = origLog;
 
   expect(logs).toContain(
-    'Max serverless function size was exceeded for 1 function'
+    'Max serverless function size was exceeded for 2 functions'
   );
   expect(logs).toContain(
     'Max serverless function size of 50 MB compressed or 250 MB uncompressed reached'

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const locales = ['en'];
+let charStart = 97;
+let charEnd = 105;
+
+// generate 81 random locales under en
+for (let i = charStart; i <= charEnd; i++) {
+  const firstChar = String.fromCharCode(i);
+
+  for (let j = charStart; j <= charEnd; j++) {
+    const secondChar = String.fromCharCode(j);
+    locales.push(`en-${firstChar}${secondChar}`);
+  }
+}
+
+assert(
+  locales.length === 82,
+  `unexpected locale count, expected 82, received ${locales.length}`
+);
+
+// generate 100MB text file which will be traced in `/api/hello`
+// which when combined with the 404 HTML files will push us over the 250MB
+// uncompressed limit
+fs.writeFileSync('data.txt', new Array(100 * 1000 * 1000).fill('a').join());
+
+module.exports = {
+  i18n: {
+    locales,
+    defaultLocale: 'en',
+  },
+};

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/package.json
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-limit",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "canary",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  }
+}

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/404.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/404.js
@@ -1,0 +1,19 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>404 | Page Not Found</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticProps({ locale }) {
+  return {
+    props: {
+      locale,
+      // 1MB string which is duplicated in HTML totalling 2MB
+      // this will be generated for each locale as well
+      largeData: new Array(1 * 1000 * 1000).fill('a').join(''),
+    },
+  };
+}

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/_app.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/_app.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+import React from 'react';
+
+if (typeof window === 'undefined') {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    fs.readdirSync(path.join(process.cwd(), 'public'));
+    fs.readdirSync(path.join(process.cwd(), 'node_modules/chrome-aws-lambda'));
+    fs.readdirSync(path.join(process.cwd(), 'node_modules/firebase'));
+  } catch (_) {}
+}
+
+export default function MyApp({ Component, pageProps }) {
+  return React.createElement(Component, pageProps);
+}

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/api/hello.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/api/hello.js
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+
+try {
+  fs.readFileSync(path.join(process.cwd(), 'data.txt'));
+} catch (_) {
+  /**/
+}
+
+export default function handler(req, res) {
+  res.end('hello');
+}

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/index.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return 'index page';
+}

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/vercel.json
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ]
+}


### PR DESCRIPTION
This ensures we properly show the max serverless function size error when the initial layer combined with a page layer causes the uncompressed or compressed size to be exceeded. An integration test for this specific case has been added to ensure this is working properly.  

### Related Issues

Fixes: https://vercel.slack.com/archives/C03LSE48JBY/p1656023651254749?thread_ts=1656021414.244989&cid=C03LSE48JBY

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
