### PR TITLE
[next] Remove old middleware test

### DIFF
--- a/packages/next/test/fixtures/00-middleware-i18n/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-i18n/vercel.json
@@ -98,16 +98,6 @@
       "mustContain": "{}"
     },
     {
-      "path": "/_next/data/testing-build-id/en/redirect-me.json",
-      "status": 307,
-      "fetchOptions": {
-        "redirect": "manual"
-      },
-      "responseHeaders": {
-        "Location": "/from-middleware/"
-      }
-    },
-    {
       "path": "/_next/data/testing-build-id/en/_sites/subdomain-1.json",
       "status": 200,
       "fetchOptions": {


### PR DESCRIPTION
### Related Issues

Follow-up to https://github.com/vercel/vercel/pull/8321 removes an additional test related to that change

x-ref: https://github.com/vercel/vercel/runs/7675630204?check_suite_focus=true

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
