### PR TITLE
[dev] consolidate dev server address parsing

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1036,7 +1036,7 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    // log address without trailing slash to maintian backwards compatibility
+    // log address without trailing slash to maintain backwards compatibility
     const addressFormatted = this.addressUrl.toString().replace(/\/$/, '');
     this.output.ready(`Available at ${link(addressFormatted)}`);
   }

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1036,7 +1036,9 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    this.output.ready(`Available at ${link(this.addressUrl.toString())}`);
+    // log address without trailing slash to maintian backwards compatibility
+    const addressFormatted = this.addressUrl.toString().replace(/\/$/, '');
+    this.output.ready(`Available at ${link(addressFormatted)}`);
   }
 
   /**

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -135,9 +135,18 @@ export default class DevServer {
   public proxy: httpProxy;
   public envConfigs: EnvConfigs;
   public files: BuilderInputs;
-  public address: string;
-  public devCacheDir: string;
 
+  private address: URL | undefined;
+  public get addressUrl(): URL {
+    if (!this.address) {
+      throw new Error(
+        'Invalid access to `addressUrl` because `start` has not yet populated `this.address`.'
+      );
+    }
+    return this.address;
+  }
+
+  public devCacheDir: string;
   private currentDevCommand?: string;
   private caseSensitive: boolean;
   private apiDir: string | null;
@@ -175,7 +184,6 @@ export default class DevServer {
     this.systemEnvValues = options.systemEnvValues || [];
     this.projectEnvs = options.projectEnvs || [];
     this.files = {};
-    this.address = '';
     this.originalProjectSettings = options.projectSettings;
     this.projectSettings = options.projectSettings;
     this.caseSensitive = false;
@@ -714,7 +722,7 @@ export default class DevServer {
         this.projectEnvs || [],
         this.systemEnvValues || [],
         this.projectSettings?.autoExposeSystemEnvs,
-        new URL(this.address).host
+        this.addressUrl.host
       );
 
       allEnv = { ...cloudEnv };
@@ -849,7 +857,7 @@ export default class DevServer {
   injectSystemValuesInDotenv(env: Env): Env {
     for (const name of Object.keys(env)) {
       if (name === 'VERCEL_URL') {
-        env['VERCEL_URL'] = new URL(this.address).host;
+        env['VERCEL_URL'] = this.addressUrl.host;
       } else if (name === 'VERCEL_REGION') {
         env['VERCEL_REGION'] = 'dev1';
       }
@@ -922,9 +930,9 @@ export default class DevServer {
       }
     }
 
-    this.address = address
-      .replace('[::]', 'localhost')
-      .replace('127.0.0.1', 'localhost');
+    this.address = new URL(
+      address.replace('[::]', 'localhost').replace('127.0.0.1', 'localhost')
+    );
 
     const vercelConfig = await this.getVercelConfig();
     const devCommandPromise = this.runDevCommand();
@@ -1028,7 +1036,7 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    this.output.ready(`Available at ${link(this.address)}`);
+    this.output.ready(`Available at ${link(this.addressUrl.toString())}`);
   }
 
   /**
@@ -1576,7 +1584,7 @@ export default class DevServer {
               const rewriteUrlParsed = new URL(rewritePath);
 
               // `this.address` already has localhost normalized from ip4 and ip6 values
-              const devServerParsed = new URL(this.address);
+              const devServerParsed = this.addressUrl;
               if (devServerParsed.origin === rewriteUrlParsed.origin) {
                 // remove origin, leaving the path
                 req.url = rewritePath.slice(rewriteUrlParsed.origin.length);
@@ -2326,7 +2334,7 @@ export default class DevServer {
 
     this.output.debug(`Spawning dev command: ${command}`);
 
-    const devPort = new URL(this.address).port;
+    const devPort = this.addressUrl.port;
     const proxyPort = new RegExp(port.toString(), 'g');
     const p = spawnCommand(command, {
       stdio: ['inherit', 'pipe', 'pipe'],

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1036,8 +1036,11 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    // log address without trailing slash to maintain backwards compatibility
-    const addressFormatted = this.addressUrl.toString().replace(/\/$/, '');
+    let addressFormatted = this.addressUrl.toString();
+    if (this.addressUrl.pathname === '/') {
+      // log address without trailing slash to maintain backwards compatibility
+      addressFormatted = addressFormatted.replace(/\/$/, '');
+    }
     this.output.ready(`Available at ${link(addressFormatted)}`);
   }
 

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1037,7 +1037,10 @@ export default class DevServer {
     await devCommandPromise;
 
     let addressFormatted = this.addressURL.toString();
-    if (this.addressURL.pathname === '/') {
+    if (
+      this.addressURL.pathname === '/' &&
+      this.addressURL.protocol === 'http:'
+    ) {
       // log address without trailing slash to maintain backwards compatibility
       addressFormatted = addressFormatted.replace(/\/$/, '');
     }

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -136,14 +136,14 @@ export default class DevServer {
   public envConfigs: EnvConfigs;
   public files: BuilderInputs;
 
-  private address: URL | undefined;
-  public get addressURL(): URL {
-    if (!this.address) {
+  private _address: URL | undefined;
+  public get address(): URL {
+    if (!this._address) {
       throw new Error(
-        'Invalid access to `addressURL` because `start` has not yet populated `this.address`.'
+        'Invalid access to `address` because `start` has not yet populated `this.address`.'
       );
     }
-    return this.address;
+    return this._address;
   }
 
   public devCacheDir: string;
@@ -722,7 +722,7 @@ export default class DevServer {
         this.projectEnvs || [],
         this.systemEnvValues || [],
         this.projectSettings?.autoExposeSystemEnvs,
-        this.addressURL.host
+        this.address.host
       );
 
       allEnv = { ...cloudEnv };
@@ -857,7 +857,7 @@ export default class DevServer {
   injectSystemValuesInDotenv(env: Env): Env {
     for (const name of Object.keys(env)) {
       if (name === 'VERCEL_URL') {
-        env['VERCEL_URL'] = this.addressURL.host;
+        env['VERCEL_URL'] = this.address.host;
       } else if (name === 'VERCEL_REGION') {
         env['VERCEL_REGION'] = 'dev1';
       }
@@ -930,7 +930,7 @@ export default class DevServer {
       }
     }
 
-    this.address = new URL(
+    this._address = new URL(
       address.replace('[::]', 'localhost').replace('127.0.0.1', 'localhost')
     );
 
@@ -1036,11 +1036,8 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    let addressFormatted = this.addressURL.toString();
-    if (
-      this.addressURL.pathname === '/' &&
-      this.addressURL.protocol === 'http:'
-    ) {
+    let addressFormatted = this.address.toString();
+    if (this.address.pathname === '/' && this.address.protocol === 'http:') {
       // log address without trailing slash to maintain backwards compatibility
       addressFormatted = addressFormatted.replace(/\/$/, '');
     }
@@ -1592,7 +1589,7 @@ export default class DevServer {
               const rewriteUrlParsed = new URL(rewritePath);
 
               // `this.address` already has localhost normalized from ip4 and ip6 values
-              const devServerParsed = this.addressURL;
+              const devServerParsed = this.address;
               if (devServerParsed.origin === rewriteUrlParsed.origin) {
                 // remove origin, leaving the path
                 req.url = rewritePath.slice(rewriteUrlParsed.origin.length);
@@ -2335,7 +2332,7 @@ export default class DevServer {
 
     this.output.debug(`Spawning dev command: ${command}`);
 
-    const devPort = this.addressURL.port;
+    const devPort = this.address.port;
     const proxyPort = new RegExp(port.toString(), 'g');
     const p = spawnCommand(command, {
       stdio: ['inherit', 'pipe', 'pipe'],

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -137,10 +137,10 @@ export default class DevServer {
   public files: BuilderInputs;
 
   private address: URL | undefined;
-  public get addressUrl(): URL {
+  public get addressURL(): URL {
     if (!this.address) {
       throw new Error(
-        'Invalid access to `addressUrl` because `start` has not yet populated `this.address`.'
+        'Invalid access to `addressURL` because `start` has not yet populated `this.address`.'
       );
     }
     return this.address;
@@ -722,7 +722,7 @@ export default class DevServer {
         this.projectEnvs || [],
         this.systemEnvValues || [],
         this.projectSettings?.autoExposeSystemEnvs,
-        this.addressUrl.host
+        this.addressURL.host
       );
 
       allEnv = { ...cloudEnv };
@@ -857,7 +857,7 @@ export default class DevServer {
   injectSystemValuesInDotenv(env: Env): Env {
     for (const name of Object.keys(env)) {
       if (name === 'VERCEL_URL') {
-        env['VERCEL_URL'] = this.addressUrl.host;
+        env['VERCEL_URL'] = this.addressURL.host;
       } else if (name === 'VERCEL_REGION') {
         env['VERCEL_REGION'] = 'dev1';
       }
@@ -1036,8 +1036,8 @@ export default class DevServer {
 
     await devCommandPromise;
 
-    let addressFormatted = this.addressUrl.toString();
-    if (this.addressUrl.pathname === '/') {
+    let addressFormatted = this.addressURL.toString();
+    if (this.addressURL.pathname === '/') {
       // log address without trailing slash to maintain backwards compatibility
       addressFormatted = addressFormatted.replace(/\/$/, '');
     }
@@ -1589,7 +1589,7 @@ export default class DevServer {
               const rewriteUrlParsed = new URL(rewritePath);
 
               // `this.address` already has localhost normalized from ip4 and ip6 values
-              const devServerParsed = this.addressUrl;
+              const devServerParsed = this.addressURL;
               if (devServerParsed.origin === rewriteUrlParsed.origin) {
                 // remove origin, leaving the path
                 req.url = rewritePath.slice(rewriteUrlParsed.origin.length);
@@ -2332,7 +2332,7 @@ export default class DevServer {
 
     this.output.debug(`Spawning dev command: ${command}`);
 
-    const devPort = this.addressUrl.port;
+    const devPort = this.addressURL.port;
     const proxyPort = new RegExp(port.toString(), 'g');
     const p = spawnCommand(command, {
       stdio: ['inherit', 'pipe', 'pipe'],

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1589,8 +1589,7 @@ export default class DevServer {
               const rewriteUrlParsed = new URL(rewritePath);
 
               // `this.address` already has localhost normalized from ip4 and ip6 values
-              const devServerParsed = this.address;
-              if (devServerParsed.origin === rewriteUrlParsed.origin) {
+              if (this.address.origin === rewriteUrlParsed.origin) {
                 // remove origin, leaving the path
                 req.url = rewritePath.slice(rewriteUrlParsed.origin.length);
               } else {
@@ -2332,7 +2331,6 @@ export default class DevServer {
 
     this.output.debug(`Spawning dev command: ${command}`);
 
-    const devPort = this.address.port;
     const proxyPort = new RegExp(port.toString(), 'g');
     const p = spawnCommand(command, {
       stdio: ['inherit', 'pipe', 'pipe'],
@@ -2349,7 +2347,7 @@ export default class DevServer {
     p.stdout.setEncoding('utf8');
 
     p.stdout.on('data', (data: string) => {
-      process.stdout.write(data.replace(proxyPort, devPort));
+      process.stdout.write(data.replace(proxyPort, this.address.port));
     });
 
     p.on('exit', (code, signal) => {


### PR DESCRIPTION
Consolidates parsing and access to `this.address` so that we don't have to `new URL(this.address)` all over the place.

---

Follow-up from: https://github.com/vercel/vercel/pull/8457#issuecomment-1238653904