### PR TITLE
[client] Fix `archive` type on `VercelClientOptions`

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -28,7 +28,7 @@ export interface VercelClientOptions {
   defaultName?: string;
   isDirectory?: boolean;
   skipAutoDetectionConfirmation?: boolean;
-  archive?: ArchiveFormat | undefined;
+  archive?: ArchiveFormat;
 }
 
 /** @deprecated Use VercelClientOptions instead. */


### PR DESCRIPTION
#8356 added a new `archive` property to the `VercelClientOptions` type, but I made a small mistake. This fixes it.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
