### PR TITLE
[tests] Skip tests that won't run on Windows due to 'mkdir -p' and symlinks

### DIFF
--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -895,6 +895,12 @@ describe('build', () => {
   });
 
   it('should apply project settings overrides from "vercel.json"', async () => {
+    if (process.platform === 'win32') {
+      // this test runs a build command with `mkdir -p` which is unsupported on Windows
+      console.log('Skipping test on Windows');
+      return;
+    }
+
     const cwd = fixture('project-settings-override');
     const output = join(cwd, '.vercel/output');
     try {

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -28,6 +28,12 @@ describe('importBuilders()', () => {
   });
 
   it('should import 3rd party Builders', async () => {
+    if (process.platform === 'win32') {
+      // this test creates symlinks which require admin by default on Windows
+      console.log('Skipping test on Windows');
+      return;
+    }
+
     const cwd = await getWriteableDirectory();
     try {
       const spec = 'vercel-deno@2.0.1';
@@ -46,6 +52,12 @@ describe('importBuilders()', () => {
   });
 
   it('should import legacy `@now/build-utils` Builders', async () => {
+    if (process.platform === 'win32') {
+      // this test creates symlinks which require admin by default on Windows
+      console.log('Skipping test on Windows');
+      return;
+    }
+
     const cwd = await getWriteableDirectory();
     try {
       const spec = '@frontity/now@1.2.0';


### PR DESCRIPTION
Found a few tests that won't run on Windows. The project settings override test runs `mkdir -p` which errors. The other two build tests fail because they try to create symlinks.

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
