### PR TITLE
[tests] update gatsby test fixture versions

### DIFF
--- a/packages/static-build/test/fixtures/gatsby-v2/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v2/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "2.32.13",
+    "gatsby": "latest-v2",
     "prop-types": "15.8.1",
     "react": "16.14.0",
     "react-dom": "16.14.0"

--- a/packages/static-build/test/fixtures/gatsby-v3/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v3/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "3.15.0",
+    "gatsby": "latest-v3",
     "gatsby-plugin-image": "1.15.0",
     "gatsby-plugin-manifest": "3.15.0",
     "gatsby-plugin-sharp": "3.15.0",

--- a/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "4.25.2",
+    "gatsby": "4.25.4",
     "gatsby-plugin-image": "^2.21.0",
     "gatsby-plugin-manifest": "^4.21.0",
     "gatsby-plugin-pnpm": "1.2.10",

--- a/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4-pnpm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "4.25.4",
+    "gatsby": "latest-v4",
     "gatsby-plugin-image": "^2.21.0",
     "gatsby-plugin-manifest": "^4.21.0",
     "gatsby-plugin-pnpm": "1.2.10",

--- a/packages/static-build/test/fixtures/gatsby-v4/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "4.25.2",
+    "gatsby": "4.25.4",
     "gatsby-plugin-image": "^2.21.0",
     "gatsby-plugin-manifest": "^4.21.0",
     "gatsby-plugin-pnpm": "1.2.10",

--- a/packages/static-build/test/fixtures/gatsby-v4/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "gatsby": "4.25.4",
+    "gatsby": "latest-v4",
     "gatsby-plugin-image": "^2.21.0",
     "gatsby-plugin-manifest": "^4.21.0",
     "gatsby-plugin-pnpm": "1.2.10",

--- a/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/package.json
@@ -15,7 +15,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "5.7.0",
+    "gatsby": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/package.json
@@ -15,7 +15,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^5.4.2",
+    "gatsby": "5.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/static-build/test/fixtures/gatsby-v5/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/package.json
@@ -8,7 +8,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "5.7.0",
+    "gatsby": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/static-build/test/fixtures/gatsby-v5/package.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/package.json
@@ -8,7 +8,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^5.4.2",
+    "gatsby": "5.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
Pins gatsby test fixtures to `latest-v` dist tags so that our tests can tell us if gatsby ever changes their internal api we rely on in a future patch or minor update.

Available dist-tags are:

```
npm view gatsby --dist-tags | grep latest
latest-dev-ssr: 2.29.0-latest-dev-ssr.31
latest-v1: 1.9.279
latest-v2: 2.32.13
latest-v3: 3.15.0
latest-v4: 4.25.4
latest: 5.7.0
```