### PR TITLE
[build-utils][cli] Update link to project-configuration

### DIFF
--- a/errors/next-functions-config-optimized-lambdas.md
+++ b/errors/next-functions-config-optimized-lambdas.md
@@ -11,4 +11,4 @@ Remove the `functions` config from your `now.json` or `vercel.json` to take adva
 
 ### Useful Links
 
-- [Functions Config Documentation](https://vercel.com/docs/configuration?query=functions#project/functions)
+- [Functions Config Documentation](https://vercel.com/docs/concepts/projects/project-configuration#functions)

--- a/errors/next-legacy-routes-optimized-lambdas.md
+++ b/errors/next-legacy-routes-optimized-lambdas.md
@@ -11,6 +11,6 @@ Migrate from using legacy `routes` to the new `rewrites`, `redirects`, and `head
 
 ### Useful Links
 
-- [Rewrites Documentation](https://vercel.com/docs/configuration?query=rewrites#project/rewrites)
-- [Redirects Documentation](https://vercel.com/docs/configuration?query=rewrites#project/redirects)
-- [Headers Documentation](https://vercel.com/docs/configuration?query=rewrites#project/headers)
+- [Rewrites Documentation](https://vercel.com/docs/concepts/projects/project-configuration#rewrites)
+- [Redirects Documentation](https://vercel.com/docs/concepts/projects/project-configuration#redirects)
+- [Headers Documentation](https://vercel.com/docs/concepts/projects/project-configuration#headers)

--- a/packages/build-utils/src/errors.ts
+++ b/packages/build-utils/src/errors.ts
@@ -44,7 +44,8 @@ export function getPrettyError(obj: {
   message?: string;
   params: any;
 }): NowBuildError {
-  const docsUrl = 'https://vercel.com/docs/configuration';
+  const docsUrl =
+    'https://vercel.com/docs/concepts/projects/project-configuration';
   try {
     const { dataPath, params, message: ajvMessage } = obj;
     const prop = getTopLevelPropertyName(dataPath);
@@ -63,7 +64,7 @@ export function getPrettyError(obj: {
     return new NowBuildError({
       code: 'INVALID_VERCEL_CONFIG',
       message: message,
-      link: prop ? `${docsUrl}#project/${prop.toLowerCase()}` : docsUrl,
+      link: prop ? `${docsUrl}#${prop.toLowerCase()}` : docsUrl,
       action: 'View Documentation',
     });
   } catch (e) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -701,7 +701,7 @@ function expandBuild(files: string[], build: Builder): Builder[] {
     throw new NowBuildError({
       code: `invalid_build_specification`,
       message: 'Field `use` is missing in build specification',
-      link: 'https://vercel.com/docs/configuration#project/builds',
+      link: 'https://vercel.com/docs/concepts/projects/project-configuration#builds',
       action: 'View Documentation',
     });
   }
@@ -711,7 +711,7 @@ function expandBuild(files: string[], build: Builder): Builder[] {
     throw new NowBuildError({
       code: `invalid_build_specification`,
       message: 'A build `src` path resolves to an empty string',
-      link: 'https://vercel.com/docs/configuration#project/builds',
+      link: 'https://vercel.com/docs/concepts/projects/project-configuration#builds',
       action: 'View Documentation',
     });
   }

--- a/packages/cli/test/integration.js
+++ b/packages/cli/test/integration.js
@@ -1967,7 +1967,11 @@ test('try to create a builds deployments with wrong now.json', async t => {
       'Error: Invalid now.json - should NOT have additional property `builder`. Did you mean `builds`?'
     )
   );
