### PR TITLE
[tests] Fix github action restore cache timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Setup Node
       if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
       uses: actions/setup-node@v3
-      timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
       with:
         node-version: 14
     - name: Cache
@@ -49,6 +48,8 @@ jobs:
         path: '**/node_modules'
         key: pnpm-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: pnpm-${{ matrix.os }}-${{ matrix.node }}
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
     - name: install pnpm@7.24.2
       run: npm i -g pnpm@7.24.2
     - name: Install

--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           go-version: '1.18'
       - uses: actions/setup-node@v3
-        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/cache@v3
@@ -43,6 +42,8 @@ jobs:
           path: '**/node_modules'
           key: pnpm-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ matrix.os }}-${{ matrix.node }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
       - name: install pnpm@7.24.2
         run: npm i -g pnpm@7.24.2
       - run: pnpm install

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,7 +35,6 @@ jobs:
         with:
             fetch-depth: 2
       - uses: actions/setup-node@v3
-        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
             node-version: ${{ matrix.node }}
       - uses: actions/cache@v3
@@ -43,6 +42,8 @@ jobs:
           path: '**/node_modules'
           key: pnpm-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ matrix.os }}-${{ matrix.node }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
       - name: install pnpm@7.24.2
         run: npm i -g pnpm@7.24.2
       - run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
-        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v3
@@ -41,6 +40,8 @@ jobs:
           path: '**/node_modules'
           key: pnpm-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ matrix.os }}-${{ matrix.node }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
       - name: install pnpm@7.24.2
         run: npm i -g pnpm@7.24.2
       - run: pnpm install
@@ -76,7 +77,6 @@ jobs:
         with:
           go-version: '1.13.15'
       - uses: actions/setup-node@v3
-        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v3
@@ -84,6 +84,8 @@ jobs:
           path: '**/node_modules'
           key: pnpm-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ matrix.os }}-${{ matrix.node }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
 
       - name: Install Hugo
         if: matrix.runner == 'macos-latest'


### PR DESCRIPTION
Github Action for actions/cache has an issue that could cause it to take 1 hour and then timeout while trying to restore the cache.

Since `actions/setup-node` is no longer used to restore the pnpm cache, the `timeout-minutes: 5` doesn't do anything for this action.

Instead we need to put an env variable on the `actions/cache` Github Action to actually set the restore cache timeout.

```
env:
  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # See https://github.com/actions/cache/issues/810
```

- See discussion here https://github.com/vercel/vercel/discussions/9340
- Related to actions/cache#810
- Follow up to #8639