### PR TITLE
[next] Fix index rsc route handling

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1403,6 +1403,17 @@ export async function serverBuild({
       ...(appDir
         ? [
             {
+              src: `^${path.posix.join('/', entryDirectory, '/')}`,
+              has: [
+                {
+                  type: 'header',
+                  key: '__rsc__',
+                },
+              ],
+              dest: path.posix.join('/', entryDirectory, '/index.rsc'),
+              check: true,
+            },
+            {
               src: `^${path.posix.join('/', entryDirectory, '/(.*)$')}`,
               has: [
                 {

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1144,7 +1144,8 @@ export async function serverBuild({
 
       if (lambdas[route]) {
         lambdas[`${route}.rsc`] = lambdas[route];
-      } else if (edgeFunctions[route]) {
+      }
+      if (edgeFunctions[route]) {
         edgeFunctions[`${route}.rsc`] = edgeFunctions[route];
       }
     }
@@ -1646,6 +1647,18 @@ export async function serverBuild({
         continue: true,
         important: true,
       },
+      ...(appDir
+        ? [
+            {
+              src: path.posix.join('/', entryDirectory, '/(.*).rsc$'),
+              headers: {
+                'content-type': 'application/octet-stream',
+              },
+              continue: true,
+              important: true,
+            },
+          ]
+        : []),
 
       // TODO: remove below workaround when `/` is allowed to be output
       // different than `/index`

--- a/packages/next/test/fixtures/00-app-dir-edge/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-edge/app/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <head>
+        <title>test app</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-edge/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-edge/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-edge/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge/vercel.json
@@ -10,6 +10,49 @@
       "path": "/edge",
       "status": 200,
       "mustContain": "edge"
+    },
+    {
+      "path": "/edge",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "mustContain": "M1:{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/edge",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "responseHeaders": {
+        "content-type": "application/octet-stream"
+      }
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "page"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "mustContain": "M1:{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "responseHeaders": {
+        "content-type": "application/octet-stream"
+      }
     }
   ]
 }

--- a/packages/next/test/fixtures/00-app-dir/app/client-component-route/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/client-component-route/page.js
@@ -1,4 +1,4 @@
-'client';
+'use client';
 
 import { useState, useEffect } from 'react';
 

--- a/packages/next/test/fixtures/00-app-dir/app/client-nested/layout.js
+++ b/packages/next/test/fixtures/00-app-dir/app/client-nested/layout.js
@@ -1,4 +1,4 @@
-'client';
+'use client';
 
 import { useState, useEffect } from 'react';
 

--- a/packages/next/test/fixtures/00-app-dir/app/dashboard/index/lazy.js
+++ b/packages/next/test/fixtures/00-app-dir/app/dashboard/index/lazy.js
@@ -1,4 +1,4 @@
-'client';
+'use client';
 
 export default function LazyComponent() {
   return (

--- a/packages/next/test/fixtures/00-app-dir/app/dashboard/index/test.js
+++ b/packages/next/test/fixtures/00-app-dir/app/dashboard/index/test.js
@@ -1,11 +1,11 @@
-'client';
+'use client';
 
 import { useState, lazy } from 'react';
 
 const Lazy = lazy(() => import('./lazy.js'));
 
 export function ClientComponent() {
-  let [state] = useState('client');
+  let [state] = useState('use client');
   return (
     <>
       <Lazy />

--- a/packages/next/test/fixtures/00-app-dir/app/should-not-serve-client/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/should-not-serve-client/page.js
@@ -1,4 +1,4 @@
-'client';
+'use client';
 
 export default function ShouldNotServeClientDotJs(props) {
   return (

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -21,6 +21,16 @@
       "mustNotContain": "<html"
     },
     {
+      "path": "/dashboard",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "responseHeaders": {
+        "content-type": "application/octet-stream"
+      }
+    },
+    {
       "path": "/dashboard/another",
       "status": 200,
       "mustContain": "hello from newroot/dashboard/another"

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -25,13 +25,11 @@
       "status": 200,
       "mustContain": "hello from newroot/dashboard/another"
     },
-    // TODO: uncomment after this is fixed upstream
-    // x-ref: https://vercel.slack.com/archives/C035J346QQL/p1663820032810519?thread_ts=1663775935.504379&cid=C035J346QQL
-    // {
-    //   "path": "/dashboard/deployments/123",
-    //   "status": 200,
-    //   "mustContain": "hello from app/dashboard/deployments/[id]. ID is: <!-- -->123"
-    // },
+    {
+      "path": "/dashboard/deployments/123",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/deployments/[id]. ID is: <!-- -->123"
+    },
     {
       "path": "/",
       "status": 200,
@@ -42,16 +40,24 @@
       "status": 200,
       "mustContain": "hello from pages/blog/[slug]"
     },
-    // TODO: uncomment after this is fixed upstream
-    // {
-    //   "path": "/dynamic/category-1/id-1",
-    //   "status": 200,
-    //   "mustContain": "{&quot;category&quot;:&quot;category-1&quot;,&quot;id&quot;:&quot;id-1&quot;}"
-    // },
+    {
+      "path": "/dynamic/category-1/id-1",
+      "status": 200,
+      "mustContain": "{&quot;category&quot;:&quot;category-1&quot;,&quot;id&quot;:&quot;id-1&quot;}"
+    },
     {
       "path": "/dashboard/changelog",
       "status": 200,
       "mustContain": "hello from app/dashboard/changelog"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "__rsc__": "1"
+      },
+      "mustContain": "M1:{",
+      "mustNotContain": "<html"
     }
   ]
 }


### PR DESCRIPTION
### Related Issues

This ensures we probably route the `/` rsc route properly and adds a regression test along with enabling some now patched tests that were skipped. 

Fixes: [slack thread](https://vercel.slack.com/archives/C043ANYDB24/p1665746921485109)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
