### PR TITLE
[tests] Fix turbo cache for test changes

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -29,7 +29,8 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
         (path.extname(n) === '.sh' ? 0o100755 : 0o100644),
     }));
 
-  const { FORCE_BUILD_IN_REGION, NOW_DEBUG, VERCEL_DEBUG } = process.env;
+  const { FORCE_BUILD_IN_REGION, NOW_DEBUG, VERCEL_DEBUG, VERCEL_CLI_VERSION } =
+    process.env;
   const nowJson = JSON.parse(bodies['vercel.json'] || bodies['now.json']);
 
   const nowDeployPayload = {
@@ -43,6 +44,7 @@ async function nowDeploy(bodies, randomness, uploadNowJson) {
         FORCE_BUILD_IN_REGION,
         NOW_DEBUG,
         VERCEL_DEBUG,
+        VERCEL_CLI_VERSION,
         NEXT_TELEMETRY_DISABLED: '1',
       },
     },

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "baseBranch": "origin/main",
-  "globalDependencies": ["$RUNNER_OS"],
+  "globalDependencies": ["$RUNNER_OS", "test/lib/**"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
When we make changes in `test/lib/**`, it should run all the E2E tests again for every package.

https://turborepo.org/docs/reference/configuration