### PR TITLE
[frameworks] Add quotes to match vitepress dep

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1732,7 +1732,7 @@ export const frameworks = [
         {
           path: 'package.json',
           matchContent:
-            '"(dev)?(d|D)ependencies":\\s*{[^}]*vitepress:\\s*".+?"[^}]*}',
+            '"(dev)?(d|D)ependencies":\\s*{[^}]*"vitepress":\\s*".+?"[^}]*}',
         },
       ],
     },


### PR DESCRIPTION
Added quotes to get the `vitepress` detector to correctly detect the dependency.