### PR TITLE
[build-utils] Allow initialHeaders and initialStatus for Prerender

### DIFF
--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -8,6 +8,8 @@ interface PrerenderOptions {
   group?: number;
   bypassToken?: string | null /* optional to be non-breaking change */;
   allowQuery?: string[];
+  initialHeaders?: Record<string, string>;
+  initialStatus?: number;
 }
 
 export class Prerender {
@@ -18,6 +20,8 @@ export class Prerender {
   public group?: number;
   public bypassToken: string | null;
   public allowQuery?: string[];
+  public initialHeaders?: Record<string, string>;
+  public initialStatus?: number;
 
   constructor({
     expiration,
@@ -26,6 +30,8 @@ export class Prerender {
     group,
     bypassToken,
     allowQuery,
+    initialHeaders,
+    initialStatus,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -63,6 +69,31 @@ export class Prerender {
       );
     }
     this.fallback = fallback;
+
+    if (initialHeaders !== undefined) {
+      if (
+        !initialHeaders ||
+        typeof initialHeaders !== 'object' ||
+        !Object.keys(initialHeaders).every(
+          key =>
+            typeof key !== 'string' || typeof initialHeaders[key] !== 'string'
+        )
+      ) {
+        throw new Error(
+          `The \`initialHeaders\` argument for \`Prerender\` must be an object with string key/values`
+        );
+      }
+      this.initialHeaders = initialHeaders;
+    }
+
+    if (initialStatus !== undefined) {
+      if (initialStatus <= 0 || !Number.isInteger(initialStatus)) {
+        throw new Error(
+          `The \`initialStatus\` argument for \`Prerender\` musta a natural number.`
+        );
+      }
+      this.initialStatus = initialStatus;
+    }
 
     if (allowQuery !== undefined) {
       if (!Array.isArray(allowQuery)) {

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -74,9 +74,9 @@ export class Prerender {
       if (
         !initialHeaders ||
         typeof initialHeaders !== 'object' ||
-        !Object.keys(initialHeaders).every(
-          key =>
-            typeof key !== 'string' || typeof initialHeaders[key] !== 'string'
+        Object.entries(initialHeaders).some(
+          ([key, value]) =>
+            typeof key !== 'string' || value !== 'string'
         )
       ) {
         throw new Error(
@@ -89,7 +89,7 @@ export class Prerender {
     if (initialStatus !== undefined) {
       if (initialStatus <= 0 || !Number.isInteger(initialStatus)) {
         throw new Error(
-          `The \`initialStatus\` argument for \`Prerender\` musta a natural number.`
+          `The \`initialStatus\` argument for \`Prerender\` must be a natural number.`
         );
       }
       this.initialStatus = initialStatus;


### PR DESCRIPTION
### Related Issues

This allows `initialHeaders` and `initialStatus` for Prender as has been discussed quite a bit so that the proper headers can be applied when serving the fallback.

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1666130102396799?thread_ts=1666122861.189349&cid=C035J346QQL)
x-ref: follow-up to https://github.com/vercel/vercel/pull/8737
x-ref: https://github.com/vercel/vercel/blob/dd94dcab3255839c7c9addbba35026dc88cf0e95/packages/next/src/server-build.ts#L970

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
