### PR TITLE
[cli] Switch to `npm` and add more context to install errors during Builder import

### DIFF
--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -212,20 +212,24 @@ async function installBuilders(
     ).join(', ')}`
   );
   try {
-    await spawnAsync('yarn', ['add', '@vercel/build-utils', ...buildersToAdd], {
-      cwd: buildersDir,
-      stdio: 'pipe',
-    });
+    await spawnAsync(
+      'npm',
+      ['install', '@vercel/build-utils', ...buildersToAdd],
+      {
+        cwd: buildersDir,
+        stdio: 'pipe',
+      }
+    );
   } catch (err: unknown) {
     if (isError(err)) {
+      (err as any).link =
+        'https://vercel.link/builder-dependencies-install-failed';
       if (isErrnoException(err) && err.code === 'ENOENT') {
-        // `yarn` is not installed
-        err.message = `Please install ${cmd('yarn')} before continuing`;
-        (err as any).link = 'https://classic.yarnpkg.com/lang/en/docs/install';
+        // `npm` is not installed
+        err.message = `Please install ${cmd('npm')} before continuing`;
       } else {
         const message = errorToString(err);
-        const notFound = /"(.*): Not found"/.exec(message);
-        (err as any).link = 'https://vercel.link/npm-install-failed-dev';
+        const notFound = /GET (.*) - Not found/.exec(message);
         if (notFound) {
           const url = new URL(notFound[1]);
           const packageName = decodeURIComponent(url.pathname.slice(1));

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -1,4 +1,5 @@
 import { URL } from 'url';
+import plural from 'pluralize';
 import npa from 'npm-package-arg';
 import { satisfies } from 'semver';
 import { dirname, join } from 'path';
@@ -205,7 +206,11 @@ async function installBuilders(
     if (err.code !== 'EEXIST') throw err;
   }
 
-  output.log(`Installing Builders: ${Array.from(buildersToAdd).join(', ')}`);
+  output.log(
+    `Installing ${plural('Builder', buildersToAdd.size)}: ${Array.from(
+      buildersToAdd
+    ).join(', ')}`
+  );
   try {
     await spawnAsync('yarn', ['add', '@vercel/build-utils', ...buildersToAdd], {
       cwd: buildersDir,

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -37,17 +37,25 @@ describe('importBuilders()', () => {
     const cwd = await getWriteableDirectory();
     try {
       const spec = 'vercel-deno@2.0.1';
-      const specs = new Set([spec]);
+      const tarballSpec = 'https://test2020-h5hdll5dz-tootallnate.vercel.app';
+      const specs = new Set([spec, tarballSpec]);
       const builders = await importBuilders(specs, cwd, client.output);
-      expect(builders.size).toEqual(1);
+      expect(builders.size).toEqual(2);
       expect(builders.get(spec)?.pkg.name).toEqual('vercel-deno');
       expect(builders.get(spec)?.pkg.version).toEqual('2.0.1');
       expect(builders.get(spec)?.pkgPath).toEqual(
         join(cwd, '.vercel/builders/node_modules/vercel-deno/package.json')
       );
-      expect(typeof builders.get(spec)?.builder.build).toEqual('function');
+      expect(builders.get(tarballSpec)?.pkg.name).toEqual('vercel-bash');
+      expect(builders.get(tarballSpec)?.pkg.version).toEqual('4.1.0');
+      expect(builders.get(tarballSpec)?.pkgPath).toEqual(
+        join(cwd, '.vercel/builders/node_modules/vercel-bash/package.json')
+      );
+      expect(typeof builders.get(tarballSpec)?.builder.build).toEqual(
+        'function'
+      );
       await expect(client.stderr).toOutput(
-        '> Installing Builder: vercel-deno@2.0.1'
+        '> Installing Builders: vercel-deno@2.0.1, https://test2020-h5hdll5dz-tootallnate.vercel.app'
       );
     } finally {
       await remove(cwd);
@@ -75,7 +83,7 @@ describe('importBuilders()', () => {
       'The package `@vercel/does-not-exist` is not published on the npm registry'
     );
     expect((err as any).link).toEqual(
-      'https://vercel.link/npm-install-failed-dev'
+      'https://vercel.link/builder-dependencies-install-failed'
     );
   });
 


### PR DESCRIPTION
Before:

<img width="1012" alt="Screen Shot 2022-09-09 at 7 03 01 PM" src="https://user-images.githubusercontent.com/71256/189464732-8cf6398a-9432-423b-8509-a52bd714333e.png">

After:

<img width="579" alt="Screen Shot 2022-09-12 at 12 27 31 PM" src="https://user-images.githubusercontent.com/71256/189739091-86399428-d9b8-4d03-b0e6-7d27a1037bce.png">

This is a precursor to https://github.com/vercel/vercel/pull/8485, since the last remaining test failure there is related to specialized messaging we had for these same cases.