### PR TITLE
[@vercel/edge] add header helpers

### DIFF
--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -1,0 +1,82 @@
+/**
+ * City of the original client IP calculated by Vercel Proxy.
+ */
+export const CITY_HEADER_NAME = 'x-vercel-ip-city';
+/**
+ * Country of the original client IP calculated by Vercel Proxy.
+ */
+export const COUNTRY_HEADER_NAME = 'x-vercel-ip-country';
+/**
+ * Ip from Vercel Proxy. Do not confuse it with the client Ip.
+ */
+export const IP_HEADER_NAME = 'x-real-ip';
+/**
+ * Latitude of the original client IP calculated by Vercel Proxy.
+ */
+export const LATITUDE_HEADER_NAME = 'x-vercel-ip-latitude';
+/**
+ * Longitude of the original client IP calculated by Vercel Proxy.
+ */
+export const LONGITUDE_HEADER_NAME = 'x-vercel-ip-longitude';
+/**
+ * Region of the original client IP calculated by Vercel Proxy.
+ */
+export const REGION_HEADER_NAME = 'x-vercel-ip-country-region';
+
+/**
+ * We define a new type so this function can be reused with
+ * the global `Request`, `node-fetch` and other types.
+ */
+interface Request {
+  headers: {
+    get(name: string): string | null;
+  };
+}
+
+/**
+ * The location information of a given request
+ */
+export interface Geo {
+  /** The city that the request originated from */
+  city?: string;
+  /** The country that the request originated from */
+  country?: string;
+  /** The Vercel Edge Network region that received the request */
+  region?: string;
+  /** The latitude of the client */
+  latitude?: string;
+  /** The longitude of the client */
+  longitude?: string;
+}
+
+function getHeader(request: Request, key: string): string | undefined {
+  return request.headers.get(key) ?? undefined;
+}
+
+/**
+ * Returns the IP address of the request from the headers.
+ *
+ * @see {@link IP_HEADER_NAME}
+ */
+export function getIp(request: Request): string | undefined {
+  return getHeader(request, IP_HEADER_NAME);
+}
+
+/**
+ * Returns the location information from for the incoming request
+ *
+ * @see {@link CITY_HEADER_NAME}
+ * @see {@link COUNTRY_HEADER_NAME}
+ * @see {@link REGION_HEADER_NAME}
+ * @see {@link LATITUDE_HEADER_NAME}
+ * @see {@link LONGITUDE_HEADER_NAME}
+ */
+export function getGeo(request: Request): Geo {
+  return {
+    city: getHeader(request, CITY_HEADER_NAME),
+    country: getHeader(request, COUNTRY_HEADER_NAME),
+    region: getHeader(request, REGION_HEADER_NAME),
+    latitude: getHeader(request, LATITUDE_HEADER_NAME),
+    longitude: getHeader(request, LONGITUDE_HEADER_NAME),
+  };
+}

--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -58,7 +58,7 @@ function getHeader(request: Request, key: string): string | undefined {
  *
  * @see {@link IP_HEADER_NAME}
  */
-export function getIp(request: Request): string | undefined {
+export function ipAddress(request: Request): string | undefined {
   return getHeader(request, IP_HEADER_NAME);
 }
 
@@ -71,7 +71,7 @@ export function getIp(request: Request): string | undefined {
  * @see {@link LATITUDE_HEADER_NAME}
  * @see {@link LONGITUDE_HEADER_NAME}
  */
-export function getGeo(request: Request): Geo {
+export function geolocation(request: Request): Geo {
   return {
     city: getHeader(request, CITY_HEADER_NAME),
     country: getHeader(request, COUNTRY_HEADER_NAME),

--- a/packages/edge/src/index.ts
+++ b/packages/edge/src/index.ts
@@ -1,2 +1,5 @@
 export type { ExtraResponseInit } from './middleware-helpers';
-export { next, rewrite } from './middleware-helpers';
+export * from './middleware-helpers';
+
+export type { Geo } from './edge-headers';
+export * from './edge-headers';

--- a/packages/edge/test/edge-headers.test.ts
+++ b/packages/edge/test/edge-headers.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import {
+  CITY_HEADER_NAME,
+  COUNTRY_HEADER_NAME,
+  Geo,
+  getGeo,
+  getIp,
+  IP_HEADER_NAME,
+  LATITUDE_HEADER_NAME,
+  LONGITUDE_HEADER_NAME,
+  REGION_HEADER_NAME,
+} from '../src';
+
+test('getIp returns the value from the header', () => {
+  const req = new Request('https://example.vercel.sh', {
+    headers: {
+      [IP_HEADER_NAME]: '127.0.0.1',
+    },
+  });
+  expect(getIp(req)).toBe('127.0.0.1');
+});
+
+describe('getGeo', () => {
+  test('returns an empty object if headers are not found', () => {
+    const req = new Request('https://example.vercel.sh');
+    expect(getGeo(req)).toEqual({});
+  });
+
+  test('reads values from headers', () => {
+    const req = new Request('https://example.vercel.sh', {
+      headers: {
+        [CITY_HEADER_NAME]: 'Tel Aviv',
+        [COUNTRY_HEADER_NAME]: 'Israel',
+        [LATITUDE_HEADER_NAME]: '32.109333',
+        [LONGITUDE_HEADER_NAME]: '34.855499',
+        [REGION_HEADER_NAME]: 'fra1',
+      },
+    });
+    expect(getGeo(req)).toEqual<Geo>({
+      city: 'Tel Aviv',
+      country: 'Israel',
+      latitude: '32.109333',
+      longitude: '34.855499',
+      region: 'fra1',
+    });
+  });
+});

--- a/packages/edge/test/edge-headers.test.ts
+++ b/packages/edge/test/edge-headers.test.ts
@@ -6,27 +6,27 @@ import {
   CITY_HEADER_NAME,
   COUNTRY_HEADER_NAME,
   Geo,
-  getGeo,
-  getIp,
+  geolocation,
+  ipAddress,
   IP_HEADER_NAME,
   LATITUDE_HEADER_NAME,
   LONGITUDE_HEADER_NAME,
   REGION_HEADER_NAME,
 } from '../src';
 
-test('getIp returns the value from the header', () => {
+test('`ipAddress` returns the value from the header', () => {
   const req = new Request('https://example.vercel.sh', {
     headers: {
       [IP_HEADER_NAME]: '127.0.0.1',
     },
   });
-  expect(getIp(req)).toBe('127.0.0.1');
+  expect(ipAddress(req)).toBe('127.0.0.1');
 });
 
-describe('getGeo', () => {
+describe('`geolocation`', () => {
   test('returns an empty object if headers are not found', () => {
     const req = new Request('https://example.vercel.sh');
-    expect(getGeo(req)).toEqual({});
+    expect(geolocation(req)).toEqual({});
   });
 
   test('reads values from headers', () => {
@@ -39,7 +39,7 @@ describe('getGeo', () => {
         [REGION_HEADER_NAME]: 'fra1',
       },
     });
-    expect(getGeo(req)).toEqual<Geo>({
+    expect(geolocation(req)).toEqual<Geo>({
       city: 'Tel Aviv',
       country: 'Israel',
       latitude: '32.109333',


### PR DESCRIPTION
This PR introduces more helpers for Vercel Middleware and Edge Functions.
It allows to extract the IP and Geo information easily using helpers instead of knowing the header names.
