### PR TITLE
[next] Fix normalize route with middleware and basePath

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1060,9 +1060,9 @@ export async function serverBuild({
           {
             src: path.posix.join(
               '^/',
-              entryDirectory,
-              trailingSlash ? '/' : '',
-              '$'
+              entryDirectory !== '.'
+                ? `${entryDirectory}${trailingSlash ? '/$' : '$'}`
+                : '$'
             ),
             has: [
               {

--- a/packages/next/test/fixtures/00-middleware-base-path/index.test.js
+++ b/packages/next/test/fixtures/00-middleware-base-path/index.test.js
@@ -24,18 +24,19 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     expect(isNaN(props.now)).toBe(false);
 
     const { pageProps: data } = await fetch(
-      `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/rewrite-to-another-site.json`
+      `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/rewrite-to-another-site.json`,
+      { headers: { 'x-nextjs-data': '1' } }
     ).then(res => res.json());
 
     expect(isNaN(data.now)).toBe(false);
 
-    const revalidateRes = await fetch(
-      `${ctx.deploymentUrl}/docs/api/revalidate?urlPath=/docs/_sites/test-revalidate`
-    );
-    expect(revalidateRes.status).toBe(200);
-    expect(await revalidateRes.json()).toEqual({ revalidated: true });
-
     await check(async () => {
+      const revalidateRes = await fetch(
+        `${ctx.deploymentUrl}/docs/api/revalidate?urlPath=/docs/_sites/test-revalidate`
+      );
+      expect(revalidateRes.status).toBe(200);
+      expect(await revalidateRes.json()).toEqual({ revalidated: true });
+
       const newProps = await propsFromHtml();
       console.log({ props, newProps });
 
@@ -52,7 +53,8 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     await check(async () => {
       const { pageProps: newData } = await fetch(
-        `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/rewrite-to-another-site.json`
+        `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/rewrite-to-another-site.json`,
+        { headers: { 'x-nextjs-data': '1' } }
       ).then(res => res.json());
 
       console.log({ newData, data });
@@ -80,18 +82,19 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     expect(isNaN(props.now)).toBe(false);
 
     const { pageProps: data } = await fetch(
-      `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/financial.json?slug=financial`
+      `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/financial.json?slug=financial`,
+      { headers: { 'x-nextjs-data': '1' } }
     ).then(res => res.json());
 
     expect(isNaN(data.now)).toBe(false);
 
-    const revalidateRes = await fetch(
-      `${ctx.deploymentUrl}/docs/api/revalidate?urlPath=/docs/financial`
-    );
-    expect(revalidateRes.status).toBe(200);
-    expect(await revalidateRes.json()).toEqual({ revalidated: true });
-
     await check(async () => {
+      const revalidateRes = await fetch(
+        `${ctx.deploymentUrl}/docs/api/revalidate?urlPath=/docs/financial`
+      );
+      expect(revalidateRes.status).toBe(200);
+      expect(await revalidateRes.json()).toEqual({ revalidated: true });
+
       const newProps = await propsFromHtml();
       console.log({ props, newProps });
 
@@ -108,7 +111,8 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
     await check(async () => {
       const { pageProps: newData } = await fetch(
-        `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/financial.json?slug=financial`
+        `${ctx.deploymentUrl}/docs/_next/data/testing-build-id/financial.json?slug=financial`,
+        { headers: { 'x-nextjs-data': '1' } }
       ).then(res => res.json());
 
       console.log({ newData, data });

--- a/packages/next/test/fixtures/00-middleware-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-middleware-base-path/vercel.json
@@ -8,6 +8,15 @@
   ],
   "probes": [
     {
+      "path": "/docs/_next/data/testing-build-id/index.json",
+      "status": 200,
+      "headers": {
+        "x-nextjs-data": 1
+      },
+      "mustContain": "\"pageProps\":{",
+      "mustNotContain": "<html"
+    },
+    {
       "path": "/docs/_next/data/testing-build-id/dynamic/static.json",
       "status": 200,
       "headers": {
@@ -44,7 +53,7 @@
         "x-nextjs-data": 1
       },
       "mustContain": "site\":\"subdomain-1\"",
-      "mustNotContain": "<html>"
+      "mustNotContain": "<html"
     },
     {
       "path": "/docs/redirect-me",
@@ -113,7 +122,7 @@
       "fetchOptions": {
         "redirect": "manual"
       },
-      "mustNotContain": "<html>",
+      "mustNotContain": "<html",
       "mustContain": "\"site\":\"subdomain-1\""
     }
   ]


### PR DESCRIPTION
This ensures we properly match the index route when normalizing routes with `x-nextjs-data` for middleware. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1674034533265989)