### PR TITLE
[static-build] adjust gatsby auto-inject semver range to exclude v5+

### DIFF
--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -24,7 +24,7 @@ export async function injectPlugins(
 
   if (process.env.VERCEL_GATSBY_BUILDER_PLUGIN && detectedVersion) {
     const version = semver.coerce(detectedVersion);
-    if (version && semver.satisfies(version, '>=4.0.0')) {
+    if (version && semver.satisfies(version, '>=4.x <5.x')) {
       pluginsToInject.push(PLUGINS.GATSBY_PLUGIN_VERCEL_BUILDER);
     }
   }


### PR DESCRIPTION
Modify the semver range the auto injection operates in so that we only add the plugin for v4 projects