### PR TITLE
[tests] fix flakey tests

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: Unit
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/packages/cli/src/util/create-git-meta.ts
+++ b/packages/cli/src/util/create-git-meta.ts
@@ -99,7 +99,7 @@ export function isDirty(directory: string): Promise<boolean> {
         if (err) {
           return reject(err);
         }
-        if (stderr?.trim()) {
+        if (stderr !== undefined && stderr.trim().length > 0) {
           return reject(new Error(stderr));
         }
 

--- a/packages/cli/src/util/create-git-meta.ts
+++ b/packages/cli/src/util/create-git-meta.ts
@@ -5,7 +5,7 @@ import git from 'git-last-commit';
 import { exec } from 'child_process';
 import { GitMetadata, Project } from '../types';
 import { Output } from './output';
-import { errorToString } from '@vercel/error-utils';
+import { errorToString, normalizeError } from '@vercel/error-utils';
 
 export async function createGitMeta(
   directory: string,
@@ -40,19 +40,27 @@ export async function createGitMeta(
     return;
   }
 
-  const [commit, dirty] = await Promise.all([
-    getLastCommit(directory).catch(err => {
-      output.debug(
-        `Failed to get last commit. The directory is likely not a Git repo, there are no latest commits, or it is corrupted.\n${err}`
-      );
-      return;
-    }),
-    isDirty(directory, output),
+  const [commitResult, dirtyResult] = await Promise.allSettled([
+    getLastCommit(directory),
+    isDirty(directory),
   ]);
 
-  if (!commit) {
+  if (commitResult.status === 'rejected') {
+    output.debug(
+      `Failed to get last commit. The directory is likely not a Git repo, there are no latest commits, or it is corrupted.\n${commitResult.reason}`
+    );
     return;
   }
+
+  if (dirtyResult.status === 'rejected') {
+    output.debug(
+      `Failed to determine if Git repo has been modified:\n${dirtyResult.reason}`
+    );
+    return;
+  }
+
+  const dirty = dirtyResult.value;
+  const commit = commitResult.value;
 
   return {
     remoteUrl,
@@ -68,7 +76,10 @@ function getLastCommit(directory: string): Promise<git.Commit> {
   return new Promise((resolve, reject) => {
     git.getLastCommit(
       (err, commit) => {
-        if (err) return reject(err);
+        if (err) {
+          return reject(normalizeError(err));
+        }
+
         resolve(commit);
       },
       { dst: directory }
@@ -76,8 +87,8 @@ function getLastCommit(directory: string): Promise<git.Commit> {
   });
 }
 
-export function isDirty(directory: string, output: Output): Promise<boolean> {
-  return new Promise(resolve => {
+export function isDirty(directory: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
     // note: we specify the `--no-optional-locks` git flag so that `git status`
     // does not perform any "optional" operations such as optimizing the index
     // in the background: https://git-scm.com/docs/git-status#_background_refresh
@@ -85,14 +96,15 @@ export function isDirty(directory: string, output: Output): Promise<boolean> {
       'git --no-optional-locks status -s',
       { cwd: directory },
       function (err, stdout, stderr) {
-        let debugMessage = `Failed to determine if Git repo has been modified:`;
-        stderr = stderr && stderr.trim();
-        if (err || stderr) {
-          if (err) debugMessage += `\n${err}`;
-          if (stderr) debugMessage += `\n${stderr.trim()}`;
-          output.debug(debugMessage);
-          return resolve(false);
+        if (err) {
+          return reject(err);
         }
+        if (stderr?.trim()) {
+          return reject(new Error(stderr));
+        }
+
+        // Example output (when dirty):
+        //    M ../fs-detectors/src/index.ts
         resolve(stdout.trim().length > 0);
       }
     );

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -174,7 +174,7 @@ describe('createGitMeta', () => {
     const directory = fixture('dirty');
     try {
       await fs.rename(join(directory, 'git'), join(directory, '.git'));
-      const dirty = await isDirty(directory, client.output);
+      const dirty = await isDirty(directory);
       expect(dirty).toBeTruthy();
     } finally {
       await fs.rename(join(directory, '.git'), join(directory, 'git'));
@@ -184,7 +184,7 @@ describe('createGitMeta', () => {
     const directory = fixture('not-dirty');
     try {
       await fs.rename(join(directory, 'git'), join(directory, '.git'));
-      const dirty = await isDirty(directory, client.output);
+      const dirty = await isDirty(directory);
       expect(dirty).toBeFalsy();
     } finally {
       await fs.rename(join(directory, '.git'), join(directory, 'git'));

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -277,13 +277,6 @@ describe('createGitMeta', () => {
         `Failed to get last commit. The directory is likely not a Git repo, there are no latest commits, or it is corrupted.`
       );
 
-      // skip next line
-      await lines.next();
-
-      line = await lines.next();
-      expect(line.value).toContain(
-        `Failed to determine if Git repo has been modified:`
-      );
       expect(data).toBeUndefined();
     } finally {
       await fs.remove(tmpDir);

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -35,7 +35,7 @@
     "@types/minimatch": "3.0.5",
     "@types/node": "14.18.33",
     "@types/semver": "7.3.10",
-    "@vercel/build-utils": "4.2.0",
+    "@vercel/build-utils": "5.7.0",
     "typescript": "4.3.4"
   }
 }

--- a/packages/static-build/src/utils/build-output-v3.ts
+++ b/packages/static-build/src/utils/build-output-v3.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { promises as fs } from 'fs';
-import { BuildResultV2, Meta } from '../../../build-utils/dist';
-import { Framework } from '../../../frameworks/dist/types';
+import { BuildResultV2, Meta } from '@vercel/build-utils';
+import { Framework } from '@vercel/frameworks';
 
 const BUILD_OUTPUT_DIR = '.vercel/output';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3384,11 +3384,6 @@
     "@typescript-eslint/types" "5.21.0"
     eslint-visitor-keys "^3.0.0"
 
-"@vercel/build-utils@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-4.2.0.tgz#251a496bd426f06ed3e882047728e07121c1d303"
-  integrity sha512-W0TKBUGaUXHj16thnPjzFUT94rR6Hkw0Zf+PlZbUN2Op7KswgBCl5At306tz5xi/BYC8lXc9WqDd3ZWnfiw4Ng==
-
 "@vercel/fun@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.0.4.tgz#5d01cca962488b2328063b0c3fc0b6fac2555c2a"


### PR DESCRIPTION
Fixes flakey tests / CI:

- git metadata test for corrupted `.git` directory
- version identifier for `build-utils` being using in `fs-detectors`'s `devDependencies`
- bad import from `../dist/..`