### PR TITLE
[next] Ensure trailing slash is handled while resolving _next/data rewrites

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -945,28 +945,13 @@ export async function serverBuild({
             continue: true,
             ...(isOverride ? { override: true } : {}),
           },
-          // handle trailing slash
-          {
-            src: path.join('^/', entryDirectory, '((?!_next/).*)/$'),
-            has: [
-              {
-                type: 'header',
-                key: 'x-nextjs-data',
-              },
-            ],
-            dest: `${path.join(
-              '/',
-              entryDirectory,
-              '/_next/data/',
-              buildId,
-              '/$1.json'
-            )}`,
-            continue: true,
-            ...(isOverride ? { override: true } : {}),
-          },
           // handle non-trailing slash
           {
-            src: path.join('^/', entryDirectory, '((?!_next/).*)$'),
+            src: path.join(
+              '^/',
+              entryDirectory,
+              '((?!_next/)(?:.*[^/]|.*))/?$'
+            ),
             has: [
               {
                 type: 'header',

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -945,6 +945,26 @@ export async function serverBuild({
             continue: true,
             ...(isOverride ? { override: true } : {}),
           },
+          // handle trailing slash
+          {
+            src: path.join('^/', entryDirectory, '((?!_next/).*)/$'),
+            has: [
+              {
+                type: 'header',
+                key: 'x-nextjs-data',
+              },
+            ],
+            dest: `${path.join(
+              '/',
+              entryDirectory,
+              '/_next/data/',
+              buildId,
+              '/$1.json'
+            )}`,
+            continue: true,
+            ...(isOverride ? { override: true } : {}),
+          },
+          // handle non-trailing slash
           {
             src: path.join('^/', entryDirectory, '((?!_next/).*)$'),
             has: [

--- a/packages/next/test/fixtures/00-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-middleware/middleware.js
@@ -77,6 +77,13 @@ export function middleware(request) {
     return NextResponse.rewrite(url);
   }
 
+  if (url.pathname === '/rewrite-to-site') {
+    const customUrl = new URL(url);
+    customUrl.pathname = '/_sites/subdomain-1/';
+    console.log('rewriting to', customUrl.pathname, customUrl.href);
+    return NextResponse.rewrite(customUrl);
+  }
+
   if (url.pathname === '/redirect-me-to-about') {
     url.pathname = '/about';
     url.searchParams.set('middleware', 'foo');

--- a/packages/next/test/fixtures/00-middleware/pages/_sites/[site].js
+++ b/packages/next/test/fixtures/00-middleware/pages/_sites/[site].js
@@ -1,0 +1,31 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>/_sites/[site]</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  };
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: { site: 'subdomain-1' },
+      },
+      {
+        params: { site: 'subdomain-2' },
+      },
+    ],
+    fallback: 'blocking',
+  };
+}

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -3,6 +3,15 @@
   "builds": [{ "src": "package.json", "use": "@vercel/next" }],
   "probes": [
     {
+      "path": "/_next/data/testing-build-id/rewrite-to-site.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "mustContain": "site\":\"subdomain-1\"",
+      "mustNotContain": "<html>"
+    },
+    {
       "path": "/redirect-me",
       "status": 307,
       "responseHeaders": {

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -188,22 +188,32 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
     hadTest = true;
   }
 
-  if (probe.mustContain || probe.mustNotContain) {
-    const shouldContain = !!probe.mustContain;
+  if (probe.mustContain) {
     const containsIt = text.includes(probe.mustContain);
-    if (
-      (!containsIt && probe.mustContain) ||
-      (containsIt && probe.mustNotContain)
-    ) {
+    if (!containsIt) {
       fs.writeFileSync(path.join(__dirname, 'failed-page.txt'), text);
       const headers = Array.from(resp.headers.entries())
         .map(([k, v]) => `  ${k}=${v}`)
         .join('\n');
       throw new Error(
-        `Fetched page ${probeUrl} does${shouldContain ? ' not' : ''} contain ${
-          shouldContain ? probe.mustContain : probe.mustNotContain
-        }.` +
-          (shouldContain ? ` Instead it contains ${text.slice(0, 60)}` : '') +
+        `Fetched page ${probeUrl} does not contain ${probe.mustContain}.` +
+          ` Content ${text}` +
+          ` Response headers:\n ${headers}`
+      );
+    }
+    hadTest = true;
+  }
+
+  if (probe.mustNotContain) {
+    const containsIt = text.includes(probe.mustNotContain);
+    if (containsIt) {
+      fs.writeFileSync(path.join(__dirname, 'failed-page.txt'), text);
+      const headers = Array.from(resp.headers.entries())
+        .map(([k, v]) => `  ${k}=${v}`)
+        .join('\n');
+      throw new Error(
+        `Fetched page ${probeUrl} does contain ${probe.mustNotContain}.` +
+          ` Content ${text}` +
           ` Response headers:\n ${headers}`
       );
     }


### PR DESCRIPTION
This ensures we handle a trailing slash being included in a rewrite while resolving `_next/data` rewrites as this can occur when `NextUrl`'s normalizing isn't able to be applied. 

This also fixes our `mustNotContain` probe as it previously wasn't asserting correctly and also didn't allow being combined with a `mustContain` check in the same probe. 

### Related Issues

x-ref: https://github.com/vercel/examples/pull/331
x-ref: [slack thread](https://vercel.slack.com/archives/C01MYAM1G0K/p1656130164891489)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
