### PR TITLE
[error-utils] Allow publishing to npm

### DIFF
--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@vercel/error-utils",
   "version": "1.0.1",
-  "private": true,
   "description": "A collection of error utilities for vercel/vercel",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
> If you set "private": true in your package.json, then npm will refuse to publish it.


https://docs.npmjs.com/cli/v8/configuring-npm/package-json#private