### PR TITLE
[next] Update data route handling for i18n and static routes

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1401,16 +1401,22 @@ export async function serverBuild({
               );
 
               const { pathname } = new URL(route.dest || '/', 'http://n');
-              let prerenderPathname = pathname;
+              let isPrerender = !!prerenders[path.join('./', pathname)];
 
               if (routesManifest.i18n) {
-                prerenderPathname = pathname.replace(
-                  /^\/\$nextLocale/,
-                  `/${routesManifest.i18n.defaultLocale}`
-                );
+                for (const locale of routesManifest.i18n?.locales || []) {
+                  const prerenderPathname = pathname.replace(
+                    /^\/\$nextLocale/,
+                    `/${locale}`
+                  );
+                  if (prerenders[path.join('./', prerenderPathname)]) {
+                    isPrerender = true;
+                    break;
+                  }
+                }
               }
 
-              if (prerenders[path.join('./', prerenderPathname)]) {
+              if (isPrerender) {
                 route.dest = `/_next/data/${buildId}${pathname}.json`;
               }
               return route;

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1384,6 +1384,15 @@ export async function serverBuild({
       // re-build /_next/data URL after resolving
       ...denormalizeNextDataRoute(),
 
+      ...(isNextDataServerResolving
+        ? dataRoutes.filter(route => {
+            // filter to only static data routes as dynamic routes will be handled
+            // below
+            const { pathname } = new URL(route.dest || '/', 'http://n');
+            return !isDynamicRoute(pathname.replace(/\.json$/, ''));
+          })
+        : []),
+
       // /_next/data routes for getServerProps/getStaticProps pages
       ...(isNextDataServerResolving
         ? // when resolving data routes for middleware we need to include

--- a/packages/next/test/fixtures/00-middleware-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/vercel.json
@@ -8,6 +8,13 @@
   ],
   "probes": [
     {
+      "path": "/_next/data/testing-build-id/en/about.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-matched-path": "/en/about"
+      }
+    },
+    {
       "path": "/_next/data/testing-build-id/en/dynamic/static.json",
       "status": 200,
       "headers": {

--- a/packages/next/test/fixtures/00-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-middleware/vercel.json
@@ -8,6 +8,13 @@
   ],
   "probes": [
     {
+      "path": "/_next/data/testing-build-id/about.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-matched-path": "/about"
+      }
+    },
+    {
       "path": "/_next/data/testing-build-id/dynamic/static.json",
       "status": 200,
       "headers": {


### PR DESCRIPTION
### Related Issues

Follow-up to https://github.com/vercel/vercel/pull/8297 this fixes some failing E2E test cases from the Next.js test suite and ensures we output data routes correctly when the default locale doesn't have a prerender and ensures we output static data routes correctly. 

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
