### PR TITLE
[cli] Change error message from `Error!` to `Error:`

### DIFF
--- a/packages/cli/scripts/preinstall.js
+++ b/packages/cli/scripts/preinstall.js
@@ -4,7 +4,7 @@ const { statSync } = require('fs');
 const pkg = require('../package');
 
 function error(command) {
-  console.error('> Error!', command);
+  console.error('> Error:', command);
 }
 
 function debug(str) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ try {
   process.cwd();
 } catch (err: unknown) {
   if (isError(err) && err.message.includes('uv_cwd')) {
-    console.error('Error! The current working directory does not exist.');
+    console.error('Error: The current working directory does not exist.');
     process.exit(1);
   }
 }

--- a/packages/cli/src/util/output/create-output.ts
+++ b/packages/cli/src/util/output/create-output.ts
@@ -73,7 +73,7 @@ export class Output {
     link?: string,
     action = 'Learn More'
   ) => {
-    this.print(`${chalk.red(`Error!`)} ${str}\n`);
+    this.print(`${chalk.red(`Error:`)} ${str}\n`);
     const details = slug ? `https://err.sh/vercel/${slug}` : link;
     if (details) {
       this.print(`${chalk.bold(action)}: ${renderLink(details)}\n`);

--- a/packages/cli/src/util/output/error.ts
+++ b/packages/cli/src/util/output/error.ts
@@ -23,5 +23,5 @@ export default function error(
     metric.exception(messages.join('\n')).send();
   }
 
-  return `${chalk.red('Error!')} ${messages.join('\n')}`;
+  return `${chalk.red('Error:')} ${messages.join('\n')}`;
 }

--- a/packages/cli/src/util/validate-paths.ts
+++ b/packages/cli/src/util/validate-paths.ts
@@ -22,28 +22,28 @@ export async function validateRootDirectory(
   const suffix = errorSuffix ? ` ${errorSuffix}` : '';
 
   if (!pathStat) {
-    output.print(
-      `${chalk.red('Error!')} The provided path ${chalk.cyan(
+    output.error(
+      `The provided path ${chalk.cyan(
         `“${toHumanPath(path)}”`
-      )} does not exist.${suffix}\n`
+      )} does not exist.${suffix}`
     );
     return false;
   }
 
   if (!pathStat.isDirectory()) {
-    output.print(
-      `${chalk.red('Error!')} The provided path ${chalk.cyan(
+    output.error(
+      `The provided path ${chalk.cyan(
         `“${toHumanPath(path)}”`
-      )} is a file, but expected a directory.${suffix}\n`
+      )} is a file, but expected a directory.${suffix}`
     );
     return false;
   }
 
   if (!path.startsWith(cwd)) {
-    output.print(
-      `${chalk.red('Error!')} The provided path ${chalk.cyan(
+    output.error(
+      `The provided path ${chalk.cyan(
         `“${toHumanPath(path)}”`
-      )} is outside of the project.${suffix}\n`
+      )} is outside of the project.${suffix}`
     );
     return false;
   }
@@ -59,7 +59,7 @@ export default async function validatePaths(
 
   // can't deploy more than 1 path
   if (paths.length > 1) {
-    output.print(`${chalk.red('Error!')} Can't deploy more than one path.\n`);
+    output.error(`Can't deploy more than one path.`);
     return { valid: false, exitCode: 1 };
   }
 
@@ -69,11 +69,7 @@ export default async function validatePaths(
   const pathStat = await stat(path).catch(() => null);
 
   if (!pathStat) {
-    output.print(
-      `${chalk.red('Error!')} Could not find ${chalk.cyan(
-        `“${toHumanPath(path)}”`
-      )}\n`
-    );
+    output.error(`Could not find ${chalk.cyan(`“${toHumanPath(path)}”`)}`);
     return { valid: false, exitCode: 1 };
   }
 

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -360,7 +360,7 @@ test('default command should prompt login with empty auth.json', async t => {
   } catch (err) {
     t.true(
       err.stderr.includes(
-        'Error! No existing credentials found. Please run `vercel login` or pass "--token"'
+        'Error: No existing credentials found. Please run `vercel login` or pass "--token"'
       )
     );
   }
@@ -749,7 +749,7 @@ test('deploy fails using --local-config flag with non-existent path', async t =>
 
   t.is(exitCode, 1, formatOutput({ stderr, stdout }));
 
-  t.regex(stderr, /Error! Couldn't find a project configuration file at/);
+  t.regex(stderr, /Error: Couldn't find a project configuration file at/);
   t.regex(stderr, /does-not-exist\.json/);
 });
 
@@ -1451,7 +1451,7 @@ test('login with unregistered user', async t => {
   console.log(stdout);
   console.log(exitCode);
 
-  const goal = `Error! Please sign up: https://vercel.com/signup`;
+  const goal = `Error: Please sign up: https://vercel.com/signup`;
   const lines = stderr.trim().split('\n');
   const last = lines[lines.length - 1];
 
@@ -1629,7 +1629,7 @@ test('try to purchase a domain', async t => {
   t.is(exitCode, 1);
   t.regex(
     stderr,
-    /Error! Could not purchase domain\. Please add a payment method using/
+    /Error: Could not purchase domain\. Please add a payment method using/
   );
 });
 
@@ -1655,7 +1655,7 @@ test('try to transfer-in a domain with "--code" option', async t => {
 
   t.true(
     stderr.includes(
-      `Error! The domain "${session}-test.com" is not transferable.`
+      `Error: The domain "${session}-test.com" is not transferable.`
     )
   );
   t.is(exitCode, 1);
@@ -1680,7 +1680,7 @@ test('try to move an invalid domain', async t => {
   console.log(stdout);
   console.log(exitCode);
 
-  t.true(stderr.includes(`Error! Domain not found under `));
+  t.true(stderr.includes(`Error: Domain not found under `));
   t.is(exitCode, 1);
 });
 
@@ -1964,7 +1964,7 @@ test('try to create a builds deployments with wrong now.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
+      'Error: Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
     )
   );
   t.true(stderr.includes('https://vercel.com/docs/configuration'));
@@ -1988,7 +1988,7 @@ test('try to create a builds deployments with wrong vercel.json', async t => {
   t.is(exitCode, 1);
   t.true(
     stderr.includes(
-      'Error! Invalid vercel.json - should NOT have additional property `fake`. Please remove it.'
+      'Error: Invalid vercel.json - should NOT have additional property `fake`. Please remove it.'
     )
   );
   t.true(stderr.includes('https://vercel.com/docs/configuration'));
@@ -2009,7 +2009,7 @@ test('try to create a builds deployments with wrong `build.env` property', async
   t.is(exitCode, 1, formatOutput({ stdout, stderr }));
   t.true(
     stderr.includes(
-      'Error! Invalid vercel.json - should NOT have additional property `build.env`. Did you mean `{ "build": { "env": {"name": "value"} } }`?'
+      'Error: Invalid vercel.json - should NOT have additional property `build.env`. Did you mean `{ "build": { "env": {"name": "value"} } }`?'
     ),
     formatOutput({ stdout, stderr })
   );
@@ -2171,7 +2171,7 @@ test('use build-env', async t => {
 });
 
 test('try to deploy non-existing path', async t => {
-  const goal = `Error! The specified file or directory "${session}" does not exist.`;
+  const goal = `Error: The specified file or directory "${session}" does not exist.`;
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -2191,7 +2191,7 @@ test('try to deploy non-existing path', async t => {
 
 test('try to deploy with non-existing team', async t => {
   const target = fixture('static-deployment');
-  const goal = `Error! The specified scope does not exist`;
+  const goal = `Error: The specified scope does not exist`;
 
   const { stderr, stdout, exitCode } = await execa(
     binaryPath,
@@ -2274,7 +2274,7 @@ test('try to initialize example to existing directory', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    'Error! Destination path "angular" already exists and is not an empty directory. You may use `--force` or `-f` to override it.';
+    'Error: Destination path "angular" already exists and is not an empty directory. You may use `--force` or `-f` to override it.';
 
   await ensureDir(path.join(cwd, 'angular'));
   createFile(path.join(cwd, 'angular', '.gitignore'));
@@ -2291,7 +2291,7 @@ test('try to initialize misspelled example (noce) in non-tty', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    'Error! No example found for noce, run `vercel init` to see the list of available examples.';
+    'Error: No example found for noce, run `vercel init` to see the list of available examples.';
 
   const { stdout, stderr, exitCode } = await execute(['init', 'noce'], { cwd });
 
@@ -2307,7 +2307,7 @@ test('try to initialize example "example-404"', async t => {
   tmpDir = tmp.dirSync({ unsafeCleanup: true });
   const cwd = tmpDir.name;
   const goal =
-    'Error! No example found for example-404, run `vercel init` to see the list of available examples.';
+    'Error: No example found for example-404, run `vercel init` to see the list of available examples.';
 
   const { stdout, stderr, exitCode } = await execute(['init', 'example-404'], {
     cwd,
@@ -2483,7 +2483,7 @@ test('`vercel rm` should fail with unexpected option', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.regex(
     output.stderr,
-    /Error! unknown or unexpected option: --fake/gm,
+    /Error: unknown or unexpected option: --fake/gm,
     formatOutput(output)
   );
 });
@@ -2777,7 +2777,7 @@ test('invalid `--token`', async t => {
   t.is(output.exitCode, 1, formatOutput(output));
   t.true(
     output.stderr.includes(
-      'Error! You defined "--token", but its contents are invalid. Must not contain: "\\n", ",", "."'
+      'Error: You defined "--token", but its contents are invalid. Must not contain: "\\n", ",", "."'
     )
   );
 });
@@ -3500,7 +3500,7 @@ test('reject deploying with invalid token', async t => {
   t.is(exitCode, 1, formatOutput({ stderr, stdout }));
   t.regex(
     stderr,
-    /Error! Could not retrieve Project Settings\. To link your Project, remove the `\.vercel` directory and deploy again\./g
+    /Error: Could not retrieve Project Settings\. To link your Project, remove the `\.vercel` directory and deploy again\./g
   );
 });
 

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -711,7 +711,7 @@ describe('build', () => {
 
       // Error gets printed to the terminal
       await expect(client.stderr).toOutput(
-        'Error! Function must contain at least one property.'
+        'Error: Function must contain at least one property.'
       );
 
       // `builds.json` contains top-level "error" property

--- a/packages/cli/test/unit/commands/deploy.test.ts
+++ b/packages/cli/test/unit/commands/deploy.test.ts
@@ -12,7 +12,7 @@ describe('deploy', () => {
     client.setArgv('deploy', __filename);
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error! Support for single file deployments has been removed.\nLearn More: https://vercel.link/no-single-file-deployments\n`
+      `Error: Support for single file deployments has been removed.\nLearn More: https://vercel.link/no-single-file-deployments\n`
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -21,7 +21,7 @@ describe('deploy', () => {
     client.setArgv('deploy', __filename, join(__dirname, 'inspect.test.ts'));
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error! Can't deploy more than one path.\n`
+      `Error: Can't deploy more than one path.\n`
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -30,7 +30,7 @@ describe('deploy', () => {
     client.setArgv('deploy', 'does-not-exists');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error! The specified file or directory "does-not-exists" does not exist.\n`
+      `Error: The specified file or directory "does-not-exists" does not exist.\n`
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -41,7 +41,7 @@ describe('deploy', () => {
     client.setArgv('deploy', cwd, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      '> Prebuilt deployment cannot be created because `vercel build` failed with error:\n\nError! The build failed (top-level)\n'
+      '> Prebuilt deployment cannot be created because `vercel build` failed with error:\n\nError: The build failed (top-level)\n'
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -52,7 +52,7 @@ describe('deploy', () => {
     client.setArgv('deploy', cwd, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      '> Prebuilt deployment cannot be created because `vercel build` failed with error:\n\nError! The build failed within a Builder\n'
+      '> Prebuilt deployment cannot be created because `vercel build` failed with error:\n\nError: The build failed within a Builder\n'
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -61,7 +61,7 @@ describe('deploy', () => {
     client.setArgv('deploy', __dirname, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'Error! The "--prebuilt" option was used, but no prebuilt output found in ".vercel/output". Run `vercel build` to generate a local build.\n'
+      'Error: The "--prebuilt" option was used, but no prebuilt output found in ".vercel/output". Run `vercel build` to generate a local build.\n'
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -80,7 +80,7 @@ describe('deploy', () => {
     client.setArgv('deploy', cwd, '--prebuilt', '--prod');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'Error! The "--prebuilt" option was used with the target environment "production",' +
+      'Error: The "--prebuilt" option was used with the target environment "production",' +
         ' but the prebuilt output found in ".vercel/output" was built with target environment "preview".' +
         ' Please run `vercel --prebuilt`.\n' +
         'Learn More: https://vercel.link/prebuilt-environment-mismatch\n'
@@ -102,7 +102,7 @@ describe('deploy', () => {
     client.setArgv('deploy', cwd, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'Error! The "--prebuilt" option was used with the target environment "preview",' +
+      'Error: The "--prebuilt" option was used with the target environment "preview",' +
         ' but the prebuilt output found in ".vercel/output" was built with target environment "production".' +
         ' Please run `vercel --prebuilt --prod`.\n' +
         'Learn More: https://vercel.link/prebuilt-environment-mismatch\n'
@@ -118,7 +118,7 @@ describe('deploy', () => {
     };
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'Error! The value of the `version` property within vercel.json can only be `2`.\n'
+      'Error: The value of the `version` property within vercel.json can only be `2`.\n'
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });
@@ -132,7 +132,7 @@ describe('deploy', () => {
     };
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      'Error! The `version` property inside your vercel.json file must be a number.\n'
+      'Error: The `version` property inside your vercel.json file must be a number.\n'
     );
     await expect(exitCodePromise).resolves.toEqual(1);
   });

--- a/packages/cli/test/unit/commands/git.test.ts
+++ b/packages/cli/test/unit/commands/git.test.ts
@@ -80,7 +80,7 @@ describe('git', () => {
         const exitCode = await git(client);
         expect(exitCode).toEqual(1);
         await expect(client.stderr).toOutput(
-          `Error! No local Git repository found. Run \`git clone <url>\` to clone a remote Git repository first.\n`
+          `Error: No local Git repository found. Run \`git clone <url>\` to clone a remote Git repository first.\n`
         );
       } finally {
         process.chdir(originalCwd);
@@ -102,7 +102,7 @@ describe('git', () => {
         const exitCode = await git(client);
         expect(exitCode).toEqual(1);
         await expect(client.stderr).toOutput(
-          `Error! No remote URLs found in your Git config. Make sure you've configured a remote repo in your local Git config. Run \`git remote --help\` for more details.`
+          `Error: No remote URLs found in your Git config. Make sure you've configured a remote repo in your local Git config. Run \`git remote --help\` for more details.`
         );
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
@@ -129,7 +129,7 @@ describe('git', () => {
           `Connecting Git remote: bababooey`
         );
         await expect(client.stderr).toOutput(
-          `Error! Failed to parse Git repo data from the following remote URL: bababooey\n`
+          `Error: Failed to parse Git repo data from the following remote URL: bababooey\n`
         );
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));

--- a/packages/cli/test/unit/commands/inspect.test.ts
+++ b/packages/cli/test/unit/commands/inspect.test.ts
@@ -33,7 +33,7 @@ describe('inspect', () => {
     const exitCode = await inspect(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput(
-      `Error! Failed to find deployment "bad.com" in ${user.username}\n`
+      `Error: Failed to find deployment "bad.com" in ${user.username}\n`
     );
   });
 });

--- a/packages/cli/test/unit/commands/login.test.ts
+++ b/packages/cli/test/unit/commands/login.test.ts
@@ -7,7 +7,7 @@ describe('login', () => {
     client.setArgv('login', '--token', 'foo');
     const exitCodePromise = login(client);
     await expect(client.stderr).toOutput(
-      'Error! `--token` may not be used with the "login" command\n'
+      'Error: `--token` may not be used with the "login" command\n'
     );
     await expect(exitCodePromise).resolves.toEqual(2);
   });


### PR DESCRIPTION
We have code that tries to detect and highlight errors in the build logs, however it doesn't look for `Error!`, only `Error:`.

We could update that highlight code or we could update Vercel CLI to make it consistent.

This PR is the latter.