### PR TITLE
[edge] Add `json()` helper function

### DIFF
--- a/packages/edge/docs/README.md
+++ b/packages/edge/docs/README.md
@@ -22,6 +22,7 @@
 
 - [geolocation](README.md#geolocation)
 - [ipAddress](README.md#ipaddress)
+- [json](README.md#json)
 - [next](README.md#next)
 - [rewrite](README.md#rewrite)
 
@@ -166,6 +167,43 @@ Returns the IP address of the request from the headers.
 #### Defined in
 
 [src/edge-headers.ts:77](https://github.com/vercel/vercel/blob/main/packages/edge/src/edge-headers.ts#L77)
+
+---
+
+### json
+
+▸ **json**(`data`, `init?`): `Response`
+
+Returns a Response that contains a JSON payload as the response body.
+
+**`Example`**
+
+<caption>JSON response body</caption>
+
+```ts
+import { json } from '@vercel/edge';
+
+export default function middleware(_req: Request) {
+  return json({
+    hello: 'world',
+  });
+}
+```
+
+#### Parameters
+
+| Name    | Type                                                   | Description                         |
+| :------ | :----------------------------------------------------- | :---------------------------------- |
+| `data`  | `unknown`                                              | The payload to serialize as JSON    |
+| `init?` | [`ExtraResponseInit`](interfaces/ExtraResponseInit.md) | Additional options for the response |
+
+#### Returns
+
+`Response`
+
+#### Defined in
+
+[src/middleware-helpers.ts:176](https://github.com/vercel/vercel/blob/main/packages/edge/src/middleware-helpers.ts#L176)
 
 ---
 

--- a/packages/edge/src/middleware-helpers.ts
+++ b/packages/edge/src/middleware-helpers.ts
@@ -176,7 +176,7 @@ export function next(init?: ExtraResponseInit): Response {
 export function json(data: unknown, init?: ExtraResponseInit): Response {
   const headers = new Headers(init?.headers ?? {});
   if (!headers.has('content-type')) {
-    headers.set('content-type', 'application/json; charset=utf-8');
+    headers.set('content-type', 'application/json');
   }
   const body = JSON.stringify(data);
   return new Response(body, {

--- a/packages/edge/src/middleware-helpers.ts
+++ b/packages/edge/src/middleware-helpers.ts
@@ -153,3 +153,34 @@ export function next(init?: ExtraResponseInit): Response {
     headers,
   });
 }
+
+/**
+ * Returns a Response that contains a JSON payload as the response body.
+ *
+ * @param data The payload to serialize as JSON
+ * @param init Additional options for the response
+ *
+ * @example
+ * <caption>JSON response body</caption>
+ *
+ * ```ts
+ * import { json } from '@vercel/edge';
+ *
+ * export default function middleware(_req: Request) {
+ *   return json({
+ *     hello: 'world'
+ *   });
+ * }
+ * ```
+ */
+export function json(data: unknown, init?: ExtraResponseInit): Response {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json; charset=utf-8');
+  }
+  const body = JSON.stringify(data);
+  return new Response(body, {
+    ...init,
+    headers,
+  });
+}


### PR DESCRIPTION
`Response.json()` static function is not yet available in TypeScript's build-in DOM types, so we can offer this helper function in the meantime.