### PR TITLE
[build-utils] Add meta buildEnv to spawn env

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -218,7 +218,7 @@ export function getSpawnOptions(
   nodeVersion: NodeVersion
 ): SpawnOptions {
   const opts = {
-    env: cloneEnv(process.env),
+    env: { ...cloneEnv(process.env), ...meta.buildEnv },
   };
 
   if (!meta.isDev) {

--- a/packages/build-utils/test/unit.get-spawn-options.test.ts
+++ b/packages/build-utils/test/unit.get-spawn-options.test.ts
@@ -108,4 +108,20 @@ describe('Test `getSpawnOptions()`', () => {
       expect(opts.env?.PATH).toBe(want);
     });
   }
+
+  describe('meta buildEnv', () => {
+    it('should add meta buildEnv to the env', () => {
+      const opts = getSpawnOptions({
+        buildEnv: {
+          NEXT_PRIVATE_STANDALONE: 'true'
+        }
+      }, {
+        major: 18, range: '18.x', runtime: 'nodejs18.x'
+      })
+
+      expect(opts.env.NEXT_PRIVATE_STANDALONE).toBe('true')
+    })
+  })
 });
+
+


### PR DESCRIPTION
**Related Issues**
I'd like to be able to pass env variables to `build`, eg:

```ts
await nextBuild({
   meta: {
      buildEnv: { NEXT_PRIVATE_STANDLONE: 'true' }
   }
})
```

📋 Checklist

**Tests**

- [ ]  The code changed/added as part of this PR has been covered with tests
- [ ] All tests pass locally with yarn test-unit

Code Review
 
- [ ] This PR has a concise title and thorough description useful to a reviewer