### PR TITLE
[cli][dev] support environment variables in edge functions during `vc dev`

### DIFF
--- a/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
@@ -17,6 +17,7 @@ export default async function edge(request, event) {
       decamelized: decamelize('someCamelCaseThing'),
       uppercase: upper('someThing'),
       optionalChaining: request?.doesnotexist ?? 'fallback',
+      ENV_VAR_IN_EDGE: process.env.ENV_VAR_IN_EDGE,
     })
   );
 }

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -16,7 +16,11 @@ const {
 
 test('[vercel dev] should support edge functions', async () => {
   const dir = fixture('edge-function');
-  const { dev, port, readyResolver } = await testFixture(dir);
+  const { dev, port, readyResolver } = await testFixture(dir, {
+    env: {
+      ENV_VAR_IN_EDGE: '1',
+    },
+  });
 
   try {
     await readyResolver;
@@ -42,6 +46,7 @@ test('[vercel dev] should support edge functions', async () => {
       decamelized: 'some_camel_case_thing',
       uppercase: 'SOMETHING',
       optionalChaining: 'fallback',
+      ENV_VAR_IN_EDGE: '1',
     });
   } finally {
     await dev.kill('SIGTERM');

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -242,6 +242,9 @@ async function createEdgeRuntime(userCode: string | undefined) {
           module: {
             exports: {},
           },
+          process: {
+            env: process.env,
+          },
         });
         return context;
       },


### PR DESCRIPTION
Edge Function support in `vc dev` was not passing through the environment variables, which is supported by [production Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions/edge-functions-api#environment-variables).

This PR passes those through. I updated a test for it and manually tested on a separate project.
