### PR TITLE
[cli] prevent git connection during vc pull

### DIFF
--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -98,6 +98,10 @@ async function ensureLink(
       autoConfirm: yes,
       successEmoji: 'link',
       setupMsg: 'Set up',
+      // always skip git provider connection
+      // because the intent behind `vc pull` is not
+      // project setup, like it often is with `vc link`
+      skipGitProviderConnection: true,
     });
 
     if (link.status === 'not_linked') {

--- a/packages/cli/src/util/create-git-meta.ts
+++ b/packages/cli/src/util/create-git-meta.ts
@@ -93,6 +93,11 @@ export function isDirty(directory: string, output: Output): Promise<boolean> {
 
 export async function parseGitConfig(configPath: string, output: Output) {
   try {
+    const configExists = await fs.pathExists(configPath);
+    if (!configExists) {
+      return;
+    }
+
     return ini.parse(await fs.readFile(configPath, 'utf-8'));
   } catch (err: unknown) {
     output.debug(`Error while parsing repo data: ${errorToString(err)}`);

--- a/packages/cli/src/util/link/add-git-connection.ts
+++ b/packages/cli/src/util/link/add-git-connection.ts
@@ -70,13 +70,18 @@ async function addSingleGitRemote(
     return 1;
   }
   const { org: parsedOrg, repo, provider } = repoInfo;
-  const alreadyLinked =
+
+  // The Project calls a Git Provider Connection a "link",
+  // which is not the same as linking a local repo to a Vercel Project
+  const alreadyConnected =
     project.link &&
     project.link.org === parsedOrg &&
     project.link.repo === repo &&
     project.link.type === provider;
-  if (alreadyLinked) {
-    client.output.debug('Project already linked. Skipping...');
+  if (alreadyConnected) {
+    client.output.debug(
+      `Project already connected to Git Provider: ${remoteUrl}. Skipping...`
+    );
     return;
   }
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -37,6 +37,7 @@ export interface SetupAndLinkOptions {
   successEmoji: EmojiLabel;
   setupMsg: string;
   projectName?: string;
+  skipGitProviderConnection?: boolean;
 }
 
 export default async function setupAndLink(
@@ -48,6 +49,7 @@ export default async function setupAndLink(
     successEmoji,
     setupMsg,
     projectName,
+    skipGitProviderConnection = false,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { localConfig, output, config } = client;
@@ -130,17 +132,20 @@ export default async function setupAndLink(
   } else {
     const project = projectOrNewProjectName;
 
-    const remoteUrls = await getRemoteUrls(join(path, '.git/config'), output);
-    if (remoteUrls && !project.skipGitConnectDuringLink) {
-      const connectGit = await addGitConnection(
-        client,
-        org,
-        project,
-        remoteUrls,
-        autoConfirm
-      );
-      if (typeof connectGit === 'number') {
-        return { status: 'error', exitCode: connectGit };
+    if (!skipGitProviderConnection) {
+      const remoteUrls = await getRemoteUrls(join(path, '.git/config'), output);
+
+      if (remoteUrls && !project.skipGitConnectDuringLink) {
+        const connectGit = await addGitConnection(
+          client,
+          org,
+          project,
+          remoteUrls,
+          autoConfirm
+        );
+        if (typeof connectGit === 'number') {
+          return { status: 'error', exitCode: connectGit };
+        }
       }
     }
 
@@ -258,18 +263,20 @@ export default async function setupAndLink(
 
     const project = await createProject(client, newProjectName);
 
-    const remoteUrls = await getRemoteUrls(join(path, '.git/config'), output);
-    if (remoteUrls) {
-      const connectGit = await addGitConnection(
-        client,
-        org,
-        project,
-        remoteUrls,
-        autoConfirm,
-        settings
-      );
-      if (typeof connectGit === 'number') {
-        return { status: 'error', exitCode: connectGit };
+    if (!skipGitProviderConnection) {
+      const remoteUrls = await getRemoteUrls(join(path, '.git/config'), output);
+      if (remoteUrls && !project.skipGitConnectDuringLink) {
+        const connectGit = await addGitConnection(
+          client,
+          org,
+          project,
+          remoteUrls,
+          autoConfirm,
+          settings
+        );
+        if (typeof connectGit === 'number') {
+          return { status: 'error', exitCode: connectGit };
+        }
       }
     }
 

--- a/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/.gitignore
+++ b/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/.gitignore
@@ -1,0 +1,2 @@
+.next
+yarn.lock

--- a/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/git/config
+++ b/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/git/config
@@ -1,0 +1,13 @@
+[core]
+        repositoryformatversion = 0
+        filemode = true
+        bare = false
+        logallrefupdates = true
+        ignorecase = true
+        precomposeunicode = true
+[remote "origin"]
+        url = https://github.com/user/repo.git
+        fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "master"]
+        remote = origin
+        merge = refs/heads/master

--- a/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/package.json
+++ b/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "build": "next build",
+    "dev": "next",
+    "now-build": "next build"
+  },
+  "dependencies": {
+    "next": "^8.0.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/pages/index.js
+++ b/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/pages/index.js
@@ -1,0 +1,11 @@
+import { withRouter } from 'next/router';
+
+function Index({ router }) {
+  const data = {
+    pathname: router.pathname,
+    query: router.query,
+  };
+  return <div>{JSON.stringify(data)}</div>;
+}
+
+export default withRouter(Index);

--- a/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/vercel.json
+++ b/packages/cli/test/fixtures/unit/vercel-pull-unlinked-git/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "name": "vercel-pull-next",
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index?route-param=b"
+    }
+  ]
+}

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -193,6 +193,9 @@ export function useUnknownProject() {
     Object.assign(project, req.body);
     res.json(project);
   });
+  client.scenario.get(`/v8/projects/:id/env`, (_req, res) => {
+    res.json({ envs });
+  });
 }
 
 export function useProject(project: Partial<Project> = defaultProject) {

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -24,12 +24,12 @@ describe('getOriginUrl', () => {
     const data = await getOriginUrl(configPath, client.output);
     expect(data).toBeNull();
   });
-  it('displays debug message when repo data cannot be parsed', async () => {
+  it('does not find git data when `.git/config` does not exist', async () => {
     const dir = await getWriteableDirectory();
     client.output.debugEnabled = true;
     const data = await getOriginUrl(join(dir, 'git/config'), client.output);
     expect(data).toBeNull();
-    await expect(client.stderr).toOutput('Error while parsing repo data');
+    await expect(client.stderr).not.toOutput('Error while parsing repo data');
   });
 });
 


### PR DESCRIPTION
When running `vc pull`, if the project is not yet linked, the logic behind `vc link` is called. When that happens, if there is no Git Provider on the project, the Git Provider Connection logic can run.

This is confusing for the user running `vc pull`. I think we should skip Git Provider Connection logic when the original CLI command was not `vc link`. This PR implements that.