### PR TITLE
[cli] fix vc bisect off by one

### DIFF
--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -149,7 +149,9 @@ export default async function main(client: Client): Promise<number> {
 
   if (badDeployment) {
     if (badDeployment instanceof Error) {
-      badDeployment.message += ` when requesting "${normalizeURL(bad)}"`;
+      badDeployment.message += ` when requesting bad deployment "${normalizeURL(
+        bad
+      )}"`;
       output.prettyError(badDeployment);
       return 1;
     }
@@ -164,7 +166,9 @@ export default async function main(client: Client): Promise<number> {
 
   if (goodDeployment) {
     if (goodDeployment instanceof Error) {
-      goodDeployment.message += ` "${good}"`;
+      goodDeployment.message += ` when requesting good deployment "${normalizeURL(
+        good
+      )}"`;
       output.prettyError(goodDeployment);
       return 1;
     }

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -2,7 +2,6 @@ import open from 'open';
 import boxen from 'boxen';
 import execa from 'execa';
 import plural from 'pluralize';
-import inquirer from 'inquirer';
 import { resolve } from 'path';
 import chalk, { Chalk } from 'chalk';
 import { URLSearchParams, parse } from 'url';
@@ -150,7 +149,7 @@ export default async function main(client: Client): Promise<number> {
 
   if (badDeployment) {
     if (badDeployment instanceof Error) {
-      badDeployment.message += ` "${bad}"`;
+      badDeployment.message += ` when requesting "${normalizeURL(bad)}"`;
       output.prettyError(badDeployment);
       return 1;
     }
@@ -226,7 +225,8 @@ export default async function main(client: Client): Promise<number> {
     // If we have the "good" deployment in this chunk, then we're done
     for (let i = 0; i < newDeployments.length; i++) {
       if (newDeployments[i].url === good) {
-        newDeployments = newDeployments.slice(0, i + 1);
+        // grab all deployments up until the good one
+        newDeployments = newDeployments.slice(0, i);
         next = undefined;
         break;
       }
@@ -316,7 +316,7 @@ export default async function main(client: Client): Promise<number> {
       if (openEnabled) {
         await open(testUrl);
       }
-      const answer = await inquirer.prompt({
+      const answer = await client.prompt({
         type: 'expand',
         name: 'action',
         message: 'Select an action:',

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -146,10 +146,15 @@ export default class Client extends EventEmitter implements Stdio {
         const error = await responseError(res);
 
         if (isSAMLError(error)) {
-          // A SAML error means the token is expired, or is not
-          // designated for the requested team, so the user needs
-          // to re-authenticate
-          await this.reauthenticate(error);
+          try {
+            // A SAML error means the token is expired, or is not
+            // designated for the requested team, so the user needs
+            // to re-authenticate
+            await this.reauthenticate(error);
+          } catch (reauthError) {
+            // there's no sense in retrying
+            return bail(reauthError as Error);
+          }
         } else if (res.status >= 400 && res.status < 500) {
           // Any other 4xx should bail without retrying
           return bail(error);
@@ -186,7 +191,7 @@ export default class Client extends EventEmitter implements Stdio {
           `Failed to re-authenticate for ${bold(error.scope)} scope`
         );
       }
-      process.exit(1);
+      throw error;
     }
 
     this.authConfig.token = result.token;

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -23,6 +23,7 @@ import type {
 } from '../types';
 import { sharedPromise } from './promise';
 import { APIError } from './errors-ts';
+import { normalizeError } from './is-error';
 
 const isSAMLError = (v: any): v is SAMLError => {
   return v && v.saml;

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -153,7 +153,7 @@ export default class Client extends EventEmitter implements Stdio {
             await this.reauthenticate(error);
           } catch (reauthError) {
             // there's no sense in retrying
-            return bail(reauthError as Error);
+            return bail(normalizeError(reauthError));
           }
         } else if (res.status >= 400 && res.status < 500) {
           // Any other 4xx should bail without retrying

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -65,19 +65,6 @@ export function useDeployment({
   return deployment;
 }
 
-export function useDeploymentWithSamlError() {
-  client.scenario.get(`/:version/deployments/:id`, (req, res) => {
-    res.statusCode = 403;
-    res.json({
-      code: 'forbidden',
-      scope: 'vercel',
-      teamId: 'dummy_team',
-      enforced: true,
-      saml: true,
-    });
-  });
-}
-
 export function useDeploymentMissingProjectSettings() {
   client.scenario.post('/:version/deployments', (_req, res) => {
     res.status(400).json({

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -12,11 +12,13 @@ type State = Deployment['readyState'];
 export function useDeployment({
   creator,
   state = 'READY',
+  createdAt,
 }: {
   creator: Pick<User, 'id' | 'email' | 'name' | 'username'>;
   state?: State;
+  createdAt?: number;
 }) {
-  const createdAt = Date.now();
+  createdAt = createdAt || Date.now();
   const url = new URL(chance().url());
   const name = chance().name();
   const id = `dpl_${chance().guid()}`;
@@ -57,6 +59,18 @@ export function useDeployment({
   deploymentBuilds.set(deployment, []);
 
   return deployment;
+}
+
+export function useDeployments() {
+  client.scenario.get('/:version/deployments', (_req, res) => {
+    const currentDeployments = Array.from(deployments.values());
+    res.json({
+      pagination: {
+        count: currentDeployments.length,
+      },
+      deployments: currentDeployments,
+    });
+  });
 }
 
 export function useDeploymentMissingProjectSettings() {

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -1,0 +1,47 @@
+import { client } from '../../mocks/client';
+import { useUser } from '../../mocks/user';
+import bisect from '../../../src/commands/bisect';
+import { useDeployments, useDeployment } from '../../mocks/deployment';
+
+describe('bisect', () => {
+  it('should ...', async () => {
+    const user = useUser();
+
+    const now = Date.now();
+    const deployment1 = useDeployment({ creator: user, createdAt: now });
+    const deployment2 = useDeployment({ creator: user, createdAt: now + 5000 });
+    const deployment3 = useDeployment({
+      creator: user,
+      createdAt: now + 10000,
+    });
+    useDeployments();
+
+    // TODO: remove
+    console.log({
+      deployment1: deployment1.url,
+      deployment2: deployment2.url,
+      deployment3: deployment3.url,
+    });
+
+    const bisectPromise = bisect(client);
+
+    await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
+    client.stdin.write(`${deployment3.url}\n`);
+
+    await expect(client.stderr).toOutput(
+      'Specify a URL where the bug does not occur:'
+    );
+    client.stdin.write(`${deployment1.url}\n`);
+
+    await expect(client.stderr).toOutput(
+      'Specify the URL subpath where the bug occurs:'
+    );
+    client.stdin.write('/docs\n');
+
+    await expect(client.stderr).toOutput(
+      `The first bad deployment is: https://${deployment1.url}`
+    );
+
+    await expect(bisectPromise).resolves.toEqual(0);
+  });
+});

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -1,7 +1,10 @@
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
 import bisect from '../../../src/commands/bisect';
-import { useDeployments, useDeployment } from '../../mocks/deployment';
+import {
+  useDeployment,
+  useDeploymentWithSamlError,
+} from '../../mocks/deployment';
 
 describe('bisect', () => {
   it('should find the bad deployment', async () => {
@@ -9,17 +12,23 @@ describe('bisect', () => {
 
     const now = Date.now();
     const deployment1 = useDeployment({ creator: user, createdAt: now });
-    useDeployment({ creator: user, createdAt: now + 10000 });
+    const deployment2 = useDeployment({
+      creator: user,
+      createdAt: now + 10000,
+    });
     const deployment3 = useDeployment({
       creator: user,
       createdAt: now + 20000,
     });
-    useDeployments();
+    const deployment4 = useDeployment({
+      creator: user,
+      createdAt: now + 30000,
+    });
 
     const bisectPromise = bisect(client);
 
     await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
-    client.stdin.write(`https://${deployment3.url}\n`);
+    client.stdin.write(`https://${deployment4.url}\n`);
 
     await expect(client.stderr).toOutput(
       'Specify a URL where the bug does not occur:'
@@ -31,10 +40,55 @@ describe('bisect', () => {
     );
     client.stdin.write('/docs\n');
 
+    await expect(client.stderr).toOutput('Bisecting');
     await expect(client.stderr).toOutput(
-      `The first bad deployment is: https://${deployment1.url}`
+      `Deployment URL: https://${deployment2.url}`
+    );
+    client.stdin.write('g\n');
+
+    await expect(client.stderr).toOutput('Bisecting');
+    await expect(client.stderr).toOutput(
+      `Deployment URL: https://${deployment3.url}`
+    );
+    client.stdin.write('b\n');
+
+    await expect(client.stderr).toOutput(
+      `The first bad deployment is: https://${deployment3.url}`
     );
 
     await expect(bisectPromise).resolves.toEqual(0);
+  });
+
+  it('should prompt for login', async () => {
+    useDeploymentWithSamlError();
+
+    const bisectPromise = bisect(client);
+
+    await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
+    client.stdin.write(`https://some-9s8df0.vercel.sh\n`);
+
+    await expect(client.stderr).toOutput(
+      'Specify a URL where the bug does not occur:'
+    );
+    client.stdin.write(`https://some-vbn9udf.vercel.sh\n`);
+
+    await expect(client.stderr).toOutput(
+      'Specify the URL subpath where the bug occurs:'
+    );
+    client.stdin.write('/docs\n');
+
+    await expect(client.stderr).toOutput(
+      'You must re-authenticate with SAML to use vercel scope.'
+    );
+    await expect(client.stderr).toOutput('Log in with SAML?');
+    client.stdin.write('n\n');
+
+    await expect(client.stderr).toOutput(
+      'Response Error (403) when requesting "https://some-9s8df0.vercel.sh"'
+    );
+
+    expect(bisectPromise).resolves.toBe(1);
+
+    console.log('TEST OVER');
   });
 });

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -4,34 +4,27 @@ import bisect from '../../../src/commands/bisect';
 import { useDeployments, useDeployment } from '../../mocks/deployment';
 
 describe('bisect', () => {
-  it('should ...', async () => {
+  it('should find the bad deployment', async () => {
     const user = useUser();
 
     const now = Date.now();
     const deployment1 = useDeployment({ creator: user, createdAt: now });
-    const deployment2 = useDeployment({ creator: user, createdAt: now + 5000 });
+    useDeployment({ creator: user, createdAt: now + 10000 });
     const deployment3 = useDeployment({
       creator: user,
-      createdAt: now + 10000,
+      createdAt: now + 20000,
     });
     useDeployments();
-
-    // TODO: remove
-    console.log({
-      deployment1: deployment1.url,
-      deployment2: deployment2.url,
-      deployment3: deployment3.url,
-    });
 
     const bisectPromise = bisect(client);
 
     await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
-    client.stdin.write(`${deployment3.url}\n`);
+    client.stdin.write(`https://${deployment3.url}\n`);
 
     await expect(client.stderr).toOutput(
       'Specify a URL where the bug does not occur:'
     );
-    client.stdin.write(`${deployment1.url}\n`);
+    client.stdin.write(`https://${deployment1.url}\n`);
 
     await expect(client.stderr).toOutput(
       'Specify the URL subpath where the bug occurs:'

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -87,8 +87,6 @@ describe('bisect', () => {
       'Response Error (403) when requesting "https://some-9s8df0.vercel.sh"'
     );
 
-    expect(bisectPromise).resolves.toBe(1);
-
-    console.log('TEST OVER');
+    await expect(bisectPromise).resolves.toBe(1);
   });
 });

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -1,10 +1,7 @@
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
 import bisect from '../../../src/commands/bisect';
-import {
-  useDeployment,
-  useDeploymentWithSamlError,
-} from '../../mocks/deployment';
+import { useDeployment } from '../../mocks/deployment';
 
 describe('bisect', () => {
   it('should find the bad deployment', async () => {
@@ -20,15 +17,11 @@ describe('bisect', () => {
       creator: user,
       createdAt: now + 20000,
     });
-    const deployment4 = useDeployment({
-      creator: user,
-      createdAt: now + 30000,
-    });
 
     const bisectPromise = bisect(client);
 
     await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
-    client.stdin.write(`https://${deployment4.url}\n`);
+    client.stdin.write(`https://${deployment3.url}\n`);
 
     await expect(client.stderr).toOutput(
       'Specify a URL where the bug does not occur:'
@@ -44,49 +37,12 @@ describe('bisect', () => {
     await expect(client.stderr).toOutput(
       `Deployment URL: https://${deployment2.url}`
     );
-    client.stdin.write('g\n');
-
-    await expect(client.stderr).toOutput('Bisecting');
-    await expect(client.stderr).toOutput(
-      `Deployment URL: https://${deployment3.url}`
-    );
     client.stdin.write('b\n');
 
     await expect(client.stderr).toOutput(
-      `The first bad deployment is: https://${deployment3.url}`
+      `The first bad deployment is: https://${deployment2.url}`
     );
 
     await expect(bisectPromise).resolves.toEqual(0);
-  });
-
-  it('should prompt for login', async () => {
-    useDeploymentWithSamlError();
-
-    const bisectPromise = bisect(client);
-
-    await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');
-    client.stdin.write(`https://some-9s8df0.vercel.sh\n`);
-
-    await expect(client.stderr).toOutput(
-      'Specify a URL where the bug does not occur:'
-    );
-    client.stdin.write(`https://some-vbn9udf.vercel.sh\n`);
-
-    await expect(client.stderr).toOutput(
-      'Specify the URL subpath where the bug occurs:'
-    );
-    client.stdin.write('/docs\n');
-
-    await expect(client.stderr).toOutput(
-      'You must re-authenticate with SAML to use vercel scope.'
-    );
-    await expect(client.stderr).toOutput('Log in with SAML?');
-    client.stdin.write('n\n');
-
-    await expect(client.stderr).toOutput(
-      'Response Error (403) when requesting "https://some-9s8df0.vercel.sh"'
-    );
-
-    await expect(bisectPromise).resolves.toBe(1);
   });
 });

--- a/packages/cli/test/unit/commands/bisect.test.ts
+++ b/packages/cli/test/unit/commands/bisect.test.ts
@@ -18,6 +18,13 @@ describe('bisect', () => {
       createdAt: now + 20000,
     });
 
+    // also create an extra deployment before the known good deployment
+    // to make sure the bisect pool doesn't include it
+    useDeployment({
+      creator: user,
+      createdAt: now - 30000,
+    });
+
     const bisectPromise = bisect(client);
 
     await expect(client.stderr).toOutput('Specify a URL where the bug occurs:');


### PR DESCRIPTION
There's a bug in `vc bisect` where the known "good" deployment ends up in the list of deployments to check. This can result in the command asking the user if the known "good" deployment is good or bad, which it should already know.

This PR fixes the issue and adds a test that proves it works.