### PR TITLE
[hydrogen] Polyfill Oxygen global in Hydrogen

### DIFF
--- a/packages/hydrogen/edge-entry.js
+++ b/packages/hydrogen/edge-entry.js
@@ -5,8 +5,10 @@ import indexTemplate from '__RELATIVE__/dist/client/index.html?raw';
 import { ReadableStream } from 'web-streams-polyfill/ponyfill';
 Object.assign(globalThis, { ReadableStream });
 
-export default (request, event) =>
-  handleRequest(request, {
+export default (request, event) => {
+  globalThis.Oxygen = { env: process.env };
+  return handleRequest(request, {
     indexTemplate,
     context: event,
   });
+}


### PR DESCRIPTION
### Related Issues

It's currently not possible to access environment variables in Hydrogen projects deployed to Vercel. The reason is that Hydrogen currently relies on a global [`Oxygen.env` that needs to be polyfilled](https://shopify.dev/custom-storefronts/hydrogen/framework/environment-variables#private-variables-in-production) in the platform. This PR adds the global object using `process.env`, which is [mentioned in the docs](https://vercel.com/docs/concepts/functions/edge-functions/edge-functions-api#environment-variables) as the way to access environment variables in Edge Functions.

@TooTallNate Can you double check if this is correct? I'm not quite sure `process.env` is the right thing here even if it's mentioned in the docs 😅 

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
