### PR TITLE
[all] Bump typescript to 4.8.2

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -44,7 +44,7 @@
     "multistream": "2.1.1",
     "node-fetch": "2.6.7",
     "semver": "6.1.1",
-    "typescript": "4.3.4",
+    "typescript": "4.8.2",
     "yazl": "2.5.1"
   }
 }

--- a/packages/build-utils/src/fs/read-config-file.ts
+++ b/packages/build-utils/src/fs/read-config-file.ts
@@ -6,7 +6,7 @@ async function readFileOrNull(file: string) {
   try {
     const data = await readFile(file);
     return data;
-  } catch (err) {
+  } catch (err: any) {
     if (err.code !== 'ENOENT') {
       throw err;
     }
@@ -28,7 +28,7 @@ export async function readConfigFile<T>(
       if (name.endsWith('.json')) {
         return JSON.parse(str) as T;
       } else if (name.endsWith('.toml')) {
-        return (toml.parse(str) as unknown) as T;
+        return toml.parse(str) as unknown as T;
       } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
         return yaml.safeLoad(str, { filename: name }) as T;
       }

--- a/packages/build-utils/test/unit.get-platform-env.test.ts
+++ b/packages/build-utils/test/unit.get-platform-env.test.ts
@@ -30,15 +30,14 @@ describe('Test `getPlatformEnv()`', () => {
       process.env.NOW_FOO = 'bar';
       process.env.VERCEL_FOO = 'baz';
       getPlatformEnv('FOO');
-    } catch (_err) {
+    } catch (_err: any) {
       err = _err;
     } finally {
       delete process.env.NOW_FOO;
       delete process.env.VERCEL_FOO;
     }
-    assert(err);
     assert.equal(
-      err!.message,
+      err?.message,
       'Both "VERCEL_FOO" and "NOW_FOO" env vars are defined. Please only define the "VERCEL_FOO" env var.'
     );
   });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -168,7 +168,7 @@
     "tmp-promise": "1.0.3",
     "tree-kill": "1.2.2",
     "ts-node": "10.9.1",
-    "typescript": "4.7.4",
+    "typescript": "4.8.2",
     "universal-analytics": "0.4.20",
     "utility-types": "2.1.0",
     "which": "2.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,7 +32,7 @@
     "@types/node-fetch": "2.5.4",
     "@types/recursive-readdir": "2.2.0",
     "@types/tar-fs": "1.16.1",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/client/src/utils/ready-state.ts
+++ b/packages/client/src/utils/ready-state.ts
@@ -10,7 +10,8 @@ export const isFailed = ({
 }: Deployment | DeploymentBuild): boolean =>
   readyState
     ? readyState.endsWith('_ERROR') || readyState === 'ERROR'
-    : (state && state.endsWith('_ERROR')) || state === 'ERROR';
+    : (typeof state === 'string' && (state as string).endsWith('_ERROR')) ||
+      state === 'ERROR';
 export const isDone = (
   buildOrDeployment: Deployment | DeploymentBuild
 ): boolean => isReady(buildOrDeployment) || isFailed(buildOrDeployment);

--- a/packages/client/tests/paths.test.ts
+++ b/packages/client/tests/paths.test.ts
@@ -19,7 +19,7 @@ describe('path handling', () => {
           name: 'now-client-tests-v2',
         }
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(e.code).toEqual('invalid_path');
     }
   });
@@ -35,7 +35,7 @@ describe('path handling', () => {
           name: 'now-client-tests-v2',
         }
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(e.code).toEqual('invalid_path');
     }
   });

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -19,7 +19,7 @@
     "typedoc": "0.23.10",
     "typedoc-plugin-markdown": "3.13.4",
     "typedoc-plugin-mdn-links": "2.0.0",
-    "typescript": "4.8.2"
+    "typescript": "4.7.4"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -19,7 +19,7 @@
     "typedoc": "0.23.10",
     "typedoc-plugin-markdown": "3.13.4",
     "typedoc-plugin-mdn-links": "2.0.0",
-    "typescript": "4.7.4"
+    "typescript": "4.8.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -23,6 +23,6 @@
     "@types/node-fetch": "2.5.8",
     "@vercel/routing-utils": "2.0.2",
     "ajv": "6.12.2",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/frameworks/src/read-config-file.ts
