### PR TITLE
[test] Use execFileSync() to get processes

### DIFF
--- a/packages/cli/test/dev/utils.js
+++ b/packages/cli/test/dev/utils.js
@@ -522,7 +522,7 @@ async function ps(parentPid, pids = {}) {
       : ['ps', '-o', 'pid', '--no-headers', '--ppid', parentPid];
 
   try {
-    const { stdout: buf } = execFileSync(cmd[0], cmd.slice(1), {
+    const buf = execFileSync(cmd[0], cmd.slice(1), {
       encoding: 'utf-8',
     });
     for (let pid of buf.match(/\d+/g)) {

--- a/packages/cli/test/dev/utils.js
+++ b/packages/cli/test/dev/utils.js
@@ -10,7 +10,7 @@ const { version: cliVersion } = require('../../package.json');
 const {
   fetchCachedToken,
 } = require('../../../../test/lib/deployment/now-deploy');
-const { spawnSync } = require('child_process');
+const { spawnSync, execFileSync } = require('child_process');
 
 jest.setTimeout(6 * 60 * 1000);
 
@@ -522,7 +522,7 @@ async function ps(parentPid, pids = {}) {
       : ['ps', '-o', 'pid', '--no-headers', '--ppid', parentPid];
 
   try {
-    const { stdout: buf } = spawnSync(cmd[0], cmd.slice(1), {
+    const { stdout: buf } = execFileSync(cmd[0], cmd.slice(1), {
       encoding: 'utf-8',
     });
     for (let pid of buf.match(/\d+/g)) {


### PR DESCRIPTION
`spawnSync()` does not throw if the command can't be found in the PATH or if an error occurs. If we use `execFileSync()`, it will throw and that was likely the desired behavior in this test utility function.