### PR TITLE
[build-utils] Replace `npm bin` with custom implementation

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -23,8 +23,7 @@ export interface ScanParentDirsResult {
    */
   cliType: CliType;
   /**
-   * The file path of found `package.json` file, or `undefined` if none was
-   * found.
+   * The file path of found `package.json` file, or `undefined` if not found.
    */
   packageJsonPath?: string;
   /**
@@ -33,8 +32,13 @@ export interface ScanParentDirsResult {
    */
   packageJson?: PackageJson;
   /**
-   * The `lockfileVersion` number from the `package-lock.json` file,
-   * when present.
+   * The file path of the lockfile (`yarn.lock`, `package-lock.json`, or `pnpm-lock.yaml`)
+   * or `undefined` if not found.
+   */
+  lockfilePath?: string;
+  /**
+   * The `lockfileVersion` number from lockfile (`package-lock.json` or `pnpm-lock.yaml`),
+   * or `undefined` if not found.
    */
   lockfileVersion?: number;
 }
@@ -178,25 +182,8 @@ export async function getNodeBinPath({
 }: {
   cwd: string;
 }): Promise<string> {
-  const { code, stdout, stderr } = await execAsync('npm', ['bin'], {
-    cwd,
-    prettyCommand: 'npm bin',
-
-    // in some rare cases, we saw `npm bin` exit with a non-0 code, but still
-    // output the right bin path, so we ignore the exit code
-    ignoreNon0Exit: true,
-  });
-
-  const nodeBinPath = stdout.trim();
-
-  if (path.isAbsolute(nodeBinPath)) {
-    return nodeBinPath;
-  }
-
-  throw new NowBuildError({
-    code: `BUILD_UTILS_GET_NODE_BIN_PATH`,
-    message: `Running \`npm bin\` failed to return a valid bin path (code=${code}, stdout=${stdout}, stderr=${stderr})`,
-  });
+  const { lockfilePath } = await scanParentDirs(cwd);
+  return lockfilePath || path.join(cwd, 'node_modules', '.bin');
 }
 
 async function chmodPlusX(fsPath: string) {
@@ -319,6 +306,7 @@ export async function scanParentDirs(
     start: destPath,
     filenames: ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'],
   });
+  let lockfilePath: string | undefined;
   let lockfileVersion: number | undefined;
   let cliType: CliType = 'yarn';
 
