### PR TITLE
[next] Update size limit test

### DIFF
--- a/packages/next/test/integration/test-limit-exceeded-server-build/pages/api/chrome.js
+++ b/packages/next/test/integration/test-limit-exceeded-server-build/pages/api/chrome.js
@@ -1,6 +1,12 @@
 /* eslint-disable */
 import chrome from 'chrome-aws-lambda';
+import fs from 'fs';
+import path from 'path';
 
 export default (req, res) => {
+  try {
+    fs.readdirSync(path.join(process.cwd(), 'public'));
+  } catch (_) {}
+
   res.json({ hello: 'world', chrome: true });
 };


### PR DESCRIPTION
This test is failing due to a decrease in the server layer so it is no longer over the limit as expected so this adds some more data to the specific route to ensure it does hit the limit. 

Fixes: https://github.com/vercel/vercel/runs/7469021922?check_suite_focus=true#step:9:6800
