### PR TITLE
[next] Update env variable for output trace root

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -415,8 +415,13 @@ export const build: BuildV2 = async ({
     // this helps us catch cases where we can't locate the next.config.js
     // correctly
     env.NEXT_PRIVATE_TARGET = target;
+    env.NEXT_PUBLIC_TARGET = target;
   }
+  // Only NEXT_PUBLIC_ is considered for turbo/nx cache keys
+  // and caches may not have the correct trace root so we
+  // need to ensure this included in the cache key
   env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = baseDir;
+  env.NEXT_PUBLIC_OUTPUT_TRACE_ROOT = baseDir;
 
   if (isServerMode) {
     // when testing with jest NODE_ENV will be set to test so ensure

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -408,6 +408,7 @@ export const build: BuildV2 = async ({
 
   const env: typeof process.env = { ...spawnOpts.env };
   env.NEXT_EDGE_RUNTIME_PROVIDER = 'vercel';
+  env.NEXT_PUBLIC_EDGE_RUNTIME_PROVIDER = env.NEXT_EDGE_RUNTIME_PROVIDER;
 
   if (target) {
     // Since version v10.0.8-canary.15 of Next.js the NEXT_PRIVATE_TARGET env


### PR DESCRIPTION
Since turbo and nx only consider `NEXT_PUBLIC_` prefixed env variables for the cache key this ensures we expose variables that affect the build in that format as well so that an incompatible build cache isn't attempted to be leveraged. No additional tests were added here as this related to build cache which can't be reliably tested here. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1675821643786319)