### PR TITLE
[dev] Update the templates to get closer to production

### DIFF
--- a/packages/cli/src/util/dev/templates/error.jst
+++ b/packages/cli/src/util/dev/templates/error.jst
@@ -1,9 +1,26 @@
 <main>
+  {{? it.error_code == 'EDGE_FUNCTION_INVOCATION_FAILED' }}
+    <p class="error-title error-title-guilty">
+      <strong>This Edge Function</strong><span> has crashed.</span>
+    </p>
+  {{? }}
+  {{? it.error_code == 'FUNCTION_INVOCATION_FAILED' }}
+    <p class="error-title error-title-guilty">
+      <strong>This Serverless Function</strong><span> has crashed.</span>
+    </p>
+  {{? }}
   <p class="devinfo-container">
     <span class="error-code"><strong>{{= it.http_status_code }}</strong>: {{! it.http_status_description }}</span>
     {{? it.error_code }}
     <span class="devinfo-line">Code: <code>{{! it.error_code }}</code></span>
     {{?}}
     <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
+  </p>
+  <p>
+    <ul>
+      <li>
+        Check the logs in your terminal window to see the application error.
+      </li>
+    </ul>
   </p>
 </main>

--- a/packages/cli/src/util/dev/templates/error_404.jst
+++ b/packages/cli/src/util/dev/templates/error_404.jst
@@ -6,4 +6,6 @@
     {{?}}
     <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
   </p>
+  
+  <a href="https://vercel.link/404"><div class="note">Click here to learn more about this error.</div></a>
 </main>

--- a/packages/cli/src/util/dev/templates/error_502.jst
+++ b/packages/cli/src/util/dev/templates/error_502.jst
@@ -1,38 +1,4 @@
-<header>
-  <div class="header-item first{{? it.app_error }} active{{?}}">
-    <svg class="header-item-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      {{? it.app_error }}
-      <circle cx="8" cy="8" r="8" fill="#FF0080" />
-      {{??}}
-      <circle cx="8" cy="8" r="7.5" stroke="#CCCCCC" />
-      {{?}}
-    </svg>
-    <div class="header-item-content">
-      <h1>Application Error</h1>
-      <p>The error occurred in the hosted application</p>
-    </div>
-  </div>
-  <div class="header-item{{? !it.app_error }} active{{?}}">
-    <svg class="header-item-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      {{? !it.app_error }}
-      <circle cx="8" cy="8" r="8" fill="#FF0080" />
-      {{??}}
-      <circle cx="8" cy="8" r="7.5" stroke="#CCCCCC" />
-      {{?}}
-    </svg>
-    <div class="header-item-content">
-      <h1>Platform Error</h1>
-      <p>The error occurred in the infrastructure layer</p>
-    </div>
-  </div>
-</header>
 <main>
-  <p>
-    <h1 class="error-title">{{! it.title }}</h1>
-    {{? it.subtitle }}
-    <p>{{! it.subtitle }}</p>
-    {{?}}
-  </p>
   <p class="devinfo-container">
     <span class="error-code"><strong>{{= it.http_status_code }}</strong>: {{! it.http_status_description }}</span>
     {{? it.error_code }}
@@ -40,22 +6,11 @@
     {{?}}
     <span class="devinfo-line">ID: <code>{{! it.request_id }}</code>
   </p>
-  {{? it.app_error }}
   <p>
     <ul>
       <li>
         Check the logs in your terminal window to see the application error.
       </li>
     </ul>
-    <a target="_blank" href="https://vercel.com/docs/error/application/{{= it.error_code }}" class="docs-link" rel="noopener noreferrer">Developer Documentation →</a>
   </p>
-  {{??}}
-  <p>
-    <ul>
-      <li>
-        Please open a <a target="_blank" href="https://github.com/vercel/vercel/issues/new/choose">GitHub issue</a> describing the problem you are experiencing with <code>vercel dev</code>.
-      </li>
-    </ul>
-  </p>
-  {{?}}
 </main>

--- a/packages/cli/src/util/dev/templates/error_base.jst
+++ b/packages/cli/src/util/dev/templates/error_base.jst
@@ -8,7 +8,8 @@
     <style>
       html {
         font-size: 62.5%;
-        box-sizing: border-box
+        box-sizing: border-box;
+        height: -webkit-fill-available
       }
 
       *,
