### PR TITLE
[cli] Remove `qs` dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,8 +50,7 @@
     "@vercel/redwood": "workspace:1.0.45",
     "@vercel/remix": "workspace:1.1.7",
     "@vercel/ruby": "workspace:1.3.50",
-    "@vercel/static-build": "workspace:1.1.1",
-    "qs": "6.11.0"
+    "@vercel/static-build": "workspace:1.1.1"
   },
   "devDependencies": {
     "@alex_neo/jest-expect-message": "1.0.5",

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -34,7 +34,7 @@ const help = () => {
   )} Connect your Vercel Project to your Git repository defined in your local .git config
 
     ${chalk.cyan(`$ ${getPkgName()} git connect`)}
-  
+
   ${chalk.gray(
     '–'
   )} Connect your Vercel Project to a Git repository using the remote URL
@@ -96,6 +96,7 @@ export default async function main(client: Client) {
   }
 
   const { org, project } = linkedProject;
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
   switch (subcommand) {
     case 'connect':

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -1,5 +1,4 @@
 import Client from '../client';
-import { stringify } from 'qs';
 import { Org } from '../../types';
 import chalk from 'chalk';
 import link from '../output/link';
@@ -19,9 +18,7 @@ export async function disconnectGitProvider(
   org: Org,
   projectId: string
 ) {
-  const fetchUrl = `/v9/projects/${projectId}/link?${stringify({
-    teamId: org.type === 'team' ? org.id : undefined,
-  })}`;
+  const fetchUrl = `/v9/projects/${projectId}/link`;
   return client.fetch(fetchUrl, {
     method: 'DELETE',
     headers: {
@@ -37,9 +34,7 @@ export async function connectGitProvider(
   type: string,
   repo: string
 ) {
-  const fetchUrl = `/v9/projects/${projectId}/link?${stringify({
-    teamId: org.type === 'team' ? org.id : undefined,
-  })}`;
+  const fetchUrl = `/v9/projects/${projectId}/link`;
   try {
     return await client.fetch(fetchUrl, {
       method: 'POST',

--- a/packages/cli/test/dev/fixtures/04-create-react-app/.nowignore
+++ b/packages/cli/test/dev/fixtures/04-create-react-app/.nowignore
@@ -1,2 +1,0 @@
-README.md
-yarn.lock

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,7 +271,6 @@ importers:
       promisepipe: 3.0.0
       psl: 1.1.31
       qr-image: 3.2.0
-      qs: 6.11.0
       raw-body: 2.4.1
       rimraf: 3.0.2
       semver: 5.5.0
@@ -303,7 +302,6 @@ importers:
       '@vercel/remix': link:../remix
       '@vercel/ruby': link:../ruby
       '@vercel/static-build': link:../static-build
-      qs: 6.11.0
     devDependencies:
       '@alex_neo/jest-expect-message': 1.0.5
       '@next/env': 11.1.2
@@ -5602,6 +5600,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.3
+    dev: true
 
   /call-matcher/1.1.0:
     resolution: {integrity: sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==}
@@ -8014,6 +8013,7 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
+    dev: true
 
   /get-own-enumerable-property-symbols/3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -8383,6 +8383,7 @@ packages:
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
@@ -11580,10 +11581,6 @@ packages:
       kind-of: 3.2.2
     dev: true
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-    dev: false
-
   /object-is/1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
@@ -12365,13 +12362,6 @@ packages:
     resolution: {integrity: sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw==}
     dev: true
 
-  /qs/6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      side-channel: 1.0.4
-    dev: false
-
   /qs/6.5.2:
     resolution: {integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==}
     engines: {node: '>=0.6'}
@@ -13008,14 +12998,6 @@ packages:
       vscode-oniguruma: 1.7.0
       vscode-textmate: 5.2.0
     dev: true
-
-  /side-channel/1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
-    dev: false
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}


### PR DESCRIPTION
There is no need for `qs` because the query string for `teamId` is already handled here:

https://github.com/vercel/vercel/blob/5b88f673f89c44b9e91e44247e29be6bed43805a/packages/cli/src/util/client.ts#L99
