### PR TITLE
[build-utils] Fix `runNpmInstall()` error when install fails

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -492,7 +492,7 @@ export async function runNpmInstall(
 
     try {
       await spawnAsync(cliType, commandArgs, opts);
-    } catch (_) {
+    } catch (err: unknown) {
       const potentialErrorPath = path.join(
         process.env.HOME || '/',
         '.npm',
@@ -508,6 +508,8 @@ export async function runNpmInstall(
         );
         commandArgs.push('--legacy-peer-deps');
         await spawnAsync(cliType, commandArgs, opts);
+      } else {
+        throw err;
       }
     }
     debug(`Install complete [${Date.now() - installTime}ms]`);

--- a/packages/build-utils/test/unit.run-npm-install.test.ts
+++ b/packages/build-utils/test/unit.run-npm-install.test.ts
@@ -1,3 +1,5 @@
+let spawnExitCode = 0;
+
 const spawnMock = jest.fn();
 jest.mock('cross-spawn', () => {
   const spawn = (...args: any) => {
@@ -5,7 +7,7 @@ jest.mock('cross-spawn', () => {
     const child = {
       on: (type: string, fn: (code: number) => void) => {
         if (type === 'close') {
-          return fn(0);
+          return fn(spawnExitCode);
         }
       },
     };
@@ -15,6 +17,7 @@ jest.mock('cross-spawn', () => {
 });
 
 afterEach(() => {
+  spawnExitCode = 0;
   spawnMock.mockClear();
 });
 
@@ -193,5 +196,29 @@ it('should only invoke `runNpmInstall()` once per `package.json` file (parallel)
     prettyCommand: 'yarn install',
     stdio: 'inherit',
     env: expect.any(Object),
+  });
+});
+
+it('should throw error when install failed - yarn', async () => {
+  spawnExitCode = 1;
+  const meta: Meta = {};
+  const fixture = path.join(__dirname, 'fixtures', '19-yarn-v2');
+  await expect(
+    runNpmInstall(fixture, [], undefined, meta)
+  ).rejects.toMatchObject({
+    name: 'Error',
+    message: 'Command "yarn install" exited with 1',
+  });
+});
+
+it('should throw error when install failed - npm', async () => {
+  spawnExitCode = 1;
+  const meta: Meta = {};
+  const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
+  await expect(
+    runNpmInstall(fixture, [], undefined, meta)
+  ).rejects.toMatchObject({
+    name: 'Error',
+    message: 'Command "npm install" exited with 1',
   });
 });


### PR DESCRIPTION
Fixes a regression where the thrown error was not propagated to the caller when npm deps failed to install.