### PR TITLE
[cli] fix: undefined variable

### DIFF
--- a/packages/cli/test/helpers/read-output-stream.ts
+++ b/packages/cli/test/helpers/read-output-stream.ts
@@ -9,7 +9,7 @@ export function readOutputStream(
     let lines = 0;
     const timeout = setTimeout(() => {
       reject(
-        new Error(`Was waiting for ${length} lines, but only received ${chunks.length}`)
+        new Error(`Was waiting for ${length} lines, but only received ${lines}`)
       );
     }, 3000);
 


### PR DESCRIPTION
The variable `chunks` doesn't exist in this context. Updated the error message to reference the `lines` count instead.