### PR TITLE
Update __layout.svelte to correct the Analytics ID Environment variable name to reflect the current Vercel deployment

### DIFF
--- a/examples/sveltekit/src/routes/__layout.svelte
+++ b/examples/sveltekit/src/routes/__layout.svelte
@@ -5,7 +5,7 @@
   import { page } from '$app/stores';
   import '../app.css';
 
-  let analyticsId = import.meta.env.VERCEL_ANALYTICS_ID;
+  let analyticsId = import.meta.env.VITE_VERCEL_ANALYTICS_ID;
 
   $: if (browser && analyticsId) {
     webVitals({


### PR DESCRIPTION
Corrected SvelteKit VERCEL_ANALYTICS_ID to VITE_VERCEL_ANALYTICS_ID for use on the Vercel Platform

### Related Issues

> Fixes #8427

