### PR TITLE
[build-utils] Filter out files outside of `cwd` when glob is in "follow" mode

### DIFF
--- a/packages/build-utils/src/fs/glob.ts
+++ b/packages/build-utils/src/fs/glob.ts
@@ -63,7 +63,7 @@ export default async function glob(
       (isSymlink || (await lstat(fsPath)).isSymbolicLink())
     ) {
       const target = await readlink(absPath);
-      const absTarget = path.join(path.dirname(absPath), target);
+      const absTarget = path.resolve(path.dirname(absPath), target);
       if (path.posix.relative(options.cwd, absTarget).startsWith('../')) {
         continue;
       }

--- a/packages/build-utils/src/fs/glob.ts
+++ b/packages/build-utils/src/fs/glob.ts
@@ -64,7 +64,7 @@ export default async function glob(
     ) {
       const target = await readlink(absPath);
       const absTarget = path.join(path.dirname(absPath), target);
-      if (path.posix.relative(options.cwd, absTarget).startsWith('../')) {
+      if (path.relative(options.cwd, absTarget).startsWith(`..${path.sep}`)) {
         continue;
       }
     }

--- a/packages/build-utils/test/unit.glob.test.ts
+++ b/packages/build-utils/test/unit.glob.test.ts
@@ -78,14 +78,17 @@ describe('glob()', () => {
           ),
         fs.mkdirp(join(dir, 'another/subdir')),
         fs.symlink('root.txt', join(dir, 'root-link')),
+        fs.symlink(join(dir, 'root.txt'), join(dir, 'abs-root-link')),
         fs.symlink('dir-with-file', join(dir, 'dir-link')),
         fs.symlink('empty-dir', join(dir, 'empty-dir-link')),
         fs.symlink('../root.txt', join(dir, 'outside-cwd-link')),
+        fs.symlink(join(dir, '../root.txt'), join(dir, 'abs-outside-cwd-link')),
       ]);
       const files = await glob('**', { cwd: dir, follow: true });
       const fileNames = Object.keys(files).sort();
-      expect(fileNames).toHaveLength(4);
+      expect(fileNames).toHaveLength(5);
       expect(fileNames).toEqual([
+        'abs-root-link',
         'dir-link/data.json',
         'dir-with-file/data.json',
         'root-link',

--- a/packages/build-utils/test/unit.glob.test.ts
+++ b/packages/build-utils/test/unit.glob.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { glob, isDirectory } from '../src';
+import { glob, isDirectory, isSymbolicLink } from '../src';
 
 describe('glob()', () => {
   it('should not return entries for empty directories by default', async () => {
@@ -58,6 +58,42 @@ describe('glob()', () => {
       expect(isDirectory(files['dir-with-file/data.json'].mode)).toEqual(false);
       expect(isDirectory(files['root.txt'].mode)).toEqual(false);
       expect(files['dir-with-file']).toBeUndefined();
+    } finally {
+      await fs.remove(dir);
+    }
+  });
+
+  it('should allow for following symlinks', async () => {
+    const rootDir = await fs.mkdtemp(join(tmpdir(), 'build-utils-test'));
+    const dir = await fs.mkdtemp(join(rootDir, 'build-utils-test'));
+    try {
+      await Promise.all([
+        fs.writeFile(join(rootDir, 'root.txt'), 'file outside of "dir"'),
+        fs.writeFile(join(dir, 'root.txt'), 'file at the root'),
+        fs.mkdirp(join(dir, 'empty-dir')),
+        fs
+          .mkdirp(join(dir, 'dir-with-file'))
+          .then(() =>
+            fs.writeFile(join(dir, 'dir-with-file/data.json'), '{"a":"b"}')
+          ),
+        fs.mkdirp(join(dir, 'another/subdir')),
+        fs.symlink('root.txt', join(dir, 'root-link')),
+        fs.symlink('dir-with-file', join(dir, 'dir-link')),
+        fs.symlink('empty-dir', join(dir, 'empty-dir-link')),
+        fs.symlink('../root.txt', join(dir, 'outside-cwd-link')),
+      ]);
+      const files = await glob('**', { cwd: dir, follow: true });
+      const fileNames = Object.keys(files).sort();
+      expect(fileNames).toHaveLength(4);
+      expect(fileNames).toEqual([
+        'dir-link/data.json',
+        'dir-with-file/data.json',
+        'root-link',
+        'root.txt',
+      ]);
+      for (const file of Object.values(files)) {
+        expect(isSymbolicLink(file.mode)).toEqual(false);
+      }
     } finally {
       await fs.remove(dir);
     }


### PR DESCRIPTION
Enables `glob()` to operate in "follow" mode, but filters out any values where a symlink points to a target that lives outside of the `cwd.