### PR TITLE
[routing-utils] Allow to appendRoutes add null phase

### DIFF
--- a/packages/routing-utils/src/append.ts
+++ b/packages/routing-utils/src/append.ts
@@ -26,9 +26,17 @@ export function appendRoutesToPhase({
 
   if (isInPhase) {
     routes.push(...newRoutes);
+  } else if (phase === null) {
+    // If the phase is null, we want to insert the routes at the beginning
+    const lastPhase = routes.findIndex(r => isHandler(r) && r.handle);
+    if (lastPhase === -1) {
+      routes.push(...newRoutes);
+    } else {
+      routes.splice(lastPhase, 0, ...newRoutes);
+    }
   } else if (insertIndex > -1) {
     routes.splice(insertIndex, 0, ...newRoutes);
-  } else {
+  } else if (phase !== null) {
     routes.push({ handle: phase });
     routes.push(...newRoutes);
   }

--- a/packages/routing-utils/src/append.ts
+++ b/packages/routing-utils/src/append.ts
@@ -36,7 +36,7 @@ export function appendRoutesToPhase({
     }
   } else if (insertIndex > -1) {
     routes.splice(insertIndex, 0, ...newRoutes);
-  } else if (phase !== null) {
+  } else {
     routes.push({ handle: phase });
     routes.push(...newRoutes);
   }

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -122,6 +122,7 @@ export interface AppendRoutesToPhaseProps {
   newRoutes: Route[] | null;
   /**
    * The phase to append the routes such as `filesystem`.
+   * If the phase is `null`, the routes will be appended prior to the first handle being found.
    */
   phase: HandleValue | null;
 }

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -123,5 +123,5 @@ export interface AppendRoutesToPhaseProps {
   /**
    * The phase to append the routes such as `filesystem`.
    */
-  phase: HandleValue;
+  phase: HandleValue | null;
 }

--- a/packages/routing-utils/test/append.spec.ts
+++ b/packages/routing-utils/test/append.spec.ts
@@ -166,3 +166,38 @@ test('appendRoutesToPhase to null phase with no handle', () => {
 
   deepEqual(actual, expected);
 });
+
+test('appendRoutesToPhase to null phase with two new routes ', () => {
+  const routes: Route[] = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+    { handle: 'filesystem' },
+    { src: '/third', dest: '/three' },
+  ];
+  const newRoutes = [
+    { src: '/new1', dest: '/to1' },
+    { src: '/new2', dest: '/to2' },
+  ];
+  const phase = null;
+  const actual = appendRoutesToPhase({ routes, newRoutes, phase });
+  const expected = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+    { src: '/new1', dest: '/to1' },
+    { src: '/new2', dest: '/to2' },
+    { handle: 'filesystem' },
+    { src: '/third', dest: '/three' },
+  ];
+
+  deepEqual(actual, expected);
+});
+
+test('appendRoutesToPhase to null phase `routes=[]`', () => {
+  const routes: Route[] = [];
+  const newRoutes = [{ src: '/new', dest: '/to' }];
+  const phase = null;
+  const actual = appendRoutesToPhase({ routes, newRoutes, phase });
+  const expected = [{ src: '/new', dest: '/to' }];
+
+  deepEqual(actual, expected);
+});

--- a/packages/routing-utils/test/append.spec.ts
+++ b/packages/routing-utils/test/append.spec.ts
@@ -128,3 +128,41 @@ test('appendRoutesToPhase one routes before, two routes in phase, two routes in 
   ];
   deepEqual(actual, expected);
 });
+
+test('appendRoutesToPhase to null phase', () => {
+  const routes: Route[] = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+    { handle: 'filesystem' },
+    { src: '/third', dest: '/three' },
+  ];
+  const newRoutes = [{ src: '/new', dest: '/to' }];
+  const phase = null;
+  const actual = appendRoutesToPhase({ routes, newRoutes, phase });
+  const expected = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+    { src: '/new', dest: '/to' },
+    { handle: 'filesystem' },
+    { src: '/third', dest: '/three' },
+  ];
+
+  deepEqual(actual, expected);
+});
+
+test('appendRoutesToPhase to null phase with no handle', () => {
+  const routes: Route[] = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+  ];
+  const newRoutes = [{ src: '/new', dest: '/to' }];
+  const phase = null;
+  const actual = appendRoutesToPhase({ routes, newRoutes, phase });
+  const expected = [
+    { src: '/first', dest: '/one' },
+    { src: '/second', dest: '/two' },
+    { src: '/new', dest: '/to' },
+  ];
+
+  deepEqual(actual, expected);
+});


### PR DESCRIPTION
### Related Issues

For Analytics V2 we need to append routes to the `null` phase instead of `filesystem`.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
