### PR TITLE
[cli] Fix flaky error in `builds.json` tests

### DIFF
--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -658,11 +658,13 @@ describe('build', () => {
     const output = join(cwd, '.vercel/output');
     try {
       process.chdir(cwd);
-      const exitCodePromise = build(client);
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      // Error gets printed to the terminal
       await expect(client.stderr).toOutput(
         'Error! Function must contain at least one property.'
       );
-      await expect(exitCodePromise).resolves.toEqual(1);
 
       // `builds.json` contains top-level "error" property
       const builds = await fs.readJSON(join(output, 'builds.json'));
@@ -687,9 +689,11 @@ describe('build', () => {
     const output = join(cwd, '.vercel/output');
     try {
       process.chdir(cwd);
-      const exitCodePromise = build(client);
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      // Error gets printed to the terminal
       await expect(client.stderr).toOutput("Duplicate identifier 'res'.");
-      await expect(exitCodePromise).resolves.toEqual(1);
 
       // `builds.json` contains "error" build
       const builds = await fs.readJSON(join(output, 'builds.json'));


### PR DESCRIPTION
Follow-up to #8305.

The `expect().toOutput()` call was frequently timing out before the command writes the error to the terminal, causing the test to fail. So wait for the command to return the exit code before running assertion on the printed output.