### PR TITLE
[dev] fix middleware rewrites to relative paths that do not exist

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1645,7 +1645,7 @@ export default class DevServer {
       prevUrl =
         routeResult.continue && routeResult.dest
           ? getReqUrl(routeResult)
-          : req.url;
+          : prevUrl;
       prevHeaders =
         routeResult.continue && routeResult.headers ? routeResult.headers : {};
 

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1644,12 +1644,16 @@ export default class DevServer {
         missRoutes,
         phase
       );
-      prevUrl =
-        routeResult.continue && routeResult.dest
-          ? getReqUrl(routeResult)
-          : prevUrl;
-      prevHeaders =
-        routeResult.continue && routeResult.headers ? routeResult.headers : {};
+
+      if (routeResult.continue) {
+        if (routeResult.dest) {
+          prevUrl = getReqUrl(routeResult);
+        }
+
+        if (routeResult.headers) {
+          prevHeaders = routeResult.headers;
+        }
+      }
 
       if (routeResult.isDestUrl) {
         // Mix the `routes` result dest query params into the req path

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1579,7 +1579,9 @@ export default class DevServer {
               const devServerParsed = new URL(this.address);
               if (devServerParsed.origin === rewriteUrlParsed.origin) {
                 // remove origin, leaving the path
-                req.url = rewritePath.slice(rewriteUrlParsed.origin.length);
+                req.url =
+                  rewritePath.slice(rewriteUrlParsed.origin.length) || '/';
+                prevUrl = req.url;
               } else {
                 // Proxy to absolute URL with different origin
                 debug(`ProxyPass: ${rewritePath}`);

--- a/packages/cli/test/dev/fixtures/middleware-rewrite-404/api/edge.ts
+++ b/packages/cli/test/dev/fixtures/middleware-rewrite-404/api/edge.ts
@@ -1,0 +1,7 @@
+export const config = {
+  runtime: 'experimental-edge',
+};
+
+export default async function edge(request: Request, event: Event) {
+  return new Response('heyo');
+}

--- a/packages/cli/test/dev/fixtures/middleware-rewrite-404/index.html
+++ b/packages/cli/test/dev/fixtures/middleware-rewrite-404/index.html
@@ -1,0 +1,1 @@
+<h1>Hello from Index</h1>

--- a/packages/cli/test/dev/fixtures/middleware-rewrite-404/middleware.ts
+++ b/packages/cli/test/dev/fixtures/middleware-rewrite-404/middleware.ts
@@ -1,0 +1,21 @@
+export const config = {
+  runtime: 'experimental-edge',
+};
+
+export default async function edge(request: Request, event: Event) {
+  if (request.url.indexOf('/index.html') > -1) {
+    return new Response(null, {
+      headers: {
+        'x-middleware-rewrite': '/does-not-exist.html',
+      },
+    });
+  }
+
+  if (request.url.indexOf('/api/edge') > -1) {
+    return new Response(null, {
+      headers: {
+        'x-middleware-rewrite': '/api/does-not-exist',
+      },
+    });
+  }
+}

--- a/packages/cli/test/dev/integration-4.test.ts
+++ b/packages/cli/test/dev/integration-4.test.ts
@@ -511,6 +511,14 @@ test(
 );
 
 test(
+  '[vercel dev] Middleware that rewrites to 404s',
+  testFixtureStdio('middleware-rewrite-404', async (testPath: any) => {
+    await testPath(404, '/api/edge', /NOT_FOUND/);
+    await testPath(404, '/index.html', /NOT_FOUND/);
+  })
+);
+
+test(
   '[vercel dev] Middleware that redirects',
   testFixtureStdio('middleware-redirect', async (testPath: any) => {
     await testPath(302, '/', null, {


### PR DESCRIPTION
When using a `rewrite` in middleware to a relative path that does not exist, the logic gets confused and falls back to the original path.

This was caused by two changes that, in combination, caused this behavior.

1. `prevUrl` was created to keep track of route results that point to other routes, but falls back to `req.url` (`prevUrl`'s initial value): [#4033](https://github.com/vercel/vercel/commit/40e4b6926756528364a4ed9d4c5a7f871f89c945#diff-142c93a61d03a1718eb765cd25e5f18d07a95358bb27ce5d5d4da314ee2fa286R1283-R1284)
2. `prevUrl` was reassigned when handling middleware: [#7973](https://github.com/vercel/vercel/commit/ee1211416f50ac04e2644b24e89403414179a3e9#diff-00ef6e7b63ed4cae298afc2a8c84f49247855a2506270f748e4d3e41da97ad99R1538)

Because `prevUrl` was reset back to `req.url` after the first `phase` (null) was run, the updated `prevUrl` value from middleware was lost. This only matters if the second `phase` ("filesystem") was going to be hit.

Further confusing matters, this was partially fixed by https://github.com/vercel/vercel/pull/8457 because it either returned a proxy pass (which doesn't have this problem) or assigned `req.url` to include the `rewritePath`, which meant that later when `prevUrl` would default to `req.url`, it still had come from `rewritePath`. So, this is fixed for the absolute URL case, but not the relative path case.

Given all that, I think the fix we need is to keep `prevUrl` at its current value when it's not being updated based on the `routeResult`.

---

So, I made that change here. I added a test that exercises this specific behavior.

