### PR TITLE
see what all fails when not looking for "Error!"

### DIFF
--- a/packages/cli/test/dev/utils.js
+++ b/packages/cli/test/dev/utils.js
@@ -348,7 +348,10 @@ function testFixtureStdio(
               : []),
             'deploy',
             ...(process.env.VERCEL_CLI_VERSION
-              ? ['--build-env', `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION}`]
+              ? [
+                  '--build-env',
+                  `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION}`,
+                ]
               : []),
             '--public',
             '--debug',
@@ -430,7 +433,7 @@ function testFixtureStdio(
           );
         }
 
-        if (stderr.includes('Command failed') || stderr.includes('Error!')) {
+        if (stderr.includes('Command failed')) {
           dev.kill('SIGTERM');
           throw new Error(`Failed for "${directory}" with stderr "${stderr}".`);
         }


### PR DESCRIPTION
See what happens when `testFixtureStdio` no longer checks for "Error!".