### PR TITLE
[next] Update middleware data routes to fix caching

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1375,7 +1375,10 @@ export async function serverBuild({
                 route.src.replace(/(^\^|\$$)/g, '') + '.json$'
               );
 
-              const { pathname } = new URL(route.dest || '/', 'http://n');
+              const { pathname, search } = new URL(
+                route.dest || '/',
+                'http://n'
+              );
               let isPrerender = !!prerenders[path.join('./', pathname)];
 
               if (routesManifest.i18n) {
@@ -1392,7 +1395,9 @@ export async function serverBuild({
               }
 
               if (isPrerender) {
-                route.dest = `/_next/data/${buildId}${pathname}.json`;
+                route.dest = `/_next/data/${buildId}${pathname}.json${
+                  search || ''
+                }`;
               }
               return route;
             })

--- a/packages/next/test/fixtures/00-middleware/index.test.js
+++ b/packages/next/test/fixtures/00-middleware/index.test.js
@@ -1,8 +1,69 @@
 const path = require('path');
-const { deployAndTest } = require('../../utils');
+const cheerio = require('cheerio');
+const { deployAndTest, check } = require('../../utils');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
+  let ctx = {};
+
   it('should deploy and pass probe checks', async () => {
-    await deployAndTest(__dirname);
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+
+  it('should revalidate content correctly for middleware rewrite', async () => {
+    const propsFromHtml = async () => {
+      let res = await fetch(`${ctx.deploymentUrl}/rewrite-to-another-site`);
+      let $ = cheerio.load(await res.text());
+      let props = JSON.parse($('#props').text());
+      return props;
+    };
+    let props = await propsFromHtml();
+    expect(isNaN(props.now)).toBe(false);
+
+    const { pageProps: data } = await fetch(
+      `${ctx.deploymentUrl}/_next/data/testing-build-id/rewrite-to-another-site.json`
+    ).then(res => res.json());
+
+    expect(isNaN(data.now)).toBe(false);
+
+    const revalidateRes = await fetch(
+      `${ctx.deploymentUrl}/api/revalidate?urlPath=/_sites/test-revalidate`
+    );
+    expect(revalidateRes.status).toBe(200);
+    expect(await revalidateRes.json()).toEqual({ revalidated: true });
+
+    await check(async () => {
+      const newProps = await propsFromHtml();
+      console.log({ props, newProps });
+
+      if (isNaN(newProps.now)) {
+        throw new Error();
+      }
+      return newProps.now !== props.now
+        ? 'success'
+        : JSON.stringify({
+            newProps,
+            props,
+          });
+    }, 'success');
+
+    await check(async () => {
+      const { pageProps: newData } = await fetch(
+        `${ctx.deploymentUrl}/_next/data/testing-build-id/rewrite-to-another-site.json`
+      ).then(res => res.json());
+
+      console.log({ newData, data });
+
+      if (isNaN(newData.now)) {
+        throw new Error();
+      }
+      return newData.now !== data.now
+        ? 'success'
+        : JSON.stringify({
+            newData,
+            data,
+          });
+    }, 'success');
   });
 });

--- a/packages/next/test/fixtures/00-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-middleware/middleware.js
@@ -94,6 +94,13 @@ export function middleware(request) {
     return NextResponse.rewrite(customUrl);
   }
 
+  if (url.pathname === '/rewrite-to-another-site') {
+    const customUrl = new URL(url);
+    customUrl.pathname = '/_sites/test-revalidate';
+    console.log('rewriting to', customUrl.pathname, customUrl.href);
+    return NextResponse.rewrite(customUrl);
+  }
+
   if (url.pathname === '/redirect-me-to-about') {
     url.pathname = '/about';
     url.searchParams.set('middleware', 'foo');

--- a/packages/next/test/fixtures/00-middleware/pages/_sites/[site].js
+++ b/packages/next/test/fixtures/00-middleware/pages/_sites/[site].js
@@ -2,7 +2,7 @@ export default function Page(props) {
   return (
     <>
       <p>/_sites/[site]</p>
-      <p>{JSON.stringify(props)}</p>
+      <p id="props">{JSON.stringify(props)}</p>
     </>
   );
 }

--- a/packages/next/test/fixtures/00-middleware/pages/api/revalidate.js
+++ b/packages/next/test/fixtures/00-middleware/pages/api/revalidate.js
@@ -1,0 +1,4 @@
+export default async function handler(req, res) {
+  await res.revalidate(req.query.urlPath);
+  res.json({ revalidated: true });
+}


### PR DESCRIPTION
### Related Issues

This fixes caches for data routes with middleware due to search params not matching between the non-data variant and the data variant. Additional tests have been added to ensure this is working as expected. 

Fixes: https://github.com/vercel/next.js/issues/39595

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
