### PR TITLE
[node] fix TypeScript + ESM in Windows

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "node build",
     "test": "jest --env node --verbose --bail --runInBand",
-    "test-unit": "pnpm test test/prepare-cache.test.ts test/utils.test.ts",
+    "test-unit": "pnpm test test/prepare-cache.test.ts test/utils.test.ts test/dev.test.ts",
     "test-e2e": "pnpm test test/integration-*.test.js"
   },
   "files": [

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -1,0 +1,93 @@
+import once from '@tootallnate/once';
+import { cloneEnv, Config, Meta } from '@vercel/build-utils';
+import { ChildProcess, fork, ForkOptions } from 'child_process';
+import { join } from 'path';
+
+export function forkDevServer(options: {
+  tsConfig: any;
+  config: Config;
+  maybeTranspile: boolean;
+  workPath: string | undefined;
+  isTypeScript: boolean;
+  isEsm: boolean;
+  require_: NodeRequire;
+  entrypoint: string;
+  meta: Meta;
+  devServerPath?: string;
+}) {
+  let nodeOptions = process.env.NODE_OPTIONS;
+  const tsNodePath = options.require_.resolve('ts-node');
+  // const esmLoader = url.pathToFileURL(join(tsNodePath, '..', '..', 'esm.mjs'));
+  const esmLoader = join(tsNodePath, '..', '..', 'esm.mjs');
+  const cjsLoader = join(tsNodePath, '..', '..', 'register', 'index.js');
+  const devServerPath =
+    options.devServerPath || join(__dirname, 'dev-server.js');
+
+  if (options.maybeTranspile) {
+    if (options.isTypeScript) {
+      if (options.isEsm) {
+        nodeOptions = `--loader ${esmLoader} ${nodeOptions || ''}`;
+      } else {
+        nodeOptions = `--require ${cjsLoader} ${nodeOptions || ''}`;
+      }
+    } else {
+      if (options.isEsm) {
+        // no transform needed because Node.js supports ESM natively
+      } else {
+        nodeOptions = `--require ${cjsLoader} ${nodeOptions || ''}`;
+      }
+    }
+  }
+
+  const forkOptions: ForkOptions = {
+    cwd: options.workPath,
+    execArgv: [],
+    env: cloneEnv(process.env, options.meta.env, {
+      VERCEL_DEV_ENTRYPOINT: options.entrypoint,
+      VERCEL_DEV_IS_ESM: options.isEsm ? '1' : undefined,
+      VERCEL_DEV_CONFIG: JSON.stringify(options.config),
+      VERCEL_DEV_BUILD_ENV: JSON.stringify(options.meta.buildEnv || {}),
+      TS_NODE_TRANSPILE_ONLY: '1',
+      TS_NODE_COMPILER_OPTIONS: options.tsConfig?.compilerOptions
+        ? JSON.stringify(options.tsConfig.compilerOptions)
+        : undefined,
+      NODE_OPTIONS: nodeOptions,
+    }),
+  };
+  const child = fork(devServerPath, [], forkOptions);
+
+  checkForPid(devServerPath, child);
+
+  return child;
+}
+
+function checkForPid(
+  path: string,
+  process: ChildProcess
+): asserts process is ChildProcess & { pid: number } {
+  if (!process.pid) {
+    throw new Error(`Child Process has no "pid" when forking: "${path}"`);
+  }
+}
+
+export async function readMessage(
+  child: ChildProcess
+): Promise<
+  | { state: 'message'; value: { port: number } }
+  | { state: 'exit'; value: [number, string | null] }
+> {
+  const onMessage = once<{ port: number }>(child, 'message');
+  const onExit = once.spread<[number, string | null]>(child, 'close');
+  const result = await Promise.race([
+    onMessage.then(x => {
+      return { state: 'message' as const, value: x };
+    }),
+    onExit.then(v => {
+      return { state: 'exit' as const, value: v };
+    }),
+  ]);
+  onExit.cancel();
+  onMessage.cancel();
+
+  return result;
+}

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -1,6 +1,7 @@
 import once from '@tootallnate/once';
 import { cloneEnv, Config, Meta } from '@vercel/build-utils';
 import { ChildProcess, fork, ForkOptions } from 'child_process';
+import { pathToFileURL } from 'url';
 import { join } from 'path';
 
 export function forkDevServer(options: {
@@ -17,8 +18,7 @@ export function forkDevServer(options: {
 }) {
   let nodeOptions = process.env.NODE_OPTIONS;
   const tsNodePath = options.require_.resolve('ts-node');
-  // const esmLoader = url.pathToFileURL(join(tsNodePath, '..', '..', 'esm.mjs'));
-  const esmLoader = join(tsNodePath, '..', '..', 'esm.mjs');
+  const esmLoader = pathToFileURL(join(tsNodePath, '..', '..', 'esm.mjs'));
   const cjsLoader = join(tsNodePath, '..', '..', 'register', 'index.js');
   const devServerPath =
     options.devServerPath || join(__dirname, 'dev-server.js');

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -14,6 +14,10 @@ export function forkDevServer(options: {
   require_: NodeRequire;
   entrypoint: string;
   meta: Meta;
+
+  /**
+   * A path to the dev-server path. This is used in tests.
+   */
   devServerPath?: string;
 }) {
   let nodeOptions = process.env.NODE_OPTIONS;
@@ -70,6 +74,11 @@ function checkForPid(
   }
 }
 
+/**
+ * When launching a dev-server, we want to know its state.
+ * This function will be used to know whether it was exited (due to some error),
+ * or it is listening to new requests, and we can start proxying requests.
+ */
 export async function readMessage(
   child: ChildProcess
 ): Promise<

--- a/packages/node/test/dev-fixtures/esm-module.mjs
+++ b/packages/node/test/dev-fixtures/esm-module.mjs
@@ -1,0 +1,4 @@
+export default (_req, res) => {
+  res.setHeader('x-hello', 'world');
+  res.send('Hello, world!').end();
+};

--- a/packages/node/test/dev-fixtures/esm-module.ts
+++ b/packages/node/test/dev-fixtures/esm-module.ts
@@ -1,0 +1,6 @@
+import type { VercelRequest, VercelResponse } from '../..';
+
+export default (_req: VercelRequest, res: VercelResponse) => {
+  res.setHeader('x-hello', 'world');
+  res.send('Hello, world!').end();
+};

--- a/packages/node/test/dev.test.ts
+++ b/packages/node/test/dev.test.ts
@@ -1,0 +1,81 @@
+import { forkDevServer, readMessage } from '../src/fork-dev-server';
+import { resolve } from 'path';
+import fetch from 'node-fetch';
+
+test('runs a mjs endpoint', async () => {
+  const child = forkDevServer({
+    maybeTranspile: true,
+    config: {},
+    isEsm: true,
+    isTypeScript: false,
+    meta: {},
+    require_: require,
+    tsConfig: undefined,
+    workPath: resolve(__dirname, './dev-fixtures'),
+    entrypoint: './esm-module.mjs',
+    devServerPath: resolve(__dirname, '../dist/dev-server.js'),
+  });
+
+  try {
+    const result = await readMessage(child);
+    if (result.state !== 'message') {
+      throw new Error('Exited. error: ' + JSON.stringify(result.value));
+    }
+
+    const response = await fetch(
+      `http://localhost:${result.value.port}/api/hello`
+    );
+    expect({
+      status: response.status,
+      headers: response.headers.raw(),
+      text: await response.text(),
+    }).toEqual({
+      status: 200,
+      headers: expect.objectContaining({
+        'x-hello': ['world'],
+      }),
+      text: 'Hello, world!',
+    });
+  } finally {
+    child.kill(9);
+  }
+});
+
+test('runs a esm typescript endpoint', async () => {
+  const child = forkDevServer({
+    maybeTranspile: true,
+    config: {},
+    isEsm: true,
+    isTypeScript: true,
+    meta: {},
+    require_: require,
+    tsConfig: undefined,
+    workPath: resolve(__dirname, './dev-fixtures'),
+    entrypoint: './esm-module.ts',
+    devServerPath: resolve(__dirname, '../dist/dev-server.js'),
+  });
+
+  try {
+    const result = await readMessage(child);
+    if (result.state !== 'message') {
+      throw new Error('Exited. error: ' + JSON.stringify(result.value));
+    }
+
+    const response = await fetch(
+      `http://localhost:${result.value.port}/api/hello`
+    );
+    expect({
+      status: response.status,
+      headers: response.headers.raw(),
+      text: await response.text(),
+    }).toEqual({
+      status: 200,
+      headers: expect.objectContaining({
+        'x-hello': ['world'],
+      }),
+      text: 'Hello, world!',
+    });
+  } finally {
+    child.kill(9);
+  }
+});


### PR DESCRIPTION
ESM on Windows versions of Node.js require `--loader PATH` to be a `file://` protocol.
This PR allows `vc dev` to be used with both TypeScript and ESM