### PR TITLE
[docs] Improve docs for `@vercel/next` no pages built message

### DIFF
--- a/errors/now-next-no-serverless-pages-built.md
+++ b/errors/now-next-no-serverless-pages-built.md
@@ -14,9 +14,9 @@ In order to create the smallest possible lambdas Next.js has to be configured to
 npm install next --save
 ```
 
-2. Check the Node version used for the build step. This is a Vercel project setting. Using an old or incompatible Node version can cause the build step to fail with this error message.
+2. Check [Node.js Version](https://vercel.link/node-version) in your Project Settings. Using an old or incompatible version of Node.js can cause the Build Step to fail with this error message.
 
-4. Add the `now-build` script to your `package.json` [deprecated]
+3. Add the `now-build` script to your `package.json` [deprecated]
 
 ```json
 {

--- a/errors/now-next-no-serverless-pages-built.md
+++ b/errors/now-next-no-serverless-pages-built.md
@@ -14,7 +14,9 @@ In order to create the smallest possible lambdas Next.js has to be configured to
 npm install next --save
 ```
 
-2. Add the `now-build` script to your `package.json`
+2. Check the Node version used for the build step. This is a Vercel project setting. Using an old or incompatible Node version can cause the build step to fail with this error message.
+
+4. Add the `now-build` script to your `package.json` [deprecated]
 
 ```json
 {
@@ -24,7 +26,7 @@ npm install next --save
 }
 ```
 
-3. Add `target: 'serverless'` to `next.config.js` [deprecated]
+4. Add `target: 'serverless'` to `next.config.js` [deprecated]
 
 ```js
 module.exports = {
@@ -33,9 +35,9 @@ module.exports = {
 };
 ```
 
-4. Remove `distDir` from `next.config.js` as `@vercel/next` can't parse this file and expects your build output at `/.next`
+5. Remove `distDir` from `next.config.js` as `@vercel/next` can't parse this file and expects your build output at `/.next`
 
-5. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
+6. Optionally make sure the `"src"` in `"builds"` points to your application `package.json`
 
 ```js
 {


### PR DESCRIPTION
After many hours of debugging, I tracked down that having an old Node version (eg 14.x) listed in your Vercel project settings can result in the build step failing with a confusing and unhelpful error message "`@vercel/next` No Serverless Pages Built". Note that this is a case where it "can" cause it to fail, including with NextJS 13.1.6 and Vercel CLI 28.16.2, but it is not guaranteed to fail. I have six NextJS projects. They have identical next.config.js, tsconfig.json, eslintrc.js, and .gitignore files, and other than a few seemingly non-critical dependencies they have identical package.json files. Four of the six consistently built and deployed in the cloud without issue. Two consistently failed to build in the cloud. All built successfully locally including using vercel build locally, and all would vercel deploy --prebuilt successfully. Switching all the vercel cloud project settings from Node 14.x to Node 18.x enabled all the projects to build and deploy successfully in the vercel cloud without needing local vercel build and local vercel deploy --prebuilt steps.