### PR TITLE
feat(node,cli): allows 'edge' as possible runtime value

### DIFF
--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-no-handler.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-no-handler.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export async function notTheDefaultExport(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-runtime.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-runtime.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-startup.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-startup.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-syntax.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-syntax.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge'
+  runtime: 'edge'
 }
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-unknown-import.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-error-unknown-import.js
@@ -1,7 +1,7 @@
 import unknownModule from 'unknown-module-893427589372458934795843';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function-error/api/edge-no-response.js
+++ b/packages/cli/test/dev/fixtures/edge-function-error/api/edge-no-response.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function/api/edge-500-response.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/edge-500-response.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function/api/edge-import-browser.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/edge-import-browser.js
@@ -1,7 +1,7 @@
 import generateUUID from '../vendor/generate-uuid';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/edge-success.js
@@ -2,7 +2,7 @@ import { snakeCase } from 'snake-case';
 import { upper } from '../lib/upper';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/edge-function/api/webassembly.js
+++ b/packages/cli/test/dev/fixtures/edge-function/api/webassembly.js
@@ -1,6 +1,6 @@
 import mod from '../increment.wasm?module';
 
-export const config = { runtime: 'experimental-edge' };
+export const config = { runtime: 'edge' };
 
 const init$ = WebAssembly.instantiate(mod);
 

--- a/packages/cli/test/dev/fixtures/middleware-no-response/middleware.js
+++ b/packages/cli/test/dev/fixtures/middleware-no-response/middleware.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request, event) {

--- a/packages/cli/test/dev/fixtures/middleware-rewrite-404/api/edge.ts
+++ b/packages/cli/test/dev/fixtures/middleware-rewrite-404/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request: Request, event: Event) {

--- a/packages/cli/test/dev/fixtures/middleware-rewrite-404/middleware.ts
+++ b/packages/cli/test/dev/fixtures/middleware-rewrite-404/middleware.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default async function edge(request: Request, event: Event) {

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -194,7 +194,7 @@ test('[vercel dev] should handle config errors thrown in edge functions', async 
       /<strong>500<\/strong>: INTERNAL_SERVER_ERROR/g
     );
     expect(stderr).toMatch(
-      /Invalid function runtime "invalid-runtime-value" for "api\/edge-error-config.js". Valid runtimes are: \["experimental-edge"\]/g
+      /Invalid function runtime "invalid-runtime-value" for "api\/edge-error-config.js". Valid runtimes are: \["edge","experimental-edge"\]/g
     );
     expect(stderr).toMatch(
       /Failed to complete request to \/api\/edge-error-config: Error: socket hang up/g

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -356,7 +356,7 @@ test(
 
       const fileContents = `
           export const config = {
-            runtime: 'experimental-edge'
+            runtime: 'edge'
           }
 
           export default async function edge(request, event) {

--- a/packages/cli/test/fixtures/unit/commands/build/edge-function/api/edge.js
+++ b/packages/cli/test/fixtures/unit/commands/build/edge-function/api/edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default req => new Response('from edge');

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-browser.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-browser.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/prefer-browser';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-main.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-main.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/prefer-main';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-module.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/prefer-module.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/prefer-module';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-browser.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-browser.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/only-browser';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-classic.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-classic.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/only-classic';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-main.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-main.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/only-main';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-module.js
+++ b/packages/cli/test/fixtures/unit/commands/build/import-from-main-keys/api/use-module.js
@@ -1,7 +1,7 @@
 import describeYourself from '../packages/only-module';
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default function () {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -53,7 +53,12 @@ import type {
 import { getConfig } from '@vercel/static-config';
 
 import { Register, register } from './typescript';
-import { entrypointToOutputPath, getRegExpFromMatchers } from './utils';
+import {
+  EdgeRuntimes,
+  entrypointToOutputPath,
+  getRegExpFromMatchers,
+  isEdgeRuntime,
+} from './utils';
 
 export { shouldServe };
 
@@ -73,7 +78,7 @@ function isPortInfo(v: any): v is PortInfo {
   return v && typeof v.port === 'number';
 }
 
-const ALLOWED_RUNTIMES = ['nodejs', 'experimental-edge'];
+const ALLOWED_RUNTIMES = ['nodejs', ...Object.values(EdgeRuntimes)];
 
 const require_ = eval('require');
 
@@ -393,7 +398,7 @@ export const build: BuildV3 = async ({
 
   // Will output an `EdgeFunction` for when `config.middleware = true`
   // (i.e. for root-level "middleware" file) or if source code contains:
-  // `export const config = { runtime: 'experimental-edge' }`
+  // `export const config = { runtime: 'edge' }`
   let isEdgeFunction = isMiddleware;
 
   const project = new Project();
@@ -406,7 +411,7 @@ export const build: BuildV3 = async ({
         )} (must be one of: ${JSON.stringify(ALLOWED_RUNTIMES)})`
       );
     }
-    isEdgeFunction = staticConfig.runtime === 'experimental-edge';
+    isEdgeFunction = isEdgeRuntime(staticConfig.runtime);
   }
 
   debug('Tracing input files...');

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -67,3 +67,15 @@ export function logError(error: Error) {
     debug(error.stack.substring(errorMessageLength + 1));
   }
 }
+
+export enum EdgeRuntimes {
+  Edge = 'edge',
+  ExperimentalEdge = 'experimental-edge',
+}
+
+export function isEdgeRuntime(runtime?: string): runtime is EdgeRuntimes {
+  return (
+    runtime !== undefined &&
+    Object.values(EdgeRuntimes).includes(runtime as EdgeRuntimes)
+  );
+}

--- a/packages/node/test/fixtures/61-edge-function/api/edge.js
+++ b/packages/node/test/fixtures/61-edge-function/api/edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default req => {

--- a/packages/node/test/fixtures/62-edge-middleware/api/edge.js
+++ b/packages/node/test/fixtures/62-edge-middleware/api/edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 };
 
 export default req => {


### PR DESCRIPTION
### 📖 What's in there?

As part of Edge function GA, we're allowing `edge` as a runtime value.
This is adding to the allowed list, so we stay backward compatible.

[Linear ticket](https://linear.app/vercel/issue/EC-481/add-edge-to-the-list-of-allowed-runtimes)

I've kept one instance of `experimental-edge` in the test fixtures to ensure we still supports it.

### 📋 Checklist

####  🧪 Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [x] Issue from task tracker has a link to this PR
