### PR TITLE
[tests] Update package.json scripts

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -14,8 +14,7 @@
     "build": "node build",
     "test": "jest --env node --verbose --runInBand --bail",
     "test-unit": "yarn test test/unit.*test.*",
-    "test-integration-once": "yarn test test/integration.test.ts",
-    "prepublishOnly": "node build"
+    "test-integration-once": "yarn test test/integration.test.ts"
   },
   "devDependencies": {
     "@iarna/toml": "2.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,6 @@
     "test-unit": "yarn test test/unit/",
     "test-integration-cli": "rimraf test/fixtures/integration && ava test/integration.js --serial --fail-fast --verbose",
     "test-integration-dev": "yarn test test/dev/",
-    "prepublishOnly": "yarn build",
     "coverage": "codecov",
     "build": "ts-node ./scripts/build.ts",
     "dev": "ts-node ./src/index.ts"

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
-    "test-unit": "jest",
-    "prepublishOnly": "yarn build"
+    "test": "jest --env node --verbose --runInBand --bail",
+    "test-unit": "yarn test"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "1.1.0-beta.7",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -14,9 +14,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "tsc",
     "build": "tsc",
-    "test": "yarn jest --env node --verbose --runInBand --bail test/unit.*test.*",
+    "test": "jest --env node --verbose --runInBand --bail test/unit.*test.*",
     "test-unit": "yarn test"
   },
   "dependencies": {

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -11,9 +11,8 @@
   },
   "scripts": {
     "build": "node build",
-    "test": "yarn jest --env node --verbose --runInBand --bail",
-    "test-integration-once": "yarn test",
-    "prepublishOnly": "node build"
+    "test": "jest --env node --verbose --runInBand --bail",
+    "test-integration-once": "yarn test"
   },
   "files": [
     "dist"

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "build": "node build.js",
     "test-integration-once": "yarn test test/test.js",
-    "test": "jest --env node --verbose --bail --runInBand",
-    "prepublishOnly": "node build.js"
+    "test": "jest --env node --verbose --bail --runInBand"
   },
   "files": [
     "dist",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -11,8 +11,7 @@
     "test-unit": "yarn test test/build.test.ts  test/unit/",
     "test-next-local": "jest --env node --verbose --bail --forceExit --testTimeout=360000 test/integration/*.test.js test/integration/*.test.ts",
     "test-next-local:middleware": "jest --env node --verbose --bail --useStderr --testTimeout=360000 test/integration/middleware.test.ts",
-    "test-integration-once": "rm test/builder-info.json; jest --env node --verbose --runInBand --bail test/fixtures/**/*.test.js",
-    "prepublishOnly": "yarn build"
+    "test-integration-once": "rm test/builder-info.json; jest --env node --verbose --runInBand --bail test/fixtures/**/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,8 +13,7 @@
     "build": "node build",
     "test": "jest --env node --verbose --bail --runInBand",
     "test-unit": "yarn test test/prepare-cache.test.ts test/utils.test.ts",
-    "test-integration-once": "yarn test test/integration-*.test.js",
-    "prepublishOnly": "node build"
+    "test-integration-once": "yarn test test/integration-*.test.js"
   },
   "files": [
     "dist"

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -17,8 +17,7 @@
     "build": "node build",
     "test": "jest --env node --verbose --runInBand --bail",
     "test-unit": "yarn test test/unit.test.ts",
-    "test-integration-once": "yarn test test/integration.test.ts",
-    "prepublishOnly": "node build"
+    "test-integration-once": "yarn test test/integration.test.ts"
   },
   "devDependencies": {
     "@types/execa": "^0.9.0",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -16,8 +16,7 @@
     "build": "node build.js",
     "test-integration-once": "yarn test test/test.js",
     "test": "jest --env node --verbose --bail --runInBand",
-    "test-unit": "yarn test test/prepare-cache.test.js",
-    "prepublishOnly": "node build.js"
+    "test-unit": "yarn test test/prepare-cache.test.js"
   },
   "dependencies": {
     "@vercel/nft": "0.21.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -13,8 +13,7 @@
     "build": "node build.js",
     "test-integration-once": "yarn test test/test.js",
     "test": "jest --env node --verbose --bail --runInBand",
-    "test-unit": "yarn test test/build.test.ts",
-    "prepublishOnly": "node build.js"
+    "test-unit": "yarn test test/build.test.ts"
   },
   "files": [
     "dist",

--- a/packages/routing-utils/package.json
+++ b/packages/routing-utils/package.json
@@ -14,9 +14,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublishOnly": "tsc",
     "build": "tsc",
-    "watch": "tsc --watch",
     "test": "jest --env node --verbose --runInBand --bail",
     "test-unit": "yarn test"
   },

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "build": "node build",
     "test": "jest --env node --verbose --runInBand --bail",
-    "test-integration-once": "yarn test",
-    "prepublishOnly": "node build"
+    "test-integration-once": "yarn test"
   },
   "devDependencies": {
     "@types/fs-extra": "8.0.0",

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -16,8 +16,7 @@
     "build": "node build",
     "test": "jest --env node --verbose --bail --runInBand",
     "test-unit": "yarn test test/build.test.ts test/prepare-cache.test.ts",
-    "test-integration-once": "yarn test test/integration-*.test.js",
-    "prepublishOnly": "node build"
+    "test-integration-once": "yarn test test/integration-*.test.js"
   },
   "jest": {
     "preset": "ts-jest/presets/default",

--- a/packages/static-config/package.json
+++ b/packages/static-config/package.json
@@ -10,9 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test-unit": "jest",
-    "test": "jest",
-    "prepublishOnly": "tsc"
+    "test-unit": "yarn test",
+    "test": "jest --env node --verbose --runInBand --bail"
   },
   "files": [
     "dist"


### PR DESCRIPTION
This PR consolidates all the `test` scripts to be the same and removes the `prepublishOnly` script since we always run `build` before publishing to npm.