### PR TITLE
[next] Ensure we warn when leveraging next export

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -817,6 +817,10 @@ export const build: BuildV2 = async ({
         }
       });
 
+    console.log(
+      'Notice: detected `next export`, this de-opts some Next.js features\nSee more info: https://nextjs.org/docs/advanced-features/static-html-export'
+    );
+
     return {
       output,
       images: getImagesConfig(imagesManifest),

--- a/packages/next/test/fixtures/11-export-clean-urls/vercel.json
+++ b/packages/next/test/fixtures/11-export-clean-urls/vercel.json
@@ -13,6 +13,9 @@
     {
       "path": "/",
       "mustContain": "nextExport\":true"
+    },
+    {
+      "logMustContain": "Notice: detected `next export`, this de-opts some Next.js features"
     }
   ]
 }


### PR DESCRIPTION
We currently don't make it obvious when `next export` is being leveraged which de-opts features like `middleware`, `rewrites`, `redirects`, etc. so this adds a notice to let users know when we are using `next export` output. 
