### PR TITLE
[hydrogen] Polyfill Oxygen global in Hydrogen

### DIFF
--- a/packages/hydrogen/edge-entry.js
+++ b/packages/hydrogen/edge-entry.js
@@ -3,7 +3,15 @@ import indexTemplate from '__RELATIVE__/dist/client/index.html?raw';
 
 // ReadableStream is bugged in Vercel Edge, overwrite with polyfill
 import { ReadableStream } from 'web-streams-polyfill/ponyfill';
-Object.assign(globalThis, { ReadableStream });
+Object.assign(globalThis, {
+  // ReadableStream is bugged in Vercel Edge, overwrite with polyfill
+  ReadableStream,
+
+  // Hydrogen exposes env vars through `Oxygen.env`
+  Oxygen: {
+    env: process.env
+  }
+});
 
 export default (request, event) =>
   handleRequest(request, {


### PR DESCRIPTION
### Related Issues

Description stolen from https://github.com/vercel/vercel/pull/8413
It's currently not possible to access environment variables in Hydrogen projects deployed to Vercel. The reason is that Hydrogen currently relies on a global [Oxygen.env that needs to be polyfilled](https://shopify.dev/custom-storefronts/hydrogen/framework/environment-variables#private-variables-in-production) in the platform. This PR adds the global object using process.env, which is [mentioned in the docs](https://vercel.com/docs/concepts/functions/edge-functions/edge-functions-api#environment-variables) as the way to access environment variables in Edge Functions.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
