### PR TITLE
[remix] use `@remix-run/dev` version when `@remix-run/vercel` package is missing

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -29,8 +29,7 @@ import { findConfig } from './utils';
 // Name of the Remix runtime adapter npm package for Vercel
 const REMIX_RUNTIME_ADAPTER_NAME = '@remix-run/vercel';
 
-// Pinned version of the last verified working version of the adapter
-const REMIX_RUNTIME_ADAPTER_VERSION = '1.6.1';
+const REMIX_DEV_NAME = '@remix-run/dev';
 
 export const build: BuildV2 = async ({
   entrypoint,
@@ -81,8 +80,10 @@ export const build: BuildV2 = async ({
       await fs.readFile(packageJsonPath, 'utf8')
     );
     const { dependencies = {}, devDependencies = {} } = packageJson;
-
     let modified = false;
+
+    const remixVersion = devDependencies[REMIX_DEV_NAME];
+
     if (REMIX_RUNTIME_ADAPTER_NAME in devDependencies) {
       dependencies[REMIX_RUNTIME_ADAPTER_NAME] =
         devDependencies[REMIX_RUNTIME_ADAPTER_NAME];
@@ -92,9 +93,9 @@ export const build: BuildV2 = async ({
       );
       modified = true;
     } else if (!(REMIX_RUNTIME_ADAPTER_NAME in dependencies)) {
-      dependencies[REMIX_RUNTIME_ADAPTER_NAME] = REMIX_RUNTIME_ADAPTER_VERSION;
+      dependencies[REMIX_RUNTIME_ADAPTER_NAME] = remixVersion;
       console.log(
-        `Warning: Adding "${REMIX_RUNTIME_ADAPTER_NAME}" v${REMIX_RUNTIME_ADAPTER_VERSION} to \`dependencies\`. You should commit this change.`
+        `Warning: Adding "${REMIX_RUNTIME_ADAPTER_NAME}" v${remixVersion} to \`dependencies\`. You should commit this change.`
       );
       modified = true;
     }


### PR DESCRIPTION
deploying a remix app without explicitly having the `@remix-run/vercel` package installed will cause an older version (1.6.1) to be installed which then results in some runtime issues as we end up with multiple copies of remix packages due to us using a pinned version in each of our packages

this PR removes the hardcoded 1.6.1 version, and instead will get the version from `@remix-run/dev`

Signed-off-by: Logan McAnsh <logan@mcan.sh>

### Related Issues

> closes #9010 
> closes https://github.com/remix-run/remix/issues/4759

### 📋 Checklist

<!--
  Please keep your PR as a Draft until the checklist is complete
-->

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
