### PR TITLE
[next] Handle prerender-manifest v4

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2116,6 +2116,8 @@ export const build: BuildV2 = async ({
         ...Object.entries(prerenderManifest.fallbackRoutes),
         ...Object.entries(prerenderManifest.blockingFallbackRoutes),
       ].forEach(([, { dataRouteRegex, dataRoute }]) => {
+        if (!dataRoute || !dataRouteRegex) return;
+
         dataRoutes.push({
           // Next.js provided data route regex
           src: dataRouteRegex.replace(

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1734,7 +1734,6 @@ export const onPrerenderRouteInitial = (
       };
     }
 
-    console.log('adding nonLambda', route);
     nonLambdaSsgPages.add(route === '/' ? '/index' : route);
   }
 


### PR DESCRIPTION
Updates to handle the updated fields in the `prerender-manifest@v4` which is required for new app ISR handling. Tests added in https://github.com/vercel/next.js/pull/46133