### PR TITLE
[remix] Fix module file path resolution

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -169,9 +169,7 @@ export const build: BuildV2 = async ({
 
   try {
     if (remixConfigFile) {
-      const remixConfigModule = await import(
-        pathToFileURL(remixConfigFile).href
-      );
+      const remixConfigModule = await import(remixConfigFile);
       const remixConfig: AppConfig = remixConfigModule?.default || {};
 
       // If `serverBuildTarget === 'vercel'` then Remix will output a handler

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -24,7 +24,6 @@ import type {
 } from '@vercel/build-utils';
 import { nodeFileTrace } from '@vercel/nft';
 import type { AppConfig } from './types';
-import { pathToFileURL } from 'url';
 import { findConfig } from './utils';
 
 // Name of the Remix runtime adapter npm package for Vercel

--- a/packages/remix/src/prepare-cache.ts
+++ b/packages/remix/src/prepare-cache.ts
@@ -16,9 +16,7 @@ export const prepareCache: PrepareCache = async ({
   try {
     const remixConfigFile = findConfig(entrypointFsDirname, 'remix.config');
     if (remixConfigFile) {
-      const remixConfigModule = await import(
-        pathToFileURL(remixConfigFile).href
-      );
+      const remixConfigModule = await import(remixConfigFile);
       const remixConfig: AppConfig = remixConfigModule?.default || {};
       if (remixConfig.cacheDirectory) {
         cacheDirectory = remixConfig.cacheDirectory;

--- a/packages/remix/src/prepare-cache.ts
+++ b/packages/remix/src/prepare-cache.ts
@@ -1,5 +1,4 @@
 import { dirname, join, relative } from 'path';
-import { pathToFileURL } from 'url';
 import { glob } from '@vercel/build-utils';
 import type { PrepareCache } from '@vercel/build-utils';
 import type { AppConfig } from './types';


### PR DESCRIPTION
This was introduced in: https://github.com/vercel/vercel/pull/8793
and causing some issues for remix users: https://github.com/orgs/vercel/discussions/1282

The underlying error is `MODULE_NOT_FOUND`.

`import()` should work with `file://` URIs, however, since it's using typescript, the `import` gets compiled to `require()`, which does not support `file://` protocol scheme.