### PR TITLE
[cli] Only throw DeploymentNotReady if deployment not ready

### DIFF
--- a/packages/cli/src/util/alias/create-alias.ts
+++ b/packages/cli/src/util/alias/create-alias.ts
@@ -88,6 +88,9 @@ async function performCreateAlias(
       if (err.code === 'invalid_alias') {
         return new ERRORS.InvalidAlias(alias);
       }
+      if (err.code === 'deployment_not_ready') {
+        return new ERRORS.DeploymentNotReady({ url: deployment.url });
+      }
       if (err.status === 403) {
         if (err.code === 'alias_in_use') {
           return new ERRORS.AliasInUse(alias);
@@ -95,9 +98,6 @@ async function performCreateAlias(
         if (err.code === 'forbidden') {
           return new ERRORS.DomainPermissionDenied(alias, contextName);
         }
-      }
-      if (err.status === 400) {
-        return new ERRORS.DeploymentNotReady({ url: deployment.url });
       }
     }
 


### PR DESCRIPTION
When adding an alias, the server can return a 400 Bad Request under these circumstances:

1. Invalid alias: no alias, empty string, null alias, alias domain is invalid, alias is not public, alias is not a subdomain (code: `'invalid_alias'`)
2. The deployment is indeed not ready (code `'deployment_not_ready'`)
3. The cert for the provided alias is not ready (code `'cert_missing'`)
4. There was an error assigning the alias (code varies)

`vc alias add` will treat all 4 of those bad request errors as the deployment "is not ready". Instead of treating all 400's as not ready, only return `DeploymentNotReady` if the `code` is set to `'deployment_not_ready'`.