### PR TITLE
[cli] add --env support to `vercel build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -57,6 +57,7 @@ import { initCorepack, cleanupCorepack } from '../util/build/corepack';
 import { sortBuilders } from '../util/build/sort-builders';
 import { toEnumerableError } from '../util/error';
 import { validateConfig } from '../util/validate-config';
+import { parseEnv } from '../util/parse-env';
 
 import { setMonorepoDefaultSettings } from '../util/build/monorepo';
 
@@ -131,6 +132,7 @@ export default async function main(client: Client): Promise<number> {
   // Parse CLI args
   const argv = getArgs(client.argv.slice(2), {
     '--cwd': String,
+    '--env': [String],
     '--output': String,
     '--prod': Boolean,
     '--yes': Boolean,
@@ -227,6 +229,15 @@ export default async function main(client: Client): Promise<number> {
       output.debug(`Loaded environment variables from "${envPath}"`);
     }
 
+    // Merge dotenv config, `env` from `--env` / `-e` arguments
+    const deploymentEnv = Object.assign({}, parseEnv(argv['--env']));
+
+    if (Object.keys(deploymentEnv).length > 0) {
+      output.debug(`Loaded environment variables from --env`);
+      for (const key of Object.keys(deploymentEnv)) {
+        process.env[key] = deploymentEnv[key];
+      }
+    }
     // For Vercel Analytics support
     if (project.settings.analyticsId) {
       envToUnset.add('VERCEL_ANALYTICS_ID');

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -72,7 +72,7 @@ import { isValidArchive } from '../../util/deploy/validate-archive-format';
 import { parseEnv } from '../../util/parse-env';
 import { errorToString, isErrnoException, isError } from '@vercel/error-utils';
 import { pickOverrides } from '../../util/projects/project-settings';
-
+import { addProcessEnv } from '../../util/add-process-env';
 export default async (client: Client): Promise<number> => {
   const { output } = client;
 
@@ -806,37 +806,6 @@ function handleCreateDeployError(
 
   return error;
 }
-
-const addProcessEnv = async (
-  log: (str: string) => void,
-  env: typeof process.env
-) => {
-  let val;
-
-  for (const key of Object.keys(env)) {
-    if (typeof env[key] !== 'undefined') {
-      continue;
-    }
-
-    val = process.env[key];
-
-    if (typeof val === 'string') {
-      log(
-        `Reading ${chalk.bold(
-          `"${chalk.bold(key)}"`
-        )} from your env (as no value was specified)`
-      );
-      // Escape value if it begins with @
-      env[key] = val.replace(/^@/, '\\@');
-    } else {
-      throw new Error(
-        `No value specified for env ${chalk.bold(
-          `"${chalk.bold(key)}"`
-        )} and it was not found in your env.`
-      );
-    }
-  }
-};
 
 const printDeploymentStatus = async (
   output: Output,

--- a/packages/cli/src/util/add-process-env.ts
+++ b/packages/cli/src/util/add-process-env.ts
@@ -1,0 +1,31 @@
+import chalk from 'chalk';
+
+export const addProcessEnv = async (
+  log: (str: string) => void,
+  env: typeof process.env
+) => {
+  let val;
+  for (const key of Object.keys(env)) {
+    if (typeof env[key] !== 'undefined') {
+      continue;
+    }
+
+    val = process.env[key];
+
+    if (typeof val === 'string') {
+      log(
+        `Reading ${chalk.bold(
+          `"${chalk.bold(key)}"`
+        )} from your env (as no value was specified)`
+      );
+      // Escape value if it begins with @
+      env[key] = val.replace(/^@/, '\\@');
+    } else {
+      throw new Error(
+        `No value specified for env ${chalk.bold(
+          `"${chalk.bold(key)}"`
+        )} and it was not found in your env.`
+      );
+    }
+  }
+};


### PR DESCRIPTION
### Related Issues

Adds support for supplying environment variables via `--env` for `vercel build`.

This will make deploying runtime environment variables much more straightforward for Vercel customers that are primarily deploying via the CLI and do not have a git repository linked.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
