### PR TITLE
Add in `VERCEL_ENV` for `vc deploy`

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -247,7 +247,7 @@ export default async (client: Client): Promise<number> => {
     }
 
     // Ensure that the deploy target matches the build target
-    const assumedTarget = target || process.env['VERCEL_ENV'] || 'preview';
+    const assumedTarget = target || 'preview';
     if (prebuiltBuild?.target && prebuiltBuild.target !== assumedTarget) {
       let specifyTarget = '';
       if (prebuiltBuild.target === 'production') {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -247,7 +247,7 @@ export default async (client: Client): Promise<number> => {
     }
 
     // Ensure that the deploy target matches the build target
-    const assumedTarget = target || 'preview';
+    const assumedTarget = target || process.env['VERCEL_ENV'] || 'preview';
     if (prebuiltBuild?.target && prebuiltBuild.target !== assumedTarget) {
       let specifyTarget = '';
       if (prebuiltBuild.target === 'production') {

--- a/packages/cli/src/util/deploy/parse-target.ts
+++ b/packages/cli/src/util/deploy/parse-target.ts
@@ -37,11 +37,24 @@ export default function parseTarget(
     return 'production';
   }
 
-  if (process.env.VERCEL_ENV) {
+  const VERCEL_ENV = process.env.VERCEL_ENV;
+  if (VERCEL_ENV) {
+    if (!['preview', 'staging', 'production'].includes(VERCEL_ENV)) {
+      output.error(
+        `The specified environment variable ${param('VERCEL_ENV')} ${code(
+          VERCEL_ENV
+        )} is not valid.`
+      );
+      return 1;
+    }
     output.debug(
       `Setting target to ${process.env.VERCEL_ENV} using VERCEL_ENV environment variable.`
     );
-    return process.env.VERCEL_ENV;
+    if (VERCEL_ENV == 'preview') {
+      // If the target is `undefined` then the API will create it as a preview, however if you explicitly set it to preview then it will fail.
+      return undefined;
+    }
+    return VERCEL_ENV;
   }
 
   return undefined;

--- a/packages/cli/src/util/deploy/parse-target.ts
+++ b/packages/cli/src/util/deploy/parse-target.ts
@@ -37,5 +37,12 @@ export default function parseTarget(
     return 'production';
   }
 
+  if (process.env.VERCEL_ENV) {
+    output.debug(
+      `Setting target to ${process.env.VERCEL_ENV} using VERCEL_ENV environment variable.`
+    );
+    return process.env.VERCEL_ENV;
+  }
+
   return undefined;
 }

--- a/packages/cli/test/unit/util/deploy/parse-target.test.ts
+++ b/packages/cli/test/unit/util/deploy/parse-target.test.ts
@@ -52,4 +52,44 @@ describe('parseTarget', () => {
     let result = parseTarget(output, undefined, false);
     expect(result).toEqual(undefined);
   });
+
+  it('parses VERCEL_ENV', () => {
+    try {
+      process.env.VERCEL_ENV = 'staging';
+      let result = parseTarget(output);
+      expect(result).toEqual('staging');
+    } finally {
+      delete process.env.VERCEL_ENV;
+    }
+  });
+
+  it('returns VERCEL_ENV of preview as undefined', () => {
+    try {
+      process.env.VERCEL_ENV = 'preview';
+      let result = parseTarget(output);
+      expect(result).toEqual(undefined);
+    } finally {
+      delete process.env.VERCEL_ENV;
+    }
+  });
+
+  it('prefers production argument over VERCEL_ENV', () => {
+    try {
+      process.env.VERCEL_ENV = 'preview';
+      let result = parseTarget(output, undefined, true);
+      expect(result).toEqual('production');
+    } finally {
+      delete process.env.VERCEL_ENV;
+    }
+  });
+
+  it('validates VERCEL_ENV', () => {
+    try {
+      process.env.VERCEL_ENV = 'foo';
+      let result = parseTarget(output);
+      expect(result).toEqual(1);
+    } finally {
+      delete process.env.VERCEL_ENV;
+    }
+  });
 });


### PR DESCRIPTION
It would be nice in vc pull if an environment variable could be used. So that it can be done once and is consistent for multiple commands. This adds in `VERCEL_ENV` as a environment variable.

For other commands you can use the `--environment` variable. For `deploy` it assumed to be preview unless you specify `--prod`.

This again has `VERCEL_ENV` as a fallback, that is overridden by setting the `--prod` argument.

- [x] `--prebuilt` support
- [x] support when `--prebuilt` is not specified