### PR TITLE
[frameworks] Update screenshot for Next.js example

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -63,7 +63,7 @@ export const frameworks = [
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/next-dark.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1647366075/front/import/nextjs.png',
+      'https://assets.vercel.com/image/upload/v1673027027/front/import/nextjs.png',
     tagline:
       'Next.js makes you productive with React instantly — whether you want to build static or dynamic sites.',
     description: 'A Next.js app and a Serverless Function API.',


### PR DESCRIPTION
Related issue: https://vercel.slack.com/archives/C017QMYC5FB/p1673025728939139

Updates the screenshot used for the Next.js template that shows up on the import/new project flow. The asset has been updated on Cloudinary (`/front/import/nextjs`) and this PR updates the version # of the url.