### PR TITLE
[cli] Allow `vc link` to overwrite existing link

### DIFF
--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -1,4 +1,4 @@
-import Client from '../client';
+import type Client from '../client';
 
 export default async function confirm(
   client: Client,

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -34,7 +34,7 @@ export async function ensureLink(
 ): Promise<LinkResult | number> {
   let link = await getLinkedProject(client, cwd);
 
-  if (link.status === 'not_linked') {
+  if (opts.forceDelete || link.status === 'not_linked') {
     link = await setupAndLink(client, cwd, opts);
 
     if (link.status === 'not_linked') {

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -34,7 +34,10 @@ export async function ensureLink(
 ): Promise<LinkResult | number> {
   let link = await getLinkedProject(client, cwd);
 
-  if (opts.forceDelete || link.status === 'not_linked') {
+  if (
+    (link.status === 'linked' && opts.forceDelete) ||
+    link.status === 'not_linked'
+  ) {
     link = await setupAndLink(client, cwd, opts);
 
     if (link.status === 'not_linked') {

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -23,7 +23,7 @@ class MockStream extends PassThrough {
     this.isTTY = true;
   }
 
-  // These is for the `ora` module
+  // These are for the `ora` module
   clearLine() {}
   cursorTo() {}
 }

--- a/packages/cli/test/unit/commands/link.test.ts
+++ b/packages/cli/test/unit/commands/link.test.ts
@@ -12,6 +12,8 @@ import {
 import { tmpdir } from 'os';
 
 describe('link', () => {
+  const origCwd = process.cwd();
+
   it('should prompt for link', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
     try {
@@ -48,6 +50,7 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(project.id);
     } finally {
+      process.chdir(origCwd);
       await remove(cwd);
     }
   });
@@ -78,6 +81,7 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(project.id);
     } finally {
+      process.chdir(origCwd);
       await remove(cwd);
     }
   });
@@ -114,6 +118,7 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(proj2.id);
     } finally {
+      process.chdir(origCwd);
       await remove(cwd);
     }
   });

--- a/packages/cli/test/unit/commands/link.test.ts
+++ b/packages/cli/test/unit/commands/link.test.ts
@@ -1,0 +1,120 @@
+import { basename, join } from 'path';
+import { mkdtemp, readJSON, remove } from 'fs-extra';
+import link from '../../../src/commands/link';
+import { client } from '../../mocks/client';
+import { useUser } from '../../mocks/user';
+import { useTeams } from '../../mocks/team';
+import {
+  defaultProject,
+  useProject,
+  useUnknownProject,
+} from '../../mocks/project';
+import { tmpdir } from 'os';
+
+describe('link', () => {
+  it('should prompt for link', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    try {
+      process.chdir(cwd);
+      const user = useUser();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(user.id);
+      expect(projectJson.projectId).toEqual(project.id);
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should allow specifying `--project` flag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    try {
+      process.chdir(cwd);
+      const user = useUser();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.setArgv('--project', project.name!, '--yes');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(user.id);
+      expect(projectJson.projectId).toEqual(project.id);
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should allow overwriting existing link', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    try {
+      process.chdir(cwd);
+      const user = useUser();
+      useTeams('team_dummy');
+      const { project: proj1 } = useProject({
+        ...defaultProject,
+        id: 'one',
+        name: 'one',
+      });
+      const { project: proj2 } = useProject({
+        ...defaultProject,
+        id: 'two',
+        name: 'two',
+      });
+      useUnknownProject();
+
+      client.setArgv('--project', proj1.name!, '--yes');
+      await expect(link(client)).resolves.toEqual(0);
+
+      let projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(user.id);
+      expect(projectJson.projectId).toEqual(proj1.id);
+
+      client.setArgv('--project', proj2.name!, '--yes');
+      await expect(link(client)).resolves.toEqual(0);
+
+      projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+      expect(projectJson.orgId).toEqual(user.id);
+      expect(projectJson.projectId).toEqual(proj2.id);
+    } finally {
+      await remove(cwd);
+    }
+  });
+});


### PR DESCRIPTION
There was a regression in #8670 which caused `vc link` to be a no-op when there was already a link to a Vercel project in the `.vercel` directory.