### PR TITLE
[next] Ensure app routes are handled

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2644,7 +2644,10 @@ async function getServerlessPages(params: {
   const [pages, appPaths, middlewareManifest] = await Promise.all([
     glob('**/!(_middleware).js', params.pagesDir),
     params.appPathRoutesManifest
-      ? glob('**/page.js', path.join(params.pagesDir, '../app'))
+      ? Promise.all([
+          glob('**/page.js', path.join(params.pagesDir, '../app')),
+          glob('**/route.js', path.join(params.pagesDir, '../app')),
+        ]).then(items => Object.assign(...items))
       : Promise.resolve({}),
     getMiddlewareManifest(params.entryPath, params.outputDirectory),
   ]);


### PR DESCRIPTION
This ensures we properly handle the `route` file names as well. Tests are added in the Next.js repo which can be re-enabled once this is landed. 

x-ref: https://github.com/vercel/next.js/pull/45931