### PR TITLE
[next] Fix un-necessary edge routes being added

### DIFF
--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2326,8 +2326,16 @@ export async function getMiddlewareBundle({
     for (const worker of workerConfigs.values()) {
       const edgeFile = worker.edgeFunction.name;
       const shortPath = edgeFile.replace(/^pages\//, '');
+
       worker.edgeFunction.name = shortPath;
       source.edgeFunctions[shortPath] = worker.edgeFunction;
+
+      // we don't add the route for edge functions as these
+      // are already added in the routes-manifest under dynamicRoutes
+      if (worker.type === 'function') {
+        continue;
+      }
+
       const route: Route = {
         continue: true,
         src: worker.routeSrc,
@@ -2340,13 +2348,9 @@ export async function getMiddlewareBundle({
         ],
       };
 
-      if (worker.type === 'function') {
-        route.dest = shortPath;
-      } else {
-        route.middlewarePath = shortPath;
-        if (isCorrectMiddlewareOrder) {
-          route.override = true;
-        }
+      route.middlewarePath = shortPath;
+      if (isCorrectMiddlewareOrder) {
+        route.override = true;
       }
 
       if (routesManifest.version > 3 && isDynamicRoute(worker.page)) {

--- a/packages/next/test/fixtures/00-edge-runtime/index.test.js
+++ b/packages/next/test/fixtures/00-edge-runtime/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-edge-runtime/next.config.js
+++ b/packages/next/test/fixtures/00-edge-runtime/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/next/test/fixtures/00-edge-runtime/package.json
+++ b/packages/next/test/fixtures/00-edge-runtime/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-edge-runtime/pages/api/[id].js
+++ b/packages/next/test/fixtures/00-edge-runtime/pages/api/[id].js
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export default function handler(req) {
+  return NextResponse.json({ page: '[id]' });
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+};

--- a/packages/next/test/fixtures/00-edge-runtime/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-edge-runtime/pages/api/hello.js
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export default function handler(req) {
+  return NextResponse.json({ page: 'hello' });
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+};

--- a/packages/next/test/fixtures/00-edge-runtime/pages/index.js
+++ b/packages/next/test/fixtures/00-edge-runtime/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'index page';
+}

--- a/packages/next/test/fixtures/00-edge-runtime/probes.json
+++ b/packages/next/test/fixtures/00-edge-runtime/probes.json
@@ -1,5 +1,4 @@
 {
-  "version": 2,
   "probes": [
     {
       "path": "/",

--- a/packages/next/test/fixtures/00-edge-runtime/vercel.json
+++ b/packages/next/test/fixtures/00-edge-runtime/vercel.json
@@ -1,0 +1,25 @@
+{
+  "version": 2,
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "index page",
+      "status": 200
+    },
+    {
+      "path": "/api/hello",
+      "status": 200,
+      "mustContain": "hello"
+    },
+    {
+      "path": "/api/another",
+      "status": 200,
+      "mustContain": "[id]"
+    },
+    {
+      "path": "/api/one-more",
+      "status": 200,
+      "mustContain": "[id]"
+    }
+  ]
+}


### PR DESCRIPTION
Currently we are adding routes for edge function un-necessarily as static edge functions don't need routes added and dynamic edge functions already have their routes included in `dynamicRoutes` in the `routes-manifest`. 

### Related Issues

Fixes: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1660571876385869)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
