### PR TITLE
[fs-detectors] Remove output directory placeholder

### DIFF
--- a/packages/fs-detectors/src/monorepos/monorepo-managers.ts
+++ b/packages/fs-detectors/src/monorepos/monorepo-managers.ts
@@ -66,7 +66,7 @@ export const monorepoManagers: Array<
         value: null,
       },
       outputDirectory: {
-        placeholder: 'Nx default',
+        value: null,
       },
       installCommand: {
         value: null,
@@ -93,7 +93,7 @@ export const monorepoManagers: Array<
         value: null,
       },
       outputDirectory: {
-        placeholder: 'Rush default',
+        value: null,
       },
       installCommand: {
         placeholder: 'Rush default',


### PR DESCRIPTION
### Related Issues

Related - https://github.com/vercel/api/pull/15027
Removing setting the output directory placeholder - it is not extremely reliable https://vercel.slack.com/archives/C02HEJASXGD/p1667234137439189?thread_ts=1667232443.320769&cid=C02HEJASXGD

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
