### PR TITLE
[build-utils] Add passQuery field to Prerender

### DIFF
--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -10,6 +10,7 @@ interface PrerenderOptions {
   allowQuery?: string[];
   initialHeaders?: Record<string, string>;
   initialStatus?: number;
+  passQuery?: boolean;
 }
 
 export class Prerender {
@@ -22,6 +23,7 @@ export class Prerender {
   public allowQuery?: string[];
   public initialHeaders?: Record<string, string>;
   public initialStatus?: number;
+  public passQuery?: boolean;
 
   constructor({
     expiration,
@@ -32,6 +34,7 @@ export class Prerender {
     allowQuery,
     initialHeaders,
     initialStatus,
+    passQuery,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -51,6 +54,17 @@ export class Prerender {
       );
     }
     this.group = group;
+
+    if (passQuery === true) {
+      this.passQuery = true;
+    } else if (
+      typeof passQuery !== 'boolean' &&
+      typeof passQuery !== 'undefined'
+    ) {
+      throw new Error(
+        `The \`passQuery\` argument for \`Prerender\` must be a boolean.`
+      );
+    }
 
     if (bypassToken == null) {
       this.bypassToken = null;

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -318,6 +318,36 @@ it('should support initialHeaders and initialStatus correctly', async () => {
   });
 });
 
+it('should support passQuery correctly', async () => {
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    passQuery: true,
+  });
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    passQuery: false,
+  });
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    passQuery: undefined,
+  });
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+});
+
 it('should support require by path for legacy builders', () => {
   const index = require('../');
 

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -346,6 +346,19 @@ it('should support passQuery correctly', async () => {
     group: 1,
     bypassToken: 'some-long-bypass-token-to-make-it-work',
   });
+
+  expect(() => {
+    new Prerender({
+      expiration: 1,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      // @ts-expect-error testing invalid field
+      passQuery: 'true',
+    });
+  }).toThrowError(
+    `The \`passQuery\` argument for \`Prerender\` must be a boolean.`
+  );
 });
 
 it('should support require by path for legacy builders', () => {


### PR DESCRIPTION
This adds a new `passQuery` field to `Prerender` outputs to allow opting into new behavior for passing query/route matches in the URL instead of the `x-now-route-matches` header. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1675704226492169)
x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1660070208792189)