### PR TITLE
[next] Ensure we resolve _next/data dynamic routes correctly with i18n

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1401,8 +1401,16 @@ export async function serverBuild({
               );
 
               const { pathname } = new URL(route.dest || '/', 'http://n');
+              let prerenderPathname = pathname;
 
-              if (prerenders[path.join('./', pathname)]) {
+              if (routesManifest.i18n) {
+                prerenderPathname = pathname.replace(
+                  /^\/\$nextLocale/,
+                  `/${routesManifest.i18n.defaultLocale}`
+                );
+              }
+
+              if (prerenders[path.join('./', prerenderPathname)]) {
                 route.dest = `/_next/data/${buildId}${pathname}.json`;
               }
               return route;

--- a/packages/next/test/fixtures/00-middleware-i18n/index.test.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-middleware-i18n/middleware.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/middleware.js
@@ -1,0 +1,248 @@
+import { NextResponse } from 'next/server';
+
+const ALLOWED = ['allowed'];
+
+export const config = {
+  matcher: [
+    '/dynamic/:path*',
+    '/_sites/:path*',
+    '/:teamId/:slug',
+    '/:path*',
+    '/',
+  ],
+};
+
+export function middleware(request) {
+  const url = request.nextUrl;
+  const pathname = url.pathname;
+
+  if (process.env.FOO) {
+    console.log(`Includes env variable ${process.env.FOO}`);
+  }
+
+  if (url.pathname === '/redirect-me') {
+    url.pathname = '/from-middleware';
+    return NextResponse.redirect(url, 307);
+  }
+
+  if (url.pathname === '/next') {
+    return NextResponse.next();
+  }
+
+  if (url.pathname === '/version') {
+    return NextResponse.json({
+      enumerable: Object.keys(self).includes('VercelRuntime'),
+      version: self.VercelRuntime.version,
+    });
+  }
+
+  if (url.pathname === '/globals') {
+    const globalThisKeys = Object.keys(globalThis);
+    const globalKeys = globalThisKeys.reduce((acc, globalName) => {
+      const key = globalName.toString();
+      if (global[key]) acc.push(key);
+      return acc;
+    }, []);
+
+    const res = NextResponse.next();
+    res.headers.set(
+      'data',
+      JSON.stringify({ globals: globalKeys, globalThis: globalThisKeys })
+    );
+    return res;
+  }
+
+  if (url.pathname === '/log') {
+    console.log('hi there');
+    return;
+  }
+
+  if (url.pathname === '/somewhere') {
+    url.pathname = '/from-middleware';
+    return NextResponse.redirect(url);
+  }
+
+  if (url.pathname === '/logs') {
+    console.clear();
+    for (let i = 0; i < 3; i++) console.count();
+    console.count('test');
+    console.count('test');
+    console.dir({ hello: 'world' });
+    console.log('hello');
+    console.log('world');
+    return;
+  }
+
+  if (url.pathname === '/greetings') {
+    const data = { message: 'hello world!' };
+    const res = NextResponse.next();
+    res.headers.set('x-example', 'edge');
+    res.headers.set('data', JSON.stringify(data));
+    return res;
+  }
+
+  if (url.pathname === '/rewrite-me-to-about') {
+    url.pathname = '/about';
+    url.searchParams.set('middleware', 'foo');
+    return NextResponse.rewrite(url);
+  }
+
+  if (url.pathname === '/rewrite-to-site') {
+    const customUrl = new URL(url);
+    customUrl.pathname = '/_sites/subdomain-1/';
+    console.log('rewriting to', customUrl.pathname, customUrl.href);
+    return NextResponse.rewrite(customUrl);
+  }
+
+  if (url.pathname === '/redirect-me-to-about') {
+    url.pathname = '/about';
+    url.searchParams.set('middleware', 'foo');
+    return Response.redirect(url);
+  }
+
+  if (url.pathname === '/rewrite-absolute') {
+    return NextResponse.rewrite('https://example.vercel.sh/foo?foo=bar');
+  }
+
+  if (url.pathname === '/rewrite-relative') {
+    url.pathname = '/foo';
+    url.searchParams.set('foo', 'bar');
+    return NextResponse.rewrite(url);
+  }
+
+  if (url.pathname === '/redirect-absolute') {
+    return Response.redirect('https://vercel.com');
+  }
+
+  if (url.pathname === '/redirect-301') {
+    url.pathname = '/greetings';
+    return NextResponse.redirect(url, 301);
+  }
+
+  if (url.pathname === '/reflect') {
+    const res = NextResponse.next();
+    res.headers.set(
+      'data',
+      JSON.stringify({
+        geo: request.geo,
+        headers: Object.fromEntries(request.headers),
+        ip: request.ip,
+        method: request.method,
+        nextUrl: {
+          hash: request.nextUrl.hash,
+          hostname: request.nextUrl.hostname,
+          pathname: request.nextUrl.pathname,
+          port: request.nextUrl.port,
+          protocol: request.nextUrl.protocol,
+          search: request.nextUrl.search,
+        },
+        url: request.url,
+      })
+    );
+    return res;
+  }
+
+  if (url.pathname === '/stream-response') {
+    const { readable, writable } = new TransformStream();
+    const waitUntil = (async () => {
+      const enc = new TextEncoder();
+      const writer = writable.getWriter();
+      writer.write(enc.encode('this is a streamed '));
+      writer.write(enc.encode('response '));
+      return writer.close();
+    })();
+
+    return {
+      waitUntil,
+      response: NextResponse.next(),
+    };
+  }
+
+  if (url.pathname === '/throw-error') {
+    const error = new Error('oh no!');
+    console.log('This is not worker.js');
+    console.error(error);
+    return new Promise((_, reject) => reject(error));
+  }
+
+  if (url.pathname === '/throw-error-internal') {
+    function myFunctionName() {
+      throw new Error('Oh no!');
+    }
+
+    function anotherFunction() {
+      return myFunctionName();
+    }
+
+    try {
+      anotherFunction();
+    } catch (err) {
+      console.error(err);
+    }
+
+    return new Promise((_, reject) => reject(new Error('oh no!')));
+  }
+
+  if (url.pathname === '/unhandledrejection') {
+    Promise.reject(new TypeError('captured unhandledrejection error.'));
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/query-params')) {
+    if (pathname.endsWith('/clear')) {
+      const strategy =
+        url.searchParams.get('strategy') === 'rewrite' ? 'rewrite' : 'redirect';
+
+      for (const key of [...url.searchParams.keys()]) {
+        if (!ALLOWED.includes(key)) {
+          url.searchParams.delete(key);
+        }
+      }
+
+      const newPath = url.pathname.replace(/\/clear$/, '');
+      url.pathname = newPath;
+
+      if (strategy === 'redirect') {
+        return NextResponse.redirect(url);
+      } else {
+        return NextResponse.rewrite(url);
+      }
+    }
+
+    const obj = Object.fromEntries([...url.searchParams.entries()]);
+
+    const res = NextResponse.next();
+    res.headers.set('data', JSON.stringify(obj));
+    return res;
+  }
+
+  if (pathname.startsWith('/home')) {
+    if (!request.cookies.get('bucket')) {
+      const bucket = Math.random() >= 0.5 ? 'a' : 'b';
+      url.pathname = `/home/${bucket}`;
+      const response = NextResponse.rewrite(url);
+      response.cookies.set('bucket', bucket);
+      return response;
+    }
+
+    url.pathname = `/home/${request.cookies.get('bucket')}`;
+    return NextResponse.rewrite(url);
+  }
+
+  if (pathname.startsWith('/fetch-subrequest')) {
+    const destinationUrl =
+      url.searchParams.get('url') || 'https://example.vercel.sh';
+    return fetch(destinationUrl, { headers: request.headers });
+  }
+
+  if (url.pathname === '/dynamic/greet') {
+    const res = NextResponse.next();
+    res.headers.set(
+      'data',
+      JSON.stringify({
+        message: url.searchParams.get('greeting') || 'Hi friend',
+      })
+    );
+    return res;
+  }
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/next.config.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/next.config.js
@@ -1,0 +1,42 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  i18n: {
+    locales: ['en', 'fr'],
+    defaultLocale: 'en',
+  },
+  redirects() {
+    return [
+      {
+        source: '/redirect-me',
+        destination: '/from-next-config',
+        permanent: false,
+      },
+    ];
+  },
+  rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/rewrite-before-files',
+          destination: '/somewhere',
+        },
+      ],
+      afterFiles: [
+        {
+          source: '/after-file-rewrite',
+          destination: '/about',
+        },
+        {
+          source: '/after-file-rewrite-auto-static',
+          destination: '/home/a',
+        },
+        {
+          source: '/after-file-rewrite-auto-static-dynamic',
+          destination: '/dynamic/first',
+        },
+      ],
+    };
+  },
+};

