### PR TITLE
[static-build] Use tarball URLs for Gatsby plugin E2E tests

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -32,7 +32,7 @@ export async function generateVercelBuildOutputAPI3Output({
   };
 
   if (validateGatsbyState(state)) {
-    console.log('▲ Creating Vercel build output (nate test)');
+    console.log('▲ Creating Vercel build output');
     await remove(join('.vercel', 'output'));
 
     const { pages, redirects, functions, config: gatsbyConfig } = state;

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -32,7 +32,7 @@ export async function generateVercelBuildOutputAPI3Output({
   };
 
   if (validateGatsbyState(state)) {
-    console.log('▲ Creating Vercel build output');
+    console.log('▲ Creating Vercel build output (nate test)');
     await remove(join('.vercel', 'output'));
 
     const { pages, redirects, functions, config: gatsbyConfig } = state;

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -22,8 +22,8 @@ const PLUGIN_VERSIONS = new Map<PluginName, string>([
 ]);
 
 // For E2E tests, ensure the same version of the plugin is used as the source code
-const { NODE_ENV, VERCEL_CLI_VERSION } = process.env;
-if (NODE_ENV === 'test' && VERCEL_CLI_VERSION) {
+const { VERCEL_CLI_VERSION } = process.env;
+if (VERCEL_CLI_VERSION?.startsWith('https://')) {
   for (const name of PLUGIN_VERSIONS.keys()) {
     PLUGIN_VERSIONS.set(
       name,

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -21,7 +21,7 @@ const PLUGIN_VERSIONS = new Map<PluginName, string>([
   ['@vercel/gatsby-plugin-vercel-builder', 'latest'],
 ]);
 
-// For E2E tests, ensure the same version of the plugin is used as the source code
+// Use the tarball URL for E2E tests
 const { VERCEL_CLI_VERSION } = process.env;
 if (VERCEL_CLI_VERSION?.startsWith('https://')) {
   for (const name of PLUGIN_VERSIONS.keys()) {
@@ -29,7 +29,6 @@ if (VERCEL_CLI_VERSION?.startsWith('https://')) {
     PLUGIN_VERSIONS.set(name, url.href);
   }
 }
-console.log(PLUGIN_VERSIONS);
 
 const GATSBY_CONFIG_FILE = 'gatsby-config';
 

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -25,7 +25,7 @@ const PLUGIN_VERSIONS = new Map<PluginName, string>([
 const { VERCEL_CLI_VERSION } = process.env;
 if (VERCEL_CLI_VERSION?.startsWith('https://')) {
   for (const name of PLUGIN_VERSIONS.keys()) {
-    const url = new URL(`../${name}.tgz`, VERCEL_CLI_VERSION);
+    const url = new URL(`./${name}.tgz`, VERCEL_CLI_VERSION);
     PLUGIN_VERSIONS.set(name, url.href);
   }
 }

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -25,10 +25,8 @@ const PLUGIN_VERSIONS = new Map<PluginName, string>([
 const { VERCEL_CLI_VERSION } = process.env;
 if (VERCEL_CLI_VERSION?.startsWith('https://')) {
   for (const name of PLUGIN_VERSIONS.keys()) {
-    PLUGIN_VERSIONS.set(
-      name,
-      new URL(`../${name}.tgz`, VERCEL_CLI_VERSION).href
-    );
+    const url = new URL(`../${name}.tgz`, VERCEL_CLI_VERSION);
+    PLUGIN_VERSIONS.set(name, url.href);
   }
 }
 console.log(PLUGIN_VERSIONS);


### PR DESCRIPTION
When running the static-build integration tests, use the tarball URL for the Gatsby plugins, so that any changes made to the plugin(s) in the PR will be reflected in the test deployments without having to publish to npm first.

Example screenshots of a deployment's build logs before I removed the debugging:

<img width="1045" alt="Screenshot 2023-01-23 at 7 35 32 PM" src="https://user-images.githubusercontent.com/71256/214207250-24695a11-051d-4abb-a132-729ab0ab167a.png">
<img width="517" alt="Screenshot 2023-01-23 at 7 35 41 PM" src="https://user-images.githubusercontent.com/71256/214207254-74265e05-ed17-4fbb-b54d-9edc2234a3e4.png">
