### PR TITLE
[build-utils] Handle `npm bin` exit code 7

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -180,6 +180,7 @@ export async function getNodeBinPath({
 }): Promise<string | undefined> {
   const { code, stdout, stderr } = await execAsync('npm', ['bin'], {
     cwd,
+    prettyCommand: 'npm bin',
     ignoreNon0Exit: true,
   });
 

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -63,10 +63,11 @@ export interface SpawnOptionsExtended extends SpawnOptions {
   prettyCommand?: string;
 
   /**
-   * Returns instead of throwing an error. When relevant, the returned object
-   * will include the error code, stdout and stderr.
+   * Returns instead of throwing an error when the process exits with a
+   * non-0 exit code. When relevant, the returned object will include
+   * the error code, stdout and stderr.
    */
-  returnInsteadOfThrowing?: boolean;
+  ignoreNon0Exit?: boolean;
 }
 
 export function spawnAsync(
@@ -85,7 +86,7 @@ export function spawnAsync(
 
     child.on('error', reject);
     child.on('close', (code, signal) => {
-      if (code === 0 || opts.returnInsteadOfThrowing) {
+      if (code === 0 || opts.ignoreNon0Exit) {
         return resolve();
       }
 
@@ -129,7 +130,7 @@ export function execAsync(
 
       child.on('error', reject);
       child.on('close', (code, signal) => {
-        if (code === 0 || opts.returnInsteadOfThrowing) {
+        if (code === 0 || opts.ignoreNon0Exit) {
           return resolve({
             code,
             stdout: Buffer.concat(stdoutList).toString(),
@@ -179,7 +180,7 @@ export async function getNodeBinPath({
 }): Promise<string | undefined> {
   const { code, stdout, stderr } = await execAsync('npm', ['bin'], {
     cwd,
-    returnInsteadOfThrowing: true,
+    ignoreNon0Exit: true,
   });
 
   // in some rare cases, we saw `npm bin` exit with code 7, but still

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -19,7 +19,7 @@ it('should return if the command exits with non-0 code and ignoreNon0Exit=true',
     ignoreNon0Exit: true,
   });
 
-  expect(code).toBe(1);
+  expect(code).toBe(process.platform === 'win32' ? 2 : 1);
   expect(stdout).toBe('');
   expect(stderr).toContain('No such file or directory');
 });

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -4,18 +4,18 @@ it('should execute a command', async () => {
   const { code, stdout, stderr } = await execAsync('echo', ['hello']);
 
   expect(code).toBe(0);
-  expect(stdout).toBe('hello\n');
+  expect(stdout).toContain('hello');
   expect(stderr).toBe('');
 });
 
 it('should throw if the command exits with non-0 code', async () => {
-  await expect(execAsync('cat', ['unknown-file'])).rejects.toBeInstanceOf(
+  await expect(execAsync('cd', ['unknown-dir'])).rejects.toBeInstanceOf(
     NowBuildError
   );
 });
 
 it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
-  const { code, stdout, stderr } = await execAsync('cat', ['unknown-file'], {
+  const { code, stdout, stderr } = await execAsync('cd', ['unknown-dir'], {
     ignoreNon0Exit: true,
   });
 

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -3,7 +3,7 @@ import { execAsync, NowBuildError } from '../src';
 it('should execute a command', async () => {
   const { code, stdout, stderr } = await execAsync('echo', ['hello']);
 
-  expect(code).toBe(0);
+  expect(code).toBe(process.platform === 'win32' ? 2 : 1);
   expect(stdout).toContain('hello');
   expect(stderr).toBe('');
 });

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -3,7 +3,7 @@ import { execAsync, NowBuildError } from '../src';
 it('should execute a command', async () => {
   const { code, stdout, stderr } = await execAsync('echo', ['hello']);
 
-  expect(code).toBe(process.platform === 'win32' ? 2 : 1);
+  expect(code).toBe(0);
   expect(stdout).toContain('hello');
   expect(stderr).toBe('');
 });

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -1,0 +1,25 @@
+import { execAsync, NowBuildError } from '../src';
+
+it('should execute a command', async () => {
+  const { code, stdout, stderr } = await execAsync('echo', ['hello']);
+
+  expect(code).toBe(0);
+  expect(stdout).toBe('hello\n');
+  expect(stderr).toBe('');
+});
+
+it('should throw if the command exits with non-0 code', async () => {
+  await expect(execAsync('cat', ['unknown-file'])).rejects.toBeInstanceOf(
+    NowBuildError
+  );
+});
+
+it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
+  const { code, stdout, stderr } = await execAsync('cat', ['unknown-file'], {
+    ignoreNon0Exit: true,
+  });
+
+  expect(code).toBe(1);
+  expect(stdout).toBe('');
+  expect(stderr).toContain('No such file or directory');
+});

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -21,5 +21,9 @@ it('should return if the command exits with non-0 code and ignoreNon0Exit=true',
 
   expect(code).toBe(process.platform === 'win32' ? 2 : 1);
   expect(stdout).toBe('');
-  expect(stderr).toContain('No such file or directory');
+  expect(stderr).toContain(
+    process.platform === 'win32'
+      ? 'Parameter format not correct'
+      : 'No such file or directory'
+  );
 });

--- a/packages/build-utils/test/unit.exec-async.test.ts
+++ b/packages/build-utils/test/unit.exec-async.test.ts
@@ -9,13 +9,13 @@ it('should execute a command', async () => {
 });
 
 it('should throw if the command exits with non-0 code', async () => {
-  await expect(execAsync('cd', ['unknown-dir'])).rejects.toBeInstanceOf(
+  await expect(execAsync('find', ['unknown-file'])).rejects.toBeInstanceOf(
     NowBuildError
   );
 });
 
 it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
-  const { code, stdout, stderr } = await execAsync('cd', ['unknown-dir'], {
+  const { code, stdout, stderr } = await execAsync('find', ['unknown-file'], {
     ignoreNon0Exit: true,
   });
 

--- a/packages/build-utils/test/unit.spawn-async.test.ts
+++ b/packages/build-utils/test/unit.spawn-async.test.ts
@@ -1,0 +1,15 @@
+import { spawnAsync, NowBuildError } from '../src';
+
+it('should execute a command', async () => {
+  await expect(spawnAsync('echo', ['hello'])).resolves.toBeDefined();
+});
+
+it('should throw if the command exits with non-0 code', async () => {
+  await expect(spawnAsync('cat', ['unknown-file'])).rejects.toBeInstanceOf(
+    NowBuildError
+  );
+});
+
+it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
+  await expect(spawnAsync('echo', ['hello'])).resolves.toBeDefined();
+});

--- a/packages/build-utils/test/unit.spawn-async.test.ts
+++ b/packages/build-utils/test/unit.spawn-async.test.ts
@@ -6,7 +6,7 @@ it('should execute a command', async () => {
 });
 
 it('should throw if the command exits with non-0 code', async () => {
-  await expect(spawnAsync('cat', ['unknown-file'])).rejects.toBeInstanceOf(
+  await expect(spawnAsync('cd', ['unknown-dir'])).rejects.toBeInstanceOf(
     NowBuildError
   );
 });
@@ -14,7 +14,7 @@ it('should throw if the command exits with non-0 code', async () => {
 it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
   // should resolve (it doesn't return anything, so it resolves with "undefined")
   await expect(
-    spawnAsync('echo', ['hello'], {
+    spawnAsync('cd', ['unknown-dir'], {
       ignoreNon0Exit: true,
     })
   ).resolves.toBeUndefined();

--- a/packages/build-utils/test/unit.spawn-async.test.ts
+++ b/packages/build-utils/test/unit.spawn-async.test.ts
@@ -1,7 +1,8 @@
 import { spawnAsync, NowBuildError } from '../src';
 
 it('should execute a command', async () => {
-  await expect(spawnAsync('echo', ['hello'])).resolves.toBeDefined();
+  // should resolve (it doesn't return anything, so it resolves with "undefined")
+  await expect(spawnAsync('echo', ['hello'])).resolves.toBeUndefined();
 });
 
 it('should throw if the command exits with non-0 code', async () => {
@@ -11,5 +12,10 @@ it('should throw if the command exits with non-0 code', async () => {
 });
 
 it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
-  await expect(spawnAsync('echo', ['hello'])).resolves.toBeDefined();
+  // should resolve (it doesn't return anything, so it resolves with "undefined")
+  await expect(
+    spawnAsync('echo', ['hello'], {
+      ignoreNon0Exit: true,
+    })
+  ).resolves.toBeUndefined();
 });

--- a/packages/build-utils/test/unit.spawn-async.test.ts
+++ b/packages/build-utils/test/unit.spawn-async.test.ts
@@ -6,7 +6,7 @@ it('should execute a command', async () => {
 });
 
 it('should throw if the command exits with non-0 code', async () => {
-  await expect(spawnAsync('cd', ['unknown-dir'])).rejects.toBeInstanceOf(
+  await expect(spawnAsync('find', ['unknown-file'])).rejects.toBeInstanceOf(
     NowBuildError
   );
 });
@@ -14,7 +14,7 @@ it('should throw if the command exits with non-0 code', async () => {
 it('should return if the command exits with non-0 code and ignoreNon0Exit=true', async () => {
   // should resolve (it doesn't return anything, so it resolves with "undefined")
   await expect(
-    spawnAsync('cd', ['unknown-dir'], {
+    spawnAsync('find', ['unknown-file'], {
       ignoreNon0Exit: true,
     })
   ).resolves.toBeUndefined();


### PR DESCRIPTION
In some rare cases, `npm bin` exits with code 7, but still outputs the right bin path.

To reproduce, try:
```
npm init -y
echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
vc
# enter "echo build" for the build command, leave the other configuration as default
```

The build will fail with `Error: Command exited with 7` because `npm bin` fails with code 7, for some reason.

In this PR, we do 2 things:
(1) Ignore exit codes from `npm bin`. It still outputs the right path when it exits with code 7 so we just read the output and check if it's a valid path.
(2) Throw a more specific error message when `npm bin` fails to give us the bin path. The current error was hard to debug because it looked like it was coming from the install commmand. We can do better by emitting a custom error.

Alternative considered for (2): Do not throw errors. If `npm bin` fails, emit a warning and let the build continue.

Related Issues:
- https://github.com/vercel/customer-issues/issues/585 (internal)
