### PR TITLE
[build-utils] Fix npm version detection for `--legacy-peer-deps`

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -461,7 +461,8 @@ export async function runNpmInstall(
     let commandArgs: string[];
     const isPotentiallyBrokenNpm =
       cliType === 'npm' &&
-      nodeVersion?.major === 16 &&
+      (nodeVersion?.major === 16 ||
+        opts.env.PATH?.includes('/node16/bin-npm7')) &&
       !args.includes('--legacy-peer-deps') &&
       spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK !== '1';
 

--- a/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/.gitignore
+++ b/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vercel

--- a/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/package-lock.json
+++ b/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "react": {
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.0.tgz",
+      "integrity": "sha512-g+nikW2D48kqgWSPwNo0NH9tIGG3DsQFlrtrQ1kj6W77z5ahyIHG0w8kPpz4Sdj6gyLnz0lEd/xsjOoGge2MYQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.0"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw=="
+    }
+  }
+}

--- a/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/package.json
+++ b/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir -p public && echo 'legacy peer deps' > public/index.txt"
+  },
+  "packageManager": "npm@6.14.17",
+  "dependencies": {
+    "swr": "1.3.0",
+    "react": "16.8.0"
+  }
+}

--- a/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/probes.json
+++ b/packages/build-utils/test/fixtures/14-npm-6-legacy-peer-deps/probes.json
@@ -1,0 +1,3 @@
+{
+  "probes": [{ "path": "/", "mustContain": "legacy peer deps" }]
+}

--- a/packages/build-utils/test/unit.run-npm-install.test.ts
+++ b/packages/build-utils/test/unit.run-npm-install.test.ts
@@ -34,7 +34,7 @@ it('should not include peer dependencies when missing VERCEL_NPM_LEGACY_PEER_DEP
   const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
   const meta: Meta = {};
   const spawnOpts = getTestSpawnOpts({});
-  const nodeVersion = { major: 16 } as any;
+  const nodeVersion = getNodeVersion(16);
   await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
   expect(spawnMock.mock.calls.length).toBe(1);
   const args = spawnMock.mock.calls[0];
@@ -71,11 +71,38 @@ it('should include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node1
   });
 });
 
-it('should not include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node14', async () => {
+it('should include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node14 and npm7+', async () => {
   const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
   const meta: Meta = {};
   const spawnOpts = getTestSpawnOpts({ VERCEL_NPM_LEGACY_PEER_DEPS: '1' });
+
   const nodeVersion = getNodeVersion(14);
+  console.log({ nodeVersion, path: spawnOpts.env.PATH });
+  await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
+  expect(spawnMock.mock.calls.length).toBe(1);
+  const args = spawnMock.mock.calls[0];
+  expect(args[0]).toEqual('npm');
+  expect(args[1]).toEqual([
+    'install',
+    '--no-audit',
+    '--unsafe-perm',
+    '--legacy-peer-deps',
+  ]);
+  expect(args[2]).toEqual({
+    cwd: fixture,
+    prettyCommand: 'npm install',
+    stdio: 'inherit',
+    env: expect.any(Object),
+  });
+});
+
+it('should not include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node14 and npm6', async () => {
+  const fixture = path.join(__dirname, 'fixtures', '14-npm-6-legacy-peer-deps');
+  const meta: Meta = {};
+  const spawnOpts = getTestSpawnOpts({ VERCEL_NPM_LEGACY_PEER_DEPS: '1' });
+
+  const nodeVersion = getNodeVersion(14);
+  console.log({ nodeVersion, path: spawnOpts.env.PATH });
   await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
   expect(spawnMock.mock.calls.length).toBe(1);
   const args = spawnMock.mock.calls[0];


### PR DESCRIPTION
There was a case where the npm version wasn't decided base on Node.js version but instead based on the lockfile.
This PR fixes the case when a newer npm version is detected base on the lockfile.

- Follow up to #8598
- Follow up to #8550