### PR TITLE
feat: Script + workflow for upgrading SvelteKit example repo

### DIFF
--- a/.github/workflows/cron-update-sveltekit.yml
+++ b/.github/workflows/cron-update-sveltekit.yml
@@ -1,0 +1,25 @@
+name: Cron Update Next
+
+on:
+  # Run every 4 hours https://crontab.guru/every-4-hours
+  schedule:
+    - cron: '0 */4 * * *'
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        # 0 means fetch all commits so we can commit and push in the script below
+        with:
+          fetch-depth: 0
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # See https://github.com/actions/github-script#run-a-separate-file-with-an-async-function
+        with:
+          script: |
+            const script = require('./utils/update-sveltekit.js')
+            await script({ github, context })

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/parser": "5.21.0",
     "async-retry": "1.2.3",
     "buffer-replace": "1.0.0",
+    "create-svelte": "2.0.0-next.198",
     "eslint": "8.14.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "26.1.5",

--- a/utils/update-sveltekit.js
+++ b/utils/update-sveltekit.js
@@ -66,23 +66,21 @@ module.exports = async ({ github, context }) => {
 
   // replace the default adapter-static with adapter-vercel
   // fs paths are root-relative
-  const packageJsonContents = JSON.parse(
-    fs.readFileSync(PACKAGE_JSON_PATH.slice(1), 'utf8')
-  );
-  const svelteKitConfigContents = fs.readFileSync(
-    SVELTEKIT_CONFIG_PATH.slice(1),
-    'utf8'
-  );
+  const pjResolved = require.resolve(PACKAGE_JSON_PATH);
+  const skResolved = require.resolve(SVELTEKIT_CONFIG_PATH);
+
+  const packageJsonContents = JSON.parse(fs.readFileSync(pjResolved, 'utf8'));
+  const svelteKitConfigContents = fs.readFileSync(skResolved, 'utf8');
 
   delete packageJsonContents.devDependencies['@sveltejs/adapter-static'];
   packageJsonContents.devDependencies['@sveltejs/adapter-vercel'] = newVercel;
 
   fs.writeFileSync(
-    PACKAGE_JSON_PATH.slice(1),
+    pjResolved,
     JSON.stringify(packageJsonContents, null, '\t') + '\n'
   );
   fs.writeFileSync(
-    SVELTEKIT_CONFIG_PATH.slice(1),
+    skResolved,
     svelteKitConfigContents.replace('adapter-auto', 'adapter-vercel')
   );
 

--- a/utils/update-sveltekit.js
+++ b/utils/update-sveltekit.js
@@ -66,15 +66,18 @@ module.exports = async ({ github, context }) => {
 
   // replace the default adapter-static with adapter-vercel
 
-  const packageJsonContents = fs.readFileSync(PACKAGE_JSON_PATH, 'utf8');
+  const packageJsonContents = require(PACKAGE_JSON_PATH);
   const svelteKitConfigContents = fs.readFileSync(
     SVELTEKIT_CONFIG_PATH,
     'utf8'
   );
 
+  delete packageJsonContents.dependencies['@sveltejs/adapter-static'];
+  packageJsonContents.dependencies['@sveltejs/adapter-vercel'] = newVercel;
+
   fs.writeFileSync(
     PACKAGE_JSON_PATH,
-    packageJsonContents.replace('adapter-auto', 'adapter-vercel')
+    JSON.stringify(packageJsonContents, null, '\t') + '\n'
   );
   fs.writeFileSync(
     SVELTEKIT_CONFIG_PATH,

--- a/utils/update-sveltekit.js
+++ b/utils/update-sveltekit.js
@@ -30,15 +30,16 @@ module.exports = async ({ github, context }) => {
   const newKit = newVersion('@sveltejs/kit');
   const newVercel = newVersion('@sveltejs/adapter-vercel');
   const newCreate = newVersion('create-svelte');
-  const branch = `sveltekit-${`${newKit}-${newVercel}-${newCreate}`.replaceAll(
-    '.',
-    '-'
-  )}`;
 
   if (oldKit === newKit && oldVercel === newVercel && oldCreate === newCreate) {
     console.log(`SvelteKit package versions did not change; skipping update.`);
     return;
   }
+
+  const branch = `sveltekit-${`${newKit}-${newVercel}-${newCreate}`.replaceAll(
+    '.',
+    '-'
+  )}`;
 
   if (
     exec('git', ['ls-remote', '--heads', 'origin', branch]).toString().trim()

--- a/utils/update-sveltekit.js
+++ b/utils/update-sveltekit.js
@@ -1,0 +1,109 @@
+const { execFileSync } = require('child_process');
+let { create } = require('create-svelte');
+const fs = require('fs/promises');
+
+function exec(cmd, args, opts) {
+  console.log({ input: `${cmd} ${args.join(' ')}` });
+  const output = execFileSync(cmd, args, opts).toString().trim();
+  console.log({ output });
+  console.log();
+  return output;
+}
+
+function newVersion(packageName) {
+  return exec('npm', ['view', packageName, 'dist-tags.latest']);
+}
+
+const PACKAGE_JSON_PATH = '../examples/sveltekit/package.json';
+const SVELTEKIT_CONFIG_PATH = '../examples/sveltekit/svelte.config.js';
+
+/**
+ * Update the SvelteKit example. We care about three packages: SvelteKit,
+ * `adapter-vercel`, and `create-svelte`. If SvelteKit or `adapter-vercel` have changed,
+ * we can simply run `create-svelte` to update the example. If `create-svelte` has
+ * changed, we need to upgrade it, then run it to update the example.
+ */
+module.exports = async ({ github, context }) => {
+  const { '@sveltejs/kit': oldKit, '@sveltejs/adapter-vercel': oldVercel } =
+    require(PACKAGE_JSON_PATH).dependencies;
+  const { 'create-svelte': oldCreate } = require('./package.json').dependencies;
+  const newKit = newVersion('@sveltejs/kit');
+  const newVercel = newVersion('@sveltejs/adapter-vercel');
+  const newCreate = newVersion('create-svelte');
+  const branch = `sveltekit-${`${newKit}-${newVercel}-${newCreate}`.replaceAll(
+    '.',
+    '-'
+  )}`;
+
+  if (oldKit === newKit && oldVercel === newVercel && oldCreate === newCreate) {
+    console.log(`SvelteKit package versions did not change; skipping update.`);
+    return;
+  }
+
+  if (
+    exec('git', ['ls-remote', '--heads', 'origin', branch]).toString().trim()
+  ) {
+    console.log(`Branch ${branch} already exists, skipping update.`);
+    return;
+  }
+
+  if (oldCreate !== newCreate) {
+    exec('yarn', ['upgrade', 'create-svelte']);
+    const module = require('create-svelte');
+    create = module.create;
+  }
+
+  exec('rm', ['-rf', './examples/sveltekit']);
+  await create('./examples/sveltekit', {
+    name: 'sveltekit',
+    template: 'default',
+    types: 'checkjs',
+    prettier: true,
+    eslint: true,
+    playwright: true,
+    vitest: true,
+  });
+
+  // replace the default adapter-static with adapter-vercel
+
+  const packageJsonContents = fs.readFileSync(PACKAGE_JSON_PATH, 'utf8');
+  const svelteKitConfigContents = fs.readFileSync(
+    SVELTEKIT_CONFIG_PATH,
+    'utf8'
+  );
+
+  fs.writeFileSync(
+    PACKAGE_JSON_PATH,
+    packageJsonContents.replace('adapter-auto', 'adapter-vercel')
+  );
+  fs.writeFileSync(
+    SVELTEKIT_CONFIG_PATH,
+    svelteKitConfigContents.replace('adapter-auto', 'adapter-vercel')
+  );
+
+  exec('git', ['config', '--global', 'user.email', 'team@zeit.co']);
+  exec('git', ['config', '--global', 'user.name', 'Vercel Team Bot']);
+  exec('git', ['checkout', 'main']);
+  exec('git', ['checkout', '-b', branch]);
+  exec('git', ['add', '-A']);
+  exec('git', ['commit', '-m', branch]);
+  exec('git', ['push', 'origin', branch]);
+
+  const { repo, owner } = context.repo;
+
+  const pr = await github.rest.pulls.create({
+    owner,
+    repo,
+    head: branch,
+    base: 'main',
+    title: `[examples] Upgrade SvelteKit to version ${newKit}`,
+    body: `This auto-generated PR updates SvelteKit to version ${newKit}, adapter-vercel to version ${newVercel}, and create-svelte to version ${newCreate}.`,
+  });
+
+  await github.rest.pulls.requestReviewers({
+    owner,
+    repo,
+    pull_number: pr.data.number,
+    reviewers: ['ijjk', 'styfle'], // who?
+  });
+};

--- a/utils/update-sveltekit.js
+++ b/utils/update-sveltekit.js
@@ -1,6 +1,6 @@
 const { execFileSync } = require('child_process');
 let { create } = require('create-svelte');
-const fs = require('fs/promises');
+const fs = require('fs');
 
 function exec(cmd, args, opts) {
   console.log({ input: `${cmd} ${args.join(' ')}` });
@@ -65,22 +65,24 @@ module.exports = async ({ github, context }) => {
   });
 
   // replace the default adapter-static with adapter-vercel
-
-  const packageJsonContents = require(PACKAGE_JSON_PATH);
+  // fs paths are root-relative
+  const packageJsonContents = JSON.parse(
+    fs.readFileSync(PACKAGE_JSON_PATH.slice(1), 'utf8')
+  );
   const svelteKitConfigContents = fs.readFileSync(
-    SVELTEKIT_CONFIG_PATH,
+    SVELTEKIT_CONFIG_PATH.slice(1),
     'utf8'
   );
 
-  delete packageJsonContents.dependencies['@sveltejs/adapter-static'];
-  packageJsonContents.dependencies['@sveltejs/adapter-vercel'] = newVercel;
+  delete packageJsonContents.devDependencies['@sveltejs/adapter-static'];
+  packageJsonContents.devDependencies['@sveltejs/adapter-vercel'] = newVercel;
 
   fs.writeFileSync(
-    PACKAGE_JSON_PATH,
+    PACKAGE_JSON_PATH.slice(1),
     JSON.stringify(packageJsonContents, null, '\t') + '\n'
   );
   fs.writeFileSync(
-    SVELTEKIT_CONFIG_PATH,
+    SVELTEKIT_CONFIG_PATH.slice(1),
     svelteKitConfigContents.replace('adapter-auto', 'adapter-vercel')
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5246,6 +5246,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+create-svelte@2.0.0-next.198:
+  version "2.0.0-next.198"
+  resolved "https://registry.yarnpkg.com/create-svelte/-/create-svelte-2.0.0-next.198.tgz#cc6221853d6f6aee529caed3fa28f7b5b8cad0ba"
+  integrity sha512-XeZZGGoVMI0oG8Ql3q8+LccGL1ftGvIRIwT9hMXbaHeJj5DUqgjKIr6vVIf9Hqm/YZH+sL+BPAc2pwV7D9inew==
+  dependencies:
+    kleur "^4.1.5"
+    prompts "^2.4.2"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -9190,6 +9198,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kleur@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
 latest-version@^5.0.0, latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -11175,6 +11188,14 @@ prompts@^2.0.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
   integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
+prompts@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"


### PR DESCRIPTION
DO NOT MERGE UNTIL SK LAUNCH. Because the template currently uses the "next" tag, it'll always open a PR.

Adds a script and associated workflow to automatically keep the SvelteKit example up-to-date. This script checks three packages:

- `@sveltejs/kit`
- `@sveltejs/adapter-vercel`
- `create-svelte`

If either of the first two have changed, we can just rerun `create-svelte`. If `create-svelte` has changed, we have to bump its package version (it's installed in the workspace root), re-import it, and then run it. We also have to do a find-and-replace in `/examples/sveltekit/package.json` and `/examples/sveltekit/svelte.config.js` for `adapter-auto` => `adapter-vercel`.

### Related Issues

N/A that I'm aware of -- discussed via Slack with @leerob and @Rich-Harris 

### 📋 Checklist
 
- [x] Add workflow to fire version check logic
- [x] Write version check logic
- [ ] Who should be marked as reviewers? @ijjk and @styfle are, currently, as they were on the Next.js script, but I'd be happy to instead list myself and (potentially, not volunteering them on their behalf), @Rich-Harris and/or @dummdidumm.

#### Tests

- [ ] The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with `yarn test-unit`

#### Code Review

- [x] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