+++ b/packages/frameworks/src/read-config-file.ts
@@ -8,7 +8,7 @@ async function readFileOrNull(file: string) {
   try {
     const data = await readFile(file);
     return data;
-  } catch (err) {
+  } catch (err: any) {
     if (err.code !== 'ENOENT') {
       throw err;
     }
@@ -30,7 +30,7 @@ export async function readConfigFile<T>(
       if (name.endsWith('.json')) {
         return JSON.parse(str) as T;
       } else if (name.endsWith('.toml')) {
-        return (toml.parse(str) as unknown) as T;
+        return toml.parse(str) as unknown as T;
       } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
         return yaml.safeLoad(str, { filename: name }) as T;
       }

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -34,6 +34,6 @@
     "@types/node": "12.12.20",
     "@types/semver": "7.3.10",
     "@vercel/build-utils": "4.2.0",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/go/go-helpers.ts
+++ b/packages/go/go-helpers.ts
@@ -188,7 +188,7 @@ async function parseGoVersion(modulePath: string): Promise<string> {
     } else {
       console.log(`Warning: Unknown Go version in ${file}`);
     }
-  } catch (err) {
+  } catch (err: any) {
     if (err.code === 'ENOENT') {
       debug(`File not found: ${file}`);
     } else {

--- a/packages/go/index.ts
+++ b/packages/go/index.ts
@@ -521,7 +521,7 @@ export async function build({
         undoDirectoryCreation,
         undoFunctionRenames
       );
-    } catch (error) {
+    } catch (error: any) {
       console.log(`Build cleanup failed: ${error.message}`);
       debug('Cleanup Error: ' + error);
     }
@@ -771,7 +771,7 @@ async function waitForPortFile_(opts: {
         console.error('Could not delete port file: %j: %s', opts.portFile, err);
       });
       return { port };
-    } catch (err) {
+    } catch (err: any) {
       if (err.code !== 'ENOENT') {
         throw err;
       }

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -43,6 +43,6 @@
     "node-fetch": "^2.2.1",
     "string-argv": "0.3.1",
     "tar": "4.4.6",
-    "typescript": "4.8.2"
+    "typescript": "4.3.4"
   }
 }

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -43,6 +43,6 @@
     "node-fetch": "^2.2.1",
     "string-argv": "0.3.1",
     "tar": "4.4.6",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/go/test/index.test.ts
+++ b/packages/go/test/index.test.ts
@@ -2,29 +2,27 @@ import { getNewHandlerFunctionName } from '../index';
 
 describe('getNewHandlerFunctionName', function () {
   it('does nothing with empty original function name', async () => {
-    let error;
+    let error: any;
     try {
       getNewHandlerFunctionName('', 'some/kind-of-file.js');
-    } catch (err) {
+    } catch (err: any) {
       error = err;
     }
 
-    expect(error).toBeDefined();
-    expect(error.message).toEqual(
+    expect(error?.message).toEqual(
       'Handler function renaming failed because original function name was empty.'
     );
   });
 
   it('does nothing with empty original function name', async () => {
-    let error;
+    let error: any;
     try {
       getNewHandlerFunctionName('Handler', '');
-    } catch (err) {
+    } catch (err: any) {
       error = err;
     }
 
-    expect(error).toBeDefined();
-    expect(error.message).toEqual(
+    expect(error?.message).toEqual(
       'Handler function renaming failed because entrypoint was empty.'
     );
   });

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -22,6 +22,6 @@
     "@types/jest": "27.5.1",
     "@types/node": "*",
     "@vercel/build-utils": "5.4.0",
-    "typescript": "4.6.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -66,7 +66,7 @@
     "source-map": "0.7.3",
     "test-listen": "1.1.0",
     "text-table": "0.2.0",
-    "typescript": "4.5.2",
+    "typescript": "4.8.2",
     "webpack-sources": "3.2.3"
   }
 }

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -25,6 +25,6 @@
     "@vercel/build-utils": "5.4.0",
     "@vercel/ncc": "0.24.0",
     "execa": "^1.0.0",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/python/test/integration.test.ts
+++ b/packages/python/test/integration.test.ts
@@ -87,10 +87,8 @@ for (const fixture of fs.readdirSync(fixturesPath)) {
     it(`should fail to build ${fixture}`, async () => {
       try {
         await testDeployment(path.join(fixturesPath, fixture));
-      } catch (err) {
-        expect(err).toBeTruthy();
-        expect(err.deployment).toBeTruthy();
-        expect(err.deployment.errorMessage).toBe(errMsg);
+      } catch (err: any) {
+        expect(err?.deployment?.errorMessage).toBe(errMsg);
       }
     });
     continue; //eslint-disable-line

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -27,6 +27,7 @@
     "@types/aws-lambda": "8.10.19",
     "@types/node": "*",
     "@types/semver": "6.0.0",
-    "@vercel/build-utils": "5.4.0"
+    "@vercel/build-utils": "5.4.0",
+    "typescript": "4.8.2"
   }
 }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -26,6 +26,6 @@
     "@types/jest": "27.5.1",
     "@types/node": "*",
     "@vercel/build-utils": "5.4.0",
-    "typescript": "4.6.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/routing-utils/package.json
+++ b/packages/routing-utils/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "27.4.1",
     "@types/node": "12.12.20",
     "ajv": "^6.0.0",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   },
   "optionalDependencies": {
     "ajv": "^6.0.0"

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -27,6 +27,6 @@
     "execa": "2.0.4",
     "fs-extra": "^7.0.1",
     "semver": "6.1.1",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -46,6 +46,6 @@
     "ms": "2.1.2",
     "node-fetch": "2.6.7",
     "rc9": "1.2.0",
-    "typescript": "4.3.4"
+    "typescript": "4.8.2"
   }
 }

--- a/packages/static-build/src/utils/build-output-v2.ts
+++ b/packages/static-build/src/utils/build-output-v2.ts
@@ -118,7 +118,7 @@ async function getMiddleware(
     if (manifest.pages['_middleware.js'].runtime !== 'web') {
       return;
     }
-  } catch (error) {
+  } catch (error: any) {
     if (error.code !== 'ENOENT') throw error;
     return;
   }

--- a/packages/static-config/package.json
+++ b/packages/static-config/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "@swc/core": "1.2.182",
     "@types/jest": "27.4.1",
-    "@types/node": "*"
+    "@types/node": "*",
+    "typescript": "4.8.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12639,20 +12639,10 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
-
-typescript@4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
-
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 uglify-js@^3.1.4:
   version "3.13.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12639,6 +12639,11 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 typescript@4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"


### PR DESCRIPTION
This bumps `typescript` to [4.8.2](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/) for most packages in the monorepo.

However, it does not bump the following:

- `@vercel/node`
- `@vercel/node-bridge`
- `@vercel/edge`

Because these packages use typescript at runtime so we can't consider that semver patch.