### PR TITLE
[frameworks] fix blitzjs detection

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -29,9 +29,12 @@ export const frameworks = [
     envPrefix: 'NEXT_PUBLIC_',
     useRuntime: { src: 'package.json', use: '@vercel/next' },
     detectors: {
-      every: [
+      some: [
         {
-          path: 'blitz.config.(js|ts)',
+          path: 'blitz.config.js',
+        },
+        {
+          path: 'blitz.config.ts',
         },
       ],
     },

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -420,5 +420,13 @@ describe('DetectorFilesystem', () => {
 
       expect(await detectFramework({ fs, frameworkList })).toBe('zola');
     });
+
+    it('Detect Blitz.js (Legacy)', async () => {
+      const fs = new VirtualFilesystem({
+        'blitz.config.js': '// some config',
+      });
+
+      expect(await detectFramework({ fs, frameworkList })).toBe('blitzjs');
+    });
   });
 });


### PR DESCRIPTION
The framework detectors do not support this syntax:

```
path: 'blitz.config.(js|ts)',
```

This PR fixes framework detection for "Blitz.js (Legacy)".