### PR TITLE
[next][node][redwood][remix] Update `@vercel/nft` to 0.21.0

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -46,7 +46,7 @@
     "@types/text-table": "0.2.1",
     "@types/webpack-sources": "3.2.0",
     "@vercel/build-utils": "5.0.3",
-    "@vercel/nft": "0.20.1",
+    "@vercel/nft": "0.21.0",
     "@vercel/routing-utils": "2.0.0",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/next.config.js
@@ -23,7 +23,9 @@ assert(
 // generate 100MB text file which will be traced in `/api/hello`
 // which when combined with the 404 HTML files will push us over the 250MB
 // uncompressed limit
-fs.writeFileSync('data.txt', new Array(100 * 1000 * 1000).fill('a').join());
+fs.writeFileSync('data.txt', Buffer.alloc(100 * 1024 * 1024));
+
+console.log(fs.readdirSync('.'));
 
 module.exports = {
   i18n: {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -53,7 +53,7 @@
     "@types/node-fetch": "^2.6.1",
     "@types/test-listen": "1.1.0",
     "@vercel/ncc": "0.24.0",
-    "@vercel/nft": "0.20.1",
+    "@vercel/nft": "0.21.0",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "node build.js"
   },
   "dependencies": {
-    "@vercel/nft": "0.20.1",
+    "@vercel/nft": "0.21.0",
     "@vercel/routing-utils": "2.0.0",
     "semver": "6.1.1"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -21,7 +21,7 @@
     "default-server.js"
   ],
   "dependencies": {
-    "@vercel/nft": "0.20.1"
+    "@vercel/nft": "0.21.0"
   },
   "devDependencies": {
     "@types/jest": "27.5.1",

--- a/test/lib/run-build-lambda.js
+++ b/test/lib/run-build-lambda.js
@@ -39,11 +39,13 @@ async function runBuildLambda(inputPath) {
     config: build.config,
   });
 
-  const workPath = path.join(
+  let workPath = path.join(
     os.tmpdir(),
     `vercel-${Date.now()}-${Math.floor(Math.random() * 100)}`
   );
   await fs.ensureDir(workPath);
+
+  workPath = await fs.realpath(workPath);
   console.log('building in', workPath);
 
   const buildResult = await wrapper.build({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,22 +3088,6 @@
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.0.tgz#a2e8783a185caa99b5d8961a57dfc9665de16296"
   integrity sha512-crqItMcIwCkvdXY/V3/TzrHJQx6nbIaRqE1cOopJhgGX6izvNov40SmD//nS5flfEvdK54YGjwVVq+zG6crjOg==
 
-"@vercel/nft@0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.20.1.tgz#41e559af189405c526ac1f6709773bc99995b95b"
-  integrity sha512-hSLcr64KHOkcNiTAlv154K4p4faEFBwYIi2eIgu1QCDhB1qyQYvFuEhtw3eaapNjA4/7x/2jcclfCAjILua/ag==
-  dependencies:
-    "@mapbox/node-pre-gyp" "^1.0.5"
-    acorn "^8.6.0"
-    bindings "^1.4.0"
-    estree-walker "2.0.2"
-    glob "^7.1.3"
-    graceful-fs "^4.2.9"
-    micromatch "^4.0.2"
-    node-gyp-build "^4.2.2"
-    resolve-from "^5.0.0"
-    rollup-pluginutils "^2.8.2"
-
 "@vercel/nft@0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.21.0.tgz#e0715b1997cd7021a7c7c48b584ef2295fd4b810"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,6 +3104,23 @@
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
 
+"@vercel/nft@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.21.0.tgz#e0715b1997cd7021a7c7c48b584ef2295fd4b810"
+  integrity sha512-hFCAETfI5cG8l5iAiLhMC2bReC5K7SIybzrxGorv+eGspIbIFsVw7Vg85GovXm/LxA08pIDrAlrhR6GN36XB/Q==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.5"
+    acorn "^8.6.0"
+    async-sema "^3.1.1"
+    bindings "^1.4.0"
+    estree-walker "2.0.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.2"
+    node-gyp-build "^4.2.2"
+    resolve-from "^5.0.0"
+    rollup-pluginutils "^2.8.2"
+
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"
@@ -3577,6 +3594,11 @@ async-sema@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-3.0.1.tgz#404225197ea43e3be91ac7d711fb7088f2469c79"
   integrity sha512-fKT2riE8EHAvJEfLJXZiATQWqZttjx1+tfgnVshCDrH8vlw4YC8aECe0B8MU184g+aVRFVgmfxFlKZKaozSrNw==
+
+async-sema@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/async-sema/-/async-sema-3.1.1.tgz#e527c08758a0f8f6f9f15f799a173ff3c40ea808"
+  integrity sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
### Related Issues

Updates to the latest version of `@vercel/nft` which adds fs concurrency limits to help alleviate memory usage. 

x-ref: https://github.com/vercel/nft/pull/301

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
