### PR TITLE
[build-utils] Support directory entries in `Lambda#createZip()`

### DIFF
--- a/packages/build-utils/src/fs/download.ts
+++ b/packages/build-utils/src/fs/download.ts
@@ -9,8 +9,13 @@ export interface DownloadedFiles {
   [filePath: string]: FileFsRef;
 }
 
-const S_IFMT = 61440; /* 0170000 type of file */
+const S_IFDIR = 16384; /* 0040000 directory */
 const S_IFLNK = 40960; /* 0120000 symbolic link */
+const S_IFMT = 61440; /* 0170000 type of file */
+
+export function isDirectory(mode: number): boolean {
+  return (mode & S_IFMT) === S_IFDIR;
+}
 
 export function isSymbolicLink(mode: number): boolean {
   return (mode & S_IFMT) === S_IFLNK;

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -3,7 +3,7 @@ import Sema from 'async-sema';
 import { ZipFile } from 'yazl';
 import minimatch from 'minimatch';
 import { readlink } from 'fs-extra';
-import { isSymbolicLink } from './fs/download';
+import { isSymbolicLink, isDirectory } from './fs/download';
 import streamToBuffer from './fs/stream-to-buffer';
 import type { Files, Config } from './types';
 
@@ -200,6 +200,8 @@ export async function createZip(files: Files): Promise<Buffer> {
       const symlinkTarget = symlinkTargets.get(name);
       if (typeof symlinkTarget === 'string') {
         zipFile.addBuffer(Buffer.from(symlinkTarget, 'utf8'), name, opts);
+      } else if (file.mode && isDirectory(file.mode)) {
+        zipFile.addEmptyDirectory(name, opts);
       } else {
         const stream = file.toStream();
         stream.on('error', reject);

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -1,0 +1,89 @@
+import path from 'path';
+import { tmpdir } from 'os';
+import fs from 'fs-extra';
+import { createZip } from '../src/lambda';
+import { FileBlob, glob, spawnAsync } from '../src';
+
+describe('Lambda', () => {
+  it('should create zip file with symlinks', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+    const files = await glob('**', path.join(__dirname, 'symlinks'));
+    expect(Object.keys(files)).toHaveLength(4);
+
+    const outFile = path.join(__dirname, 'symlinks.zip');
+    await fs.remove(outFile);
+
+    const outDir = path.join(__dirname, 'symlinks-out');
+    await fs.remove(outDir);
+    await fs.mkdirp(outDir);
+
+    await fs.writeFile(outFile, await createZip(files));
+    await spawnAsync('unzip', [outFile], { cwd: outDir });
+
+    const [linkStat, linkDirStat, aStat] = await Promise.all([
+      fs.lstat(path.join(outDir, 'link.txt')),
+      fs.lstat(path.join(outDir, 'link-dir')),
+      fs.lstat(path.join(outDir, 'a.txt')),
+    ]);
+    expect(linkStat.isSymbolicLink()).toEqual(true);
+    expect(linkDirStat.isSymbolicLink()).toEqual(true);
+    expect(aStat.isFile()).toEqual(true);
+  });
+
+  it('should create zip file with empty directory', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'create-zip-empty-dir'));
+    try {
+      const files = {
+        a: new FileBlob({
+          data: 'contents',
+          mode: 33188,
+        }),
+        empty: new FileBlob({
+          data: '',
+          mode: 16877,
+        }),
+        'b/a': new FileBlob({
+          data: 'inside dir b',
+          mode: 33188,
+        }),
+        c: new FileBlob({
+          data: '',
+          mode: 16877,
+        }),
+        'c/a': new FileBlob({
+          data: 'inside dir c',
+          mode: 33188,
+        }),
+      };
+
+      const outFile = path.join(dir, 'lambda.zip');
+
+      const outDir = path.join(dir, 'out');
+      await fs.mkdirp(outDir);
+
+      await fs.writeFile(outFile, await createZip(files));
+      await spawnAsync('unzip', [outFile], { cwd: outDir });
+
+      expect(fs.statSync(path.join(outDir, 'empty')).isDirectory()).toEqual(
+        true
+      );
+      expect(fs.statSync(path.join(outDir, 'b')).isDirectory()).toEqual(true);
+      expect(fs.statSync(path.join(outDir, 'c')).isDirectory()).toEqual(true);
+      expect(fs.readFileSync(path.join(outDir, 'a'), 'utf8')).toEqual(
+        'contents'
+      );
+      expect(fs.readFileSync(path.join(outDir, 'b/a'), 'utf8')).toEqual(
+        'inside dir b'
+      );
+      expect(fs.readFileSync(path.join(outDir, 'c/a'), 'utf8')).toEqual(
+        'inside dir c'
+      );
+      expect(fs.readdirSync(path.join(outDir, 'empty'))).toHaveLength(0);
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+});

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -4,6 +4,9 @@ import fs from 'fs-extra';
 import { createZip } from '../src/lambda';
 import { FileBlob, glob, spawnAsync } from '../src';
 
+const MODE_DIRECTORY = 16877; /* drwxr-xr-x */
+const MODE_FILE = 33188; /* -rw-r--r-- */
+
 describe('Lambda', () => {
   it('should create zip file with symlinks', async () => {
     if (process.platform === 'win32') {
@@ -44,23 +47,23 @@ describe('Lambda', () => {
       const files = {
         a: new FileBlob({
           data: 'contents',
-          mode: 33188,
+          mode: MODE_FILE,
         }),
         empty: new FileBlob({
           data: '',
-          mode: 16877,
+          mode: MODE_DIRECTORY,
         }),
         'b/a': new FileBlob({
           data: 'inside dir b',
-          mode: 33188,
+          mode: MODE_FILE,
         }),
         c: new FileBlob({
           data: '',
-          mode: 16877,
+          mode: MODE_DIRECTORY,
         }),
         'c/a': new FileBlob({
           data: 'inside dir c',
-          mode: 33188,
+          mode: MODE_FILE,
         }),
       };
 

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -34,6 +34,11 @@ describe('Lambda', () => {
   });
 
   it('should create zip file with empty directory', async () => {
+    if (process.platform === 'win32') {
+      console.log('Skipping test on windows');
+      return;
+    }
+
     const dir = await fs.mkdtemp(path.join(tmpdir(), 'create-zip-empty-dir'));
     try {
       const files = {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -2,12 +2,10 @@ import ms from 'ms';
 import path from 'path';
 import fs, { readlink } from 'fs-extra';
 import { strict as assert, strictEqual } from 'assert';
-import { createZip } from '../src/lambda';
 import { getSupportedNodeVersion } from '../src/fs/node-version';
 import download from '../src/fs/download';
 import {
   glob,
-  spawnAsync,
   getNodeVersion,
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
@@ -139,34 +137,6 @@ it('should re-create FileBlob symlinks properly', async () => {
 
   strictEqual(linkDirContents, 'dir');
   strictEqual(linkTextContents, 'a.txt');
-});
-
-it('should create zip files with symlinks properly', async () => {
-  if (process.platform === 'win32') {
-    console.log('Skipping test on windows');
-    return;
-  }
-  const files = await glob('**', path.join(__dirname, 'symlinks'));
-  assert.equal(Object.keys(files).length, 4);
-
-  const outFile = path.join(__dirname, 'symlinks.zip');
-  await fs.remove(outFile);
-
-  const outDir = path.join(__dirname, 'symlinks-out');
-  await fs.remove(outDir);
-  await fs.mkdirp(outDir);
-
-  await fs.writeFile(outFile, await createZip(files));
-  await spawnAsync('unzip', [outFile], { cwd: outDir });
-
-  const [linkStat, linkDirStat, aStat] = await Promise.all([
-    fs.lstat(path.join(outDir, 'link.txt')),
-    fs.lstat(path.join(outDir, 'link-dir')),
-    fs.lstat(path.join(outDir, 'a.txt')),
-  ]);
-  assert(linkStat.isSymbolicLink());
-  assert(linkDirStat.isSymbolicLink());
-  assert(aStat.isFile());
 });
 
 it('should download symlinks even with incorrect file', async () => {


### PR DESCRIPTION
Adds support for empty directory entries in the Lambda `createZip()` function.