### PR TITLE
[gatsby-plugin-vercel-builder] Strip `assetPrefix` from `pathPrefix`

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -1,3 +1,4 @@
+import url from 'url';
 import { getTransformedRoutes } from '@vercel/routing-utils';
 import { writeJson } from 'fs-extra';
 import { validateGatsbyState } from './schemas';
@@ -19,7 +20,7 @@ export interface GenerateVercelBuildOutputAPI3OutputOptions {
 }
 
 export async function generateVercelBuildOutputAPI3Output({
-  pathPrefix,
+  pathPrefix: _pathPrefix,
   gatsbyStoreState,
 }: GenerateVercelBuildOutputAPI3OutputOptions) {
   const state = {
@@ -31,6 +32,11 @@ export async function generateVercelBuildOutputAPI3Output({
 
   if (validateGatsbyState(state)) {
     console.log('▲ Creating Vercel build output');
+
+    // `_pathPrefix` contains `assetPrefix` + `pathPrefix`,
+    // so strip off the `assetPrefix` portion
+    const pathPrefix = url.parse(_pathPrefix).pathname ?? '';
+    console.log({ _pathPrefix, pathPrefix });
 
     const { pages, redirects, functions, config: gatsbyConfig } = state;
 

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -36,7 +36,6 @@ export async function generateVercelBuildOutputAPI3Output({
     // `_pathPrefix` contains `assetPrefix` + `pathPrefix`,
     // so strip off the `assetPrefix` portion
     const pathPrefix = url.parse(_pathPrefix).pathname ?? '';
-    console.log({ _pathPrefix, pathPrefix });
 
     const { pages, redirects, functions, config: gatsbyConfig } = state;
 

--- a/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/gatsby-config.js
+++ b/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/gatsby-config.js
@@ -8,4 +8,5 @@ module.exports = {
   },
   plugins: [],
   pathPrefix: '/foo',
+  assetPrefix: 'https://example.com',
 };


### PR DESCRIPTION
Removes the `assetPrefix` value from the `pathPrefix` config value, since Gatsby concats them for some reason.