### PR TITLE
[examples] Pin Node version to 16.x for Parcel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "dependencies": {
     "lerna": "5.6.2"
   },
+    "engines": {
+      "node": "16.x"
+  },
   "devDependencies": {
     "@types/node": "14.18.33",
     "@typescript-eslint/eslint-plugin": "5.21.0",


### PR DESCRIPTION
Looks like our Parcel examples are currently failing in Node 18.x. Pinning Node version to 16.x till we update the example