### PR TITLE
[docs] add more details on local development

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,6 +23,12 @@ yarn test-unit
 
 Make sure all the tests pass before making changes.
 
+### Running Vercel CLI Changes
+
+You can use `yarn dev <cli-commands...>` to invoke Vercel CLI with local changes.
+
+See [CLI Local Development](../packages/cli#local-development) for more details.
+
 ## Verifying your change
 
 Once you are done with your changes (we even suggest doing it along the way), make sure all the tests still pass by running:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project uses [yarn](https://yarnpkg.com/) to install dependencies and run s
 
 You can use the `dev` script to run local changes as if you were invoking Vercel CLI. For example, `vercel deploy --cwd=/path/to/project` could be run with local changes with `yarn dev deploy --cwd=/path/to/project`.
 
-See the [Contributing Guidelines](./.github/CONTRIBUTING.md) for full documentation.
+See the [Contributing Guidelines](./.github/CONTRIBUTING.md) for more details.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ For details on how to use Vercel, check out our [documentation](https://vercel.c
 
 ## Contributing
 
+This project uses [yarn](https://yarnpkg.com/) to install dependencies and run scripts.
+
+You can use the `dev` script to run local changes as if you were invoking Vercel CLI. For example, `vercel deploy --cwd=/path/to/project` could be run with local changes with `yarn dev deploy --cwd=/path/to/project`.
+
+See the [Contributing Guidelines](./.github/CONTRIBUTING.md) for full documentation.
+
+## Reference
+
 - [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
-- [Contributing Guidelines](./.github/CONTRIBUTING.md)
+- 
 - [Apache 2.0 License](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ See the [Contributing Guidelines](./.github/CONTRIBUTING.md) for full documentat
 ## Reference
 
 - [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
-- 
+- [Contributing Guidelines](./.github/CONTRIBUTING.md)
 - [Apache 2.0 License](./LICENSE)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,6 +51,8 @@ At this point you can make modifications to the CLI source code and test them ou
 cd packages/cli
 ```
 
+### `yarn dev <cli-commands...>`
+
 From within the `packages/cli` directory, you can use the "dev" script to quickly execute Vercel CLI from its TypeScript source code directly (without having to manually compile first). For example:
 
 ```bash


### PR DESCRIPTION
Add more places that make it clear you can `yarn dev <cli commands>` to the in-repo docs.