### PR TITLE
[cli][tests] remove dupe `inspectorUrl`

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
           "selector": "MemberExpression > Identifier[name='substr']"
         }
       ],
+      "no-dupe-keys": 2,
       "require-atomic-updates": 0,
       "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/camelcase": 0,

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -24,7 +24,6 @@ export function useDeployment({
   const deployment: Deployment = {
     id,
     url: url.hostname,
-    inspectorUrl: `https://vercel.com/team/project/${id.replace('dpl_', '')}`,
     name,
     meta: {},
     regions: [],


### PR DESCRIPTION
This duplicate value was added in https://github.com/vercel/vercel/pull/8151/files#diff-912ecd0b3f7b44cac96f04be048647f24d0efbb34593c0145455b9edea7c104fR27 but the diff window didn't show that the value already existed.

I added the lint rule for this. There are no other offenders to fix. 
