### PR TITLE
[build-utils] Add `includeDirectories` option to `glob()`

### DIFF
--- a/packages/build-utils/test/unit.glob.test.ts
+++ b/packages/build-utils/test/unit.glob.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { glob, isDirectory } from '../src';
 
 describe('glob()', () => {
-  it('should return entries for empty directories', async () => {
+  it('should not return entries for empty directories by default', async () => {
     const dir = await fs.mkdtemp(join(tmpdir(), 'build-utils-test'));
     try {
       await Promise.all([
@@ -18,6 +18,33 @@ describe('glob()', () => {
         fs.mkdirp(join(dir, 'another/subdir')),
       ]);
       const files = await glob('**', dir);
+      const fileNames = Object.keys(files).sort();
+      expect(fileNames).toHaveLength(2);
+      expect(fileNames).toEqual(['dir-with-file/data.json', 'root.txt']);
+      expect(isDirectory(files['dir-with-file/data.json'].mode)).toEqual(false);
+      expect(isDirectory(files['root.txt'].mode)).toEqual(false);
+      expect(files['dir-with-file']).toBeUndefined();
+      expect(files['another/subdir']).toBeUndefined();
+      expect(files['empty-dir']).toBeUndefined();
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+
+  it('should return entries for empty directories with `includeDirectories: true`', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'build-utils-test'));
+    try {
+      await Promise.all([
+        fs.writeFile(join(dir, 'root.txt'), 'file at the root'),
+        fs.mkdirp(join(dir, 'empty-dir')),
+        fs
+          .mkdirp(join(dir, 'dir-with-file'))
+          .then(() =>
+            fs.writeFile(join(dir, 'dir-with-file/data.json'), '{"a":"b"}')
+          ),
+        fs.mkdirp(join(dir, 'another/subdir')),
+      ]);
+      const files = await glob('**', { cwd: dir, includeDirectories: true });
       const fileNames = Object.keys(files).sort();
       expect(fileNames).toHaveLength(4);
       expect(fileNames).toEqual([


### PR DESCRIPTION
Instead of always including empty directories in `glob()`, make it an opt-in behavior because technically it's a breaking change to include them by default.