### PR TITLE
[cli] Cope with socket hang up

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -610,6 +610,21 @@ const main = async () => {
       return 1;
     }
 
+    if (isErrnoException(err) && err.code === 'ECONNRESET') {
+      // Error message will look like the following:
+      // request to https://api.vercel.com/v2/user failed, reason: socket hang up
+      const matches = /request to https:\/\/(.*?)\//.exec(err.message || '');
+      if (matches && matches[1]) {
+        const hostname = matches[1];
+        output.error(
+          `Connection to ${highlight(
+            hostname
+          )} interrupted. Please verify your internet connectivity and DNS configuration.`
+        );
+      }
+      return 1;
+    }
+
     if (
       isErrnoException(err) &&
       (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -614,8 +614,8 @@ const main = async () => {
       // Error message will look like the following:
       // request to https://api.vercel.com/v2/user failed, reason: socket hang up
       const matches = /request to https:\/\/(.*?)\//.exec(err.message || '');
-      if (matches && matches[1]) {
-        const hostname = matches[1];
+      const hostname = matches?.[1];
+      if (hostname) {
         output.error(
           `Connection to ${highlight(
             hostname


### PR DESCRIPTION
### Related Issues

Copes with `socket hang up` errors.

I tested with https://github.com/Shopify/toxiproxy and set up a proxy that generated a socket hangup error. With a test URL etc it looks like this:

<img width="935" alt="Screen Shot 2022-10-21 at 2 13 48 PM" src="https://user-images.githubusercontent.com/74699/197289788-9467ebef-d4dd-4fae-bf41-f635b7857d03.png">

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
