### PR TITLE
[cli] Fix middleware 500 in `vc dev`

### DIFF
--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1448,7 +1448,9 @@ export default class DevServer {
             }
           );
 
-          if (middlewareRes.status === 500) {
+          const middlewareBody = await middlewareRes.buffer();
+
+          if (middlewareRes.status === 500 && middlewareBody.byteLength === 0) {
             await this.sendError(
               req,
               res,
@@ -1493,7 +1495,6 @@ export default class DevServer {
           }
 
           if (!shouldContinue) {
-            const middlewareBody = await middlewareRes.buffer();
             this.setResponseHeaders(res, requestId);
             if (middlewareBody.length > 0) {
               res.setHeader('content-length', middlewareBody.length);

--- a/packages/cli/test/dev/fixtures/middleware-500-response/middleware.js
+++ b/packages/cli/test/dev/fixtures/middleware-500-response/middleware.js
@@ -1,1 +1,1 @@
-export default () => new Response(null, { status: 500 });
+export default () => new Response('Example Error', { status: 500 });

--- a/packages/cli/test/dev/integration-4.test.ts
+++ b/packages/cli/test/dev/integration-4.test.ts
@@ -551,7 +551,7 @@ test(
 test(
   '[vercel dev] Middleware with an explicit 500 response',
   testFixtureStdio('middleware-500-response', async (testPath: any) => {
-    await testPath(500, '/', /EDGE_FUNCTION_INVOCATION_FAILED/);
+    await testPath(500, '/', 'Example Error');
   })
 );
 


### PR DESCRIPTION
The status code no longer prints the generic error page.