### PR TITLE
[static-build] Return BOA v3 result without `vercel build`

### DIFF
--- a/packages/static-build/src/utils/build-output-v3.ts
+++ b/packages/static-build/src/utils/build-output-v3.ts
@@ -43,20 +43,15 @@ export function createBuildOutput(
   buildOutputPath: string,
   framework?: Framework
 ): BuildResultV2 {
-  if (!meta.cliVersion) {
+  if (meta.isDev) {
     let buildCommandName: string;
 
     if (buildCommand) buildCommandName = `"${buildCommand}"`;
     else if (framework) buildCommandName = framework.name;
     else buildCommandName = 'the "build" script';
 
-    if (meta.isDev) {
-      throw new Error(
-        `Detected Build Output v3 from ${buildCommandName}, but it is not supported for \`vercel dev\`. Please set the Development Command in your Project Settings.`
-      );
-    }
     throw new Error(
-      `Detected Build Output v3 from ${buildCommandName}, but this Deployment is not using \`vercel build\`.\nPlease set the \`ENABLE_VC_BUILD=1\` environment variable.`
+      `Detected Build Output v3 from ${buildCommandName}, but it is not supported for \`vercel dev\`. Please set the Development Command in your Project Settings.`
     );
   }
 

--- a/packages/static-build/test/build.test.ts
+++ b/packages/static-build/test/build.test.ts
@@ -99,7 +99,7 @@ describe('build()', () => {
   });
 
   describe('Build Output API v3', () => {
-    it('should detect the output format', async () => {
+    it('should detect the output format with `vercel build`', async () => {
       const workPath = path.join(
         __dirname,
         'build-fixtures',
@@ -125,29 +125,28 @@ describe('build()', () => {
       );
     });
 
-    it('should throw an Error without `vercel build`', async () => {
-      let err;
+    it('should detect the output format without `vercel build`', async () => {
       const workPath = path.join(
         __dirname,
         'build-fixtures',
         '09-build-output-v3'
       );
-      try {
-        await build({
-          files: {},
-          entrypoint: 'package.json',
-          repoRootPath: workPath,
-          workPath,
-          config: {},
-          meta: {
-            skipDownload: true,
-          },
-        });
-      } catch (_err: any) {
-        err = _err;
+      const buildResult = await build({
+        files: {},
+        entrypoint: 'package.json',
+        repoRootPath: workPath,
+        workPath,
+        config: {},
+        meta: {
+          skipDownload: true,
+        },
+      });
+      if ('output' in buildResult) {
+        throw new Error('Unexpected `output` in build result');
       }
-      expect(err.message).toEqual(
-        `Detected Build Output v3 from the "build" script, but this Deployment is not using \`vercel build\`.\nPlease set the \`ENABLE_VC_BUILD=1\` environment variable.`
+      expect(buildResult.buildOutputVersion).toEqual(3);
+      expect(buildResult.buildOutputPath).toEqual(
+        path.join(workPath, '.vercel/output')
       );
     });
 


### PR DESCRIPTION
This will allow Build Output API v3 to be produced by a build script without the `ENABLE_VC_BUILD=1` env var being necessary.