### PR TITLE
[tests] Remove turbo's `dependsOn` to speed up tests

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,27 +20,27 @@
       ]
     },
     "test-unit": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test-integration-dev": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test-integration-cli": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test-integration-once": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test-next-local": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "outputs": []
     }
   }


### PR DESCRIPTION
Since CI is already setup to run Build and then Test, we don't need to add it as an explicit turbo dependency so this PR removes `dependsOn: ['build']` from each test task.

In fact, the `test-unit` step doesn't need `build` in most cases now that jest is configured to run the TS sources directly. 

This PR will also improve the time it takes to run the "Find Changes" job since it can ask jest for relevant files that changed without waiting for a build. This drops the time down from 2 minutes to 8 seconds.