### PR TITLE
[cli] improve `vc build --help` language

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -91,7 +91,7 @@ const help = () => {
       --output [path]                Directory where built assets should be written to
       --prod                         Build a production deployment
       -d, --debug                    Debug mode [off]
-      -y, --yes                      Pull environment variables and project settings if not found locally
+      -y, --yes                      Skip the confirmation prompt about pulling environment variables and project settings when not found locally
 
     ${chalk.dim('Examples:')}
 


### PR DESCRIPTION
Tweak the `--yes` help language for the `build` command to be more consistent with other flag descriptions.

---

Related to: https://github.com/vercel/vercel/pull/8330