### PR TITLE
[node] Add caching to TS compile per tsconfig.json

### DIFF
--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -114,6 +114,11 @@ function cachedLookup<T>(fn: (arg: string) => T): (arg: string) => T {
 }
 
 /**
+ * Maps the config path to a build func
+ */
+const configFileToBuildMap = new Map<string, Build>();
+
+/**
  * Register TypeScript compiler.
  */
 export function register(opts: Options = {}): Register {
@@ -184,10 +189,8 @@ export function register(opts: Options = {}): Register {
     }
   }
 
-  // we create a custom build per tsconfig.json instance
-  const builds = new Map<string, Build>();
   function getBuild(configFileName = ''): Build {
-    let build = builds.get(configFileName);
+    let build = configFileToBuildMap.get(configFileName);
     if (build) return build;
 
     const config = readConfig(configFileName);
@@ -314,13 +317,8 @@ export function register(opts: Options = {}): Register {
       };
     }
 
-    builds.set(
-      configFileName,
-      (build = {
-        getOutput,
-        getOutputTypeCheck,
-      })
-    );
+    build = { getOutput, getOutputTypeCheck };
+    configFileToBuildMap.set(configFileName, build);
     return build;
   }
 


### PR DESCRIPTION
Since introducing `vc build`, we no longer have isolated builds. This means we can share the cache across builds and improve TS compile across multiple builds.

For example, `api/foo.js` and `api/bar.js` are two different builds but they will likely share the same `tsconfig.json`. So this PR caches the initialization used before running the TS compiler so that it can be shared between builds of the same deployment.

In one customer build, we saw deployment time drop from 14 min to 7 min.

- Related to https://github.com/vercel/customer-issues/issues/925