### PR TITLE
[fs-detectors] Add writeFile to DetectorFilesystem

### DIFF
--- a/packages/fs-detectors/src/detectors/filesystem.ts
+++ b/packages/fs-detectors/src/detectors/filesystem.ts
@@ -98,8 +98,9 @@ export abstract class DetectorFilesystem {
    * @param name the name of the file to write
    * @param content The content of the file
    */
-  public writeFile(name: string, content: string): void {
-    this.readFileCache.set(name, Promise.resolve(Buffer.from(content)));
+  public writeFile(name: string, content?: string): void {
+    if (content)
+      this.readFileCache.set(name, Promise.resolve(Buffer.from(content)));
     this.fileCache.set(name, Promise.resolve(true));
     this.pathCache.set(name, Promise.resolve(true));
   }

--- a/packages/fs-detectors/src/detectors/filesystem.ts
+++ b/packages/fs-detectors/src/detectors/filesystem.ts
@@ -92,4 +92,15 @@ export abstract class DetectorFilesystem {
   public chdir = (name: string): DetectorFilesystem => {
     return this._chdir(name);
   };
+
+  /**
+   * Writes a file to the filesystem cache.
+   * @param name the name of the file to write
+   * @param content The content of the file
+   */
+  public writeFile(name: string, content: string): void {
+    this.readFileCache.set(name, Promise.resolve(Buffer.from(content)));
+    this.fileCache.set(name, Promise.resolve(true));
+    this.pathCache.set(name, Promise.resolve(true));
+  }
 }

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -160,6 +160,17 @@ describe('DetectorFilesystem', () => {
     ]);
   });
 
+  it('should be able to write files', async () => {
+    const files = {};
+    const fs = new VirtualFilesystem(files);
+
+    fs.writeFile('file.txt', 'Hello World');
+
+    expect(await fs.readFile('file.txt')).toEqual(Buffer.from('Hello World'));
+    expect(await fs.hasPath('file.txt')).toBe(true);
+    expect(await fs.isFile('file.txt')).toBe(true);
+  });
+
   it('should be able to change directories', async () => {
     const nextPackageJson = JSON.stringify({
       dependencies: {


### PR DESCRIPTION
Adds a `writeFile` function to `DetectorFilesystem` that will be used to update the various file cache maps.

When detecting npm7+ monorepos, we identified a performance improvement where the service can inspect the `package-lock.json` file for workspaces, and reuse the package information for each workspace in framework-detection.

The pseudo code in `vercel/api` will look something like this

For a given lockfile
```json
{
  ...,
  "packages": {
    "": {
      "name": "npm-workspaces",
      "version": "1.0.0",
      "license": "ISC",
      "workspaces": {
        "packages": [
          "apps/*"
        ]
      }
    },
    "apps/admin": {
      "version": "0.1.0",
      "dependencies": {
        "next": "12.2.5",
        "react": "18.2.0",
        "react-dom": "18.2.0"
      },
      "devDependencies": {
        "eslint": "8.23.0",
        "eslint-config-next": "12.2.5"
      }
    },
    ...,
}
```

```ts
// for each projectPath we detect in package-lock.json
// switch the cwd of the fs to the project directory
const projectFs = fs.chdir(projectPath);
// gets the package info from the lockfile
const projectPackageInfo = lockFile.packages[projectPath];
// insert this content into fs cache
projectFs.writeFile('package.json', projectPackageInfo)
// call detectFramework, which should now have a cached "package.json" file 
const projectFramework = await detectFramework(projectFs);
```

### Related Issues

Related to [HIT-57](https://linear.app/vercel/issue/HIT-57/monorepo-detection-api-prevent-rate-limits)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
