### PR TITLE
[tests] Change PR automerge label

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [merge]
-automerge_label = ["semver-major","semver-minor","semver-patch"]
+automerge_label = ["pr: automerge"]
 blacklist_title_regex = "^WIP.*"
 blacklist_labels = ["work in progress"]
 method = "squash"


### PR DESCRIPTION
We decided to change this to an explicit label and rely on a separate action to check for correct labels (see #8464).

This action likely won't work for PRs from forks, but that might be okay because our other actions don't work for forks either.