### PR TITLE
[fs-detectors] Use json5 parser for Rush to have valid json parsing

### DIFF
--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -23,6 +23,7 @@
     "@vercel/routing-utils": "2.0.2",
     "glob": "8.0.3",
     "js-yaml": "4.1.0",
+    "json5": "^2.2.1",
     "minimatch": "3.0.4",
     "semver": "6.1.1"
   },

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -23,7 +23,7 @@
     "@vercel/routing-utils": "2.0.2",
     "glob": "8.0.3",
     "js-yaml": "4.1.0",
-    "json5": "^2.2.1",
+    "json5": "2.2.1",
     "minimatch": "3.0.4",
     "semver": "6.1.1"
   },

--- a/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
+++ b/packages/fs-detectors/src/workspaces/get-workspace-package-paths.ts
@@ -1,6 +1,7 @@
 import _path from 'path';
 import yaml from 'js-yaml';
 import glob from 'glob';
+import json5 from 'json5';
 import { DetectorFilesystem } from '../detectors/filesystem';
 import { Workspace } from './get-workspaces';
 import { getGlobFs } from './get-glob-fs';
@@ -144,7 +145,7 @@ async function getRushWorkspacePackagePaths({
 }: GetPackagePathOptions): Promise<string[]> {
   const rushWorkspaceAsBuffer = await fs.readFile('rush.json');
 
-  const { projects = [] } = JSON.parse(
+  const { projects = [] } = json5.parse(
     rushWorkspaceAsBuffer.toString()
   ) as RushWorkspaces;
 

--- a/packages/fs-detectors/test/fixtures/40-rush-monorepo/rush.json
+++ b/packages/fs-detectors/test/fixtures/40-rush-monorepo/rush.json
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
 
   "rushVersion": "5.76.1",
-
   "pnpmVersion": "6.7.1",
 
   "pnpmOptions": {
@@ -22,6 +21,7 @@
 
     "postRushBuild": []
   },
+  // comment
   "variants": [],
   "projects": [
     {

--- a/packages/fs-detectors/test/fixtures/42-rush-json-invalid/rush.json
+++ b/packages/fs-detectors/test/fixtures/42-rush-json-invalid/rush.json
@@ -12,7 +12,9 @@
   "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
 
   "gitPolicy": {},
-
+  /* 
+  this is a comment
+  */
   "repository": {},
   "eventHooks": {
     "preRushInstall": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8480,17 +8480,17 @@ json5@2.1.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@2.2.1, json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
 json5@^2.1.0, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
-
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonc-parser@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
### Related Issues

Parse `rush.json` files with `json5` because it is very common for these to have comments in them

[Template for people to clone for Rush](https://rushjs.io/pages/configs/rush_json/) which has comments in it as a default which most people will clone
 
Docs of Rush showing to not use `JSON.parse`
https://rushjs.io/pages/help/faq/#why-do-rushs-json-config-files-contain--comments-that-github-shows-in-red

Added in tests with block comments and single line comments

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
