### PR TITLE
[cli] fix content-type header population for vercel dev

### DIFF
--- a/packages/cli/src/util/dev/mime-type.ts
+++ b/packages/cli/src/util/dev/mime-type.ts
@@ -1,5 +1,6 @@
 import { contentType } from 'mime-types';
 
 export default function getMimeType(fileName: string) {
-  return contentType(fileName) || 'application/octet-stream';
+  const extension = /[^.]+$/.exec(filename);
+  return contentType(extension) || 'application/octet-stream';
 }


### PR DESCRIPTION
### Summary

I think I found a bug here, it makes `vercel dev` unusable for me so here is a fix I think will work. Example of the bug is below and then explanation of the fix.

bug repro:

I made a minimal example repo which just tries to load a css file in a link tag.

```
git clone git@github.com:OscarSaharoy/vercel-dev-test.git
cd vercel-dev-test
vercel dev
```
Then go to [http://localhost:3000](http://localhost:3000) in firefox and see the error in the console, check the Content-Type of the response for the request to http://localhost:3000/css/test.css

You can see the Content-Type is the filename which makes the browser unable to apply the style.

![image](https://user-images.githubusercontent.com/29902113/220139787-08da7050-cff4-4637-81ee-9560828c74bb.png)
![image](https://user-images.githubusercontent.com/29902113/220140032-3676f303-2ae5-4afa-944e-10fe1500346d.png)

The fix:


you can see the contentType function takes an extension but is being called with an entire filename. I put in a regex to extract the file extension from the filename and pass that into the function instead.


vercel/packages/cli/src/util/dev/mime-type.ts
```
import { contentType } from 'mime-types';
 
export default function getMimeType(fileName: string) {
   return contentType(fileName) || 'application/octet-stream';
}
```


vercel/packages/cli/node_modules/mime-types/index.js
```
 70 /**
 71  * Create a full Content-Type header given a MIME type or extension.
 72  *
 73  * @param {string} str
 74  * @return {boolean|string}
 75  */
 76 
 77 function contentType (str) {
 78   // TODO: should this even be in this module?
 79   if (!str || typeof str !== 'string') {
 80     return false
 81   }
 82 
 83   var mime = str.indexOf('/') === -1
 84     ? exports.lookup(str)
 85     : str
 86 
 87   if (!mime) {
 88     return false
 89   }
 90 
 91   // TODO: use content-type or other module
 92   if (mime.indexOf('charset') === -1) {
 93     var charset = exports.charset(mime)
 94     if (charset) mime += '; charset=' + charset.toLowerCase()
 95   }
 96 
 97   return mime
 98 }
```