### PR TITLE
[tests] set retry count to 0 when running tests locally

### DIFF
--- a/packages/cli/test/dev/utils.js
+++ b/packages/cli/test/dev/utils.js
@@ -13,6 +13,7 @@ const {
 
 jest.setTimeout(6 * 60 * 1000);
 
+const isCI = !!process.env.CI;
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 const isCanary = () => getDistTag(cliVersion) === 'canary';
 
@@ -52,7 +53,7 @@ function fetchWithRetry(url, opts = {}) {
       return res;
     },
     {
-      retries: opts.retries || 3,
+      retries: opts.retries ?? 3,
       factor: 1,
     }
   );
@@ -150,9 +151,9 @@ async function testPath(
   fetchOpts = {}
 ) {
   const opts = {
+    retries: isCI ? 5 : 0,
     ...fetchOpts,
     redirect: 'manual-dont-change',
-    retries: 5,
     status,
   };
   const url = `${origin}${path}`;
@@ -330,7 +331,7 @@ function testFixtureStdio(
                 Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify(projectSettings),
-              retries: 3,
+              retries: isCI ? 3 : 0,
               status: 200,
             }
           );


### PR DESCRIPTION
When running tests locally that fail to make a fetch request, the retries add a lot of noise to debugging. This PR sets those retry counts to `0` locally, but keeps them at their current value for CI.