### PR TITLE
[fs-detectors] use project path instead of name for turbo filter

### DIFF
--- a/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
+++ b/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
@@ -66,7 +66,7 @@ export async function getMonorepoDefaultSettings(
 
     return {
       monorepoManager: 'turbo',
-      buildCommand: `cd ${relativeToRoot} && npx turbo run build --filter=${projectName}...`,
+      buildCommand: `cd ${relativeToRoot} && npx turbo run build --filter={${projectPath}}...`,
       installCommand: `cd ${relativeToRoot} && ${packageManager} install`,
       commandForIgnoringBuildStep: `cd ${relativeToRoot} && npx turbo-ignore`,
     };

--- a/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
+++ b/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
@@ -37,7 +37,8 @@ describe('getMonorepoDefaultSettings', () => {
     const expectedResultMap: Record<string, Record<string, string>> = {
       turbo: {
         monorepoManager: 'turbo',
-        buildCommand: 'cd ../.. && npx turbo run build --filter=app-1...',
+        buildCommand:
+          'cd ../.. && npx turbo run build --filter={packages/app-1}...',
         installCommand: 'cd ../.. && yarn install',
         commandForIgnoringBuildStep: 'cd ../.. && npx turbo-ignore',
       },


### PR DESCRIPTION
Fixes: https://github.com/orgs/vercel/discussions/1218