### PR TITLE
[node-bridge] Add `res.waitUntil` for lambdas and wait for handler to finish

### DIFF
--- a/packages/node-bridge/bridge.d.ts
+++ b/packages/node-bridge/bridge.d.ts
@@ -14,5 +14,10 @@ export declare class Bridge {
   listen(): void | Server;
   launcher(event: VercelProxyEvent, context: any): Promise<VercelProxyResponse>;
   consumeEvent(reqId: string): VercelProxyRequest;
+  waitUntil(
+    waitUntilId: string,
+    promise: Promise<any>,
+    isHandler: boolean
+  ): void;
 }
 export {};

--- a/packages/node-bridge/types.ts
+++ b/packages/node-bridge/types.ts
@@ -68,4 +68,5 @@ export type VercelResponse = ServerResponse & {
   json: (jsonBody: any) => VercelResponse;
   status: (statusCode: number) => VercelResponse;
   redirect: (statusOrUrl: string | number, url?: string) => VercelResponse;
+  waitUntil: (promise: Promise<any>) => void;
 };


### PR DESCRIPTION
An attempt to add `waitUntil` to node lambdas and to prevent code execution from getting cut after `res.end()`

**DISCLAIMER**: this is my first time reading into the node/node-bridge packages, and I haven't found a good way to run/test this locally, so I might have missed some edge cases

From reading into node-bridge, I realized the reason why the execution of the handler can get cut-off is because in the bridge, we only wait for the response to be streamed back to end the event, but not for the actual handler to finish.

I tried to add a `waitUntil` helper that gets attached to the response backed by the node-bridge for a specific request by id.
It also adds the handler itself, so it can be awaited before finishing execution.

There's a few areas that I'm unsure about:

### 1

```
const req = request(
        { hostname: '127.0.0.1', port, path, method },
        socket && url && cipher
          ? getStreamResponseCallback({ url, socket, cipher, resolve, reject })
          : getResponseCallback({ isApiGateway, resolve, reject })
      );
```

Here, I'm not sure when each case happens, but reading through it, it seems like if `getStreamResponseCallback` is used, this will work as expected and stream the response back, while waiting to finish the tasks afterwards. But if `getResponseCallback` is used, then it'll still wait for the tasks to finish but it'll also hold the response until those are done.

### 2

In `node-bridge/launcher.js`, in `getListener` there's a 3rd case for exporting an entire Server object, or even having a server listen automatically. In those cases this wrapper won't apply, since it wraps the listener.

I _could_ try to make it work by wrapping the prototype of `ServerResponse` like we do for the `Server`, but I wasn't sure if this is something legacy that we don't need to worry about before I go down that route.

### 3

I _think_ this will automatically work for Next.js as well, since from what I see the lambda just uses this launcher as well, but it'll probably need updated types and actual implementation of a similar functionality in the next.js repo as well, to handle the dev/prod server.

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
