### PR TITLE
[cli] fix typo: `configuarion` -> `configuration`

### DIFF
--- a/packages/cli/src/util/build/monorepo.ts
+++ b/packages/cli/src/util/build/monorepo.ts
@@ -39,7 +39,7 @@ export async function setMonorepoDefaultSettings(
   ) => {
     if (projectSettings[command]) {
       output.warn(
-        `Cannot automatically assign ${command} as it is already set via project settings or configuarion overrides.`
+        `Cannot automatically assign ${command} as it is already set via project settings or configuration overrides.`
       );
     } else {
       projectSettings[command] = value;

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -1270,10 +1270,10 @@ describe('build', () => {
             const exitCode = await build(client);
             expect(exitCode).toBe(0);
             await expect(client.stderr).toOutput(
-              'Cannot automatically assign buildCommand as it is already set via project settings or configuarion overrides.'
+              'Cannot automatically assign buildCommand as it is already set via project settings or configuration overrides.'
             );
             await expect(client.stderr).toOutput(
-              'Cannot automatically assign installCommand as it is already set via project settings or configuarion overrides.'
+              'Cannot automatically assign installCommand as it is already set via project settings or configuration overrides.'
             );
           } finally {
             process.chdir(originalCwd);
@@ -1307,10 +1307,10 @@ describe('build', () => {
             const exitCode = await build(client);
             expect(exitCode).toBe(0);
             await expect(client.stderr).toOutput(
-              'Cannot automatically assign buildCommand as it is already set via project settings or configuarion overrides.'
+              'Cannot automatically assign buildCommand as it is already set via project settings or configuration overrides.'
             );
             await expect(client.stderr).toOutput(
-              'Cannot automatically assign installCommand as it is already set via project settings or configuarion overrides.'
+              'Cannot automatically assign installCommand as it is already set via project settings or configuration overrides.'
             );
           } finally {
             process.chdir(originalCwd);


### PR DESCRIPTION
### Related Issues

No related issue, this is a drive-by fix

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
