### PR TITLE
[tests] Add retry to npm tests

### DIFF
--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -520,7 +520,7 @@ it('should only invoke `runNpmInstall()` once per `package.json` file (parallel)
   const meta: Meta = {};
   const fixture = path.join(__dirname, 'fixtures', '02-zero-config-api');
   const apiDir = path.join(fixture, 'api');
-  let results: [boolean, boolean, boolean];
+  let results: [boolean, boolean, boolean] | undefined;
   await retry(
     async () => {
       results = await Promise.all([
@@ -531,7 +531,6 @@ it('should only invoke `runNpmInstall()` once per `package.json` file (parallel)
     },
     { maxRetryTime: 3000 }
   );
-  // @ts-ignore use-before-assign
   const [run1, run2, run3] = results || [];
   expect(run1).toEqual(true);
   expect(run2).toEqual(false);

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -1,6 +1,7 @@
 import ms from 'ms';
 import path from 'path';
 import fs, { readlink } from 'fs-extra';
+import retry from 'async-retry';
 import { strict as assert, strictEqual } from 'assert';
 import { createZip } from '../src/lambda';
 import { getSupportedNodeVersion } from '../src/fs/node-version';
@@ -494,28 +495,44 @@ it('should only invoke `runNpmInstall()` once per `package.json` file (serial)',
   const meta: Meta = {};
   const fixture = path.join(__dirname, 'fixtures', '02-zero-config-api');
   const apiDir = path.join(fixture, 'api');
-  const run1 = await runNpmInstall(apiDir, [], undefined, meta);
-  expect(run1).toEqual(true);
-  expect(
-    (meta.runNpmInstallSet as Set<string>).has(
-      path.join(fixture, 'package.json')
-    )
-  ).toEqual(true);
-  const run2 = await runNpmInstall(apiDir, [], undefined, meta);
-  expect(run2).toEqual(false);
-  const run3 = await runNpmInstall(fixture, [], undefined, meta);
-  expect(run3).toEqual(false);
+  const retryOpts = { maxRetryTime: 1000 };
+  let run1, run2, run3;
+  await retry(async () => {
+    run1 = await runNpmInstall(apiDir, [], undefined, meta);
+    expect(run1).toEqual(true);
+    expect(
+      (meta.runNpmInstallSet as Set<string>).has(
+        path.join(fixture, 'package.json')
+      )
+    ).toEqual(true);
+  }, retryOpts);
+  await retry(async () => {
+    run2 = await runNpmInstall(apiDir, [], undefined, meta);
+    expect(run2).toEqual(false);
+  }, retryOpts);
+  await retry(async () => {
+    run3 = await runNpmInstall(fixture, [], undefined, meta);
+    expect(run3).toEqual(false);
+  }, retryOpts);
 });
 
 it('should only invoke `runNpmInstall()` once per `package.json` file (parallel)', async () => {
   const meta: Meta = {};
   const fixture = path.join(__dirname, 'fixtures', '02-zero-config-api');
   const apiDir = path.join(fixture, 'api');
-  const [run1, run2, run3] = await Promise.all([
-    runNpmInstall(apiDir, [], undefined, meta),
-    runNpmInstall(apiDir, [], undefined, meta),
-    runNpmInstall(fixture, [], undefined, meta),
-  ]);
+  let results: [boolean, boolean, boolean];
+  await retry(
+    async () => {
+      results = await Promise.all([
+        runNpmInstall(apiDir, [], undefined, meta),
+        runNpmInstall(apiDir, [], undefined, meta),
+        runNpmInstall(fixture, [], undefined, meta),
+      ]);
+    },
+    { maxRetryTime: 3000 }
+  );
+  // @ts-ignore use-before-assign
+  const [run1, run2, run3] = results || [];
   expect(run1).toEqual(true);
   expect(run2).toEqual(false);
   expect(run3).toEqual(false);


### PR DESCRIPTION
These tests fail occasionally on GH Actions due to flakey network IO, so this PR adds retry logic.

https://github.com/vercel/vercel/runs/7289659634?check_suite_focus=true#step:13:328