### PR TITLE
[tests] Fix jest-haste-map: Haste module naming collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "packageManager": "pnpm@7.24.2",
   "dependencies": {
     "lerna": "5.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
+  "packageManager": "pnpm@7.24.2",
   "dependencies": {
     "lerna": "5.6.2"
   },

--- a/packages/build-utils/test/fixtures/21-npm-workspaces/a/package.json
+++ b/packages/build-utils/test/fixtures/21-npm-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a21",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/21-npm-workspaces/b/package.json
+++ b/packages/build-utils/test/fixtures/21-npm-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b21",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/21-npm-workspaces/package.json
+++ b/packages/build-utils/test/fixtures/21-npm-workspaces/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "21-npm-workspaces",
+  "private": true,
   "version": "1.0.0",
   "workspaces": [
     "a",

--- a/packages/build-utils/test/fixtures/22-pnpm/package.json
+++ b/packages/build-utils/test/fixtures/22-pnpm/package.json
@@ -1,14 +1,8 @@
 {
-  "name": "22-pnpm",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "build": "mkdir -p public && (printf \"pnpm version: \" && pnpm -v) > public/index.txt"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "once": "^1.4.0"
   }

--- a/packages/build-utils/test/fixtures/23-pnpm-workspaces/c/package.json
+++ b/packages/build-utils/test/fixtures/23-pnpm-workspaces/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c23",
+  "name": "build-c23",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/build-utils/test/fixtures/23-pnpm-workspaces/c/package.json
+++ b/packages/build-utils/test/fixtures/23-pnpm-workspaces/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c",
+  "name": "c23",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/build-utils/test/fixtures/23-pnpm-workspaces/d/package.json
+++ b/packages/build-utils/test/fixtures/23-pnpm-workspaces/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d23",
+  "name": "build-d23",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/build-utils/test/fixtures/23-pnpm-workspaces/d/package.json
+++ b/packages/build-utils/test/fixtures/23-pnpm-workspaces/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d",
+  "name": "d23",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/build-utils/test/fixtures/24-pnpm-hoisted/package.json
+++ b/packages/build-utils/test/fixtures/24-pnpm-hoisted/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "24-pnpm-hoisted",
+  "private": true,
   "scripts": {
     "build": "ls -Al node_modules && node index.js"
   },

--- a/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/a/package.json
+++ b/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/a/package.json
+++ b/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a25",
+  "name": "build-a25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/b/package.json
+++ b/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b25",
+  "name": "build-b25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/b/package.json
+++ b/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/package.json
+++ b/packages/build-utils/test/fixtures/25-multiple-lock-files-yarn/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "25-multiple-lock-files-yarn",
+  "private": true,
   "workspaces": [
     "a",
     "b"

--- a/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
+++ b/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
+++ b/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a26",
+  "name": "build-a26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
+++ b/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b26",
+  "name": "build-b26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
+++ b/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/package.json
+++ b/packages/build-utils/test/fixtures/26-multiple-lock-files-pnpm/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "26-multiple-lock-files-pnpm",
+  "private": true,
   "workspaces": [
     "a",
     "b"

--- a/packages/fs-detectors/test/fixtures/21-npm-workspaces/a/package.json
+++ b/packages/fs-detectors/test/fixtures/21-npm-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "npm-workspace-a21",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/21-npm-workspaces/b/package.json
+++ b/packages/fs-detectors/test/fixtures/21-npm-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "npm-workspace-b21",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/21-npm-workspaces/package.json
+++ b/packages/fs-detectors/test/fixtures/21-npm-workspaces/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "21-npm-workspaces",
-  "version": "1.0.0",
+  "private": true,
   "workspaces": [
     "a",
     "b"

--- a/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/c/package.json
+++ b/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c23",
+  "name": "fs-c23",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/c/package.json
+++ b/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c",
+  "name": "c23",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/d/package.json
+++ b/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d",
+  "name": "d23",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/d/package.json
+++ b/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d23",
+  "name": "fs-d23",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/package.json
+++ b/packages/fs-detectors/test/fixtures/23-pnpm-workspaces/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "23-pnpm-workspaces",
   "license": "MIT",
   "version": "1.0.0"
 }

--- a/packages/fs-detectors/test/fixtures/24-pnpm-hoisted/package.json
+++ b/packages/fs-detectors/test/fixtures/24-pnpm-hoisted/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "24-pnpm-hoisted",
+  "private": true,
   "scripts": {
     "build": "ls -Al node_modules && node index.js"
   },

--- a/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/a/package.json
+++ b/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/a/package.json
+++ b/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a25",
+  "name": "fs-a25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/b/package.json
+++ b/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b25",
+  "name": "fs-b25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/b/package.json
+++ b/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b25",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/package.json
+++ b/packages/fs-detectors/test/fixtures/25-multiple-lock-files-yarn/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "25-multiple-lock-files-yarn",
+  "private": true,
   "workspaces": [
     "a",
     "b"

--- a/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
+++ b/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
+++ b/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a26",
+  "name": "fs-a26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
+++ b/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b26",
+  "name": "fs-b26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
+++ b/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b26",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/package.json
+++ b/packages/fs-detectors/test/fixtures/26-multiple-lock-files-pnpm/package.json
@@ -1,6 +1,5 @@
 {
-  "private": "true",
-  "name": "26-multiple-lock-files-pnpm",
+  "private": true,
   "workspaces": [
     "a",
     "b"

--- a/packages/fs-detectors/test/fixtures/27-yarn-workspaces/a/package.json
+++ b/packages/fs-detectors/test/fixtures/27-yarn-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a27",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/27-yarn-workspaces/a/package.json
+++ b/packages/fs-detectors/test/fixtures/27-yarn-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a27",
+  "name": "fs-a27",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/27-yarn-workspaces/b/package.json
+++ b/packages/fs-detectors/test/fixtures/27-yarn-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b27",
+  "name": "fs-b27",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/27-yarn-workspaces/b/package.json
+++ b/packages/fs-detectors/test/fixtures/27-yarn-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b27",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/27-yarn-workspaces/package.json
+++ b/packages/fs-detectors/test/fixtures/27-yarn-workspaces/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "21-npm-workspaces",
-  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/28-pnpm-7/package.json
+++ b/packages/fs-detectors/test/fixtures/28-pnpm-7/package.json
@@ -1,5 +1,5 @@
 {
-  "private": "true",
+  "private": true,
   "scripts": {
     "build": "mkdir -p public && (printf \"pnpm version: \" && pnpm -v) > public/index.txt"
   },

--- a/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/a/package.json
+++ b/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a28",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/a/package.json
+++ b/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a28",
+  "name": "fs-a28",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/b/package.json
+++ b/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b28",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/b/package.json
+++ b/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b28",
+  "name": "fs-b28",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/package.json
+++ b/packages/fs-detectors/test/fixtures/28-turborepo-with-yarn-workspaces/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "21-npm-workspaces",
-  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/c/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c",
+  "name": "backend-c29",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/d/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d",
+  "name": "backend-d29",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/backend/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "29-nested-workspaces-backend",
   "license": "MIT",
   "version": "1.0.0"
 }

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/a/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "frontend-a29",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/b/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "frontend-b29",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/29-nested-workspaces/frontend/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "29-nested-workspaces-frontend",
-  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/c/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "c",
+  "name": "backend-c30",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/d/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/d/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d",
+  "name": "backend-d30",
   "license": "MIT",
   "version": "0.1.0",
   "devDependencies": {

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/backend/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "30-double-nested-workspaces-packages-backend",
   "license": "MIT",
   "version": "1.0.0"
 }

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/a/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "frontend-a30",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/b/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "frontend-b30",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/30-double-nested-workspaces/packages/frontend/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "30-double-nested-workspaces-packages-frontend",
-  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/a/package.json
+++ b/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a31",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/b/package.json
+++ b/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b31",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/package.json
+++ b/packages/fs-detectors/test/fixtures/31-turborepo-in-package-json/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "21-npm-workspaces",
-  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/backend/app-three/package.json
+++ b/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/backend/app-three/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-three",
+  "name": "backend-app-three-32",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/backend/package.json
+++ b/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "backend-32",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "frontend-app-one-32",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "frontend-app-one-32",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/32-monorepo-highly-nested/src/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "frontend-32",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/backend/app-three/package.json
+++ b/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/backend/app-three/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-three",
+  "name": "app-three33",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/backend/package.json
+++ b/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "backend33",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/frontend/a/package.json
+++ b/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/frontend/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "frontend-33a",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/frontend/b/package.json
+++ b/packages/fs-detectors/test/fixtures/33-hybrid-monorepo/frontend/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "frontend-33b",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/backend/app-three/package.json
+++ b/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/backend/app-three/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-three",
+  "name": "backend-app-three-34",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/backend/package.json
+++ b/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "backend34",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "frontend-app-one-34",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "frontend-app-two-34",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/34-monorepo-no-workspaces/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "frontend34",
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/35-no-monorepo/package.json
+++ b/packages/fs-detectors/test/fixtures/35-no-monorepo/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "app-one",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/app-one/app-three/package.json
+++ b/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/app-one/app-three/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "app-one-app-three-36",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "app-two36",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/package.json
+++ b/packages/fs-detectors/test/fixtures/36-monorepo-some-nested/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "private": true,
   "license": "MIT",
   "version": "0.1.0"
 }

--- a/packages/fs-detectors/test/fixtures/37-project-depth-one-level/package.json
+++ b/packages/fs-detectors/test/fixtures/37-project-depth-one-level/package.json
@@ -1,14 +1,8 @@
 {
-  "name": "app-one",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "next": "^4.3.2"
   }

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/a/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "a38",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/b/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "b38",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/package.json
+++ b/packages/fs-detectors/test/fixtures/38-workspaces-no-lock-file/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "21-npm-workspaces",
+  "private": true,
   "version": "1.0.0",
   "workspaces": [
     "a",

--- a/packages/fs-detectors/test/fixtures/40-rush-monorepo/apps/my-app/package.json
+++ b/packages/fs-detectors/test/fixtures/40-rush-monorepo/apps/my-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "my-app40",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/40-rush-monorepo/apps/my-second-app/package.json
+++ b/packages/fs-detectors/test/fixtures/40-rush-monorepo/apps/my-second-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-second-app",
+  "name": "my-second-app40",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/41-nx-workspace/apps/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/41-nx-workspace/apps/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "app-one41",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/41-nx-workspace/apps/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/41-nx-workspace/apps/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "app-two41",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/42-npm-workspace-with-nx/apps/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/42-npm-workspace-with-nx/apps/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "app-one42",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/42-npm-workspace-with-nx/apps/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/42-npm-workspace-with-nx/apps/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "app-two42",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/43-nx-json-misshaped/apps/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/43-nx-json-misshaped/apps/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "app-one43",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/43-nx-json-misshaped/apps/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/43-nx-json-misshaped/apps/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "app-two43",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/44-nx-json-string/apps/app-one/package.json
+++ b/packages/fs-detectors/test/fixtures/44-nx-json-string/apps/app-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-one",
+  "name": "app-one44",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/44-nx-json-string/apps/app-two/package.json
+++ b/packages/fs-detectors/test/fixtures/44-nx-json-string/apps/app-two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-two",
+  "name": "app-two44",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/45-rush-no-project-folder/apps/my-app/package.json
+++ b/packages/fs-detectors/test/fixtures/45-rush-no-project-folder/apps/my-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "my-app45",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/fs-detectors/test/fixtures/45-rush-no-project-folder/apps/my-second-app/package.json
+++ b/packages/fs-detectors/test/fixtures/45-rush-no-project-folder/apps/my-second-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-second-app",
+  "name": "my-second-app45",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n/package.json
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "notfound-deploy-test",
-  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate/package.json
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "notfound-deploy-test",
-  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/next/test/fixtures/00-server-build-legacy-monorepo/package.json
+++ b/packages/next/test/fixtures/00-server-build-legacy-monorepo/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "server-build-legacy-monorepo",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/next/test/fixtures/00-server-build-root-directory/package.json
+++ b/packages/next/test/fixtures/00-server-build-root-directory/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "server-build-legacy-monorepo",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/next/test/fixtures/00-test-limit-server-build/package.json
+++ b/packages/next/test/fixtures/00-test-limit-server-build/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "test-limit",
-  "version": "1.0.0",
+  "private": true,
   "scripts": {
     "build": "next build"
   },

--- a/packages/next/test/fixtures/00-test-limit-shared-lambdas/package.json
+++ b/packages/next/test/fixtures/00-test-limit-shared-lambdas/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "test-limit",
-  "version": "1.0.0",
+  "private": true,
   "scripts": {
     "build": "next build"
   },

--- a/packages/next/test/fixtures/25-mono-repo-404/package.json
+++ b/packages/next/test/fixtures/25-mono-repo-404/package.json
@@ -2,6 +2,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "private": true,
-  "name": "mono-repo"
+  "private": true
 }

--- a/packages/next/test/fixtures/25-mono-repo-404/packages/webapp/package.json
+++ b/packages/next/test/fixtures/25-mono-repo-404/packages/webapp/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "webapp",
   "version": "0.0.1",
   "engines": {
     "node": "14.x"

--- a/packages/next/test/fixtures/25-mono-repo-404/packages/webapp/package.json
+++ b/packages/next/test/fixtures/25-mono-repo-404/packages/webapp/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "25-mono-repo-packages-webapp",
   "version": "0.0.1",
   "engines": {
     "node": "14.x"

--- a/packages/next/test/fixtures/26-mono-repo-404-lambda/package.json
+++ b/packages/next/test/fixtures/26-mono-repo-404-lambda/package.json
@@ -2,6 +2,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "private": true,
-  "name": "mono-repo"
+  "private": true
 }

--- a/packages/next/test/fixtures/26-mono-repo-404-lambda/packages/webapp/package.json
+++ b/packages/next/test/fixtures/26-mono-repo-404-lambda/packages/webapp/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "webapp",
-  "version": "0.0.1",
+  "private": true,
   "engines": {
     "node": "14.x"
   },

--- a/packages/next/test/fixtures/26-mono-repo-404-lambda/packages/webapp/package.json
+++ b/packages/next/test/fixtures/26-mono-repo-404-lambda/packages/webapp/package.json
@@ -1,5 +1,6 @@
 {
-  "private": true,
+  "name": "26-packages-webapp",
+  "version": "0.0.1",
   "engines": {
     "node": "14.x"
   },

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/package.json
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "api",
+  "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@redwoodjs/api": "0.15.0"

--- a/packages/redwood/test/fixtures/01-create-redwood-app/api/package.json
+++ b/packages/redwood/test/fixtures/01-create-redwood-app/api/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "api",
-  "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@redwoodjs/api": "0.15.0"

--- a/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
+++ b/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api",
   "version": "0.0.0",
+  "private": true,
   "dependencies": {
     "@redwoodjs/api": "^0.15.3"
   }

--- a/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
+++ b/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "api",
-  "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@redwoodjs/api": "^0.15.3"

--- a/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
+++ b/packages/redwood/test/fixtures/02-create-redwood-app/api/package.json
@@ -1,5 +1,6 @@
 {
-  "private": true,
+  "name": "api",
+  "version": "0.0.0",
   "dependencies": {
     "@redwoodjs/api": "^0.15.3"
   }

--- a/packages/static-build/test/build-fixtures/02-gatsby-user-config/package.json
+++ b/packages/static-build/test/build-fixtures/02-gatsby-user-config/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-starter-default",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/static-build/test/build-fixtures/03-gatsby-with-plugins/package.json
+++ b/packages/static-build/test/build-fixtures/03-gatsby-with-plugins/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-starter-default",
   "private": true,
   "description": "A simple starter to get up and developing quickly with Gatsby",
   "version": "0.1.0",

--- a/packages/static-build/test/fixtures/gatsby-v2/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v2/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-v2",
   "private": true,
   "dependencies": {
     "gatsby": "2.32.13",

--- a/packages/static-build/test/fixtures/gatsby-v3/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v3/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-v3",
   "private": true,
   "dependencies": {
     "gatsby": "3.15.0",

--- a/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-v4",
   "private": true,
   "dependencies": {
     "gatsby": "4.25.2",

--- a/packages/static-build/test/fixtures/gatsby-v4/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "gatsby-v4",
   "private": true,
   "dependencies": {
     "gatsby": "4.25.2",

--- a/packages/static-build/test/fixtures/gatsby-v5/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/package.json
@@ -1,12 +1,5 @@
 {
-  "name": "gatsby-v5",
-  "version": "1.0.0",
   "private": true,
-  "description": "gatsby-v5",
-  "author": "Ethan Arrowood",
-  "keywords": [
-    "gatsby"
-  ],
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",


### PR DESCRIPTION
```
jest-haste-map: Haste module naming collision: app-three
The following files share their name; please adjust your hasteImpl:
  * <rootDir>/test/fixtures/33-hybrid-monorepo/backend/app-three/package.json
  * <rootDir>/test/fixtures/34-monorepo-no-workspaces/backend/app-three/package.json
```