### PR TITLE
[docs] Delete duplicate security.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,9 +1,0 @@
-# Reporting Security Issues
-
-If you believe you have found a security vulnerability in Vercel, we encourage you to let us know right away.
-
-We will investigate all legitimate reports and do our best to quickly fix the problem.
-
-Please email `responsible.disclosure@vercel.com` to disclose any security vulnerabilities.
-
-https://vercel.com/security


### PR DESCRIPTION
This file is redundant because it is already [inherited from the org](https://github.com/vercel/.github/blob/main/SECURITY.md). 

This will allow us to manage the security policy in one place for all repos.

See [the docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for more info.