### PR TITLE
[ruby] Handle exit code 18 gracefully

### DIFF
--- a/packages/ruby/index.ts
+++ b/packages/ruby/index.ts
@@ -62,7 +62,10 @@ async function bundleInstall(
     }
   );
 
-  if (exitCode === 0 || exitCode === 18) {
+  if (
+    exitCode === 0 ||
+    (exitCode === 18 && stderr.includes('Gemfile specified -1'))
+  ) {
     // Gemfile might contain "2.7.x" so install might exit with code 18 and message:
     // "Your Ruby patchlevel is 0, but your Gemfile specified -1"
     // See https://github.com/rubygems/bundler/blob/3f0638c6c8d340c2f2405ecb84eb3b39c433e36e/lib/bundler/errors.rb#L49

--- a/packages/ruby/index.ts
+++ b/packages/ruby/index.ts
@@ -67,7 +67,9 @@ async function bundleInstall(
     // "Your Ruby patchlevel is 0, but your Gemfile specified -1"
     // See https://github.com/rubygems/bundler/blob/3f0638c6c8d340c2f2405ecb84eb3b39c433e36e/lib/bundler/errors.rb#L49
   } else {
-    throw new Error(stdout + stderr);
+    throw new Error(
+      `"bundle install" failed with exit code ${exitCode}: ${stdout}\n${stderr}`
+    );
   }
 }
 

--- a/packages/ruby/install-ruby.ts
+++ b/packages/ruby/install-ruby.ts
@@ -5,15 +5,13 @@ import { Meta, NodeVersion, debug, NowBuildError } from '@vercel/build-utils';
 
 interface RubyVersion extends NodeVersion {
   minor: number;
-  patch: number;
 }
 
 const allOptions: RubyVersion[] = [
-  { major: 2, minor: 7, patch: 0, range: '2.7.x', runtime: 'ruby2.7' },
+  { major: 2, minor: 7, range: '2.7.x', runtime: 'ruby2.7' },
   {
     major: 2,
     minor: 5,
-    patch: 0,
     range: '2.5.x',
     runtime: 'ruby2.5',
     discontinueDate: new Date('2021-11-30'),
@@ -57,7 +55,7 @@ function getRubyPath(meta: Meta, gemfileContents: string) {
       if (isDiscontinued(selection)) {
         const latest = getLatestRubyVersion();
         const intro = `Found \`Gemfile\` with discontinued Ruby version: \`${line}.\``;
-        const hint = `Please set \`ruby "~> ${latest.major}.${latest.minor}.${latest.patch}"\` in your \`Gemfile\` to use the latest Ruby version.`;
+        const hint = `Please set \`ruby "~> ${latest.range}"\` in your \`Gemfile\` to use Ruby ${latest.range}.`;
         throw new NowBuildError({
           code: 'RUBY_DISCONTINUED_VERSION',
           link: 'http://vercel.link/ruby-version',

--- a/packages/ruby/test/fixtures/02-cowsay-vendored/Gemfile
+++ b/packages/ruby/test/fixtures/02-cowsay-vendored/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby "~> 2.7.0"
+ruby "~> 2.7.x"
 
 gem "cowsay", "~> 0.3.0"

--- a/packages/ruby/test/fixtures/04-cowsay-vendored-nested/project/Gemfile
+++ b/packages/ruby/test/fixtures/04-cowsay-vendored-nested/project/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby "~> 2.7.0"
+ruby "~> 2.7.x"
 
 gem "cowsay", "~> 0.3.0"

--- a/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile
+++ b/packages/ruby/test/fixtures/11-version-2-5-error/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby "~> 2.5.0"
+ruby "~> 2.5.x"
 
 gem "cowsay", "~> 0.3.0"

--- a/packages/ruby/test/test.js
+++ b/packages/ruby/test/test.js
@@ -12,7 +12,7 @@ const fixturesPath = path.resolve(__dirname, 'fixtures');
 const testsThatFailToBuild = new Map([
   [
     '11-version-2-5-error',
-    'Found `Gemfile` with discontinued Ruby version: `ruby "~> 2.5.0".` Please set `ruby "~> 2.7.0"` in your `Gemfile` to use the latest Ruby version.',
+    'Found `Gemfile` with discontinued Ruby version: `ruby "~> 2.5.x".` Please set `ruby "~> 2.7.x"` in your `Gemfile` to use Ruby 2.7.x.',
   ],
 ]);
 


### PR DESCRIPTION
This reverts #8381 and instead supports the "2.7.x" syntax.

- Related to https://github.com/vercel/customer-issues/issues/684