### PR TITLE
[next] Lock test fixture dependency

### DIFF
--- a/packages/next/test/integration/legacy-custom-dependency/package.json
+++ b/packages/next/test/integration/legacy-custom-dependency/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "isomorphic-unfetch": "latest",
+    "isomorphic-unfetch": "3.1.0",
     "next": "7.0.0"
   }
 }


### PR DESCRIPTION
This locks the test dependency down for this fixture since the version of Next.js doesn't support the `node:` prefixed imports added in the latest version of `isomorphic-unfetch`. 

Fixes: https://github.com/vercel/vercel/actions/runs/3833489157/jobs/6525280122#step:9:6013