### PR TITLE
[tests] Update workflow to examine both labels and use annotations

### DIFF
--- a/.github/workflows/required-pr-label.yml
+++ b/.github/workflows/required-pr-label.yml
@@ -10,13 +10,17 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            let missing = false;
             const labels = context.payload.pull_request.labels.map(l => l.name);
             if (labels.filter(l => l.startsWith('area:')).length === 0) {
-              console.error('\u001b[31mMissing label: Please add at least one "area" label.');
-              process.exit(1);
+              console.error('::error::Missing label: Please add at least one "area" label.');
+              missing = true;
             }
             if (labels.filter(l => l.startsWith('semver:')).length !== 1) {
-              console.error('\u001b[31mMissing label: Please add exactly one "semver" label.');
+              console.error('::error::Missing label: Please add exactly one "semver" label.');
+              missing = true;
+            }
+            if (missing) {
               process.exit(1);
             }
-            console.log('\u001b[32mSuccess: This pull request has correct labels, thanks!');
+            console.log('::notice::Success: This pull request has correct labels, thanks!');


### PR DESCRIPTION
### Related Issues

I couldn't find an issue related to this, but just noticed it when I submitted a request. I got a build failing because I failed to add in an `area` label, so added that label and it failed again this time on `semver`. This change makes it so the workflow looks at both labels, rather than just one and exiting early. This might save some people doing 2 builds, like I did 😄 

Also changed it to use Actions annotations, which does colourization for you. Docs on that are here: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-debug-message

But the output is now something like this ([test repo](https://github.com/andymckay/test-config)). Missing both labels:

<img width="724" alt="Screen Shot 2022-10-17 at 4 01 35 PM" src="https://user-images.githubusercontent.com/74699/196299860-9f8ec5e7-fe40-4fe4-8e36-486bf00b2d13.png">

And in the log:

<img width="805" alt="Screen Shot 2022-10-17 at 4 01 41 PM" src="https://user-images.githubusercontent.com/74699/196299903-149a56e0-2538-419d-8e9f-8e459c7fb42a.png">

And if you've got the labels:

<img width="576" alt="Screen Shot 2022-10-17 at 4 02 59 PM" src="https://user-images.githubusercontent.com/74699/196299931-88f7f623-f08f-4189-83ec-cd75c466e6a5.png">

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
