### PR TITLE
[node] allow to extract Edge Function regions from source code

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -22,6 +22,7 @@
     "@types/jest": "27.5.1",
     "@types/node": "*",
     "@vercel/build-utils": "5.5.5",
+    "@vercel/static-config": "2.0.3",
     "typescript": "4.6.4"
   }
 }

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -125,10 +125,7 @@ export const build: BuildV2 = async ({
         const project = new Project();
         const config = getConfig(project, edgeFunctionFiles['index.js'].fsPath);
         return config?.regions;
-      } catch (err) {
-        console.warn(
-          `Could not parse the entrypoint file to get the regions: ${err}`
-        );
+      } catch {
         return undefined;
       }
     })(),

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -15,6 +15,8 @@ import {
   scanParentDirs,
 } from '@vercel/build-utils';
 import type { BuildV2, PackageJson } from '@vercel/build-utils';
+import { getConfig } from '@vercel/static-config';
+import { Project } from 'ts-morph';
 
 export const build: BuildV2 = async ({
   entrypoint,
@@ -118,6 +120,18 @@ export const build: BuildV2 = async ({
     deploymentTarget: 'v8-worker',
     entrypoint: 'index.js',
     files: edgeFunctionFiles,
+    regions: (() => {
+      try {
+        const project = new Project();
+        const config = getConfig(project, edgeFunctionFiles['index.js'].fsPath);
+        return config?.regions;
+      } catch (err) {
+        console.warn(
+          `Could not parse the entrypoint file to get the regions: ${err}`
+        );
+        return undefined;
+      }
+    })(),
   });
 
   // The `index.html` file is a template, but we want to serve the

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -454,6 +454,8 @@ export const build: BuildV3 = async ({
       entrypoint: handler,
       files: preparedFiles,
 
+      ...(staticConfig?.regions && { regions: staticConfig?.regions }),
+
       // TODO: remove - these two properties should not be required
       name: outputPath,
       deploymentTarget: 'v8-worker',

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -454,7 +454,7 @@ export const build: BuildV3 = async ({
       entrypoint: handler,
       files: preparedFiles,
 
-      ...(staticConfig?.regions && { regions: staticConfig?.regions }),
+      regions: staticConfig?.regions
 
       // TODO: remove - these two properties should not be required
       name: outputPath,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -453,8 +453,7 @@ export const build: BuildV3 = async ({
     output = new EdgeFunction({
       entrypoint: handler,
       files: preparedFiles,
-
-      regions: staticConfig?.regions
+      regions: staticConfig?.regions,
 
       // TODO: remove - these two properties should not be required
       name: outputPath,

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -40,6 +40,7 @@
     "@vercel/frameworks": "1.1.8",
     "@vercel/ncc": "0.24.0",
     "@vercel/routing-utils": "2.0.2",
+    "@vercel/static-config": "2.0.3",
     "fs-extra": "10.0.0",
     "get-port": "5.0.0",
     "is-port-reachable": "2.0.1",

--- a/packages/static-build/src/utils/build-output-v2.ts
+++ b/packages/static-build/src/utils/build-output-v2.ts
@@ -10,6 +10,8 @@ import {
   BuildResultV2,
 } from '@vercel/build-utils';
 import { isObjectEmpty } from './_shared';
+import { Project } from 'ts-morph';
+import { getConfig } from '@vercel/static-config';
 
 const BUILD_OUTPUT_DIR = '.output';
 const BRIDGE_MIDDLEWARE_V2_TO_V3 = `
@@ -78,6 +80,15 @@ export async function readBuildOutputDirectory({
         '_middleware.js': middleware.file,
       },
       name: 'middleware',
+      regions: (() => {
+        try {
+          const project = new Project();
+          const config = getConfig(project, middleware.file.fsPath);
+          return config?.regions;
+        } catch (err) {
+          return undefined;
+        }
+      })(),
     });
   }
 

--- a/packages/static-config/src/index.ts
+++ b/packages/static-config/src/index.ts
@@ -17,8 +17,15 @@ export const BaseFunctionConfigSchema = {
     memory: { type: 'number' },
     maxDuration: { type: 'number' },
     regions: {
-      type: 'array',
-      items: { type: 'string' },
+      oneOf: [
+        {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        {
+          enum: ['all', 'default', 'auto'],
+        },
+      ],
     },
   },
 } as const;


### PR DESCRIPTION
This allows to export `config = { runtime: 'auto' | 'all' | 'default' | string[] }` for edge functions.

### Related Issues

- Resolves [EC-156](https://linear.app/vercel/issue/EC-156/make-nodejs-builder-extract-preferred-regions-from-source-code)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
