### PR TITLE
[tests] Update to use `actions/cache@v3`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,13 @@ jobs:
       timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
       with:
         node-version: 14
-        cache: 'yarn'
+    - name: Cache
+      if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+      uses: actions/cache@v3
+      with:
+        path: '**/node_modules'
+        key: yarn-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: yarn-${{ matrix.os }}-${{ matrix.node }}
     - name: Install
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       run: yarn install --check-files --frozen-lockfile --network-timeout 1000000

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
       with:
         node-version: 14
-    - name: Cache // testing rerun with a comment
+    - name: Cache
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       uses: actions/cache@v3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
       with:
         node-version: 14
-    - name: Cache
+    - name: Cache // testing rerun with a comment
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       uses: actions/cache@v3
       with:

--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -38,7 +38,11 @@ jobs:
         timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ matrix.os }}-${{ matrix.node }}
       - run: yarn install --network-timeout 1000000 --frozen-lockfile
       - run: yarn run build
       - run: yarn test-integration-cli

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -38,7 +38,11 @@ jobs:
         timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
             node-version: ${{ matrix.node }}
-            cache: 'yarn'
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ matrix.os }}-${{ matrix.node }}
       - run: yarn install --network-timeout 1000000 --frozen-lockfile
       - run: yarn run build
       - run: yarn run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,11 @@ jobs:
         timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ matrix.os }}-${{ matrix.node }}
       - run: yarn install --network-timeout 1000000 --frozen-lockfile
       - id: set-tests
         run: |
@@ -73,7 +77,11 @@ jobs:
         timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: yarn-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ matrix.os }}-${{ matrix.node }}
 
       - name: Install Hugo
         if: matrix.runner == 'macos-latest'


### PR DESCRIPTION
Use `actions/cache` directly instead of relying on `actions/setup-node` to see if this solves [the hanging restore](https://github.com/vercel/vercel/actions/runs/3660219547/jobs/6187125554).

- Related to https://github.com/actions/cache/issues/810
- Related to https://github.com/Azure/azure-sdk-for-js/issues/22321


This also shaves a minute off cache restore time since we are caching 250MB instead of multiple GB. 