### PR TITLE
[tests] Replace `::set-output` with `>> $GITHUB_OUTPUT` in gh actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,9 @@ jobs:
         tag="$(git describe --tags --exact-match 2> /dev/null || :)"
         if [[ -z "$tag" ]];
           then
-            echo "::set-output name=IS_RELEASE::false"
+            echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=IS_RELEASE::true"
+            echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
         fi
     - name: Setup Go
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           TESTS_ARRAY=$(node utils/chunk-tests.js $SCRIPT_NAME)
           echo "Files to test:"
           echo "$TESTS_ARRAY"
-          echo "::set-output name=tests::$TESTS_ARRAY"
+          echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
       - uses: patrickedqvist/wait-for-vercel-preview@ae34b392ef30297f2b672f9afb3c329bde9bd487
         id: waitForTarball
         with:


### PR DESCRIPTION
This PR fixes a deprecation warning we have been seeing in GitHub Actions for a few months. See [example](https://github.com/vercel/vercel/actions/runs/3849500423/jobs/6558559310#step:7:453).

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/