### PR TITLE
[tests] Turbo should use full logs when listing tests

### DIFF
--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -14,7 +14,14 @@ async function getChunkedTests() {
   const rootPath = path.resolve(__dirname, '..');
 
   const dryRunText = (
-    await turbo([`run`, ...scripts, `--cache-dir=.turbo`, '--', '--listTests'])
+    await turbo([
+      `run`,
+      ...scripts,
+      `--cache-dir=.turbo`,
+      '--output-logs=full',
+      '--',
+      '--listTests',
+    ])
   ).toString('utf8');
 
   /**


### PR DESCRIPTION
In PR #9168, the output mode was changed so it doesnt print logs when the result is cached. However, we need the output for the dry run where we list all relevant tests. So the flag was added to that one script only to avoid this skipped problem:

![skipped](https://user-images.githubusercontent.com/229881/210870102-a597d1b9-f007-41ba-8e1d-f53aa765b740.png)
