### PR TITLE
[tests] Speed up vc tarball

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,8 +5,7 @@
   "description": "API for the vercel/vercel repo",
   "main": "index.js",
   "scripts": {
-    "//TODO": "We should add this pkg to yarn workspaces",
-    "vercel-build": "cd .. && yarn install && yarn vercel-build"
+    "//TODO": "We should add this pkg to yarn workspaces"
   },
   "dependencies": {
     "@sentry/node": "5.11.1",


### PR DESCRIPTION
This updates the API that generates tarballs so that it doesn't need to generate tarballs for every Serverless Function and instead generates it one time. This cuts the time in half.