### PR TITLE
[next] Update trailing slash handling for _next/data resolving

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -924,6 +924,7 @@ export const build: BuildV2 = async ({
   }
 
   const trailingSlashRedirects: Route[] = [];
+  let trailingSlash = false;
 
   redirects = redirects.filter(_redir => {
     const redir = _redir as Source;
@@ -941,6 +942,10 @@ export const build: BuildV2 = async ({
       // moving underneath i18n routes
       redir.continue = true;
       trailingSlashRedirects.push(redir);
+
+      if (location === '/$1/') {
+        trailingSlash = true;
+      }
       return false;
     }
     return true;
@@ -1257,6 +1262,7 @@ export const build: BuildV2 = async ({
       return serverBuild({
         config,
         nextVersion,
+        trailingSlash,
         dynamicPages,
         canUsePreviewMode,
         staticPages,

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -85,6 +85,7 @@ export async function serverBuild({
   lambdaPages,
   nextVersion,
   canUsePreviewMode,
+  trailingSlash,
   prerenderManifest,
   omittedPrerenderRoutes,
   trailingSlashRedirects,
@@ -93,6 +94,7 @@ export async function serverBuild({
   requiredServerFilesManifest,
 }: {
   dynamicPages: string[];
+  trailingSlash: boolean;
   config: Config;
   pagesDir: string;
   baseDir: string;
@@ -885,7 +887,12 @@ export async function serverBuild({
               escapedBuildId,
               '/(.*).json'
             )}`,
-            dest: `${path.join('/', entryDirectory, '/$1')}`,
+            dest: `${path.join(
+              '/',
+              entryDirectory,
+              '/$1',
+              trailingSlash ? '/' : ''
+            )}`,
             ...(isOverride ? { override: true } : {}),
             continue: true,
             has: [
@@ -898,14 +905,14 @@ export async function serverBuild({
           // normalize "/index" from "/_next/data/index.json" to -> just "/"
           // as matches a rewrite sources will expect just "/"
           {
-            src: path.join('^/', entryDirectory, '/index'),
+            src: path.join('^/', entryDirectory, '/index(?:/)?'),
             has: [
               {
                 type: 'header',
                 key: 'x-nextjs-data',
               },
             ],
-            dest: path.join('/', entryDirectory),
+            dest: path.join('/', entryDirectory, trailingSlash ? '/' : ''),
             ...(isOverride ? { override: true } : {}),
             continue: true,
           },
@@ -917,7 +924,7 @@ export async function serverBuild({
     return isNextDataServerResolving
       ? [
           {
-            src: path.join('^/', entryDirectory, '$'),
+            src: path.join('^/', entryDirectory, trailingSlash ? '/' : '', '$'),
             has: [
               {
                 type: 'header',
@@ -934,7 +941,6 @@ export async function serverBuild({
             continue: true,
             ...(isOverride ? { override: true } : {}),
           },
-          // handle non-trailing slash
           {
             src: path.join(
               '^/',


### PR DESCRIPTION
This ensures we correctly add a trailing slash when it is expected to be present in the destination during `_next/data` resolving with middleware. Tests are added in https://github.com/vercel/next.js/pull/38282

### Related Issues

x-ref: https://github.com/vercel/next.js/pull/38282

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
