### PR TITLE
[node] Update to TypeScript v4.7.4

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -39,7 +39,7 @@
     "exit-hook": "2.2.1",
     "node-fetch": "2.6.7",
     "ts-node": "8.9.1",
-    "typescript": "4.3.4"
+    "typescript": "4.7.4"
   },
   "devDependencies": {
     "@babel/core": "7.5.0",

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -50,7 +50,7 @@ if (!process.env.VERCEL_DEV_IS_ESM) {
   if (tsconfig) {
     try {
       config = ts.readConfigFile(tsconfig, ts.sys.readFile).config;
-    } catch (err) {
+    } catch (err: any) {
       if (err.code !== 'ENOENT') {
         console.error(`Error while parsing "${tsconfig}"`);
         throw err;
@@ -219,11 +219,11 @@ async function compileUserCode(
           }));
         }
       })`;
-  } catch (error) {
+  } catch (err: any) {
     // We can't easily show a meaningful stack trace from ncc -> edge-runtime.
     // So, stick with just the message for now.
     console.error(`Failed to instantiate edge runtime.`);
-    logError(error);
+    logError(err);
     return undefined;
   }
 }
@@ -254,11 +254,11 @@ async function createEdgeRuntime(userCode: string | undefined) {
     exitHook(server.close);
 
     return server;
-  } catch (error) {
+  } catch (err: any) {
     // We can't easily show a meaningful stack trace from ncc -> edge-runtime.
     // So, stick with just the message for now.
     console.error('Failed to instantiate edge runtime.');
-    logError(error);
+    logError(err);
     return undefined;
   }
 }
@@ -364,9 +364,9 @@ async function main() {
     handleEvent = await createEventHandler(entrypoint!, config, {
       shouldAddHelpers,
     });
-  } catch (error) {
-    logError(error);
-    handlerEventError = error;
+  } catch (err: any) {
+    logError(err);
+    handlerEventError = err;
   }
 
   const address = proxyServer.address();
@@ -418,9 +418,9 @@ export async function onDevRequest(
       }
     }
     res.end(Buffer.from(result.body, result.encoding));
-  } catch (error) {
+  } catch (err: any) {
     res.statusCode = 500;
-    res.end(error.stack);
+    res.end(err.stack);
   }
 }
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -207,12 +207,12 @@ async function compile(
           fsCache.set(relPath, entry);
           sourceCache.set(relPath, source);
           return source.toString();
-        } catch (e) {
-          if (e.code === 'ENOENT' || e.code === 'EISDIR') {
+        } catch (err: any) {
+          if (err.code === 'ENOENT' || err.code === 'EISDIR') {
             sourceCache.set(relPath, null);
             return null;
           }
-          throw e;
+          throw err;
         }
       },
     }
@@ -567,7 +567,7 @@ async function doTypeCheck(
     const json = JSON.stringify(tsconfig, null, '\t');
     await fsp.mkdir(entrypointCacheDir, { recursive: true });
     await fsp.writeFile(tsconfigPath, json, { flag: 'wx' });
-  } catch (err) {
+  } catch (err: any) {
     // Don't throw if the file already exists
     if (err.code !== 'EEXIST') {
       throw err;


### PR DESCRIPTION
Follow-up to #8250, by updating TypeScript for `@vercel/node`.

Note that this is a BREAKING CHANGE since it will change the default version of TypeScript that is used for user Vercel deployments to v4.7.4.

We should schedule a date for this change to happen, pre-announce that the change in default version is coming, and publish a changelog once it happens.