### PR TITLE
[remix] Remove `render` path

### DIFF
--- a/packages/remix/src/types.ts
+++ b/packages/remix/src/types.ts
@@ -5,3 +5,11 @@ export interface AppConfig {
   serverBuildPath?: string;
   serverBuildTarget?: string;
 }
+
+export interface RemixBuildManifest {
+  routes: {
+    [id: string]: {
+      path: string;
+    };
+  };
+}

--- a/packages/remix/test/fixtures/01-remix-basics/app/routes/b.tsx
+++ b/packages/remix/test/fixtures/01-remix-basics/app/routes/b.tsx
@@ -1,0 +1,7 @@
+export default function B() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>B page</h1>
+    </div>
+  );
+}

--- a/packages/remix/test/fixtures/01-remix-basics/app/routes/nested/another.tsx
+++ b/packages/remix/test/fixtures/01-remix-basics/app/routes/nested/another.tsx
@@ -1,0 +1,7 @@
+export default function Another() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Nested another page</h1>
+    </div>
+  );
+}

--- a/packages/remix/test/fixtures/01-remix-basics/app/routes/nested/index.tsx
+++ b/packages/remix/test/fixtures/01-remix-basics/app/routes/nested/index.tsx
@@ -1,0 +1,7 @@
+export default function Nested() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Nested index page</h1>
+    </div>
+  );
+}

--- a/packages/remix/test/fixtures/01-remix-basics/vercel.json
+++ b/packages/remix/test/fixtures/01-remix-basics/vercel.json
@@ -9,5 +9,12 @@
       }
     }
   ],
-  "probes": [{ "path": "/", "mustContain": "Welcome to Remix" }]
+  "probes": [
+    { "path": "/", "mustContain": "Welcome to Remix" },
+    { "path": "/b", "mustContain": "B page" },
+    { "path": "/nested", "mustContain": "Nested index page" },
+    { "path": "/nested/another", "mustContain": "Nested another page" },
+    { "path": "/nested/index", "mustContain": "Not Found" },
+    { "path": "/asdf", "mustContain": "Not Found" }
+  ]
 }


### PR DESCRIPTION
Instead of outputting a single SSR function at `/render` path, scan the build manifest file to determine the proper paths to output the SSR function at.