### PR TITLE
[@vercel/node] favor workPath over repoRootPath

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -339,7 +339,7 @@ export const build: BuildV3 = async ({
   config = {},
   meta = {},
 }) => {
-  const baseDir = repoRootPath || workPath;
+  const baseDir = workPath || repoRootPath;
   const awsLambdaHandler = getAWSLambdaHandler(entrypoint, config);
 
   const { entrypointPath, entrypointFsDirname, nodeVersion, spawnOpts } =


### PR DESCRIPTION
Middleware in monorepos are getting the wrong name, instead of being a simple `middleware`
the name provided is `[full_path_to]/middleware`

This PR changes the `baseDir` to favor `workPath` over `repoRootPath`
