### PR TITLE
[next] Fix build time 404 route with trailingSlash: true

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1007,7 +1007,7 @@ export async function serverBuild({
           currentRouteSrc.length - 1
         )}${
           currentRouteSrc[currentRouteSrc.length - 2] === '(' ? '' : '|'
-        }${route})`;
+        }${route}/?)`;
 
         if (isLastRoute) {
           pushRoute(currentRouteSrc);

--- a/packages/next/test/fixtures/00-trailing-slash-add/pages/ssg/[slug].js
+++ b/packages/next/test/fixtures/00-trailing-slash-add/pages/ssg/[slug].js
@@ -1,0 +1,21 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>/ssg/[slug]</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticProps() {
+  return {
+    notFound: true,
+  };
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/ssg/first', '/ssg/second'],
+    fallback: 'blocking',
+  };
+}

--- a/packages/next/test/fixtures/00-trailing-slash-add/probes.json
+++ b/packages/next/test/fixtures/00-trailing-slash-add/probes.json
@@ -1,7 +1,20 @@
 {
-  "version": 2,
-  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
   "probes": [
+    {
+      "path": "/ssg/first/",
+      "status": 404,
+      "mustContain": "This page could not be found"
+    },
+    {
+      "path": "/ssg/second/",
+      "status": 404,
+      "mustContain": "This page could not be found"
+    },
+    {
+      "path": "/ssg/third/",
+      "status": 404,
+      "mustContain": "This page could not be found"
+    },
     { "path": "/foo/", "status": 200, "mustContain": "foo page" },
     {
       "fetchOptions": { "redirect": "manual" },


### PR DESCRIPTION
This ensures we properly handle trailing slashes in the `notFound: true` build time routes. 

Fixes: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1663691719703509)

