### PR TITLE
chore(docs): use relative links for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ For details on how to use Vercel, check out our [documentation](https://vercel.c
 
 ## Contributing
 
-- [Code of Conduct](https://github.com/vercel/vercel/blob/main/.github/CODE_OF_CONDUCT.md)
-- [Contributing Guidelines](https://github.com/vercel/vercel/blob/main/.github/CONTRIBUTING.md)
-- [MIT License](https://github.com/vercel/vercel/blob/main/LICENSE)
+- [Code of Conduct](.github/CODE_OF_CONDUCT.md)
+- [Contributing Guidelines](.github/CONTRIBUTING.md)
+- [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ For details on how to use Vercel, check out our [documentation](https://vercel.c
 
 ## Contributing
 
-- [Code of Conduct](.github/CODE_OF_CONDUCT.md)
-- [Contributing Guidelines](.github/CONTRIBUTING.md)
-- [MIT License](LICENSE)
+- [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
+- [Contributing Guidelines](./.github/CONTRIBUTING.md)
+- [MIT License](./LICENSE)


### PR DESCRIPTION
This allows README links to work locally (within your IDE) without kicking to a browser - and maintains the current functionality elsewhere. 