### PR TITLE
[remix] Handle escaped characters in route names

### DIFF
--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -49,7 +49,13 @@ export function getRegExpFromPath(path: string): RegExp | false {
   // Replace "/*" at the end to handle "splat routes"
   const splatPath = '/:params+';
   const rePath =
-    path === '*' ? splatPath : `/${path.replace(/\/\*$/, splatPath)}`;
+    path === '*'
+      ? splatPath
+      : `/${path
+          .replace(/\/\*$/, splatPath)
+          .replace(/\[(.+)\]/g, (_, m: string) => {
+            return m.replace(/([.:?])/g, '\\$1');
+          })}`;
   const re = pathToRegexp(rePath, keys);
   return keys.length > 0 ? re : false;
 }

--- a/packages/remix/test/unit.get-regexp-from-path.test.ts
+++ b/packages/remix/test/unit.get-regexp-from-path.test.ts
@@ -2,12 +2,16 @@ import { getRegExpFromPath } from '../src/utils';
 
 describe('getRegExpFromPath()', () => {
   describe('paths without parameters', () => {
-    it.each([{ path: 'index' }, { path: 'api/hello' }, { path: 'projects' }])(
-      'should return `false` for "$path"',
-      ({ path }) => {
-        expect(getRegExpFromPath(path)).toEqual(false);
-      }
-    );
+    it.each([
+      { path: 'index' },
+      { path: 'api/hello' },
+      { path: 'projects' },
+      { path: '[:]' },
+      { path: '[::]' },
+      { path: 'blog/[about.pdf]' },
+    ])('should return `false` for "$path"', ({ path }) => {
+      expect(getRegExpFromPath(path)).toEqual(false);
+    });
   });
 
   describe.each([
@@ -103,6 +107,19 @@ describe('getRegExpFromPath()', () => {
         },
         {
           url: '/blog/123/another',
+          expected: false,
+        },
+      ],
+    },
+    {
+      path: '[:]/:page',
+      urls: [
+        {
+          url: '/:/1',
+          expected: true,
+        },
+        {
+          url: '/other',
           expected: false,
         },
       ],


### PR DESCRIPTION
Remix allows to use `[]` brackets to escape the characters within the brackets in the URL path. So we need to escape those characters as well (and remove the brackets) from the RegExp that gets created for `routes`.

See: https://remix.run/docs/en/v1/guides/resource-routes#url-escaping

Fixes: https://github.com/orgs/vercel/discussions/1594 (probably)