### PR TITLE
[build-utils] Support empty directory entries in `createZip()`

### DIFF
--- a/packages/build-utils/.gitignore
+++ b/packages/build-utils/.gitignore
@@ -1,4 +1,2 @@
 ?.js
 dist
-test/symlinks-out
-test/symlinks.zip

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -183,6 +183,7 @@ it('should create zip files with empty directories', async () => {
     const files = {
       dir: new FileBlob({
         mode: 16877,
+        // contents are not used for directories
         data: Buffer.alloc(0),
       }),
       file: new FileBlob({


### PR DESCRIPTION
Adds support for creating empty directories inside of a Lambda zip file.

Some refactoring was also done so I suggest reviewing with [whitespace ignored](https://github.com/vercel/vercel/pull/8503/files?w=1).