### PR TITLE
[fs-detectors] Remove increments of 64 limit for function memory

### DIFF
--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -602,12 +602,11 @@ function validateFunctions({ functions = {} }: Options) {
 
     if (
       func.memory !== undefined &&
-      (func.memory < 128 || func.memory > 3008 || func.memory % 64 !== 0)
+      (func.memory < 128 || func.memory > 3008)
     ) {
       return {
         code: 'invalid_function_memory',
-        message:
-          'Functions must have a memory value between 128 and 3008 in steps of 64.',
+        message: 'Functions must have a memory value between 128 and 3008',
       };
     }
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -473,7 +473,7 @@ describe('Test `detectBuilders`', () => {
   });
 
   it('invalid function memory', async () => {
-    const functions = { 'pages/index.ts': { memory: 200 } };
+    const functions = { 'pages/index.ts': { memory: 127 } };
     const files = ['pages/index.ts'];
     const { builders, errors } = await detectBuilders(files, null, {
       functions,
@@ -482,6 +482,17 @@ describe('Test `detectBuilders`', () => {
     expect(builders).toBe(null);
     expect(errors!.length).toBe(1);
     expect(errors![0].code).toBe('invalid_function_memory');
+  });
+
+  it('should build with function memory not dividable by 64', async () => {
+    const functions = { 'api/index.ts': { memory: 1000 } };
+    const files = ['api/index.ts'];
+    const { builders, errors } = await detectBuilders(files, null, {
+      functions,
+    });
+
+    expect(builders![0].use).toBe('@vercel/node');
+    expect(errors).toBeNull();
   });
 
   it('missing runtime version', async () => {
@@ -1720,7 +1731,7 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
   });
 
   it('invalid function memory', async () => {
-    const functions = { 'pages/index.ts': { memory: 200 } };
+    const functions = { 'pages/index.ts': { memory: 127 } };
     const files = ['pages/index.ts'];
     const { builders, errors } = await detectBuilders(files, null, {
       functions,
@@ -1730,6 +1741,18 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders).toBe(null);
     expect(errors!.length).toBe(1);
     expect(errors![0].code).toBe('invalid_function_memory');
+  });
+
+  it('should build with function memory not dividable by 64', async () => {
+    const functions = { 'api/index.ts': { memory: 1000 } };
+    const files = ['api/index.ts'];
+    const { builders, errors } = await detectBuilders(files, null, {
+      functions,
+      featHandleMiss,
+    });
+
+    expect(builders![0].use).toBe('@vercel/node');
+    expect(errors).toBeNull();
   });
 
   it('missing runtime version', async () => {


### PR DESCRIPTION
Missed this occurrence so it still prevents the upload of serverless functions that have a mem value that is not dividable by 64.
Should be the last place before we can ship the documentation update.

#### Related PRs
- #9440