### PR TITLE
[cli] Print error from Builder in `vc build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -469,6 +469,8 @@ async function doBuild(
         )
       );
     } catch (err: any) {
+      output.prettyError(err);
+
       const writeConfigJsonPromise = fs.writeJSON(
         join(outputDir, 'config.json'),
         { version: 3 },

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -658,8 +658,11 @@ describe('build', () => {
     const output = join(cwd, '.vercel/output');
     try {
       process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
+      const exitCodePromise = build(client);
+      await expect(client.stderr).toOutput(
+        'Error! Function must contain at least one property.'
+      );
+      await expect(exitCodePromise).resolves.toEqual(1);
 
       // `builds.json` contains top-level "error" property
       const builds = await fs.readJSON(join(output, 'builds.json'));
@@ -684,8 +687,9 @@ describe('build', () => {
     const output = join(cwd, '.vercel/output');
     try {
       process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
+      const exitCodePromise = build(client);
+      await expect(client.stderr).toOutput("Duplicate identifier 'res'.");
+      await expect(exitCodePromise).resolves.toEqual(1);
 
       // `builds.json` contains "error" build
       const builds = await fs.readJSON(join(output, 'builds.json'));


### PR DESCRIPTION
Ensures that errors that are serialized into `builds.json` are also printed to the terminal when running the `vc build` command.