### PR TITLE
[cli] Remove `DEBUG=corepack` env var

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -336,8 +336,7 @@ export default async function main(client: Client): Promise<number> {
   const buildResults: Map<Builder, BuildResult> = new Map();
   const overrides: PathOverride[] = [];
   const repoRootPath = cwd;
-  const rootPackageJsonPath = repoRootPath || workPath;
-  const corepackShimDir = await initCorepack({ cwd, rootPackageJsonPath });
+  const corepackShimDir = await initCorepack({ repoRootPath });
 
   for (const build of builds) {
     if (typeof build.src !== 'string') continue;

--- a/packages/cli/src/util/build/corepack.ts
+++ b/packages/cli/src/util/build/corepack.ts
@@ -6,11 +6,9 @@ import { VERCEL_DIR } from '../projects/link';
 import readJSONFile from '../read-json-file';
 
 export async function initCorepack({
-  cwd,
-  rootPackageJsonPath,
+  repoRootPath,
 }: {
-  cwd: string;
-  rootPackageJsonPath: string;
+  repoRootPath: string;
 }): Promise<string | null> {
   if (process.env.ENABLE_EXPERIMENTAL_COREPACK !== '1') {
     // Since corepack is experimental, we need to exit early
@@ -18,7 +16,7 @@ export async function initCorepack({
     return null;
   }
   const pkg = await readJSONFile<PackageJson>(
-    join(rootPackageJsonPath, 'package.json')
+    join(repoRootPath, 'package.json')
   );
   if (pkg instanceof CantParseJSONFile) {
     console.warn(
@@ -32,7 +30,7 @@ export async function initCorepack({
     console.log(
       `Detected ENABLE_EXPERIMENTAL_COREPACK=1 and "${pkg.packageManager}" in package.json`
     );
-    const corepackRootDir = join(cwd, VERCEL_DIR, 'cache', 'corepack');
+    const corepackRootDir = join(repoRootPath, VERCEL_DIR, 'cache', 'corepack');
     const corepackHomeDir = join(corepackRootDir, 'home');
     const corepackShimDir = join(corepackRootDir, 'shim');
     await fs.mkdirp(corepackHomeDir);

--- a/packages/cli/src/util/build/corepack.ts
+++ b/packages/cli/src/util/build/corepack.ts
@@ -39,9 +39,6 @@ export async function initCorepack({
     await fs.mkdirp(corepackShimDir);
     process.env.COREPACK_HOME = corepackHomeDir;
     process.env.PATH = `${corepackShimDir}${delimiter}${process.env.PATH}`;
-    process.env.DEBUG = process.env.DEBUG
-      ? `corepack,${process.env.DEBUG}`
-      : 'corepack';
     const pkgManagerName = pkg.packageManager.split('@')[0];
     // We must explicitly call `corepack enable npm` since `corepack enable`
     // doesn't work with npm. See https://github.com/nodejs/corepack/pull/24
@@ -71,12 +68,5 @@ export function cleanupCorepack(corepackShimDir: string) {
       `${corepackShimDir}${delimiter}`,
       ''
     );
-  }
-  if (process.env.DEBUG) {
-    if (process.env.DEBUG === 'corepack') {
-      delete process.env.DEBUG;
-    } else {
-      process.env.DEBUG = process.env.DEBUG.replace('corepack,', '');
-    }
   }
 }


### PR DESCRIPTION
This debug log was originally added in #7871 because corepack has no output by default. In particular, it was nice to see the first deployment was not stalled when the package manager is being installed.

That being said, this gets noisy really fast because cache detections also print a log line.
For example, here's a deployment that prints 3 times:

```
Detected ENABLE_EXPERIMENTAL_COREPACK=1 and "npm@8.10.0" in package.json
Running "install" command: `npm install --prefix=.. --no-audit --engine-strict=false`...
2022-07-11T18:27:00.696Z corepack Reusing npm@8.10.0
356 packages are looking for funding
Running "npm run vercel-build"
2022-07-11T18:27:06.664Z corepack Reusing npm@8.10.0
> front@0.0.0 vercel-build
> npm run buildonly && npm run build:rss
2022-07-11T18:27:07.088Z corepack Reusing npm@8.10.0
> front@0.0.0 buildonly
> next build
```

I think its best to let users add this env var themselves if they want to debug what corepack is doing, so this PR removes that environment variable.