### PR TITLE
[tests] Add `workflow_dispatch` to cron workflows

### DIFF
--- a/.github/workflows/cron-update-next.yml
+++ b/.github/workflows/cron-update-next.yml
@@ -1,6 +1,8 @@
 name: Cron Update Next
 
 on:
+  # Allow manual runs
+  workflow_dispatch:
   # Run every 4 hours https://crontab.guru/every-4-hours
   schedule:
     - cron: '0 */4 * * *'

--- a/.github/workflows/cron-update-turbo.yml
+++ b/.github/workflows/cron-update-turbo.yml
@@ -1,6 +1,8 @@
 name: Cron Update Turbo
 
 on:
+  # Allow manual runs
+  workflow_dispatch:
   # Run every week https://crontab.guru/every-week
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
This `workflow_dispatch` prop allows manual runs by clicking a button on https://github.com/vercel/vercel/actions