### PR TITLE
[next] Fix dynamic routes order for app dir

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1147,7 +1147,7 @@ export async function serverBuild({
         ...route,
         src: route.src.replace(
           new RegExp(escapeStringRegexp('(?:/)?$')),
-          '(?:\\.rsc)?(?:/)?$'
+          '(?:\\.rsc)(?:/)?$'
         ),
         dest: route.dest?.replace(/($|\?)/, '.rsc$1'),
       });

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1143,7 +1143,6 @@ export async function serverBuild({
 
   if (appDir) {
     for (const route of dynamicRoutes) {
-      completeDynamicRoutes.push(route);
       completeDynamicRoutes.push({
         ...route,
         src: route.src.replace(
@@ -1152,6 +1151,7 @@ export async function serverBuild({
         ),
         dest: route.dest?.replace(/($|\?)/, '.rsc$1'),
       });
+      completeDynamicRoutes.push(route);
     }
   } else {
     completeDynamicRoutes.push(...dynamicRoutes);

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -7,6 +7,15 @@
   ],
   "probes": [
     {
+      "path": "/dynamic/category-1/id-1",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
       "path": "/ssg",
       "status": 200,
       "mustContain": "hello from /ssg",


### PR DESCRIPTION
This ensures the RSC dynamic routes come before the HTML route as it's more specific and the HTML route can end up matching first unexpectedly. 

Test deployment with fix: https://discord-gmki6w031-vtest314-ijjk-testing.vercel.app/

Fixes: https://github.com/vercel/next.js/issues/44728

