### PR TITLE
[cli] Fix invalid vercel.json config error serialization

### DIFF
--- a/packages/build-utils/src/errors.ts
+++ b/packages/build-utils/src/errors.ts
@@ -61,14 +61,14 @@ export function getPrettyError(obj: {
     }
 
     return new NowBuildError({
-      code: 'DEV_VALIDATE_CONFIG',
+      code: 'INVALID_LOCAL_CONFIG',
       message: message,
       link: prop ? `${docsUrl}#project/${prop.toLowerCase()}` : docsUrl,
       action: 'View Documentation',
     });
   } catch (e) {
     return new NowBuildError({
-      code: 'DEV_VALIDATE_CONFIG',
+      code: 'INVALID_LOCAL_CONFIG',
       message: `Failed to validate configuration.`,
       link: docsUrl,
       action: 'View Documentation',

--- a/packages/build-utils/src/errors.ts
+++ b/packages/build-utils/src/errors.ts
@@ -61,14 +61,14 @@ export function getPrettyError(obj: {
     }
 
     return new NowBuildError({
-      code: 'INVALID_LOCAL_CONFIG',
+      code: 'invalid_vercel_config',
       message: message,
       link: prop ? `${docsUrl}#project/${prop.toLowerCase()}` : docsUrl,
       action: 'View Documentation',
     });
   } catch (e) {
     return new NowBuildError({
-      code: 'INVALID_LOCAL_CONFIG',
+      code: 'invalid_vercel_config',
       message: `Failed to validate configuration.`,
       link: docsUrl,
       action: 'View Documentation',

--- a/packages/build-utils/src/errors.ts
+++ b/packages/build-utils/src/errors.ts
@@ -61,14 +61,14 @@ export function getPrettyError(obj: {
     }
 
     return new NowBuildError({
-      code: 'invalid_vercel_config',
+      code: 'INVALID_VERCEL_CONFIG',
       message: message,
       link: prop ? `${docsUrl}#project/${prop.toLowerCase()}` : docsUrl,
       action: 'View Documentation',
     });
   } catch (e) {
     return new NowBuildError({
-      code: 'invalid_vercel_config',
+      code: 'INVALID_VERCEL_CONFIG',
       message: `Failed to validate configuration.`,
       link: docsUrl,
       action: 'View Documentation',

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -291,8 +291,7 @@ async function doBuild(
   const validateError = validateConfig(localConfig);
 
   if (validateError) {
-    output.prettyError(validateError);
-    return 1;
+    throw validateError;
   }
 
   const projectSettings = {

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -965,7 +965,7 @@ describe('build', () => {
           'Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?',
         stack: expect.stringContaining('at validateConfig'),
         hideStackTrace: true,
-        code: 'INVALID_LOCAL_CONFIG',
+        code: 'invalid_vercel_config',
         link: 'https://vercel.com/docs/configuration#project/rewrites',
         action: 'View Documentation',
       });

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -965,7 +965,7 @@ describe('build', () => {
           'Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?',
         stack: expect.stringContaining('at validateConfig'),
         hideStackTrace: true,
-        code: 'invalid_vercel_config',
+        code: 'INVALID_VERCEL_CONFIG',
         link: 'https://vercel.com/docs/configuration#project/rewrites',
         action: 'View Documentation',
       });

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -947,6 +947,7 @@ describe('build', () => {
 
   it('should fail with invalid "rewrites" configuration from `vercel.json`', async () => {
     const cwd = fixture('invalid-rewrites');
+    const output = join(cwd, '.vercel/output');
     try {
       process.chdir(cwd);
       const exitCode = await build(client);
@@ -956,6 +957,20 @@ describe('build', () => {
           '\n' +
           'View Documentation: https://vercel.com/docs/configuration#project/rewrites'
       );
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.builds).toBeUndefined();
+      expect(builds.error).toEqual({
+        name: 'Error',
+        message:
+          'Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?',
+        stack: expect.stringContaining('at validateConfig'),
+        hideStackTrace: true,
+        code: 'INVALID_LOCAL_CONFIG',
+        link: 'https://vercel.com/docs/configuration#project/rewrites',
+        action: 'View Documentation',
+      });
+      const configJson = await fs.readJSON(join(output, 'config.json'));
+      expect(configJson.version).toBe(3);
     } finally {
       process.chdir(originalCwd);
       delete process.env.__VERCEL_BUILD_RUNNING;


### PR DESCRIPTION
Follow up to #8622 since we should be throwing errors so the error is correctly serialized to `builds.json`.