### PR TITLE
[node] upgrade edge-runtime to v1.1.0

### DIFF
--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -12,7 +12,7 @@
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"
   },
   "devDependencies": {
-    "@edge-runtime/jest-environment": "1.1.0-beta.36",
+    "@edge-runtime/jest-environment": "1.1.0",
     "@types/jest": "27.4.1",
     "ts-node": "8.9.1",
     "tsup": "6.1.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,12 +29,12 @@
     }
   },
   "dependencies": {
-    "@edge-runtime/vm": "1.1.0-beta.37",
+    "@edge-runtime/vm": "1.1.0",
     "@types/node": "*",
     "@vercel/build-utils": "5.5.5",
     "@vercel/node-bridge": "3.0.0",
     "@vercel/static-config": "2.0.3",
-    "edge-runtime": "1.1.0-beta.40",
+    "edge-runtime": "1.1.0",
     "esbuild": "0.14.47",
     "exit-hook": "2.2.1",
     "node-fetch": "2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,34 +719,34 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@edge-runtime/format@1.1.0-beta.34":
-  version "1.1.0-beta.34"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/format/-/format-1.1.0-beta.34.tgz#5dc7549966d26edc64d39e776d0be967dce9592b"
-  integrity sha512-AdV7FlpBDDiwdPxmrCmq2ICMxzJr3Zoq/bUuIMC09jEmx8fpIAepAABVTEqr+X/6vhIiD2ermIog8qvAG4RZMg==
+"@edge-runtime/format@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/format/-/format-1.1.0.tgz#5a209221a8bae7791d6e465c480f146249d1e15f"
+  integrity sha512-MkLDDtPhXZIMx83NykdFmOpF7gVWIdd6GBHYb8V/E+PKWvD2pK/qWx9B30oN1iDJ2XBm0SGDjz02S8nDHI9lMQ==
 
-"@edge-runtime/jest-environment@1.1.0-beta.36":
-  version "1.1.0-beta.36"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/jest-environment/-/jest-environment-1.1.0-beta.36.tgz#299cf468833eb308782a92425754e8e082db8434"
-  integrity sha512-A4geGu+6i61CBlOGd5eqwNGiREatm7aWO3wJ4gUGcA2BH23v4SgVIJUdt0cpNQku69nMshb0AGk3XhHnqUC5rg==
+"@edge-runtime/jest-environment@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/jest-environment/-/jest-environment-1.1.0.tgz#556d62a07440a5b59e87572599205ad8099f109a"
+  integrity sha512-YwiR+zxAt3BksS1DrOuVdqnDw+18EZxm3vpGo8vuxqKXOg9UNdmj7c3nfkdTdhQ3gr3+sSpcS/4+vLoqW1QSKA==
   dependencies:
-    "@edge-runtime/vm" "1.1.0-beta.37"
+    "@edge-runtime/vm" "1.1.0"
     "@jest/environment" "28.1.3"
     "@jest/fake-timers" "28.1.3"
     "@jest/types" "28.1.3"
     jest-mock "28.1.3"
     jest-util "28.1.3"
 
-"@edge-runtime/primitives@1.1.0-beta.37":
-  version "1.1.0-beta.37"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-1.1.0-beta.37.tgz#7650f3a0652b10dad70ddb7d44cc30e2578d2d6b"
-  integrity sha512-S3aN8X6wXhM7CJI3FRF480CMNkw4mH6grMV/enQz8VWGrvD1U5njQNRh/Zymoe0RHzEI/aIDjSk3V49h+ULt9g==
+"@edge-runtime/primitives@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-1.1.0.tgz#75d9aa97e239825a7c9c00de808acdd2ab5b5908"
+  integrity sha512-MpL5fKlOs9mz5DMRuFchLe3Il84t7XpfbPq4qtaEK37uNMCRx1MzA3d7A4aTsR/guXSZvV/AtEbKVqBWjuSThA==
 
-"@edge-runtime/vm@1.1.0-beta.37":
-  version "1.1.0-beta.37"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-1.1.0-beta.37.tgz#60edbb46d6d7c500a3fd38361c1198a876899458"
-  integrity sha512-1OrFifIxDFpwb1VyrFD8kwWVppc6D1uN7xh5jQzW7jHaVJ0Dw4C2nSAbLe6YKPYj67o09vW72WLzfUcryeD0Pg==
+"@edge-runtime/vm@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-1.1.0.tgz#e2a58ab4c244fa3b157c7de80a5bcdd1259dc147"
+  integrity sha512-a3PSCdznoop5+ifkNDaSINB9V+Anwh+wpoaASIWhq9PLQuBF9D6Yxe/mLRZkuZRkOJ2ZmaTzMGDI5ROUChTL7g==
   dependencies:
-    "@edge-runtime/primitives" "1.1.0-beta.37"
+    "@edge-runtime/primitives" "1.1.0"
 
 "@eslint/eslintrc@^1.2.2":
   version "1.2.2"
@@ -5461,13 +5461,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-edge-runtime@1.1.0-beta.40:
-  version "1.1.0-beta.40"
-  resolved "https://registry.yarnpkg.com/edge-runtime/-/edge-runtime-1.1.0-beta.40.tgz#02623b41324be86b73972e76934561d1c2e71eff"
-  integrity sha512-KuoSRsQZUMyec6gtD9YOFA5ohmWtquTXKco+pLv1/1zcHmD0/rXU1QkTkE40BKwq+O02Esk9iPlx9LkHaQr3vg==
+edge-runtime@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/edge-runtime/-/edge-runtime-1.1.0.tgz#69cae85cfb6b333540be8f90aca4996477dccc4e"
+  integrity sha512-CvUOrwV3Qx0V56LttLEvQWyuRsjaEKJH+UOT5Z8xmy0vr3/PAJC2RGW317LCl3XZgbiym4gcf36kQAbrsjKXmw==
   dependencies:
-    "@edge-runtime/format" "1.1.0-beta.34"
-    "@edge-runtime/vm" "1.1.0-beta.37"
+    "@edge-runtime/format" "1.1.0"
+    "@edge-runtime/vm" "1.1.0"
     exit-hook "2.2.1"
     http-status "1.5.3"
     mri "1.2.0"


### PR DESCRIPTION
Hello,

We tagged Edge Runtime v.1.1.0 as the same as the latest beta, so nothing actually changed, just removed the beta suffix 🙂