### PR TITLE
[next] Fix legacy pages/404 case

### DIFF
--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1899,8 +1899,7 @@ export const onPrerenderRoute =
       // we can output pure static outputs instead of prerenders
       if (
         !canUsePreviewMode ||
-        (routeKey === '/404' &&
-          (initialRevalidate === false || !lambdas[outputPathPage]))
+        (routeKey === '/404' && !lambdas[outputPathPage])
       ) {
         htmlFsRef.contentType = htmlContentType;
         prerenders[outputPathPage] = htmlFsRef;

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1897,7 +1897,11 @@ export const onPrerenderRoute =
 
       // if preview mode/On-Demand ISR can't be leveraged
       // we can output pure static outputs instead of prerenders
-      if (!canUsePreviewMode) {
+      if (
+        !canUsePreviewMode ||
+        (routeKey === '/404' &&
+          (initialRevalidate === false || !lambdas[outputPathPage]))
+      ) {
         htmlFsRef.contentType = htmlContentType;
         prerenders[outputPathPage] = htmlFsRef;
         prerenders[outputPathData] = jsonFsRef;

--- a/packages/next/test/fixtures/00-legacy-404/index.test.js
+++ b/packages/next/test/fixtures/00-legacy-404/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-legacy-404/package.json
+++ b/packages/next/test/fixtures/00-legacy-404/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "9.5.5",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  }
+}

--- a/packages/next/test/fixtures/00-legacy-404/pages/404.js
+++ b/packages/next/test/fixtures/00-legacy-404/pages/404.js
@@ -1,0 +1,11 @@
+export default function Page() {
+  return <p>custom 404</p>;
+}
+
+export function getStaticProps() {
+  return {
+    props: {
+      is404: true,
+    },
+  };
+}

--- a/packages/next/test/fixtures/00-legacy-404/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-legacy-404/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  return res.json({ hello: 'world' });
+}

--- a/packages/next/test/fixtures/00-legacy-404/pages/index.js
+++ b/packages/next/test/fixtures/00-legacy-404/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index page</p>;
+}

--- a/packages/next/test/fixtures/00-legacy-404/probes.json
+++ b/packages/next/test/fixtures/00-legacy-404/probes.json
@@ -1,0 +1,14 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/non-existent",
+      "status": 404,
+      "mustContain": "custom 404"
+    }
+  ]
+}


### PR DESCRIPTION
### Related Issues

This ensures we handle the case were a lambda isn't present for `pages/404.js` with `getStaticProps` which can occur in older Next.js versions e.g. `v9.5.5`. This also adds a regression test for this specific version to ensure it is working as expected. 

x-ref: https://github.com/vercel/vercel/pull/8663
Fixes: [slack thread](https://vercel.slack.com/archives/C03DQ3QFV7C/p1664945825621409)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
