### PR TITLE
[tests] Added cron workflow to update turbo

### DIFF
--- a/.github/workflows/cron-update-turbo.yml
+++ b/.github/workflows/cron-update-turbo.yml
@@ -1,0 +1,27 @@
+name: Cron Update Turbo
+
+on:
+  # Run every 4 hours https://crontab.guru/every-4-hours
+  schedule:
+    - cron: '0 */4 * * *'
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        # 0 means fetch all commits so we can commit and push in the script below
+        with:
+          fetch-depth: 0
+      - name: install pnpm@7.26.0
+        run: npm i -g pnpm@7.26.0
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # See https://github.com/actions/github-script#run-a-separate-file-with-an-async-function
+        with:
+          script: |
+            const script = require('./utils/update-turbo.js')
+            await script({ github, context })

--- a/.github/workflows/cron-update-turbo.yml
+++ b/.github/workflows/cron-update-turbo.yml
@@ -1,9 +1,9 @@
 name: Cron Update Turbo
 
 on:
-  # Run every 4 hours https://crontab.guru/every-4-hours
+  # Run every week https://crontab.guru/every-week
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 0 * * 0'
 
 jobs:
   create-pull-request:

--- a/utils/update-turbo.js
+++ b/utils/update-turbo.js
@@ -1,0 +1,56 @@
+const { execFileSync } = require('child_process');
+const { readFileSync, writeFileSync } = require('fs');
+
+function exec(cmd, args, opts) {
+  // eslint-disable-next-line no-console
+  console.log({ input: `${cmd} ${args.join(' ')}` });
+  const output = execFileSync(cmd, args, opts).toString().trim();
+  console.log({ output });
+  console.log();
+  return output;
+}
+
+module.exports = async ({ github, context }) => {
+  const pkgJson = JSON.parse(readFileSync('package.json', 'utf-8'));
+  const oldVersion = pkgJson.devDependencies.turbo;
+  const newVersion = exec('npm', ['view', 'turbo', 'dist-tags.canary']);
+  const branch = `turbo-${newVersion.replaceAll('.', '-')}`;
+
+  if (oldVersion === newVersion) {
+    // eslint-disable-next-line no-console
+    console.log(`Turbo version ${newVersion} did not change, skipping update.`);
+    return;
+  }
+
+  if (exec('git', ['ls-remote', '--heads', 'origin', branch])) {
+    // eslint-disable-next-line no-console
+    console.log(`Branch ${branch} already exists, skipping update.`);
+    return;
+  }
+
+  pkgJson.devDependencies.turbo = newVersion;
+  writeFileSync(
+    'package.json',
+    JSON.stringify(pkgJson, null, 2) + '\n',
+    'utf-8'
+  );
+
+  exec('git', ['config', '--global', 'user.email', 'infra+release@vercel.com']);
+  exec('git', ['config', '--global', 'user.name', 'vercel-release-bot']);
+  exec('git', ['checkout', '-b', branch]);
+  exec('pnpm', ['install', '--lockfile-only']);
+  exec('git', ['add', '-A']);
+  exec('git', ['commit', '-m', branch]);
+  exec('git', ['push', 'origin', branch]);
+
+  const { repo, owner } = context.repo;
+
+  await github.rest.pulls.create({
+    owner,
+    repo,
+    head: branch,
+    base: 'main',
+    title: `[tests] Upgrade Turbo to version ${newVersion}`,
+    body: `This auto-generated PR updates Turbo to version ${newVersion}`,
+  });
+};


### PR DESCRIPTION
Linear: https://linear.app/vercel/issue/VCCLI-450/add-cron-update-turbo-workflow

Based on the Next.js update script, this PR adds a cron job that checks for the latest Turbo canary release, then updates the `package.json` and `pnpm-lock.yaml` files.