### PR TITLE
[cli] Always set `BROWSER=none` env var for frontend dev server in `vc dev`

### DIFF
--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -61,7 +61,6 @@ export default async function dev(
   }
 
   let devCommand: string | undefined;
-  let frameworkSlug: string | undefined;
   let projectSettings: ProjectSettings | undefined;
   let projectEnvs: ProjectEnvVariable[] = [];
   let systemEnvValues: string[] = [];
@@ -77,10 +76,6 @@ export default async function dev(
       const framework = frameworks.find(f => f.slug === project.framework);
 
       if (framework) {
-        if (framework.slug) {
-          frameworkSlug = framework.slug;
-        }
-
         const defaults = framework.settings.devCommand.value;
         if (defaults) {
           devCommand = defaults;
@@ -120,7 +115,6 @@ export default async function dev(
   const devServer = new DevServer(cwd, {
     output,
     devCommand,
-    frameworkSlug,
     projectSettings,
     projectEnvs,
     systemEnvValues,

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -131,7 +131,6 @@ export default class DevServer {
   public output: Output;
   public proxy: httpProxy;
   public envConfigs: EnvConfigs;
-  public frameworkSlug?: string;
   public files: BuilderInputs;
   public address: string;
   public devCacheDir: string;
@@ -175,7 +174,6 @@ export default class DevServer {
     this.address = '';
     this.devCommand = options.devCommand;
     this.projectSettings = options.projectSettings;
-    this.frameworkSlug = options.frameworkSlug;
     this.caseSensitive = false;
     this.apiDir = null;
     this.apiExtensions = new Set();
@@ -2210,7 +2208,10 @@ export default class DevServer {
       // Because of child process 'pipe' below, isTTY will be false.
       // Most frameworks use `chalk`/`supports-color` so we enable it anyway.
       FORCE_COLOR: process.stdout.isTTY ? '1' : '0',
-      ...(this.frameworkSlug === 'create-react-app' ? { BROWSER: 'none' } : {}),
+      // Prevent framework dev servers from automatically opening a web
+      // browser window, since it will not be the port that `vc dev`
+      // is listening on and thus will be missing Vercel features.
+      BROWSER: 'none',
       ...process.env,
       ...this.envConfigs.allEnv,
       PORT: `${port}`,

--- a/packages/cli/src/util/dev/types.ts
+++ b/packages/cli/src/util/dev/types.ts
@@ -24,7 +24,6 @@ export { VercelConfig };
 export interface DevServerOptions {
   output: Output;
   devCommand?: string;
-  frameworkSlug?: string;
   projectSettings?: ProjectSettings;
   systemEnvValues?: string[];
   projectEnvs?: ProjectEnvVariable[];


### PR DESCRIPTION
Previously `vc dev` would only set this env var for "create-react-app" Framework preset, but other frameworks do the "auto-open browser window" behavior as well, and respect this env var (Docusaurus, specifically).

So always set the `BROWSER=none` env var regardless of which framework preset is selected. Also simplifies the code since this was the only place `frameworkSlug` property was being used.