### PR TITLE
[cli] add missing deprecation warnings for builders/runtimes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -171,7 +171,7 @@
     "tmp-promise": "1.0.3",
     "tree-kill": "1.2.2",
     "ts-node": "10.9.1",
-    "typescript": "4.7.4",
+    "typescript": "4.9.4",
     "universal-analytics": "0.4.20",
     "utility-types": "2.1.0",
     "write-json-file": "2.2.0",

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -219,7 +219,7 @@ async function installBuilders(
       }
     );
     stderr
-      .split('\n')
+      .split('/\r?\n/')
       .filter(line => line.includes('npm WARN deprecated'))
       .forEach(line => {
         output.warn(line);

--- a/packages/cli/test/unit/util/build/import-builders.test.ts
+++ b/packages/cli/test/unit/util/build/import-builders.test.ts
@@ -105,6 +105,7 @@ describe('importBuilders()', () => {
       await expect(client.stderr).toOutput(
         '> Installing Builder: @vercel/node'
       );
+      await expect(client.stderr).not.toOutput('npm WARN deprecated');
     } finally {
       await remove(cwd);
     }
@@ -140,6 +141,33 @@ describe('importBuilders()', () => {
       );
       await expect(client.stderr).toOutput(
         '> Installing Builders: vercel-deno@2.0.1, https://test2020-h5hdll5dz-tootallnate.vercel.app'
+      );
+    } finally {
+      await remove(cwd);
+    }
+  });
+
+  it('should install and warn when Builder is deprecated', async () => {
+    if (process.platform === 'win32') {
+      // this test creates symlinks which require admin by default on Windows
+      console.log('Skipping test on Windows');
+      return;
+    }
+
+    const cwd = await getWriteableDirectory();
+    try {
+      const spec = '@now/node';
+      const specs = new Set([spec]);
+      const builders = await importBuilders(specs, cwd, client.output);
+      expect(builders.size).toEqual(1);
+      expect(builders.get(spec)?.pkg.name).toEqual('@now/node');
+      expect(builders.get(spec)?.pkg.version).toEqual('1.8.5');
+      expect(builders.get(spec)?.pkgPath).toEqual(
+        join(cwd, '.vercel/builders/node_modules/@now/node/package.json')
+      );
+      expect(typeof builders.get(spec)?.builder.build).toEqual('function');
+      await expect(client.stderr).toOutput(
+        'npm WARN deprecated @now/node@1.8.5: "@now/node" is deprecated and will stop receiving updates on December 31, 2020. Please use "@vercel/node" instead.'
       );
     } finally {
       await remove(cwd);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,7 +284,7 @@ importers:
       tmp-promise: 1.0.3
       tree-kill: 1.2.2
       ts-node: 10.9.1
-      typescript: 4.7.4
+      typescript: 4.9.4
       universal-analytics: 0.4.20
       utility-types: 2.1.0
       write-json-file: 2.2.0
@@ -419,8 +419,8 @@ importers:
       title: 3.4.1
       tmp-promise: 1.0.3
       tree-kill: 1.2.2
-      ts-node: 10.9.1_h4ad5mqkmlr6vlnzdne3idyzoy
-      typescript: 4.7.4
+      ts-node: 10.9.1_j2g5vy3qcga7tp65fndlxsubb4
+      typescript: 4.9.4
       universal-analytics: 0.4.20
       utility-types: 2.1.0
       write-json-file: 2.2.0
@@ -12261,6 +12261,18 @@ packages:
         optional: true
     dev: false
 
+  /follow-redirects/1.15.2_debug@3.1.0:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 3.1.0
+    dev: true
+
   /follow-redirects/1.15.2_debug@3.2.7:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -13732,7 +13744,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2_debug@3.2.7
+      follow-redirects: 1.15.2_debug@3.1.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -21044,7 +21056,7 @@ packages:
       '@ts-morph/common': 0.11.1
       code-block-writer: 10.1.1
 
-  /ts-node/10.9.1_h4ad5mqkmlr6vlnzdne3idyzoy:
+  /ts-node/10.9.1_j2g5vy3qcga7tp65fndlxsubb4:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -21071,7 +21083,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.7.4
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true


### PR DESCRIPTION
We used to print deprecations on the old build pipeline but this was lost when switching to `vercel build`.

This PR ensures that `vercel build` prints deprecation warnings if available.

## Example

https://npmjs.com/package/@now/node

<img width="751" alt="image" src="https://user-images.githubusercontent.com/229881/214143779-f71c88c8-6ee3-47ce-b459-a86154474991.png">
