### PR TITLE
[node-bridge] Fix multiple `Set-Cookie` headers in streaming mode

### DIFF
--- a/packages/node-bridge/bridge.js
+++ b/packages/node-bridge/bridge.js
@@ -435,7 +435,13 @@ function getStreamResponseCallback({ url, socket, cipher, resolve, reject }) {
     headers += `x-vercel-status-code: ${response.statusCode || 200}${CRLF}`;
     for (const [name, value] of getHeadersIterator(response.headers)) {
       if (!['connection', 'transfer-encoding'].includes(name)) {
-        headers += `x-vercel-header-${name}: ${value}${CRLF}`;
+        if (typeof value === 'string') {
+          headers += `x-vercel-header-${name}: ${value}${CRLF}`;
+        } else {
+          for (const val of value) {
+            headers += `x-vercel-header-${name}: ${val}${CRLF}`;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Multiple `Set-Cookie` headers are being concat'd instead of being sent individually when in streaming mode.

**Non-streaming:**

```
$ curl -v https://01-remix-basics-eqztqyq3y.vercel-support.app/set-cookie 2>&1 | grep cookie
* h2h3 [:path: /set-cookie]
> GET /set-cookie HTTP/2
< set-cookie: foo=bar
< set-cookie: sessionId=38afes7a8
```

**Streaming:**

```
$ curl -v https://01-remix-basics-9b18alizh.vercel-support.app/set-cookie 2>&1 | grep cookie
* h2h3 [:path: /set-cookie]
> GET /set-cookie HTTP/2
< set-cookie: foo=bar,sessionId=38afes7a8
```