### PR TITLE
[docs] make `yarn dev` usage clearer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,12 @@ Make sure all the tests pass before making changes.
 
 ### Running Vercel CLI Changes
 
-You can use `yarn dev <cli-commands...>` to invoke Vercel CLI with local changes.
+You can use `yarn dev` from the `cli` package to invoke Vercel CLI with local changes:
+
+```
+cd ./packages/cli
+yarn dev <cli-commands...>
+```
 
 See [CLI Local Development](../packages/cli#local-development) for more details.
 


### PR DESCRIPTION
Follow-up from: https://github.com/vercel/vercel/pull/8960

Makes the `yarn dev` usage clearer. It needs to be run in the CLI package.