### PR TITLE
[build-utils] Allow file-ref sema to be controlled through env flag

### DIFF
--- a/packages/build-utils/src/file-fs-ref.ts
+++ b/packages/build-utils/src/file-fs-ref.ts
@@ -5,7 +5,9 @@ import path from 'path';
 import Sema from 'async-sema';
 import { FileBase } from './types';
 
-const semaToPreventEMFILE = new Sema(20);
+const semaToPreventEMFILE = new Sema(
+  parseInt(process.env.VERCEL_INTERNAL_FILE_FS_REF_SEMA, 10) || 20
+);
 
 interface FileFsRefOptions {
   mode?: number;

--- a/packages/build-utils/src/file-fs-ref.ts
+++ b/packages/build-utils/src/file-fs-ref.ts
@@ -5,8 +5,12 @@ import path from 'path';
 import Sema from 'async-sema';
 import { FileBase } from './types';
 
+const DEFAULT_SEMA = 20;
 const semaToPreventEMFILE = new Sema(
-  parseInt(process.env.VERCEL_INTERNAL_FILE_FS_REF_SEMA, 10) || 20
+  parseInt(
+    process.env.VERCEL_INTERNAL_FILE_FS_REF_SEMA || String(DEFAULT_SEMA),
+    10
+  ) || DEFAULT_SEMA
 );
 
 interface FileFsRefOptions {

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -17,8 +17,7 @@ const semaToDownloadFromS3 = new Sema(
   parseInt(
     process.env.VERCEL_INTERNAL_FILE_REF_SEMA || String(DEFAULT_SEMA),
     10
-  ),
-  DEFAULT_SEMA
+  ) || DEFAULT_SEMA
 );
 
 class BailableError extends Error {

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -12,7 +12,14 @@ interface FileRefOptions {
   mutable?: boolean;
 }
 
-const semaToDownloadFromS3 = new Sema(parseInt(process.env.VERCEL_INTERNAL_FILE_REF_SEMA,10), 5);
+const DEFAULT_SEMA = 5;
+const semaToDownloadFromS3 = new Sema(
+  parseInt(
+    process.env.VERCEL_INTERNAL_FILE_REF_SEMA || String(DEFAULT_SEMA),
+    10
+  ),
+  DEFAULT_SEMA
+);
 
 class BailableError extends Error {
   public bail: boolean;

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -12,7 +12,7 @@ interface FileRefOptions {
   mutable?: boolean;
 }
 
-const semaToDownloadFromS3 = new Sema(5);
+const semaToDownloadFromS3 = new Sema(parseInt(process.env.VERCEL_INTERNAL_FILE_REF_SEMA,10), 5);
 
 class BailableError extends Error {
   public bail: boolean;


### PR DESCRIPTION
My IDE tells me `process` is unknown but mentions something about package.json so that may just be a superficial issue. I guess CI/CD will tell me soon enough.

This adds an env flag to override the file ref sema's so we can experiment with setting a higher sema.

One potential problem I'm seeing is that this is a generic sema for all the things that use this class. Not sure if that's going to work out as intended but in that case we'll have to find a different way :)