@@ -29,7 +30,9 @@
         text-rendering: optimizeLegibility;
         hyphens: auto;
         height: 100vh;
+        height: -webkit-fill-available;
         max-height: 100vh;
+        max-height: -webkit-fill-available;
         margin: 0
       }
 
@@ -88,7 +91,7 @@
         display: flex;
         justify-content: center;
         flex-direction: column;
-        min-height: 100vh
+        min-height: 100%
       }
 
       main {
@@ -103,11 +106,17 @@
 
       .error-title {
         font-size: 2rem;
-        border-left: 2px solid #ff0080;
         padding-left: 22px;
         line-height: 1.5;
         margin-bottom: 24px;
-        font-weight: 500
+      }
+
+      .error-title-guilty {
+        border-left: 2px solid #ED367F;
+      }
+
+      .error-title-innocent {
+        border-left: 2px solid #59B89C;
       }
 
       main p {
@@ -222,11 +231,16 @@
         margin-left: .8rem
       }
 
+      .note {
+        padding: 8pt 16pt;
+        border-radius: 5px;
+        border: 1px solid #0070f3;
+        font-size: 14px;
+        line-height: 1.8;
+        color: #0070f3;
+      }
+
       @media (max-width:500px) {
-        .devinfo-container .devinfo-line {
-          display: flex;
-          flex-direction: column
-        }
         .devinfo-container .devinfo-line code {
           margin-top: .4rem
         }
@@ -253,25 +267,18 @@
           font-size: 1.4rem;
           line-height: 1.55;
         }
+        footer {
+          display: none;
+        }
+        .note {
+          margin-top: 16px;
+        }
       }
     </style>
   </head>
   <body>
     <div class="container">
       {{=it.view}}
-      <footer>
-        <a href="https://vercel.com" target="_blank" rel="noopener noreferrer">Powered by
-          <svg height="20" viewBox="0 0 131 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17.0669.0 34.1338 29.5211H0L17.0669.0z" fill="#000"></path>
-            <path d="M73.6183 15.6831C73.6183 10.932 70.1127 7.61091 65.0849 7.61091 60.057 7.61091 56.5514 10.932 56.5514 15.6831 56.5514 20.3419 60.3338 23.7553 65.5461 23.7553 68.406 23.7553 70.9891 22.6944 72.6497 20.757L69.513 18.9581C68.5444 19.9268 67.1144 20.5264 65.5461 20.5264 63.2398 20.5264 61.2563 19.281 60.5644 17.3898L60.4261 17.0669H73.4799C73.5722 16.6056 73.6183 16.1444 73.6183 15.6831zM60.3799 14.2993 60.4722 14.0225C61.0718 12.0391 62.8246 10.8398 65.0387 10.8398 67.2989 10.8398 69.0056 12.0391 69.6053 14.0225L69.6975 14.2993H60.3799z" fill="#000"></path>
-            <path d="M123.297 15.6831C123.297 10.932 119.791 7.61091 114.763 7.61091 109.736 7.61091 106.23 10.932 106.23 15.6831 106.23 20.3419 110.012 23.7553 115.225 23.7553 118.085 23.7553 120.668 22.6944 122.328 20.757L119.192 18.9581C118.223 19.9268 116.793 20.5264 115.225 20.5264 112.918 20.5264 110.935 19.281 110.243 17.3898L110.105 17.0669H123.158C123.251 16.6056 123.297 16.1444 123.297 15.6831zM110.058 14.2993 110.151 14.0225C110.75 12.0391 112.503 10.8398 114.717 10.8398 116.977 10.8398 118.684 12.0391 119.284 14.0225L119.376 14.2993H110.058z" fill="#000"></path>
-            <path d="M101.156 13.0539 104.293 11.2549C102.817 8.94858 100.187 7.65703 97.0046 7.65703 91.9768 7.65703 88.4711 10.9782 88.4711 15.7292 88.4711 20.4803 91.9768 23.8014 97.0046 23.8014 100.187 23.8014 102.817 22.5098 104.293 20.2035L101.156 18.4046C100.326 19.7884 98.8497 20.5725 97.0046 20.5725 94.0986 20.5725 92.1613 18.6352 92.1613 15.7292 92.1613 12.8232 94.0986 10.8859 97.0046 10.8859 98.8035 10.8859 100.326 11.6701 101.156 13.0539z" fill="#000"></path>
-            <path d="M130.216 2.5831H126.526V23.3401H130.216V2.5831z" fill="#000"></path>
-            <path d="M59.2729 2.5831H55.0292L46.9109 16.6056 38.7926 2.5831H34.5028L46.9109 23.9859 59.2729 2.5831z" fill="#000"></path>
-            <path d="M85.3806 11.9007C85.7958 11.9007 86.2109 11.9468 86.6261 12.0391V8.1183C83.4894 8.21056 80.5373 9.96338 80.5373 12.1313V8.1183H76.8472V23.3401H80.5373V16.744C80.5373 13.8841 82.5208 11.9007 85.3806 11.9007z" fill="#000"></path>
-          </svg>
-        </a>
-      </footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### Related Issues

