### PR TITLE
[fs-detectors] Remove "solidstart" framework from FS API v2 detection

### DIFF
--- a/packages/fs-detectors/src/detect-file-system-api.ts
+++ b/packages/fs-detectors/src/detect-file-system-api.ts
@@ -13,8 +13,6 @@ interface Metadata {
   hasMiddleware: boolean;
 }
 
-const enableFileSystemApiFrameworks = new Set(['solidstart']);
-
 /**
  * If the Deployment can be built with the new File System API,
  * return the new Builder. Otherwise an "Exclusion Condition"
@@ -61,11 +59,7 @@ export async function detectFileSystemAPI({
     hasMiddleware,
   };
 
-  const isEnabled =
-    enableFlag ||
-    hasMiddleware ||
-    hasDotOutput ||
-    enableFileSystemApiFrameworks.has(framework);
+  const isEnabled = enableFlag || hasMiddleware || hasDotOutput;
   if (!isEnabled) {
     return { metadata, fsApiBuilder: null, reason: 'Flag not enabled.' };
   }


### PR DESCRIPTION
"solidstart" framework doesn't need to use the FS API v2 Builder anymore since:

  1) Newer versions output Build Output API v3
  2) Older versions that output FS API v2 will be handled by the compatbility shim that was added in https://github.com/vercel/vercel/pull/7690