### PR TITLE
[tests] Fix invoke path of `update-canary-tag.js` script

### DIFF
--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -35,4 +35,4 @@ git checkout yarn.lock
 yarn run lerna publish from-git $dist_tag --no-verify-access --yes
 
 # always update canary dist-tag as we no longer publish canary versions separate
-node ./update-canary-tag.js
+node ./utils/update-canary-tag.js


### PR DESCRIPTION
See related CI failure: https://github.com/vercel/vercel/runs/7228051741?check_suite_focus=true