### PR TITLE
[build-utils][cli] Remove 64 increment limit for serverless functions

### DIFF
--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -13,10 +13,8 @@ export const functionsSchema = {
           maxLength: 256,
         },
         memory: {
-          // Number between 128 and 3008 in steps of 64
-          enum: Object.keys(Array.from({ length: 50 }))
-            .slice(2, 48)
-            .map(x => Number(x) * 64),
+          minimum: 128,
+          maximum: 3008,
         },
         maxDuration: {
           type: 'number',

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -233,7 +233,7 @@ describe('validateConfig', () => {
     );
   });
 
-  it('should error with invalid memory value', async () => {
+  it('should error with too low memory value', async () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
@@ -242,7 +242,23 @@ describe('validateConfig', () => {
       },
     });
     expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].memory` should be equal to one of the allowed values."
+      "Invalid vercel.json - `functions['api/test.js'].memory` should be >= 128."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with too high memory value', async () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          memory: 3009,
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].memory` should be <= 3008."
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'


### PR DESCRIPTION
We no longer require the memory to be provided in steps of 64mb for serverless functions.
Instead the memory can now be chosen freely from `128mb` to `3008mb` in `1mb increments`.

Updates the `vercel.json` schema to reflect that change.