### PR TITLE
[routing-utils] MAJOR refactor getTransformedRoutes and types

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -206,7 +206,7 @@ export default async function main(client: Client): Promise<number> {
     normalizePath(relative(workPath, f))
   );
 
-  const routesResult = getTransformedRoutes({ nowConfig: vercelConfig || {} });
+  const routesResult = getTransformedRoutes(vercelConfig || {});
   if (routesResult.error) {
     output.prettyError(routesResult.error);
     return 1;

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -558,9 +558,8 @@ export default class DevServer {
     ]);
 
     await this.validateVercelConfig(vercelConfig);
-    const { error: routeError, routes: maybeRoutes } = getTransformedRoutes({
-      nowConfig: vercelConfig,
-    });
+    const { error: routeError, routes: maybeRoutes } =
+      getTransformedRoutes(vercelConfig);
     if (routeError) {
       this.output.prettyError(routeError);
       await this.exit();

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -1,7 +1,7 @@
 import minimatch from 'minimatch';
 import { valid as validSemver } from 'semver';
 import { parse as parsePath, extname } from 'path';
-import type { Route, Source } from '@vercel/routing-utils';
+import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import frameworkList, { Framework } from '@vercel/frameworks';
 import type {
   PackageJson,
@@ -155,8 +155,8 @@ export async function detectBuilders(
 
   let fallbackEntrypoint: string | null = null;
 
-  const apiRoutes: Source[] = [];
-  const dynamicRoutes: Source[] = [];
+  const apiRoutes: RouteWithSrc[] = [];
+  const dynamicRoutes: RouteWithSrc[] = [];
 
   // API
   for (const fileName of sortedFiles) {
@@ -692,7 +692,7 @@ function getApiRoute(
   options: Options,
   absolutePathCache: Map<string, string>
 ): {
-  apiRoute: Source | null;
+  apiRoute: RouteWithSrc | null;
   isDynamic: boolean;
   routeError: ErrorResponse | null;
 } {
@@ -886,7 +886,7 @@ function createRouteFromPath(
   filePath: string,
   featHandleMiss: boolean,
   cleanUrls: boolean
-): { route: Source; isDynamic: boolean } {
+): { route: RouteWithSrc; isDynamic: boolean } {
   const parts = filePath.split('/');
 
   let counter = 1;
@@ -932,7 +932,7 @@ function createRouteFromPath(
     ? `^/${srcParts.slice(0, -1).join('/')}${srcParts.slice(-1)[0]}$`
     : `^/${srcParts.join('/')}$`;
 
-  let route: Source;
+  let route: RouteWithSrc;
 
   if (featHandleMiss) {
     const extensionless = ext ? filePath.slice(0, -ext.length) : filePath;
@@ -959,8 +959,8 @@ interface LimitedRoutes {
 
 function getRouteResult(
   pkg: PackageJson | undefined | null,
-  apiRoutes: Source[],
-  dynamicRoutes: Source[],
+  apiRoutes: RouteWithSrc[],
+  dynamicRoutes: RouteWithSrc[],
   outputDirectory: string,
   apiBuilders: Builder[],
   frontendBuilder: Builder | null,

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -1,4 +1,8 @@
-import type { Source, Route, Handler } from '@vercel/routing-utils';
+import type {
+  Route,
+  RouteWithHandle as Handler,
+  RouteWithSrc as Source,
+} from '@vercel/routing-utils';
 import {
   detectBuilders,
   detectOutputDirectory,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -24,7 +24,7 @@ import {
   NodejsLambda,
   BuildResultV2Typical as BuildResult,
 } from '@vercel/build-utils';
-import { Handler, Route, Source } from '@vercel/routing-utils';
+import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
 import {
   convertHeaders,
   convertRedirects,
@@ -896,7 +896,7 @@ export const build: BuildV2 = async ({
         ...(output[path.join('./', entryDirectory, '404')] ||
         output[path.join('./', entryDirectory, '404/index')]
           ? [
-              { handle: 'error' } as Handler,
+              { handle: 'error' } as RouteWithHandle,
 
               {
                 status: 404,
@@ -928,7 +928,7 @@ export const build: BuildV2 = async ({
   let trailingSlash = false;
 
   redirects = redirects.filter(_redir => {
-    const redir = _redir as Source;
+    const redir = _redir as RouteWithSrc;
     // detect the trailing slash redirect and make sure it's
     // kept above the wildcard mapping to prevent erroneous redirects
     // since non-continue routes come after continue the $wildcard
@@ -1146,7 +1146,7 @@ export const build: BuildV2 = async ({
                 continue;
               }
 
-              const route: Source & { dest: string } = {
+              const route: RouteWithSrc & { dest: string } = {
                 src: (
                   dataRoute.namedDataRouteRegex || dataRoute.dataRouteRegex
                 ).replace(/^\^/, `^${appMountPrefixNoTrailingSlash}`),
@@ -1175,7 +1175,7 @@ export const build: BuildV2 = async ({
               if (isOmittedRoute && isServerMode) {
                 // only match this route when in preview mode so
                 // preview works for non-prerender fallback: false pages
-                (route as Source).has = [
+                (route as RouteWithSrc).has = [
                   {
                     type: 'cookie',
                     key: '__prerender_bypass',
@@ -2454,7 +2454,7 @@ export const build: BuildV2 = async ({
         ? []
         : [
             // Custom Next.js 404 page
-            { handle: 'error' } as Handler,
+            { handle: 'error' } as RouteWithHandle,
 
             ...(i18n && (static404Page || hasIsr404Page)
               ? [

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -14,7 +14,7 @@ import {
   Files,
   BuildResultV2Typical as BuildResult,
 } from '@vercel/build-utils';
-import { Handler, Route, Source } from '@vercel/routing-utils';
+import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
 import { MAX_AGE_ONE_YEAR } from '.';
 import {
   NextRequiredServerFilesManifest,
@@ -822,7 +822,7 @@ export async function serverBuild({
   const { staticFiles, publicDirectoryFiles, staticDirectoryFiles } =
     await getStaticFiles(entryPath, entryDirectory, outputDirectory);
 
-  const notFoundPreviewRoutes: Source[] = [];
+  const notFoundPreviewRoutes: RouteWithSrc[] = [];
 
   if (prerenderManifest.notFoundRoutes?.length > 0 && canUsePreviewMode) {
     // we combine routes into one src here to reduce the number of needed
@@ -1378,7 +1378,7 @@ export async function serverBuild({
       },
 
       // error handling
-      { handle: 'error' } as Handler,
+      { handle: 'error' } as RouteWithHandle,
 
       // Custom Next.js 404 page
       ...(i18n && (static404Page || hasIsr404Page || lambdaPages['404.js'])

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -16,7 +16,7 @@ import {
   EdgeFunction,
 } from '@vercel/build-utils';
 import { NodeFileTraceReasons } from '@vercel/nft';
-import { Header, Rewrite, Route, Source } from '@vercel/routing-utils';
+import { Header, Rewrite, Route, RouteWithSrc } from '@vercel/routing-utils';
 import { Sema } from 'async-sema';
 import crc32 from 'buffer-crc32';
 import fs, { lstat, stat } from 'fs-extra';
@@ -273,8 +273,8 @@ export async function getDynamicRoutes(
   canUsePreviewMode?: boolean,
   bypassToken?: string,
   isServerMode?: boolean,
-  dynamicMiddlewareRouteMap?: Map<string, Source>
-): Promise<Source[]> {
+  dynamicMiddlewareRouteMap?: Map<string, RouteWithSrc>
+): Promise<RouteWithSrc[]> {
   if (routesManifest) {
     switch (routesManifest.version) {
       case 1:
@@ -307,7 +307,7 @@ export async function getDynamicRoutes(
             }
 
             const { page, namedRegex, regex, routeKeys } = params;
-            const route: Source = {
+            const route: RouteWithSrc = {
               src: namedRegex || regex,
               dest: `${!isDev ? path.join('/', entryDirectory, page) : page}${
                 routeKeys
@@ -400,7 +400,7 @@ export async function getDynamicRoutes(
     matcher: getRouteRegex && getRouteRegex(pageName).re,
   }));
 
-  const routes: Source[] = [];
+  const routes: RouteWithSrc[] = [];
   pageMatchers.forEach(pageMatcher => {
     // in `vercel dev` we don't need to prefix the destination
     const dest = !isDev
@@ -419,7 +419,7 @@ export async function getDynamicRoutes(
 }
 
 export function localizeDynamicRoutes(
-  dynamicRoutes: Source[],
+  dynamicRoutes: RouteWithSrc[],
   dynamicPrefix: string,
   entryDirectory: string,
   staticPages: Files,
@@ -427,8 +427,8 @@ export function localizeDynamicRoutes(
   routesManifest?: RoutesManifest,
   isServerMode?: boolean,
   isCorrectLocaleAPIRoutes?: boolean
-): Source[] {
-  return dynamicRoutes.map((route: Source) => {
+): RouteWithSrc[] {
+  return dynamicRoutes.map((route: RouteWithSrc) => {
     // i18n is already handled for middleware
     if (route.middleware !== undefined || route.middlewarePath !== undefined)
       return route;
@@ -2292,7 +2292,7 @@ export async function getMiddlewareBundle({
 
     const source: {
       staticRoutes: Route[];
-      dynamicRouteMap: Map<string, Source>;
+      dynamicRouteMap: Map<string, RouteWithSrc>;
       edgeFunctions: Record<string, EdgeFunction>;
     } = {
       staticRoutes: [],

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -283,12 +283,10 @@ export const build: BuildV2 = async ({
     : '/index';
 
   const defaultRoutesConfig = getTransformedRoutes({
-    nowConfig: {
-      // this makes sure we send back 200.html for unprerendered pages
-      rewrites: [{ source: '/(.*)', destination: fallbackHtmlPage }],
-      cleanUrls: true,
-      trailingSlash: false,
-    },
+    // this makes sure we send back 200.html for unprerendered pages
+    rewrites: [{ source: '/(.*)', destination: fallbackHtmlPage }],
+    cleanUrls: true,
+    trailingSlash: false,
   });
 
   if (defaultRoutesConfig.error) {

--- a/packages/redwood/test/test.js
+++ b/packages/redwood/test/test.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { version } = require('../package.json');
 
 const {
   packAndDeploy,
@@ -9,10 +8,15 @@ const {
 
 jest.setTimeout(12 * 60 * 1000);
 
+let buildUtilsUrl;
 let builderUrl;
-const buildUtilsUrl = version.includes('canary') ? '@canary' : undefined;
 
 beforeAll(async () => {
+  if (!buildUtilsUrl) {
+    const buildUtilsPath = path.resolve(__dirname, '..', '..', 'build-utils');
+    buildUtilsUrl = await packAndDeploy(buildUtilsPath);
+    console.log('buildUtilsUrl', buildUtilsUrl);
+  }
   const builderPath = path.resolve(__dirname, '..');
   builderUrl = await packAndDeploy(builderPath);
   console.log('builderUrl', builderUrl);

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -1,28 +1,27 @@
 import { parse as parseUrl } from 'url';
-export * from './schemas';
-export * from './types';
 import {
-  Route,
-  Handler,
-  NormalizedRoutes,
-  GetRoutesProps,
-  RouteApiError,
-  Redirect,
-  HasField,
-} from './types';
-import {
+  collectHasSegments,
   convertCleanUrls,
-  convertRewrites,
-  convertRedirects,
   convertHeaders,
+  convertRedirects,
+  convertRewrites,
   convertTrailingSlash,
   sourceToRegex,
-  collectHasSegments,
 } from './superstatic';
-
-export { getCleanUrls } from './superstatic';
-export { mergeRoutes } from './merge';
+import {
+  GetRoutesProps,
+  HasField,
+  NormalizedRoutes,
+  Redirect,
+  Route,
+  RouteApiError,
+  RouteWithHandle,
+} from './types';
 export { appendRoutesToPhase } from './append';
+export { mergeRoutes } from './merge';
+export * from './schemas';
+export { getCleanUrls } from './superstatic';
+export * from './types';
 
 const VALID_HANDLE_VALUES = [
   'filesystem',
@@ -35,8 +34,8 @@ const VALID_HANDLE_VALUES = [
 const validHandleValues = new Set<string>(VALID_HANDLE_VALUES);
 export type HandleValue = typeof VALID_HANDLE_VALUES[number];
 
-export function isHandler(route: Route): route is Handler {
-  return typeof (route as Handler).handle !== 'undefined';
+export function isHandler(route: Route): route is RouteWithHandle {
+  return typeof (route as RouteWithHandle).handle !== 'undefined';
 }
 
 export function isValidHandleValue(handle: string): handle is HandleValue {
@@ -249,11 +248,12 @@ function notEmpty<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 
-export function getTransformedRoutes({
-  nowConfig,
-}: GetRoutesProps): NormalizedRoutes {
-  const { cleanUrls, rewrites, redirects, headers, trailingSlash } = nowConfig;
-  let { routes = null } = nowConfig;
+export function getTransformedRoutes(
+  vercelConfig: GetRoutesProps
+): NormalizedRoutes {
+  const { cleanUrls, rewrites, redirects, headers, trailingSlash } =
+    vercelConfig;
+  let { routes = null } = vercelConfig;
   if (routes) {
     const hasNewProperties =
       typeof cleanUrls !== 'undefined' ||

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -21,7 +21,7 @@ export type HasField = Array<
     }
 >;
 
-export type Source = {
+export type RouteWithSrc = {
   src: string;
   dest?: string;
   headers?: { [name: string]: string };
@@ -49,14 +49,14 @@ export type Source = {
   middleware?: number;
 };
 
-export type Handler = {
+export type RouteWithHandle = {
   handle: HandleValue;
   src?: string;
   dest?: string;
   status?: number;
 };
 
-export type Route = Source | Handler;
+export type Route = RouteWithSrc | RouteWithHandle;
 
 export type NormalizedRoutes = {
   routes: Route[] | null;
@@ -64,7 +64,12 @@ export type NormalizedRoutes = {
 };
 
 export interface GetRoutesProps {
-  nowConfig: VercelConfig;
+  routes?: Route[];
+  cleanUrls?: boolean;
+  rewrites?: Rewrite[];
+  redirects?: Redirect[];
+  headers?: Header[];
+  trailingSlash?: boolean;
 }
 
 export interface MergeRoutesProps {
@@ -76,17 +81,6 @@ export interface Build {
   use: string;
   entrypoint: string;
   routes?: Route[];
-}
-
-export interface VercelConfig {
-  name?: string;
-  version?: number;
-  routes?: Route[];
-  cleanUrls?: boolean;
-  rewrites?: Rewrite[];
-  redirects?: Redirect[];
-  headers?: Header[];
-  trailingSlash?: boolean;
 }
 
 export interface Rewrite {
@@ -131,18 +125,3 @@ export interface AppendRoutesToPhaseProps {
    */
   phase: HandleValue;
 }
-
-/** @deprecated Use VercelConfig instead. */
-export type NowConfig = VercelConfig;
-
-/** @deprecated Use Rewrite instead. */
-export type NowRewrite = Rewrite;
-
-/** @deprecated Use Redirect instead. */
-export type NowRedirect = Redirect;
-
-/** @deprecated Use Header instead. */
-export type NowHeader = Header;
-
-/** @deprecated Use HeaderKeyValue instead. */
-export type NowHeaderKeyValue = HeaderKeyValue;

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -775,24 +775,24 @@ describe('normalizeRoutes', () => {
 });
 
 describe('getTransformedRoutes', () => {
-  test('should normalize nowConfig.routes', () => {
-    const nowConfig = { routes: [{ src: '/page', dest: '/page.html' }] };
-    const actual = getTransformedRoutes({ nowConfig });
-    const expected = normalizeRoutes(nowConfig.routes);
+  test('should normalize vercelConfig.routes', () => {
+    const vercelConfig = { routes: [{ src: '/page', dest: '/page.html' }] };
+    const actual = getTransformedRoutes(vercelConfig);
+    const expected = normalizeRoutes(vercelConfig.routes);
     assert.deepEqual(actual, expected);
     assertValid(actual.routes);
   });
 
   test('should not error when routes is null and cleanUrls is true', () => {
-    const nowConfig = { cleanUrls: true, routes: null };
+    const vercelConfig = { cleanUrls: true, routes: null };
     // @ts-expect-error intentionally passing invalid `routes: null` here
-    const actual = getTransformedRoutes({ nowConfig });
+    const actual = getTransformedRoutes(vercelConfig);
     assert.equal(actual.error, null);
     assertValid(actual.routes);
   });
 
   test('should not error when has segment is used in destination', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '/redirect',
@@ -809,17 +809,17 @@ describe('getTransformedRoutes', () => {
     };
 
     // @ts-expect-error not sure if this one is an error or not…
-    const actual = getTransformedRoutes({ nowConfig });
+    const actual = getTransformedRoutes(vercelConfig);
     assert.equal(actual.error, null);
     assertValid(actual.routes);
   });
 
   test('should error when routes is defined and cleanUrls is true', () => {
-    const nowConfig = {
+    const vercelConfig = {
       cleanUrls: true,
       routes: [{ src: '/page', dest: '/file.html' }],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_mixed_routes');
     assert.equal(
@@ -831,10 +831,10 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when redirects is invalid regex', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [{ source: '^/(*.)\\.html$', destination: '/file.html' }],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_redirect');
     assert.equal(
@@ -846,10 +846,10 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when redirects is invalid pattern', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [{ source: '/:?', destination: '/file.html' }],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_redirect');
     assert.equal(
@@ -861,7 +861,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when redirects defines both permanent and statusCode', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '^/both$',
@@ -871,7 +871,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_redirect');
     assert.equal(
@@ -883,7 +883,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when headers is invalid regex', () => {
-    const nowConfig = {
+    const vercelConfig = {
       headers: [
         {
           source: '^/(*.)\\.html$',
@@ -896,7 +896,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_header');
     assert.equal(
@@ -908,12 +908,12 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when headers is invalid pattern', () => {
-    const nowConfig = {
+    const vercelConfig = {
       headers: [
         { source: '/:?', headers: [{ key: 'x-hello', value: 'world' }] },
       ],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_header');
     assert.equal(
@@ -925,10 +925,10 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when rewrites is invalid regex', () => {
-    const nowConfig = {
+    const vercelConfig = {
       rewrites: [{ source: '^/(*.)\\.html$', destination: '/file.html' }],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_rewrite');
     assert.equal(
@@ -940,10 +940,10 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when rewrites is invalid pattern', () => {
-    const nowConfig = {
+    const vercelConfig = {
       rewrites: [{ source: '/:?', destination: '/file.html' }],
     };
-    const { error } = getTransformedRoutes({ nowConfig });
+    const { error } = getTransformedRoutes(vercelConfig);
     assert.notEqual(error, null);
     assert.equal(error?.code, 'invalid_rewrite');
     assert.equal(
@@ -955,7 +955,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should normalize all redirects before rewrites', () => {
-    const nowConfig = {
+    const vercelConfig = {
       cleanUrls: true,
       rewrites: [{ source: '/v1', destination: '/v2/api.py' }],
       redirects: [
@@ -967,7 +967,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { error, routes } = getTransformedRoutes({ nowConfig });
+    const { error, routes } = getTransformedRoutes(vercelConfig);
     const expected = [
       {
         src: '^/(?:(.+)/)?index(?:\\.html)?/?$',
@@ -998,7 +998,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should validate schemas', () => {
-    const nowConfig = {
+    const vercelConfig = {
       cleanUrls: true,
       rewrites: [
         { source: '/page', destination: '/page.html' },
@@ -1071,22 +1071,22 @@ describe('getTransformedRoutes', () => {
       ],
       trailingSlashSchema: false,
     };
-    assertValid(nowConfig.cleanUrls, cleanUrlsSchema);
-    assertValid(nowConfig.rewrites, rewritesSchema);
-    assertValid(nowConfig.redirects, redirectsSchema);
-    assertValid(nowConfig.headers, headersSchema);
-    assertValid(nowConfig.trailingSlashSchema, trailingSlashSchema);
+    assertValid(vercelConfig.cleanUrls, cleanUrlsSchema);
+    assertValid(vercelConfig.rewrites, rewritesSchema);
+    assertValid(vercelConfig.redirects, redirectsSchema);
+    assertValid(vercelConfig.headers, headersSchema);
+    assertValid(vercelConfig.trailingSlashSchema, trailingSlashSchema);
   });
 
   test('should return null routes if no transformations are performed', () => {
-    const nowConfig = { routes: null };
+    const vercelConfig = { routes: null };
     // @ts-expect-error intentionally passing invalid `routes: null`
-    const { routes } = getTransformedRoutes({ nowConfig });
+    const { routes } = getTransformedRoutes(vercelConfig);
     assert.equal(routes, null);
   });
 
   test('should error when segment is defined in `destination` but not `source`', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1094,7 +1094,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { routes, error } = getTransformedRoutes({ nowConfig });
+    const { routes, error } = getTransformedRoutes(vercelConfig);
     assert.deepEqual(routes, null);
     assert.ok(
       error?.message.includes(
@@ -1105,7 +1105,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when segment is defined in HTTPS `destination` but not `source`', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1113,7 +1113,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { routes, error } = getTransformedRoutes({ nowConfig });
+    const { routes, error } = getTransformedRoutes(vercelConfig);
     assert.deepEqual(routes, null);
     assert.ok(
       error?.message.includes(
@@ -1124,7 +1124,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when segment is defined in `destination` query string but not `source`', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1132,7 +1132,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { routes, error } = getTransformedRoutes({ nowConfig });
+    const { routes, error } = getTransformedRoutes(vercelConfig);
     assert.deepEqual(routes, null);
     assert.ok(
       error?.message.includes(
@@ -1143,7 +1143,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should error when segment is defined in HTTPS `destination` query string but not `source`', () => {
-    const nowConfig = {
+    const vercelConfig = {
       redirects: [
         {
           source: '/iforgot/:id',
@@ -1151,7 +1151,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const { routes, error } = getTransformedRoutes({ nowConfig });
+    const { routes, error } = getTransformedRoutes(vercelConfig);
     assert.deepEqual(routes, null);
     assert.ok(
       error?.message.includes(
@@ -1162,7 +1162,7 @@ describe('getTransformedRoutes', () => {
   });
 
   test('should work with content-security-policy header containing URL', () => {
-    const nowConfig = {
+    const vercelConfig = {
       headers: [
         {
           source: '/(.*)',
@@ -1201,7 +1201,7 @@ describe('getTransformedRoutes', () => {
         },
       ],
     };
-    const actual = getTransformedRoutes({ nowConfig });
+    const actual = getTransformedRoutes(vercelConfig);
     assert.deepEqual(actual.routes, [
       {
         continue: true,

--- a/packages/routing-utils/test/superstatic.spec.ts
+++ b/packages/routing-utils/test/superstatic.spec.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from 'assert';
-import { Route, Source, normalizeRoutes } from '../src';
+import { Route, RouteWithSrc, normalizeRoutes } from '../src';
 import {
   getCleanUrls,
   convertCleanUrls,
@@ -15,7 +15,7 @@ function routesToRegExps(routeArray: Route[]) {
     throw error;
   }
   return (routes || [])
-    .filter((r): r is Source => 'src' in r)
+    .filter((r): r is RouteWithSrc => 'src' in r)
     .map(r => new RegExp(r.src));
 }
 

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -31,7 +31,7 @@ import {
   NowBuildError,
   scanParentDirs,
 } from '@vercel/build-utils';
-import type { Route, Source } from '@vercel/routing-utils';
+import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import * as BuildOutputV1 from './utils/build-output-v1';
 import * as BuildOutputV2 from './utils/build-output-v2';
 import * as BuildOutputV3 from './utils/build-output-v3';
@@ -173,8 +173,8 @@ const nowDevChildProcesses = new Set<ChildProcess>();
   });
 });
 
-const getDevRoute = (srcBase: string, devPort: number, route: Source) => {
-  const basic: Source = {
+const getDevRoute = (srcBase: string, devPort: number, route: RouteWithSrc) => {
+  const basic: RouteWithSrc = {
     src: `${srcBase}${route.src}`,
     dest: `http://localhost:${devPort}${route.dest}`,
   };


### PR DESCRIPTION
This is a semver major change to the public API for `@vercel/routing-utils` which includes the following breaking changes.

1. `getTransformedRoutes({ nowConfig })` props changed to `getTransformedRoutes(nowConfig)`
2. `type Source` renamed `type RouteWithSrc`
3. `type Handler` renamed `type RouteWithHandle`
4. `interface VercelConfig` removed
5. `type NowConfig` removed
6. `type NowRewrite` removed
7. `type NowRedirect` removed
8. `type NowHeader` removed
9. `type NowHeaderKeyValue` removed
