### PR TITLE
[build-utils] support providing execution regions in Edge Functions

### DIFF
--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -38,6 +38,9 @@ export class EdgeFunction {
    */
   assets?: { name: string; path: string }[];
 
+  /** The regions where the edge function will be executed on */
+  regions?: 'auto' | string[] | 'all' | 'default';
+
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';
     this.name = params.name;
@@ -46,5 +49,6 @@ export class EdgeFunction {
     this.files = params.files;
     this.envVarsInUse = params.envVarsInUse;
     this.assets = params.assets;
+    this.regions = params.regions;
   }
 }


### PR DESCRIPTION
This PR enables declaring the preferred execution regions of an Edge Function and Middleware.

### Related Issues

- Resolves EC-235

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
