### PR TITLE
[tests] Adding missing jest-matcher-utils dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -139,6 +139,7 @@
     "is-port-reachable": "3.1.0",
     "is-url": "1.2.2",
     "jaro-winkler": "0.2.8",
+    "jest-matcher-utils": "29.3.1",
     "json5": "2.2.1",
     "jsonlines": "0.1.1",
     "line-async-iterator": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,7 @@ importers:
       is-port-reachable: 3.1.0
       is-url: 1.2.2
       jaro-winkler: 0.2.8
+      jest-matcher-utils: 29.3.1
       json5: 2.2.1
       jsonlines: 0.1.1
       line-async-iterator: 3.0.0
@@ -389,6 +390,7 @@ importers:
       is-port-reachable: 3.1.0
       is-url: 1.2.2
       jaro-winkler: 0.2.8
+      jest-matcher-utils: 29.3.1
       json5: 2.2.1
       jsonlines: 0.1.1
       line-async-iterator: 3.0.0
@@ -6673,6 +6675,11 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
+  /diff-sequences/29.3.1:
+    resolution: {integrity: sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -7487,7 +7494,7 @@ packages:
     dependencies:
       '@jest/expect-utils': 29.2.2
       jest-get-type: 29.2.0
-      jest-matcher-utils: 29.2.2
+      jest-matcher-utils: 29.3.1
       jest-message-util: 29.2.1
       jest-util: 29.2.1
     dev: true
@@ -9546,6 +9553,16 @@ packages:
       pretty-format: 29.2.1
     dev: true
 
+  /jest-diff/29.3.1:
+    resolution: {integrity: sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.3.1
+      jest-get-type: 29.2.0
+      pretty-format: 29.3.1
+    dev: true
+
   /jest-docblock/28.0.2:
     resolution: {integrity: sha512-FH10WWw5NxLoeSdQlJwu+MTiv60aXV/t8KEwIRGEv74WARE1cXIqh1vGdy2CraHuWOOrnzTWj/azQKqW4fO7xg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9705,6 +9722,16 @@ packages:
       pretty-format: 29.2.1
     dev: true
 
+  /jest-matcher-utils/29.3.1:
+    resolution: {integrity: sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.3.1
+      jest-get-type: 29.2.0
+      pretty-format: 29.3.1
+    dev: true
+
   /jest-message-util/28.1.3:
     resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9730,7 +9757,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.10
       micromatch: 4.0.5
-      pretty-format: 29.2.1
+      pretty-format: 29.3.1
       slash: 3.0.0
       stack-utils: 2.0.3
     dev: true
@@ -12229,6 +12256,15 @@ packages:
 
   /pretty-format/29.2.1:
     resolution: {integrity: sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      ansi-styles: 5.2.0
+      react-is: 18.1.0
+    dev: true
+
+  /pretty-format/29.3.1:
+    resolution: {integrity: sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/schemas': 29.0.0


### PR DESCRIPTION
Fixes the following error when tests are run:

```
Cannot find module 'jest-matcher-utils' from 'test/mocks/matchers/to-output.ts'
```

Log: https://github.com/vercel/vercel/actions/runs/3898221824/jobs/6656730316#step:10:3049