### PR TITLE
[fs-detectors] Add a default workspace manager when there's no lock file

### DIFF
--- a/packages/fs-detectors/src/workspaces/workspace-managers.ts
+++ b/packages/fs-detectors/src/workspaces/workspace-managers.ts
@@ -61,7 +61,7 @@ export const workspaceManagers: Array<
   },
   {
     name: 'default',
-    slug: 'npm',
+    slug: 'yarn',
     detectors: {
       every: [
         {

--- a/packages/fs-detectors/src/workspaces/workspace-managers.ts
+++ b/packages/fs-detectors/src/workspaces/workspace-managers.ts
@@ -59,6 +59,19 @@ export const workspaceManagers: Array<
       ],
     },
   },
+  {
+    name: 'default',
+    slug: 'npm',
+    detectors: {
+      every: [
+        {
+          path: 'package.json',
+          matchContent:
+            '"workspaces":\\s*(?:\\[[^\\]]*]|{[^}]*"packages":[^}]*})',
+        },
+      ],
+    },
+  },
 ];
 
 export default workspaceManagers;

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/a/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/a/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "^4.3.2"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/b/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cowsay": "^1.5.0"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "21-npm-workspaces",
+  "version": "1.0.0",
+  "workspaces": [
+    "a",
+    "b"
+  ]
+}

--- a/packages/fs-detectors/test/unit.detect-workspace-managers.test.ts
+++ b/packages/fs-detectors/test/unit.detect-workspace-managers.test.ts
@@ -11,7 +11,7 @@ describe('workspace-managers', () => {
     ['25-multiple-lock-files-yarn', 'yarn'],
     ['26-multiple-lock-files-pnpm', 'pnpm'],
     ['22-pnpm', null],
-    ['38-workspaces-no-lock-file', 'npm'],
+    ['38-workspaces-no-lock-file', 'yarn'],
   ])('with detectFramework', (fixturePath, frameworkSlug) => {
     const testName = frameworkSlug
       ? `should detect a ${frameworkSlug} workspace for ${fixturePath}`

--- a/packages/fs-detectors/test/unit.detect-workspace-managers.test.ts
+++ b/packages/fs-detectors/test/unit.detect-workspace-managers.test.ts
@@ -11,6 +11,7 @@ describe('workspace-managers', () => {
     ['25-multiple-lock-files-yarn', 'yarn'],
     ['26-multiple-lock-files-pnpm', 'pnpm'],
     ['22-pnpm', null],
+    ['38-workspaces-no-lock-file', 'npm'],
   ])('with detectFramework', (fixturePath, frameworkSlug) => {
     const testName = frameworkSlug
       ? `should detect a ${frameworkSlug} workspace for ${fixturePath}`


### PR DESCRIPTION
This fixes an issue with this example,

https://vercel.com/api/v1/integrations/detect-eligible-projects?url=https%3A%2F%2Fgithub.com%2Fvercel%2Fturborepo%2Ftree%2Fmain%2Fexamples%2Fkitchen-sink

Where the repo has no lockfile, and hence our workspace detection fails.  This fix is to add a fallback of "npm" in this scenario

### Related Issues

Fixes https://github.com/vercel/turbo-internal/issues/232

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
