### PR TITLE
[tests] Fix tarball lookup with sha contains 0

### DIFF
--- a/api/_lib/script/build.ts
+++ b/api/_lib/script/build.ts
@@ -57,7 +57,7 @@ async function main() {
     );
     const packageJson = JSON.parse(packageJsonRaw);
     const files = await fs.readdir(fullDir);
-    const tarballName = files.find(f => /^vercel-(.+)\.tgz$/.test(f));
+    const tarballName = files.find(f => /^vercel-.+\.tgz$/.test(f));
     if (!tarballName) {
       throw new Error(
         `Expected vercel-*.tgz in ${fullDir} but found ${JSON.stringify(


### PR DESCRIPTION
This PR fixes an issue when the sha begins with `0` and causes [an error](https://vercel.com/vercel/vercel/EP7fVcXKsoodzWRy3fwG8AoeQcs6) when looking up the tarball:

> Error: ENOENT: no such file or directory, 
> copyfile '/vercel/path0/packages/build-utils/vercel-build-utils-v5.4.2-0251253.tgz' 
>  -> '/vercel/path0/public/tarballs/@vercel/build-utils.tgz'

The fix is to no longer rely on the exact tarball name because we can't guarantee the name from `yarn pack` and instead rely on a pattern for the tarball name.