### PR TITLE
[static-build] Add .vercel to static-build ignore list regardless of config

### DIFF
--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -503,7 +503,7 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
         },
       }),
     },
-    'zero-config-dist-dir': {
+    'static-build-dist-dir': {
       '.vercel/project.json': JSON.stringify({
         orgId: '.',
         projectId: '.',
@@ -518,6 +518,31 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
             src: 'package.json',
             use: '@vercel/static-build',
             config: { distDir: '.' },
+          },
+        ],
+      }),
+      'package.json': JSON.stringify({
+        private: true,
+        scripts: {
+          build: 'echo "Hello, World!" >> index.txt',
+        },
+      }),
+    },
+    'static-build-zero-config-output-directory': {
+      '.vercel/project.json': JSON.stringify({
+        orgId: '.',
+        projectId: '.',
+        settings: {
+          framework: null,
+        },
+      }),
+      'vercel.json': JSON.stringify({
+        version: 2,
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+            config: { zeroConfig: true, outputDirectory: '.' },
           },
         ],
       }),

--- a/packages/cli/test/helpers/prepare.js
+++ b/packages/cli/test/helpers/prepare.js
@@ -503,6 +503,31 @@ module.exports = async function prepare(session, binaryPath, tmpFixturesDir) {
         },
       }),
     },
+    'zero-config-dist-dir': {
+      '.vercel/project.json': JSON.stringify({
+        orgId: '.',
+        projectId: '.',
+        settings: {
+          framework: null,
+        },
+      }),
+      'vercel.json': JSON.stringify({
+        version: 2,
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+            config: { distDir: '.' },
+          },
+        ],
+      }),
+      'package.json': JSON.stringify({
+        private: true,
+        scripts: {
+          build: 'echo "Hello, World!" >> index.txt',
+        },
+      }),
+    },
   };
 
   for (const [typeName, needed] of Object.entries(spec)) {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -3921,31 +3921,24 @@ test('[vc build] should build project with `@vercel/static-build`', async t => {
   t.is(builds.builds[0].use, '@vercel/static-build');
 });
 
-test('[vc build] should not include .vercel when outputDirectory is set to "."', async t => {
-  const directory = fixture('zero-config-dist-dir');
+test('[vc build] should not include .vercel when distDir is "."', async t => {
+  const directory = fixture('static-build-dist-dir');
+  const output = await execute(['build'], { cwd: directory });
+  t.is(output.exitCode, 0);
+  t.true(output.stderr.includes('Build Completed in .vercel/output'));
+  const dir = await fs.readdir(path.join(directory, '.vercel/output/static'));
+  t.false(dir.includes('.vercel'));
+  t.true(dir.includes('index.txt'));
+});
 
-  async function deployAndAssert() {
-    const output = await execute(['build'], { cwd: directory });
-
-    t.is(output.exitCode, 0);
-    t.true(output.stderr.includes('Build Completed in .vercel/output'));
-
-    const dir = await fs.readdir(path.join(directory, '.vercel/output/static'));
-
-    t.false(dir.includes('.vercel'));
-    t.true(dir.includes('index.txt'));
-  }
-
-  // Test without zeroConfig
-  await deployAndAssert();
-
-  // Test with zeroConfig enabled
-  const vercelJsonPath = path.join(directory, 'vercel.json');
-  const vercelJsonData = JSON.parse(await fs.readFile(vercelJsonPath));
-  vercelJsonData.builds[0].config.zeroConfig = 'true';
-  await fs.writeFile(vercelJsonPath, JSON.stringify(vercelJsonData));
-
-  await deployAndAssert();
+test('[vc build] should not include .vercel when zeroConfig is true and outputDirectory is "."', async t => {
+  const directory = fixture('static-build-zero-config-output-directory');
+  const output = await execute(['build'], { cwd: directory });
+  t.is(output.exitCode, 0);
+  t.true(output.stderr.includes('Build Completed in .vercel/output'));
+  const dir = await fs.readdir(path.join(directory, '.vercel/output/static'));
+  t.false(dir.includes('.vercel'));
+  t.true(dir.includes('index.txt'));
 });
 
 test('vercel.json configuration overrides in a new project prompt user and merges settings correctly', async t => {

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -3921,6 +3921,19 @@ test('[vc build] should build project with `@vercel/static-build`', async t => {
   t.is(builds.builds[0].use, '@vercel/static-build');
 });
 
+test('[vc build] should not include .vercel when outputDirectory is set to "."', async t => {
+  const directory = fixture('zero-config-dist-dir');
+  const output = await execute(['build'], { cwd: directory });
+  console.log(output);
+  t.is(output.exitCode, 0);
+  t.true(output.stderr.includes('Build Completed in .vercel/output'));
+
+  const dir = await fs.readdir(path.join(directory, '.vercel/output/static'));
+
+  t.false(dir.includes('.vercel'));
+  t.true(dir.includes('index.txt'));
+});
+
 test('vercel.json configuration overrides in a new project prompt user and merges settings correctly', async t => {
   const directory = fixture(
     'vercel-json-configuration-overrides-merging-prompts'

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -713,6 +713,7 @@ export const build: BuildV2 = async ({
             '.env',
             '.env.*',
             '.git/**',
+            '.vercel/**',
             'node_modules/**',
             'yarn.lock',
             'package-lock.json',

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -707,8 +707,8 @@ export const build: BuildV2 = async ({
           routes.push(...frameworkRoutes);
         }
 
-        let ignore: string[] = ['.vercel/**'];
-        if (config.zeroConfig && config.outputDirectory === '.') {
+        let ignore: string[] = [];
+        if (config.outputDirectory === '.' || config.distDir === '.') {
           ignore = [
             '.env',
             '.env.*',

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -707,13 +707,12 @@ export const build: BuildV2 = async ({
           routes.push(...frameworkRoutes);
         }
 
-        let ignore: string[] = [];
+        let ignore: string[] = ['.vercel/**'];
         if (config.zeroConfig && config.outputDirectory === '.') {
           ignore = [
             '.env',
             '.env.*',
             '.git/**',
-            '.vercel/**',
             'node_modules/**',
             'yarn.lock',
             'package-lock.json',


### PR DESCRIPTION
### Related Issues

Adds `.vercel` path to the ignore list regardless if `zeroConfig` is enabled. This fixes a bug where the `.vercel` folder was being copied into the resulting `.vercel/output/static` directory after running `vc build` with `distDir: "."` configured for static-build.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
