### PR TITLE
[cli] Add `vc project disconnect`

### DIFF
--- a/packages/cli/src/commands/project/disconnect.ts
+++ b/packages/cli/src/commands/project/disconnect.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk';
+import { Org, Project, Team } from '../../types';
+import Client from '../../util/client';
+import { getCommandName } from '../../util/pkg-name';
+import { disconnectGitProvider } from '../../util/projects/connect-git-provider';
+
+export default async function disconnect(
+  client: Client,
+  args: string[],
+  project: Project | undefined,
+  org: Org | undefined,
+  team: Team | null
+) {
+  const { output } = client;
+
+  if (args.length !== 0) {
+    output.error(
+      `Invalid number of arguments. Usage: ${chalk.cyan(
+        `${getCommandName('project disconnect')}`
+      )}`
+    );
+    return 2;
+  }
+  if (!project || !org) {
+    output.error('An unexpected error occurred.');
+    return 1;
+  }
+
+  await disconnectGitProvider(client, team, project.id);
+}

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -10,6 +10,7 @@ import { getPkgName } from '../../util/pkg-name';
 import validatePaths from '../../util/validate-paths';
 import add from './add';
 import connect from './connect';
+import disconnect from './disconnect';
 import list from './list';
 import rm from './rm';
 
@@ -92,7 +93,7 @@ export default async function main(client: Client) {
   let contextName = '';
   let team = null;
 
-  if (subcommand === 'connect') {
+  if (subcommand === 'connect' || subcommand === 'disconnect') {
     const linkedProject = await ensureLink('project', client, path, confirm);
     if (typeof linkedProject === 'number') {
       return linkedProject;
@@ -122,6 +123,8 @@ export default async function main(client: Client) {
       return await rm(client, args);
     case 'connect':
       return await connect(client, argv, args, project, org, team);
+    case 'disconnect':
+      return await disconnect(client, args, project, org, team);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       help();

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -21,7 +21,8 @@ const help = () => {
   ${chalk.dim('Commands:')}
 
     ls                               Show all projects in the selected team/user
-    connect                          Connect a Git provider to your project
+    connect                          Connect a Git provider repository to your project
+    disconnect                       Disconnect a Git provider repository from your project
     add      [name]                  Add a new project
     rm       [name]                  Remove a project
 


### PR DESCRIPTION
This PR adds a new subcommand, `vc project disconnect`, which disconnects a Git provider repository.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
