### PR TITLE
[node] update typescript detection message

### DIFF
--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -142,7 +142,7 @@ export function register(opts: Options = {}): Register {
   const ts: typeof _ts = require_(compiler);
   if (compiler.startsWith(nowNodeBase)) {
     console.log(
-      `Using TypeScript ${ts.version} (no local "typescript" package detected)`
+      `Using built-in TypeScript ${ts.version} since "typescript" missing from "devDependencies"`
     );
   } else {
     console.log(`Using TypeScript ${ts.version} (local user-provided)`);

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -141,9 +141,11 @@ export function register(opts: Options = {}): Register {
   //eslint-disable-next-line @typescript-eslint/no-var-requires
   const ts: typeof _ts = require_(compiler);
   if (compiler.startsWith(nowNodeBase)) {
-    console.log('Using TypeScript ' + ts.version + ' (no local tsconfig.json)');
+    console.log(
+      `Using TypeScript ${ts.version} (no local "typescript" package detected)`
+    );
   } else {
-    console.log('Using TypeScript ' + ts.version + ' (local user-provided)');
+    console.log(`Using TypeScript ${ts.version} (local user-provided)`);
   }
   const transformers = options.transformers || undefined;
   const readFile = options.readFile || ts.sys.readFile;


### PR DESCRIPTION
When deploying a project that uses typescript, but typescript is not a dependency, the default typescript is used. The message that's logged when this happens says:

> Using TypeScript 4.3.4 (no local tsconfig.json)

which is not necessarily true. You can have a `tsconfig.json` file with no typescript dependency.

This message leads to bad debugging paths.

This PR updates the message to be more specific. Now the message will say:

> Using TypeScript 4.3.4 (no local "typescript" package detected)
