### PR TITLE
[cli] Add `createdAt` to project settings in `vc pull`

### DIFF
--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 export type ProjectLinkAndSettings = ProjectLink & {
   settings: {
+    createdAt: Project['createdAt'];
     installCommand: Project['installCommand'];
     buildCommand: Project['buildCommand'];
     devCommand: Project['devCommand'];
@@ -28,6 +29,7 @@ export async function writeProjectSettings(
     projectId: project.id,
     orgId: org.id,
     settings: {
+      createdAt: project.createdAt,
       framework: project.framework,
       devCommand: project.devCommand,
       installCommand: project.installCommand,

--- a/packages/cli/test/unit/commands/pull.test.ts
+++ b/packages/cli/test/unit/commands/pull.test.ts
@@ -101,7 +101,9 @@ describe('pull', () => {
         Object {
           "orgId": "team_dummy",
           "projectId": "vercel-pull-next",
-          "settings": Object {},
+          "settings": Object {
+            "createdAt": 1555413045188,
+          },
         }
       `);
     } finally {


### PR DESCRIPTION
The `createdAt` property is checked in the `detectBuilders()` function, so it needs to be present in the local copy of the project settings.