### PR TITLE
[remix] Simplify ESM detection of `remix.config.js`

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -108,11 +108,7 @@ export const build: BuildV2 = async ({
     try {
       _require(renamedRemixConfigPath);
     } catch (err: any) {
-      if (err.code === 'ERR_REQUIRE_ESM') {
-        isESM = true;
-      } else {
-        throw err;
-      }
+      isESM = err.code === 'ERR_REQUIRE_ESM';
     }
 
     let patchedConfig: string;

--- a/packages/remix/test/fixtures/01-remix-basics/package.json
+++ b/packages/remix/test/fixtures/01-remix-basics/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "remix build",
+    "build": "mkdir node_modules/ui && touch node_modules/ui/index.js && remix build",
     "dev": "remix dev",
     "start": "remix-serve build"
   },

--- a/packages/remix/test/fixtures/01-remix-basics/remix.config.js
+++ b/packages/remix/test/fixtures/01-remix-basics/remix.config.js
@@ -7,4 +7,5 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
+  watchPaths: [require.resolve('ui')],
 };


### PR DESCRIPTION
In a Turborepo setup, there was this in the `remix.config.js` file:

```js
  watchPaths: [require.resolve("ui")],
```

Since we attempt to `require()` the `remix.config.js` file in order to determine whether or not it is using ESM syntax, this would fail since the require happens before the Build Command is executed.

To fix, treat any non `ERR_REQUIRE_ESM` error as CJS, instead of re-throwing the error. If there really is an issue with importing the config, then that'll happen right after when `remix build` is doing it.