### PR TITLE
[node] Allow VercelApiHandler to also return a Promise

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -20,7 +20,7 @@ export type VercelResponse = ServerResponse & {
 export type VercelApiHandler = (
   req: VercelRequest,
   res: VercelResponse
-) => void;
+) => void | Promise<void>;
 
 /** @deprecated Use VercelRequestCookies instead. */
 export type NowRequestCookies = VercelRequestCookies;

--- a/packages/node/test/fixtures/15-helpers/ts/async-handler.ts
+++ b/packages/node/test/fixtures/15-helpers/ts/async-handler.ts
@@ -1,0 +1,8 @@
+import { VercelApiHandler } from './types';
+
+const listener: VercelApiHandler = async (req, res) => {
+  res.status(200);
+  res.send('hello:RANDOMNESS_PLACEHOLDER');
+};
+
+export default listener;


### PR DESCRIPTION
### Related Issues

Otherwise you are not able to write a serverless function that returns a Promise when using the ESLint rule [@typescript-eslint/no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises/)

Following function

```typescript
const handler: VercelApiHandler = async () => {};
```

will report a `Promise-returning function provided to variable where a void return was expected`

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
