### PR TITLE
[tests] Increase test timeout from 5s to 10s

### DIFF
--- a/packages/node/test/dev.test.ts
+++ b/packages/node/test/dev.test.ts
@@ -2,6 +2,8 @@ import { forkDevServer, readMessage } from '../src/fork-dev-server';
 import { resolve } from 'path';
 import fetch from 'node-fetch';
 
+jest.setTimeout(10 * 1000);
+
 test('runs a mjs endpoint', async () => {
   const child = forkDevServer({
     maybeTranspile: true,


### PR DESCRIPTION
Fixes this error:

```
@vercel/node:test-unit: FAIL test/dev.test.ts (14.891 s)
@vercel/node:test-unit:   × runs a mjs endpoint (5057 ms)
@vercel/node:test-unit:   × runs a esm typescript endpoint (5122 ms)
@vercel/node:test-unit: 
@vercel/node:test-unit:   ● runs a mjs endpoint
@vercel/node:test-unit: 
@vercel/node:test-unit:     thrown: "Exceeded timeout of 5000 ms for a test.
@vercel/node:test-unit:     Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
```

https://github.com/vercel/vercel/actions/runs/4247588973/jobs/7385801227#step:9:1039