### PR TITLE
Allow `VERCEL_ENV` for `vc build`

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -143,7 +143,10 @@ export default async function main(client: Client): Promise<number> {
   const cwd = process.cwd();
 
   // Build `target` influences which environment variables will be used
-  const target = argv['--prod'] ? 'production' : 'preview';
+  const target =
+    argv['--prod'] || process.env['VERCEL_ENV'] == 'production'
+      ? 'production'
+      : 'preview';
   const yes = Boolean(argv['--yes']);
 
   // TODO: read project settings from the API, fall back to local `project.json` if that fails

--- a/packages/cli/test/unit/commands/build.test.ts
+++ b/packages/cli/test/unit/commands/build.test.ts
@@ -445,6 +445,46 @@ describe('build', () => {
     }
   });
 
+  it('should pull "production" env vars VERCEL_ENV set to `production`', async () => {
+    const cwd = fixture('static-pull');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+    const envFilePath = join(cwd, '.vercel', '.env.production.local');
+    const projectJsonPath = join(cwd, '.vercel', 'project.json');
+    const originalProjectJson = await fs.readJSON(
+      join(cwd, '.vercel/project.json')
+    );
+    try {
+      console.log('*' * 100);
+      process.chdir(cwd);
+      process.env.VERCEL_ENV = 'production';
+      client.setArgv('build', '--yes');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      const prodEnv = await fs.readFile(envFilePath, 'utf8');
+      const envFileHasProductionEnv1 = prodEnv.includes(
+        'REDIS_CONNECTION_STRING'
+      );
+      expect(envFileHasProductionEnv1).toBeTruthy();
+      const envFileHasProductionEnv2 = prodEnv.includes(
+        'SQL_CONNECTION_STRING'
+      );
+      expect(envFileHasProductionEnv2).toBeTruthy();
+    } finally {
+      await fs.remove(envFilePath);
+      await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
+      process.chdir(originalCwd);
+      delete process.env.__VERCEL_BUILD_RUNNING;
+      delete process.env.VERCEL_ENV;
+    }
+  });
+
   it('should build root-level `middleware.js` and exclude from static files', async () => {
     const cwd = fixture('middleware');
     const output = join(cwd, '.vercel/output');


### PR DESCRIPTION
It would be nice in vc env if an environment variable could be used instead of --environment. So that it can be done once and is consistent for multiple commands. This adds in VERCEL_ENV as a environment variable.

Setting --environment on the command line will override it.