### PR TITLE
[frameworks] add `envPrefix` to `hydrogen` framework

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1698,6 +1698,7 @@ export const frameworks = [
     description: 'React framework for headless commerce',
     website: 'https://hydrogen.shopify.dev',
     useRuntime: { src: 'package.json', use: '@vercel/hydrogen' },
+    envPrefix: 'PUBLIC_',
     detectors: {
       some: [
         {


### PR DESCRIPTION
Hydrogen uses the `PUBLIC_` env prefix, [it also supports `VITE_`](https://github.com/Shopify/hydrogen/blob/8168cd2dd850b59fb051e610d1db918f7e4ef327/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts#L127) but [the docs only talk about `PUBLIC_`](https://shopify.dev/custom-storefronts/hydrogen/environment-variables#public-variables).