--- a/packages/next/test/fixtures/00-middleware-i18n/package.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/[teamId]/[slug].js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/[teamId]/[slug].js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>/[teamId]/[slug]</p>;
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/_sites/[site].js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/_sites/[site].js
@@ -1,0 +1,31 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>/_sites/[site]</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  };
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: { site: 'subdomain-1' },
+      },
+      {
+        params: { site: 'subdomain-2' },
+      },
+    ],
+    fallback: 'blocking',
+  };
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/about.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/about.js
@@ -1,0 +1,17 @@
+export default function Main({ message, middleware }) {
+  return (
+    <div>
+      <h1 className="title">About Page</h1>
+      <p className={message}>{message}</p>
+      <p className="middleware">{middleware}</p>
+    </div>
+  );
+}
+
+export const getServerSideProps = ({ query }) => ({
+  props: {
+    middleware: query.middleware || '',
+    message: query.message || '',
+    page: 'about',
+  },
+});

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/dynamic/[id]/index.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/dynamic/[id]/index.js
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <p className="title">Dynamic route</p>;
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/dynamic/static.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/dynamic/static.js
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <p className="title">static route</p>;
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/fetch-subrequest/index.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/fetch-subrequest/index.js
@@ -1,0 +1,16 @@
+export default function Main({ message, middleware }) {
+  return (
+    <div>
+      <h1 className="title">About Page</h1>
+      <p className={message}>{message}</p>
+      <p className="middleware">{middleware}</p>
+    </div>
+  );
+}
+
+export const getServerSideProps = ({ query }) => ({
+  props: {
+    middleware: query.middleware || '',
+    message: query.message || '',
+  },
+});

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/home/a.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/home/a.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Home A</h1>;
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/home/b.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/home/b.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Home B</h1>;
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/pages/index.js
+++ b/packages/next/test/fixtures/00-middleware-i18n/pages/index.js
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+
+export default function Index() {
+  return (
+    <div>
+      <h1>Demo</h1>
+      <ul>
+        <li>
+          <Link href="/home">
+            <a>A/B Testing</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/rewrite-me-to-about">
+            <a>Rewrite to existing page</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/redirect-me-to-about">
+            <a>Redirect to existing page</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/rewrite">
+            <a>Rewrite to external site</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/redirect">
+            <a>Redirect to external site</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/greetings">
+            <a>Respond with JSON</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/stream-response">
+            <a>Respond with Stream</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/dynamic/greet?greeting=hola">
+            <a>Dynamic Nested Middleware</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/eval">
+            <a>do a eval</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/logs">
+            <a>print some logs</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/fetch">
+            <a>perform a fetch</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/throw-error">
+            <a>throw an error</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/throw-error-internal">
+            <a>throw a controller error</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/timeout">
+            <a>simulate timeout</a>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/00-middleware-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/vercel.json
@@ -3,7 +3,7 @@
   "builds": [
     {
       "src": "package.json",
-      "use": "@vercelruntimes/next@https://files-9tn6zofic-ijjk-testing.vercel.app"
+      "use": "@vercel/next"
     }
   ],
   "probes": [

--- a/packages/next/test/fixtures/00-middleware-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/vercel.json
@@ -1,0 +1,120 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercelruntimes/next@https://files-9tn6zofic-ijjk-testing.vercel.app"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/_next/data/testing-build-id/en/dynamic/static.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "responseHeaders": {
+        "x-matched-path": "/en/dynamic/static"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/team-1/slug-1.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "responseHeaders": {
+        "x-matched-path": "/en/[teamId]/[slug]"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/dynamic/id-1.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "responseHeaders": {
+        "x-matched-path": "/en/dynamic/[id]"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/rewrite-to-site.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "mustContain": "site\":\"subdomain-1\"",
+      "mustNotContain": "<html>"
+    },
+    {
+      "path": "/redirect-me",
+      "status": 307,
+      "responseHeaders": {
+        "Location": "/from-next-config/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/rewrite-before-files",
+      "status": 404,
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/somewhere",
+      "status": 307,
+      "responseHeaders": {
+        "Location": "/from-middleware/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/after-file-rewrite",
+      "status": 200,
+      "mustContain": "About Page"
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/after-file-rewrite.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": "1"
+      },
+      "mustContain": "page\":\"about\""
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/after-file-rewrite-auto-static-dynamic.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": "1"
+      },
+      "responseHeaders": {
+        "x-matched-path": "/en/dynamic/[id]"
+      },
+      "mustContain": "{}"
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/redirect-me.json",
+      "status": 307,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "Location": "/from-middleware/"
+      }
+    },
+    {
+      "path": "/_next/data/testing-build-id/en/_sites/subdomain-1.json",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "mustNotContain": "<html>",
+      "mustContain": "\"site\":\"subdomain-1\""
+    }
+  ]
+}


### PR DESCRIPTION
### Related Issues

Follow-up to https://github.com/vercel/vercel/pull/8278 this ensures we correctly map _next/data dynamic routes with i18n enabled. The E2E tests in the Next.js repo caught this although added additional coverage here to catch this faster.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
