### PR TITLE
[WIP] feat(node-bridge, node, cli): experiment wrapping edge-compliant signature for serverless

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -31,6 +31,7 @@ packages/node-bridge/bridge.js
 packages/node-bridge/launcher.js
 packages/node-bridge/helpers.js
 packages/node-bridge/source-map-support.js
+packages/node-bridge/web-handler.js
 
 # middleware
 packages/middleware/src/entries.js

--- a/packages/build-utils/src/nodejs-lambda.ts
+++ b/packages/build-utils/src/nodejs-lambda.ts
@@ -4,22 +4,24 @@ interface NodejsLambdaOptions extends LambdaOptionsWithFiles {
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
   awsLambdaHandler?: string;
+  launcherType?: 'Nodejs' | 'Web';
 }
 
 export class NodejsLambda extends Lambda {
-  launcherType: 'Nodejs';
+  launcherType: 'Nodejs' | 'Web';
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
   awsLambdaHandler?: string;
 
   constructor({
+    launcherType,
     shouldAddHelpers,
     shouldAddSourcemapSupport,
     awsLambdaHandler,
     ...opts
   }: NodejsLambdaOptions) {
     super(opts);
-    this.launcherType = 'Nodejs';
+    this.launcherType = launcherType || 'Nodejs';
     this.shouldAddHelpers = shouldAddHelpers;
     this.shouldAddSourcemapSupport = shouldAddSourcemapSupport;
     this.awsLambdaHandler = awsLambdaHandler;

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -31,6 +31,10 @@ export const functionsSchema = {
           type: 'string',
           maxLength: 256,
         },
+        launcherType: {
+          type: 'string',
+          enum: ['Nodejs', 'Web'],
+        },
       },
     },
   },

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -319,6 +319,7 @@ export interface BuilderFunctions {
     runtime?: string;
     includeFiles?: string;
     excludeFiles?: string;
+    launcherType?: 'Nodejs' | 'Web';
   };
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,11 +41,11 @@
     "node": ">= 14"
   },
   "dependencies": {
-    "@vercel/build-utils": "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz",
+    "@vercel/build-utils": "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz",
     "@vercel/go": "2.2.17",
     "@vercel/hydrogen": "0.0.31",
     "@vercel/next": "3.2.13",
-    "@vercel/node": "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz",
+    "@vercel/node": "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz",
     "@vercel/python": "3.1.27",
     "@vercel/redwood": "1.0.37",
     "@vercel/remix": "1.0.37",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,11 +41,11 @@
     "node": ">= 14"
   },
   "dependencies": {
-    "@vercel/build-utils": "5.5.9",
+    "@vercel/build-utils": "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz",
     "@vercel/go": "2.2.17",
     "@vercel/hydrogen": "0.0.31",
     "@vercel/next": "3.2.13",
-    "@vercel/node": "2.6.4",
+    "@vercel/node": "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz",
     "@vercel/python": "3.1.27",
     "@vercel/redwood": "1.0.37",
     "@vercel/remix": "1.0.37",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,11 +41,11 @@
     "node": ">= 14"
   },
   "dependencies": {
-    "@vercel/build-utils": "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz",
+    "@vercel/build-utils": "5.5.9",
     "@vercel/go": "2.2.17",
     "@vercel/hydrogen": "0.0.31",
     "@vercel/next": "3.2.13",
-    "@vercel/node": "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz",
+    "@vercel/node": "2.6.4",
     "@vercel/python": "3.1.27",
     "@vercel/redwood": "1.0.37",
     "@vercel/remix": "1.0.37",

--- a/packages/node-bridge/.gitignore
+++ b/packages/node-bridge/.gitignore
@@ -1,2 +1,3 @@
 /helpers.js
 /source-map-support.js
+/web-handler.js

--- a/packages/node-bridge/build.js
+++ b/packages/node-bridge/build.js
@@ -47,6 +47,7 @@ async function bundle(sourceFile, finalName) {
     join(outputDir, 'index.js'),
     join(__dirname, `${finalName}.js`)
   );
+  console.error(`ncc: Writing ${finalName}.js`);
   await fs.remove(outputDir);
 }
 

