### PR TITLE
[build-utils] allow EdgeFunction constructor to receive any string as a region

### DIFF
--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -39,7 +39,12 @@ export class EdgeFunction {
   assets?: { name: string; path: string }[];
 
   /** The regions where the edge function will be executed on */
-  regions?: 'auto' | string[] | 'all' | 'default';
+  regions?:
+    | 'auto'
+    | string[]
+    | 'all'
+    | 'default'
+    | (string & Record<never, unknown>);
 
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';

--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -39,12 +39,7 @@ export class EdgeFunction {
   assets?: { name: string; path: string }[];
 
   /** The regions where the edge function will be executed on */
-  regions?:
-    | 'auto'
-    | string[]
-    | 'all'
-    | 'default'
-    | (string & Record<never, unknown>);
+  regions?: string | string[];
 
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';


### PR DESCRIPTION
### Related Issues

This will allow a shorthand form of `export const config = { regions: 'iad1' }`

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
