### PR TITLE
[docs] Replace references to @now/next in error docs

### DIFF
--- a/errors/now-next-legacy-mode.md
+++ b/errors/now-next-legacy-mode.md
@@ -1,8 +1,8 @@
-# `@now/next` Legacy Mode
+# `@vercel/next` Legacy Mode
 
 #### Why This Warning Occurred
 
-`@now/next` has two modes: `legacy` and `serverless`. You will always want to use the `serverless` mode. `legacy` is to provide backwards compatibility with previous `@now/next` versions.
+`@vercel/next` has two modes: `legacy` and `serverless`. You will always want to use the `serverless` mode. `legacy` is to provide backwards compatibility with previous `@vercel/next` versions.
 
 The differences:
 
@@ -63,7 +63,7 @@ module.exports = {
 ```js
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@now/next" }]
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
 }
 ```
 

--- a/errors/now-next-no-serverless-pages-built.md
+++ b/errors/now-next-no-serverless-pages-built.md
@@ -1,4 +1,4 @@
-# `@now/next` No Serverless Pages Built
+# `@vercel/next` No Serverless Pages Built
 
 #### Why This Error Occurred
 
@@ -33,13 +33,13 @@ module.exports = {
 };
 ```
 
-4. Remove `distDir` from `next.config.js` as `@now/next` can't parse this file and expects your build output at `/.next`
+4. Remove `distDir` from `next.config.js` as `@vercel/next` can't parse this file and expects your build output at `/.next`
 
 5. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
 
 ```js
 {
   "version": 2,
-  "builds": [{ "src": "package.json", "use": "@now/next" }]
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
 }
 ```


### PR DESCRIPTION
It's been long enough I think we can change these to refer to `@vercel/next` instead. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03DQ3QFV7C/p1674849801196389)