### PR TITLE
[tests] Add timeout for broken `actions/setup-node@v3`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
     - name: Setup Node
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       uses: actions/setup-node@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
       with:
         node-version: 14
         cache: 'yarn'

--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -31,6 +31,8 @@ jobs:
         with:
             fetch-depth: 2
       - uses: actions/setup-node@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
         with:
             node-version: ${{ matrix.node }}
             cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -65,6 +67,8 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'


### PR DESCRIPTION
This PR will make sure that CI fails fast if there is a network issue when restoring the cache.

This has been a known issue for 3 months and no resolution:

- https://github.com/actions/cache/issues/810