### PR TITLE
[cli] Fix global detection for fnm

### DIFF
--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -76,6 +76,10 @@ async function isGlobal() {
       return true;
     }
 
+    if (installPath.includes(['', 'fnm', 'node-versions', ''].join(sep))) {
+      return true;
+    }
+
     const prefixPath =
       process.env.PREFIX ||
       process.env.npm_config_prefix ||


### PR DESCRIPTION
Fix `--global` install detection when [fnm](https://github.com/Schniz/fnm) was used to install node