### PR TITLE
[cli] Refactor doBuild to return void

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -411,6 +411,12 @@ async function doBuild(
     })
   );
   buildsJson.builds = Array.from(buildsJsonBuilds.values());
+  const buildsJsonPath = join(outputDir, 'builds.json');
+  const writeBuildsJsonPromise = fs.writeJSON(buildsJsonPath, buildsJson, {
+    spaces: 2,
+  });
+
+  ops.push(writeBuildsJsonPromise);
 
   // The `meta` config property is re-used for each Builder
   // invocation so that Builders can share state between
@@ -427,7 +433,6 @@ async function doBuild(
   const overrides: PathOverride[] = [];
   const repoRootPath = cwd;
   const corepackShimDir = await initCorepack({ repoRootPath });
-  let builderError: Error | undefined;
 
   for (const build of sortedBuilders) {
     if (typeof build.src !== 'string') continue;
@@ -489,8 +494,8 @@ async function doBuild(
       const buildJsonBuild = buildsJsonBuilds.get(build);
       if (buildJsonBuild) {
         buildJsonBuild.error = toEnumerableError(err);
-        builderError = err;
       }
+      throw err;
     }
   }
 
@@ -505,11 +510,6 @@ async function doBuild(
     if (error) {
       throw error;
     }
-  }
-
-  // One or more builders threw an error
-  if (builderError) {
-    throw builderError;
   }
 
   // Merge existing `config.json` file into the one that will be produced

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -411,12 +411,9 @@ async function doBuild(
     })
   );
   buildsJson.builds = Array.from(buildsJsonBuilds.values());
-  const buildsJsonPath = join(outputDir, 'builds.json');
-  const writeBuildsJsonPromise = fs.writeJSON(buildsJsonPath, buildsJson, {
+  await fs.writeJSON(join(outputDir, 'builds.json'), buildsJson, {
     spaces: 2,
   });
-
-  ops.push(writeBuildsJsonPromise);
 
   // The `meta` config property is re-used for each Builder
   // invocation so that Builders can share state between

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -750,11 +750,22 @@ describe('build', () => {
       const errorBuilds = builds.builds.filter((b: any) => 'error' in b);
       expect(errorBuilds).toHaveLength(1);
 
-      expect(errorBuilds[0].error.name).toEqual('Error');
-      expect(errorBuilds[0].error.message).toMatch(`TS1005`);
-      expect(errorBuilds[0].error.message).toMatch(`',' expected.`);
-      expect(errorBuilds[0].error.hideStackTrace).toEqual(true);
-      expect(errorBuilds[0].error.code).toEqual('NODE_TYPESCRIPT_ERROR');
+      expect(errorBuilds[0].error).toEqual({
+        name: 'Error',
+        message: expect.stringContaining('TS1005'),
+        stack: expect.stringContaining('api/typescript.ts'),
+        hideStackTrace: true,
+        code: 'NODE_TYPESCRIPT_ERROR',
+      });
+
+      // top level "error" also contains the same error
+      expect(builds.error).toEqual({
+        name: 'Error',
+        message: expect.stringContaining('TS1005'),
+        stack: expect.stringContaining('api/typescript.ts'),
+        hideStackTrace: true,
+        code: 'NODE_TYPESCRIPT_ERROR',
+      });
 
       // `config.json` contains `version`
       const configJson = await fs.readJSON(join(output, 'config.json'));


### PR DESCRIPTION
This PR refactor `doBuild()` to return `void`.

This will prevent accidental bugs like #8623 where an exit code number was returned instead of throwing on error.