### PR TITLE
edge: format MB with sepace separator

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/aws-lambda": "8.10.19",
     "@types/buffer-crc32": "0.2.0",
+    "@types/bytes": "3.1.1",
     "@types/convert-source-map": "1.5.2",
     "@types/find-up": "4.0.0",
     "@types/fs-extra": "8.0.0",
@@ -49,6 +50,7 @@
     "@vercel/routing-utils": "2.1.3",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",
+    "bytes": "3.1.2",
     "cheerio": "1.0.0-rc.10",
     "convert-source-map": "1.8.0",
     "esbuild": "0.12.22",

--- a/packages/next/src/edge-function-source/get-edge-function-source.ts
+++ b/packages/next/src/edge-function-source/get-edge-function-source.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { EDGE_FUNCTION_SIZE_LIMIT } from './constants';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import { prettyKibibytes } from '../utils';
+import { prettyBytes } from '../utils';
 
 // @ts-expect-error this is a prebuilt file, based on `../../scripts/build-edge-function-template.js`
 import template from '../../dist/___get-nextjs-edge-function.js';
@@ -85,9 +85,9 @@ async function validateSize(script: string, wasmFiles: string[]) {
   const gzipped = await gzip(content);
   if (gzipped.length > EDGE_FUNCTION_SIZE_LIMIT) {
     throw new Error(
-      `Exceeds maximum edge function size: ${prettyKibibytes(
+      `Exceeds maximum edge function size: ${prettyBytes(
         gzipped.length
-      )} / ${prettyKibibytes(EDGE_FUNCTION_SIZE_LIMIT)}`
+      )} / ${prettyBytes(EDGE_FUNCTION_SIZE_LIMIT)}`
     );
   }
 }

--- a/packages/next/src/edge-function-source/get-edge-function-source.ts
+++ b/packages/next/src/edge-function-source/get-edge-function-source.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { EDGE_FUNCTION_SIZE_LIMIT } from './constants';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import bytes from 'pretty-bytes';
+import { prettyKibibytes } from '../utils';
 
 // @ts-expect-error this is a prebuilt file, based on `../../scripts/build-edge-function-template.js`
 import template from '../../dist/___get-nextjs-edge-function.js';
@@ -44,7 +44,9 @@ export async function getNextjsEdgeFunctionSource(
    * We validate at this point because we want to verify against user code.
    * It should not count the Worker wrapper nor the Next.js wrapper.
    */
-  const wasmFiles = (wasm ?? []).map(({ filePath }) => join(outputDir, filePath));
+  const wasmFiles = (wasm ?? []).map(({ filePath }) =>
+    join(outputDir, filePath)
+  );
   await validateSize(text, wasmFiles);
 
   // Wrap to fake module.exports
@@ -83,9 +85,9 @@ async function validateSize(script: string, wasmFiles: string[]) {
   const gzipped = await gzip(content);
   if (gzipped.length > EDGE_FUNCTION_SIZE_LIMIT) {
     throw new Error(
-      `Exceeds maximum edge function size: ${bytes(
+      `Exceeds maximum edge function size: ${prettyKibibytes(
         gzipped.length
-      )} / ${bytes(EDGE_FUNCTION_SIZE_LIMIT)}`
+      )} / ${prettyKibibytes(EDGE_FUNCTION_SIZE_LIMIT)}`
     );
   }
 }

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -43,7 +43,8 @@ import bytes from 'bytes';
 
 type stringMap = { [key: string]: string };
 
-export const prettyKibibytes = (n: number) => bytes(n, { unitSeparator: ' ' });
+const _prettyBytes = (n: number) => bytes(n, { unitSeparator: ' ' });
+export { _prettyBytes as prettyBytes }
 
 // Identify /[param]/ in route string
 // eslint-disable-next-line no-useless-escape

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -39,8 +39,11 @@ import { getNextjsEdgeFunctionSource } from './edge-function-source/get-edge-fun
 import type { LambdaOptionsWithFiles } from '@vercel/build-utils/dist/lambda';
 import { stringifySourceMap } from './sourcemapped';
 import type { RawSourceMap } from 'source-map';
+import bytes from 'bytes';
 
 type stringMap = { [key: string]: string };
+
+export const prettyKibibytes = (n: number) => bytes(n, { unitSeparator: ' ' });
 
 // Identify /[param]/ in route string
 // eslint-disable-next-line no-useless-escape

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,6 +2626,11 @@
   resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.0.0.tgz#549eeacd0a8fecfaa459334583a4edcee738e6db"
   integrity sha512-ZF43+CIIlzngQe8/Zo7L1kpY9W8O6rO006VDz3c5iM21ddtXWxCEyOXyft+q4pVF2tGqvrVuVrEDH1+gJEi1fQ==
 
+"@types/bytes@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.1.1.tgz#67a876422e660dc4c10a27f3e5bcfbd5455f01d0"
+  integrity sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==
+
 "@types/chance@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.3.tgz#d19fe9391288d60fdccd87632bfc9ab2b4523fea"
@@ -4394,6 +4399,11 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cac@^6.7.12:
   version "6.7.12"


### PR DESCRIPTION
The Edge Function size limit is declared in KiB, not in KB:

https://github.com/vercel/vercel/blob/d7654e2252660f6e3fd6f1de375ab8237dc6e178/packages/next/src/edge-function-source/constants.ts#L8

And `pretty-bytes` doesn't support base-2 as input:

```js
require('pretty-bytes')(1024 * 1024* 4) // => '4.19 MB' :(
```

Instead, `bytes` is used:

```js
require('bytes')(1024 * 1024* 4, { unitSeparator: ' ' }) // => '4 MB' 🙂
```
