### PR TITLE
[routing-utils] Added middlewareRawSrc to RouteWithSrc type

### DIFF
--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -44,6 +44,10 @@ export type RouteWithSrc = {
    */
   middlewarePath?: string;
   /**
+   * The original middleware matchers.
+   */
+  middlewareRawSrc?: string[];
+  /**
    * A middleware index in the `middleware` key under the build result
    */
   middleware?: number;


### PR DESCRIPTION
This PR adds a new `middlewareRawSrc` prop to the `RouteWithSrc` type which is used for edge middleware routes. The existing `middlewarePath` prop contains a regex of all the middleware `matcher` routes which isn't very user friendly on the front end.

By preserving the original middleware matchers, the front end can display the list in a much more presentable fashion.

This feature blocks 3 other PRs.
1. https://github.com/vercel/api/pull/17231 depends on `Route` type for schema validation and translates `middlewareRawSrc` to `rawMatchers` for front end consumption
2. https://github.com/vercel/vercel/pull/9435 sets the `middlewareRawSrc` in the BOA output
3. https://github.com/vercel/front/pull/19606 displays the `rawMatchers` under the Edge Middleware section for a deployment

Linear: https://linear.app/vercel/issue/VCCLI-411/display-uncompressed-edge-middleware-matcher-show-the-list-of-matches