### PR TITLE
[fs-detectors] Add monorepo managers

### DIFF
--- a/packages/fs-detectors/src/monorepos/monorepo-managers.ts
+++ b/packages/fs-detectors/src/monorepos/monorepo-managers.ts
@@ -31,6 +31,28 @@ export const monorepoManagers: Array<
       ],
     },
   },
+  {
+    name: 'Nx',
+    slug: 'nx',
+    detectors: {
+      every: [
+        {
+          path: 'nx.json',
+        },
+      ],
+    },
+  },
+  {
+    name: 'Rush',
+    slug: 'rush',
+    detectors: {
+      every: [
+        {
+          path: 'rush.json',
+        },
+      ],
+    },
+  },
 ];
 
 export default monorepoManagers;

--- a/packages/fs-detectors/test/fixtures/39-nx-monorepo/apps/app/project.json
+++ b/packages/fs-detectors/test/fixtures/39-nx-monorepo/apps/app/project.json
@@ -1,0 +1,119 @@
+{
+  "projectType": "application",
+  "generators": {
+    "@nrwl/workspace:component": {
+      "style": "scss"
+    }
+  },
+  "sourceRoot": "apps/products/src",
+  "prefix": "nx-example",
+  "targets": {
+    "build": {
+      "executor": "@angular-devkit/build-angular:browser",
+      "options": {
+        "aot": true,
+        "outputPath": "dist/apps/products",
+        "index": "apps/products/src/index.html",
+        "main": "apps/products/src/main.ts",
+        "polyfills": "apps/products/src/polyfills.ts",
+        "tsConfig": "apps/products/tsconfig.app.json",
+        "assets": [
+          "apps/products/src/_redirects",
+          {
+            "input": "libs/shared/assets/src/assets",
+            "glob": "**/*",
+            "output": "assets"
+          },
+          {
+            "input": "libs/shared/assets/src",
+            "glob": "favicon.ico",
+            "output": "."
+          }
+        ],
+        "styles": [
+          "libs/shared/styles/src/index.scss",
+          "libs/shared/header/index.scss",
+          "node_modules/normalize.css/normalize.css"
+        ],
+        "scripts": []
+      },
+      "configurations": {
+        "production": {
+          "fileReplacements": [
+            {
+              "replace": "apps/products/src/environments/environment.ts",
+              "with": "apps/products/src/environments/environment.prod.ts"
+            }
+          ],
+          "optimization": true,
+          "outputHashing": "all",
+          "sourceMap": false,
+          "namedChunks": false,
+          "aot": true,
+          "extractLicenses": true,
+          "vendorChunk": false,
+          "buildOptimizer": true,
+          "budgets": [
+            {
+              "type": "initial",
+              "maximumWarning": "2mb",
+              "maximumError": "5mb"
+            },
+            {
+              "type": "anyComponentStyle",
+              "maximumWarning": "6kb"
+            }
+          ]
+        }
+      },
+      "outputs": ["{options.outputPath}"]
+    },
+    "serve": {
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "options": {
+        "browserTarget": "products:build"
+      },
+      "configurations": {
+        "production": {
+          "browserTarget": "products:build:production"
+        }
+      }
+    },
+    "extract-i18n": {
+      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "options": {
+        "browserTarget": "products:build"
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": [
+          "apps/products/src/**/*.ts",
+          "apps/products/src/**/*.html"
+        ]
+      },
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "options": {
+        "jestConfig": "apps/products/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "outputs": ["coverage/apps/products"]
+    },
+    "deploy": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/deploy --siteName nrwl-nx-examples-products --outputPath dist/apps/products"
+          }
+        ]
+      }
+    }
+  },
+  "tags": ["type:app", "scope:products"],
+  "implicitDependencies": ["shared-assets", "shared-styles"]
+}

--- a/packages/fs-detectors/test/fixtures/39-nx-monorepo/nx.json
+++ b/packages/fs-detectors/test/fixtures/39-nx-monorepo/nx.json
@@ -1,0 +1,51 @@
+{
+  "implicitDependencies": {
+    "package.json": {
+      "dependencies": "*",
+      "devDependencies": "*"
+    },
+    ".eslintrc.json": "*"
+  },
+  "affected": {
+    "defaultBase": "master"
+  },
+  "npmScope": "nx-example",
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "@nrwl/nx-cloud",
+      "options": {
+        "accessToken": "YmM1MGMwMTUtNzAyYi00ZjM4LWExNGUtZDM2ZjYyNzNiODAxfHJlYWQ=",
+        "cacheableOperations": ["build", "lint", "test"],
+        "parallel": 1
+      }
+    }
+  },
+  "cli": {
+    "warnings": {
+      "versionMismatch": false
+    },
+    "packageManager": "yarn",
+    "analytics": false
+  },
+  "generators": {
+    "@nrwl/angular:application": {
+      "unitTestRunner": "jest",
+      "e2eTestRunner": "cypress"
+    },
+    "@nrwl/angular:library": {
+      "unitTestRunner": "jest"
+    },
+    "@nrwl/angular": {
+      "convert-tslint-to-eslint": {
+        "removeTSLintIfNoMoreTSLintTargets": true
+      }
+    }
+  },
+  "defaultProject": "app",
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/fs-detectors/test/fixtures/40-rush-monorepo/rush.json
+++ b/packages/fs-detectors/test/fixtures/40-rush-monorepo/rush.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
+
+  "rushVersion": "5.76.1",
+
+  "pnpmVersion": "6.7.1",
+
+  "pnpmOptions": {
+    "useWorkspaces": true
+  },
+
+  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+
+  "gitPolicy": {},
+
+  "repository": {},
+  "eventHooks": {
+    "preRushInstall": [],
+
+    "postRushInstall": [],
+    "preRushBuild": [],
+
+    "postRushBuild": []
+  },
+  "variants": [],
+  "projects": []
+}

--- a/packages/fs-detectors/test/unit.detect-monorepo-managers.test.ts
+++ b/packages/fs-detectors/test/unit.detect-monorepo-managers.test.ts
@@ -8,6 +8,8 @@ describe('monorepo-managers', () => {
     ['28-turborepo-with-yarn-workspaces', 'turbo'],
     ['31-turborepo-in-package-json', 'turbo'],
     ['22-pnpm', null],
+    ['39-nx-monorepo', 'nx'],
+    ['40-rush-monorepo', 'rush'],
   ])('with detectFramework', (fixturePath, frameworkSlug) => {
     const testName = frameworkSlug
       ? `should detect a ${frameworkSlug} workspace for ${fixturePath}`


### PR DESCRIPTION
### Related Issues

Adding in Nx and Rush as monorepo managers.
This will allow to help with starting zero config for both the above managers.
I have added in unit tests for both Nx and Rush.

### 📋 Checklist

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
