### PR TITLE
[gatsby-plugin-vercel-builder] Don't delete `.vercel/output`

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -1,6 +1,5 @@
-import { join } from 'path';
 import { getTransformedRoutes } from '@vercel/routing-utils';
-import { writeJson, remove } from 'fs-extra';
+import { writeJson } from 'fs-extra';
 import { validateGatsbyState } from './schemas';
 import {
   createServerlessFunctions,
@@ -32,7 +31,6 @@ export async function generateVercelBuildOutputAPI3Output({
 
   if (validateGatsbyState(state)) {
     console.log('▲ Creating Vercel build output');
-    await remove(join('.vercel', 'output'));
 
     const { pages, redirects, functions, config: gatsbyConfig } = state;
 


### PR DESCRIPTION
`.vercel/output` is already made fresh when running `vc build`, so the plugin should not be doing this. In fact, it makes the `builds.json` file be wiped away, which we don't want to happen.