### PR TITLE
[tests] Increase unit test timeout from 10s to 20s

### DIFF
--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -19,7 +19,7 @@ import {
   Meta,
 } from '../src';
 
-jest.setTimeout(10 * 1000);
+jest.setTimeout(20 * 1000);
 
 async function expectBuilderError(promise: Promise<any>, pattern: string) {
   let result;


### PR DESCRIPTION
A build utils unit test (https://github.com/vercel/vercel/actions/runs/3071089584/jobs/4983197110#step:9:775) is timing out on Windows machines. The current timeout is 10 seconds, but that is not sufficient and thus we should bump the timeout to 20 seconds.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
