### PR TITLE
[tests] Fix timeout for `actions/setup-node`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,7 @@ jobs:
     - name: Setup Node
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       uses: actions/setup-node@v3
-      env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
+      timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
       with:
         node-version: 14
         cache: 'yarn'

--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -31,8 +31,7 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
+        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -31,8 +31,7 @@ jobs:
         with:
             fetch-depth: 2
       - uses: actions/setup-node@v3
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
+        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
             node-version: ${{ matrix.node }}
             cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
+        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -67,8 +66,7 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 5 # https://github.com/actions/cache/issues/810
+        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'


### PR DESCRIPTION
Try fixing the timeout again. For example: https://github.com/vercel/vercel/actions/runs/3130757219/jobs/5081381465

- Follow up to #8613 
- Related to https://github.com/actions/cache/issues/810 
- Related to https://github.com/Azure/azure-sdk-for-js/issues/22321 