### PR TITLE
[cli] write config.json when exiting because of error in builder

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -406,7 +406,16 @@ export default async function main(client: Client): Promise<number> {
         )
       );
     } catch (err: any) {
-      await writeBuildsJsonPromise;
+      const configJson = {
+        version: 3,
+      };
+      const configJsonPromise = fs.writeJSON(
+        join(outputDir, 'config.json'),
+        configJson,
+        { spaces: 2 }
+      );
+
+      await Promise.all([writeBuildsJsonPromise, configJsonPromise]);
 
       const buildJsonBuild = buildsJsonBuilds.get(build);
       if (buildJsonBuild) {

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -642,6 +642,10 @@ describe('build', () => {
       expect(errorBuilds[0].error.message).toMatch(`',' expected.`);
       expect(errorBuilds[0].error.hideStackTrace).toEqual(true);
       expect(errorBuilds[0].error.code).toEqual('NODE_TYPESCRIPT_ERROR');
+
+      // `config.json`` contains `version`
+      const configJson = await fs.readJSON(join(output, 'config.json'));
+      expect(configJson.version).toBe(3);
     } finally {
       process.chdir(originalCwd);
       delete process.env.__VERCEL_BUILD_RUNNING;


### PR DESCRIPTION
When there's an error in a builder, the `builds.json` contains the error, but the output directory does not contain `config.json`, which is required to be considered Build Output API.

This PR ensures that file exists with `version` set to `3`.

---

Related: https://github.com/vercel/vercel/pull/8148