### PR TITLE
[cli] Remove redundant mock project endpoint

### DIFF
--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -157,12 +157,6 @@ export function useProject(project: Partial<Project> = defaultProject) {
 
     res.json({ envs });
   });
-  client.scenario.get(`/v4/projects`, (req, res) => {
-    res.json({
-      projects: [defaultProject],
-      pagination: null,
-    });
-  });
 
   return { project, envs };
 }


### PR DESCRIPTION
- https://github.com/vercel/vercel/pull/8053

While writing tests for this PR, I added a mock project endpoint that always returned a default project. This was probably incorrect and no longer needed (tests pass without it). I should have removed it before merging #8053, but I didn't catch this before merging.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
