### PR TITLE
[gatsby-plugin-vercel-builder] Get rid of the `_ssr` function

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/src/utils/symlink.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/utils/symlink.ts
@@ -1,5 +1,4 @@
 import path, { join, normalize, sep } from 'path';
-
 import { ensureDir, symlinkSync } from 'fs-extra';
 
 const removeTrailingSlash = (str: string) => str.replace(/\/$/, '');


### PR DESCRIPTION
Right now we create the SSR serverless function at path `_ssr`, and then symlink all the other pages to that function.

Instead just make the first page encountered be the "real" function, and symlink all the other pages to that endpoint.