### PR TITLE
[next] Ensure .rsc outputs are not created for route handlers

### DIFF
--- a/packages/next/test/fixtures/00-app-dir/app/edge-route-handler/route.js
+++ b/packages/next/test/fixtures/00-app-dir/app/edge-route-handler/route.js
@@ -1,0 +1,7 @@
+export const runtime = 'experimental-edge';
+
+export const GET = req => {
+  // use query to trigger dynamic usage
+  console.log('query', Object.fromEntries(req.nextUrl.searchParams));
+  return new Response('hello world');
+};

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -32,6 +32,10 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     expect(buildResult.output['dashboard/changelog']).toBeDefined();
     expect(buildResult.output['dashboard/deployments/[id]']).toBeDefined();
 
+    expect(buildResult.output['edge-route-handler']).toBeDefined();
+    expect(buildResult.output['edge-route-handler'].type).toBe('EdgeFunction');
+    expect(buildResult.output['edge-route-handler.rsc']).not.toBeDefined();
+
     // prefixed static generation output with `/app` under dist server files
     expect(buildResult.output['dashboard'].type).toBe('Prerender');
     expect(buildResult.output['dashboard'].fallback.fsPath).toMatch(


### PR DESCRIPTION
This ensures `api/` prefix route handlers works correctly (tested in https://github.com/vercel/next.js/pull/46133) and also ensures we don't output `.rsc` output paths for route handlers as they aren't needed. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1676973888475579?thread_ts=1676938768.842079&cid=C03S8ED1DKM)
x-ref: https://github.com/vercel/next.js/pull/46133