### PR TITLE
[cli] Improved 'vc git' help description for --yes flag

### DIFF
--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -25,7 +25,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}   Login token
-    -y, --yes                 Skip questions when setting up new project using default scope and settings
+    -y, --yes                 Skip confirmation when connecting a Git provider
 
   ${chalk.dim('Examples:')}
 
@@ -35,7 +35,9 @@ const help = () => {
 
     ${chalk.cyan(`$ ${getPkgName()} git connect`)}
   
-  ${chalk.gray('–')} Connect your Vercel Project to a Git repository using the remote URL
+  ${chalk.gray(
+    '–'
+  )} Connect your Vercel Project to a Git repository using the remote URL
 
     ${chalk.cyan(
       `$ ${getPkgName()} git connect https://github.com/user/repo.git`


### PR DESCRIPTION
When adding the `--yes` flag to the `vc git` command's help screen, the description was copy/pasted and not accurate, so this PR improves the description to be more accurate.

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
