### PR TITLE
[utils] allow a github PAT token to get past rate limit

### DIFF
--- a/utils/changelog.js
+++ b/utils/changelog.js
@@ -11,7 +11,7 @@ process.chdir(join(__dirname, '..'));
 async function getLatestStableTag() {
   const headers = {};
 
-  const token = process.env.GITHUB_PAT;
+  const token = process.env.GITHUB_TOKEN;
   if (token) {
     headers['authorization'] = `token ${token}`;
   }

--- a/utils/changelog.js
+++ b/utils/changelog.js
@@ -22,8 +22,13 @@ async function getLatestStableTag() {
       headers,
     }
   );
-  const { tag_name } = await res.json();
-  return tag_name;
+  const result = await res.json();
+  if (!result.tag_name) {
+    const message = result.message || JSON.stringify(result);
+    throw new Error(`Failed to fetch releases from github: ${message}`);
+  }
+
+  return result.tag_name;
 }
 
 function serializeLog(groupedLog) {

--- a/utils/changelog.js
+++ b/utils/changelog.js
@@ -9,8 +9,18 @@ const groupLog = require('./changelog/group');
 process.chdir(join(__dirname, '..'));
 
 async function getLatestStableTag() {
+  const headers = {};
+
+  const token = process.env.GITHUB_PAT;
+  if (token) {
+    headers['authorization'] = `token ${token}`;
+  }
+
   const res = await fetch(
-    'https://api.github.com/repos/vercel/vercel/releases/latest'
+    'https://api.github.com/repos/vercel/vercel/releases/latest',
+    {
+      headers,
+    }
   );
   const { tag_name } = await res.json();
   return tag_name;


### PR DESCRIPTION
If you run `yarn changelog` when your IP is already rate limited by github, you'll get an error. This allows you to set a [Github PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to get past the generic rate limit.

Given a PAT with value `MY_PAT_TOKEN`, you can run:

```
$ GITHUB_TOKEN=MY_PAT_TOKEN yarn changelog
```

If you do get an error, it now actually shows up in the output:

```
$  yarn changelog
yarn run v1.22.18
$ node utils/changelog.js
Error: Failed to fetch releases from github: API rate limit exceeded for 98.139.180.149. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```