### PR TITLE
[tests] Remove `watchPaths` from remix test fixture

### DIFF
--- a/packages/remix/test/fixtures/01-remix-basics/package.json
+++ b/packages/remix/test/fixtures/01-remix-basics/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
-    "build": "mkdir node_modules/ui && touch node_modules/ui/index.js && remix build",
+    "build": "remix build",
     "dev": "remix dev",
     "start": "remix-serve build"
   },

--- a/packages/remix/test/fixtures/01-remix-basics/remix.config.js
+++ b/packages/remix/test/fixtures/01-remix-basics/remix.config.js
@@ -7,5 +7,4 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  watchPaths: [require.resolve('ui')],
 };


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/9512 which is a revert of the test fixture.

The fixture was actually broken in the previous commit (https://github.com/vercel/vercel/pull/9506) since it now is trying to read the config file before running the Build Command. Having a setup like this will not be able to be supported, especially in order to land https://github.com/vercel/vercel/pull/9504.