### PR TITLE
[next] Remove hardcoded NODE_OPTIONS

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -45,7 +45,6 @@ import {
   remove,
   writeFile,
 } from 'fs-extra';
-import os from 'os';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
@@ -408,8 +407,6 @@ export const build: BuildV2 = async ({
   }
 
   const env: typeof process.env = { ...spawnOpts.env };
-  const memoryToConsume = Math.floor(os.totalmem() / 1024 ** 2) - 128;
-  env.NODE_OPTIONS = `--max_old_space_size=${memoryToConsume}`;
   env.NEXT_EDGE_RUNTIME_PROVIDER = 'vercel';
 
   if (target) {


### PR DESCRIPTION
The `NODE_OPTIONS` env var value is wrong here and we shouldn't be overriding the user's setting to begin with.

Typically, it will be assigned in a build container or project settings.