### PR TITLE
[tests] Bump turbo and update turbo.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "2.6.2",
     "ts-eager": "2.0.2",
     "ts-jest": "28.0.5",
-    "turbo": "1.4.7"
+    "turbo": "1.6.3"
   },
   "scripts": {
     "lerna": "lerna",

--- a/turbo.json
+++ b/turbo.json
@@ -20,27 +20,27 @@
       ]
     },
     "test-unit": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "test-integration-dev": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "test-integration-cli": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "test-integration-once": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "test-next-local": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "test": {
-      "dependsOn": [],
+      "dependsOn": ["build"],
       "outputs": []
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -1,18 +1,20 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "baseBranch": "origin/main",
   "globalDependencies": ["turbo-cache-key.json", "test/lib/**"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": ["dist/**"]
     },
     "@vercel/node-bridge#build": {
       "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": ["helpers.js", "source-map-support.js"]
     },
     "vercel#build": {
       "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": [
         "dist/**",
         "src/util/constants.ts",
@@ -20,27 +22,33 @@
       ]
     },
     "test-unit": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     },
     "test-integration-dev": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     },
     "test-integration-cli": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     },
     "test-integration-once": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     },
     "test-next-local": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
       "outputs": []
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13106,95 +13106,47 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-android-arm64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-android-arm64/-/turbo-android-arm64-1.4.7.tgz#553f68a1f475495549fb8a260461239c90f40410"
-  integrity sha512-BtWtH8e8w1GhtYpGQmkcDS/AUzVZhQ4ZZN+qtUFei1wZD7VAdtJ9Wcsfi3WD+mXA6vtpIpRJVfQMcShr8l8ErA==
+turbo-darwin-64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.6.3.tgz#fad7e078784b0fafc0b1f75ce9378828918595f5"
+  integrity sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==
 
-turbo-darwin-64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.4.7.tgz#c23e2452a01115136e631dc06aa6a9bb379d2d32"
-  integrity sha512-bMvZaAz5diec9feZ0XpQosYI8U0kiOQM2tj2sv0Y2WZbe227wodVMCQMyUowmcotO8nr6NF76Xo5E+H+dnY6LQ==
+turbo-darwin-arm64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.3.tgz#f0a32cae39e3fcd3da5e3129a94c18bb2e3ed6aa"
+  integrity sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==
 
-turbo-darwin-arm64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.4.7.tgz#4212917f4892159033cfa88bafa662f6e865fe49"
-  integrity sha512-AyfxYfKgh1EigQKjypbnDoMLuy4e/n/go+KYiWKKIpOaWXWLBokrBWzYN/aI3NMDRUJWK5ExdlWI9Nleelq8uQ==
+turbo-linux-64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.6.3.tgz#8ddc6ac55ef84641182fe5ff50647f1b355826b0"
+  integrity sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==
 
-turbo-freebsd-64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.4.7.tgz#7d60d44a623bd000f53673a0db0205a16d8815e6"
-  integrity sha512-T5/osfbCh0rL53MFS5byFFfsR3vPMHIKIJ4fMMCNkoHsmFj2R0Pv53nqhEItogt0FJwCDHPyt7oBqO83H/AWQQ==
+turbo-linux-arm64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.6.3.tgz#846c1dc84d8dc741651906613c16acccba30428c"
+  integrity sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==
 
-turbo-freebsd-arm64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.4.7.tgz#35e5b23313d42aab074e69c1d1c44cab17f438ac"
-  integrity sha512-PL+SaO78AUCas+YKj01UiS2rpmGcxz8XPmLdFWmq6PYjPX6GL5UBAc3pkBphIm0aTLZtsikoEul+JrwAuAy6UA==
+turbo-windows-64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.6.3.tgz#89ac819fa76ad31d12fbfdeb3045bcebd0d308eb"
+  integrity sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==
 
-turbo-linux-32@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.4.7.tgz#2861539d767cdfca058224f284991d918d7b1965"
-  integrity sha512-dK94UwDzySMALoQtjBVVPbWJZP6xw3yHGuytM3q5p4kfMZPSA+rgNBn5T5Af2Rc7jxlLAsu5ODJ0SgIbWSF5Hg==
+turbo-windows-arm64@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.6.3.tgz#977607c9a51f0b76076c8b158bafce06ce813070"
+  integrity sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==
 
-turbo-linux-64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.4.7.tgz#5ff0e648a1d0b0053ad2f3c6a4fc735744cadc16"
-  integrity sha512-F6IM23zgTYo9gYJaNp17gVvQBt0hMIvz52OF91DpPYSLpV2h9OSlzPJ3j5TGaWueS/bc/YCV23+VojXX/MauGQ==
-
-turbo-linux-arm64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.4.7.tgz#c5cb63db0ab59dd2ea37be4e44efef119a289ad1"
-  integrity sha512-kFe5jzj3FoY6jAEwyNEswndj1t/fPl0qyxfcQv6aNPz7Nb2Lh7mY/EEse+CG3ydIo5RZKba7ppQoBSDmHx7JsA==
-
-turbo-linux-arm@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.4.7.tgz#93ed9e43a95760e660a42dbf65cbfd430e558e89"
-  integrity sha512-FTh4itdMNZ7IxGKknFnQ6iPO9vGGKqyySkCYLR01lnw6BTnKL9KuM9XUCBRyn7dNmHhAnqu1ZtVsBkH7CE7DEw==
-
-turbo-linux-mips64le@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.4.7.tgz#77357165c3ae0102fd5924dd85229676938dd717"
-  integrity sha512-756nG8dnPQVcnl9s70S4NQ43aJjpsnc2h0toktPO+9u2ayv9XTbIPvZLFsS55bDeYhodDGvxoB96W6Xnx01hyQ==
-
-turbo-linux-ppc64le@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.4.7.tgz#2a7399d6ee31d894d48aea393ed1f9addc4a310c"
-  integrity sha512-VS2ofGN/XsafNGJdZ21UguURHb7KRG879yWLj59hO1d+0xXXQbx7ljsmEPOhiE4UjEdx4Ur6P44BhztTgDx9Og==
-
-turbo-windows-32@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.4.7.tgz#e93233d8681886dc0b609c897447991afa378340"
-  integrity sha512-M5GkZdA0CbJAOcR8SScM63CBV+NtX7qjhoNNOl0F99nGJ+rO3dH71CcM/rbhlz9SQzKQoX8rcuwZHe4r2HZAug==
-
-turbo-windows-64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.4.7.tgz#da9fe6b6bf2b6fd1f85ecdc186fc7a49b8411d22"
-  integrity sha512-ftZUtZ1BX1vi8MbxKr+a7riIkhwvGnNTtWGprVu+aDJ8PnV+lNqbkrLJGvKP7Cn22hGTfzcjNNPcJ5PBZpQEQw==
-
-turbo-windows-arm64@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.4.7.tgz#c60a772aab36c45ce461e3305e35d1c22a00e516"
-  integrity sha512-mZ79XeJFfaeVKdBV3w0eoGaqAxFnwxrme0jZtSWemAbeDSCF/13wcbLGwtq0+Lu0LxEGweeQ5AqsCIc9t9i6sA==
-
-turbo@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.4.7.tgz#859989a5dce2a7b1fa51f17ac4fb1e34dbfd455d"
-  integrity sha512-oIk7PAISPidDOkTM5M+ydEe5GDQ/+TahDgIbaYKeAAy2Qpmur4s0HybSDWHIdxLqI96OPD/mOKymRLrjh3Mdhg==
+turbo@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.6.3.tgz#ec26cc8907c38a9fd6eb072fb10dad254733543e"
+  integrity sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==
   optionalDependencies:
-    turbo-android-arm64 "1.4.7"
-    turbo-darwin-64 "1.4.7"
-    turbo-darwin-arm64 "1.4.7"
-    turbo-freebsd-64 "1.4.7"
-    turbo-freebsd-arm64 "1.4.7"
-    turbo-linux-32 "1.4.7"
-    turbo-linux-64 "1.4.7"
-    turbo-linux-arm "1.4.7"
-    turbo-linux-arm64 "1.4.7"
-    turbo-linux-mips64le "1.4.7"
-    turbo-linux-ppc64le "1.4.7"
-    turbo-windows-32 "1.4.7"
-    turbo-windows-64 "1.4.7"
-    turbo-windows-arm64 "1.4.7"
+    turbo-darwin-64 "1.6.3"
+    turbo-darwin-arm64 "1.6.3"
+    turbo-linux-64 "1.6.3"
+    turbo-linux-arm64 "1.6.3"
+    turbo-windows-64 "1.6.3"
+    turbo-windows-arm64 "1.6.3"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
This PR does a few things
- Revert https://github.com/vercel/vercel/pull/8264 because it was causing some tests not to run (for example, modifying `@vercel/build-utils` should run tests for all packages)
- Bump `turbo` to version 1.6.3
- Update [`outputMode`](https://turbo.build/repo/docs/reference/configuration#outputmode) to new-only
- Update [`dependsOn`](https://turbo.build/repo/docs/reference/configuration#dependson) to `^` to ensure all dependencies are considered