### PR TITLE
[build-utils] Stricter `getNodeBinPath` return type

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -177,7 +177,7 @@ export async function getNodeBinPath({
   cwd,
 }: {
   cwd: string;
-}): Promise<string | undefined> {
+}): Promise<string> {
   const { code, stdout, stderr } = await execAsync('npm', ['bin'], {
     cwd,
     prettyCommand: 'npm bin',


### PR DESCRIPTION
In https://github.com/vercel/vercel/pull/8058, I made `getNodeBinPath` return type too broad. The function can never return `undefined` so we can make it more strict.
