### PR TITLE
[build-utils] Fix symlink on download

### DIFF
--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -47,22 +47,22 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
 
   if (isSymbolicLink(mode)) {
     const target = await prepareSymlinkTarget(file, fsPath);
-    console.log('Found symlink', { target, fsPath });
 
     try {
       await symlink(target, fsPath);
     } catch (error: any) {
       if (error?.code === 'EEXIST') {
-        const fsLink = await readlink(fsPath).catch((err: Error) => err);
-        console.log('Symlink already exists', { target, fsPath, fsLink });
-      } else {
-        throw error;
+        // HACK: Some builders resolve symlinks and return both
+        // a file, node_modules/<symlink>/package.json, and
+        // node_modules/<symlink>, a symlink.
+        // This remove() matches how the yazl lambda zip behaves
+        // so we can use download() with `vercel build`.
+        await remove(fsPath);
+        await symlink(target, fsPath);
       }
     }
 
     return FileFsRef.fromFsPath({ mode, fsPath });
-  } else {
-    console.log('Found file', { fsPath });
   }
 
   const stream = file.toStream();
@@ -96,21 +96,21 @@ export default async function download(
 
   const start = Date.now();
   const files2: DownloadedFiles = {};
-  const entries = Object.entries(files);
+  const filenames = Object.keys(files);
 
   await Promise.all(
-    entries.map(async ([name, file]) => {
+    filenames.map(async name => {
       // If the file does not exist anymore, remove it.
       if (Array.isArray(filesRemoved) && filesRemoved.includes(name)) {
         await removeFile(basePath, name);
         return;
       }
-
       // If a file didn't change, do not re-download it.
       if (Array.isArray(filesChanged) && !filesChanged.includes(name)) {
         return;
       }
 
+      const file = files[name];
       const fsPath = path.join(basePath, name);
 
       files2[name] = await downloadFile(file, fsPath);
@@ -118,7 +118,7 @@ export default async function download(
   );
 
   const duration = Date.now() - start;
-  debug(`Downloaded ${entries.length} source files: ${duration}ms`);
+  debug(`Downloaded ${filenames.length} source files: ${duration}ms`);
 
   return files2;
 }

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -49,7 +49,6 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
     const target = await prepareSymlinkTarget(file, fsPath);
 
     await symlink(target, fsPath);
-
     return FileFsRef.fromFsPath({ mode, fsPath });
   }
 

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -53,7 +53,8 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
       await symlink(target, fsPath);
     } catch (error: any) {
       if (error?.code === 'EEXIST') {
-        console.log('Symlink already exists', { target, fsPath });
+        const fsLink = await readlink(fsPath);
+        console.log('Symlink already exists', { target, fsPath, fsLink });
       } else {
         throw error;
       }

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -92,7 +92,7 @@ export default async function download(
     // source files are already available.
     return files as DownloadedFiles;
   }
-  debug('Downloading deployment source files to ', basePath);
+  debug('Downloading deployment source files...');
 
   const start = Date.now();
   const files2: DownloadedFiles = {};

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -47,6 +47,7 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
 
   if (isSymbolicLink(mode)) {
     const target = await prepareSymlinkTarget(file, fsPath);
+    console.log('Found symlink', { target, fsPath });
 
     try {
       await symlink(target, fsPath);
@@ -88,7 +89,7 @@ export default async function download(
     // source files are already available.
     return files as DownloadedFiles;
   }
-  debug('Downloading deployment source files...');
+  debug('Downloading deployment source files to ', basePath);
 
   const start = Date.now();
   const files2: DownloadedFiles = {};

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -48,7 +48,16 @@ async function downloadFile(file: File, fsPath: string): Promise<FileFsRef> {
   if (isSymbolicLink(mode)) {
     const target = await prepareSymlinkTarget(file, fsPath);
 
-    await symlink(target, fsPath);
+    try {
+      await symlink(target, fsPath);
+    } catch (error: any) {
+      if (error?.code === 'EEXIST') {
+        console.log('Symlink already exists', { target, fsPath });
+      } else {
+        throw error;
+      }
+    }
+
     return FileFsRef.fromFsPath({ mode, fsPath });
   }
 

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -103,7 +103,7 @@ export default async function download(
       // Removing the file matches how the yazl lambda zip
       // behaves so we can use download() with `vercel build`.
       const parts = name.split('/');
-      for (let i = 0; i < parts.length; i++) {
+      for (let i = 1; i < parts.length; i++) {
         const dir = parts.slice(0, i).join('/');
         const parent = files[dir];
         if (parent && isSymbolicLink(parent.mode)) {

--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -107,7 +107,7 @@ export default async function download(
         const dir = parts.slice(0, i).join('/');
         const parent = files[dir];
         if (parent && isSymbolicLink(parent.mode)) {
-          console.log(
+          console.warn(
             `Warning: file "${name}" is within a symlinked directory "${dir}" and will be ignored`
           );
           return;


### PR DESCRIPTION
Some builders, such as `@vercel/next`, return both the symlinked directory and the resolved file.

When `vc build` iterates over the files to recreate them in `.vercel/output`, it fails with `EEXIST: file already exists` when creating the symlink because it first creates the file `node_modules/<symlink>/package.json` and then attempts to create the symlink `node_modules/<symlink>`.

This happened to work before `vc build` because yazl would accept the symlinked directory instead of the package.json file, so this PR is created to match that behavior.