### PR TITLE
[cli] Consume `--no-clipboard`

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -187,7 +187,7 @@ export default async (client: Client) => {
   if (argv['--no-clipboard']) {
     output.print(
       `${prependEmoji(
-        `The ${param('--no-clipboard')} option is deprecated.`,
+        `The ${param('--no-clipboard')} option was ignored because it is the default behavior. Please remove it.`,
         emoji('warning')
       )}\n`
     );

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -95,6 +95,7 @@ export default async (client: Client) => {
       // deprecated
       '--name': String,
       '-n': '--name',
+      '--no-clipboard': Boolean,
       '--target': String,
     });
   } catch (error) {
@@ -178,6 +179,15 @@ export default async (client: Client) => {
         `The ${param(
           '--name'
         )} option is deprecated (https://vercel.link/name-flag)`,
+        emoji('warning')
+      )}\n`
+    );
+  }
+  // deprecate --no-clipboard
+  if (argv['--no-clipboard']) {
+    output.print(
+      `${prependEmoji(
+        `The ${param('--no-clipboard')} option is deprecated.`,
         emoji('warning')
       )}\n`
     );

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -183,11 +183,13 @@ export default async (client: Client) => {
       )}\n`
     );
   }
-  // deprecate --no-clipboard
+
   if (argv['--no-clipboard']) {
     output.print(
       `${prependEmoji(
-        `The ${param('--no-clipboard')} option was ignored because it is the default behavior. Please remove it.`,
+        `The ${param(
+          '--no-clipboard'
+        )} option was ignored because it is the default behavior. Please remove it.`,
         emoji('warning')
       )}\n`
     );


### PR DESCRIPTION
#8085 removed the clipboard copy feature in `vc deploy`, along with the `--no-clipboard` flag. Right now, the CLI exits and returns an error when someone includes the `--no-clipboard` flag. This PR instead consumes the flag and warns the user that the flag is deprecated.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
