### PR TITLE
[cli] Strip scheme from `vc inspect` argument

### DIFF
--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -66,7 +66,7 @@ export default async function main(client: Client) {
   const { print, log, error } = client.output;
 
   // extract the first parameter
-  const [, deploymentIdOrHost] = argv._;
+  let [, deploymentIdOrHost] = argv._;
 
   if (argv._.length !== 2) {
     error(`${getCommandName('inspect <url>')} expects exactly one argument`);
@@ -92,6 +92,7 @@ export default async function main(client: Client) {
 
   // resolve the deployment, since we might have been given an alias
   const depFetchStart = Date.now();
+  deploymentIdOrHost = stripScheme(deploymentIdOrHost);
   client.output.spinner(
     `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(contextName)}`
   );
@@ -211,4 +212,12 @@ function stateString(s: Deployment['readyState']) {
     default:
       return chalk.gray('UNKNOWN');
   }
+}
+
+function stripScheme(deploymentIdOrHost: string): string {
+  const match = deploymentIdOrHost.match(/http:\/\/|https:\/\//g)?.[0];
+  if (match) {
+    deploymentIdOrHost = deploymentIdOrHost.replace(match, '');
+  }
+  return deploymentIdOrHost;
 }

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -15,6 +15,7 @@ import { Build } from '../types';
 import title from 'title';
 import { isErrnoException } from '../util/is-error';
 import { isAPIError } from '../util/errors-ts';
+import { URL } from 'url';
 
 const help = () => {
   console.log(`
@@ -90,13 +91,16 @@ export default async function main(client: Client) {
     throw err;
   }
 
-  // resolve the deployment, since we might have been given an alias
   const depFetchStart = Date.now();
-  deploymentIdOrHost = stripScheme(deploymentIdOrHost);
+
+  try {
+    deploymentIdOrHost = new URL(deploymentIdOrHost).hostname;
+  } catch {}
   client.output.spinner(
     `Fetching deployment "${deploymentIdOrHost}" in ${chalk.bold(contextName)}`
   );
 
+  // resolve the deployment, since we might have been given an alias
   try {
     deployment = await getDeployment(client, deploymentIdOrHost);
   } catch (err: unknown) {
@@ -212,12 +216,4 @@ function stateString(s: Deployment['readyState']) {
     default:
       return chalk.gray('UNKNOWN');
   }
-}
-
-function stripScheme(deploymentIdOrHost: string): string {
-  const match = deploymentIdOrHost.match(/http:\/\/|https:\/\//g)?.[0];
-  if (match) {
-    deploymentIdOrHost = deploymentIdOrHost.replace(match, '');
-  }
-  return deploymentIdOrHost;
 }

--- a/packages/cli/test/unit/commands/inspect.test.ts
+++ b/packages/cli/test/unit/commands/inspect.test.ts
@@ -15,6 +15,17 @@ describe('inspect', () => {
     );
   });
 
+  it('should strip the scheme of a url', async () => {
+    const user = useUser();
+    const deployment = useDeployment({ creator: user });
+    client.setArgv('inspect', `http://${deployment.url}`);
+    const exitCode = await inspect(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      `> Fetched deployment ${deployment.url} in ${user.username}`
+    );
+  });
+
   it('should print error when deployment not found', async () => {
     const user = useUser();
     useDeployment({ creator: user });


### PR DESCRIPTION
Right now, `vc inspect` fails to find a deployment if you include `http://` before it. But it works with no scheme and with `https://`.

Since it appears no scheme is what the API looks for anyway, and to avoid confusion, this PR strips any included scheme from the `deploymentIdOrHost` argument.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
