### PR TITLE
[build-utils] add framework slug and version to build output

### DIFF
--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -1,4 +1,4 @@
-import type { Cron, Files } from './types';
+import type { Cron, Files, Framework } from './types';
 
 /**
  * An Edge Functions output
@@ -45,10 +45,7 @@ export class EdgeFunction {
   cron?: Cron;
 
   /** The framework */
-  framework?: {
-    slug: string;
-    version?: string;
-  };
+  framework?: Framework;
 
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';

--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -44,6 +44,9 @@ export class EdgeFunction {
   /** Cronjob definition for the edge function */
   cron?: Cron;
 
+  /** The framework */
+  framework?: string;
+
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';
     this.name = params.name;
@@ -54,5 +57,6 @@ export class EdgeFunction {
     this.assets = params.assets;
     this.regions = params.regions;
     this.cron = params.cron;
+    this.framework = params.framework;
   }
 }

--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -45,7 +45,10 @@ export class EdgeFunction {
   cron?: Cron;
 
   /** The framework */
-  framework?: string;
+  framework?: {
+    slug: string;
+    version?: string;
+  };
 
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';

--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -1,4 +1,4 @@
-import type { Cron, Files, Framework } from './types';
+import type { Cron, Files, FunctionFramework } from './types';
 
 /**
  * An Edge Functions output
@@ -45,7 +45,7 @@ export class EdgeFunction {
   cron?: Cron;
 
   /** The framework */
-  framework?: Framework;
+  framework?: FunctionFramework;
 
   constructor(params: Omit<EdgeFunction, 'type'>) {
     this.type = 'EdgeFunction';

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -5,7 +5,7 @@ import minimatch from 'minimatch';
 import { readlink } from 'fs-extra';
 import { isSymbolicLink, isDirectory } from './fs/download';
 import streamToBuffer from './fs/stream-to-buffer';
-import type { Files, Config, Cron } from './types';
+import type { Files, Config, Cron, Framework } from './types';
 
 interface Environment {
   [key: string]: string;
@@ -26,10 +26,7 @@ export interface LambdaOptionsBase {
   experimentalResponseStreaming?: boolean;
   operationType?: string;
   cron?: Cron;
-  framework?: {
-    slug: string;
-    version?: string;
-  };
+  framework?: Framework;
 }
 
 export interface LambdaOptionsWithFiles extends LambdaOptionsBase {
@@ -75,10 +72,7 @@ export class Lambda {
   supportsMultiPayloads?: boolean;
   supportsWrapper?: boolean;
   experimentalResponseStreaming?: boolean;
-  framework?: {
-    slug: string;
-    version?: string;
-  };
+  framework?: Framework;
 
   constructor(opts: LambdaOptions) {
     const {

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -5,7 +5,7 @@ import minimatch from 'minimatch';
 import { readlink } from 'fs-extra';
 import { isSymbolicLink, isDirectory } from './fs/download';
 import streamToBuffer from './fs/stream-to-buffer';
-import type { Files, Config, Cron, Framework } from './types';
+import type { Files, Config, Cron, FunctionFramework } from './types';
 
 interface Environment {
   [key: string]: string;
@@ -26,7 +26,7 @@ export interface LambdaOptionsBase {
   experimentalResponseStreaming?: boolean;
   operationType?: string;
   cron?: Cron;
-  framework?: Framework;
+  framework?: FunctionFramework;
 }
 
 export interface LambdaOptionsWithFiles extends LambdaOptionsBase {
@@ -72,7 +72,7 @@ export class Lambda {
   supportsMultiPayloads?: boolean;
   supportsWrapper?: boolean;
   experimentalResponseStreaming?: boolean;
-  framework?: Framework;
+  framework?: FunctionFramework;
 
   constructor(opts: LambdaOptions) {
     const {

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -26,6 +26,10 @@ export interface LambdaOptionsBase {
   experimentalResponseStreaming?: boolean;
   operationType?: string;
   cron?: Cron;
+  framework?: {
+    slug: string;
+    version?: string;
+  };
 }
 
 export interface LambdaOptionsWithFiles extends LambdaOptionsBase {
@@ -71,6 +75,10 @@ export class Lambda {
   supportsMultiPayloads?: boolean;
   supportsWrapper?: boolean;
   experimentalResponseStreaming?: boolean;
+  framework?: {
+    slug: string;
+    version?: string;
+  };
 
   constructor(opts: LambdaOptions) {
     const {
@@ -86,6 +94,7 @@ export class Lambda {
       supportsWrapper,
       experimentalResponseStreaming,
       operationType,
+      framework,
     } = opts;
     if ('files' in opts) {
       assert(typeof opts.files === 'object', '"files" must be an object');
@@ -139,6 +148,20 @@ export class Lambda {
       assert(typeof cron === 'string', '"cron" is not a string');
     }
 
+    if (framework !== undefined) {
+      assert(typeof framework === 'object', '"framework" is not an object');
+      assert(
+        typeof framework.slug === 'string',
+        '"framework.slug" is not a string'
+      );
+      if (framework.version !== undefined) {
+        assert(
+          typeof framework.version === 'string',
+          '"framework.version" is not a string'
+        );
+      }
+    }
+
     this.type = 'Lambda';
     this.operationType = operationType;
     this.files = 'files' in opts ? opts.files : undefined;
@@ -154,6 +177,7 @@ export class Lambda {
     this.supportsMultiPayloads = supportsMultiPayloads;
     this.supportsWrapper = supportsWrapper;
     this.experimentalResponseStreaming = experimentalResponseStreaming;
+    this.framework = framework;
   }
 
   async createZip(): Promise<Buffer> {

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -412,6 +412,11 @@ export interface BuildResultBuildOutput {
 }
 
 export type Cron = string;
+/** The framework which created the function */
+export interface Framework {
+  slug: string;
+  version?: string;
+}
 
 /**
  * When a Builder implements `version: 2`, the `build()` function is expected

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -413,7 +413,7 @@ export interface BuildResultBuildOutput {
 
 export type Cron = string;
 /** The framework which created the function */
-export interface Framework {
+export interface FunctionFramework {
   slug: string;
   version?: string;
 }


### PR DESCRIPTION
Adds framework to Lambda and edge build outputs so that we can distinguish which framework they originated from when certain features should be applied to specific frameworks.

Breaking up https://github.com/vercel/vercel/pull/9447 into two parts:
This PR introduces the frameworks type. Part 2: https://github.com/vercel/vercel/pull/9449

ticket: ED-131

x-ref: [slack channel](https://vercel.slack.com/archives/C042LHPJ1NX)