### PR TITLE
[node] Add log for unused config runtime

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -413,6 +413,11 @@ export const build: BuildV3 = async ({
         )} (must be one of: ${JSON.stringify(ALLOWED_RUNTIMES)})`
       );
     }
+    if (staticConfig.runtime === 'nodejs') {
+      console.log(
+        `Detected unused static config runtime "nodejs" in "${entrypointPath}"`
+      );
+    }
     isEdgeFunction = isEdgeRuntime(staticConfig.runtime);
   }
 


### PR DESCRIPTION
Both `runtime: undefined` and `runtime: nodejs` have the same behavior but we want to change that in the future.

The first step is to see if `runtime: nodejs` is currently used at all.