### PR TITLE
[cli] Add `Client#stdin` / `Client#stdout`

### DIFF
--- a/packages/cli/src/commands/alias/rm.ts
+++ b/packages/cli/src/commands/alias/rm.ts
@@ -10,7 +10,6 @@ import confirm from '../../util/input/confirm';
 import findAliasByAliasOrId from '../../util/alias/find-alias-by-alias-or-id';
 
 import { Alias } from '../../types';
-import { Output } from '../../util/output';
 import { isValidName } from '../../util/is-valid-name';
 import { getCommandName } from '../../util/pkg-name';
 
@@ -71,7 +70,7 @@ export default async function rm(
   }
 
   const removeStamp = stamp();
-  if (!opts['--yes'] && !(await confirmAliasRemove(output, alias))) {
+  if (!opts['--yes'] && !(await confirmAliasRemove(client, alias))) {
     output.log('Aborted');
     return 0;
   }
@@ -85,7 +84,7 @@ export default async function rm(
   return 0;
 }
 
-async function confirmAliasRemove(output: Output, alias: Alias) {
+async function confirmAliasRemove(client: Client, alias: Alias) {
   const srcUrl = alias.deployment
     ? chalk.underline(alias.deployment.url)
     : null;
@@ -104,7 +103,7 @@ async function confirmAliasRemove(output: Output, alias: Alias) {
     }
   );
 
-  output.log(`The following alias will be removed permanently`);
-  output.print(`  ${tbl}\n`);
-  return confirm(chalk.red('Are you sure?'), false);
+  client.output.log(`The following alias will be removed permanently`);
+  client.output.print(`  ${tbl}\n`);
+  return confirm(client, chalk.red('Are you sure?'), false);
 }

--- a/packages/cli/src/commands/billing/index.js
+++ b/packages/cli/src/commands/billing/index.js
@@ -187,6 +187,7 @@ export default async client => {
       if (cardId) {
         const label = `Are you sure that you to set this card as the default?`;
         const confirmation = await promptBool(label, {
+          ...client,
           trailing: '\n',
         });
 
@@ -262,7 +263,7 @@ export default async client => {
       // typed `vercel billing rm <some-id>`) is valid
       if (cardId) {
         const label = `Are you sure that you want to remove this card?`;
-        const confirmation = await promptBool(label);
+        const confirmation = await promptBool(label, client);
         if (!confirmation) {
           console.log('Aborted');
           break;

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -140,6 +140,7 @@ export default async function main(client: Client): Promise<number> {
       }
 
       confirmed = await confirm(
+        client,
         `No Project Settings found locally. Run ${cli.getCommandName(
           'pull'
         )} for retrieving them?`,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -165,7 +165,7 @@ export default async (client: Client) => {
   const quiet = !isTTY;
 
   // check paths
-  const pathValidation = await validatePaths(output, paths);
+  const pathValidation = await validatePaths(client, paths);
 
   if (!pathValidation.valid) {
     return pathValidation.exitCode;
@@ -243,6 +243,7 @@ export default async (client: Client) => {
     const shouldStartSetup =
       autoConfirm ||
       (await confirm(
+        client,
         `Set up and deploy ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
         true
       ));
@@ -287,7 +288,7 @@ export default async (client: Client) => {
 
     if (typeof projectOrNewProjectName === 'string') {
       newProjectName = projectOrNewProjectName;
-      rootDirectory = await inputRootDirectory(path, output, autoConfirm);
+      rootDirectory = await inputRootDirectory(client, path, autoConfirm);
     } else {
       project = projectOrNewProjectName;
       rootDirectory = project.rootDirectory;
@@ -521,7 +522,7 @@ export default async (client: Client) => {
       }
 
       const settings = await editProjectSettings(
-        output,
+        client,
         projectSettings,
         framework,
         false,

--- a/packages/cli/src/commands/dns/add.ts
+++ b/packages/cli/src/commands/dns/add.ts
@@ -46,7 +46,7 @@ export default async function add(
 
   const addStamp = stamp();
   const { domain, data: argData } = parsedParams;
-  const data = await getDNSData(output, argData);
+  const data = await getDNSData(client, argData);
   if (!data) {
     output.log(`Aborted`);
     return 1;

--- a/packages/cli/src/commands/domains/buy.ts
+++ b/packages/cli/src/commands/domains/buy.ts
@@ -87,7 +87,8 @@ export default async function buy(
     !(await promptBool(
       `Buy now for ${chalk.bold(`$${price}`)} (${`${period}yr${
         period > 1 ? 's' : ''
-      }`})?`
+      }`})?`,
+      client
     ))
   ) {
     return 0;
@@ -99,7 +100,7 @@ export default async function buy(
       : `Auto renew every ${renewalPrice.period} years for ${chalk.bold(
           `$${price}`
         )}?`,
-    { defaultValue: true }
+    { ...client, defaultValue: true }
   );
 
   let buyResult;

--- a/packages/cli/src/commands/domains/move.ts
+++ b/packages/cli/src/commands/domains/move.ts
@@ -77,7 +77,8 @@ export default async function move(
       !(await promptBool(
         `Are you sure you want to move ${param(domainName)} to ${param(
           destination
-        )}?`
+        )}?`,
+        client
       ))
     ) {
       output.log('Aborted');
@@ -95,7 +96,8 @@ export default async function move(
       );
       if (
         !(await promptBool(
-          `Are you sure you want to move ${param(domainName)}?`
+          `Are you sure you want to move ${param(domainName)}?`,
+          client
         ))
       ) {
         output.log('Aborted');

--- a/packages/cli/src/commands/domains/rm.ts
+++ b/packages/cli/src/commands/domains/rm.ts
@@ -92,7 +92,10 @@ export default async function rm(
   const skipConfirmation = opts['--yes'] || false;
   if (
     !skipConfirmation &&
-    !(await promptBool(`Are you sure you want to remove ${param(domainName)}?`))
+    !(await promptBool(
+      `Are you sure you want to remove ${param(domainName)}?`,
+      client
+    ))
   ) {
     output.log('Aborted');
     return 0;
@@ -230,7 +233,7 @@ async function removeDomain(
 
     if (
       !skipConfirmation &&
-      !(await promptBool(`Remove conflicts associated with domain?`))
+      !(await promptBool(`Remove conflicts associated with domain?`, client))
     ) {
       output.log('Aborted');
       return 0;

--- a/packages/cli/src/commands/domains/transfer-in.ts
+++ b/packages/cli/src/commands/domains/transfer-in.ts
@@ -81,7 +81,8 @@ export default async function transferIn(
   const shouldTransfer = await promptBool(
     transferPolicy === 'no-change'
       ? `Transfer now for ${chalk.bold(`$${price}`)}?`
-      : `Transfer now with 1yr renewal for ${chalk.bold(`$${price}`)}?`
+      : `Transfer now with 1yr renewal for ${chalk.bold(`$${price}`)}?`,
+    client
   );
   if (!shouldTransfer) {
     return 0;

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -31,7 +31,7 @@ export default async function add(
   // improve the way we show inquirer prompts
   require('../../util/input/patch-inquirer');
 
-  const stdInput = await readStandardInput();
+  const stdInput = await readStandardInput(client.stdin);
   let [envName, envTargetArg, envGitBranch] = args;
 
   if (args.length > 3) {

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -74,6 +74,7 @@ export default async function pull(
     exists &&
     !skipConfirmation &&
     !(await confirm(
+      client,
       `Found existing file ${param(filename)}. Do you want to overwrite?`,
       false
     ))

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -104,6 +104,7 @@ export default async function rm(
   if (
     !skipConfirmation &&
     !(await confirm(
+      client,
       `Removing Environment Variable ${param(env.key)} from ${formatEnvTarget(
         env
       )} in Project ${chalk.bold(project.name)}. Are you sure?`,

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -65,7 +65,7 @@ export default async function init(
     return extractExample(client, name, dir, force, 'v1');
   }
 
-  const found = await guess(exampleList, name);
+  const found = await guess(client, exampleList, name);
 
   if (typeof found === 'string') {
     return extractExample(client, found, dir, force);
@@ -194,7 +194,7 @@ function prepareFolder(cwd: string, folder: string, force?: boolean) {
 /**
  * Guess which example user try to init
  */
-async function guess(exampleList: string[], name: string) {
+async function guess(client: Client, exampleList: string[], name: string) {
   const GuessError = new Error(
     `No example found for ${chalk.bold(name)}, run ${getCommandName(
       `init`
@@ -208,7 +208,7 @@ async function guess(exampleList: string[], name: string) {
   const found = didYouMean(name, exampleList, 0.7);
 
   if (typeof found === 'string') {
-    if (await promptBool(`Did you mean ${chalk.bold(found)}?`)) {
+    if (await promptBool(`Did you mean ${chalk.bold(found)}?`, client)) {
       return found;
     }
   } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -387,6 +387,8 @@ const main = async () => {
   // Shared API `Client` instance for all sub-commands to utilize
   client = new Client({
     apiUrl,
+    stdin: process.stdin,
+    stdout: process.stdout,
     output,
     config,
     authConfig,

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -32,6 +32,8 @@ export interface ClientOptions {
   argv: string[];
   apiUrl: string;
   authConfig: AuthConfig;
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
   output: Output;
   config: GlobalConfig;
   localConfig?: VercelConfig;
@@ -45,6 +47,8 @@ export default class Client extends EventEmitter {
   argv: string[];
   apiUrl: string;
   authConfig: AuthConfig;
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
   output: Output;
   config: GlobalConfig;
   localConfig?: VercelConfig;
@@ -55,6 +59,8 @@ export default class Client extends EventEmitter {
     this.argv = opts.argv;
     this.apiUrl = opts.apiUrl;
     this.authConfig = opts.authConfig;
+    this.stdin = opts.stdin;
+    this.stdout = opts.stdout;
     this.output = opts.output;
     this.config = opts.config;
     this.localConfig = opts.localConfig;

--- a/packages/cli/src/util/dns/get-dns-data.ts
+++ b/packages/cli/src/util/dns/get-dns-data.ts
@@ -2,26 +2,29 @@ import chalk from 'chalk';
 import { DNSRecordData } from '../../types';
 import textInput from '../input/text';
 import promptBool from '../input/prompt-bool';
-import { Output } from '../output';
+import Client from '../client';
 
 const RECORD_TYPES = ['A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'SRV', 'TXT'];
 
 export default async function getDNSData(
-  output: Output,
+  client: Client,
   data: null | DNSRecordData
 ): Promise<DNSRecordData | null> {
   if (data) {
     return data;
   }
+  const { output } = client;
 
   try {
     // first ask for type, branch from there
     const possibleTypes = new Set(RECORD_TYPES);
-    const type = (await textInput({
-      label: `- Record type (${RECORD_TYPES.join(', ')}): `,
-      validateValue: (v: string) =>
-        Boolean(v && possibleTypes.has(v.trim().toUpperCase()))
-    }))
+    const type = (
+      await textInput({
+        label: `- Record type (${RECORD_TYPES.join(', ')}): `,
+        validateValue: (v: string) =>
+          Boolean(v && possibleTypes.has(v.trim().toUpperCase())),
+      })
+    )
       .trim()
       .toUpperCase();
 
@@ -39,7 +42,7 @@ export default async function getDNSData(
           target
         )}.`
       );
-      return (await verifyData())
+      return (await verifyData(client))
         ? {
             name,
             type,
@@ -47,8 +50,8 @@ export default async function getDNSData(
               priority,
               weight,
               port,
-              target
-            }
+              target,
+            },
           }
         : null;
     }
@@ -61,23 +64,23 @@ export default async function getDNSData(
           `${mxPriority}`
         )} ${chalk.cyan(value)}`
       );
-      return (await verifyData())
+      return (await verifyData(client))
         ? {
             name,
             type,
             value,
-            mxPriority
+            mxPriority,
           }
         : null;
     }
 
     const value = await getTrimmedString(`- ${type} value: `);
     output.log(`${chalk.cyan(name)} ${chalk.bold(type)} ${chalk.cyan(value)}`);
-    return (await verifyData())
+    return (await verifyData(client))
       ? {
           name,
           type,
-          value
+          value,
         }
       : null;
   } catch (error) {
@@ -85,13 +88,13 @@ export default async function getDNSData(
   }
 }
 
-async function verifyData() {
-  return promptBool('Is this correct?');
+async function verifyData(client: Client) {
+  return promptBool('Is this correct?', client);
 }
 
 async function getRecordName(type: string) {
   const input = await textInput({
-    label: `- ${type} name: `
+    label: `- ${type} name: `,
   });
   return input === '@' ? '' : input;
 }
@@ -100,14 +103,14 @@ async function getNumber(label: string) {
   return Number(
     await textInput({
       label,
-      validateValue: v => Boolean(v && Number(v))
+      validateValue: v => Boolean(v && Number(v)),
     })
   );
 }
 async function getTrimmedString(label: string) {
   const res = await textInput({
     label,
-    validateValue: v => Boolean(v && v.trim().length > 0)
+    validateValue: v => Boolean(v && v.trim().length > 0),
   });
   return res.trim();
 }

--- a/packages/cli/src/util/domains/purchase-domain-if-available.ts
+++ b/packages/cli/src/util/domains/purchase-domain-if-available.ts
@@ -54,7 +54,8 @@ export default async function purchaseDomainIfAvailable(
       !(await promptBool(
         `Buy ${chalk.underline(domain)} for ${chalk.bold(
           `$${price}`
-        )} (${plural('yr', period, true)})?`
+        )} (${plural('yr', period, true)})?`,
+        client
       ))
     ) {
       output.print(eraseLines(1));

--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -1,12 +1,19 @@
 import inquirer from 'inquirer';
+import Client from '../client';
 
 export default async function confirm(
+  client: Client,
   message: string,
   preferred: boolean
 ): Promise<boolean> {
   require('./patch-inquirer');
 
-  const answers = await inquirer.prompt({
+  const prompt = inquirer.createPromptModule({
+    input: client.stdin,
+    output: client.stdout,
+  });
+
+  const answers = await prompt({
     type: 'confirm',
     name: 'value',
     message,

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -1,8 +1,8 @@
 import inquirer from 'inquirer';
 import confirm from './confirm';
 import chalk from 'chalk';
-import { Output } from '../output';
 import frameworkList, { Framework } from '@vercel/frameworks';
+import Client from '../client';
 import { isSettingValue } from '../is-setting-value';
 import { ProjectSettings } from '../../types';
 
@@ -22,12 +22,14 @@ const settingKeys = Object.keys(settingMap).sort() as unknown as readonly [
 export type PartialProjectSettings = Pick<ProjectSettings, ConfigKeys>;
 
 export default async function editProjectSettings(
-  output: Output,
+  client: Client,
   projectSettings: PartialProjectSettings | null,
   framework: Framework | null,
   autoConfirm: boolean,
   localConfigurationOverrides: PartialProjectSettings | null
 ): Promise<ProjectSettings> {
+  const { output } = client;
+
   // Create initial settings object defaulting everything to `null` and assigning what may exist in `projectSettings`
   const settings: ProjectSettings = Object.assign(
     {
@@ -118,7 +120,7 @@ export default async function editProjectSettings(
   // Prompt the user if they want to modify any settings not defined by local configuration.
   if (
     autoConfirm ||
-    !(await confirm('Want to modify these settings?', false))
+    !(await confirm(client, 'Want to modify these settings?', false))
   ) {
     return settings;
   }

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -47,11 +47,16 @@ export default async function inputProject(
 
   if (!detectedProject) {
     // did not auto-detect a project to link
-    shouldLinkProject = await confirm(`Link to existing project?`, false);
+    shouldLinkProject = await confirm(
+      client,
+      `Link to existing project?`,
+      false
+    );
   } else {
     // auto-detected a project to link
     if (
       await confirm(
+        client,
         `Found project ${chalk.cyan(
           `“${org.slug}/${detectedProject.name}”`
         )}. Link to it?`,
@@ -63,6 +68,7 @@ export default async function inputProject(
 
     // user doesn't want to link the auto-detected project
     shouldLinkProject = await confirm(
+      client,
       `Link to different existing project?`,
       true
     );
@@ -73,7 +79,11 @@ export default async function inputProject(
     let project: Project | ProjectNotFound | null = null;
 
     while (!project || project instanceof ProjectNotFound) {
-      const answers = await inquirer.prompt({
+      const prompt = inquirer.createPromptModule({
+        input: client.stdin,
+        output: client.stdout,
+      });
+      const answers = await prompt({
         type: 'input',
         name: 'existingProjectName',
         message: `What’s the name of your existing project?`,

--- a/packages/cli/src/util/input/input-root-directory.ts
+++ b/packages/cli/src/util/input/input-root-directory.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { Output } from '../output';
 import { validateRootDirectory } from '../validate-paths';
+import Client from '../client';
 
 export async function inputRootDirectory(
+  client: Client,
   cwd: string,
-  output: Output,
   autoConfirm = false
 ) {
   if (autoConfirm) {
@@ -15,7 +15,11 @@ export async function inputRootDirectory(
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const { rootDirectory } = await inquirer.prompt({
+    const prompt = inquirer.createPromptModule({
+      input: client.stdin,
+      output: client.stdout,
+    });
+    const { rootDirectory } = await prompt({
       type: 'input',
       name: 'rootDirectory',
       message: `In which directory is your code located?`,
@@ -38,7 +42,7 @@ export async function inputRootDirectory(
 
     if (
       (await validateRootDirectory(
-        output,
+        client.output,
         cwd,
         fullPath,
         'Please choose a different one.'

--- a/packages/cli/src/util/input/prompt-bool.ts
+++ b/packages/cli/src/util/input/prompt-bool.ts
@@ -5,21 +5,21 @@ type Options = {
   defaultValue?: boolean;
   noChar?: string;
   resolveChars?: Set<string>;
-  stdin?: NodeJS.ReadStream;
-  stdout?: NodeJS.WriteStream;
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
   trailing?: string;
   yesChar?: string;
 };
 
-export default async function promptBool(label: string, options: Options = {}) {
+export default async function promptBool(label: string, options: Options) {
   const {
+    stdin,
+    stdout,
     defaultValue = false,
     abortSequences = new Set(['\u0003']),
     resolveChars = new Set(['\r']),
     yesChar = 'y',
     noChar = 'n',
-    stdin = process.stdin,
-    stdout = process.stdout,
     trailing = '',
   } = options;
 

--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -1,13 +1,15 @@
-export default async function readStandardInput(): Promise<string> {
+export default async function readStandardInput(
+  stdin: NodeJS.ReadStream
+): Promise<string> {
   return new Promise<string>(resolve => {
     setTimeout(() => resolve(''), 500);
 
-    if (process.stdin.isTTY) {
+    if (stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
     } else {
-      process.stdin.setEncoding('utf8');
-      process.stdin.once('data', resolve);
+      stdin.setEncoding('utf8');
+      stdin.once('data', resolve);
     }
   });
 }

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -80,6 +80,7 @@ export default async function setupAndLink(
   const shouldStartSetup =
     autoConfirm ||
     (await confirm(
+      client,
       `${setupMsg} ${chalk.cyan(`“${toHumanPath(path)}”`)}?`,
       true
     ));
@@ -120,7 +121,7 @@ export default async function setupAndLink(
 
   if (typeof projectOrNewProjectName === 'string') {
     newProjectName = projectOrNewProjectName;
-    rootDirectory = await inputRootDirectory(path, output, autoConfirm);
+    rootDirectory = await inputRootDirectory(client, path, autoConfirm);
   } else {
     const project = projectOrNewProjectName;
 
@@ -224,7 +225,7 @@ export default async function setupAndLink(
       const { projectSettings, framework } = deployment;
 
       settings = await editProjectSettings(
-        output,
+        client,
         projectSettings,
         framework,
         autoConfirm,

--- a/packages/cli/src/util/login/reauthenticate.ts
+++ b/packages/cli/src/util/login/reauthenticate.ts
@@ -14,7 +14,7 @@ export default async function reauthenticate(
     client.output.log(
       `You must re-authenticate with SAML to use ${bold(error.scope)} scope.`
     );
-    if (await confirm(`Log in with SAML?`, true)) {
+    if (await confirm(client, `Log in with SAML?`, true)) {
       return doSamlLogin(client, error.teamId);
     }
   } else {

--- a/packages/cli/src/util/validate-paths.ts
+++ b/packages/cli/src/util/validate-paths.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { homedir } from 'os';
 import confirm from './input/confirm';
 import toHumanPath from './humanize-path';
+import Client from './client';
 
 const stat = promisify(lstatRaw);
 
@@ -51,9 +52,11 @@ export async function validateRootDirectory(
 }
 
 export default async function validatePaths(
-  output: Output,
+  client: Client,
   paths: string[]
 ): Promise<{ valid: true; path: string } | { valid: false; exitCode: number }> {
+  const { output } = client;
+
   // can't deploy more than 1 path
   if (paths.length > 1) {
     output.print(`${chalk.red('Error!')} Can't deploy more than one path.\n`);
@@ -85,6 +88,7 @@ export default async function validatePaths(
   // ask confirmation if the directory is home
   if (path === homedir()) {
     const shouldDeployHomeDirectory = await confirm(
+      client,
       `You are deploying your home directory. Do you want to continue?`,
       false
     );

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { PassThrough } from 'stream';
 import { createServer, Server } from 'http';
 import express, { Express, Router } from 'express';
 import listen from 'async-listen';
@@ -23,10 +24,13 @@ export class MockClient extends Client {
       // Gets populated in `startMockServer()`
       apiUrl: '',
       authConfig: {},
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
       output: new Output(),
       config: {},
       localConfig: {},
     });
+
     this.mockOutput = jest.fn();
 
     this.app = express();
@@ -53,6 +57,12 @@ export class MockClient extends Client {
   }
 
   reset() {
+    this.stdin = new PassThrough();
+    this.stdin.isTTY = true;
+
+    this.stdout = new PassThrough();
+    this.stdout.isTTY = true;
+
     this.output = new Output();
     this.mockOutput = jest.fn();
     this.output.print = s => {

--- a/packages/cli/test/unit/mock.test.ts
+++ b/packages/cli/test/unit/mock.test.ts
@@ -1,0 +1,25 @@
+import confirm from '../../src/util/input/confirm';
+import { client } from '../mocks/client';
+
+describe('MockClient', () => {
+  it('should mock `confirm()`', async () => {
+    // true
+    let confirmedPromise = confirm(client, 'Do the thing?', false);
+
+    client.stdin.write('yes\n');
+
+    client.stdout.setEncoding('utf8');
+    client.stdout.on('data', d => console.log({ d }));
+
+    let confirmed = await confirmedPromise;
+    expect(confirmed).toEqual(true);
+
+    // false
+    confirmedPromise = confirm(client, 'Do the thing?', false);
+
+    client.stdin.write('no\n');
+
+    confirmed = await confirmedPromise;
+    expect(confirmed).toEqual(false);
+  });
+});

--- a/packages/cli/test/unit/util/input/edit-project-settings.test.ts
+++ b/packages/cli/test/unit/util/input/edit-project-settings.test.ts
@@ -1,13 +1,6 @@
 import { Framework, frameworks } from '@vercel/frameworks';
 import editProjectSettings from '../../../../src/util/input/edit-project-settings';
-import { Output } from '../../../../src/util/output';
-
-let output: Output;
-
-beforeEach(() => {
-  output = new Output();
-  output.print = jest.fn();
-});
+import { client } from '../../../mocks/client';
 
 const otherFramework = frameworks.find(
   fwk => fwk.name === 'Other'
@@ -20,7 +13,7 @@ describe('editProjectSettings', () => {
   describe('with no settings, "Other" framework, and no overrides provided', () => {
     test('should default all settings to `null` and print user default framework settings', async () => {
       const settings = await editProjectSettings(
-        output,
+        client,
         null,
         otherFramework,
         true,
@@ -34,22 +27,14 @@ describe('editProjectSettings', () => {
         installCommand: null,
         outputDirectory: null,
       });
-      expect((output.print as jest.Mock).mock.calls.length).toBe(5);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(5);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /No framework detected. Default Project Settings:/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Development Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
-        /Install Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Output Directory/
-      );
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
     });
   });
 
@@ -63,29 +48,21 @@ describe('editProjectSettings', () => {
         outputDirectory: 'OUTPUT_DIRECTORY',
       };
       const settings = await editProjectSettings(
-        output,
+        client,
         projectSettings,
         otherFramework,
         true,
         null
       );
       expect(settings).toStrictEqual({ ...projectSettings, framework: null });
-      expect((output.print as jest.Mock).mock.calls.length).toBe(5);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(5);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /No framework detected. Default Project Settings:/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Development Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
-        /Install Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Output Directory/
-      );
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
     });
   });
 
@@ -99,28 +76,20 @@ describe('editProjectSettings', () => {
         outputDirectory: 'OUTPUT_DIRECTORY',
       };
       const settings = await editProjectSettings(
-        output,
+        client,
         projectSettings,
         nextJSFramework,
         true,
         null
       );
-      expect((output.print as jest.Mock).mock.calls.length).toBe(5);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(5);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /Auto-detected Project Settings/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Development Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
-        /Install Command/
-      );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Output Directory/
-      );
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
       expect(settings).toStrictEqual({
         ...projectSettings,
         framework: nextJSFramework.slug,
@@ -146,38 +115,28 @@ describe('editProjectSettings', () => {
         outputDirectory: 'OUTPUT_DIRECTORY',
       };
       const settings = await editProjectSettings(
-        output,
+        client,
         projectSettings,
         nextJSFramework,
         true,
         overrides
       );
-      expect((output.print as jest.Mock).mock.calls.length).toBe(9);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(9);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /Local settings detected in vercel.json:/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Ignore Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(
         /Development Command:/
       );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Framework:/
-      );
-      expect((output.print as jest.Mock).mock.calls[5][0]).toMatch(
-        /Install Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[6][0]).toMatch(
-        /Output Directory:/
-      );
-      expect((output.print as jest.Mock).mock.calls[7][0]).toMatch(
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
+      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
+      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
+      expect(client.mockOutput.mock.calls[7][0]).toMatch(
         /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
       );
-      expect((output.print as jest.Mock).mock.calls[8][0]).toMatch(
+      expect(client.mockOutput.mock.calls[8][0]).toMatch(
         /Auto-detected Project Settings/
       );
 
@@ -196,38 +155,28 @@ describe('editProjectSettings', () => {
         outputDirectory: 'OUTPUT_DIRECTORY',
       };
       const settings = await editProjectSettings(
-        output,
+        client,
         null,
         nextJSFramework,
         true,
         overrides
       );
-      expect((output.print as jest.Mock).mock.calls.length).toBe(9);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(9);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /Local settings detected in vercel.json:/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Ignore Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(
         /Development Command:/
       );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Framework:/
-      );
-      expect((output.print as jest.Mock).mock.calls[5][0]).toMatch(
-        /Install Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[6][0]).toMatch(
-        /Output Directory:/
-      );
-      expect((output.print as jest.Mock).mock.calls[7][0]).toMatch(
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
+      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
+      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
+      expect(client.mockOutput.mock.calls[7][0]).toMatch(
         /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
       );
-      expect((output.print as jest.Mock).mock.calls[8][0]).toMatch(
+      expect(client.mockOutput.mock.calls[8][0]).toMatch(
         /Auto-detected Project Settings/
       );
       expect(settings).toStrictEqual(overrides);
@@ -245,38 +194,28 @@ describe('editProjectSettings', () => {
         outputDirectory: 'OUTPUT_DIRECTORY',
       };
       const settings = await editProjectSettings(
-        output,
+        client,
         null,
         null,
         true,
         overrides
       );
-      expect((output.print as jest.Mock).mock.calls.length).toBe(9);
-      expect((output.print as jest.Mock).mock.calls[0][0]).toMatch(
+      expect(client.mockOutput.mock.calls.length).toBe(9);
+      expect(client.mockOutput.mock.calls[0][0]).toMatch(
         /Local settings detected in vercel.json:/
       );
-      expect((output.print as jest.Mock).mock.calls[1][0]).toMatch(
-        /Build Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[2][0]).toMatch(
-        /Ignore Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[3][0]).toMatch(
+      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
+      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
+      expect(client.mockOutput.mock.calls[3][0]).toMatch(
         /Development Command:/
       );
-      expect((output.print as jest.Mock).mock.calls[4][0]).toMatch(
-        /Framework:/
-      );
-      expect((output.print as jest.Mock).mock.calls[5][0]).toMatch(
-        /Install Command:/
-      );
-      expect((output.print as jest.Mock).mock.calls[6][0]).toMatch(
-        /Output Directory:/
-      );
-      expect((output.print as jest.Mock).mock.calls[7][0]).toMatch(
+      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
+      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
+      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
+      expect(client.mockOutput.mock.calls[7][0]).toMatch(
         /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
       );
-      expect((output.print as jest.Mock).mock.calls[8][0]).toMatch(
+      expect(client.mockOutput.mock.calls[8][0]).toMatch(
         /Auto-detected Project Settings/
       );
 


### PR DESCRIPTION
This will allow for mockability of the input streams (i.e. prompts) for CLI commands in unit tests.

There will be a follow-up to this PR that adjusts the way output streams are mocked as well.

**Example:**

```typescript
import confirm from '../../src/util/input/confirm';
import { client } from '../mocks/client';

describe('MockClient', () => {
  it('should mock `confirm()`', async () => {
    const confirmedPromise = confirm(client, 'Do the thing?', false);

    client.stdin.write('yes\n');

    const confirmed = await confirmedPromise;
    expect(confirmed).toEqual(true);
  });
});
```