### PR TITLE
feat(cli): get config from `vercel` property in package.json

### DIFF
--- a/packages/cli/src/util/get-config.ts
+++ b/packages/cli/src/util/get-config.ts
@@ -82,6 +82,19 @@ export default async function getConfig(
     return config;
   }
 
+  // Then check whether `vercel` field exists in package.json
+  const packageJsonPath = path.resolve(localPath, 'package.json');
+  const packageJson = await readJSONFile<any>(packageJsonPath);
+  if (packageJson instanceof CantParseJSONFile) {
+    return packageJson;
+  }
+  if (packageJson.vercel !== null) {
+    output.debug(`Found 'vercel' property in package.json (${packageJsonPath})`);
+    config = packageJson.vercel;
+    config[fileNameSymbol] = 'package.json';
+    return config;
+  } 
+
   // If we couldn't find the config anywhere return error
-  return new CantFindConfig([vercelFilePath, nowFilePath].map(humanizePath));
+  return new CantFindConfig([vercelFilePath, nowFilePath, packageJsonPath].map(humanizePath));
 }


### PR DESCRIPTION
## Description

This change allows Vercel CLI to get config from `vercel` property in package.json. 

I don't know how the Vercel CLI's codebase is structured. I performed a GitHub search of `vercel.json` and I was able to make out that this is the file that resolves the path and parses configuration from `vercel.json` or `now.json`. Here, I have added some lines of code which parses `package.json`, and if `packageJson.vercel !== null`, the config object is returned, otherwise not.

I would kindly request the maintainers to test this since I don't know how to compile the package and test it locally.

## Motivation

Mainly, it came from a YouTube video: [WTF are all these config files for?](https://www.youtube.com/watch?v=14WanxTD2O4) uploaded on the Beyond Fireship channel.

This idea is also inspired by the famous code-formatter prettier which allows putting the config inside a `prettier` field in package.json (https://prettier.io/docs/en/configuration.html).

The same is also done by ESLint which reads config from package.json's `eslintConfig` property.