### PR TITLE
[static-build] Include Gatsby plugins as regular dependencies

### DIFF
--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "build": "node build",
     "test": "jest --env node --verbose --bail --runInBand",
-    "test-unit": "pnpm test -- test/build.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
-    "test-integration-once": "pnpm test -- test/integration-*.test.js"
+    "test-unit": "pnpm test test/build.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
+    "test-integration-once": "pnpm test test/integration-*.test.js"
   },
   "jest": {
     "preset": "ts-jest/presets/default",

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "build": "node build",
     "test": "jest --env node --verbose --bail --runInBand",
-    "test-unit": "pnpm test test/build.test.ts test/gatsby.test.js test/prepare-cache.test.ts",
-    "test-integration-once": "pnpm test test/integration-*.test.js"
+    "test-unit": "pnpm test -- test/build.test.ts test/gatsby.test.ts test/prepare-cache.test.ts",
+    "test-integration-once": "pnpm test -- test/integration-*.test.js"
   },
   "jest": {
     "preset": "ts-jest/presets/default",

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -28,6 +28,10 @@
       }
     }
   },
+  "dependencies": {
+    "@vercel/gatsby-plugin-vercel-analytics": "1.0.7",
+    "@vercel/gatsby-plugin-vercel-builder": "1.0.0"
+  },
   "devDependencies": {
     "@types/aws-lambda": "8.10.64",
     "@types/cross-spawn": "6.0.0",
@@ -41,8 +45,6 @@
     "@vercel/build-utils": "5.9.0",
     "@vercel/frameworks": "1.2.4",
     "@vercel/fs-detectors": "3.7.5",
-    "@vercel/gatsby-plugin-vercel-analytics": "1.0.7",
-    "@vercel/gatsby-plugin-vercel-builder": "1.0.0",
     "@vercel/ncc": "0.24.0",
     "@vercel/routing-utils": "2.1.8",
     "@vercel/static-config": "2.0.11",

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -43,9 +43,7 @@ import type { ImagesConfig, BuildConfig } from './utils/_shared';
 import treeKill from 'tree-kill';
 import {
   detectFrameworkRecord,
-  detectFramework,
   LocalFileSystemDetector,
-  packageManagers,
 } from '@vercel/fs-detectors';
 
 const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
@@ -391,20 +389,7 @@ export const build: BuildV2 = async ({
       }
 
       if (framework.slug === 'gatsby') {
-        const injectedPlugins = await GatsbyUtils.injectPlugins(
-          detectedVersion,
-          entrypointDir
-        );
-
-        if (injectedPlugins) {
-          const packageManager = await detectFramework({
-            fs: localFileSystemDetector,
-            frameworkList: packageManagers,
-          });
-          if (packageManager === 'pnpm') {
-            await execCommand('pnpm install --lockfile-only');
-          }
-        }
+        await GatsbyUtils.injectPlugins(detectedVersion, entrypointDir);
       }
 
       if (process.env.VERCEL_ANALYTICS_ID) {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -511,6 +511,10 @@ export const build: BuildV2 = async ({
       }
     }
 
+    if (framework?.slug === 'gatsby') {
+      await GatsbyUtils.createPluginSymlinks(entrypointDir);
+    }
+
     let gemHome: string | undefined = undefined;
     const pathList = [];
 

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -22,7 +22,6 @@ const PLUGIN_PATHS: Record<PluginName, string> = {
     eval('require').resolve(`@vercel/gatsby-plugin-vercel-builder/package.json`)
   ),
 };
-console.log(PLUGIN_PATHS);
 
 export async function injectPlugins(
   detectedVersion: string | null,

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -150,7 +150,7 @@ async function updateGatsbyConfigMjs(
   const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
-    configPath,
+    configPath.replace(/\.js$/, '.mjs'),
     `import userConfig from ${JSON.stringify(relativeRenamedPath)};
 
 const preferDefault = (m) => (m && m.default) || m;
@@ -235,7 +235,7 @@ async function updateGatsbyNodeMjs(configPath: string) {
   const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
-    configPath,
+    configPath.replace(/\.js$/, '.mjs'),
     `import * as vercelBuilder from ${JSON.stringify(GATSBY_BUILDER_PATH)};
 import * as gatsbyNode from ${JSON.stringify(relativeRenamedPath)};
 

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -84,8 +84,8 @@ async function updateGatsbyConfig(
     await updateGatsbyConfigMjs(gatsbyConfigPathJs, plugins);
   } else {
     await fs.writeFile(
-      gatsbyConfigPathMjs,
-      `export default ${JSON.stringify({
+      gatsbyConfigPathJs,
+      `module.exports = ${JSON.stringify({
         plugins: Object.values(plugins),
       })}`
     );
@@ -192,7 +192,7 @@ async function updateGatsbyNode(dir: string) {
   } else {
     await fs.writeFile(
       gatsbyNodePathJs,
-      `module.exports = ${JSON.stringify(GATSBY_BUILDER_PATH)};`
+      `module.exports = require(${JSON.stringify(GATSBY_BUILDER_PATH)});`
     );
   }
 }

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -238,7 +238,7 @@ const gatsbyNode = require(${JSON.stringify(relativeRenamedPath)});
 
 const origOnPostBuild = gatsbyNode.onPostBuild;
 
-export const onPostBuild = async (args, options) => {
+gatsbyNode.onPostBuild = async (args, options) => {
   if (typeof origOnPostBuild === 'function') {
     await origOnPostBuild(args, options);
   }

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -1,16 +1,7 @@
-import { PackageJson } from '@vercel/build-utils';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import semver from 'semver';
-import { URL } from 'url';
-import {
-  fileExists,
-  readPackageJson,
-  DeepWriteable,
-  writePackageJson,
-} from './_shared';
-
-const { VERCEL_CLI_VERSION } = process.env;
+import { fileExists } from './_shared';
 
 const PLUGINS = [
   '@vercel/gatsby-plugin-vercel-analytics',
@@ -21,13 +12,21 @@ type PluginName = typeof PLUGINS[number];
 const GATSBY_CONFIG_FILE = 'gatsby-config';
 const GATSBY_NODE_FILE = 'gatsby-node';
 
+const GATSBY_BUILDER_PATH = eval('require').resolve(
+  `@vercel/gatsby-plugin-vercel-builder/gatsby-node.js`
+);
+const GATSBY_ANALYTICS_PATH = eval('require').resolve(
+  `@vercel/gatsby-plugin-vercel-analytics`
+);
+console.log({ GATSBY_ANALYTICS_PATH, GATSBY_BUILDER_PATH });
+
 export async function injectPlugins(
   detectedVersion: string | null,
   dir: string
 ) {
   const plugins = new Set<PluginName>();
 
-  if (process.env.VERCEL_GATSBY_BUILDER_PLUGIN && detectedVersion) {
+  if (process.env.VERCEL_GATSBY_BUILDER_PLUGIN === '1' && detectedVersion) {
     const version = semver.coerce(detectedVersion);
     if (version && semver.satisfies(version, '>=4.0.0')) {
       plugins.add('@vercel/gatsby-plugin-vercel-builder');
@@ -43,11 +42,21 @@ export async function injectPlugins(
     return false;
   }
 
-  const ops = [addGatsbyPackage(dir, plugins)];
+  let pluginsStr = 'plugin';
+  if (plugins.size > 1) {
+    pluginsStr += 's';
+  }
+  console.log(
+    `Injecting Gatsby.js ${pluginsStr} ${Array.from(plugins)
+      .map(p => `"${p}"`)
+      .join(', ')}`
+  );
+
+  const ops = [];
 
   if (plugins.has('@vercel/gatsby-plugin-vercel-analytics')) {
     ops.push(
-      updateGatsbyConfig(dir, ['@vercel/gatsby-plugin-vercel-analytics'])
+      updateGatsbyConfig(dir, { '@vercel/gatsby-plugin-vercel-analytics': '' })
     );
   }
 
@@ -60,85 +69,42 @@ export async function injectPlugins(
   return true;
 }
 
-function printInjectingPlugins(
-  plugins: Iterable<PluginName>,
-  configPath: string
-) {
-  const pluginsArray = Array.from(plugins);
-  let pluginsStr = 'plugin';
-  if (pluginsArray.length > 1) {
-    pluginsStr += 's';
-  }
-  console.log(
-    `Injecting Gatsby.js ${pluginsStr} ${pluginsArray
-      .map(p => `"${p}"`)
-      .join(', ')} to \`${configPath}\``
-  );
-}
-
-async function addGatsbyPackage(
+async function updateGatsbyConfig(
   dir: string,
-  plugins: Iterable<PluginName>
-): Promise<void> {
-  const pkgJson = (await readPackageJson(dir)) as DeepWriteable<PackageJson>;
-  if (!pkgJson.dependencies) {
-    pkgJson.dependencies = {};
-  }
-
-  for (const plugin of plugins) {
-    if (!pkgJson.dependencies[plugin]) {
-      console.log(`Adding "${plugin}" to \`package.json\` "dependencies"`);
-      let version = 'latest';
-
-      // Use the tarball URL for E2E tests
-      if (VERCEL_CLI_VERSION?.startsWith('https://')) {
-        version = new URL(`./${plugin}.tgz`, VERCEL_CLI_VERSION).href;
-      }
-
-      pkgJson.dependencies[plugin] = version;
-    }
-  }
-
-  await writePackageJson(dir, pkgJson);
-}
-
-async function updateGatsbyConfig(dir: string, plugins: Iterable<PluginName>) {
+  plugins: Partial<Record<PluginName, string>>
+) {
   const gatsbyConfigPathTs = path.join(dir, `${GATSBY_CONFIG_FILE}.ts`);
   const gatsbyConfigPathMjs = path.join(dir, `${GATSBY_CONFIG_FILE}.mjs`);
   const gatsbyConfigPathJs = path.join(dir, `${GATSBY_CONFIG_FILE}.js`);
   if (await fileExists(gatsbyConfigPathTs)) {
-    printInjectingPlugins(plugins, gatsbyConfigPathTs);
     await updateGatsbyConfigTs(gatsbyConfigPathTs, plugins);
   } else if (await fileExists(gatsbyConfigPathMjs)) {
-    printInjectingPlugins(plugins, gatsbyConfigPathMjs);
     await updateGatsbyConfigMjs(gatsbyConfigPathMjs, plugins);
+  } else if (await fileExists(gatsbyConfigPathJs)) {
+    await updateGatsbyConfigMjs(gatsbyConfigPathJs, plugins);
   } else {
-    printInjectingPlugins(plugins, gatsbyConfigPathJs);
-    if (await fileExists(gatsbyConfigPathJs)) {
-      await updateGatsbyConfigJs(gatsbyConfigPathJs, plugins);
-    } else {
-      await fs.writeFile(
-        gatsbyConfigPathJs,
-        `module.exports = ${JSON.stringify({
-          plugins: Array.from(plugins),
-        })}`
-      );
-    }
+    await fs.writeFile(
+      gatsbyConfigPathMjs,
+      `export default ${JSON.stringify({
+        plugins: Object.values(plugins),
+      })}`
+    );
   }
 }
 
 async function updateGatsbyConfigTs(
   configPath: string,
-  plugins: Iterable<PluginName>
+  plugins: Partial<Record<PluginName, string>>
 ): Promise<void> {
   const renamedPath = `${configPath}.__vercel_builder_backup__.ts`;
   if (!(await fileExists(renamedPath))) {
     await fs.rename(configPath, renamedPath);
   }
+  const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
     configPath,
-    `import userConfig from "./gatsby-config.ts.__vercel_builder_backup__.ts";
+    `import userConfig from ${JSON.stringify(relativeRenamedPath)}
 import type { PluginRef } from "gatsby";
 
 const preferDefault = (m: any) => (m && m.default) || m;
@@ -152,7 +118,9 @@ if (!vercelConfig.plugins) {
   vercelConfig.plugins = [];
 }
 
-for (const plugin of ${JSON.stringify(Array.from(plugins))}) {
+const injectedPlugins = ${JSON.stringify(plugins)};
+
+for (const plugin of Object.keys(plugins)) {
   const hasPlugin = vercelConfig.plugins.find(
     (p: PluginRef) =>
       p && (p === plugin || p.resolve === plugin)
@@ -160,7 +128,7 @@ for (const plugin of ${JSON.stringify(Array.from(plugins))}) {
 
   if (!hasPlugin) {
     vercelConfig.plugins = vercelConfig.plugins.slice();
-    vercelConfig.plugins.push(plugin);
+    vercelConfig.plugins.push(injectedPlugins[plugin]);
   }
 }
 
@@ -171,16 +139,19 @@ export default vercelConfig;
 
 async function updateGatsbyConfigMjs(
   configPath: string,
-  plugins: Iterable<PluginName>
+  plugins: Partial<Record<PluginName, string>>
 ): Promise<void> {
-  const renamedPath = `${configPath}.__vercel_builder_backup__.mjs`;
+  const renamedPath = `${configPath}.__vercel_builder_backup__${path.extname(
+    configPath
+  )}`;
   if (!(await fileExists(renamedPath))) {
     await fs.rename(configPath, renamedPath);
   }
+  const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
     configPath,
-    `import userConfig from "./gatsby-config.mjs.__vercel_builder_backup__.mjs";
+    `import userConfig from ${JSON.stringify(relativeRenamedPath)};
 
 const preferDefault = (m) => (m && m.default) || m;
 
@@ -188,60 +159,25 @@ const vercelConfig = Object.assign(
   {},
   preferDefault(userConfig)
 );
+
 if (!vercelConfig.plugins) {
   vercelConfig.plugins = [];
 }
 
-for (const plugin of ${JSON.stringify(Array.from(plugins))}) {
+const injectedPlugins = ${JSON.stringify(plugins)};
+
+for (const plugin of Object.keys(injectedPlugins)) {
   const hasPlugin = vercelConfig.plugins.find(
     (p) => p && (p === plugin || p.resolve === plugin)
   );
 
   if (!hasPlugin) {
     vercelConfig.plugins = vercelConfig.plugins.slice();
-    vercelConfig.plugins.push(plugin);
+    vercelConfig.plugins.push(injectedPlugins[plugin]);
   }
 }
 
 export default vercelConfig;
-`
-  );
-}
-
-async function updateGatsbyConfigJs(
-  configPath: string,
-  plugins: Iterable<PluginName>
-): Promise<void> {
-  const renamedPath = `${configPath}.__vercel_builder_backup__.js`;
-  if (!(await fileExists(renamedPath))) {
-    await fs.rename(configPath, renamedPath);
-  }
-
-  await fs.writeFile(
-    configPath,
-    `const userConfig = require("./gatsby-config.js.__vercel_builder_backup__.js");
-
-const preferDefault = m => (m && m.default) || m;
-
-const vercelConfig = Object.assign(
-  {},
-  preferDefault(userConfig)
-);
-if (!vercelConfig.plugins) {
-  vercelConfig.plugins = [];
-}
-
-for (const plugin of ${JSON.stringify(Array.from(plugins))}) {
-  const hasPlugin = vercelConfig.plugins.find(
-    (p) => p && (p === plugin || p.resolve === plugin)
-  );
-
-  if (!hasPlugin) {
-    vercelConfig.plugins = vercelConfig.plugins.slice();
-    vercelConfig.plugins.push(plugin);
-  }
-}
-module.exports = vercelConfig;
 `
   );
 }
@@ -255,11 +191,11 @@ async function updateGatsbyNode(dir: string) {
   } else if (await fileExists(gatsbyNodePathMjs)) {
     await updateGatsbyNodeMjs(gatsbyNodePathMjs);
   } else if (await fileExists(gatsbyNodePathJs)) {
-    await updateGatsbyNodeJs(gatsbyNodePathJs);
+    await updateGatsbyNodeMjs(gatsbyNodePathJs);
   } else {
     await fs.writeFile(
-      gatsbyNodePathJs,
-      `module.exports = require('@vercel/gatsby-plugin-vercel-builder/gatsby-node.js');`
+      gatsbyNodePathMjs,
+      `export * from ${JSON.stringify(GATSBY_BUILDER_PATH)};`
     );
   }
 }
@@ -269,14 +205,15 @@ async function updateGatsbyNodeTs(configPath: string) {
   if (!(await fileExists(renamedPath))) {
     await fs.rename(configPath, renamedPath);
   }
+  const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
     configPath,
     `import type { GatsbyNode } from 'gatsby';
-import * as vercelBuilder from '@vercel/gatsby-plugin-vercel-builder/gatsby-node.js';
-import * as gatsbyNode from './gatsby-node.ts.__vercel_builder_backup__.ts';
+import * as vercelBuilder from ${JSON.stringify(GATSBY_BUILDER_PATH)};
+import * as gatsbyNode from ${JSON.stringify(relativeRenamedPath)};
 
-export * from './gatsby-node.ts.__vercel_builder_backup__.ts';
+export * from ${JSON.stringify(relativeRenamedPath)};
 
 export const onPostBuild: GatsbyNode['onPostBuild'] = async (args, options) => {
   if (typeof (gatsbyNode as any).onPostBuild === 'function') {
@@ -289,17 +226,20 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async (args, options) => {
 }
 
 async function updateGatsbyNodeMjs(configPath: string) {
-  const renamedPath = `${configPath}.__vercel_builder_backup__.mjs`;
+  const renamedPath = `${configPath}.__vercel_builder_backup__${path.extname(
+    configPath
+  )}`;
   if (!(await fileExists(renamedPath))) {
     await fs.rename(configPath, renamedPath);
   }
+  const relativeRenamedPath = `.${path.sep}${path.basename(renamedPath)}`;
 
   await fs.writeFile(
     configPath,
-    `import * as vercelBuilder from '@vercel/gatsby-plugin-vercel-builder/gatsby-node.js';
-import * as gatsbyNode from './gatsby-node.mjs.__vercel_builder_backup__.mjs';
+    `import * as vercelBuilder from ${JSON.stringify(GATSBY_BUILDER_PATH)};
+import * as gatsbyNode from ${JSON.stringify(relativeRenamedPath)};
 
-export * from './gatsby-node.mjs.__vercel_builder_backup__.mjs';
+export * from ${JSON.stringify(relativeRenamedPath)};
 
 export const onPostBuild = async (args, options) => {
   if (typeof gatsbyNode.onPostBuild === 'function') {
@@ -307,31 +247,6 @@ export const onPostBuild = async (args, options) => {
   }
   await vercelBuilder.onPostBuild(args, options);
 };
-`
-  );
-}
-
-async function updateGatsbyNodeJs(configPath: string) {
-  const renamedPath = `${configPath}.__vercel_builder_backup__.js`;
-  if (!(await fileExists(renamedPath))) {
-    await fs.rename(configPath, renamedPath);
-  }
-
-  await fs.writeFile(
-    configPath,
-    `const vercelBuilder = require('@vercel/gatsby-plugin-vercel-builder/gatsby-node.js');
-const gatsbyNode = require('./gatsby-node.js.__vercel_builder_backup__.js');
-
-const origOnPostBuild = gatsbyNode.onPostBuild;
-
-gatsbyNode.onPostBuild = async (args, options) => {
-  if (typeof origOnPostBuild === 'function') {
-    await origOnPostBuild(args, options);
-  }
-  await vercelBuilder.onPostBuild(args, options);
-};
-
-module.exports = gatsbyNode;
 `
   );
 }

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -127,7 +127,7 @@ for (const plugin of ${JSON.stringify(plugins)}) {
 
   if (!hasPlugin) {
     vercelConfig.plugins = vercelConfig.plugins.slice();
-    vercelConfig.plugins.push(injectedPlugins[plugin]);
+    vercelConfig.plugins.push(plugin);
   }
 }
 
@@ -170,7 +170,7 @@ for (const plugin of ${JSON.stringify(plugins)}) {
 
   if (!hasPlugin) {
     vercelConfig.plugins = vercelConfig.plugins.slice();
-    vercelConfig.plugins.push(injectedPlugins[plugin]);
+    vercelConfig.plugins.push(plugin);
   }
 }
 

--- a/packages/static-build/test/gatsby.test.ts
+++ b/packages/static-build/test/gatsby.test.ts
@@ -1,4 +1,4 @@
-import { injectPlugins } from '../src/utils/gatsby';
+import { injectPlugins, createPluginSymlinks } from '../src/utils/gatsby';
 import path from 'path';
 import {
   detectFrameworkRecord,
@@ -58,19 +58,9 @@ describe('gatsby utilities', () => {
     const fixture = await prepareFixture(path.join(fixturesPath, 'gatsby-v3'));
     const version = await detectVersion(fixture);
     await injectPlugins(version, fixture);
-    const [packageJSON, gatsbyConfig] = await Promise.all([
-      fs.readFile(path.join(fixture, 'package.json'), 'utf-8'),
+    const [gatsbyConfig] = await Promise.all([
       fs.readFile(path.join(fixture, 'gatsby-config.js'), 'utf-8'),
     ]);
-    expect(packageJSON).toMatchInlineSnapshot(`
-      "{
-        \\"dependencies\\": {
-          \\"gatsby\\": \\"3.0.0\\",
-          \\"@vercel/gatsby-plugin-vercel-analytics\\": \\"latest\\"
-        }
-      }
-      "
-    `);
     expect(gatsbyConfig).toMatchInlineSnapshot(
       `"module.exports = {\\"plugins\\":[\\"@vercel/gatsby-plugin-vercel-analytics\\"]}"`
     );
@@ -82,21 +72,10 @@ describe('gatsby utilities', () => {
     const fixture = await prepareFixture(path.join(fixturesPath, 'gatsby-v4'));
     const version = await detectVersion(fixture);
     await injectPlugins(version, fixture);
-    const [packageJSON, gatsbyNode, gatsbyConfig] = await Promise.all([
-      fs.readFile(path.join(fixture, 'package.json'), 'utf-8'),
+    const [gatsbyNode, gatsbyConfig] = await Promise.all([
       fs.readFile(path.join(fixture, 'gatsby-node.js'), 'utf-8'),
       fs.readFile(path.join(fixture, 'gatsby-config.js'), 'utf-8'),
     ]);
-    expect(packageJSON).toMatchInlineSnapshot(`
-      "{
-        \\"dependencies\\": {
-          \\"gatsby\\": \\"4.25.2\\",
-          \\"@vercel/gatsby-plugin-vercel-builder\\": \\"latest\\",
-          \\"@vercel/gatsby-plugin-vercel-analytics\\": \\"latest\\"
-        }
-      }
-      "
-    `);
     expect(gatsbyNode).toMatchInlineSnapshot(
       `"module.exports = require('@vercel/gatsby-plugin-vercel-builder/gatsby-node.js');"`
     );
@@ -113,35 +92,19 @@ describe('gatsby utilities', () => {
     );
     const version = await detectVersion(fixture);
     await injectPlugins(version, fixture);
-    const [
-      packageJSON,
-      gatsbyNode,
-      gatsbyNodeBackup,
-      gatsbyConfig,
-      gatsbyConfigBackup,
-    ] = await Promise.all([
-      fs.readFile(path.join(fixture, 'package.json'), 'utf-8'),
-      fs.readFile(path.join(fixture, 'gatsby-node.js'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-node.js.__vercel_builder_backup__.js'),
-        'utf-8'
-      ),
-      fs.readFile(path.join(fixture, 'gatsby-config.js'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-config.js.__vercel_builder_backup__.js'),
-        'utf-8'
-      ),
-    ]);
-    expect(packageJSON).toMatchInlineSnapshot(`
-      "{
-        \\"dependencies\\": {
-          \\"gatsby\\": \\"4.25.2\\",
-          \\"@vercel/gatsby-plugin-vercel-builder\\": \\"latest\\",
-          \\"@vercel/gatsby-plugin-vercel-analytics\\": \\"latest\\"
-        }
-      }
-      "
-    `);
+    const [gatsbyNode, gatsbyNodeBackup, gatsbyConfig, gatsbyConfigBackup] =
+      await Promise.all([
+        fs.readFile(path.join(fixture, 'gatsby-node.js'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-node.js.__vercel_builder_backup__.js'),
+          'utf-8'
+        ),
+        fs.readFile(path.join(fixture, 'gatsby-config.js'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-config.js.__vercel_builder_backup__.js'),
+          'utf-8'
+        ),
+      ]);
     expect(gatsbyNode).toMatchInlineSnapshot(`
       "const vercelBuilder = require('@vercel/gatsby-plugin-vercel-builder/gatsby-node.js');
       const gatsbyNode = require('./gatsby-node.js.__vercel_builder_backup__.js');
@@ -171,6 +134,7 @@ describe('gatsby utilities', () => {
         {},
         preferDefault(userConfig)
       );
+
       if (!vercelConfig.plugins) {
         vercelConfig.plugins = [];
       }
@@ -202,35 +166,19 @@ describe('gatsby utilities', () => {
     );
     const version = await detectVersion(fixture);
     await injectPlugins(version, fixture);
-    const [
-      packageJSON,
-      gatsbyNode,
-      gatsbyNodeBackup,
-      gatsbyConfig,
-      gatsbyConfigBackup,
-    ] = await Promise.all([
-      fs.readFile(path.join(fixture, 'package.json'), 'utf-8'),
-      fs.readFile(path.join(fixture, 'gatsby-node.ts'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-node.ts.__vercel_builder_backup__.ts'),
-        'utf-8'
-      ),
-      fs.readFile(path.join(fixture, 'gatsby-config.ts'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-config.ts.__vercel_builder_backup__.ts'),
-        'utf-8'
-      ),
-    ]);
-    expect(packageJSON).toMatchInlineSnapshot(`
-      "{
-        \\"dependencies\\": {
-          \\"gatsby\\": \\"4.25.2\\",
-          \\"@vercel/gatsby-plugin-vercel-builder\\": \\"latest\\",
-          \\"@vercel/gatsby-plugin-vercel-analytics\\": \\"latest\\"
-        }
-      }
-      "
-    `);
+    const [gatsbyNode, gatsbyNodeBackup, gatsbyConfig, gatsbyConfigBackup] =
+      await Promise.all([
+        fs.readFile(path.join(fixture, 'gatsby-node.ts'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-node.ts.__vercel_builder_backup__.ts'),
+          'utf-8'
+        ),
+        fs.readFile(path.join(fixture, 'gatsby-config.ts'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-config.ts.__vercel_builder_backup__.ts'),
+          'utf-8'
+        ),
+      ]);
     expect(gatsbyNode).toMatchInlineSnapshot(`
       "import type { GatsbyNode } from 'gatsby';
       import * as vercelBuilder from '@vercel/gatsby-plugin-vercel-builder/gatsby-node.js';
@@ -294,35 +242,19 @@ describe('gatsby utilities', () => {
     );
     const version = await detectVersion(fixture);
     await injectPlugins(version, fixture);
-    const [
-      packageJSON,
-      gatsbyNode,
-      gatsbyNodeBackup,
-      gatsbyConfig,
-      gatsbyConfigBackup,
-    ] = await Promise.all([
-      fs.readFile(path.join(fixture, 'package.json'), 'utf-8'),
-      fs.readFile(path.join(fixture, 'gatsby-node.mjs'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-node.mjs.__vercel_builder_backup__.mjs'),
-        'utf-8'
-      ),
-      fs.readFile(path.join(fixture, 'gatsby-config.mjs'), 'utf-8'),
-      fs.readFile(
-        path.join(fixture, 'gatsby-config.mjs.__vercel_builder_backup__.mjs'),
-        'utf-8'
-      ),
-    ]);
-    expect(packageJSON).toMatchInlineSnapshot(`
-      "{
-        \\"dependencies\\": {
-          \\"gatsby\\": \\"4.25.2\\",
-          \\"@vercel/gatsby-plugin-vercel-builder\\": \\"latest\\",
-          \\"@vercel/gatsby-plugin-vercel-analytics\\": \\"latest\\"
-        }
-      }
-      "
-    `);
+    const [gatsbyNode, gatsbyNodeBackup, gatsbyConfig, gatsbyConfigBackup] =
+      await Promise.all([
+        fs.readFile(path.join(fixture, 'gatsby-node.mjs'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-node.mjs.__vercel_builder_backup__.mjs'),
+          'utf-8'
+        ),
+        fs.readFile(path.join(fixture, 'gatsby-config.mjs'), 'utf-8'),
+        fs.readFile(
+          path.join(fixture, 'gatsby-config.mjs.__vercel_builder_backup__.mjs'),
+          'utf-8'
+        ),
+      ]);
     expect(gatsbyNode).toMatchInlineSnapshot(`
       "import * as vercelBuilder from '@vercel/gatsby-plugin-vercel-builder/gatsby-node.js';
       import * as gatsbyNode from './gatsby-node.mjs.__vercel_builder_backup__.mjs';
@@ -350,6 +282,7 @@ describe('gatsby utilities', () => {
         {},
         preferDefault(userConfig)
       );
+
       if (!vercelConfig.plugins) {
         vercelConfig.plugins = [];
       }
@@ -372,5 +305,27 @@ describe('gatsby utilities', () => {
       "module.exports = {};
       "
     `);
+  });
+
+  describe(`createPluginSymlinks()`, () => {
+    it('should add symlinks for Gatsby plugins', async () => {
+      const fixture = await prepareFixture(
+        path.join(fixturesPath, 'gatsby-v4-existing-files-mjs')
+      );
+
+      await createPluginSymlinks(fixture);
+
+      const analytics = require(path.join(
+        fixture,
+        'node_modules/@vercel/gatsby-plugin-vercel-analytics'
+      ));
+      expect(typeof analytics).toEqual('object');
+
+      const builder = require(path.join(
+        fixture,
+        'node_modules/@vercel/gatsby-plugin-vercel-builder/gatsby-node.js'
+      ));
+      expect(typeof builder.onPostBuild).toEqual('function');
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -971,6 +971,9 @@ importers:
       tree-kill: 1.2.2
       ts-morph: 12.0.0
       typescript: 4.3.4
+    dependencies:
+      '@vercel/gatsby-plugin-vercel-analytics': link:../gatsby-plugin-vercel-analytics
+      '@vercel/gatsby-plugin-vercel-builder': link:../gatsby-plugin-vercel-builder
     devDependencies:
       '@types/aws-lambda': 8.10.64
       '@types/cross-spawn': 6.0.0
@@ -984,8 +987,6 @@ importers:
       '@vercel/build-utils': link:../build-utils
       '@vercel/frameworks': link:../frameworks
       '@vercel/fs-detectors': link:../fs-detectors
-      '@vercel/gatsby-plugin-vercel-analytics': link:../gatsby-plugin-vercel-analytics
-      '@vercel/gatsby-plugin-vercel-builder': link:../gatsby-plugin-vercel-builder
       '@vercel/ncc': 0.24.0
       '@vercel/routing-utils': link:../routing-utils
       '@vercel/static-config': link:../static-config


### PR DESCRIPTION
Right now, static-build will add the necessary Gatsby plugins to the project's `package.json` at build-time, which has been bothersome for package managers when using a frozen lockfile.

Another issue with it is that we install `latest` version of the plugin, so the version used becomes disjointed from the CLI version itself, which leads to unpredictability when trying to debug issues or help users roll back to a previous behavior if something breaks.

So instead of patching `package.json` directly, include the plugins as deps of static-build itself, and create symlinks to those paths into the project's `node_modules` directory.