### PR TITLE
[gatsby-plugin-vercel-builder] Use `pathPrefix` from BuildArgs

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/gatsby-node.ts
+++ b/packages/gatsby-plugin-vercel-builder/gatsby-node.ts
@@ -1,28 +1,15 @@
-import path from 'path';
-
 import type { GatsbyNode } from 'gatsby';
 
 // this gets built separately, so import from "dist" instead of "src"
 import { generateVercelBuildOutputAPI3Output } from './dist';
 
-export const pluginOptionsSchema: GatsbyNode['pluginOptionsSchema'] = ({
-  Joi,
+export const onPostBuild: GatsbyNode['onPostBuild'] = async ({
+  pathPrefix,
+  store,
 }) => {
-  return Joi.object({
-    exportPath: Joi.string().optional(),
-  });
-};
-
-export const onPostBuild: GatsbyNode['onPostBuild'] = async (
-  { store },
-  pluginOptions
-) => {
-  // validated by `pluginOptionSchema`
-  const exportPath = (pluginOptions?.exportPath ??
-    path.join('.vercel', 'output', 'config.json')) as string;
-
   await generateVercelBuildOutputAPI3Output({
-    exportPath,
+    pathPrefix,
+    // validated by `pluginOptionSchema`
     gatsbyStoreState: store.getState(),
   });
 };

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -16,8 +16,8 @@ export interface GenerateVercelBuildOutputAPI3OutputOptions {
     functions: unknown;
     config: unknown;
   };
-  [x: string]: unknown;
 }
+
 export async function generateVercelBuildOutputAPI3Output({
   pathPrefix,
   gatsbyStoreState,

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -9,7 +9,7 @@ import { createStaticDir } from './helpers/static';
 import type { Config } from './types';
 
 export interface GenerateVercelBuildOutputAPI3OutputOptions {
-  exportPath: string;
+  pathPrefix: string;
   gatsbyStoreState: {
     pages: Map<string, unknown>;
     redirects: unknown;
@@ -19,7 +19,7 @@ export interface GenerateVercelBuildOutputAPI3OutputOptions {
   [x: string]: unknown;
 }
 export async function generateVercelBuildOutputAPI3Output({
-  exportPath,
+  pathPrefix,
   gatsbyStoreState,
 }: GenerateVercelBuildOutputAPI3OutputOptions) {
   const state = {
@@ -38,14 +38,14 @@ export async function generateVercelBuildOutputAPI3Output({
       .map(p => p[1])
       .filter(page => page.mode === 'SSR' || page.mode === 'DSG');
 
-    const ops: Promise<void>[] = [createStaticDir(gatsbyConfig.pathPrefix)];
+    const ops: Promise<void>[] = [createStaticDir(pathPrefix)];
 
     if (functions.length > 0) {
-      ops.push(createAPIRoutes(functions, gatsbyConfig.pathPrefix));
+      ops.push(createAPIRoutes(functions, pathPrefix));
     }
 
     if (ssrRoutes.length > 0) {
-      ops.push(createServerlessFunctions(ssrRoutes, gatsbyConfig.pathPrefix));
+      ops.push(createServerlessFunctions(ssrRoutes, pathPrefix));
     }
 
     await Promise.all(ops);
@@ -71,7 +71,7 @@ export async function generateVercelBuildOutputAPI3Output({
       routes: routes || undefined,
     };
 
-    await writeJson(exportPath, config);
+    await writeJson('.vercel/output/config.json', config);
     console.log('Vercel output has been generated');
   } else {
     throw new Error(

--- a/packages/gatsby-plugin-vercel-builder/src/schemas.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/schemas.ts
@@ -55,10 +55,7 @@ const GatsbyRedirectSchema: JSONSchemaType<GatsbyRedirect> = {
   required: ['fromPath', 'toPath'],
 } as const;
 
-export type GatsbyConfig = Pick<
-  IGatsbyConfig,
-  'trailingSlash' | 'assetPrefix' | 'pathPrefix'
->;
+export type GatsbyConfig = Pick<IGatsbyConfig, 'trailingSlash'>;
 
 const GatsbyConfigSchema: JSONSchemaType<GatsbyConfig> = {
   type: 'object',
@@ -66,14 +63,6 @@ const GatsbyConfigSchema: JSONSchemaType<GatsbyConfig> = {
     trailingSlash: {
       type: 'string',
       enum: ['always', 'never', 'ignore', 'legacy'],
-      nullable: true,
-    },
-    assetPrefix: {
-      type: 'string',
-      nullable: true,
-    },
-    pathPrefix: {
-      type: 'string',
       nullable: true,
     },
   },


### PR DESCRIPTION
Instead of using `pathPrefix` from the Redux store, grab the value directly from the "BuildArgs" passed to `onPostBuild()`. This value seems to properly reflect whether or not `--prefix-path` mode was enabled during the Gatsby build process.