### PR TITLE
[cli] Fix `vc build` lambda serialization when there's a broken symlink

### DIFF
--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -385,8 +385,14 @@ export async function* findDirs(
   }
   for (const path of paths) {
     const abs = join(dir, path);
-    const s = await fs.lstat(abs);
-    if (s.isDirectory()) {
+    let stat: fs.Stats;
+    try {
+      stat = await fs.lstat(abs);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    if (stat.isDirectory()) {
       if (path === name) {
         yield relative(root, abs);
       } else {

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -385,7 +385,7 @@ export async function* findDirs(
   }
   for (const path of paths) {
     const abs = join(dir, path);
-    const s = await fs.stat(abs);
+    const s = await fs.lstat(abs);
     if (s.isDirectory()) {
       if (path === name) {
         yield relative(root, abs);


### PR DESCRIPTION
There's some cleanup directory walking logic that was choking when a Lambda outputs a file with a broken symlink. We shouldn't need to traverse into those directories in the case of a symlink anyways, so use `lstat()` instead of `stat()` to prevent that filesystem call from throwing an error.