### PR TITLE
[tests] add missing dep that used to be hoisted

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -127,6 +127,7 @@
     "execa": "3.2.0",
     "express": "4.17.1",
     "fast-deep-equal": "3.1.3",
+    "find-up": "4.1.0",
     "fs-extra": "10.0.0",
     "get-port": "5.1.1",
     "git-last-commit": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,7 @@ importers:
       execa: 3.2.0
       express: 4.17.1
       fast-deep-equal: 3.1.3
+      find-up: 4.1.0
       fs-extra: 10.0.0
       get-port: 5.1.1
       git-last-commit: 1.0.1
@@ -308,6 +309,7 @@ importers:
       '@vercel/remix': link:../remix
       '@vercel/ruby': link:../ruby
       '@vercel/static-build': link:../static-build
+      find-up: 4.1.0
     devDependencies:
       '@alex_neo/jest-expect-message': 1.0.5
       '@next/env': 11.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,7 +309,6 @@ importers:
       '@vercel/remix': link:../remix
       '@vercel/ruby': link:../ruby
       '@vercel/static-build': link:../static-build
-      find-up: 4.1.0
     devDependencies:
       '@alex_neo/jest-expect-message': 1.0.5
       '@next/env': 11.1.2
@@ -385,6 +384,7 @@ importers:
       execa: 3.2.0
       express: 4.17.1
       fast-deep-equal: 3.1.3
+      find-up: 4.1.0
       fs-extra: 10.0.0
       get-port: 5.1.1
       git-last-commit: 1.0.1
@@ -12048,18 +12048,6 @@ packages:
         optional: true
     dev: false
 
-  /follow-redirects/1.15.2_debug@3.1.0:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 3.1.0
-    dev: true
-
   /follow-redirects/1.15.2_debug@3.2.7:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -13531,7 +13519,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2_debug@3.1.0
+      follow-redirects: 1.15.2_debug@3.2.7
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
It looks like `find-up` was working before because of yarn hoisting, but not anymore. I don't know why this works sometimes and not others, though.

This module is imported from: https://github.com/vercel/vercel/blob/main/packages/cli/test/helpers/setup-fixture.ts#L1

I stuck with version `4.1.0` because that looks like the version being used before.

---

Trying to fix: https://github.com/vercel/vercel/actions/runs/4147054878/jobs/7174327469#step:9:2622