### PR TITLE
[frameworks] Fix vitepress output directory

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1790,7 +1790,7 @@ export const frameworks = [
         value: 'docs/.vitepress/dist',
       },
     },
-    getOutputDirName: async () => '.vitepress/dist',
+    getOutputDirName: async () => 'docs/.vitepress/dist',
   },
   {
     name: 'VuePress',


### PR DESCRIPTION
In July 2022, VitePress changed (https://github.com/vuejs/vitepress/pull/931) the output directory from `.vitepress/dist` to `docs/.vitepress/dist`, however the framework detector was still referencing the old .vitepress/dist` output directory.