### PR TITLE
[edge] publish process.env types for edge functions

### DIFF
--- a/packages/edge/src/index.ts
+++ b/packages/edge/src/index.ts
@@ -4,3 +4,5 @@ export * from './middleware-helpers';
 export type { Geo } from './edge-headers';
 export * from './edge-headers';
 export * from './response';
+
+import './published-types.d.ts';

--- a/packages/edge/src/published-types.d.ts
+++ b/packages/edge/src/published-types.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable no-var */
+
+declare global {
+  // must be `var` to work
+  var process: {
+    env: Record<string, string>;
+  };
+}


### PR DESCRIPTION


When running `vc dev` on an edge function that leverages `process.env`, you'll see a typescript error:

![image](https://user-images.githubusercontent.com/41545/207930813-4dcd4486-0230-4cda-8f9a-df3e3fda4d49.png)

Example edge function:

```
export const config = {
  runtime: 'experimental-edge'
}

export default async function edge(request, event) {
  const pw = process.env.PASSWORD;
  
  return new Response(JSON.stringify({
    hello: "world",
    pw
  }));
}
```

There are two symptoms of the same problem.

1. In `vc dev`, the async type checking will render an error.
2. In IDEs, the passive type checking will render an error.

We can solve the `vc dev` case by default with tsconfig overrides, but we can't solve the IDE case by default.

This PR publishes a global `process.env` type under `@vercel/edge` to make this error go away. To use it, after this is published, you need to add the `@vercel/edge` dependency and config `tsconfig.json` to look at it for type info.

This solves both cases.

---

Project `tsconfig.json`:

```
{
  "compilerOptions": {
    "types": ["@vercel/edge"]
  }
}
```

Project `package.json`:

```
{
  "name": "example-edge-app",
  "dependencies": {
    "@vercel/edge": "^0.1.2",
  }
}
```

---

I tested this locally with `yarn link` and it seems to work great.