### PR TITLE
Add "rush" workspace

### DIFF
--- a/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
+++ b/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
@@ -33,6 +33,12 @@ export async function getWorkspacePackagePaths({
     case 'pnpm':
       results = await getPnpmWorkspacePackagePaths({ fs: workspaceFs });
       break;
+    case 'rush':
+      // /common/temp is the location that Rush defaults adding the pnpm workspace file
+      results = await getPnpmWorkspacePackagePaths({
+        fs: fs.chdir('/common/temp'),
+      });
+      break;
     default:
       throw new Error(`Unknown workspace implementation: ${type}`);
   }

--- a/packages/fs-detectors/src/workspaces/get-workspaces.ts
+++ b/packages/fs-detectors/src/workspaces/get-workspaces.ts
@@ -12,7 +12,7 @@ export interface GetWorkspaceOptions {
   cwd?: string;
 }
 
-export type WorkspaceType = 'yarn' | 'pnpm' | 'npm';
+export type WorkspaceType = 'yarn' | 'pnpm' | 'npm' | 'rush';
 
 export type Workspace = {
   type: WorkspaceType;

--- a/packages/fs-detectors/src/workspaces/workspace-managers.ts
+++ b/packages/fs-detectors/src/workspaces/workspace-managers.ts
@@ -60,6 +60,18 @@ export const workspaceManagers: Array<
     },
   },
   {
+    name: 'rush',
+    slug: 'rush',
+    detectors: {
+      every: [
+        {
+          path: 'rush.json',
+          matchContent: '"useWorkspaces":\\strue',
+        },
+      ],
+    },
+  },
+  {
     name: 'default',
     slug: 'yarn',
     detectors: {


### PR DESCRIPTION
### Related Issues

Rush does not intrinsically have its own version of workspaces. But it does allow for a user to set `useWorkspaces: true` within the `rush.json`
This will utilize pnpm workspaces BUT the catch is the yaml file for this is found within the defaulted `/common/temp` folder.

[As stated in the documentation](https://rushjs.io/pages/configs/rush_json/) for rush.json, the workspace feature is experimental

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
