### PR TITLE
[cli] Fix `vc build` to error early when runtime is discontinued

### DIFF
--- a/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/.gitignore
@@ -1,0 +1,2 @@
+.vercel/builders
+.vercel/output

--- a/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/api/index.php
+++ b/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/api/index.php
@@ -1,0 +1,1 @@
+<?php echo 'This version of vercel-php uses the nodejs12.x Lambda Runtime'; ?>

--- a/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/discontinued-nodejs12.x/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/index.php": {
+      "runtime": "vercel-php@0.1.0"
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -776,7 +776,11 @@ describe('build', () => {
     }
   });
 
-  it('should fail when "functions" defined that emits discontinued "nodejs12.x" runtime', async () => {
+  it('should error when "functions" has runtime that emits discontinued "nodejs12.x"', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on Windows');
+      return;
+    }
     const cwd = fixture('discontinued-nodejs12.x');
     const output = join(cwd, '.vercel/output');
     try {


### PR DESCRIPTION
This moves an existing error from the build container to `vercel build`.

Its rare, but [Vercel Runtimes](https://vercel.com/docs/runtimes) might target a discontinued [AWS Lambda Runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) so we should fail fast when we know this has happened in `vercel build`.

A test has been added to demonstrate the failure using an old PHP version.