### PR TITLE
fix(remix): splat routes

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -266,13 +266,21 @@ module.exports = config;`;
     // If this is a dynamic route then add a Vercel route
     const keys: Key[] = [];
     // Replace "/*" at the end to handle "splat routes"
-    const rePath = `/${path.replace(/\/\*$/, '/:params+')}`;
-    const re = pathToRegexp(rePath, keys);
-    if (keys.length > 0) {
+
+    if (path === "*") {
       routes.push({
-        src: re.source,
+        src: `/${path.replace(/\/\*$/, "/(.*)")}`,
         dest: path,
       });
+    } else {
+      const rePath = `/${path.replace(/\/\*$/, '/:params+')}`;
+      const re = pathToRegexp(rePath, keys);
+      if (keys.length > 0) {
+        routes.push({
+          src: re.source,
+          dest: path,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
pathToRegexp blows up on splat routes `app/routes/$.tsx` where path is `*`, it's fine for nested splat routes `app/routes/nested/$.tsx` as the path is `nested/*`

note the new splat regex was made by GitHub copilot so feel to tweak if desired