### PR TITLE
[edge] fix broken link on npmjs.org

### DIFF
--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -1,4 +1,4 @@
 # `@vercel/edge`
 
 A set of utilities to help you deploy any framework on the Edge using Vercel.
-Please [follow the documentation](https://github.com/vercel/vercel/blob/main/packages/edge/docs) for examples and usage.
+Please [follow the documentation](https://vercel.com/docs/concepts/functions/edge-functions/edge-functions-api#the-@vercel/edge-package) for examples and usage.

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -1,4 +1,4 @@
 # `@vercel/edge`
 
 A set of utilities to help you deploy any framework on the Edge using Vercel.
-Please [follow the documentation](./docs) for examples and usage.
+Please [follow the documentation](https://github.com/vercel/vercel/blob/main/packages/edge/docs) for examples and usage.


### PR DESCRIPTION
Before this change clicking on "follow the documentation" from https://www.npmjs.com/package/@vercel/edge would lead to a 404 as the docs link is relative.

### Related Issues

To reproduce
1. Open https://www.npmjs.com/package/@vercel/edge
2. Click on "follow the documentation"
3. You will see a 404 page

### Note

Merging this change will not actually fix npm yet, as npm only updates the README with new releases. But at least this will be fixed in the next one then.