--- a/packages/node-bridge/build.js
+++ b/packages/node-bridge/build.js
@@ -4,40 +4,34 @@ const execa = require('execa');
 const { join } = require('path');
 
 async function main() {
+  await fs.remove(join(__dirname, 'helpers.js'));
+  await fs.remove(join(__dirname, 'web-handler.js'));
+
   // Build TypeScript files
   await execa('tsc', [], {
     stdio: 'inherit',
   });
 
   // Bundle `helpers.ts` with ncc
-  await fs.remove(join(__dirname, 'helpers.js'));
-  const helpersDir = join(__dirname, 'helpers');
-  await execa(
-    'ncc',
-    [
-      'build',
-      join(__dirname, 'helpers.ts'),
-      '-e',
-      '@vercel/node-bridge',
-      '-e',
-      '@vercel/build-utils',
-      '-e',
-      'typescript',
-      '-o',
-      helpersDir,
-    ],
-    { stdio: 'inherit' }
-  );
-  await fs.rename(join(helpersDir, 'index.js'), join(__dirname, 'helpers.js'));
-  await fs.remove(helpersDir);
+  await bundle(join(__dirname, 'helpers.ts'), 'helpers');
 
   // Bundle `source-map-support/register` with ncc for source maps
-  const sourceMapSupportDir = join(__dirname, 'source-map-support');
+  await bundle(
+    join(__dirname, '../../node_modules/source-map-support/register'),
+    'source-map-support'
+  );
+
+  // Bundle `web-handler.ts` with ncc
+  await bundle(join(__dirname, 'web-handler.ts'), 'web-handler');
+}
+
+async function bundle(sourceFile, finalName) {
+  const outputDir = join(__dirname, finalName);
   await execa(
     'ncc',
     [
       'build',
-      join(__dirname, '../../node_modules/source-map-support/register'),
+      sourceFile,
       '-e',
       '@vercel/node-bridge',
       '-e',
@@ -45,15 +39,15 @@ async function main() {
       '-e',
       'typescript',
       '-o',
-      sourceMapSupportDir,
+      outputDir,
     ],
     { stdio: 'inherit' }
   );
   await fs.rename(
-    join(sourceMapSupportDir, 'index.js'),
-    join(__dirname, 'source-map-support.js')
+    join(outputDir, 'index.js'),
+    join(__dirname, `${finalName}.js`)
   );
-  await fs.remove(sourceMapSupportDir);
+  await fs.remove(outputDir);
 }
 
 main().catch(err => {

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -2,6 +2,7 @@ const { parse, pathToFileURL } = require('url');
 const { createServer, Server } = require('http');
 const { isAbsolute } = require('path');
 const { Bridge } = require('./bridge.js');
+const { wrapWebHandler } = require('./web-handler.js');
 
 /**
  * @param {import('./types').LauncherConfiguration} config
@@ -42,6 +43,7 @@ function getVercelLauncher({
   helpersPath,
   shouldAddHelpers = false,
   useRequire = false,
+  webSignature = false,
 }) {
   return function () {
     const bridge = new Bridge();
@@ -86,6 +88,9 @@ function getVercelLauncher({
           bridge.setServer(server);
           bridge.listen();
         } else if (typeof listener === 'function') {
+          if (webSignature) {
+            listener = wrapWebHandler(listener);
+          }
           Server.prototype.listen = originalListen;
           if (shouldAddHelpers) {
             bridge.setStoreEvents(true);

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -15,7 +15,6 @@ function makeVercelLauncher(config) {
     sourcemapSupportPath,
     shouldAddHelpers = false,
     shouldAddSourcemapSupport = false,
-    webSignature = false,
   } = config;
   return `
 const { parse, pathToFileURL } = require('url');
@@ -31,8 +30,6 @@ const entrypointPath = ${JSON.stringify(entrypointPath)};
 const shouldAddHelpers = ${JSON.stringify(shouldAddHelpers)};
 const helpersPath = ${JSON.stringify(helpersPath)};
 const useRequire = false;
-
-console.log("${JSON.stringify(config)}");
 
 const func = (${getVercelLauncher(config).toString()})();
 exports.launcher = func.launcher;`;
@@ -91,7 +88,7 @@ function getVercelLauncher({
           bridge.setServer(server);
           bridge.listen();
         } else if (typeof listener === 'function') {
-          if (webSignature) {
+          if (listener.webSignature) {
             listener = wrapWebHandler(listener);
           }
           Server.prototype.listen = originalListen;

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -41,6 +41,7 @@ exports.launcher = func.launcher;`;
  * @param {import('./types').LauncherConfiguration} config
  */
 function getVercelLauncher({
+  launcherType,
   entrypointPath,
   helpersPath,
   webHandlerPath,
@@ -84,7 +85,7 @@ function getVercelLauncher({
 
     getListener(entrypointPath)
       .then(listener => {
-        if (listener.webSignature) {
+        if (launcherType === 'Web') {
           return import(webHandlerPath).then(({ wrapWebHandler }) =>
             wrapWebHandler(listener)
           );

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -15,6 +15,7 @@ function makeVercelLauncher(config) {
     sourcemapSupportPath,
     shouldAddHelpers = false,
     shouldAddSourcemapSupport = false,
+    webSignature = false,
   } = config;
   return `
 const { parse, pathToFileURL } = require('url');
@@ -30,6 +31,8 @@ const entrypointPath = ${JSON.stringify(entrypointPath)};
 const shouldAddHelpers = ${JSON.stringify(shouldAddHelpers)};
 const helpersPath = ${JSON.stringify(helpersPath)};
 const useRequire = false;
+
+console.log("${JSON.stringify(config)}");
 
 const func = (${getVercelLauncher(config).toString()})();
 exports.launcher = func.launcher;`;

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -9,6 +9,7 @@ const { wrapWebHandler } = require('./web-handler.js');
  */
 function makeVercelLauncher(config) {
   const {
+    launcherType = 'Nodejs',
     entrypointPath,
     bridgePath,
     helpersPath,
@@ -31,6 +32,7 @@ const entrypointPath = ${JSON.stringify(entrypointPath)};
 const shouldAddHelpers = ${JSON.stringify(shouldAddHelpers)};
 const helpersPath = ${JSON.stringify(helpersPath)};
 const webHandlerPath = ${JSON.stringify(webHandlerPath)}
+const launcherType = ${JSON.stringify(launcherType)}
 const useRequire = false;
 
 const func = (${getVercelLauncher(config).toString()})();

--- a/packages/node-bridge/package.json
+++ b/packages/node-bridge/package.json
@@ -13,7 +13,8 @@
     "launcher.*",
     "index.js",
     "helpers.js",
-    "source-map-support.js"
+    "source-map-support.js",
+    "web-handler.js"
   ],
   "scripts": {
     "build": "node build.js",
@@ -21,6 +22,7 @@
     "test-unit": "yarn test"
   },
   "devDependencies": {
+    "@edge-runtime/primitives": "2.0.2",
     "@types/aws-lambda": "8.10.19",
     "@types/node": "14.18.33",
     "jsonlines": "0.1.1",

--- a/packages/node-bridge/package.json
+++ b/packages/node-bridge/package.json
@@ -22,7 +22,6 @@
     "test-unit": "yarn test"
   },
   "devDependencies": {
-    "@edge-runtime/primitives": "2.0.2",
     "@types/aws-lambda": "8.10.19",
     "@types/node": "14.18.33",
     "jsonlines": "0.1.1",

--- a/packages/node-bridge/package.json
+++ b/packages/node-bridge/package.json
@@ -22,6 +22,7 @@
     "test-unit": "yarn test"
   },
   "devDependencies": {
+    "@edge-runtime/primitives": "2.0.2",
     "@types/aws-lambda": "8.10.19",
     "@types/node": "14.18.33",
     "jsonlines": "0.1.1",

--- a/packages/node-bridge/test/web-handler.test.js
+++ b/packages/node-bridge/test/web-handler.test.js
@@ -1,0 +1,147 @@
+// Note: browser globals are only available because they'll be added to the global scope when invoking wrapWebHandler()
+/* eslint-env node, browser */
+
+const { createServer } = require('http');
+const { wrapWebHandler } = require('../web-handler.js');
+
+describe('Web handler wrapper', () => {
+  let server;
+
+  async function invokeWebHandler(handler) {
+    // starts a server with provided handler and invokes it
+    server = createServer(wrapWebHandler(handler));
+
+    // TODO fetch connections are hanging, despite the lack of keepalive.
+    // inspire from https://github.com/isaacs/server-destroy/blob/master/index.js to force-close them.
+    const connections = new Map();
+    server.on('connection', connection => {
+      const key = `${connection.remoteAddress}:${connection.remotePort}`;
+      connections.set(key, connection);
+      connection.on('close', () => connections.delete(key));
+    });
+    server.destroy = done => {
+      for (const connection of connections.values()) {
+        connection.destroy();
+      }
+      server.close(done);
+    };
+
+    await new Promise((resolve, reject) =>
+      server.listen(err => {
+        err ? reject(err) : resolve();
+      })
+    );
+    const response = await fetch(`http://localhost:${server.address().port}`);
+
+    // extract response content to ease expectations
+    const headers = {};
+    for (const [name, value] of await response.headers) {
+      headers[name] = value;
+    }
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+      text: await response.clone().text(),
+      json:
+        headers['content-type'] === 'application/json'
+          ? await response.json()
+          : undefined,
+    };
+  }
+
+  afterEach(done => {
+    server.destroy(done);
+  });
+
+  it('turns null response into an empty request', async () => {
+    const response = await invokeWebHandler(() => null);
+    expect(response).toMatchObject({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-length': '0' },
+      text: '',
+    });
+  });
+
+  it('returns an empty response', async () => {
+    const response = await invokeWebHandler(() => new Response(null));
+    expect(response).toMatchObject({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-length': '0' },
+      text: '',
+    });
+  });
+
+  it('can change response text and status', async () => {
+    const response = await invokeWebHandler(
+      () => new Response(null, { status: 204, statusText: 'MY STATUS' })
+    );
+    expect(response).toMatchObject({
+      status: 204,
+      statusText: 'MY STATUS',
+    });
+  });
+
+  it('returns a text response', async () => {
+    const response = await invokeWebHandler(() => new Response('OK'));
+    expect(response).toMatchObject({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      text: 'OK',
+    });
+  });
+
+  it('returns a json response', async () => {
+    const json = { works: 'jsut right' };
+    const response = await invokeWebHandler(() => Response.json(json));
+    expect(response).toMatchObject({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      json,
+    });
+  });
+
+  it('can configure response headers', async () => {
+    const response = await invokeWebHandler(() => {
+      const response = new Response();
+      response.headers.set('x-vercel-custom', '1');
+      return response;
+    });
+    expect(response).toMatchObject({
+      status: 200,
+      headers: { 'x-vercel-custom': '1' },
+    });
+  });
+
+  it('returns a streams of data', async () => {
+    const data = ['lorem', 'ipsum', 'nec', 'mergitur'];
+
+    const response = await invokeWebHandler(
+      () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              let rank = 0;
+              function write() {
+                controller.enqueue(data[rank++]);
+                if (rank < data.length) {
+                  setTimeout(write, 500);
+                } else {
+                  controller.close();
+                }
+              }
+              write();
+            },
+          })
+        )
+    );
+    expect(response).toMatchObject({
+      status: 200,
+      text: data.join(''),
+    });
+  });
+});

--- a/packages/node-bridge/tsconfig.json
+++ b/packages/node-bridge/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "noEmit": true,
     "noImplicitReturns": true,
     "strict": true,
@@ -10,6 +10,6 @@
     "declaration": true,
     "module": "commonjs"
   },
-  "include": ["helpers.ts", "bridge.js", "launcher.js"],
+  "include": ["helpers.ts", "bridge.js", "launcher.js", "web-handler.js"],
   "exclude": ["node_modules"]
 }

--- a/packages/node-bridge/types.ts
+++ b/packages/node-bridge/types.ts
@@ -51,6 +51,7 @@ export type LauncherConfiguration = {
   shouldAddSourcemapSupport?: boolean;
   awsLambdaHandler?: string;
   useRequire?: boolean;
+  webSignature?: boolean;
 };
 
 export type VercelRequestCookies = { [key: string]: string };

--- a/packages/node-bridge/types.ts
+++ b/packages/node-bridge/types.ts
@@ -43,6 +43,7 @@ export interface ServerLike {
   ) => Server | void;
 }
 export type LauncherConfiguration = {
+  launcherType: 'Nodejs' | 'Web';
   entrypointPath: string;
   bridgePath: string;
   helpersPath: string;

--- a/packages/node-bridge/types.ts
+++ b/packages/node-bridge/types.ts
@@ -46,12 +46,12 @@ export type LauncherConfiguration = {
   entrypointPath: string;
   bridgePath: string;
   helpersPath: string;
+  webHandlerPath: string;
   sourcemapSupportPath: string;
   shouldAddHelpers?: boolean;
   shouldAddSourcemapSupport?: boolean;
   awsLambdaHandler?: string;
   useRequire?: boolean;
-  webSignature?: boolean;
 };
 
 export type VercelRequestCookies = { [key: string]: string };

--- a/packages/node-bridge/web-handler.ts
+++ b/packages/node-bridge/web-handler.ts
@@ -15,7 +15,7 @@ type WebHandler = (req: Request) => Promise<Response> | Response;
 const { Readable } = require('stream');
 
 export function wrapWebHandler(handler: WebHandler): NodeHandler {
-  enrichGlobalWithPrimitives();
+  // enrichGlobalWithPrimitives();
 
   return (request: IncomingMessage, response: ServerResponse) => {
     // TODO add the second parameter
@@ -110,8 +110,8 @@ function buildStreamFromReadableStream(readableStream: ReadableStream) {
   return readable;
 }
 
-function enrichGlobalWithPrimitives() {
-  Object.assign(global, require('@edge-runtime/primitives/abort-controller'));
-  Object.assign(global, require('@edge-runtime/primitives/streams'));
-  Object.assign(global, require('@edge-runtime/primitives/fetch'));
-}
+// function enrichGlobalWithPrimitives() {
+//   Object.assign(global, require('@edge-runtime/primitives/abort-controller'));
+//   Object.assign(global, require('@edge-runtime/primitives/streams'));
+//   Object.assign(global, require('@edge-runtime/primitives/fetch'));
+// }

--- a/packages/node-bridge/web-handler.ts
+++ b/packages/node-bridge/web-handler.ts
@@ -15,7 +15,7 @@ type WebHandler = (req: Request) => Promise<Response> | Response;
 const { Readable } = require('stream');
 
 export function wrapWebHandler(handler: WebHandler): NodeHandler {
-  // enrichGlobalWithPrimitives();
+  enrichGlobalWithPrimitives();
 
   return (request: IncomingMessage, response: ServerResponse) => {
     // TODO add the second parameter
@@ -110,8 +110,8 @@ function buildStreamFromReadableStream(readableStream: ReadableStream) {
   return readable;
 }
 
-// function enrichGlobalWithPrimitives() {
-//   Object.assign(global, require('@edge-runtime/primitives/abort-controller'));
-//   Object.assign(global, require('@edge-runtime/primitives/streams'));
-//   Object.assign(global, require('@edge-runtime/primitives/fetch'));
-// }
+function enrichGlobalWithPrimitives() {
+  Object.assign(global, require('@edge-runtime/primitives/abort-controller'));
+  Object.assign(global, require('@edge-runtime/primitives/streams'));
+  Object.assign(global, require('@edge-runtime/primitives/fetch'));
+}

--- a/packages/node-bridge/web-handler.ts
+++ b/packages/node-bridge/web-handler.ts
@@ -1,0 +1,117 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+// TODO Typescript has some issue with these :(
+/*import type {
+  ReadableStream,
+  Request,
+  Response,
+} from '@edge-runtime/primitives';*/
+type Response = any;
+type ReadableStream = any;
+type Request = any;
+
+type NodeHandler = (req: IncomingMessage, res: ServerResponse) => void;
+type WebHandler = (req: Request) => Promise<Response> | Response;
+
+const { Readable } = require('stream');
+
+export function wrapWebHandler(handler: WebHandler): NodeHandler {
+  enrichGlobalWithPrimitives();
+
+  return (request: IncomingMessage, response: ServerResponse) => {
+    // TODO add the second parameter
+    // @ts-ignore TODO map IncompingMessage into Request
+    const maybePromise = handler(request);
+    const mapResponse = buildResponseMapper(response);
+    if (maybePromise instanceof Promise) {
+      maybePromise.then(mapResponse);
+    } else {
+      mapResponse(maybePromise);
+    }
+  };
+}
+
+function buildResponseMapper(serverResponse: ServerResponse) {
+  return function (webResponse: Response) {
+    if (!webResponse) {
+      serverResponse.end();
+      return;
+    }
+    // TODO check for webResponse compliance
+    for (const [name, value] of webResponse.headers.entries()) {
+      serverResponse.setHeader(name, value);
+    }
+    serverResponse.statusCode = webResponse.status;
+    serverResponse.statusMessage = webResponse.statusText;
+    // TODO trailers? https://nodejs.org/api/http.html#responseaddtrailersheaders https://developer.mozilla.org/en-US/docs/Web/API/Response
+    if (!webResponse.body) {
+      serverResponse.end();
+      return;
+    }
+    buildStreamFromReadableStream(webResponse.body).pipe(serverResponse);
+  };
+}
+
+/**
+ * @see https://github.com/nodejs/node/blob/bd462ad81bc30e547e52e699ee3b6fa3d7c882c9/lib/internal/webstreams/adapters.js#L458
+ */
+function buildStreamFromReadableStream(readableStream: ReadableStream) {
+  const reader = readableStream.getReader();
+  let closed = false;
+
+  const readable = new Readable({
+    objectMode: false,
+    read() {
+      reader.read().then(
+        (chunk: any) => {
+          if (chunk.done) {
+            readable.push(null);
+          } else {
+            readable.push(chunk.value);
+          }
+        },
+        (error: any) => readable.destroy(error)
+      );
+    },
+
+    destroy(error: any, callback: (arg0: any) => void) {
+      function done() {
+        try {
+          callback(error);
+        } catch (error) {
+          // In a next tick because this is happening within
+          // a promise context, and if there are any errors
+          // thrown we don't want those to cause an unhandled
+          // rejection. Let's just escape the promise and
+          // handle it separately.
+          process.nextTick(() => {
+            throw error;
+          });
+        }
+      }
+
+      if (!closed) {
+        reader.cancel(error).then(done, done);
+        return;
+      }
+      done();
+    },
+  });
+
+  reader.closed.then(
+    () => {
+      closed = true;
+    },
+    (error: any) => {
+      closed = true;
+      readable.destroy(error);
+    }
+  );
+
+  return readable;
+}
+
+function enrichGlobalWithPrimitives() {
+  Object.assign(global, require('@edge-runtime/primitives/abort-controller'));
+  Object.assign(global, require('@edge-runtime/primitives/streams'));
+  Object.assign(global, require('@edge-runtime/primitives/fetch'));
+}

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -86,7 +86,7 @@ function listen(server: Server, port: number, host: string): Promise<void> {
   });
 }
 
-const validRuntimes = ['experimental-edge'];
+const validRuntimes = ['experimental-edge', 'web'];
 function parseRuntime(
   entrypoint: string,
   entryPointPath: string
@@ -127,7 +127,8 @@ async function createEventHandler(
   return createServerlessEventHandler(entrypointPath, {
     shouldAddHelpers: options.shouldAddHelpers,
     useRequire,
-    launcherType: findLauncherType(entrypoint, config),
+    launcherType:
+      runtime === 'web' ? 'Web' : findLauncherType(entrypoint, config),
   });
 }
 

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -148,6 +148,7 @@ async function main() {
   const proxyServer = createServer(onDevRequest);
   await listen(proxyServer, 0, '127.0.0.1');
 
+  console.log('>>> invoke handler', entrypoint, config);
   try {
     handleEvent = await createEventHandler(entrypoint!, config, {
       shouldAddHelpers,

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -107,7 +107,7 @@ function parseRuntime(
 
 async function createEventHandler(
   entrypoint: string,
-  config: Config,
+  config: Config & { launcherType?: 'Nodejs' | 'Web' }, // TODO while changing @vercel/build-utils
   options: { shouldAddHelpers: boolean }
 ): Promise<(request: IncomingMessage) => Promise<VercelProxyResponse>> {
   const entrypointPath = join(process.cwd(), entrypoint!);
@@ -127,6 +127,7 @@ async function createEventHandler(
   return createServerlessEventHandler(entrypointPath, {
     shouldAddHelpers: options.shouldAddHelpers,
     useRequire,
+    launcherType: config.launcherType || 'Nodejs',
   });
 }
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -73,7 +73,7 @@ function isPortInfo(v: any): v is PortInfo {
   return v && typeof v.port === 'number';
 }
 
-const ALLOWED_RUNTIMES = ['nodejs', 'experimental-edge'];
+const ALLOWED_RUNTIMES = ['nodejs', 'experimental-edge', 'web'];
 
 const require_ = eval('require');
 
@@ -471,6 +471,7 @@ export const build: BuildV3 = async ({
     output = new NodejsLambda({
       files: preparedFiles,
       handler,
+      launcherType: staticConfig?.runtime === 'web' ? 'Web' : 'Nodejs',
       runtime: nodeVersion.runtime,
       shouldAddHelpers,
       shouldAddSourcemapSupport,

--- a/packages/node/src/serverless-functions/serverless-handler.ts
+++ b/packages/node/src/serverless-functions/serverless-handler.ts
@@ -29,6 +29,7 @@ export async function createServerlessEventHandler(
   const launcher = getVercelLauncher({
     entrypointPath: entrypoint,
     helpersPath: './helpers.js',
+    webHandlerPath: './web-handler.js',
     shouldAddHelpers: options.shouldAddHelpers,
     useRequire: options.useRequire,
 

--- a/packages/node/src/serverless-functions/serverless-handler.ts
+++ b/packages/node/src/serverless-functions/serverless-handler.ts
@@ -22,6 +22,7 @@ function rawBody(readable: Readable): Promise<Buffer> {
 export async function createServerlessEventHandler(
   entrypoint: string,
   options: {
+    launcherType: 'Nodejs' | 'Web';
     shouldAddHelpers: boolean;
     useRequire: boolean;
   }
@@ -32,7 +33,7 @@ export async function createServerlessEventHandler(
     webHandlerPath: './web-handler.js',
     shouldAddHelpers: options.shouldAddHelpers,
     useRequire: options.useRequire,
-    launcherType: 'Nodejs',
+    launcherType: options.launcherType,
 
     // not used
     bridgePath: '',

--- a/packages/node/src/serverless-functions/serverless-handler.ts
+++ b/packages/node/src/serverless-functions/serverless-handler.ts
@@ -32,6 +32,7 @@ export async function createServerlessEventHandler(
     webHandlerPath: './web-handler.js',
     shouldAddHelpers: options.shouldAddHelpers,
     useRequire: options.useRequire,
+    launcherType: 'Nodejs',
 
     // not used
     bridgePath: '',

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
     },
     "@vercel/node-bridge#build": {
       "dependsOn": ["^build"],
-      "outputs": ["helpers.js", "source-map-support.js"]
+      "outputs": ["helpers.js", "source-map-support.js", "web-handler.js"]
     },
     "vercel#build": {
       "dependsOn": ["^build"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,6 +3389,10 @@
   resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-4.2.0.tgz#251a496bd426f06ed3e882047728e07121c1d303"
   integrity sha512-W0TKBUGaUXHj16thnPjzFUT94rR6Hkw0Zf+PlZbUN2Op7KswgBCl5At306tz5xi/BYC8lXc9WqDd3ZWnfiw4Ng==
 
+"@vercel/build-utils@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz":
+  version "5.5.9-3afb179"
+  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz#2e0d4b065e0cb556832eeede33ceee0f50de30f5"
+
 "@vercel/fun@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.4.tgz#5d01cca962488b2328063b0c3fc0b6fac2555c2a"
@@ -3436,6 +3440,34 @@
     node-gyp-build "^4.2.2"
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
+
+"@vercel/node-bridge@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz":
+  version "3.1.2-3afb179"
+  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz#9e8a9b306ce96e164358d67130b60f1ab527ac4c"
+
+"@vercel/node@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz":
+  version "2.6.4-3afb179"
+  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz#36439a235b47b0fc13d199e20b4bf9f51f60e88e"
+  dependencies:
+    "@edge-runtime/vm" "2.0.0"
+    "@types/node" "14.18.33"
+    "@vercel/build-utils" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz"
+    "@vercel/node-bridge" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz"
+    "@vercel/static-config" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz"
+    edge-runtime "2.0.0"
+    esbuild "0.14.47"
+    exit-hook "2.2.1"
+    node-fetch "2.6.7"
+    ts-node "8.9.1"
+    typescript "4.3.4"
+
+"@vercel/static-config@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz":
+  version "2.0.6-3afb179"
+  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz#5e21b7e17b3f020fba0f063a5b2394def3be3e22"
+  dependencies:
+    ajv "8.6.3"
+    json-schema-to-ts "1.6.4"
+    ts-morph "12.0.0"
 
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,9 +3389,9 @@
   resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-4.2.0.tgz#251a496bd426f06ed3e882047728e07121c1d303"
   integrity sha512-W0TKBUGaUXHj16thnPjzFUT94rR6Hkw0Zf+PlZbUN2Op7KswgBCl5At306tz5xi/BYC8lXc9WqDd3ZWnfiw4Ng==
 
-"@vercel/build-utils@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz":
-  version "5.5.9-3afb179"
-  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz#2e0d4b065e0cb556832eeede33ceee0f50de30f5"
+"@vercel/build-utils@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz":
+  version "5.5.9-b85dfd3"
+  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz#654e82b1936e2c16190ca7a6e8ca3e050a1f3a8b"
 
 "@vercel/fun@1.0.4":
   version "1.0.4"
@@ -3441,19 +3441,19 @@
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
 
-"@vercel/node-bridge@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz":
-  version "3.1.2-3afb179"
-  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz#9e8a9b306ce96e164358d67130b60f1ab527ac4c"
+"@vercel/node-bridge@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz":
+  version "3.1.2-b85dfd3"
+  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz#5ff13e3c856e61099cc99af9354e99a6a9165320"
 
-"@vercel/node@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz":
-  version "2.6.4-3afb179"
-  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node.tgz#36439a235b47b0fc13d199e20b4bf9f51f60e88e"
+"@vercel/node@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz":
+  version "2.6.4-b85dfd3"
+  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz#a1c0d60749348e0f5e6e25acf6ecb632006f8722"
   dependencies:
     "@edge-runtime/vm" "2.0.0"
     "@types/node" "14.18.33"
-    "@vercel/build-utils" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/build-utils.tgz"
-    "@vercel/node-bridge" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/node-bridge.tgz"
-    "@vercel/static-config" "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz"
+    "@vercel/build-utils" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz"
+    "@vercel/node-bridge" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz"
+    "@vercel/static-config" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz"
     edge-runtime "2.0.0"
     esbuild "0.14.47"
     exit-hook "2.2.1"
@@ -3461,9 +3461,9 @@
     ts-node "8.9.1"
     typescript "4.3.4"
 
-"@vercel/static-config@https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz":
-  version "2.0.6-3afb179"
-  resolved "https://vercel-plypu7hux.vercel.sh/tarballs/@vercel/static-config.tgz#5e21b7e17b3f020fba0f063a5b2394def3be3e22"
+"@vercel/static-config@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz":
+  version "2.0.6-b85dfd3"
+  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz#a62fc41be981847d4ea6ae69e78e0976ccd4606b"
   dependencies:
     ajv "8.6.3"
     json-schema-to-ts "1.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,11 +753,6 @@
   resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-2.0.0.tgz#b4bf44f9cab36aee3027fe4c3ff3cc1d5713e155"
   integrity sha512-AXqUq1zruTJAICrllUvZcgciIcEGHdF6KJ3r6FM0n4k8LpFxZ62tPWVIJ9HKm+xt+ncTBUZxwgUaQ73QMUQEKw==
 
-"@edge-runtime/primitives@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-2.0.2.tgz#55225bb123a272fc9cb2d311155118a9a52dcaa6"
-  integrity sha512-pE/VlEMzF2+WOdQUR8vgecd0b5kY4/d2Z5rA8tdq2uANQvqallJQ6tJvLmWxResq75kMFln4NDXrtzNBw3mgXA==
-
 "@edge-runtime/vm@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-2.0.0.tgz#9170d2d03761eff4e27687888c4b2d9af1f94c7d"
@@ -3389,10 +3384,6 @@
   resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-4.2.0.tgz#251a496bd426f06ed3e882047728e07121c1d303"
   integrity sha512-W0TKBUGaUXHj16thnPjzFUT94rR6Hkw0Zf+PlZbUN2Op7KswgBCl5At306tz5xi/BYC8lXc9WqDd3ZWnfiw4Ng==
 
-"@vercel/build-utils@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz":
-  version "5.5.9-b85dfd3"
-  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz#654e82b1936e2c16190ca7a6e8ca3e050a1f3a8b"
-
 "@vercel/fun@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.4.tgz#5d01cca962488b2328063b0c3fc0b6fac2555c2a"
@@ -3440,34 +3431,6 @@
     node-gyp-build "^4.2.2"
     resolve-from "^5.0.0"
     rollup-pluginutils "^2.8.2"
-
-"@vercel/node-bridge@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz":
-  version "3.1.2-b85dfd3"
-  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz#5ff13e3c856e61099cc99af9354e99a6a9165320"
-
-"@vercel/node@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz":
-  version "2.6.4-b85dfd3"
-  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node.tgz#a1c0d60749348e0f5e6e25acf6ecb632006f8722"
-  dependencies:
-    "@edge-runtime/vm" "2.0.0"
-    "@types/node" "14.18.33"
-    "@vercel/build-utils" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/build-utils.tgz"
-    "@vercel/node-bridge" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/node-bridge.tgz"
-    "@vercel/static-config" "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz"
-    edge-runtime "2.0.0"
-    esbuild "0.14.47"
-    exit-hook "2.2.1"
-    node-fetch "2.6.7"
-    ts-node "8.9.1"
-    typescript "4.3.4"
-
-"@vercel/static-config@https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz":
-  version "2.0.6-b85dfd3"
-  resolved "https://vercel-m5his95f7.vercel.sh/tarballs/@vercel/static-config.tgz#a62fc41be981847d4ea6ae69e78e0976ccd4606b"
-  dependencies:
-    ajv "8.6.3"
-    json-schema-to-ts "1.6.4"
-    ts-morph "12.0.0"
 
 "@zeit/dns-cached-resolve@2.1.0":
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,6 +753,11 @@
   resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-2.0.0.tgz#b4bf44f9cab36aee3027fe4c3ff3cc1d5713e155"
   integrity sha512-AXqUq1zruTJAICrllUvZcgciIcEGHdF6KJ3r6FM0n4k8LpFxZ62tPWVIJ9HKm+xt+ncTBUZxwgUaQ73QMUQEKw==
 
+"@edge-runtime/primitives@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-2.0.2.tgz#55225bb123a272fc9cb2d311155118a9a52dcaa6"
+  integrity sha512-pE/VlEMzF2+WOdQUR8vgecd0b5kY4/d2Z5rA8tdq2uANQvqallJQ6tJvLmWxResq75kMFln4NDXrtzNBw3mgXA==
+
 "@edge-runtime/vm@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-2.0.0.tgz#9170d2d03761eff4e27687888c4b2d9af1f94c7d"


### PR DESCRIPTION
### :book: What's in there?

This is a very early proof of concept of running serverless functions with the signature of an edge function.
[Linear ticket](https://linear.app/vercel/issue/EC-239/investigate-isomorphic-signature-for-serverless-and-edge).

**Don't review yet!**

This covers:
- feat(node-bridge): based on configured `launcherType` property, wraps the user-provided, web compliant, function into a node.js compliant function
- feat(node-bridge): imports some `edge-runtime` primitives to allow running web compliant code on a serverless node.js environment.
- feat(node): allows specifying `launcherType` for a given function in `vercel.json` file (for `vc dev` & `vc deploy`)

### 🧪 How to test?

First of all, this needs a build-container deployed in `lhr1` that includes tarballs from the branch for `@vercel/node` and `@vercel/node-bridge`.  Like in this PR: https://github.com/vercel/api/pull/15475.

Then you can try:

#### a prebuilt, build output v3 compliant, application

I created one locally in a folder, let's say `isomorphic-signature-vc-prebuilt/`:

file `.vercel/output/functions/serverless.func/index.js`:
```js
export default async function handler() {
  return Response.json({ works: 'just right from serverless' });
}
```
This is a web-compliant signature! Using Web's Response object.

file `.vercel/output/functions/serverless.func/package.json`:
```js
{ "type": "module" }
```
This is required to enabled ESM export.

file `.vercel/output/functions/serverless.func/.vc-config.json`:
```js
{
  "runtime": "nodejs14.x",
  "handler": "index.js",
  "launcherType": "Web"
}
```
You can also use `nodejs16.x` or `nodejs18.x`. Providing `launcherType` enables the feature.

Then deploy it: `vc deploy -b VERCEL_DEBUG=1 -b FORCE_BUILD_IN_REGION=lhr1 --force --prebuilt`


#### a vercel application

I created one locally in a folder, let's say `isomorphic-signature-vc/`:

file `api/serverless.js`:
```js
export default async function handler() {
  return Response.json({ works: 'just right from serverless' });
}

// this is option A: use the existing runtime key with a new value
export const config = { runtime: 'web' }
```

file `vercel.json`:
```js
{
  "functions": {
    "api/serverless.js": {
      "launcherType": "Web"
    }
  }
}
```
Using `vercel.json` is another option for enabling the feature.

Now install the cli from the tarballs: `(p)pnpm -g remove vercel` + `(p)npm -g i https://vercel-XYZ.vercel.sh/tarballs/vercel.tgz`

You can try it in dev mode: `vc dev -d` + `curl -s http://localhost:3000/api/serverless | jq .`

Option A can be deployed with `vc deploy -b VERCEL_DEBUG=1 -b FORCE_BUILD_IN_REGION=lhr1 --force`.
Option B can not, because it depends on `api-deployment` service, which does not allow `launcherType` key in configuration file.
