### PR TITLE
[node] Fix incorrect stack trace of TS error

### DIFF
--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -166,11 +166,6 @@ export function register(opts: Options = {}): Register {
     getCanonicalFileName: path => path,
   };
 
-  function createTSError(diagnostics: ReadonlyArray<_ts.Diagnostic>) {
-    const message = formatDiagnostics(diagnostics, diagnosticHost);
-    return new NowBuildError({ code: 'NODE_TYPESCRIPT_ERROR', message });
-  }
-
   function reportTSError(
     diagnostics: _ts.Diagnostic[],
     shouldExit: boolean | undefined
@@ -178,13 +173,13 @@ export function register(opts: Options = {}): Register {
     if (!diagnostics || diagnostics.length === 0) {
       return;
     }
-    const error = createTSError(diagnostics);
+    const message = formatDiagnostics(diagnostics, diagnosticHost);
 
     if (shouldExit) {
-      throw error;
+      throw new NowBuildError({ code: 'NODE_TYPESCRIPT_ERROR', message });
     } else {
       // Print error in red color and continue execution.
-      console.error('\x1b[31m%s\x1b[0m', error);
+      console.error(message);
     }
   }
 

--- a/packages/node/test/fixtures/46-noEmitOnError-false/vercel.json
+++ b/packages/node/test/fixtures/46-noEmitOnError-false/vercel.json
@@ -4,7 +4,8 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "no-emit-on-error-false:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "no-emit-on-error-false:RANDOMNESS_PLACEHOLDER",
+      "logmustContain": "error TS2339: Property 'thisDoesNotExist' does not exist on type 'IncomingMessage'"
     }
   ]
 }

--- a/packages/node/test/fixtures/46-noEmitOnError-false/vercel.json
+++ b/packages/node/test/fixtures/46-noEmitOnError-false/vercel.json
@@ -5,7 +5,7 @@
     {
       "path": "/",
       "mustContain": "no-emit-on-error-false:RANDOMNESS_PLACEHOLDER",
-      "logmustContain": "error TS2339: Property 'thisDoesNotExist' does not exist on type 'IncomingMessage'"
+      "logMustContain": "error TS2339: Property 'thisDoesNotExist' does not exist on type 'IncomingMessage'"
     }
   ]
 }


### PR DESCRIPTION
### Description

TS has an option, `noEmitOnError`, that is used to either fail the build by throwing when `true` or just print the error and continuing to build when `false`.

This PR fixes the case when `noEmitOnError: false`. Previously showing an error stack trace but now it correctly shows the error message without the stack.

### Before

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/229881/218186616-9e6f04ea-0256-4ed6-8705-50e8dd5090f5.png">

### After

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/229881/218186818-526b2b6a-599e-43e1-aa7b-7f536887730a.png">
