### PR TITLE
[cli][dev] ensure `EdgeRuntime` is defined properly in edge functions

### DIFF
--- a/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
@@ -18,6 +18,8 @@ export default async function edge(request, event) {
       upperCase: upper('someThing'),
       optionalChaining: request?.doesnotexist ?? 'fallback',
       ENV_VAR_IN_EDGE: process.env.ENV_VAR_IN_EDGE,
+      EdgeRuntime: EdgeRuntime,
+      globalThisEdgeRuntime: globalThis.EdgeRuntime,
     })
   );
 }

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -48,6 +48,8 @@ test('[vercel dev] should support edge functions', async () => {
       upperCase: 'SOMETHING',
       optionalChaining: 'fallback',
       ENV_VAR_IN_EDGE: '1',
+      EdgeRuntime: 'vercel',
+      globalThisEdgeRuntime: 'vercel',
     });
   } finally {
     await dev.kill('SIGTERM');

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -177,6 +177,11 @@ async function compileUserCode(
       entryPoints: [entrypointPath],
       write: false, // operate in memory
       format: 'cjs',
+      legalComments: 'none',
+      define: {
+        // replaces `EdgeRuntime` with `"vercel"`, allowing for dead code elimination
+        EdgeRuntime: JSON.stringify('vercel'),
+      },
     });
 
     const compiledFile = result.outputFiles?.[0];
@@ -280,6 +285,9 @@ async function createEdgeRuntime(params?: {
           process: {
             env: process.env,
           },
+
+          // sets `globalThis.EdgeRuntime` to `vercel`, allowing for runtime detection
+          EdgeRuntime: 'vercel',
 
           // These are the global bindings for WebAssembly module
           ...wasmBindings,


### PR DESCRIPTION
The `EdgeRuntime` global is supposed to be available to edge functions so they can determine if they are currently in an edge function. The docs say to test for this to be a string (in edge environment) or undefined (not). That works in `vc dev` today, but the actual values are different.

This PR sets the correct value so that it matches production.

Before: `EdgeRuntime === "edge-runtime"`
After: `EdgeRuntime === "vercel"`
