### PR TITLE
[tests] Pass in builder to `runBuildLambda()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "@typescript-eslint/parser": "5.21.0",
     "@vercel/build-utils": "*",
     "@vercel/ncc": "0.24.0",
-    "@vercel/next": "*",
-    "@vercel/static-build": "*",
     "async-retry": "1.2.3",
     "buffer-replace": "1.0.0",
     "create-svelte": "2.0.1",

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -2,7 +2,7 @@ process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');
 const fs = require('fs-extra');
-const builder = require('../..');
+const builder = require('../../');
 const {
   createRunBuildLambda,
 } = require('../../../../test/lib/run-build-lambda');

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -2,8 +2,12 @@ process.env.NEXT_TELEMETRY_DISABLED = '1';
 
 const path = require('path');
 const fs = require('fs-extra');
+const builder = require('../..');
+const {
+  createRunBuildLambda,
+} = require('../../../../test/lib/run-build-lambda');
 
-const runBuildLambda = require('../../../../test/lib/run-build-lambda');
+const runBuildLambda = createRunBuildLambda(builder);
 
 jest.setTimeout(360000);
 

--- a/packages/next/test/integration/middleware.test.ts
+++ b/packages/next/test/integration/middleware.test.ts
@@ -6,9 +6,12 @@ import type { Context } from '../types';
 import { duplicateWithConfig } from '../utils';
 import fs from 'fs-extra';
 import path from 'path';
-import runBuildLambda from '../../../../test/lib/run-build-lambda';
+import * as builder from '../../';
+import { createRunBuildLambda } from '../../../../test/lib/run-build-lambda';
 import { EdgeFunction, Files, streamToBuffer } from '@vercel/build-utils';
 import { createHash } from 'crypto';
+
+const runBuildLambda = createRunBuildLambda(builder);
 
 const SIMPLE_PROJECT = path.resolve(
   __dirname,

--- a/packages/next/test/unit/export.test.js
+++ b/packages/next/test/unit/export.test.js
@@ -1,6 +1,0 @@
-describe('export', () => {
-  it('should require by path main', async () => {
-    const main = require('@vercel/next');
-    expect(main).toBeDefined();
-  });
-});

--- a/packages/static-build/test/builds.test.js
+++ b/packages/static-build/test/builds.test.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const fs = require('fs-extra');
-const runBuildLambda = require('../../../test/lib/run-build-lambda');
+const builder = require('../');
+const { createRunBuildLambda } = require('../../../test/lib/run-build-lambda');
+
+const runBuildLambda = createRunBuildLambda(builder);
 
 const FOUR_MINUTES = 240000;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,6 @@ importers:
       '@typescript-eslint/parser': 5.21.0
       '@vercel/build-utils': '*'
       '@vercel/ncc': 0.24.0
-      '@vercel/next': '*'
-      '@vercel/static-build': '*'
       async-retry: 1.2.3
       buffer-replace: 1.0.0
       create-svelte: 2.0.1
@@ -40,8 +38,6 @@ importers:
       '@typescript-eslint/parser': 5.21.0_eslint@8.14.0
       '@vercel/build-utils': link:packages/build-utils
       '@vercel/ncc': 0.24.0
-      '@vercel/next': link:packages/next
-      '@vercel/static-build': link:packages/static-build
       async-retry: 1.2.3
       buffer-replace: 1.0.0
       create-svelte: 2.0.1
@@ -1214,7 +1210,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@7.2.0
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       lru-cache: 5.1.1
@@ -1719,7 +1715,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@7.2.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1849,7 +1845,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@7.2.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1858,7 +1854,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.12_supports-color@7.2.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 

--- a/test/lib/run-build-lambda.js
+++ b/test/lib/run-build-lambda.js
@@ -4,75 +4,56 @@ const fs = require('fs-extra');
 const json5 = require('json5');
 const { glob } = require('@vercel/build-utils');
 
-function runAnalyze(wrapper, context) {
-  if (wrapper.analyze) {
-    return wrapper.analyze(context);
-  }
+exports.createRunBuildLambda = async function (builder) {
+  return async inputPath => {
+    const inputFiles = await glob('**', inputPath);
+    const nowJsonRef = inputFiles['vercel.json'] || inputFiles['now.json'];
 
-  return 'this-is-a-fake-analyze-result-from-default-analyze';
-}
+    if (typeof expect !== 'undefined') {
+      expect(nowJsonRef).toBeDefined();
+    }
+    const nowJson = json5.parse(await fs.readFile(nowJsonRef.fsPath, 'utf8'));
+    const build = nowJson.builds[0];
 
-async function runBuildLambda(inputPath) {
-  const inputFiles = await glob('**', inputPath);
-  const nowJsonRef = inputFiles['vercel.json'] || inputFiles['now.json'];
+    if (typeof expect !== 'undefined') {
+      expect(build.src.includes('*')).toBeFalsy();
+    }
+    const entrypoint = build.src.replace(/^\//, ''); // strip leftmost slash
 
-  if (typeof expect !== 'undefined') {
-    expect(nowJsonRef).toBeDefined();
-  }
-  const nowJson = json5.parse(await fs.readFile(nowJsonRef.fsPath, 'utf8'));
-  const build = nowJson.builds[0];
-
-  if (typeof expect !== 'undefined') {
-    expect(build.src.includes('*')).toBeFalsy();
-  }
-  const entrypoint = build.src.replace(/^\//, ''); // strip leftmost slash
-
-  if (typeof expect !== 'undefined') {
-    expect(inputFiles[entrypoint]).toBeDefined();
-  }
-  inputFiles[entrypoint].digest =
-    'this-is-a-fake-digest-for-non-default-analyze';
-  const wrapper = require(build.use);
-
-  const analyzeResult = runAnalyze(wrapper, {
-    files: inputFiles,
-    entrypoint,
-    config: build.config,
-  });
-
-  let workPath = path.join(
-    os.tmpdir(),
-    `vercel-${Date.now()}-${Math.floor(Math.random() * 100)}`
-  );
-  await fs.ensureDir(workPath);
-
-  workPath = await fs.realpath(workPath);
-  console.log('building in', workPath);
-
-  const buildResult = await wrapper.build({
-    files: inputFiles,
-    entrypoint,
-    config: build.config,
-    workPath,
-  });
-  const { output } = buildResult;
-
-  // Windows support
-  if (output) {
-    buildResult.output = Object.keys(output).reduce(
-      (result, path) => ({
-        ...result,
-        [path.replace(/\\/g, '/')]: output[path],
-      }),
-      {}
+    if (typeof expect !== 'undefined') {
+      expect(inputFiles[entrypoint]).toBeDefined();
+    }
+    let workPath = path.join(
+      os.tmpdir(),
+      `vercel-${Date.now()}-${Math.floor(Math.random() * 100)}`
     );
-  }
+    await fs.ensureDir(workPath);
 
-  return {
-    analyzeResult,
-    buildResult,
-    workPath,
+    workPath = await fs.realpath(workPath);
+    console.log('building in', workPath);
+
+    const buildResult = await builder.build({
+      files: inputFiles,
+      entrypoint,
+      config: build.config,
+      workPath,
+    });
+    const { output } = buildResult;
+
+    // Windows support
+    if (output) {
+      buildResult.output = Object.keys(output).reduce(
+        (result, path) => ({
+          ...result,
+          [path.replace(/\\/g, '/')]: output[path],
+        }),
+        {}
+      );
+    }
+
+    return {
+      buildResult,
+      workPath,
+    };
   };
-}
-
-module.exports = runBuildLambda;
+};

--- a/test/lib/run-build-lambda.js
+++ b/test/lib/run-build-lambda.js
@@ -4,7 +4,7 @@ const fs = require('fs-extra');
 const json5 = require('json5');
 const { glob } = require('@vercel/build-utils');
 
-exports.createRunBuildLambda = async function (builder) {
+exports.createRunBuildLambda = function (builder) {
   return async inputPath => {
     const inputFiles = await glob('**', inputPath);
     const nowJsonRef = inputFiles['vercel.json'] || inputFiles['now.json'];


### PR DESCRIPTION
Follow-up for [this comment](https://github.com/vercel/vercel/pull/9252#discussion_r1080768761). Basically this just removes the need for `next`/`static-build` to be present in the root `package.json` file.

View with whitespace hidden: https://github.com/vercel/vercel/pull/9262/files?diff=unified&w=1