### PR TITLE
[node-bridge] Add missing lazy dependencies

### DIFF
--- a/packages/node-bridge/package.json
+++ b/packages/node-bridge/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "@types/aws-lambda": "8.10.19",
     "@types/node": "14.18.33",
+    "content-type": "1.0.4",
+    "cookie": "0.4.0",
+    "etag": "1.8.1",
     "execa": "3.2.0",
     "fs-extra": "10.0.0",
     "jsonlines": "0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,9 @@ importers:
     specifiers:
       '@types/aws-lambda': 8.10.19
       '@types/node': 14.18.33
+      content-type: 1.0.4
+      cookie: 0.4.0
+      etag: 1.8.1
       execa: 3.2.0
       fs-extra: 10.0.0
       jsonlines: 0.1.1
@@ -801,6 +804,9 @@ importers:
     devDependencies:
       '@types/aws-lambda': 8.10.19
       '@types/node': 14.18.33
+      content-type: 1.0.4
+      cookie: 0.4.0
+      etag: 1.8.1
       execa: 3.2.0
       fs-extra: 10.0.0
       jsonlines: 0.1.1


### PR DESCRIPTION
These were missing from the compiled ncc build of `helpers.ts`, and thus causing an error at runtime because the deps are not available within the Serverless Function.