### PR TITLE
[next] Handle output location

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -24,6 +24,7 @@ import {
   PrepareCache,
   NodejsLambda,
   BuildResultV2Typical as BuildResult,
+  BuildResultBuildOutput,
 } from '@vercel/build-utils';
 import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
 import {
@@ -452,6 +453,24 @@ export const build: BuildV2 = async ({
     });
   }
   debug('build command exited');
+
+  let buildOutputVersion: undefined | number;
+
+  try {
+    const data = await readJSON(
+      path.join(outputDirectory, 'output/config.json')
+    );
+    buildOutputVersion = data.version;
+  } catch (_) {
+    // tolerate for older versions
+  }
+
+  if (buildOutputVersion) {
+    return {
+      buildOutputPath: outputDirectory,
+      buildOutputVersion,
+    } as BuildResultBuildOutput;
+  }
 
   let appMountPrefixNoTrailingSlash = path.posix
     .join('/', entryDirectory)


### PR DESCRIPTION
Ensures output location is handled x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1671473159350219?thread_ts=1671467623.309669&cid=C04DUD7EB1B)