### PR TITLE
specify vite host parameter + pass env vars to Python runtime

### DIFF
--- a/packages/cli/test/dev/fixtures/vite-dev/package.json
+++ b/packages/cli/test/dev/fixtures/vite-dev/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "vite --port $PORT",
+    "dev": "vite --port $PORT --host 0.0.0.0",
     "build": "vite build",
     "serve": "vite preview"
   },

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1719,7 +1719,7 @@ export const frameworks = [
       },
       devCommand: {
         placeholder: 'vite',
-        value: 'vite --port $PORT',
+        value: 'vite --port $PORT --host 0.0.0.0',
       },
       outputDirectory: {
         value: 'dist',

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -208,7 +208,12 @@ export const build = async ({
     files: await glob('**', globOptions),
     handler: `${handlerPyFilename}.vc_handler`,
     runtime: pythonVersion.runtime,
-    environment: {},
+    environment: {
+      // This is required for environment variable access.
+      // In production, env var access is provided by static analysis
+      // so that only the used values are available.
+      ...(process.env as { [key: string]: string }),
+    },
   });
 
   return { output: lambda };

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import base64
 import json
@@ -145,7 +146,7 @@ elif 'app' in __vc_variables:
 
             for key, value in environ.items():
                 if isinstance(value, string_types):
-                    environ[key] = wsgi_encoding_dance(value)
+                    os.environ[key] = wsgi_encoding_dance(value)
 
             for key, value in headers.items():
                 key = 'HTTP_' + key.upper().replace('-', '_')


### PR DESCRIPTION
Vite 3 changes the default bind address from `0.0.0.0` to `localhost` and this seems to cause issues with the vercel dev server.

Refer to [Vite changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#300-2022-07-13).

This PR also fixes a bug where environment variables on the host system are not correctly passed to the Python serverless runtime when using Vercel dev.

### Related Issues

> Related to #8121

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