Update the templates so that `vc dev` is closer to production visually. The two are different and on production there are a large number of error conditions that `vc dev` does not handle, so this handles a few more of the more common situations. There's probably more we could do here.

I have a test application here: https://testing-errors-andymckay.vercel.app/ so here's a list of screenshots and URLs.

*404*
Example url: https://testing-errors-andymckay.vercel.app/api/not-found

`vc dev` before:

<img width="731" alt="Screen Shot 2022-11-25 at 3 50 54 PM" src="https://user-images.githubusercontent.com/74699/204063815-b0fa0e74-c397-4ce7-8c69-10df4af7b956.png">

Production:

<img width="664" alt="Screen Shot 2022-11-25 at 3 05 13 PM" src="https://user-images.githubusercontent.com/74699/204063305-e3b5fbee-9784-457f-a029-65a3c66d003e.png">

`vc dev` after:

<img width="672" alt="Screen Shot 2022-11-25 at 3 05 29 PM" src="https://user-images.githubusercontent.com/74699/204063301-39b87612-5e9b-453a-8e19-47d4c2309b89.png">

This is pretty much the same. The link goes to [this page](https://vercel.com/docs/concepts/edge-network/frequently-asked-questions#why-do-i-see-a-404-error-when-accessing-my-deployment) which I thought was useful in local development.

*500: Serverless error*
Example url: https://testing-errors-andymckay.vercel.app/api/500

`vc dev` before:

<img width="753" alt="Screen Shot 2022-11-25 at 3 52 31 PM" src="https://user-images.githubusercontent.com/74699/204063860-b6bdbd34-cff5-4398-8c30-6020bea8479d.png">

(trimmed the powered by bit at the bottom)

Production:

<img width="800" alt="Screen Shot 2022-11-25 at 3 04 55 PM" src="https://user-images.githubusercontent.com/74699/204063365-110416e2-a402-4214-ac6a-7472c7c0d279.png">

`vc dev` after:

<img width="815" alt="Screen Shot 2022-11-25 at 3 33 00 PM" src="https://user-images.githubusercontent.com/74699/204063375-85913e95-dd3c-4e78-b8da-5c5f9dadb31d.png">

Rather than pointing to logs, it refers a user to check their terminal. The message about connection and vercel working correctly seemed not relevant in a local situation.

*500: Edge error*
Example url: https://testing-errors-andymckay.vercel.app/api/middleware-error

`vc dev` before:

<img width="655" alt="Screen Shot 2022-11-25 at 3 51 58 PM" src="https://user-images.githubusercontent.com/74699/204063832-09c1b24a-e3f4-4574-8d2b-e4b84044217e.png">

Production:

<img width="850" alt="Screen Shot 2022-11-25 at 3 05 06 PM" src="https://user-images.githubusercontent.com/74699/204063410-9413f327-4c16-4f84-a508-152de5b767a8.png">

`vc dev`:

<img width="848" alt="Screen Shot 2022-11-25 at 3 33 11 PM" src="https://user-images.githubusercontent.com/74699/204063430-2985f835-57aa-427e-8d35-cee790c9f4f3.png">

Rather than pointing to logs, it refers a user to check their terminal. The message about connection and vercel working correctly seemed not relevant in a local situation.

*502: Error*

I couldn't reproduce this on production, yet. Or really in `vc dev`, yet. But it will look very similar to the 500 error but with the appropriate error code and no "blame" assigned above it.

I have removed the `Powered by Vercel` at the bottom.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
