### PR TITLE
[build-utils] Add invariant for invalid expiration on Prerender

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '14'
+  NODE_VERSION: '16'
   TURBO_REMOTE_ONLY: 'true'
   TURBO_TEAM: 'vercel'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -34,8 +34,17 @@ export class Prerender {
     initialStatus,
   }: PrerenderOptions) {
     this.type = 'Prerender';
-    this.expiration = expiration;
     this.lambda = lambda;
+
+    if (
+      expiration !== false &&
+      (expiration <= 0 || !Number.isInteger(expiration))
+    ) {
+      throw new Error(
+        `The \`expiration\` argument for \`Prerender\` needs to be a natural number or false. Received: "${expiration}"`
+      );
+    }
+    this.expiration = expiration;
 
     if (
       typeof group !== 'undefined' &&

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -465,6 +465,56 @@ it('should support initialHeaders and initialStatus correctly', async () => {
   });
 });
 
+it('should error for invalid expiration on Prerender', async () => {
+  const { Prerender } = require('@vercel/build-utils/dist/prerender.js');
+  expect(() => {
+    new Prerender({
+      expiration: 0,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      initialHeaders: {
+        'content-type': 'application/json',
+        'x-initial': 'true',
+      },
+      initialStatus: 308,
+    });
+  }).toThrow(
+    'The `expiration` argument for `Prerender` needs to be a natural number or false. Received: "0"'
+  );
+
+  expect(() => {
+    new Prerender({
+      expiration: -1,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      initialHeaders: {
+        'content-type': 'application/json',
+        'x-initial': 'true',
+      },
+      initialStatus: 308,
+    });
+  }).toThrow(
+    'The `expiration` argument for `Prerender` needs to be a natural number or false. Received: "-1"'
+  );
+  expect(() => {
+    new Prerender({
+      expiration: null,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      initialHeaders: {
+        'content-type': 'application/json',
+        'x-initial': 'true',
+      },
+      initialStatus: 308,
+    });
+  }).toThrow(
+    'The `expiration` argument for `Prerender` needs to be a natural number or false. Received: "null"'
+  );
+});
+
 it('should support require by path for legacy builders', () => {
   const index = require('@vercel/build-utils');
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,3 +1,4 @@
+// bump
 import {
   FileBlob,
   FileFsRef,


### PR DESCRIPTION
### Related Issues

This ensures we don't allow passing invalid `expiration` values to `Prerender` build outputs. 

x-ref: [slack thread](https://vercel.slack.com/archives/C048Q9QSNDA)

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
