### PR TITLE
[remix] Ignore `serverBuildPath` from Remix config

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -96,6 +96,7 @@ export const build: BuildV2 = async ({
   spawnOpts.env.NODE_ENV = 'production';
 
   let remixConfig = await chdirAndReadConfig(entrypointFsDirname);
+  console.log(remixConfig);
   const { serverEntryPoint } = remixConfig;
 
   // We need to patch the `remix.config.js` file to force some values necessary
@@ -168,6 +169,7 @@ module.exports = config;`;
       }
     }
     remixConfig = await chdirAndReadConfig(entrypointFsDirname);
+    console.log(remixConfig);
   } finally {
     // Clean up our patched `remix.config.js` to be polite
     if (remixConfigPath && renamedRemixConfigPath) {
@@ -175,7 +177,9 @@ module.exports = config;`;
     }
   }
 
-  const { serverBuildPath } = remixConfig;
+  //const { serverBuildPath } = remixConfig;
+  //console.log({ serverBuildPath, serverEntryPoint });
+
   const remixRoutes = Object.values(remixConfig.routes);
 
   // Figure out which pages should be edge functions
@@ -208,7 +212,8 @@ module.exports = config;`;
     createRenderNodeFunction(
       entrypointFsDirname,
       repoRootPath,
-      serverBuildPath,
+      //join(entrypointFsDirname, 'build/index.js'),
+      remixConfig.serverBuildPath,
       serverEntryPoint,
       nodeVersion
     ),
@@ -216,7 +221,8 @@ module.exports = config;`;
       ? createRenderEdgeFunction(
           entrypointFsDirname,
           repoRootPath,
-          serverBuildPath,
+          //join(entrypointFsDirname, 'build/index.js'),
+          remixConfig.serverBuildPath,
           serverEntryPoint
         )
       : undefined,

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -95,9 +95,8 @@ export const build: BuildV2 = async ({
   // Make `remix build` output production mode
   spawnOpts.env.NODE_ENV = 'production';
 
-  let remixConfig = await chdirAndReadConfig(entrypointFsDirname);
-  console.log(remixConfig);
-  const { serverEntryPoint } = remixConfig;
+  const remixConfig = await chdirAndReadConfig(entrypointFsDirname);
+  const remixRoutes = Object.values(remixConfig.routes);
 
   // We need to patch the `remix.config.js` file to force some values necessary
   // for a build that works on either Node.js or the Edge runtime
@@ -105,6 +104,7 @@ export const build: BuildV2 = async ({
   const renamedRemixConfigPath = remixConfigPath
     ? `${remixConfigPath}.original${extname(remixConfigPath)}`
     : undefined;
+  const serverBuildPath = 'build/index.js';
   if (remixConfigPath && renamedRemixConfigPath) {
     await fs.rename(remixConfigPath, renamedRemixConfigPath);
 
@@ -124,7 +124,7 @@ export const build: BuildV2 = async ({
 config.serverBuildTarget = undefined;
 config.serverModuleFormat = 'cjs';
 config.serverPlatform = 'node';
-config.serverBuildPath = 'build/index.js';
+config.serverBuildPath = ${JSON.stringify(serverBuildPath)}
 export default config;`;
     } else {
       patchedConfig = `const config = require('./${basename(
@@ -133,7 +133,7 @@ export default config;`;
 config.serverBuildTarget = undefined;
 config.serverModuleFormat = 'cjs';
 config.serverPlatform = 'node';
-config.serverBuildPath = 'build/index.js';
+config.serverBuildPath = ${JSON.stringify(serverBuildPath)}
 module.exports = config;`;
     }
     await fs.writeFile(remixConfigPath, patchedConfig);
@@ -168,19 +168,12 @@ module.exports = config;`;
         });
       }
     }
-    remixConfig = await chdirAndReadConfig(entrypointFsDirname);
-    console.log(remixConfig);
   } finally {
     // Clean up our patched `remix.config.js` to be polite
     if (remixConfigPath && renamedRemixConfigPath) {
       await fs.rename(renamedRemixConfigPath, remixConfigPath);
     }
   }
-
-  //const { serverBuildPath } = remixConfig;
-  //console.log({ serverBuildPath, serverEntryPoint });
-
-  const remixRoutes = Object.values(remixConfig.routes);
 
   // Figure out which pages should be edge functions
   let hasEdgeRoute = false;
@@ -212,18 +205,16 @@ module.exports = config;`;
     createRenderNodeFunction(
       entrypointFsDirname,
       repoRootPath,
-      //join(entrypointFsDirname, 'build/index.js'),
-      remixConfig.serverBuildPath,
-      serverEntryPoint,
+      join(entrypointFsDirname, serverBuildPath),
+      remixConfig.serverEntryPoint,
       nodeVersion
     ),
     hasEdgeRoute
       ? createRenderEdgeFunction(
           entrypointFsDirname,
           repoRootPath,
-          //join(entrypointFsDirname, 'build/index.js'),
-          remixConfig.serverBuildPath,
-          serverEntryPoint
+          join(entrypointFsDirname, serverBuildPath),
+          remixConfig.serverEntryPoint
         )
       : undefined,
   ]);

--- a/packages/remix/test/fixtures/02-remix-basics-mjs/remix.config.mjs
+++ b/packages/remix/test/fixtures/02-remix-basics-mjs/remix.config.mjs
@@ -3,6 +3,7 @@
  */
 export default {
   ignoredRouteFiles: ["**/.*"],
+  serverBuildTarget: "vercel",
   // When running locally in development mode, we use the built-in remix
   // server. This does not understand the vercel lambda module format,
   // so we default back to the standard build output.


### PR DESCRIPTION
We are explicitly overriding `serverBuildPath` so there is no need to use the value that `readConfig()` gives to us.

Fixes #9524.