### PR TITLE
[dev] rewrites from middleware should change path too

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1534,11 +1534,8 @@ export default class DevServer {
             debug(`Detected rewrite path from middleware: "${rewritePath}"`);
             prevUrl = rewritePath;
 
-            // Retain orginal pathname, but override query parameters from the rewrite
             const beforeRewriteUrl = req.url || '/';
-            const rewriteUrlParsed = url.parse(beforeRewriteUrl);
-            rewriteUrlParsed.search = url.parse(rewritePath).search;
-            req.url = url.format(rewriteUrlParsed);
+            req.url = rewritePath;
             debug(
               `Rewrote incoming HTTP URL from "${beforeRewriteUrl}" to "${req.url}"`
             );

--- a/packages/cli/test/dev/integration-4.test.ts
+++ b/packages/cli/test/dev/integration-4.test.ts
@@ -467,11 +467,11 @@ test(
 test(
   '[vercel dev] Middleware that rewrites with custom query params',
   testFixtureStdio('middleware-rewrite-query', async (testPath: any) => {
-    await testPath(200, '/?foo=bar', '{"url":"/?from-middleware=true"}');
+    await testPath(200, '/?foo=bar', '{"url":"/api/fn?from-middleware=true"}');
     await testPath(
       200,
       '/another?foo=bar',
-      '{"url":"/another?from-middleware=true"}'
+      '{"url":"/api/fn?from-middleware=true"}'
     );
     await testPath(
       200,


### PR DESCRIPTION
Middleware rewrites are supposed to change the path, but are currently not.

**Tests will fail until this is fixed in production as well. We will not merge until then.**

---

Blocked by:

- a similar change needs to be made in production middleware handling