### PR TITLE
[next] Improve error message when routes-manifest.json not found

### DIFF
--- a/errors/now-next-routes-manifest.md
+++ b/errors/now-next-routes-manifest.md
@@ -2,15 +2,15 @@
 
 #### Why This Error Occurred
 
-This could be caused by a misconfigured "Build Command" or "Output Directory" for your Next.js project.
+This error is often caused by a misconfigured "Build Command" or "Output Directory" for your Next.js project.
 
 #### Possible Ways to Fix It
 
 In the Vercel dashboard, open your "Project Settings" and draw attention to "Build & Development Settings":
 
-1. Ensure that the "Build Command" setting is not changed, or that it calls `next build`. If this command is not changed but you are seeing this error, double check that your `build` script in `package.json` calls `next build`.
-2. Ensure that the "Output Directory" setting is not changed. This value almost never needs to be configured, and is only necessary if you override `distDir` in `next.config.js`.
-3. For `next export` users: **do not override the "Output Directory"**. Next.js automatically detects what folder you outputted `next export` to.
+1. Ensure that the "Build Command" setting is not overridden, or that it calls `next build`. If this command is not overridden but you are seeing this error, double check that your `build` script in `package.json` calls `next build`. If `buildCommand` exists in `vercel.json`, make sure it calls `next build`.
+2. Ensure that the "Output Directory" setting is not overridden. This value almost never needs to be configured, and is only necessary if you override `distDir` in `next.config.js`. If `outputDirectory` exists in `vercel.json`, remove that property.
+3. For `next export` users: **do not override the "Output Directory"**, even if you customized the `next export` output directory. It will automatically detects the correct output.
 
 In rare scenarios, this error message can also be caused by a Next.js build failure (if your "Build Command" accidentally returns an exit code that is not 0).
 Double check for any error messages above the Routes Manifest error, which may provide additional details.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -269,12 +269,7 @@ export async function getRoutesManifest(
 
   if (shouldHaveManifest && !hasRoutesManifest) {
     throw new NowBuildError({
-      message:
-        `The file "${pathRoutesManifest}" couldn't be found. This is normally caused by a misconfiguration in your project.\n` +
-        'Please check the following, and reach out to support if you cannot resolve the problem:\n' +
-        '  1. If present, be sure your `build` script in "package.json" calls `next build`.' +
-        '  2. Navigate to your project\'s settings in the Vercel dashboard, and verify that the "Build Command" is not overridden, or that it calls `next build`.' +
-        '  3. Navigate to your project\'s settings in the Vercel dashboard, and verify that the "Output Directory" is not overridden. Note that `next export` does **not** require you change this setting, even if you customize the `next export` output directory.',
+      message: `The file "${pathRoutesManifest}" couldn't be found. This is often caused by a misconfiguration in your project.`,
       link: 'https://err.sh/vercel/vercel/now-next-routes-manifest',
       code: 'NEXT_NO_ROUTES_MANIFEST',
     });
@@ -2031,7 +2026,8 @@ export const onPrerenderRoute =
       const rscVaryHeader =
         routesManifest?.rsc?.varyHeader ||
         '__rsc__, __next_router_state_tree__, __next_router_prefetch__';
-      const rscContentTypeHeader = routesManifest?.rsc?.contentTypeHeader ||  'application/octet-stream';
+      const rscContentTypeHeader =
+        routesManifest?.rsc?.contentTypeHeader || 'application/octet-stream';
 
       prerenders[outputPathPage] = new Prerender({
         expiration: initialRevalidate,


### PR DESCRIPTION
The dashboard doesn't handle multiline errors very well because other lines are collapsed.

https://vercel.com/changelog/deployment-logs-filtering-now-available

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/229881/218832497-0bcd9404-b4f5-49fe-9edd-bd6de6d8bb8f.png">


We also show the complete error in the top and it doesn't show newlines properly.

<img width="428" alt="image" src="https://user-images.githubusercontent.com/229881/218832603-065e0d4d-ae6e-4b44-b2db-b2fff063da58.png">

The "Learn More" link already has the relevant information so we can reduce this error message to a single line to improve the call to action.
