### PR TITLE
[frameworks] Detect Sanity v3 config

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1792,6 +1792,9 @@ export const frameworks = [
         {
           path: 'sanity.config.js',
         },
+        {
+          path: 'sanity.config.ts',
+        },
       ],
     },
     settings: {

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1785,9 +1785,12 @@ export const frameworks = [
     website: 'https://www.sanity.io',
     envPrefix: 'SANITY_STUDIO_',
     detectors: {
-      every: [
+      some: [
         {
           path: 'sanity.json',
+        },
+        {
+          path: 'sanity.config.js',
         },
       ],
     },


### PR DESCRIPTION
Sanity v3 is currently in [developer preview](https://www.sanity.io/blog/sanity-studio-v3-developer-preview), and has deprecated `sanity.json` in the project root, replacing it with `sanity.config.js`. This should detect either.

All commands remain the same in both v2 and v3.

(Note though there's currently a bug affecting both versions' `dev` command on macOS: #8512)

### Related Issues

_none_

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`
  - _Though I had to add `--gitRemote upstream` to `packages/edge` `build:docs` command, otherwise GH links are updated to my fork and docs tests fail_

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