@@ -335,17 +323,25 @@ export async function scanParentDirs(
   // Priority order is Yarn > pnpm > npm
   if (hasYarnLock) {
     cliType = 'yarn';
+    lockfilePath = yarnLockPath;
   } else if (pnpmLockYaml) {
     cliType = 'pnpm';
-    // just ensure that it is read as a number and not a string
+    lockfilePath = pnpmLockPath;
     lockfileVersion = Number(pnpmLockYaml.lockfileVersion);
   } else if (packageLockJson) {
     cliType = 'npm';
+    lockfilePath = npmLockPath;
     lockfileVersion = packageLockJson.lockfileVersion;
   }
 
   const packageJsonPath = pkgJsonPath || undefined;
-  return { cliType, packageJson, lockfileVersion, packageJsonPath };
+  return {
+    cliType,
+    packageJson,
+    lockfilePath,
+    lockfileVersion,
+    packageJsonPath,
+  };
 }
 
 export async function walkParentDirs({

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -183,7 +183,8 @@ export async function getNodeBinPath({
   cwd: string;
 }): Promise<string> {
   const { lockfilePath } = await scanParentDirs(cwd);
-  return lockfilePath || path.join(cwd, 'node_modules', '.bin');
+  const dir = path.dirname(lockfilePath || cwd);
+  return path.join(dir, 'node_modules', '.bin');
 }
 
 async function chmodPlusX(fsPath: string) {

--- a/packages/build-utils/test/unit.get-npm-bin-path.test.ts
+++ b/packages/build-utils/test/unit.get-npm-bin-path.test.ts
@@ -1,0 +1,46 @@
+import { join, parse } from 'path';
+import { getNodeBinPath } from '../src';
+
+describe('Test `getNodeBinPath()`', () => {
+  it('should work with npm7', async () => {
+    const cwd = join(__dirname, 'fixtures', '20-npm-7');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, 'node_modules', '.bin'));
+  });
+
+  it('should work with yarn', async () => {
+    const cwd = join(__dirname, 'fixtures', '19-yarn-v2');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, 'node_modules', '.bin'));
+  });
+
+  it('should work with npm 6', async () => {
+    const cwd = join(__dirname, 'fixtures', '08-yarn-npm/with-npm');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, 'node_modules', '.bin'));
+  });
+
+  it('should work with npm workspaces', async () => {
+    const cwd = join(__dirname, 'fixtures', '21-npm-workspaces/a');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, '..', 'node_modules', '.bin'));
+  });
+
+  it('should work with pnpm', async () => {
+    const cwd = join(__dirname, 'fixtures', '22-pnpm');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, 'node_modules', '.bin'));
+  });
+
+  it('should work with pnpm workspaces', async () => {
+    const cwd = join(__dirname, 'fixtures', '23-pnpm-workspaces/c');
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, '..', 'node_modules', '.bin'));
+  });
+
+  it('should fallback to cwd if no lockfile found', async () => {
+    const cwd = parse(process.cwd()).root;
+    const result = await getNodeBinPath({ cwd });
+    expect(result).toBe(join(cwd, 'node_modules', '.bin'));
+  });
+});

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -501,6 +501,7 @@ it('should return lockfileVersion 2 with npm7', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('npm');
   expect(result.lockfileVersion).toEqual(2);
+  expect(result.lockfilePath).toEqual(path.join(fixture, 'package-lock.json'));
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -509,6 +510,7 @@ it('should not return lockfileVersion with yarn', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('yarn');
   expect(result.lockfileVersion).toEqual(undefined);
+  expect(result.lockfilePath).toEqual(path.join(fixture, 'yarn.lock'));
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -517,6 +519,7 @@ it('should return lockfileVersion 1 with older versions of npm', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('npm');
   expect(result.lockfileVersion).toEqual(1);
+  expect(result.lockfilePath).toEqual(path.join(fixture, 'package-lock.json'));
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -525,6 +528,9 @@ it('should detect npm Workspaces', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('npm');
   expect(result.lockfileVersion).toEqual(2);
+  expect(result.lockfilePath).toEqual(
+    path.join(fixture, '..', 'package-lock.json')
+  );
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -533,6 +539,7 @@ it('should detect pnpm without workspace', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('pnpm');
   expect(result.lockfileVersion).toEqual(5.3);
+  expect(result.lockfilePath).toEqual(path.join(fixture, 'pnpm-lock.yaml'));
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -541,6 +548,9 @@ it('should detect pnpm with workspaces', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('pnpm');
   expect(result.lockfileVersion).toEqual(5.3);
+  expect(result.lockfilePath).toEqual(
+    path.join(fixture, '..', 'pnpm-lock.yaml')
+  );
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -552,6 +562,7 @@ it('should detect package.json in nested backend', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('yarn');
   expect(result.lockfileVersion).toEqual(undefined);
+  // There is no lockfile but this test will pick up vercel/vercel/yarn.lock
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 
@@ -563,6 +574,7 @@ it('should detect package.json in nested frontend', async () => {
   const result = await scanParentDirs(fixture);
   expect(result.cliType).toEqual('yarn');
   expect(result.lockfileVersion).toEqual(undefined);
+  // There is no lockfile but this test will pick up vercel/vercel/yarn.lock
   expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
 });
 


### PR DESCRIPTION
This PR removes `npm bin` in favor of a custom implementation since the command will be removed in npm 9.

- Related to https://github.com/npm/statusboard/issues/537

