### PR TITLE
[cli] Add full stdio mockability for unit tests

### DIFF
--- a/packages/cli/src/commands/billing/add.js
+++ b/packages/cli/src/commands/billing/add.js
@@ -127,7 +127,7 @@ export default async function ({ creditCards, clear = false, contextName }) {
     }
 
     console.log(''); // New line
-    const stopSpinner = wait('Saving card');
+    const stopSpinner = wait(process.stderr, 'Saving card');
 
     try {
       const res = await creditCards.add({

--- a/packages/cli/src/commands/billing/index.js
+++ b/packages/cli/src/commands/billing/index.js
@@ -174,7 +174,7 @@ export default async client => {
         )} ${chalk.gray(`[${elapsed}]`)}`;
         const choices = buildInquirerChoices(cards);
 
-        cardId = await listInput({
+        cardId = await listInput(client, {
           message,
           choices,
           separator: true,
@@ -251,7 +251,7 @@ export default async client => {
         )} under ${chalk.bold(contextName)} ${chalk.gray(`[${elapsed}]`)}`;
         const choices = buildInquirerChoices(cards);
 
-        cardId = await listInput({
+        cardId = await listInput(client, {
           message,
           choices,
           separator: true,

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -14,7 +14,6 @@ import logo from '../../util/output/logo';
 import getArgs from '../../util/get-args';
 import Client from '../../util/client';
 import { getPkgName } from '../../util/pkg-name';
-import { Output } from '../../util/output';
 import { Deployment, PaginationOptions } from '../../types';
 import { normalizeURL } from '../../util/bisect/normalize-url';
 
@@ -86,10 +85,10 @@ export default async function main(client: Client): Promise<number> {
 
   let bad =
     argv['--bad'] ||
-    (await prompt(output, `Specify a URL where the bug occurs:`));
+    (await prompt(client, `Specify a URL where the bug occurs:`));
   let good =
     argv['--good'] ||
-    (await prompt(output, `Specify a URL where the bug does not occur:`));
+    (await prompt(client, `Specify a URL where the bug does not occur:`));
   let subpath = argv['--path'] || '';
   let run = argv['--run'] || '';
   const openEnabled = argv['--open'] || false;
@@ -143,7 +142,7 @@ export default async function main(client: Client): Promise<number> {
 
   if (!subpath) {
     subpath = await prompt(
-      output,
+      client,
       `Specify the URL subpath where the bug occurs:`
     );
   }
@@ -391,10 +390,10 @@ function getCommit(deployment: DeploymentV6) {
   return { sha, message };
 }
 
-async function prompt(output: Output, message: string): Promise<string> {
+async function prompt(client: Client, message: string): Promise<string> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const { val } = await inquirer.prompt({
+    const { val } = await client.prompt({
       type: 'input',
       name: 'val',
       message,
@@ -402,7 +401,7 @@ async function prompt(output: Output, message: string): Promise<string> {
     if (val) {
       return val;
     } else {
-      output.error('A value must be specified');
+      client.output.error('A value must be specified');
     }
   }
 }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -160,9 +160,9 @@ export default async (client: Client) => {
     }
   }
 
-  const { log, debug, error, prettyError, isTTY } = output;
+  const { log, debug, error, prettyError } = output;
 
-  const quiet = !isTTY;
+  const quiet = !client.stdout.isTTY;
 
   // check paths
   const pathValidation = await validatePaths(client, paths);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -46,7 +46,11 @@ export default async function init(
   const exampleList = examples.filter(x => x.visible).map(x => x.name);
 
   if (!name) {
-    const chosen = await chooseFromDropdown('Select example:', exampleList);
+    const chosen = await chooseFromDropdown(
+      client,
+      'Select example:',
+      exampleList
+    );
 
     if (!chosen) {
       output.log('Aborted');
@@ -90,14 +94,18 @@ async function fetchExampleList(client: Client) {
 /**
  * Prompt user for choosing which example to init
  */
-async function chooseFromDropdown(message: string, exampleList: string[]) {
+async function chooseFromDropdown(
+  client: Client,
+  message: string,
+  exampleList: string[]
+) {
   const choices = exampleList.map(name => ({
     name,
     value: name,
     short: name,
   }));
 
-  return listInput({
+  return listInput(client, {
     message,
     choices,
   });

--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -83,7 +83,7 @@ export default async function main(client: Client, desiredSlug?: string) {
     ];
 
     output.stopSpinner();
-    desiredSlug = await listInput({
+    desiredSlug = await listInput(client, {
       message: 'Switch to:',
       choices,
       eraseFinalAnswer: true,

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -54,12 +54,12 @@ export default async (client: Client): Promise<number> => {
     throw err;
   }
 
-  if (output.isTTY) {
+  if (client.stdout.isTTY) {
     output.log(contextName);
   } else {
     // If stdout is not a TTY, then only print the username
     // to support piping the output to another file / exe
-    output.print(`${contextName}\n`, { w: process.stdout });
+    client.stdout.write(`${contextName}\n`);
   }
 
   return 0;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,7 +23,7 @@ import * as Sentry from '@sentry/node';
 import hp from './util/humanize-path';
 import commands from './commands';
 import pkg from './util/pkg';
-import createOutput from './util/output';
+import createOutput from './util/output/create-output';
 import cmd from './util/output/cmd';
 import info from './util/output/info';
 import error from './util/output/error';
@@ -109,7 +109,7 @@ const main = async () => {
   }
 
   const isDebugging = argv['--debug'];
-  const output = createOutput({ debug: isDebugging });
+  const output = createOutput({ stream: process.stderr, debug: isDebugging });
 
   debug = output.debug;
 
@@ -389,6 +389,7 @@ const main = async () => {
     apiUrl,
     stdin: process.stdin,
     stdout: process.stdout,
+    stderr: output.stream,
     output,
     config,
     authConfig,
@@ -798,7 +799,5 @@ process.on('uncaughtException', handleUnexpected);
 main()
   .then(exitCode => {
     process.exitCode = exitCode;
-    // @ts-ignore - "nowExit" is a non-standard event name
-    process.emit('nowExit');
   })
   .catch(handleUnexpected);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,7 +23,7 @@ import * as Sentry from '@sentry/node';
 import hp from './util/humanize-path';
 import commands from './commands';
 import pkg from './util/pkg';
-import createOutput from './util/output/create-output';
+import { Output } from './util/output';
 import cmd from './util/output/cmd';
 import info from './util/output/info';
 import error from './util/output/error';
@@ -109,7 +109,7 @@ const main = async () => {
   }
 
   const isDebugging = argv['--debug'];
-  const output = createOutput({ stream: process.stderr, debug: isDebugging });
+  const output = new Output(process.stderr, { debug: isDebugging });
 
   debug = output.debug;
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -442,3 +442,9 @@ export interface BuildOutput {
     layers?: string[];
   } | null;
 }
+
+export interface Stdio {
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,5 @@
+import type { Readable, Writable } from 'stream';
+
 export type ProjectSettings = import('@vercel/build-utils').ProjectSettings;
 
 export type Primitive =
@@ -443,8 +445,18 @@ export interface BuildOutput {
   } | null;
 }
 
+export interface ReadableTTY extends Readable {
+  isTTY?: boolean;
+  isRaw?: boolean;
+  setRawMode?: (mode: boolean) => void;
+}
+
+export interface WritableTTY extends Writable {
+  isTTY?: boolean;
+}
+
 export interface Stdio {
-  stdin: NodeJS.ReadStream;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdin: ReadableTTY;
+  stdout: WritableTTY;
+  stderr: WritableTTY;
 }

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,3 +1,5 @@
+import { bold } from 'chalk';
+import inquirer from 'inquirer';
 import { EventEmitter } from 'events';
 import { URLSearchParams } from 'url';
 import { parse as parseUrl } from 'url';
@@ -11,10 +13,9 @@ import printIndications from './print-indications';
 import reauthenticate from './login/reauthenticate';
 import { SAMLError } from './login/types';
 import { writeToAuthConfigFile } from './config/files';
-import { AuthConfig, GlobalConfig, JSONObject } from '../types';
+import { AuthConfig, GlobalConfig, JSONObject, Stdio } from '../types';
 import { sharedPromise } from './promise';
 import { APIError } from './errors-ts';
-import { bold } from 'chalk';
 
 const isSAMLError = (v: any): v is SAMLError => {
   return v && v.saml;
@@ -28,12 +29,10 @@ export interface FetchOptions extends Omit<RequestInit, 'body'> {
   accountId?: string;
 }
 
-export interface ClientOptions {
+export interface ClientOptions extends Stdio {
   argv: string[];
   apiUrl: string;
   authConfig: AuthConfig;
-  stdin: NodeJS.ReadStream;
-  stdout: NodeJS.WriteStream;
   output: Output;
   config: GlobalConfig;
   localConfig?: VercelConfig;
@@ -43,15 +42,17 @@ export const isJSONObject = (v: any): v is JSONObject => {
   return v && typeof v == 'object' && v.constructor === Object;
 };
 
-export default class Client extends EventEmitter {
+export default class Client extends EventEmitter implements Stdio {
   argv: string[];
   apiUrl: string;
   authConfig: AuthConfig;
   stdin: NodeJS.ReadStream;
   stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
   output: Output;
   config: GlobalConfig;
   localConfig?: VercelConfig;
+  prompt!: inquirer.PromptModule;
   private requestIdCounter: number;
 
   constructor(opts: ClientOptions) {
@@ -61,10 +62,12 @@ export default class Client extends EventEmitter {
     this.authConfig = opts.authConfig;
     this.stdin = opts.stdin;
     this.stdout = opts.stdout;
+    this.stderr = opts.stderr;
     this.output = opts.output;
     this.config = opts.config;
     this.localConfig = opts.localConfig;
     this.requestIdCounter = 1;
+    this._createPromptModule();
   }
 
   retry<T>(fn: RetryFunction<T>, { retries = 3, maxTimeout = Infinity } = {}) {
@@ -130,7 +133,7 @@ export default class Client extends EventEmitter {
     return this.retry(async bail => {
       const res = await this._fetch(url, opts);
 
-      printIndications(res);
+      printIndications(this, res);
 
       if (!res.ok) {
         const error = await responseError(res);
@@ -186,4 +189,11 @@ export default class Client extends EventEmitter {
   _onRetry = (error: Error) => {
     this.output.debug(`Retrying: ${error}\n${error.stack}`);
   };
+
+  _createPromptModule() {
+    this.prompt = inquirer.createPromptModule({
+      input: this.stdin,
+      output: this.stderr,
+    });
+  }
 }

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -13,7 +13,14 @@ import printIndications from './print-indications';
 import reauthenticate from './login/reauthenticate';
 import { SAMLError } from './login/types';
 import { writeToAuthConfigFile } from './config/files';
-import { AuthConfig, GlobalConfig, JSONObject, Stdio } from '../types';
+import type {
+  AuthConfig,
+  GlobalConfig,
+  JSONObject,
+  Stdio,
+  ReadableTTY,
+  WritableTTY,
+} from '../types';
 import { sharedPromise } from './promise';
 import { APIError } from './errors-ts';
 
@@ -46,9 +53,9 @@ export default class Client extends EventEmitter implements Stdio {
   argv: string[];
   apiUrl: string;
   authConfig: AuthConfig;
-  stdin: NodeJS.ReadStream;
-  stdout: NodeJS.WriteStream;
-  stderr: NodeJS.WriteStream;
+  stdin: ReadableTTY;
+  stdout: WritableTTY;
+  stderr: WritableTTY;
   output: Output;
   config: GlobalConfig;
   localConfig?: VercelConfig;
@@ -192,8 +199,8 @@ export default class Client extends EventEmitter implements Stdio {
 
   _createPromptModule() {
     this.prompt = inquirer.createPromptModule({
-      input: this.stdin,
-      output: this.stderr,
+      input: this.stdin as NodeJS.ReadStream,
+      output: this.stderr as NodeJS.WriteStream,
     });
   }
 }

--- a/packages/cli/src/util/get-files.ts
+++ b/packages/cli/src/util/get-files.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
 import fs from 'fs-extra';
+import { resolve } from 'path';
 import { getVercelIgnore } from '@vercel/client';
 import uniqueStrings from './unique-strings';
 import { Output } from './output/create-output';

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -530,7 +530,7 @@ export default class Now extends EventEmitter {
       `${opts.method || 'GET'} ${this._apiUrl}${_url} ${opts.body || ''}`,
       fetch(`${this._apiUrl}${_url}`, { ...opts, body })
     );
-    printIndications(res);
+    printIndications(this._client, res);
     return res;
   }
 

--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -1,4 +1,3 @@
-import inquirer from 'inquirer';
 import Client from '../client';
 
 export default async function confirm(
@@ -8,12 +7,7 @@ export default async function confirm(
 ): Promise<boolean> {
   require('./patch-inquirer');
 
-  const prompt = inquirer.createPromptModule({
-    input: client.stdin,
-    output: client.stdout,
-  });
-
-  const answers = await prompt({
+  const answers = await client.prompt({
     type: 'confirm',
     name: 'value',
     message,

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -1,5 +1,4 @@
 import Client from '../client';
-import inquirer from 'inquirer';
 import confirm from './confirm';
 import getProjectByIdOrName from '../projects/get-project-by-id-or-name';
 import chalk from 'chalk';
@@ -15,11 +14,6 @@ export default async function inputProject(
 ): Promise<Project | string> {
   const { output } = client;
   const slugifiedName = slugify(detectedProjectName);
-
-  const prompt = inquirer.createPromptModule({
-    input: client.stdin,
-    output: client.stdout,
-  });
 
   // attempt to auto-detect a project to link
   let detectedProject = null;
@@ -84,7 +78,7 @@ export default async function inputProject(
     let project: Project | ProjectNotFound | null = null;
 
     while (!project || project instanceof ProjectNotFound) {
-      const answers = await prompt({
+      const answers = await client.prompt({
         type: 'input',
         name: 'existingProjectName',
         message: `What’s the name of your existing project?`,
@@ -115,7 +109,7 @@ export default async function inputProject(
   let newProjectName: string | null = null;
 
   while (!newProjectName) {
-    const answers = await prompt({
+    const answers = await client.prompt({
       type: 'input',
       name: 'newProjectName',
       message: `What’s your project’s name?`,

--- a/packages/cli/src/util/input/input-project.ts
+++ b/packages/cli/src/util/input/input-project.ts
@@ -16,6 +16,11 @@ export default async function inputProject(
   const { output } = client;
   const slugifiedName = slugify(detectedProjectName);
 
+  const prompt = inquirer.createPromptModule({
+    input: client.stdin,
+    output: client.stdout,
+  });
+
   // attempt to auto-detect a project to link
   let detectedProject = null;
   output.spinner('Searching for existing projects…', 1000);
@@ -79,10 +84,6 @@ export default async function inputProject(
     let project: Project | ProjectNotFound | null = null;
 
     while (!project || project instanceof ProjectNotFound) {
-      const prompt = inquirer.createPromptModule({
-        input: client.stdin,
-        output: client.stdout,
-      });
       const answers = await prompt({
         type: 'input',
         name: 'existingProjectName',
@@ -114,7 +115,7 @@ export default async function inputProject(
   let newProjectName: string | null = null;
 
   while (!newProjectName) {
-    const answers = await inquirer.prompt({
+    const answers = await prompt({
       type: 'input',
       name: 'newProjectName',
       message: `What’s your project’s name?`,

--- a/packages/cli/src/util/input/input-root-directory.ts
+++ b/packages/cli/src/util/input/input-root-directory.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import chalk from 'chalk';
-import inquirer from 'inquirer';
 import { validateRootDirectory } from '../validate-paths';
 import Client from '../client';
 
@@ -15,11 +14,7 @@ export async function inputRootDirectory(
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const prompt = inquirer.createPromptModule({
-      input: client.stdin,
-      output: client.stdout,
-    });
-    const { rootDirectory } = await prompt({
+    const { rootDirectory } = await client.prompt({
       type: 'input',
       name: 'rootDirectory',
       message: `In which directory is your code located?`,

--- a/packages/cli/src/util/input/list.ts
+++ b/packages/cli/src/util/input/list.ts
@@ -1,5 +1,6 @@
 import inquirer from 'inquirer';
 import stripAnsi from 'strip-ansi';
+import Client from '../client';
 import eraseLines from '../output/erase-lines';
 
 interface ListEntry {
@@ -35,21 +36,24 @@ function getLength(input: string): number {
   return biggestLength;
 }
 
-export default async function list({
-  message = 'the question',
-  // eslint-disable-line no-unused-vars
-  choices: _choices = [
-    {
-      name: 'something\ndescription\ndetails\netc',
-      value: 'something unique',
-      short: 'generally the first line of `name`',
-    },
-  ],
-  pageSize = 15, // Show 15 lines without scrolling (~4 credit cards)
-  separator = false, // Puts a blank separator between each choice
-  abort = 'end', // Whether the `abort` option will be at the `start` or the `end`,
-  eraseFinalAnswer = false, // If true, the line with the final answer that inquirer prints will be erased before returning
-}: ListOptions): Promise<string> {
+export default async function list(
+  client: Client,
+  {
+    message = 'the question',
+    // eslint-disable-line no-unused-vars
+    choices: _choices = [
+      {
+        name: 'something\ndescription\ndetails\netc',
+        value: 'something unique',
+        short: 'generally the first line of `name`',
+      },
+    ],
+    pageSize = 15, // Show 15 lines without scrolling (~4 credit cards)
+    separator = false, // Puts a blank separator between each choice
+    abort = 'end', // Whether the `abort` option will be at the `start` or the `end`,
+    eraseFinalAnswer = false, // If true, the line with the final answer that inquirer prints will be erased before returning
+  }: ListOptions
+): Promise<string> {
   require('./patch-inquirer-legacy');
 
   let biggestLength = 0;
@@ -106,7 +110,7 @@ export default async function list({
     choices.push(abortSeparator, _abort);
   }
 
-  const answer = await inquirer.prompt({
+  const answer = await client.prompt({
     name: 'value',
     type: 'list',
     default: selected,

--- a/packages/cli/src/util/input/prompt-bool.ts
+++ b/packages/cli/src/util/input/prompt-bool.ts
@@ -1,12 +1,13 @@
 import chalk from 'chalk';
+import type { ReadableTTY, WritableTTY } from '../../types';
 
 type Options = {
   abortSequences?: Set<string>;
   defaultValue?: boolean;
   noChar?: string;
   resolveChars?: Set<string>;
-  stdin: NodeJS.ReadStream;
-  stdout: NodeJS.WriteStream;
+  stdin: ReadableTTY;
+  stdout: WritableTTY;
   trailing?: string;
   yesChar?: string;
 };

--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -1,10 +1,12 @@
+import type { Readable } from 'stream';
+
 export default async function readStandardInput(
-  stdin: NodeJS.ReadStream
+  stdin: Readable | NodeJS.ReadStream
 ): Promise<string> {
   return new Promise<string>(resolve => {
     setTimeout(() => resolve(''), 500);
 
-    if (stdin.isTTY) {
+    if ('isTTY' in stdin && stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
     } else {

--- a/packages/cli/src/util/input/read-standard-input.ts
+++ b/packages/cli/src/util/input/read-standard-input.ts
@@ -1,12 +1,12 @@
-import type { Readable } from 'stream';
+import type { ReadableTTY } from '../../types';
 
 export default async function readStandardInput(
-  stdin: Readable | NodeJS.ReadStream
+  stdin: ReadableTTY
 ): Promise<string> {
   return new Promise<string>(resolve => {
     setTimeout(() => resolve(''), 500);
 
-    if ('isTTY' in stdin && stdin.isTTY) {
+    if (stdin.isTTY) {
       // found tty so we know there is nothing piped to stdin
       resolve('');
     } else {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -56,7 +56,7 @@ export default async function setupAndLink(
     return { status: 'error', exitCode: 1, reason: 'PATH_IS_FILE' };
   }
   const link = await getLinkedProject(client, path);
-  const isTTY = process.stdout.isTTY;
+  const isTTY = client.stdin.isTTY;
   const quiet = !isTTY;
   let rootDirectory: string | null = null;
   let sourceFilesOutsideRootDirectory = true;

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -176,7 +176,7 @@ async function getVerificationTokenOutOfBand(client: Client, url: URL) {
   output.log(
     `After login is complete, enter the verification code printed in your browser.`
   );
-  const verificationToken = await readInput('Verification code:');
+  const verificationToken = await readInput(client, 'Verification code:');
   output.print(eraseLines(6));
 
   // If the pasted token begins with "saml_", then the `ssoUserId` was returned.

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -1,4 +1,3 @@
-import inquirer from 'inquirer';
 import Client from '../client';
 import error from '../output/error';
 import listInput from '../input/list';
@@ -32,7 +31,7 @@ export default async function prompt(
     choices.pop();
   }
 
-  const choice = await listInput({
+  const choice = await listInput(client, {
     message: 'Log in to Vercel',
     choices,
   });
@@ -44,22 +43,26 @@ export default async function prompt(
   } else if (choice === 'bitbucket') {
     result = await doBitbucketLogin(client, outOfBand, ssoUserId);
   } else if (choice === 'email') {
-    const email = await readInput('Enter your email address:');
+    const email = await readInput(client, 'Enter your email address:');
     result = await doEmailLogin(client, email, ssoUserId);
   } else if (choice === 'saml') {
-    const slug = error?.teamId || (await readInput('Enter your Team slug:'));
+    const slug =
+      error?.teamId || (await readInput(client, 'Enter your Team slug:'));
     result = await doSamlLogin(client, slug, outOfBand, ssoUserId);
   }
 
   return result;
 }
 
-export async function readInput(message: string): Promise<string> {
+export async function readInput(
+  client: Client,
+  message: string
+): Promise<string> {
   let input;
 
   while (!input) {
     try {
-      const { val } = await inquirer.prompt({
+      const { val } = await client.prompt({
         type: 'input',
         name: 'val',
         message,

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -113,10 +113,13 @@ export class Output {
       if (this._spinner) {
         this._spinner.text = message;
       } else {
-        this._spinner = wait({
-          text: message,
-          stream: this.stream
-        }, delay);
+        this._spinner = wait(
+          {
+            text: message,
+            stream: this.stream,
+          },
+          delay
+        );
       }
     } else {
       this.print(`${message}\n`);

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -1,41 +1,39 @@
 import chalk from 'chalk';
 import renderLink from './link';
 import wait, { StopSpinner } from './wait';
-import { Writable } from 'stream';
 
 export interface OutputOptions {
+  stream?: NodeJS.WriteStream;
   debug?: boolean;
 }
 
-export interface PrintOptions {
-  w?: Writable;
-}
-
-export interface LogOptions extends PrintOptions {
+export interface LogOptions {
   color?: typeof chalk;
 }
 
 export class Output {
+  stream: NodeJS.WriteStream;
   debugEnabled: boolean;
   private spinnerMessage: string;
   private _spinner: StopSpinner | null;
-  isTTY: boolean;
 
-  constructor({ debug: debugEnabled = false }: OutputOptions = {}) {
+  constructor({
+    stream = process.stderr,
+    debug: debugEnabled = false,
+  }: OutputOptions = {}) {
+    this.stream = stream;
     this.debugEnabled = debugEnabled;
     this.spinnerMessage = '';
     this._spinner = null;
-    this.isTTY = process.stdout.isTTY || false;
   }
 
   isDebugEnabled = () => {
     return this.debugEnabled;
   };
 
-  print = (str: string, { w }: PrintOptions = { w: process.stderr }) => {
+  print = (str: string) => {
     this.stopSpinner();
-    const stream: Writable = w || process.stderr;
-    stream.write(str);
+    this.stream.write(str);
   };
 
   log = (str: string, color = chalk.grey) => {
@@ -111,11 +109,14 @@ export class Output {
       this.debug(`Spinner invoked (${message}) with a ${delay}ms delay`);
       return;
     }
-    if (this.isTTY) {
+    if (this.stream.isTTY) {
       if (this._spinner) {
         this._spinner.text = message;
       } else {
-        this._spinner = wait(message, delay);
+        this._spinner = wait({
+          text: message,
+          stream: this.stream
+        }, delay);
       }
     } else {
       this.print(`${message}\n`);

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import renderLink from './link';
 import wait, { StopSpinner } from './wait';
+import type { WritableTTY } from '../../types';
 
 export interface OutputOptions {
-  stream?: NodeJS.WriteStream;
   debug?: boolean;
 }
 
@@ -12,15 +12,15 @@ export interface LogOptions {
 }
 
 export class Output {
-  stream: NodeJS.WriteStream;
+  stream: WritableTTY;
   debugEnabled: boolean;
   private spinnerMessage: string;
   private _spinner: StopSpinner | null;
 
-  constructor({
-    stream = process.stderr,
-    debug: debugEnabled = false,
-  }: OutputOptions = {}) {
+  constructor(
+    stream: WritableTTY,
+    { debug: debugEnabled = false }: OutputOptions = {}
+  ) {
     this.stream = stream;
     this.debugEnabled = debugEnabled;
     this.spinnerMessage = '';
@@ -160,8 +160,4 @@ export class Output {
 
     return promise;
   };
-}
-
-export default function createOutput(opts?: OutputOptions) {
-  return new Output(opts);
 }

--- a/packages/cli/src/util/output/index.ts
+++ b/packages/cli/src/util/output/index.ts
@@ -1,2 +1,2 @@
-export { default, Output } from './create-output';
+export { Output } from './create-output';
 export { StopSpinner } from './wait';

--- a/packages/cli/src/util/output/wait.ts
+++ b/packages/cli/src/util/output/wait.ts
@@ -9,7 +9,7 @@ export interface StopSpinner {
 
 export default function wait(
   opts: ora.Options,
-  delay: number = 300,
+  delay: number = 300
 ): StopSpinner {
   let text = opts.text;
   let spinner: ora.Ora | null = null;

--- a/packages/cli/src/util/output/wait.ts
+++ b/packages/cli/src/util/output/wait.ts
@@ -8,14 +8,19 @@ export interface StopSpinner {
 }
 
 export default function wait(
-  msg: string,
+  opts: ora.Options,
   delay: number = 300,
-  _ora = ora
 ): StopSpinner {
-  let spinner: ReturnType<typeof _ora> | null = null;
+  let text = opts.text;
+  let spinner: ora.Ora | null = null;
+
+  if (typeof text !== 'string') {
+    throw new Error(`"text" is required for Ora spinner`);
+  }
 
   const timeout = setTimeout(() => {
-    spinner = _ora(chalk.gray(msg));
+    spinner = ora(opts);
+    spinner.text = chalk.gray(text);
     spinner.color = 'gray';
     spinner.start();
   }, delay);
@@ -29,23 +34,21 @@ export default function wait(
     }
   };
 
-  stop.text = msg;
+  stop.text = text;
 
   // Allow `text` property to update the text while the spinner is in action
   Object.defineProperty(stop, 'text', {
     get() {
-      return msg;
+      return text;
     },
 
     set(v: string) {
-      msg = v;
+      text = v;
       if (spinner) {
         spinner.text = chalk.gray(v);
       }
     },
   });
 
-  // @ts-ignore
-  process.once('nowExit', stop);
   return stop;
 }

--- a/packages/cli/src/util/print-indications.ts
+++ b/packages/cli/src/util/print-indications.ts
@@ -1,11 +1,10 @@
 import chalk from 'chalk';
 import { Response } from 'node-fetch';
-import { emoji, EmojiLabel, prependEmoji } from './emoji';
-import createOutput from './output';
+import Client from './client';
 import linkStyle from './output/link';
+import { emoji, EmojiLabel, prependEmoji } from './emoji';
 
-export default function printIndications(res: Response) {
-  const _output = createOutput();
+export default function printIndications(client: Client, res: Response) {
   const indications = new Set(['warning', 'notice', 'tip']);
   const regex = /^x-(?:vercel|now)-(warning|notice|tip)-(.*)$/;
 
@@ -25,7 +24,7 @@ export default function printIndications(res: Response) {
             chalk.dim(`${action || 'Learn More'}: ${linkStyle(link)}`) +
             newline;
         }
-        _output.print(message + finalLink);
+        client.output.print(message + finalLink);
       }
     }
   }

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -1958,7 +1958,7 @@ test('ensure we render a prompt when deploying home directory', async t => {
   t.is(exitCode, 0);
 
   t.true(
-    stdout.includes(
+    stderr.includes(
       'You are deploying your home directory. Do you want to continue? [y/N]'
     )
   );

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -181,7 +181,6 @@ afterAll(async () => {
   await client.stopMockServer();
 });
 
-
 //expect.extend({
 //  async toWaitFor(received: NodeJS.WriteStream, test: string) {
 //

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -22,6 +22,10 @@ class MockStream extends PassThrough {
     super();
     this.isTTY = true;
   }
+
+  // These is for the `ora` module
+  clearLine() {}
+  cursorTo() {}
 }
 
 export class MockClient extends Client {

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -1,0 +1,83 @@
+/**
+ * This file registers the custom Jest "matchers" that are useful for
+ * writing CLI unit tests, and sets them up to be recognized by TypeScript.
+ * 
+ * References:
+ *  - https://haspar.us/notes/adding-jest-custom-matchers-in-typescript
+ *  - https://gist.github.com/hasparus/4ebaa17ec5d3d44607f522bcb1cda9fb
+ */
+
+/// <reference types="@types/node" />
+/// <reference types="@types/jest" />
+import { PassThrough } from 'stream';
+import type { MatcherState } from 'expect';
+
+import * as _matchers from './matchers';
+
+const matchers = {
+  ..._matchers,
+  toHaveWordsCount(this: MatcherState, sentence: string, wordsCount: number) {
+    // implementation redacted
+  },
+};
+
+
+type Tail<T extends unknown[]> = T extends [infer _Head, ...infer Tail]
+  ? Tail
+  : never;
+
+type AnyFunction = (...args: never[]) => unknown;
+
+type GetMatchersType<
+  TMatchers,
+  TResult,
+  > = {
+    [P in keyof TMatchers]: TMatchers[P] extends AnyFunction
+      ? AnyFunction extends TMatchers[P] 
+        ? (...args: Tail<Parameters<TMatchers[P]>>) => TResult
+        : TMatchers[P]
+      : TMatchers[P]
+  };
+
+
+type FirstParam<T extends AnyFunction> = Parameters<T>[0]
+
+type OnlyMethodsWhereFirstArgIsOfType<
+  TObject,
+  TWantedFirstArg
+> = {
+    [P in keyof TObject]: TObject[P] extends AnyFunction
+      ? TWantedFirstArg extends FirstParam<TObject[P]>
+        ? TObject[P]
+        : [`Error: this function is present only when received is:`, FirstParam<TObject[P]>]
+      : TObject[P]
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Matchers<R, T = {}>
+      extends GetMatchersType<
+        OnlyMethodsWhereFirstArgIsOfType<typeof matchers, T>,
+        R
+      > {}
+  }
+}
+
+const jestExpect = (global as any).expect;
+
+if (jestExpect !== undefined) {
+  jestExpect.extend(matchers);
+} else {
+  console.error("Couldn't find Jest's global expect.");
+}
+
+// ✅
+expect(new PassThrough()).toWaitFor('test')
+expect(process.stdout).toWaitFor('test')
+expect('foo bar').toWaitFor(2);
+
+// 🔥 error as expected
+expect('foo bar').toHaveWordsCount(2);
+expect(20).toHaveWordsCount(2);

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -7,32 +7,25 @@
  *  - https://gist.github.com/hasparus/4ebaa17ec5d3d44607f522bcb1cda9fb
  */
 
-/// <reference types="@types/node" />
 /// <reference types="@types/jest" />
-import { PassThrough } from 'stream';
-import type { MatcherState } from 'expect';
 
-import * as _matchers from './matchers';
+import * as matchers from './matchers';
 
-const matchers = {
-  ..._matchers,
-  toHaveWordsCount(this: MatcherState, sentence: string, wordsCount: number) {
-    // implementation redacted
-  },
-};
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type Tail<T extends unknown[]> = T extends [infer _Head, ...infer Tail]
   ? Tail
   : never;
 
-type AnyFunction = (...args: never[]) => unknown;
+type AnyFunction = (...args: any[]) => any;
+
+type GetMatcherType<TP, TResult> = TP extends AnyFunction
+  ? AnyFunction extends TP
+    ? (...args: Tail<Parameters<TP>>) => TResult
+    : TP
+  : TP;
 
 type GetMatchersType<TMatchers, TResult> = {
-  [P in keyof TMatchers]: TMatchers[P] extends AnyFunction
-    ? AnyFunction extends TMatchers[P]
-      ? (...args: Tail<Parameters<TMatchers[P]>>) => TResult
-      : TMatchers[P]
-    : TMatchers[P];
+  [P in keyof TMatchers]: GetMatcherType<TMatchers[P], TResult>;
 };
 
 type FirstParam<T extends AnyFunction> = Parameters<T>[0];
@@ -67,12 +60,3 @@ if (jestExpect !== undefined) {
 } else {
   console.error("Couldn't find Jest's global expect.");
 }
-
-// ✅
-expect(new PassThrough()).toWaitFor('test');
-expect(process.stdout).toWaitFor('test');
-expect('foo bar').toWaitFor(2);
-
-// 🔥 error as expected
-expect('foo bar').toHaveWordsCount(2);
-expect(20).toHaveWordsCount(2);

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -1,7 +1,7 @@
 /**
  * This file registers the custom Jest "matchers" that are useful for
  * writing CLI unit tests, and sets them up to be recognized by TypeScript.
- * 
+ *
  * References:
  *  - https://haspar.us/notes/adding-jest-custom-matchers-in-typescript
  *  - https://gist.github.com/hasparus/4ebaa17ec5d3d44607f522bcb1cda9fb
@@ -21,37 +21,32 @@ const matchers = {
   },
 };
 
-
 type Tail<T extends unknown[]> = T extends [infer _Head, ...infer Tail]
   ? Tail
   : never;
 
 type AnyFunction = (...args: never[]) => unknown;
 
-type GetMatchersType<
-  TMatchers,
-  TResult,
-  > = {
-    [P in keyof TMatchers]: TMatchers[P] extends AnyFunction
-      ? AnyFunction extends TMatchers[P] 
-        ? (...args: Tail<Parameters<TMatchers[P]>>) => TResult
-        : TMatchers[P]
+type GetMatchersType<TMatchers, TResult> = {
+  [P in keyof TMatchers]: TMatchers[P] extends AnyFunction
+    ? AnyFunction extends TMatchers[P]
+      ? (...args: Tail<Parameters<TMatchers[P]>>) => TResult
       : TMatchers[P]
-  };
+    : TMatchers[P];
+};
 
+type FirstParam<T extends AnyFunction> = Parameters<T>[0];
 
-type FirstParam<T extends AnyFunction> = Parameters<T>[0]
-
-type OnlyMethodsWhereFirstArgIsOfType<
-  TObject,
-  TWantedFirstArg
-> = {
-    [P in keyof TObject]: TObject[P] extends AnyFunction
-      ? TWantedFirstArg extends FirstParam<TObject[P]>
-        ? TObject[P]
-        : [`Error: this function is present only when received is:`, FirstParam<TObject[P]>]
-      : TObject[P]
-}
+type OnlyMethodsWhereFirstArgIsOfType<TObject, TWantedFirstArg> = {
+  [P in keyof TObject]: TObject[P] extends AnyFunction
+    ? TWantedFirstArg extends FirstParam<TObject[P]>
+      ? TObject[P]
+      : [
+          `Error: this function is present only when received is:`,
+          FirstParam<TObject[P]>
+        ]
+    : TObject[P];
+};
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -74,8 +69,8 @@ if (jestExpect !== undefined) {
 }
 
 // ✅
-expect(new PassThrough()).toWaitFor('test')
-expect(process.stdout).toWaitFor('test')
+expect(new PassThrough()).toWaitFor('test');
+expect(process.stdout).toWaitFor('test');
 expect('foo bar').toWaitFor(2);
 
 // 🔥 error as expected

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -17,12 +17,15 @@ type Tail<T extends unknown[]> = T extends [infer _Head, ...infer Tail]
   : never;
 
 type AnyFunction = (...args: any[]) => any;
+type PromiseFunction = (...args: any[]) => Promise<any>;
 
-type GetMatcherType<TP, TResult> = TP extends AnyFunction
-  ? AnyFunction extends TP
-    ? (...args: Tail<Parameters<TP>>) => TResult
-    : TP
+type GetMatcherType<TP, TResult> = TP extends PromiseFunction
+  ? (...args: Tail<Parameters<TP>>) => Promise<TResult>
+  : TP extends AnyFunction
+  ? (...args: Tail<Parameters<TP>>) => TResult
   : TP;
+
+//type T = GetMatcherType<typeof matchers['toOutput'], void>;
 
 type GetMatchersType<TMatchers, TResult> = {
   [P in keyof TMatchers]: GetMatcherType<TMatchers[P], TResult>;

--- a/packages/cli/test/mocks/matchers/matchers.ts
+++ b/packages/cli/test/mocks/matchers/matchers.ts
@@ -1,11 +1,1 @@
-import type { MatcherState } from 'expect';
-
-export * from './to-wait-for';
-
-export function toHaveWordsCount(
-  this: MatcherState,
-  sentence: string,
-  wordsCount: number
-) {
-  // implementation redacted
-}
+export * from './to-output';

--- a/packages/cli/test/mocks/matchers/matchers.ts
+++ b/packages/cli/test/mocks/matchers/matchers.ts
@@ -2,6 +2,10 @@ import type { MatcherState } from 'expect';
 
 export * from './to-wait-for';
 
-export function toHaveWordsCount(this: MatcherState, sentence: string, wordsCount: number) {
-    // implementation redacted
-  }
+export function toHaveWordsCount(
+  this: MatcherState,
+  sentence: string,
+  wordsCount: number
+) {
+  // implementation redacted
+}

--- a/packages/cli/test/mocks/matchers/matchers.ts
+++ b/packages/cli/test/mocks/matchers/matchers.ts
@@ -1,0 +1,7 @@
+import type { MatcherState } from 'expect';
+
+export * from './to-wait-for';
+
+export function toHaveWordsCount(this: MatcherState, sentence: string, wordsCount: number) {
+    // implementation redacted
+  }

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -43,7 +43,6 @@ export async function toOutput(
     };
 
     function onData(data: string) {
-      //console.log({ data });
       output += data;
       if (output.includes(test)) {
         cleanup();

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -12,7 +12,7 @@ export async function toOutput(
   this: MatcherState,
   stream: Readable,
   test: string,
-  timeout = 1000
+  timeout = 3000
 ) {
   const { isNot } = this;
   const matcherName = 'toOutput';

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -12,6 +12,7 @@ export async function toOutput(
     let timeoutId = setTimeout(onTimeout, timeout);
 
     function onData(data: string) {
+      //console.log({ data });
       output += data;
       if (output.includes(test)) {
         cleanup();
@@ -26,7 +27,7 @@ export async function toOutput(
       cleanup();
       resolve({
         pass: false,
-        message: () => 'bad',
+        message: () => `Timed out after waiting ${timeout}ms`,
       });
     }
 

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -27,20 +27,17 @@ export async function toOutput(
     const message = () => {
       const labelExpected = 'Expected output';
       const labelReceived = 'Received output';
-
       const printLabel = getLabelPrinter(labelExpected, labelReceived);
-
       const hint =
         matcherHint(matcherName, 'stream', 'test', matcherHintOptions) + '\n\n';
-
       return (
         hint +
         printLabel(labelExpected) +
-        (isNot ? 'not ' : ' ') +
+        (isNot ? 'not ' : '') +
         printExpected(test) +
         '\n' +
         printLabel(labelReceived) +
-        (isNot ? '    ' : ' ') +
+        (isNot ? '    ' : '') +
         printReceived(output)
       );
     };

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -1,19 +1,17 @@
 import type { Readable } from 'stream';
 import type { MatcherState } from 'expect';
 
-export async function toWaitFor(
+export async function toOutput(
   this: MatcherState,
   stream: Readable,
   test: string
 ) {
-  //export async function toWaitFor(this: MatcherState, stream: NodeJS.ReadStream, test: string) {
   let timeout = 1000;
   return new Promise(resolve => {
     let output = '';
     let timeoutId = setTimeout(onTimeout, timeout);
 
     function onData(data: string) {
-      //console.log({ data });
       output += data;
       if (output.includes(test)) {
         cleanup();

--- a/packages/cli/test/mocks/matchers/to-wait-for.ts
+++ b/packages/cli/test/mocks/matchers/to-wait-for.ts
@@ -1,0 +1,40 @@
+import type { Readable } from 'stream';
+import type { MatcherState } from 'expect';
+
+export async function toWaitFor(this: MatcherState, stream: Readable, test: string) {
+//export async function toWaitFor(this: MatcherState, stream: NodeJS.ReadStream, test: string) {
+    let timeout = 1000;
+    return new Promise((resolve) => {
+      let output = '';
+      let timeoutId = setTimeout(onTimeout, timeout);
+
+      function onData(data: string) {
+        //console.log({ data });
+        output += data;
+        if (output.includes(test)) {
+          cleanup();
+          resolve({
+            pass: true,
+            message: () => 'got it'
+          });
+        }
+      }
+
+      function onTimeout() {
+        cleanup();
+        resolve({
+          pass: false,
+          message: () => 'bad'
+        });
+      }
+
+      function cleanup() {
+        clearTimeout(timeoutId);
+        stream.removeListener('data', onData);
+        stream.pause();
+      }
+
+      stream.on('data', onData);
+      stream.resume();
+    });
+}

--- a/packages/cli/test/mocks/matchers/to-wait-for.ts
+++ b/packages/cli/test/mocks/matchers/to-wait-for.ts
@@ -1,40 +1,44 @@
 import type { Readable } from 'stream';
 import type { MatcherState } from 'expect';
 
-export async function toWaitFor(this: MatcherState, stream: Readable, test: string) {
-//export async function toWaitFor(this: MatcherState, stream: NodeJS.ReadStream, test: string) {
-    let timeout = 1000;
-    return new Promise((resolve) => {
-      let output = '';
-      let timeoutId = setTimeout(onTimeout, timeout);
+export async function toWaitFor(
+  this: MatcherState,
+  stream: Readable,
+  test: string
+) {
+  //export async function toWaitFor(this: MatcherState, stream: NodeJS.ReadStream, test: string) {
+  let timeout = 1000;
+  return new Promise(resolve => {
+    let output = '';
+    let timeoutId = setTimeout(onTimeout, timeout);
 
-      function onData(data: string) {
-        //console.log({ data });
-        output += data;
-        if (output.includes(test)) {
-          cleanup();
-          resolve({
-            pass: true,
-            message: () => 'got it'
-          });
-        }
-      }
-
-      function onTimeout() {
+    function onData(data: string) {
+      //console.log({ data });
+      output += data;
+      if (output.includes(test)) {
         cleanup();
         resolve({
-          pass: false,
-          message: () => 'bad'
+          pass: true,
+          message: () => 'got it',
         });
       }
+    }
 
-      function cleanup() {
-        clearTimeout(timeoutId);
-        stream.removeListener('data', onData);
-        stream.pause();
-      }
+    function onTimeout() {
+      cleanup();
+      resolve({
+        pass: false,
+        message: () => 'bad',
+      });
+    }
 
-      stream.on('data', onData);
-      stream.resume();
-    });
+    function cleanup() {
+      clearTimeout(timeoutId);
+      stream.removeListener('data', onData);
+      stream.pause();
+    }
+
+    stream.on('data', onData);
+    stream.resume();
+  });
 }

--- a/packages/cli/test/unit/commands/deploy.test.ts
+++ b/packages/cli/test/unit/commands/deploy.test.ts
@@ -10,38 +10,38 @@ import { useUser } from '../../mocks/user';
 describe('deploy', () => {
   it('should reject deploying a single file', async () => {
     client.setArgv('deploy', __filename);
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       `Error! Support for single file deployments has been removed.\nLearn More: https://vercel.link/no-single-file-deployments\n`
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying multiple files', async () => {
     client.setArgv('deploy', __filename, join(__dirname, 'inspect.test.ts'));
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       `Error! Can't deploy more than one path.\n`
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying a directory that does not exist', async () => {
     client.setArgv('deploy', 'does-not-exists');
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       `Error! The specified file or directory "does-not-exists" does not exist.\n`
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying a directory that does not contain ".vercel/output" when `--prebuilt` is used', async () => {
     client.setArgv('deploy', __dirname, '--prebuilt');
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       'Error! The "--prebuilt" option was used, but no prebuilt output found in ".vercel/output". Run `vercel build` to generate a local build.\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying a directory that was built with a different target environment when `--prebuilt --prod` is used on "preview" output', async () => {
@@ -56,14 +56,14 @@ describe('deploy', () => {
     });
 
     client.setArgv('deploy', cwd, '--prebuilt', '--prod');
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       'Error! The "--prebuilt" option was used with the target environment "production",' +
         ' but the prebuilt output found in ".vercel/output" was built with target environment "preview".' +
         ' Please run `vercel --prebuilt`.\n' +
         'Learn More: https://vercel.link/prebuilt-environment-mismatch\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying a directory that was built with a different target environment when `--prebuilt` is used on "production" output', async () => {
@@ -78,14 +78,14 @@ describe('deploy', () => {
     });
 
     client.setArgv('deploy', cwd, '--prebuilt');
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       'Error! The "--prebuilt" option was used with the target environment "preview",' +
         ' but the prebuilt output found in ".vercel/output" was built with target environment "production".' +
         ' Please run `vercel --prebuilt --prod`.\n' +
         'Learn More: https://vercel.link/prebuilt-environment-mismatch\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying "version: 1"', async () => {
@@ -94,11 +94,11 @@ describe('deploy', () => {
       [fileNameSymbol]: 'vercel.json',
       version: 1,
     };
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       'Error! The value of the `version` property within vercel.json can only be `2`.\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should reject deploying "version: {}"', async () => {
@@ -108,10 +108,10 @@ describe('deploy', () => {
       // @ts-ignore
       version: {},
     };
-    const exitCode = await deploy(client);
-    expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    const exitCodePromise = deploy(client);
+    await expect(client.stderr).toOutput(
       'Error! The `version` property inside your vercel.json file must be a number.\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 });

--- a/packages/cli/test/unit/commands/env.test.ts
+++ b/packages/cli/test/unit/commands/env.test.ts
@@ -19,8 +19,12 @@ describe('env', () => {
         name: 'vercel-env-pull',
       });
       client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
-      const exitCode = await env(client);
-      expect(exitCode, client.outputBuffer).toEqual(0);
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Downloading "development" Environment Variables for Project vercel-env-pull'
+      );
+      await expect(client.stderr).toOutput('Created .env file');
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       const rawDevEnv = await fs.readFile(path.join(cwd, '.env'));
 
@@ -39,8 +43,12 @@ describe('env', () => {
         name: 'vercel-env-pull',
       });
       client.setArgv('env', 'pull', 'other.env', '--yes', '--cwd', cwd);
-      const exitCode = await env(client);
-      expect(exitCode, client.outputBuffer).toEqual(0);
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Downloading "development" Environment Variables for Project vercel-env-pull'
+      );
+      await expect(client.stderr).toOutput('Created other.env file');
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       const rawDevEnv = await fs.readFile(path.join(cwd, 'other.env'));
 
@@ -61,8 +69,12 @@ describe('env', () => {
       });
 
       client.setArgv('env', 'pull', 'other.env', '--yes', '--cwd', cwd);
-      const exitCode = await env(client);
-      expect(exitCode, client.outputBuffer).toEqual(0);
+      const exitCodePromise = env(client);
+      await expect(client.stderr).toOutput(
+        'Downloading "development" Environment Variables for Project vercel-env-pull'
+      );
+      await expect(client.stderr).toOutput('Created other.env file');
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       const rawDevEnv = await fs.readFile(path.join(cwd, 'other.env'));
 

--- a/packages/cli/test/unit/commands/inspect.test.ts
+++ b/packages/cli/test/unit/commands/inspect.test.ts
@@ -10,11 +10,9 @@ describe('inspect', () => {
     client.setArgv('inspect', deployment.url);
     const exitCode = await inspect(client);
     expect(exitCode).toEqual(0);
-    expect(
-      client.mockOutput.mock.calls[0][0].startsWith(
-        `> Fetched deployment "${deployment.url}" in ${user.username}`
-      )
-    ).toBeTruthy();
+    await expect(client.stderr).toOutput(
+      `> Fetched deployment "${deployment.url}" in ${user.username}`
+    );
   });
 
   it('should print error when deployment not found', async () => {
@@ -23,7 +21,7 @@ describe('inspect', () => {
     client.setArgv('inspect', 'bad.com');
     const exitCode = await inspect(client);
     expect(exitCode).toEqual(1);
-    expect(client.outputBuffer).toEqual(
+    await expect(client.stderr).toOutput(
       `Error! Failed to find deployment "bad.com" in ${user.username}\n`
     );
   });

--- a/packages/cli/test/unit/commands/login.test.ts
+++ b/packages/cli/test/unit/commands/login.test.ts
@@ -21,4 +21,29 @@ describe('login', () => {
     );
     await expect(exitCodePromise).resolves.toEqual(0);
   });
+
+  describe('interactive', () => {
+    it('should allow login via email', async () => {
+      const user = useUser();
+      client.setArgv('login');
+      const exitCodePromise = login(client);
+      await expect(client.stderr).toOutput(`> Log in to Vercel`);
+
+      // Move down to "Email" option
+      client.stdin.write('\x1B[B'); // Down arrow
+      client.stdin.write('\x1B[B'); // Down arrow
+      client.stdin.write('\x1B[B'); // Down arrow
+      client.stdin.write('\r'); // Return key
+
+      await expect(client.stderr).toOutput('> Enter your email address:');
+
+      client.stdin.write(`${user.email}\n`);
+
+      await expect(client.stderr).toOutput(
+        `Success! Email authentication complete for ${user.email}`
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/login.test.ts
+++ b/packages/cli/test/unit/commands/login.test.ts
@@ -7,7 +7,7 @@ describe('login', () => {
     client.setArgv('login', '--token', 'foo');
     const exitCode = await login(client);
     expect(exitCode).toEqual(2);
-    expect(client.outputBuffer).toEqual(
+    await expect(client.stderr).toOutput(
       'Error! `--token` may not be used with the "login" command\n'
     );
   });
@@ -17,10 +17,8 @@ describe('login', () => {
     client.setArgv('login', user.email);
     const exitCode = await login(client);
     expect(exitCode).toEqual(0);
-    expect(
-      client.outputBuffer.includes(
-        `Success! Email authentication complete for ${user.email}`
-      )
-    ).toEqual(true);
+    await expect(client.stderr).toOutput(
+      `Success! Email authentication complete for ${user.email}`
+    );
   });
 });

--- a/packages/cli/test/unit/commands/login.test.ts
+++ b/packages/cli/test/unit/commands/login.test.ts
@@ -5,20 +5,20 @@ import { useUser } from '../../mocks/user';
 describe('login', () => {
   it('should not allow the `--token` flag', async () => {
     client.setArgv('login', '--token', 'foo');
-    const exitCode = await login(client);
-    expect(exitCode).toEqual(2);
+    const exitCodePromise = login(client);
     await expect(client.stderr).toOutput(
       'Error! `--token` may not be used with the "login" command\n'
     );
+    await expect(exitCodePromise).resolves.toEqual(2);
   });
 
   it('should allow login via email as argument', async () => {
     const user = useUser();
     client.setArgv('login', user.email);
-    const exitCode = await login(client);
-    expect(exitCode).toEqual(0);
+    const exitCodePromise = login(client);
     await expect(client.stderr).toOutput(
       `Success! Email authentication complete for ${user.email}`
     );
+    await expect(exitCodePromise).resolves.toEqual(0);
   });
 });

--- a/packages/cli/test/unit/commands/pull.test.ts
+++ b/packages/cli/test/unit/commands/pull.test.ts
@@ -18,8 +18,17 @@ describe('pull', () => {
       name: 'vercel-pull-next',
     });
     client.setArgv('pull', cwd);
-    const exitCode = await pull(client);
-    expect(exitCode, client.outputBuffer).toEqual(0);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      'Downloading "development" Environment Variables for Project vercel-pull-next'
+    );
+    await expect(client.stderr).toOutput(
+      'Created .vercel/.env.development.local file'
+    );
+    await expect(client.stderr).toOutput(
+      'Downloaded project settings to .vercel/project.json'
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
 
     const rawDevEnv = await fs.readFile(
       path.join(cwd, '.vercel', '.env.development.local')
@@ -29,23 +38,18 @@ describe('pull', () => {
   });
 
   it('should fail with message to pull without a link and without --env', async () => {
-    try {
-      process.stdout.isTTY = undefined;
+    client.stdin.isTTY = false;
 
-      const cwd = setupFixture('vercel-pull-unlinked');
-      useUser();
-      useTeams('team_dummy');
+    const cwd = setupFixture('vercel-pull-unlinked');
+    useUser();
+    useTeams('team_dummy');
 
-      client.setArgv('pull', cwd);
-      const exitCode = await pull(client);
-      expect(exitCode, client.outputBuffer).toEqual(1);
-
-      expect(client.outputBuffer).toMatch(
-        /Command `vercel pull` requires confirmation. Use option "--yes" to confirm./gm
-      );
-    } finally {
-      process.stdout.isTTY = true;
-    }
+    client.setArgv('pull', cwd);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      'Command `vercel pull` requires confirmation. Use option "--yes" to confirm.'
+    );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should fail without message to pull without a link and with --env', async () => {
@@ -54,12 +58,11 @@ describe('pull', () => {
     useTeams('team_dummy');
 
     client.setArgv('pull', cwd, '--yes');
-    const exitCode = await pull(client);
-    expect(exitCode, client.outputBuffer).toEqual(1);
-
-    expect(client.outputBuffer).not.toMatch(
-      /Command `vercel pull` requires confirmation. Use option "--yes" to confirm./gm
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).not.toOutput(
+      'Command `vercel pull` requires confirmation. Use option "--yes" to confirm.'
     );
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should handle pulling with env vars (headless mode)', async () => {
@@ -81,8 +84,17 @@ describe('pull', () => {
         name: 'vercel-pull-next',
       });
       client.setArgv('pull', cwd);
-      const exitCode = await pull(client);
-      expect(exitCode, client.outputBuffer).toEqual(0);
+      const exitCodePromise = pull(client);
+      await expect(client.stderr).toOutput(
+        'Downloading "development" Environment Variables for Project vercel-pull-next'
+      );
+      await expect(client.stderr).toOutput(
+        'Created .vercel/.env.development.local file'
+      );
+      await expect(client.stderr).toOutput(
+        'Downloaded project settings to .vercel/project.json'
+      );
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       const config = await fs.readJSON(path.join(cwd, '.vercel/project.json'));
       expect(config).toMatchInlineSnapshot(`

--- a/packages/cli/test/unit/commands/pull.test.ts
+++ b/packages/cli/test/unit/commands/pull.test.ts
@@ -120,8 +120,17 @@ describe('pull', () => {
       name: 'vercel-pull-next',
     });
     client.setArgv('pull', '--environment=preview', cwd);
-    const exitCode = await pull(client);
-    expect(exitCode).toEqual(0);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      'Downloading "preview" Environment Variables for Project vercel-pull-next'
+    );
+    await expect(client.stderr).toOutput(
+      'Created .vercel/.env.preview.local file'
+    );
+    await expect(client.stderr).toOutput(
+      'Downloaded project settings to .vercel/project.json'
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
 
     const rawPreviewEnv = await fs.readFile(
       path.join(cwd, '.vercel', '.env.preview.local')
@@ -142,8 +151,17 @@ describe('pull', () => {
       name: 'vercel-pull-next',
     });
     client.setArgv('pull', '--environment=production', cwd);
-    const exitCode = await pull(client);
-    expect(exitCode).toEqual(0);
+    const exitCodePromise = pull(client);
+    await expect(client.stderr).toOutput(
+      'Downloading "production" Environment Variables for Project vercel-pull-next'
+    );
+    await expect(client.stderr).toOutput(
+      'Created .vercel/.env.production.local file'
+    );
+    await expect(client.stderr).toOutput(
+      'Downloaded project settings to .vercel/project.json'
+    );
+    await expect(exitCodePromise).resolves.toEqual(0);
 
     const rawProdEnv = await fs.readFile(
       path.join(cwd, '.vercel', '.env.production.local')

--- a/packages/cli/test/unit/commands/pull.test.ts
+++ b/packages/cli/test/unit/commands/pull.test.ts
@@ -23,10 +23,10 @@ describe('pull', () => {
       'Downloading "development" Environment Variables for Project vercel-pull-next'
     );
     await expect(client.stderr).toOutput(
-      'Created .vercel/.env.development.local file'
+      `Created .vercel${path.sep}.env.development.local file`
     );
     await expect(client.stderr).toOutput(
-      'Downloaded project settings to .vercel/project.json'
+      `Downloaded project settings to .vercel${path.sep}project.json`
     );
     await expect(exitCodePromise).resolves.toEqual(0);
 
@@ -89,10 +89,10 @@ describe('pull', () => {
         'Downloading "development" Environment Variables for Project vercel-pull-next'
       );
       await expect(client.stderr).toOutput(
-        'Created .vercel/.env.development.local file'
+        `Created .vercel${path.sep}.env.development.local file`
       );
       await expect(client.stderr).toOutput(
-        'Downloaded project settings to .vercel/project.json'
+        `Downloaded project settings to .vercel${path.sep}project.json`
       );
       await expect(exitCodePromise).resolves.toEqual(0);
 
@@ -125,10 +125,10 @@ describe('pull', () => {
       'Downloading "preview" Environment Variables for Project vercel-pull-next'
     );
     await expect(client.stderr).toOutput(
-      'Created .vercel/.env.preview.local file'
+      `Created .vercel${path.sep}.env.preview.local file`
     );
     await expect(client.stderr).toOutput(
-      'Downloaded project settings to .vercel/project.json'
+      `Downloaded project settings to .vercel${path.sep}project.json`
     );
     await expect(exitCodePromise).resolves.toEqual(0);
 
@@ -156,10 +156,10 @@ describe('pull', () => {
       'Downloading "production" Environment Variables for Project vercel-pull-next'
     );
     await expect(client.stderr).toOutput(
-      'Created .vercel/.env.production.local file'
+      `Created .vercel${path.sep}.env.production.local file`
     );
     await expect(client.stderr).toOutput(
-      'Downloaded project settings to .vercel/project.json'
+      `Downloaded project settings to .vercel${path.sep}project.json`
     );
     await expect(exitCodePromise).resolves.toEqual(0);
 

--- a/packages/cli/test/unit/commands/whoami.test.ts
+++ b/packages/cli/test/unit/commands/whoami.test.ts
@@ -1,6 +1,7 @@
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
 import whoami from '../../../src/commands/whoami';
+import { Readable } from 'stream';
 
 describe('whoami', () => {
   it('should reject invalid arguments', async () => {
@@ -14,14 +15,14 @@ describe('whoami', () => {
     const user = useUser();
     const exitCode = await whoami(client);
     expect(exitCode).toEqual(0);
-    expect(client.outputBuffer).toEqual(`> ${user.username}\n`);
+    await expect(client.stderr).toWaitFor(`> ${user.username}\n`);
   });
 
   it('should print only the Vercel username when output is not a TTY', async () => {
     const user = useUser();
-    client.output.isTTY = false;
+    client.stdout.isTTY = undefined;
     const exitCode = await whoami(client);
     expect(exitCode).toEqual(0);
-    expect(client.outputBuffer).toEqual(`${user.username}\n`);
+    await expect(client.stdout).toWaitFor(`${user.username}\n`);
   });
 });

--- a/packages/cli/test/unit/commands/whoami.test.ts
+++ b/packages/cli/test/unit/commands/whoami.test.ts
@@ -1,7 +1,6 @@
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
 import whoami from '../../../src/commands/whoami';
-import { Readable } from 'stream';
 
 describe('whoami', () => {
   it('should reject invalid arguments', async () => {
@@ -15,14 +14,14 @@ describe('whoami', () => {
     const user = useUser();
     const exitCode = await whoami(client);
     expect(exitCode).toEqual(0);
-    await expect(client.stderr).toWaitFor(`> ${user.username}\n`);
+    await expect(client.stderr).toOutput(`> ${user.username}\n`);
   });
 
   it('should print only the Vercel username when output is not a TTY', async () => {
     const user = useUser();
-    client.stdout.isTTY = undefined;
+    client.stdout.isTTY = false;
     const exitCode = await whoami(client);
     expect(exitCode).toEqual(0);
-    await expect(client.stdout).toWaitFor(`${user.username}\n`);
+    await expect(client.stdout).toOutput(`${user.username}\n`);
   });
 });

--- a/packages/cli/test/unit/mock.test.ts
+++ b/packages/cli/test/unit/mock.test.ts
@@ -6,20 +6,25 @@ describe('MockClient', () => {
     // true
     let confirmedPromise = confirm(client, 'Do the thing?', false);
 
-    client.stdin.write('yes\n');
+    //await client.expectStderr('Do the thing? [y/Nn');
+    //expect(await client.expectStderr('Do the thing? [y/Nn')).
+    await expect(client.stderr).toWaitFor('Do the thing? [y/N]');
 
-    client.stdout.setEncoding('utf8');
-    client.stdout.on('data', d => console.log({ d }));
+    client.stdin.write('yes\n');
 
     let confirmed = await confirmedPromise;
     expect(confirmed).toEqual(true);
 
+    //client.output.log('test');
+    console.log(client.stderr.write('test'));
+    await client.expectStderr('test');
     // false
-    confirmedPromise = confirm(client, 'Do the thing?', false);
+    //confirmedPromise = confirm(client, 'Do the thing?', true);
+    //await client.expectStderr('Do the thing? [Y/n]');
 
-    client.stdin.write('no\n');
+    //client.stdin.write('no\n');
 
-    confirmed = await confirmedPromise;
-    expect(confirmed).toEqual(false);
+    //confirmed = await confirmedPromise;
+    //expect(confirmed).toEqual(false);
   });
 });

--- a/packages/cli/test/unit/mock.test.ts
+++ b/packages/cli/test/unit/mock.test.ts
@@ -3,28 +3,32 @@ import { client } from '../mocks/client';
 
 describe('MockClient', () => {
   it('should mock `confirm()`', async () => {
-    // true
+    // true (explicit)
     let confirmedPromise = confirm(client, 'Do the thing?', false);
-
-    //await client.expectStderr('Do the thing? [y/Nn');
-    //expect(await client.expectStderr('Do the thing? [y/Nn')).
-    await expect(client.stderr).toWaitFor('Do the thing? [y/N]');
-
+    await expect(client.stderr).toOutput('Do the thing? [y/N]');
     client.stdin.write('yes\n');
-
     let confirmed = await confirmedPromise;
     expect(confirmed).toEqual(true);
 
-    //client.output.log('test');
-    console.log(client.stderr.write('test'));
-    await client.expectStderr('test');
-    // false
-    //confirmedPromise = confirm(client, 'Do the thing?', true);
-    //await client.expectStderr('Do the thing? [Y/n]');
+    // false (explicit)
+    confirmedPromise = confirm(client, 'Do the thing?', true);
+    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    client.stdin.write('no\n');
+    confirmed = await confirmedPromise;
+    expect(confirmed).toEqual(false);
 
-    //client.stdin.write('no\n');
+    // true (default)
+    confirmedPromise = confirm(client, 'Do the thing?', true);
+    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    client.stdin.write('\n');
+    confirmed = await confirmedPromise;
+    expect(confirmed).toEqual(true);
 
-    //confirmed = await confirmedPromise;
-    //expect(confirmed).toEqual(false);
+    // false (default)
+    confirmedPromise = confirm(client, 'Do the thing?', false);
+    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    client.stdin.write('\n');
+    confirmed = await confirmedPromise;
+    expect(confirmed).toEqual(false);
   });
 });

--- a/packages/cli/test/unit/mock.test.ts
+++ b/packages/cli/test/unit/mock.test.ts
@@ -4,29 +4,29 @@ import { client } from '../mocks/client';
 describe('MockClient', () => {
   it('should mock `confirm()`', async () => {
     // true (explicit)
-    let confirmedPromise = confirm(client, 'Do the thing?', false);
-    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    let confirmedPromise = confirm(client, 'Explictly true?', false);
+    await expect(client.stderr).toOutput('Explictly true? [y/N]');
     client.stdin.write('yes\n');
     let confirmed = await confirmedPromise;
     expect(confirmed).toEqual(true);
 
     // false (explicit)
-    confirmedPromise = confirm(client, 'Do the thing?', true);
-    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    confirmedPromise = confirm(client, 'Explcitly false?', true);
+    await expect(client.stderr).toOutput('Explcitly false? [Y/n]');
     client.stdin.write('no\n');
     confirmed = await confirmedPromise;
     expect(confirmed).toEqual(false);
 
     // true (default)
-    confirmedPromise = confirm(client, 'Do the thing?', true);
-    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    confirmedPromise = confirm(client, 'Default true?', true);
+    await expect(client.stderr).toOutput('Default true? [Y/n]');
     client.stdin.write('\n');
     confirmed = await confirmedPromise;
     expect(confirmed).toEqual(true);
 
     // false (default)
-    confirmedPromise = confirm(client, 'Do the thing?', false);
-    await expect(client.stderr).toOutput('Do the thing? [y/N]');
+    confirmedPromise = confirm(client, 'Default false?', false);
+    await expect(client.stderr).toOutput('Default false? [y/N]');
     client.stdin.write('\n');
     confirmed = await confirmedPromise;
     expect(confirmed).toEqual(false);

--- a/packages/cli/test/unit/util/confirm.test.ts
+++ b/packages/cli/test/unit/util/confirm.test.ts
@@ -1,8 +1,8 @@
-import confirm from '../../src/util/input/confirm';
-import { client } from '../mocks/client';
+import confirm from '../../../src/util/input/confirm';
+import { client } from '../../mocks/client';
 
-describe('MockClient', () => {
-  it('should mock `confirm()`', async () => {
+describe('confirm()', () => {
+  it('should work with multiple prompts', async () => {
     // true (explicit)
     let confirmedPromise = confirm(client, 'Explictly true?', false);
     await expect(client.stderr).toOutput('Explictly true? [y/N]');

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -22,10 +22,7 @@ describe('getRemoteUrl', () => {
     client.output.debugEnabled = true;
     const data = await getRemoteUrl(join(dir, 'git/config'), client.output);
     expect(data).toBeNull();
-    expect(
-      client.outputBuffer.includes('Error while parsing repo data'),
-      'Debug message was not found'
-    ).toBeTruthy();
+    await expect(client.stderr).toOutput('Error while parsing repo data');
   });
 });
 

--- a/packages/cli/test/unit/util/get-files.test.ts
+++ b/packages/cli/test/unit/util/get-files.test.ts
@@ -1,18 +1,15 @@
 import { join, sep } from 'path';
 // @ts-ignore - Missing types for "alpha-sort"
 import { asc as alpha } from 'alpha-sort';
-import createOutput from '../../../src/util/output';
 import { staticFiles as getStaticFiles_ } from '../../../src/util/get-files';
+import { client } from '../../mocks/client';
 
-const output = createOutput({ debug: false });
 const prefix = `${join(__dirname, '../../fixtures/unit')}${sep}`;
 const base = (path: string) => path.replace(prefix, '');
 const fixture = (name: string) => join(prefix, name);
 
 const getStaticFiles = async (dir: string) => {
-  const files = await getStaticFiles_(dir, {
-    output,
-  });
+  const files = await getStaticFiles_(dir, client);
   return normalizeWindowsPaths(files);
 };
 

--- a/packages/cli/test/unit/util/input/edit-project-settings.test.ts
+++ b/packages/cli/test/unit/util/input/edit-project-settings.test.ts
@@ -27,14 +27,13 @@ describe('editProjectSettings', () => {
         installCommand: null,
         outputDirectory: null,
       });
-      expect(client.mockOutput.mock.calls.length).toBe(5);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /No framework detected. Default Project Settings:/
+      await expect(client.stderr).toOutput(
+        'No framework detected. Default Project Settings:'
       );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
+      await expect(client.stderr).toOutput('Build Command');
+      await expect(client.stderr).toOutput('Development Command');
+      await expect(client.stderr).toOutput('Install Command');
+      await expect(client.stderr).toOutput('Output Directory');
     });
   });
 
@@ -55,14 +54,13 @@ describe('editProjectSettings', () => {
         null
       );
       expect(settings).toStrictEqual({ ...projectSettings, framework: null });
-      expect(client.mockOutput.mock.calls.length).toBe(5);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /No framework detected. Default Project Settings:/
+      await expect(client.stderr).toOutput(
+        'No framework detected. Default Project Settings:'
       );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
+      await expect(client.stderr).toOutput('Build Command');
+      await expect(client.stderr).toOutput('Development Command');
+      await expect(client.stderr).toOutput('Install Command');
+      await expect(client.stderr).toOutput('Output Directory');
     });
   });
 
@@ -82,18 +80,15 @@ describe('editProjectSettings', () => {
         true,
         null
       );
-      expect(client.mockOutput.mock.calls.length).toBe(5);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /Auto-detected Project Settings/
-      );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Development Command/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(/Install Command/);
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Output Directory/);
       expect(settings).toStrictEqual({
         ...projectSettings,
         framework: nextJSFramework.slug,
       });
+      await expect(client.stderr).toOutput('Auto-detected Project Settings');
+      await expect(client.stderr).toOutput('Build Command');
+      await expect(client.stderr).toOutput('Development Command');
+      await expect(client.stderr).toOutput('Install Command');
+      await expect(client.stderr).toOutput('Output Directory');
     });
   });
 
@@ -121,26 +116,20 @@ describe('editProjectSettings', () => {
         true,
         overrides
       );
-      expect(client.mockOutput.mock.calls.length).toBe(9);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /Local settings detected in vercel.json:/
-      );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(
-        /Development Command:/
-      );
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
-      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
-      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
-      expect(client.mockOutput.mock.calls[7][0]).toMatch(
-        /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
-      );
-      expect(client.mockOutput.mock.calls[8][0]).toMatch(
-        /Auto-detected Project Settings/
-      );
-
       expect(settings).toStrictEqual(overrides);
+      await expect(client.stderr).toOutput(
+        'Local settings detected in vercel.json:'
+      );
+      await expect(client.stderr).toOutput('Build Command:');
+      await expect(client.stderr).toOutput('Ignore Command:');
+      await expect(client.stderr).toOutput('Development Command:');
+      await expect(client.stderr).toOutput('Framework:');
+      await expect(client.stderr).toOutput('Install Command:');
+      await expect(client.stderr).toOutput('Output Directory:');
+      await expect(client.stderr).toOutput(
+        'Merging default Project Settings for Svelte. Previously listed overrides are prioritized.'
+      );
+      await expect(client.stderr).toOutput('Auto-detected Project Settings');
     });
   });
 
@@ -161,25 +150,20 @@ describe('editProjectSettings', () => {
         true,
         overrides
       );
-      expect(client.mockOutput.mock.calls.length).toBe(9);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /Local settings detected in vercel.json:/
-      );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(
-        /Development Command:/
-      );
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
-      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
-      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
-      expect(client.mockOutput.mock.calls[7][0]).toMatch(
-        /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
-      );
-      expect(client.mockOutput.mock.calls[8][0]).toMatch(
-        /Auto-detected Project Settings/
-      );
       expect(settings).toStrictEqual(overrides);
+      await expect(client.stderr).toOutput(
+        'Local settings detected in vercel.json:'
+      );
+      await expect(client.stderr).toOutput('Build Command:');
+      await expect(client.stderr).toOutput('Ignore Command:');
+      await expect(client.stderr).toOutput('Development Command:');
+      await expect(client.stderr).toOutput('Framework:');
+      await expect(client.stderr).toOutput('Install Command:');
+      await expect(client.stderr).toOutput('Output Directory:');
+      await expect(client.stderr).toOutput(
+        'Merging default Project Settings for Svelte. Previously listed overrides are prioritized.'
+      );
+      await expect(client.stderr).toOutput('Auto-detected Project Settings');
     });
   });
 
@@ -200,26 +184,20 @@ describe('editProjectSettings', () => {
         true,
         overrides
       );
-      expect(client.mockOutput.mock.calls.length).toBe(9);
-      expect(client.mockOutput.mock.calls[0][0]).toMatch(
-        /Local settings detected in vercel.json:/
-      );
-      expect(client.mockOutput.mock.calls[1][0]).toMatch(/Build Command:/);
-      expect(client.mockOutput.mock.calls[2][0]).toMatch(/Ignore Command:/);
-      expect(client.mockOutput.mock.calls[3][0]).toMatch(
-        /Development Command:/
-      );
-      expect(client.mockOutput.mock.calls[4][0]).toMatch(/Framework:/);
-      expect(client.mockOutput.mock.calls[5][0]).toMatch(/Install Command:/);
-      expect(client.mockOutput.mock.calls[6][0]).toMatch(/Output Directory:/);
-      expect(client.mockOutput.mock.calls[7][0]).toMatch(
-        /Merging default Project Settings for Svelte. Previously listed overrides are prioritized./
-      );
-      expect(client.mockOutput.mock.calls[8][0]).toMatch(
-        /Auto-detected Project Settings/
-      );
-
       expect(settings).toStrictEqual(overrides);
+      await expect(client.stderr).toOutput(
+        'Local settings detected in vercel.json:'
+      );
+      await expect(client.stderr).toOutput('Build Command:');
+      await expect(client.stderr).toOutput('Ignore Command:');
+      await expect(client.stderr).toOutput('Development Command:');
+      await expect(client.stderr).toOutput('Framework:');
+      await expect(client.stderr).toOutput('Install Command:');
+      await expect(client.stderr).toOutput('Output Directory:');
+      await expect(client.stderr).toOutput(
+        'Merging default Project Settings for Svelte. Previously listed overrides are prioritized.'
+      );
+      await expect(client.stderr).toOutput('Auto-detected Project Settings');
     });
   });
 });


### PR DESCRIPTION
This PR is a follow-up to #8039, which provides an intuitive syntax for writing unit tests for interactive CLI commands.

The heart of this is the new `await expect(stream).toOutput(test)` custom Jest matcher, which is intended for use with the mock Client `stdout` and `stderr` stream properties. The `test` is a string that will wait for the stream to output via "data" events until a match is found, or it will timeout (after 3 seconds by default). The timeout error has nice Jest-style formatting so that you can easily identify what was output:

<img width="553" alt="Screen Shot 2022-06-29 at 10 33 06 PM" src="https://user-images.githubusercontent.com/71256/176600324-cb1ebecb-e891-42d9-bdc9-4864d3594a8c.png">

Below is an example of a unit test that was added for an interactive `vc login` session:

```typescript
it('should allow login via email', async () => {
  const user = useUser();

  const exitCodePromise = login(client);

  // Wait for login interactive prompt
  await expect(client.stderr).toOutput(`> Log in to Vercel`);

  // Move down to "Email" option
  client.stdin.write('\x1B[B'); // Down arrow
  client.stdin.write('\x1B[B'); // Down arrow
  client.stdin.write('\x1B[B'); // Down arrow
  client.stdin.write('\r'); // Return key

  // Wait for email input prompt
  await expect(client.stderr).toOutput('> Enter your email address:');

  // Write user email address into prompt
  client.stdin.write(`${user.email}\n`);

  // Wait for login success message
  await expect(client.stderr).toOutput(
    `Success! Email authentication complete for ${user.email}`
  );

  // Assert that the `login()` command returned 0 exit code
  await expect(exitCodePromise).resolves.toEqual(0);
});
```

**Note:**  as a consequence of this PR, prompts are now written to stderr instead of stdout, so this change _may_ be considered a breaking change, in which case we should tag it for major release.