### PR TITLE
[cli] support package.json based turbo config in vc build automatic build/install command feature

### DIFF
--- a/packages/cli/src/util/build/monorepo.ts
+++ b/packages/cli/src/util/build/monorepo.ts
@@ -69,9 +69,9 @@ export async function setMonorepoDefaultSettings(
         hasBuildPipeline = true;
       }
     } else if (packageJsonBuf !== null) {
-      const packageJson = JSON.parse(packageJsonBuf.toString('utf-8'));
+      const packageJSON = JSON.parse(packageJsonBuf.toString('utf-8'));
 
-      if (packageJson?.turbo?.pipeline?.build) {
+      if (packageJSON?.turbo?.pipeline?.build) {
         hasBuildPipeline = true;
       }
     }
@@ -85,7 +85,10 @@ export async function setMonorepoDefaultSettings(
 
     setCommand(
       'buildCommand',
-      `cd ${relativeToRoot} && npx turbo run build --filter=${projectName}...`
+      `cd ${relativeToRoot} && npx turbo run build --filter={./${relative(
+        cwd,
+        workPath
+      )}}...`
     );
     setCommand(
       'installCommand',

--- a/packages/cli/src/util/build/monorepo.ts
+++ b/packages/cli/src/util/build/monorepo.ts
@@ -55,7 +55,7 @@ export async function setMonorepoDefaultSettings(
   }
 
   if (monorepoManager === 'turbo') {
-    const [turboJSONBuf, packageJsonBuf] = await Promise.all([
+    const [turboJSONBuf, packageJSONBuf] = await Promise.all([
       fs.readFile(join(cwd, 'turbo.json')).catch(() => null),
       fs.readFile(join(cwd, 'package.json')).catch(() => null),
     ]);
@@ -68,8 +68,8 @@ export async function setMonorepoDefaultSettings(
       if (turboJSON?.pipeline?.build) {
         hasBuildPipeline = true;
       }
-    } else if (packageJsonBuf !== null) {
-      const packageJSON = JSON.parse(packageJsonBuf.toString('utf-8'));
+    } else if (packageJSONBuf !== null) {
+      const packageJSON = JSON.parse(packageJSONBuf.toString('utf-8'));
 
       if (packageJSON?.turbo?.pipeline?.build) {
         hasBuildPipeline = true;
@@ -103,7 +103,7 @@ export async function setMonorepoDefaultSettings(
         'Missing default `build` target in nx.json. Checking for project level Nx configuration...'
       );
 
-      const [projectJSONBuf, packageJsonBuf] = await Promise.all([
+      const [projectJSONBuf, packageJSONBuf] = await Promise.all([
         fs.readFile(join(workPath, 'project.json')).catch(() => null),
         fs.readFile(join(workPath, 'package.json')).catch(() => null),
       ]);
@@ -118,8 +118,8 @@ export async function setMonorepoDefaultSettings(
         }
       }
 
-      if (packageJsonBuf) {
-        const packageJSON = JSON5.parse(packageJsonBuf.toString('utf-8'));
+      if (packageJSONBuf) {
+        const packageJSON = JSON5.parse(packageJSONBuf.toString('utf-8'));
         if (packageJSON?.nx) {
           output.log('Found package.json Nx configuration.');
           if (packageJSON.nx.targets?.build) {

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": { "outputDirectory": "dist", "rootDirectory": "packages/app-1" }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/build.js
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/build.js
@@ -1,0 +1,7 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+const public = path.join(__dirname, 'public');
+fs.rmSync(public, { recursive: true, force: true });
+fs.mkdirSync(public);
+fs.writeFileSync(path.join(public, 'index.txt'), `Hello, world`);

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/package.json
@@ -1,0 +1,21 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "turbo": "1.6.3"
+  },
+  "turbo": {
+    "pipeline": {
+      "build": {
+        "dependsOn": [
+          "^build"
+        ],
+        "outputs": [
+          "dist/**"
+        ]
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-1/index.js
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-1/index.js
@@ -1,0 +1,8 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const world = require('app-2');
+
+const dist = path.join(__dirname, 'dist');
+fs.rmSync(dist, { recursive: true, force: true });
+fs.mkdirSync(dist);
+fs.writeFileSync(path.join(dist, 'index.txt'), `Hello, ${world}`);

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-1/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-1/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app-1",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "node index.js"
+  },
+  "dependencies": {
+    "app-2": "*"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-2/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-2/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-2",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "node script.js"
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-2/script.js
+++ b/packages/cli/test/fixtures/unit/commands/build/monorepo-detection/turbo-package-config/packages/app-2/script.js
@@ -1,0 +1,7 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+const dist = path.join(__dirname, 'dist');
+fs.rmSync(dist, { recursive: true, force: true });
+fs.mkdirSync(dist);
+fs.writeFileSync(path.join(dist, 'index.js'), 'module.exports = "world"');

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -1173,13 +1173,14 @@ describe('build', () => {
     };
 
     describe.each([
-      'turbo',
       'nx',
-      'nx-project-config',
       'nx-package-config',
       'nx-project-and-package-config-1',
       'nx-project-and-package-config-2',
+      'nx-project-config',
       // 'rush',
+      'turbo',
+      'turbo-package-config',
     ])('fixture: %s', fixture => {
       const monorepoManagerMap: Record<
         string,
@@ -1409,7 +1410,15 @@ describe('build', () => {
         'turbo.json',
         'pipeline.build',
         [
-          'Missing required `build` pipeline in turbo.json. Skipping automatic setting assignment.',
+          'Missing required `build` pipeline in turbo.json or package.json Turbo configuration. Skipping automatic setting assignment.',
+        ],
+      ],
+      [
+        'turbo-package-config',
+        'package.json',
+        'turbo.pipeline.build',
+        [
+          'Missing required `build` pipeline in turbo.json or package.json Turbo configuration. Skipping automatic setting assignment.',
         ],
       ],
     ])('fixture: %s', (fixture, configFile, propertyAccessor, expectedLogs) => {


### PR DESCRIPTION
### Related Issues

Adds support for package.json based turbo configuration. 

Includes test.

Confirmed with Turbo that `turbo.json` takes precedence over `package.json` based config so that is how it is processed here.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
