### PR TITLE
[next] Update allowQuery for prerendered paths

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -56,6 +56,7 @@ import prettyBytes from 'pretty-bytes';
 const CORRECT_NOT_FOUND_ROUTES_VERSION = 'v12.0.1';
 const CORRECT_MIDDLEWARE_ORDER_VERSION = 'v12.1.7-canary.29';
 const NEXT_DATA_MIDDLEWARE_RESOLVING_VERSION = 'v12.1.7-canary.33';
+const EMPTY_ALLOW_QUERY_FOR_PRERENDERED = 'v12.2.0';
 
 export async function serverBuild({
   dynamicPages,
@@ -133,6 +134,10 @@ export async function serverBuild({
   const lambdaPageKeys = Object.keys(lambdaPages);
   const internalPages = ['_app.js', '_error.js', '_document.js'];
   const pageBuildTraces = await glob('**/*.js.nft.json', pagesDir);
+  const isEmptyAllowQueryForPrendered = semver.gte(
+    nextVersion,
+    EMPTY_ALLOW_QUERY_FOR_PRERENDERED
+  );
   const isCorrectNotFoundRoutes = semver.gte(
     nextVersion,
     CORRECT_NOT_FOUND_ROUTES_VERSION
@@ -756,6 +761,7 @@ export async function serverBuild({
     static404Page,
     hasPages404: routesManifest.pages404,
     isCorrectNotFoundRoutes,
+    isEmptyAllowQueryForPrendered,
   });
 
   Object.keys(prerenderManifest.staticRoutes).forEach(route =>

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -56,7 +56,7 @@ import prettyBytes from 'pretty-bytes';
 const CORRECT_NOT_FOUND_ROUTES_VERSION = 'v12.0.1';
 const CORRECT_MIDDLEWARE_ORDER_VERSION = 'v12.1.7-canary.29';
 const NEXT_DATA_MIDDLEWARE_RESOLVING_VERSION = 'v12.1.7-canary.33';
-const EMPTY_ALLOW_QUERY_FOR_PRERENDERED = 'v12.2.0';
+const EMPTY_ALLOW_QUERY_FOR_PRERENDERED_VERSION = 'v12.2.0';
 
 export async function serverBuild({
   dynamicPages,
@@ -136,7 +136,7 @@ export async function serverBuild({
   const pageBuildTraces = await glob('**/*.js.nft.json', pagesDir);
   const isEmptyAllowQueryForPrendered = semver.gte(
     nextVersion,
-    EMPTY_ALLOW_QUERY_FOR_PRERENDERED
+    EMPTY_ALLOW_QUERY_FOR_PRERENDERED_VERSION
   );
   const isCorrectNotFoundRoutes = semver.gte(
     nextVersion,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1901,7 +1901,7 @@ export const onPrerenderRoute =
       // a given path. All other query keys will be striped. We can automatically
       // detect this for prerender (ISR) pages by reading the routes manifest file.
       const pageKey = srcRoute || routeKey;
-      const isDynamic = isDynamicRoute(pageKey);
+      const isDynamic = isDynamicRoute(routeKey);
       const route = routesManifest?.dynamicRoutes.find(
         (r): r is RoutesManifestRoute =>
           r.page === pageKey && !('isMiddleware' in r)
@@ -1911,14 +1911,17 @@ export const onPrerenderRoute =
       // we have sufficient information to set it
       let allowQuery: string[] | undefined;
 
-      if (routeKeys) {
+      if (!isDynamic) {
+        // for non-dynamic routes we use an empty array since
+        // no query values bust the cache for non-dynamic prerenders
+        // prerendered paths also do not pass allowQuery as they match
+        // during handle: 'filesystem' so should not cache differently
+        // by query values
+        allowQuery = [];
+      } else if (routeKeys) {
         // if we have routeKeys in the routes-manifest we use those
         // for allowQuery for dynamic routes
         allowQuery = Object.values(routeKeys);
-      } else if (!isDynamic) {
-        // for non-dynamic routes we use an empty array since
-        // no query values bust the cache for non-dynamic prerenders
-        allowQuery = [];
       }
 
       prerenders[outputPathPage] = new Prerender({

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1665,6 +1665,7 @@ type OnPrerenderRouteArgs = {
   pageLambdaMap: { [key: string]: string };
   routesManifest?: RoutesManifest;
   isCorrectNotFoundRoutes?: boolean;
+  isEmptyAllowQueryForPrendered?: boolean;
 };
 let prerenderGroup = 1;
 
@@ -1698,6 +1699,7 @@ export const onPrerenderRoute =
       pageLambdaMap,
       routesManifest,
       isCorrectNotFoundRoutes,
+      isEmptyAllowQueryForPrendered,
     } = prerenderRouteArgs;
 
     if (isBlocking && isFallback) {
@@ -1901,7 +1903,6 @@ export const onPrerenderRoute =
       // a given path. All other query keys will be striped. We can automatically
       // detect this for prerender (ISR) pages by reading the routes manifest file.
       const pageKey = srcRoute || routeKey;
-      const isDynamic = isDynamicRoute(routeKey);
       const route = routesManifest?.dynamicRoutes.find(
         (r): r is RoutesManifestRoute =>
           r.page === pageKey && !('isMiddleware' in r)
@@ -1911,17 +1912,33 @@ export const onPrerenderRoute =
       // we have sufficient information to set it
       let allowQuery: string[] | undefined;
 
-      if (!isDynamic) {
-        // for non-dynamic routes we use an empty array since
-        // no query values bust the cache for non-dynamic prerenders
-        // prerendered paths also do not pass allowQuery as they match
-        // during handle: 'filesystem' so should not cache differently
-        // by query values
-        allowQuery = [];
-      } else if (routeKeys) {
-        // if we have routeKeys in the routes-manifest we use those
-        // for allowQuery for dynamic routes
-        allowQuery = Object.values(routeKeys);
+      if (isEmptyAllowQueryForPrendered) {
+        const isDynamic = isDynamicRoute(routeKey);
+
+        if (!isDynamic) {
+          // for non-dynamic routes we use an empty array since
+          // no query values bust the cache for non-dynamic prerenders
+          // prerendered paths also do not pass allowQuery as they match
+          // during handle: 'filesystem' so should not cache differently
+          // by query values
+          allowQuery = [];
+        } else if (routeKeys) {
+          // if we have routeKeys in the routes-manifest we use those
+          // for allowQuery for dynamic routes
+          allowQuery = Object.values(routeKeys);
+        }
+      } else {
+        const isDynamic = isDynamicRoute(pageKey);
+
+        if (routeKeys) {
+          // if we have routeKeys in the routes-manifest we use those
+          // for allowQuery for dynamic routes
+          allowQuery = Object.values(routeKeys);
+        } else if (!isDynamic) {
+          // for non-dynamic routes we use an empty array since
+          // no query values bust the cache for non-dynamic prerenders
+          allowQuery = [];
+        }
       }
 
       prerenders[outputPathPage] = new Prerender({

--- a/packages/next/test/fixtures/00-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-server-build/index.test.js
@@ -1,8 +1,144 @@
+/* eslint-env jest */
 const path = require('path');
-const { deployAndTest } = require('../../utils');
+const cheerio = require('cheerio');
+const { deployAndTest, check, waitFor } = require('../../utils');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
+
+async function checkForChange(url, initialValue, getNewValue) {
+  return check(async () => {
+    const res = await fetch(url);
+
+    if (res.status !== 200) {
+      throw new Error(`Invalid status code ${res.status}`);
+    }
+    const newValue = await getNewValue(res);
+
+    return initialValue !== newValue
+      ? 'success'
+      : JSON.stringify({ initialValue, newValue });
+  }, 'success');
+}
+
+const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
   it('should deploy and pass probe checks', async () => {
-    await deployAndTest(__dirname);
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+
+  it.each([
+    {
+      title: 'should update content for prerendered path correctly',
+      pathsToCheck: [
+        { urlPath: '/fallback-blocking/first' },
+        { urlPath: '/fallback-blocking/first', query: '?slug=first' },
+        { urlPath: '/fallback-blocking/first', query: '?slug=random' },
+        { urlPath: '/fallback-blocking/first', query: '?another=value' },
+      ],
+    },
+    {
+      title: 'should update content for non-prerendered path correctly',
+      pathsToCheck: [
+        { urlPath: '/fallback-blocking/on-demand-2' },
+        {
+          urlPath: '/fallback-blocking/on-demand-2',
+          query: '?slug=on-demand-2',
+        },
+        { urlPath: '/fallback-blocking/on-demand-2', query: '?slug=random' },
+        { urlPath: '/fallback-blocking/on-demand-2', query: '?another=value' },
+      ],
+    },
+  ])('$title', async ({ pathsToCheck }) => {
+    let initialRandom;
+    let initialRandomData;
+    let preRevalidateRandom;
+    let preRevalidateRandomData;
+
+    const checkPaths = async pathsToCheck => {
+      for (const { urlPath, query } of pathsToCheck) {
+        console.log('checking', {
+          urlPath,
+          query,
+          initialRandom,
+          preRevalidateRandom,
+        });
+
+        if (preRevalidateRandom) {
+          // wait for change as cache may take a little to propagate
+          const initialUrl = `${ctx.deploymentUrl}${urlPath}${query || ''}`;
+          await checkForChange(initialUrl, preRevalidateRandom, async () => {
+            const res = await fetch(initialUrl);
+            const $ = cheerio.load(await res.text());
+            return JSON.parse($('#props').text()).random;
+          });
+        }
+
+        const res = await fetch(`${ctx.deploymentUrl}${urlPath}${query || ''}`);
+        expect(res.status).toBe(200);
+
+        const $ = await cheerio.load(await res.text());
+        const props = JSON.parse($('#props').text());
+
+        if (initialRandom) {
+          // for fallback paths the initial value is generated
+          // in the foreground and then a revalidation is kicked off
+          // in the background so the initial value will be replaced
+          if (initialRandom !== props.random && urlPath.includes('on-demand')) {
+            initialRandom = props.random;
+          } else {
+            expect(initialRandom).toBe(props.random);
+          }
+        } else {
+          initialRandom = props.random;
+        }
+        expect(isNaN(initialRandom)).toBe(false);
+
+        const dataRes = await fetch(
+          `${ctx.deploymentUrl}/_next/data/testing-build-id${urlPath}.json${
+            query || ''
+          }`
+        );
+        expect(dataRes.status).toBe(200);
+
+        const { pageProps: dataProps } = await dataRes.json();
+
+        if (initialRandomData) {
+          // for fallback paths the initial value is generated
+          // in the foreground and then a revalidation is kicked off
+          // in the background so the initial value will be replaced
+          if (
+            initialRandomData !== dataProps.random &&
+            urlPath.includes('on-demand-2')
+          ) {
+            initialRandomData = dataProps.random;
+          } else {
+            expect(initialRandomData).toBe(dataProps.random);
+          }
+        } else {
+          initialRandomData = dataProps.random;
+        }
+        expect(isNaN(initialRandomData)).toBe(false);
+      }
+    };
+
+    await checkPaths(pathsToCheck);
+
+    preRevalidateRandom = initialRandom;
+    preRevalidateRandomData = initialRandomData;
+
+    initialRandom = undefined;
+    initialRandomData = undefined;
+
+    const revalidateRes = await fetch(
+      `${ctx.deploymentUrl}/api/revalidate?urlPath=${pathsToCheck[0].urlPath}`
+    );
+    expect(revalidateRes.status).toBe(200);
+    expect((await revalidateRes.json()).revalidated).toBe(true);
+
+    await checkPaths(pathsToCheck);
+
+    expect(preRevalidateRandom).not.toBe(initialRandom);
+    expect(preRevalidateRandomData).not.toBe(initialRandomData);
   });
 });

--- a/packages/next/test/fixtures/00-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-server-build/index.test.js
@@ -138,7 +138,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     await checkPaths(pathsToCheck);
 
-    expect(preRevalidateRandom).not.toBe(initialRandom);
-    expect(preRevalidateRandomData).not.toBe(initialRandomData);
+    expect(preRevalidateRandom).toBeDefined();
+    expect(preRevalidateRandomData).toBeDefined();
   });
 });

--- a/packages/next/test/fixtures/00-server-build/pages/api/revalidate.js
+++ b/packages/next/test/fixtures/00-server-build/pages/api/revalidate.js
@@ -1,0 +1,10 @@
+export default async function handler(req, res) {
+  try {
+    console.log('revalidating', req.query.urlPath);
+    await res.revalidate(req.query.urlPath);
+    return res.json({ revalidated: true });
+  } catch (err) {
+    console.error(err);
+    return res.json({ revalidated: false });
+  }
+}

--- a/packages/next/test/fixtures/00-server-build/pages/fallback-blocking/[slug].js
+++ b/packages/next/test/fixtures/00-server-build/pages/fallback-blocking/[slug].js
@@ -16,7 +16,7 @@ export const getStaticProps = ({ params }) => {
 
 export const getStaticPaths = () => {
   return {
-    paths: ['/fallback-blocking/first'],
+    paths: ['/fallback-blocking/first', '/fallback-blocking/on-demand-1'],
     fallback: 'blocking',
   };
 };

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -78,8 +78,20 @@ it('should build using server build', async () => {
   expect(output['dynamic/[slug]'].maxDuration).toBe(5);
   expect(output['fallback/[slug]'].type).toBe('Prerender');
   expect(output['fallback/[slug]'].allowQuery).toEqual(['slug']);
+  expect(output['_next/data/testing-build-id/fallback/[slug].json'].type).toBe(
+    'Prerender'
+  );
+  expect(
+    output['_next/data/testing-build-id/fallback/[slug].json'].allowQuery
+  ).toEqual(['slug']);
   expect(output['fallback/first'].type).toBe('Prerender');
-  expect(output['fallback/first'].allowQuery).toEqual(['slug']);
+  expect(output['fallback/first'].allowQuery).toEqual([]);
+  expect(output['_next/data/testing-build-id/fallback/first.json'].type).toBe(
+    'Prerender'
+  );
+  expect(
+    output['_next/data/testing-build-id/fallback/first.json'].allowQuery
+  ).toEqual([]);
   expect(output['api'].type).toBe('Lambda');
   expect(output['api'].allowQuery).toBe(undefined);
   expect(output['api'].memory).toBe(128);

--- a/packages/next/test/integration/server-build/next.config.js
+++ b/packages/next/test/integration/server-build/next.config.js
@@ -1,3 +1,6 @@
 module.exports = (phase, { defaultConfig }) => ({
   pageExtensions: [...defaultConfig.pageExtensions, 'hello.js'],
+  generateBuildId() {
+    return 'testing-build-id';
+  },
 });

--- a/packages/next/test/utils.ts
+++ b/packages/next/test/utils.ts
@@ -129,7 +129,7 @@ export async function deployAndTest(fixtureDir) {
   };
 }
 
-async function waitFor(milliseconds) {
+export async function waitFor(milliseconds) {
   return new Promise(resolve => {
     setTimeout(resolve, milliseconds);
   });


### PR DESCRIPTION
This updates our `allowQuery` generating to ignore all query values for build-time prerender paths as these will match before dynamic routes since they are filesystem routes and the query values will not be overridden properly like they are for fallback prerender paths. This also adds testing for both prerender path types with on-demand ISR to ensure the cache is updated as expected regardless of the query.  

Deployment with patch can be seen here https://nextjs-issue-odr-simple-hrjt2dagm-ijjk-testing.vercel.app/

### Related Issues

x-ref: https://github.com/vercel/next.js/issues/38306
x-ref: https://github.com/vercel/next.js/issues/38653

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
