### PR TITLE
[next] Fix rsc routes order

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1150,7 +1150,9 @@ export async function serverBuild({
   }
 
   const rscHeader = routesManifest.rsc?.header?.toLowerCase() || '__rsc__';
-  const rscVaryHeader = routesManifest?.rsc?.varyHeader || 'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
+  const rscVaryHeader =
+    routesManifest?.rsc?.varyHeader ||
+    'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
   const completeDynamicRoutes: typeof dynamicRoutes = [];
 
   if (appDir) {
@@ -1425,6 +1427,7 @@ export async function serverBuild({
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
               headers: { vary: rscVaryHeader },
               continue: true,
+              override: true,
             },
             {
               src: `^${path.posix.join(
@@ -1441,6 +1444,7 @@ export async function serverBuild({
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
               headers: { vary: rscVaryHeader },
               continue: true,
+              override: true,
             },
           ]
         : []),

--- a/packages/next/test/fixtures/00-app-dir-middleware/app/[variant]/[[...rest]]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/app/[variant]/[[...rest]]/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+const paths = ['/', '/shop', '/product', '/who-we-are', '/about', '/contact'];
+
+export default function Page({ params }) {
+  return (
+    <>
+      <p>variant: {params.variant}</p>
+      <p>slug: {params.rest?.join('/')}</p>
+      <ul>
+        {paths.map(path => {
+          return (
+            <li key={path}>
+              <Link href={path}>to {path}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-middleware/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/app/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html className="this-is-the-document-html">
+      <head>
+        <title>{`hello world`}</title>
+      </head>
+      <body className="this-is-the-document-body">{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-middleware/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/middleware.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+  request.nextUrl.pathname = `/no-variant${request.nextUrl.pathname}`;
+  return NextResponse.rewrite(request.nextUrl);
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: ['/', '/shop', '/product', '/who-we-are', '/about', '/contact'],
+};

--- a/packages/next/test/fixtures/00-app-dir-middleware/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+    runtime: 'nodejs',
+  },
+  rewrites: async () => {
+    return [
+      {
+        source: '/rewritten-to-dashboard',
+        destination: '/dashboard',
+      },
+    ];
+  },
+};

--- a/packages/next/test/fixtures/00-app-dir-middleware/package.json
+++ b/packages/next/test/fixtures/00-app-dir-middleware/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "experimental",
+    "react-dom": "experimental"
+  }
+}

--- a/packages/next/test/fixtures/00-app-dir-middleware/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  return res.json({ hello: 'world' });
+}

--- a/packages/next/test/fixtures/00-app-dir-middleware/pages/blog/[slug].js
+++ b/packages/next/test/fixtures/00-app-dir-middleware/pages/blog/[slug].js
@@ -1,0 +1,7 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>hello from pages/blog/[slug]</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-middleware/public/hello.txt
+++ b/packages/next/test/fixtures/00-app-dir-middleware/public/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
@@ -1,0 +1,82 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "mustContain": "no-variant",
+      "mustNotContain": "index"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/shop",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "mustContain": "no-variant",
+      "mustNotContain": "shop.rsc"
+    },
+    {
+      "path": "/shop",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/no-variant/shop",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "mustContain": "no-variant",
+      "mustNotContain": "shop.rsc"
+    },
+    {
+      "path": "/no-variant/shop",
+      "status": 200,
+      "fetchOptions": {
+        "redirect": "manual"
+      },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    }
+  ]
+}


### PR DESCRIPTION
This ensures we maintain the correct order for our rsc routes with reference to middleware so that they match correctly. This also adds a regression test to ensure it's working as expected. 

Fixes: https://github.com/vercel/next.js/issues/45331
x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1676926522772859?thread_ts=1676926096.412539&cid=C035J346QQL)