### PR TITLE
[remix] Fix `isMonorepo` check

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -192,6 +192,8 @@ export const build: BuildV2 = async ({
     // If we are, prepend the app root directory from config onto the build path.
     // e.g. `/apps/my-remix-app/api/index.js`
     const isMonorepo = repoRootPath && repoRootPath !== workPath;
+    console.log('config', config);
+    console.log('config.projectSettings', config.projectSettings);
     if (isMonorepo && config.projectSettings?.rootDirectory) {
       serverBuildPath = join(
         config.projectSettings.rootDirectory,

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, join, relative } from 'path';
 import {
   debug,
   download,
@@ -194,16 +194,17 @@ export const build: BuildV2 = async ({
     const isMonorepo = repoRootPath && repoRootPath !== workPath;
     console.log('config', config);
     console.log('config.projectSettings', config.projectSettings);
-    if (isMonorepo && config.projectSettings?.rootDirectory) {
-      serverBuildPath = join(
-        config.projectSettings.rootDirectory,
-        serverBuildPath
-      );
+    if (isMonorepo) {
+      const rootDirectory = relative(repoRootPath, workPath);
+      console.log({ rootDirectory });
+      serverBuildPath = join(rootDirectory, serverBuildPath);
     }
   } catch (err: any) {
     // Ignore error if `remix.config.js` does not exist
     if (err.code !== 'MODULE_NOT_FOUND') throw err;
   }
+
+  console.log({ serverBuildPath });
 
   const [staticFiles, renderFunction] = await Promise.all([
     glob('**', join(entrypointFsDirname, 'public')),

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -192,19 +192,14 @@ export const build: BuildV2 = async ({
     // If we are, prepend the app root directory from config onto the build path.
     // e.g. `/apps/my-remix-app/api/index.js`
     const isMonorepo = repoRootPath && repoRootPath !== workPath;
-    console.log('config', config);
-    console.log('config.projectSettings', config.projectSettings);
     if (isMonorepo) {
       const rootDirectory = relative(repoRootPath, workPath);
-      console.log({ rootDirectory });
       serverBuildPath = join(rootDirectory, serverBuildPath);
     }
   } catch (err: any) {
     // Ignore error if `remix.config.js` does not exist
     if (err.code !== 'MODULE_NOT_FOUND') throw err;
   }
-
-  console.log({ serverBuildPath });
 
   const [staticFiles, renderFunction] = await Promise.all([
     glob('**', join(entrypointFsDirname, 'public')),


### PR DESCRIPTION
`config.projectSettings` is not available when running `@vercel/remix` directly (i.e. when not using `vc build`), so calculate the correct root directory value based on the `workPath` relative to the `repoRootPath` value.