### PR TITLE
[fs-detectors] Don't add "api/*" 404 route when only a middleware is present

### DIFF
--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -485,9 +485,12 @@ describe('build', () => {
       expect(config).toMatchObject({
         version: 3,
         routes: [
-          { src: '^/.*$', middlewarePath: 'middleware', continue: true },
-          { handle: 'filesystem' },
-          { src: '^/api(/.*)?$', status: 404 },
+          {
+            src: '^/.*$',
+            middlewarePath: 'middleware',
+            override: true,
+            continue: true,
+          },
           { handle: 'error' },
           { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
         ],
@@ -546,9 +549,12 @@ describe('build', () => {
       expect(config).toMatchObject({
         version: 3,
         routes: [
-          { src: '^/.*$', middlewarePath: 'middleware', continue: true },
-          { handle: 'filesystem' },
-          { src: '^/api(/.*)?$', status: 404 },
+          {
+            src: '^/.*$',
+            middlewarePath: 'middleware',
+            override: true,
+            continue: true,
+          },
           { handle: 'error' },
           { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
         ],
@@ -610,10 +616,9 @@ describe('build', () => {
           {
             src: '^\\/about(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$|^\\/dashboard(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$',
             middlewarePath: 'middleware',
+            override: true,
             continue: true,
           },
-          { handle: 'filesystem' },
-          { src: '^/api(/.*)?$', status: 404 },
           { handle: 'error' },
           { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
         ],

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -1093,7 +1093,10 @@ function getRouteResult(
       rewriteRoutes.push(...dynamicRoutes);
       limitedRoutes.rewriteRoutes.push(...dynamicRoutes);
 
-      if (typeof ignoreRuntimes === 'undefined') {
+      const hasApiBuild = apiBuilders.find(builder => {
+        return builder.src?.startsWith('api/');
+      });
+      if (typeof ignoreRuntimes === 'undefined' && hasApiBuild) {
         // This route is only necessary to hide the directory listing
         // to avoid enumerating serverless function names.
         // But it causes issues in `vc dev` for frameworks that handle

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -2235,9 +2235,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('no package.json + no build + root-level "middleware.js"', async () => {
     const files = ['middleware.js', 'index.html', 'web/middleware.js'];
-    const { builders, errors } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { builders, rewriteRoutes, errors } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
+    expect(rewriteRoutes).toHaveLength(0);
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('middleware.js');
     expect(builders![0].config?.middleware).toEqual(true);
@@ -2249,9 +2254,14 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
   it('no package.json + no build + root-level "middleware.ts"', async () => {
     const files = ['middleware.ts', 'index.html', 'web/middleware.js'];
-    const { builders, errors } = await detectBuilders(files, null, {
-      featHandleMiss,
-    });
+    const { builders, rewriteRoutes, errors } = await detectBuilders(
+      files,
+      null,
+      {
+        featHandleMiss,
+      }
+    );
+    expect(rewriteRoutes).toHaveLength(0);
     expect(builders![0].use).toBe('@vercel/node');
     expect(builders![0].src).toBe('middleware.ts');
     expect(builders![0].config?.middleware).toEqual(true);


### PR DESCRIPTION
This route should not be added when there are no explicit builds under the "api" directory.

### Related Issues

Fixes https://github.com/sveltejs/kit/issues/6777.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR