### PR TITLE
[examples] Remove `ENABLE_VC_BUILD` env var from Solidstart template

### DIFF
--- a/examples/solidstart/vercel.json
+++ b/examples/solidstart/vercel.json
@@ -1,7 +1,0 @@
-{
-  "build": {
-    "env": {
-      "ENABLE_VC_BUILD": "1"
-    }
-  }
-}


### PR DESCRIPTION
Env var is no longer required.