-  t.true(stderr.includes('https://vercel.com/docs/configuration'));
+  t.true(
+    stderr.includes(
+      'https://vercel.com/docs/concepts/projects/project-configuration'
+    )
+  );
 });
 
 test('try to create a builds deployments with wrong vercel.json', async t => {
@@ -1991,7 +1995,11 @@ test('try to create a builds deployments with wrong vercel.json', async t => {
       'Error: Invalid vercel.json - should NOT have additional property `fake`. Please remove it.'
     )
   );
-  t.true(stderr.includes('https://vercel.com/docs/configuration'));
+  t.true(
+    stderr.includes(
+      'https://vercel.com/docs/concepts/projects/project-configuration'
+    )
+  );
 });
 
 test('try to create a builds deployments with wrong `build.env` property', async t => {
@@ -2014,7 +2022,9 @@ test('try to create a builds deployments with wrong `build.env` property', async
     formatOutput({ stdout, stderr })
   );
   t.true(
-    stderr.includes('https://vercel.com/docs/configuration'),
+    stderr.includes(
+      'https://vercel.com/docs/concepts/projects/project-configuration'
+    ),
     formatOutput({ stdout, stderr })
   );
 });

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1080,7 +1080,7 @@ describe('build', () => {
       await expect(client.stderr).toOutput(
         'Error: Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?' +
           '\n' +
-          'View Documentation: https://vercel.com/docs/configuration#project/rewrites'
+          'View Documentation: https://vercel.com/docs/concepts/projects/project-configuration#rewrites'
       );
       const builds = await fs.readJSON(join(output, 'builds.json'));
       expect(builds.builds).toBeUndefined();
@@ -1091,7 +1091,7 @@ describe('build', () => {
         stack: expect.stringContaining('at validateConfig'),
         hideStackTrace: true,
         code: 'INVALID_VERCEL_CONFIG',
-        link: 'https://vercel.com/docs/configuration#project/rewrites',
+        link: 'https://vercel.com/docs/concepts/projects/project-configuration#rewrites',
         action: 'View Documentation',
       });
       const configJson = await fs.readJSON(join(output, 'config.json'));

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -41,7 +41,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `rewrites[0]` should NOT have additional property `src`. Did you mean `source`?'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/rewrites'
+      'https://vercel.com/docs/concepts/projects/project-configuration#rewrites'
     );
   });
 
@@ -54,7 +54,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `routes[0]` should NOT have additional property `source`. Did you mean `src`?'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/routes'
+      'https://vercel.com/docs/concepts/projects/project-configuration#routes'
     );
   });
 
@@ -67,7 +67,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `routes` should be array.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/routes'
+      'https://vercel.com/docs/concepts/projects/project-configuration#routes'
     );
   });
 
@@ -84,7 +84,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `redirects[0]` missing required property `source`.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/redirects'
+      'https://vercel.com/docs/concepts/projects/project-configuration#redirects'
     );
   });
 
@@ -97,7 +97,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `redirects[0].permanent` should be boolean.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/redirects'
+      'https://vercel.com/docs/concepts/projects/project-configuration#redirects'
     );
   });
 
@@ -110,7 +110,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `cleanUrls` should be boolean.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/cleanurls'
+      'https://vercel.com/docs/concepts/projects/project-configuration#cleanurls'
     );
   });
 
@@ -123,7 +123,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `trailingSlash` should be boolean.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/trailingslash'
+      'https://vercel.com/docs/concepts/projects/project-configuration#trailingslash'
     );
   });
 
@@ -136,7 +136,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[0]` should NOT have additional property `Content-Type`. Please remove it.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 
@@ -149,7 +149,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[0].source` should be string.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 
@@ -162,7 +162,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[0]` should NOT have additional property `stuff`. Please remove it.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 
@@ -175,7 +175,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[0].headers[0]` should NOT have additional property `Content-Type`. Please remove it.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 
@@ -190,7 +190,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[0].headers[0]` should NOT have additional property `val`. Please remove it.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 
@@ -205,7 +205,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `redirects` should NOT have more than 1024 items.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/redirects'
+      'https://vercel.com/docs/concepts/projects/project-configuration#redirects'
     );
   });
 
@@ -229,7 +229,7 @@ describe('validateConfig', () => {
       'Invalid vercel.json - `headers[1].headers` should NOT have more than 1024 items.'
     );
     expect(error!.link).toEqual(
-      'https://vercel.com/docs/configuration#project/headers'
+      'https://vercel.com/docs/concepts/projects/project-configuration#headers'
     );
   });
 

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -233,6 +233,22 @@ describe('validateConfig', () => {
     );
   });
 
+  it('should error with invalid memory value', async () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          memory: 1000,
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].memory` should be equal to one of the allowed values."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
   it('should error with "functions" and "builds"', async () => {
     const error = validateConfig({
       builds: [

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -237,7 +237,7 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          memory: 1000,
+          memory: 127,
         },
       },
     });


### PR DESCRIPTION
The link to the documentation has changed.
It is now available under https://vercel.com/docs/concepts/projects/project-configuration

This updates:
- link generation `https://vercel.com/docs/configuration#project/*` -> `https://vercel.com/docs/concepts/projects/project-configuration#*`
-  Updates test files
- Updates static references of https://vercel.com/docs/configuration across the repo