### PR TITLE
[next] fix app dir SSG deployment paths

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1088,9 +1088,14 @@ export const build: BuildV2 = async ({
       'pages'
     );
 
+    let appDir: string | null = null;
     const appPathRoutesManifest = await readJSON(
       path.join(entryPath, outputDirectory, 'app-path-routes-manifest.json')
     ).catch(() => null);
+
+    if (appPathRoutesManifest) {
+      appDir = path.join(pagesDir, '../app');
+    }
 
     const { pages, appPaths: lambdaAppPaths } = await getServerlessPages({
       pagesDir,
@@ -2032,9 +2037,10 @@ export const build: BuildV2 = async ({
       console.timeEnd(allLambdasLabel);
     }
     const prerenderRoute = onPrerenderRoute({
+      appDir,
+      pagesDir,
       hasPages404,
       static404Page,
-      pagesDir,
       pageLambdaMap,
       lambdas,
       isServerMode,
@@ -2042,6 +2048,7 @@ export const build: BuildV2 = async ({
       entryDirectory,
       routesManifest,
       prerenderManifest,
+      appPathRoutesManifest,
       isSharedLambdas,
       canUsePreviewMode,
     });

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -881,6 +881,7 @@ export async function serverBuild({
   }
 
   const prerenderRoute = onPrerenderRoute({
+    appDir,
     pagesDir,
     pageLambdaMap: {},
     lambdas,
@@ -888,6 +889,7 @@ export async function serverBuild({
     entryDirectory,
     routesManifest,
     prerenderManifest,
+    appPathRoutesManifest,
     isServerMode: true,
     isSharedLambdas: false,
     canUsePreviewMode,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1660,10 +1660,12 @@ export const onPrerenderRouteInitial = (
 };
 
 type OnPrerenderRouteArgs = {
+  appDir: string | null;
   pagesDir: string;
   static404Page?: string;
   hasPages404: boolean;
   entryDirectory: string;
+  appPathRoutesManifest?: Record<string, string>;
   prerenderManifest: NextPrerenderedRoutes;
   isSharedLambdas: boolean;
   isServerMode: boolean;
@@ -1694,6 +1696,7 @@ export const onPrerenderRoute =
     }
   ) => {
     const {
+      appDir,
       pagesDir,
       hasPages404,
       static404Page,
@@ -1760,44 +1763,6 @@ export const onPrerenderRoute =
 
     const isNotFound = prerenderManifest.notFoundRoutes.includes(routeKey);
 
-    const htmlFsRef =
-      isBlocking || (isNotFound && !static404Page)
-        ? // Blocking pages do not have an HTML fallback
-          null
-        : new FileFsRef({
-            fsPath: path.join(
-              pagesDir,
-              isFallback
-                ? // Fallback pages have a special file.
-                  addLocaleOrDefault(
-                    prerenderManifest.fallbackRoutes[routeKey].fallback,
-                    routesManifest,
-                    locale
-                  )
-                : // Otherwise, the route itself should exist as a static HTML
-                  // file.
-                  `${
-                    isOmitted || isNotFound
-                      ? addLocaleOrDefault('/404', routesManifest, locale)
-                      : routeFileNoExt
-                  }.html`
-            ),
-          });
-    const jsonFsRef =
-      // JSON data does not exist for fallback or blocking pages
-      isFallback || isBlocking || (isNotFound && !static404Page)
-        ? null
-        : new FileFsRef({
-            fsPath: path.join(
-              pagesDir,
-              `${
-                isOmitted || isNotFound
-                  ? addLocaleOrDefault('/404.html', routesManifest, locale)
-                  : routeFileNoExt + '.json'
-              }`
-            ),
-          });
-
     let initialRevalidate: false | number;
     let srcRoute: string | null;
     let dataRoute: string;
@@ -1825,6 +1790,50 @@ export const onPrerenderRoute =
       const pr = prerenderManifest.staticRoutes[routeKey];
       ({ initialRevalidate, srcRoute, dataRoute } = pr);
     }
+
+    let isAppPathRoute = false;
+    // TODO: find another wat to determine if the current route is an app path route
+    if (srcRoute && dataRoute.endsWith('.rsc')) {
+      isAppPathRoute = true;
+    }
+
+    const htmlFsRef =
+      isBlocking || (isNotFound && !static404Page)
+        ? // Blocking pages do not have an HTML fallback
+          null
+        : new FileFsRef({
+            fsPath: path.join(
+              isAppPathRoute ? appDir! : pagesDir,
+              isFallback
+                ? // Fallback pages have a special file.
+                  addLocaleOrDefault(
+                    prerenderManifest.fallbackRoutes[routeKey].fallback,
+                    routesManifest,
+                    locale
+                  )
+                : // Otherwise, the route itself should exist as a static HTML
+                  // file.
+                  `${
+                    isOmitted || isNotFound
+                      ? addLocaleOrDefault('/404', routesManifest, locale)
+                      : routeFileNoExt
+                  }.html`
+            ),
+          });
+    const jsonFsRef =
+      // JSON data does not exist for fallback or blocking pages
+      isFallback || isBlocking || (isNotFound && !static404Page)
+        ? null
+        : new FileFsRef({
+            fsPath: path.join(
+              isAppPathRoute ? appDir! : pagesDir,
+              `${
+                isOmitted || isNotFound
+                  ? addLocaleOrDefault('/404.html', routesManifest, locale)
+                  : routeFileNoExt + '.json'
+              }`
+            ),
+          });
 
     const outputPathPage = normalizeIndexOutput(
       path.posix.join(entryDirectory, routeFileNoExt),

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1792,7 +1792,7 @@ export const onPrerenderRoute =
     }
 
     let isAppPathRoute = false;
-    // TODO: find another wat to determine if the current route is an app path route
+    // TODO: leverage manifest to determine app paths more accurately
     if (srcRoute && dataRoute.endsWith('.rsc')) {
       isAppPathRoute = true;
     }
@@ -1830,7 +1830,7 @@ export const onPrerenderRoute =
               `${
                 isOmitted || isNotFound
                   ? addLocaleOrDefault('/404.html', routesManifest, locale)
-                  : routeFileNoExt + '.json'
+                  : routeFileNoExt + (isAppPathRoute ? '.json' : '.rsc')
               }`
             ),
           });

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1792,8 +1792,8 @@ export const onPrerenderRoute =
     }
 
     let isAppPathRoute = false;
-    // TODO: find another wat to determine if the current route is an app path route
-    if (srcRoute && dataRoute.endsWith('.rsc')) {
+    // TODO: leverage manifest to determine app paths more accurately
+    if (appDir && srcRoute && dataRoute.endsWith('.rsc')) {
       isAppPathRoute = true;
     }
 
@@ -1803,7 +1803,7 @@ export const onPrerenderRoute =
           null
         : new FileFsRef({
             fsPath: path.join(
-              isAppPathRoute ? appDir! : pagesDir,
+              isAppPathRoute && appDir ? appDir : pagesDir,
               isFallback
                 ? // Fallback pages have a special file.
                   addLocaleOrDefault(
@@ -1826,10 +1826,12 @@ export const onPrerenderRoute =
         ? null
         : new FileFsRef({
             fsPath: path.join(
-              isAppPathRoute ? appDir! : pagesDir,
+              isAppPathRoute && appDir ? appDir : pagesDir,
               `${
                 isOmitted || isNotFound
                   ? addLocaleOrDefault('/404.html', routesManifest, locale)
+                  : isAppPathRoute
+                  ? dataRoute
                   : routeFileNoExt + '.json'
               }`
             ),

--- a/packages/next/test/fixtures/00-app-dir/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir/app/layout.js
@@ -8,7 +8,3 @@ export default function Root({ children }) {
     </html>
   );
 }
-
-export const config = {
-  revalidate: 0,
-};

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -24,6 +24,11 @@ it('should build with app-dir correctly', async () => {
   expect(buildResult.output['dashboard/another']).toBeDefined();
   expect(buildResult.output['dashboard/changelog']).toBeDefined();
   expect(buildResult.output['dashboard/deployments/[id]']).toBeDefined();
+
+  // prefixed static generation output with `/app` under dist server files
+  expect(buildResult.output['dashboard'].fsPath).toMatch(
+    /server\/app\/dashboard\.html$/
+  );
 });
 
 it('should build with app-dir in edg runtime correctly', async () => {

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -26,8 +26,13 @@ it('should build with app-dir correctly', async () => {
   expect(buildResult.output['dashboard/deployments/[id]']).toBeDefined();
 
   // prefixed static generation output with `/app` under dist server files
+  expect(buildResult.output['dashboard'].type).toBe('FileFsRef');
   expect(buildResult.output['dashboard'].fsPath).toMatch(
     /server\/app\/dashboard\.html$/
+  );
+  expect(buildResult.output['dashboard.rsc'].type).toBe('FileFsRef');
+  expect(buildResult.output['dashboard.rsc'].fsPath).toMatch(
+    /server\/app\/dashboard\.rsc$/
   );
 });
 
@@ -36,7 +41,6 @@ it('should build with app-dir in edg runtime correctly', async () => {
     path.join(__dirname, '../fixtures/00-app-dir-edge')
   );
 
-  console.log('buildResult', buildResult);
   const edgeFunctions = new Set();
 
   for (const key of Object.keys(buildResult.output)) {


### PR DESCRIPTION
### Related Issues

Seeing this while deploying appDir to production. The collecting path is not correct for generated dist from appDir
```
Collected static files (public/, static/, .next/static): 18.834ms
Error: ENOENT: no such file or directory, open '/vercel/path0/.next/server/pages/route-groups/checkout.html'
Error: An unexpected error occurred!
Error: ENOENT: no such file or directory, open '/vercel/path0/.next/server/pages/route-groups/checkout.html'
Error: Command "vercel build" exited with 1
```

Fix the deployment of SSG, the output html/json paths should be prefixed with `/app`

Adding a TODO now for how to determine the app path route, leveraging `.rsc` suffix in data route. Better to use app paths manifest to refactor it later.

### 📋 Checklist
<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
