### PR TITLE
[tests] Update canary dist-tag on publish

### DIFF
--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -33,3 +33,6 @@ fi
 git checkout yarn.lock
 
 yarn run lerna publish from-git $dist_tag --no-verify-access --yes
+
+# always update canary dist-tag as we no longer publish canary versions separate
+node ./update-canary-tag.js

--- a/utils/update-canary-tag.js
+++ b/utils/update-canary-tag.js
@@ -10,7 +10,7 @@ const changedFiles = execSync('git diff HEAD~ --name-only')
 const changedPackageVersions = new Map();
 
 for (const file of changedFiles) {
-  if (file.match(/packages\/.*?\/package.json/)) {
+  if (file.match(/packages\/.+\/package.json/)) {
     const packageData = JSON.parse(
       fs.readFileSync(path.join(__dirname, '../', file), 'utf8')
     );

--- a/utils/update-canary-tag.js
+++ b/utils/update-canary-tag.js
@@ -10,9 +10,9 @@ const changedFiles = execSync('git diff HEAD~ --name-only')
 const changedPackageVersions = new Map();
 
 for (const file of changedFiles) {
-  if (file.match(/packages\/.*?\/package.json/)) {
+  if (file.match(/packages\/.*+\/package.json/)) {
     const packageData = JSON.parse(
-      fs.readFileSync(path.join(__dirname, '../', file), 'utf8')
+      fs.readFileSync(path.join(__dirname, '..', file), 'utf8')
     );
     changedPackageVersions.set(packageData.name, packageData.version);
   }
@@ -21,12 +21,12 @@ for (const file of changedFiles) {
 for (const package of changedPackageVersions.keys()) {
   const version = changedPackageVersions.get(package);
 
-  if (!version.includes('canary')) {
-    console.log(execSync(`npm dist-tag add ${package}@${version} canary`));
-    console.log(`updated canary dist-tag for ${package}@${version}`);
-  } else {
+  if (version.includes('canary')) {
     console.log(
       `skipping ${package}@${version} as it is already a canary version`
     );
+  } else {
+    console.log(execSync(`npm dist-tag add ${package}@${version} canary`));
+    console.log(`updated canary dist-tag for ${package}@${version}`);
   }
 }

--- a/utils/update-canary-tag.js
+++ b/utils/update-canary-tag.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const changedFiles = execSync('git diff HEAD~ --name-only')
+  .toString()
+  .split('\n')
+  .map(file => file.trim());
+
+const changedPackageVersions = new Map();
+
+for (const file of changedFiles) {
+  if (file.match(/packages\/.*?\/package.json/)) {
+    const packageData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '../', file), 'utf8')
+    );
+    changedPackageVersions.set(packageData.name, packageData.version);
+  }
+}
+
+for (const package of changedPackageVersions.keys()) {
+  const version = changedPackageVersions.get(package);
+
+  if (!version.includes('canary')) {
+    console.log(execSync(`npm dist-tag add ${package}@${version} canary`));
+    console.log(`updated canary dist-tag for ${package}@${version}`);
+  } else {
+    console.log(
+      `skipping ${package}@${version} as it is already a canary version`
+    );
+  }
+}

--- a/utils/update-canary-tag.js
+++ b/utils/update-canary-tag.js
@@ -18,8 +18,7 @@ for (const file of changedFiles) {
   }
 }
 
-for (const package of changedPackageVersions.keys()) {
-  const version = changedPackageVersions.get(package);
+for (const [package, version] of changedPackageVersions) {
 
   if (!version.includes('canary')) {
     console.log(execSync(`npm dist-tag add ${package}@${version} canary`));


### PR DESCRIPTION
This ensures we update the canary dist-tag when publishing stable releases as we no longer need to do separate canary publishes.  

### Related Issues

x-ref: [slack thread](https://vercel.slack.com/archives/C65QW9PN1/p1657049930618119?thread_ts=1656362480.574099&cid=C65QW9PN1)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
