### PR TITLE
[cli] Create symlinks for duplicate edge functions in `vc build`

### DIFF
--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -674,7 +674,7 @@ export class CantParseJSONFile extends NowError<
     super({
       code: 'CANT_PARSE_JSON_FILE',
       meta: { file },
-      message: `Can't parse json file`,
+      message: `Can't parse json file: ${JSON.stringify(file)}`,
     });
   }
 }


### PR DESCRIPTION
Similar to how Lambda instances are de-duped using symlinks, do the same for EdgeFunction instances.

TODO: backend needs to support this first, and also add tests here.