### PR TITLE
[fs-detectors] [cli] Add automatic Rush support

### DIFF
--- a/packages/cli/src/util/build/monorepo.ts
+++ b/packages/cli/src/util/build/monorepo.ts
@@ -124,9 +124,7 @@ export async function setMonorepoDefaultSettings(
       'installCommand',
       `cd ${relativeToRoot} && ${packageManager} install`
     );
-  }
-  // TODO (@Ethan-Arrowood) - Revisit rush support when we can test it better
-  /* else if (monorepoManager === 'rush') {
+  } else if (monorepoManager === 'rush') {
     setCommand(
       'buildCommand',
       `node ${relativeToRoot}/common/scripts/install-run-rush.js build --to ${projectName}`
@@ -135,5 +133,5 @@ export async function setMonorepoDefaultSettings(
       'installCommand',
       `node ${relativeToRoot}/common/scripts/install-run-rush.js install`
     );
-  } */
+  }
 }

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -8,7 +8,7 @@ import { defaultProject, useProject } from '../../mocks/project';
 import { useTeams } from '../../mocks/team';
 import { useUser } from '../../mocks/user';
 import { setupFixture } from '../../helpers/setup-fixture';
-// import execa from 'execa';
+import execa from 'execa';
 
 jest.setTimeout(ms('1 minute'));
 
@@ -1153,11 +1153,6 @@ describe('build', () => {
     });
   });
 
-  /**
-   * TODO (@Ethan-Arrowood) - After shipping support for turbo and nx, revisit rush support
-   * Previously, rush tests were too flaky and consistently would timeout beyone the excessive
-   * timeout window granted for these tests. Maybe we are doing something wrong.
-   */
   describe('monorepo-detection', () => {
     const setupMonorepoDetectionFixture = (fixture: string) => {
       const cwd = setupFixture(`commands/build/monorepo-detection/${fixture}`);
@@ -1172,7 +1167,7 @@ describe('build', () => {
       'nx-package-config',
       'nx-project-and-package-config-1',
       'nx-project-and-package-config-2',
-      // 'rush',
+      'rush',
     ])('fixture: %s', fixture => {
       const monorepoManagerMap: Record<
         string,
@@ -1188,13 +1183,13 @@ describe('build', () => {
           buildCommand: 'cd ../.. && npx nx build app-1',
           installCommand: 'cd ../.. && yarn install',
         },
-        // rush: {
-        //   name: 'Rush',
-        //   buildCommand:
-        //     'node ../../common/scripts/install-run-rush.js build --to app-1',
-        //   installCommand:
-        //     'node ../../common/scripts/install-run-rush.js install',
-        // },
+        rush: {
+          name: 'Rush',
+          buildCommand:
+            'node ../../common/scripts/install-run-rush.js build --to app-1',
+          installCommand:
+            'node ../../common/scripts/install-run-rush.js install',
+        },
       };
 
       const { name, buildCommand, installCommand } =
@@ -1205,12 +1200,12 @@ describe('build', () => {
           try {
             const cwd = setupMonorepoDetectionFixture(fixture);
 
-            // if (fixture === 'rush') {
-            //   await execa('npx', ['@microsoft/rush', 'update'], {
-            //     cwd,
-            //     reject: false,
-            //   });
-            // }
+            if (fixture === 'rush') {
+              await execa('npx', ['@microsoft/rush', 'update'], {
+                cwd,
+                reject: false,
+              });
+            }
 
             const exitCode = await build(client);
             expect(exitCode).toBe(0);
@@ -1236,12 +1231,12 @@ describe('build', () => {
           try {
             const cwd = setupMonorepoDetectionFixture(fixture);
 
-            // if (fixture === 'rush') {
-            //   await execa('npx', ['@microsoft/rush', 'update'], {
-            //     cwd,
-            //     reject: false,
-            //   });
-            // }
+            if (fixture === 'rush') {
+              await execa('npx', ['@microsoft/rush', 'update'], {
+                cwd,
+                reject: false,
+              });
+            }
 
             const projectJSONPath = join(cwd, '.vercel/project.json');
             const projectJSON = JSON.parse(
@@ -1282,12 +1277,12 @@ describe('build', () => {
           try {
             const cwd = setupMonorepoDetectionFixture(fixture);
 
-            // if (fixture === 'rush') {
-            //   await execa('npx', ['@microsoft/rush', 'update'], {
-            //     cwd,
-            //     reject: false,
-            //   });
-            // }
+            if (fixture === 'rush') {
+              await execa('npx', ['@microsoft/rush', 'update'], {
+                cwd,
+                reject: false,
+              });
+            }
 
             await fs.writeFile(
               join(cwd, 'packages/app-1/vercel.json'),

--- a/packages/fs-detectors/src/monorepos/monorepo-managers.ts
+++ b/packages/fs-detectors/src/monorepos/monorepo-managers.ts
@@ -76,8 +76,7 @@ export const monorepoManagers: Array<
       },
     },
   },
-  // TODO (@Ethan-Arrowood) - Revisit rush support when we can test it better
-  /* {
+  {
     name: 'Rush',
     slug: 'rush',
     logo: 'https://api-frameworks.vercel.sh/monorepo-logos/rush.svg',
@@ -103,7 +102,7 @@ export const monorepoManagers: Array<
         value: null,
       },
     },
-  }, */
+  },
 ];
 
 export default monorepoManagers;

--- a/packages/fs-detectors/test/unit.detect-monorepo-managers.test.ts
+++ b/packages/fs-detectors/test/unit.detect-monorepo-managers.test.ts
@@ -9,8 +9,7 @@ describe('monorepo-managers', () => {
     ['31-turborepo-in-package-json', 'turbo'],
     ['22-pnpm', null],
     ['39-nx-monorepo', 'nx'],
-    // TODO (@Ethan-Arrowood) - Revisit rush support when we can test it better
-    // ['40-rush-monorepo', 'rush'],
+    ['40-rush-monorepo', 'rush'],
   ])('with detectFramework', (fixturePath, frameworkSlug) => {
     const testName = frameworkSlug
       ? `should detect a ${frameworkSlug} workspace for ${fixturePath}`


### PR DESCRIPTION
### Related Issues

Removes comments introduced in https://github.com/vercel/vercel/pull/8742 since Rush tests were flaky. 

In order for this to land we need to figure out why rush takes so long to test and if we can improve that.

The principle is that the other monorepo tests (turbo and nx) actually verify that the resulting builds include the local package dependencies only possible when the monorepo build script is executed vs. the singular package build script. I was trying to do the same for Rush, but Rush requires running `rush update` which does a ton of stuff and even with a 5 minute timeout, the tests were flaky and would sometimes fail. It seemed to reliably pass on Ubuntu, but Mac and Windows would often timeout for some reason we couldn't determine from the CI logs alone. Furthermore, the tests pass fine and are not flaky on my local Mac machine so I suspect it is something to do with the CI environment.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
