### PR TITLE
[next] Ensure non-static pages/500 is handled

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -477,6 +477,14 @@ export const build: BuildV2 = async ({
         : '/404'
     ]?.initialRevalidate === 'number';
 
+  const hasIsr500Page =
+    typeof prerenderManifest.staticRoutes[
+      routesManifest?.i18n
+        ? // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+          path.join('/', routesManifest?.i18n!.defaultLocale!, '/500')
+        : '/500'
+    ]?.initialRevalidate === 'number';
+
   const wildcardConfig: BuildResult['wildcard'] =
     routesManifest?.i18n?.domains && routesManifest.i18n.domains.length > 0
       ? routesManifest.i18n.domains.map(item => {
@@ -1296,6 +1304,7 @@ export const build: BuildV2 = async ({
         requiredServerFilesManifest,
         privateOutputs,
         hasIsr404Page,
+        hasIsr500Page,
       });
     }
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -80,6 +80,7 @@ export async function serverBuild({
   headers,
   dataRoutes,
   hasIsr404Page,
+  hasIsr500Page,
   imagesManifest,
   wildcardConfig,
   routesManifest,
@@ -122,6 +123,7 @@ export async function serverBuild({
   dataRoutes: Route[];
   nextVersion: string;
   hasIsr404Page: boolean;
+  hasIsr500Page: boolean;
   trailingSlashRedirects: Route[];
   routesManifest: RoutesManifest;
   lambdaCompressedByteLimit: number;
@@ -1529,10 +1531,8 @@ export async function serverBuild({
             },
           ]),
 
-      // static 500 page if present
-      ...(!hasStatic500
-        ? []
-        : i18n
+      // custom 500 page if present
+      ...(i18n && (hasStatic500 || hasIsr500Page || lambdaPages['500.js'])
         ? [
             {
               src: `${path.join(
@@ -1544,6 +1544,7 @@ export async function serverBuild({
                 .join('|')})(/.*|$)`,
               dest: path.join('/', entryDirectory, '/$nextLocale/500'),
               status: 500,
+              caseSensitive: true,
             },
             {
               src: path.join('/', entryDirectory, '.*'),
@@ -1558,7 +1559,15 @@ export async function serverBuild({
         : [
             {
               src: path.join('/', entryDirectory, '.*'),
-              dest: path.join('/', entryDirectory, '/500'),
+              dest: path.join(
+                '/',
+                entryDirectory,
+                hasStatic500 ||
+                  hasIsr500Page ||
+                  lambdas[path.join(entryDirectory, '500')]
+                  ? '/500'
+                  : '/_error'
+              ),
               status: 500,
             },
           ]),

--- a/packages/next/test/fixtures/00-lambda-pages-500/index.test.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-lambda-pages-500/next.config.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/packages/next/test/fixtures/00-lambda-pages-500/package.json
+++ b/packages/next/test/fixtures/00-lambda-pages-500/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/404.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/404.js
@@ -1,0 +1,3 @@
+export default function Error404(props) {
+  return <p>pages/404</p>;
+}

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/500.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/500.js
@@ -1,0 +1,3 @@
+export default function Error500(props) {
+  return <p>pages/500</p>;
+}

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/_app.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/_app.js
@@ -1,0 +1,11 @@
+import App from 'next/app';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+MyApp.getInitialProps = async function (ctx) {
+  return App.getInitialProps(ctx);
+};
+
+export default MyApp;

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/_error.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/_error.js
@@ -1,0 +1,18 @@
+function Error(props) {
+  return (
+    <>
+      <p>pages/_error</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+Error.getInitialProps = async function getInitialProps({ statusCode, err }) {
+  console.log('Error.getInitialProps', err);
+  return {
+    statusCode,
+    message: err?.message,
+  };
+};
+
+export default Error;

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/index.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page(props) {
+  return <p>index page</p>;
+}

--- a/packages/next/test/fixtures/00-lambda-pages-500/pages/trigger-error.js
+++ b/packages/next/test/fixtures/00-lambda-pages-500/pages/trigger-error.js
@@ -1,0 +1,7 @@
+export default function Page(props) {
+  return <p>pages/trigger-error</p>;
+}
+
+export function getServerSideProps() {
+  throw new Error('custom error');
+}

--- a/packages/next/test/fixtures/00-lambda-pages-500/probes.json
+++ b/packages/next/test/fixtures/00-lambda-pages-500/probes.json
@@ -1,0 +1,19 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/non-existent",
+      "status": 404,
+      "mustContain": "pages/404"
+    },
+    {
+      "path": "/trigger-error",
+      "status": 500,
+      "mustContain": "pages/500"
+    }
+  ]
+}


### PR DESCRIPTION
### Related Issues

Previously we were only checking for a non-static version of `pages/404` although this can also be the case for `pages/500` so this ensures we match that handling and add a test case to prevent regression. 

Fixes: [slack thread](https://vercel.slack.com/archives/C01JVJ4NYPQ/p1660917513660049)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
