### PR TITLE
[static-build] set TURBO_CI_VENDOR_ENV_KEY environment variable

### DIFF
--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -367,16 +367,20 @@ export const build: BuildV2 = async ({
       );
 
       if (process.env.VERCEL_URL) {
+        const vercelSystemEnvPrefix = 'VERCEL_';
         const { envPrefix } = framework;
         if (envPrefix) {
           Object.keys(process.env)
-            .filter(key => key.startsWith('VERCEL_'))
+            .filter(key => key.startsWith(vercelSystemEnvPrefix))
             .forEach(key => {
               const newKey = `${envPrefix}${key}`;
               if (!(newKey in process.env)) {
                 process.env[newKey] = process.env[key];
               }
             });
+
+          // tell turbo to exclude all vercel system env vars (envPrefix includes trailing underscore)
+          process.env.TURBO_CI_VENDOR_ENV_KEY = `${envPrefix}${vercelSystemEnvPrefix}`;
         }
       }
 

--- a/packages/static-build/test/fixtures/70-vercel-env-gatsby/package.json
+++ b/packages/static-build/test/fixtures/70-vercel-env-gatsby/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "build": "mkdir -p public && node -p \"Object.keys(process.env).filter(e => e.includes('VERCEL'))\" > public/index.json"
+    "build": "mkdir -p public && node -p \"Object.keys(process.env).filter(e => e.includes('VERCEL') || e.includes('TURBO'))\" > public/index.json"
   }
 }

--- a/packages/static-build/test/fixtures/70-vercel-env-gatsby/vercel.json
+++ b/packages/static-build/test/fixtures/70-vercel-env-gatsby/vercel.json
@@ -7,5 +7,11 @@
       "config": { "zeroConfig": true, "framework": "gatsby" }
     }
   ],
-  "probes": [{ "path": "/index.json", "mustContain": "GATSBY_VERCEL_URL" }]
+  "probes": [
+    { "path": "/index.json", "mustContain": "GATSBY_VERCEL_URL" },
+    {
+      "path": "/index.json",
+      "mustContain": "TURBO_CI_VENDOR_ENV_KEY"
+    }
+  ]
 }


### PR DESCRIPTION
Set `TURBO_CI_VENDOR_ENV_KEY` to support https://github.com/vercel/turborepo/pull/1622