### PR TITLE
[gatsby-plugin-vercel-builder] Fix turbo cache outputs configuration

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/.gitignore
+++ b/packages/gatsby-plugin-vercel-builder/.gitignore
@@ -1,4 +1,4 @@
 gatsby-node.*
 !gatsby-node.ts
 
-build
+dist

--- a/packages/gatsby-plugin-vercel-builder/gatsby-node.ts
+++ b/packages/gatsby-plugin-vercel-builder/gatsby-node.ts
@@ -2,8 +2,8 @@ import path from 'path';
 
 import type { GatsbyNode } from 'gatsby';
 
-// this gets built separately, so import from "build" instead of "src"
-import { generateVercelBuildOutputAPI3Output } from './build';
+// this gets built separately, so import from "dist" instead of "src"
+import { generateVercelBuildOutputAPI3Output } from './dist';
 
 export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
   Joi,

--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@vercel/gatsby-plugin-vercel-builder",
   "version": "0.1.0",
-  "main": "build/index.js",
+  "main": "dist/index.js",
   "files": [
-    "build",
+    "dist",
     "gatsby-node.ts",
     "gatsby-node.js",
     "gatsby-node.js.map"

--- a/packages/gatsby-plugin-vercel-builder/tsconfig.src.json
+++ b/packages/gatsby-plugin-vercel-builder/tsconfig.src.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,11 @@
       "outputMode": "new-only",
       "outputs": ["helpers.js", "source-map-support.js"]
     },
+    "@vercel/gatsby-plugin-vercel-builder#build": {
+      "dependsOn": ["^build"],
+      "outputMode": "new-only",
+      "outputs": ["dist/**", "gatsby-node.js"]
+    },
     "vercel#build": {
       "dependsOn": ["^build"],
       "outputMode": "new-only",


### PR DESCRIPTION
The published version on npm was missing the compiled code because Turbo was not configured to cache them properly.