### PR TITLE
[next] Add initial `vary` header to all prerendered pages when RSC is enabled

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1149,7 +1149,7 @@ export async function serverBuild({
     }
   }
 
-  const rscHeader = routesManifest.rsc?.header?.toLowerCase() || '__rsc__';
+  const rscHeader = routesManifest.rsc?.header?.toLowerCase() || 'rsc';
   const completeDynamicRoutes: typeof dynamicRoutes = [];
 
   if (appDir) {

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1150,6 +1150,7 @@ export async function serverBuild({
   }
 
   const rscHeader = routesManifest.rsc?.header?.toLowerCase() || '__rsc__';
+  const rscVaryHeader = routesManifest?.rsc?.varyHeader || 'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
   const completeDynamicRoutes: typeof dynamicRoutes = [];
 
   if (appDir) {
@@ -1422,6 +1423,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
+              headers: { vary: rscVaryHeader },
               continue: true,
             },
             {
@@ -1437,6 +1439,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
+              headers: { vary: rscVaryHeader },
               continue: true,
             },
           ]

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1149,7 +1149,7 @@ export async function serverBuild({
     }
   }
 
-  const rscHeader = routesManifest.rsc?.header?.toLowerCase() || 'rsc';
+  const rscHeader = routesManifest.rsc?.header?.toLowerCase() || '__rsc__';
   const completeDynamicRoutes: typeof dynamicRoutes = [];
 
   if (appDir) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2028,11 +2028,10 @@ export const onPrerenderRoute =
           allowQuery = [];
         }
       }
-      const rscVaryHeader =
-        routesManifest?.rsc?.varyHeader ||
-        '__rsc__, __next_router_state_tree__, __next_router_prefetch__';
-      const rscContentTypeHeader =
-        routesManifest?.rsc?.contentTypeHeader || 'application/octet-stream';
+
+      const rscEnabled = !!routesManifest?.rsc;
+      const rscVaryHeader = routesManifest?.rsc?.varyHeader || 'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
+      const rscContentTypeHeader = routesManifest?.rsc?.contentTypeHeader || 'text/x-component';
 
       prerenders[outputPathPage] = new Prerender({
         expiration: initialRevalidate,
@@ -2047,7 +2046,7 @@ export const onPrerenderRoute =
             }
           : {}),
 
-        ...(isAppPathRoute
+        ...(rscEnabled
           ? {
               initialHeaders: {
                 vary: rscVaryHeader,
@@ -2069,7 +2068,7 @@ export const onPrerenderRoute =
             }
           : {}),
 
-        ...(isAppPathRoute
+        ...(rscEnabled
           ? {
               initialHeaders: {
                 'content-type': rscContentTypeHeader,


### PR DESCRIPTION
This PR changes the fallback headers that relate to RSC to the defaults that Next.js currently uses. Also, it sets the initial `vary` header to all prerendered routes when RSC is enabled (`routesManifest?.rsc`), even for the pages directory. 

That's because although the pages directory won't return any RSC payload, it can still be used in a project that contains app routes. When the app route requests a page route for RSC data, it's important for the browser to not accidentally cache that result hence we need the `vary` header to set there as well.

More related discussions can be found [here](https://linear.app/vercel/issue/NEXT-382/add-vary-rsc-etc-header-to-all-responses-to-ensure-browser-caching).