### PR TITLE
[next] Correct RSC route for app dir with trailingSlash

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1417,7 +1417,7 @@ export async function serverBuild({
               src: `^${path.posix.join(
                 '/',
                 entryDirectory,
-                '/((?!.+\\.rsc).+)$'
+                '/((?!.+\\.rsc).+?)(?:/)?$'
               )}`,
               has: [
                 {

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(newroot)/dashboard/another/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(newroot)/dashboard/another/page.js
@@ -1,0 +1,7 @@
+export default function AnotherPage(props) {
+  return (
+    <>
+      <p>hello from newroot/dashboard/another</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(newroot)/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(newroot)/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html className="this-is-another-document-html">
+      <head>
+        <title>{`hello world`}</title>
+      </head>
+      <body className="this-is-another-document-body">{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(rootonly)/dashboard/changelog/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(rootonly)/dashboard/changelog/page.js
@@ -1,0 +1,7 @@
+export default function ChangelogPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/changelog</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(rootonly)/dashboard/hello/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/(rootonly)/dashboard/hello/page.js
@@ -1,0 +1,7 @@
+export default function HelloPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/rootonly/hello</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/page.js
@@ -1,0 +1,20 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import style from './style.module.css';
+import './style.css';
+
+export default function ClientComponentRoute() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    setCount(1);
+  }, [count]);
+  return (
+    <>
+      <p className={style.red}>
+        hello from app/client-component-route. <b>count: {count}</b>
+      </p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/style.css
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/style.css
@@ -1,0 +1,3 @@
+b {
+  color: blue;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/style.module.css
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-component-route/style.module.css
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/layout.js
@@ -1,0 +1,20 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import styles from './style.module.css';
+import './style.css';
+
+export default function ClientNestedLayout({ children }) {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    setCount(1);
+  }, []);
+  return (
+    <>
+      <h1 className={styles.red}>Client Nested. Count: {count}</h1>
+      <button onClick={() => setCount(count + 1)}>{count}</button>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/page.js
@@ -1,0 +1,7 @@
+export default function ClientPage() {
+  return (
+    <>
+      <p>hello from app/client-nested</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/style.css
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/style.css
@@ -1,0 +1,3 @@
+button {
+  color: red;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/style.module.css
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/client-nested/style.module.css
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/(custom)/deployments/breakdown/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/(custom)/deployments/breakdown/page.js
@@ -1,0 +1,7 @@
+export default function DeploymentsBreakdownPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/(custom)/deployments/breakdown</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/(custom)/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/(custom)/layout.js
@@ -1,0 +1,8 @@
+export default function CustomDashboardRootLayout({ children }) {
+  return (
+    <>
+      <h2>Custom dashboard</h2>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/[id]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/[id]/page.js
@@ -1,0 +1,7 @@
+export default function DeploymentsPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/deployments/[id]. ID is: {props.params.id}</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/[id]/settings/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/[id]/settings/page.js
@@ -1,0 +1,10 @@
+export default function DeploymentsPage(props) {
+  return (
+    <>
+      <p>
+        hello from app/dashboard/deployments/[id]/settings. ID is:{' '}
+        {props.params.id}
+      </p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/catchall/[[...rest]]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/catchall/[[...rest]]/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>catchall</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/info/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/info/page.js
@@ -1,0 +1,7 @@
+export default function DeploymentsInfoPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/deployments/info</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/deployments/layout.js
@@ -1,0 +1,8 @@
+export default function DeploymentsLayout({ message, children }) {
+  return (
+    <>
+      <h2>Deployments hello</h2>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/integrations/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/integrations/page.js
@@ -1,0 +1,7 @@
+export default function IntegrationsPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard/integrations</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/layout.js
@@ -1,0 +1,8 @@
+export default function DashboardLayout(props) {
+  return (
+    <>
+      <h1>Dashboard</h1>
+      {props.children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dashboard/page.js
@@ -1,0 +1,7 @@
+export default function DashboardPage(props) {
+  return (
+    <>
+      <p>hello from app/dashboard</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/[id]/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/[id]/layout.js
@@ -1,0 +1,11 @@
+export default function IdLayout({ children, params }) {
+  return (
+    <>
+      <h3>
+        Id Layout. Params:{' '}
+        <span id="id-layout-params">{JSON.stringify(params)}</span>
+      </h3>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/[id]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/[id]/page.js
@@ -1,0 +1,11 @@
+export default function IdPage({ children, params }) {
+  return (
+    <>
+      <p>
+        Id Page. Params:{' '}
+        <span id="id-page-params">{JSON.stringify(params)}</span>
+      </p>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/[category]/layout.js
@@ -1,0 +1,11 @@
+export default function CategoryLayout({ children, params }) {
+  return (
+    <>
+      <h2>
+        Category Layout. Params:{' '}
+        <span id="category-layout-params">{JSON.stringify(params)}</span>{' '}
+      </h2>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/dynamic/layout.js
@@ -1,0 +1,11 @@
+export default function DynamicLayout({ children, params }) {
+  return (
+    <>
+      <h1>
+        Dynamic Layout. Params:{' '}
+        <span id="dynamic-layout-params">{JSON.stringify(params)}</span>
+      </h1>
+      {children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html className="this-is-the-document-html">
+      <head>
+        <title>{`hello world`}</title>
+      </head>
+      <body className="this-is-the-document-body">{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index app page</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/partial-match-[id]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/partial-match-[id]/page.js
@@ -1,0 +1,7 @@
+export default function DeploymentsPage(props) {
+  return (
+    <>
+      <p>hello from app/partial-match-[id]. ID is: {props.params.id}</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/shared-component-route/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/shared-component-route/page.js
@@ -1,0 +1,7 @@
+export default function SharedComponentRoute() {
+  return (
+    <>
+      <p>hello from app/shared-component-route</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/should-not-serve-client/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/should-not-serve-client/page.js
@@ -1,0 +1,9 @@
+'use client';
+
+export default function ShouldNotServeClientDotJs(props) {
+  return (
+    <>
+      <p>hello from app/should-not-serve-client</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/should-not-serve-server/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/should-not-serve-server/page.js
@@ -1,0 +1,7 @@
+export default function ShouldNotServeServerDotJs(props) {
+  return (
+    <>
+      <p>hello from app/should-not-serve-server</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/loading.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading-layout">Loading layout...</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/layout.js
@@ -1,0 +1,18 @@
+import { use } from 'react';
+
+async function getData() {
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  return {
+    message: 'hello from slow layout',
+  };
+}
+
+export default function SlowLayout(props) {
+  const data = use(getData());
+  return (
+    <>
+      <p id="slow-layout-message">{data.message}</p>
+      {props.children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/loading.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading-page">Loading page...</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-and-page-with-loading/slow/page.js
@@ -1,0 +1,13 @@
+import { use } from 'react';
+
+async function getData() {
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  return {
+    message: 'hello from slow page',
+  };
+}
+
+export default function SlowPage(props) {
+  const data = use(getData());
+  return <h1 id="slow-page-message">{data.message}</h1>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/loading.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">Loading...</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/slow/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/slow/layout.js
@@ -1,0 +1,18 @@
+import { use } from 'react';
+
+async function getData() {
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  return {
+    message: 'hello from slow layout',
+  };
+}
+
+export default function SlowLayout(props) {
+  const data = use(getData());
+  return (
+    <>
+      <p id="slow-layout-message">{data.message}</p>
+      {props.children}
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/slow/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-layout-with-loading/slow/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="page-message">Hello World</h1>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-page-with-loading/loading.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-page-with-loading/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">Loading...</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-page-with-loading/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/slow-page-with-loading/page.js
@@ -1,0 +1,13 @@
+import { use } from 'react';
+
+async function getData() {
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  return {
+    message: 'hello from slow page',
+  };
+}
+
+export default function SlowPage(props) {
+  const data = use(getData());
+  return <h1 id="slow-page-message">{data.message}</h1>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/ssg/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/ssg/page.js
@@ -1,0 +1,10 @@
+export const revalidate = 3;
+
+export default function Page() {
+  return (
+    <>
+      <p>hello from /ssg</p>
+      <p>{Date.now()}</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/app/test-page/page.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/app/test-page/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page">Page</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/middleware.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/middleware.js
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+  if (request.nextUrl.pathname === '/middleware-to-dashboard/') {
+    // TODO: this does not copy __flight__ and __flight_router_state_tree__
+    return NextResponse.rewrite(new URL('/dashboard', request.url));
+  }
+
+  if (
+    request.nextUrl.pathname === '/ssg/' &&
+    request.nextUrl.searchParams.get('override')
+  ) {
+    request.nextUrl.pathname = '/overridden/';
+    return NextResponse.redirect(request.nextUrl);
+  }
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  trailingSlash: true,
+  experimental: {
+    appDir: true,
+  },
+  rewrites: async () => {
+    return [
+      {
+        source: '/rewritten-to-dashboard',
+        destination: '/dashboard',
+      },
+    ];
+  },
+};

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/package.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "experimental",
+    "react-dom": "experimental"
+  }
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  return res.json({ hello: 'world' });
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/pages/blog/[slug].js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/pages/blog/[slug].js
@@ -1,0 +1,7 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>hello from pages/blog/[slug]</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/public/hello.txt
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/public/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -1,0 +1,169 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/dynamic/category-1/id-1/",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/ssg/",
+      "status": 200,
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/ssg/",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/ssg/?override=1",
+      "status": 307,
+      "responseHeaders": {
+        "location": "/overridden/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/ssg/?override=1",
+      "status": 307,
+      "responseHeaders": {
+        "location": "/overridden/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/dashboard/deployments/123/settings/",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/dashboard/deployments/123/settings/",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/dashboard/deployments/catchall/something/",
+      "status": 200,
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/dashboard/deployments/catchall/something/",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/dashboard/",
+      "status": 200,
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/dashboard/",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/dashboard/",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "responseHeaders": {
+        "content-type": "application/octet-stream",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/dashboard/another/",
+      "status": 200,
+      "mustContain": "hello from newroot/dashboard/another"
+    },
+    {
+      "path": "/dashboard/deployments/123/",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/deployments/[id]. ID is: <!-- -->123"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "index app page"
+    },
+    {
+      "path": "/blog/123/",
+      "status": 200,
+      "mustContain": "hello from pages/blog/[slug]"
+    },
+    {
+      "path": "/dynamic/category-1/id-1/",
+      "status": 200,
+      "mustContain": "{&quot;category&quot;:&quot;category-1&quot;,&quot;id&quot;:&quot;id-1&quot;}"
+    },
+    {
+      "path": "/dashboard/changelog/",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/changelog"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    }
+  ]
+}


### PR DESCRIPTION
This ensures we correctly match the trailing slash when routing RSC routes for app directory. Regression tests for trailing slash support has also been added. 

Fixes: https://github.com/vercel/next.js/issues/45062