### PR TITLE
[docs] Remove "watch" from `DEVELOPING_A_RUNTIME.md`

### DIFF
--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -63,9 +63,6 @@ export async function build(options: BuildOptions) {
   const lambda = createLambda(/* … */);
   return {
     output: lambda,
-    watch: [
-      // Dependent files to trigger a rebuild in `vercel dev` go here…
-    ],
     routes: [
       // If your Runtime needs to define additional routing, define it here…
     ],


### PR DESCRIPTION
`vercel dev` no longer utilizes the `watch` field, so let's not document it here.