### PR TITLE
[next] Update max route src check for generated route

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -997,7 +997,7 @@ export async function serverBuild({
       const isLastRoute = i === prerenderManifest.notFoundRoutes.length - 1;
 
       if (prerenderManifest.staticRoutes[route]?.initialRevalidate === false) {
-        if (currentRouteSrc.length + route.length + 1 >= 4096) {
+        if (currentRouteSrc.length + route.length + 1 >= 4000) {
           pushRoute(currentRouteSrc);
           currentRouteSrc = starterRouteSrc;
         }


### PR DESCRIPTION
### Related Issues

This reduces the max length we check for when generating routes to ensure we stay under the 4096 limit after normalizing. 

x-ref: https://github.com/vercel/customer-issues/issues/779

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
