### PR TITLE
[tests] Properly test for multiple headers with same name in probes

### DIFF
--- a/packages/python/test/fixtures/20-multivalue-header/vercel.json
+++ b/packages/python/test/fixtures/20-multivalue-header/vercel.json
@@ -17,7 +17,7 @@
     {
       "path": "/cookie_wsgi.py",
       "responseHeaders": {
-        "set-cookie": ["one=first", "two=second"]
+        "set-cookie": ["one=first; Path=/", "two=second; Path=/"]
       }
     }
   ]

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -243,7 +243,6 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
       if (!Array.isArray(expectedArr)) {
         expectedArr = [expectedArr];
       }
-      console.log({ header, actualArr, expectedArr });
       for (const expected of expectedArr) {
         let isEqual = false;
         for (const actual of actualArr) {


### PR DESCRIPTION
Updates the `responseHeaders` probe checks to properly test for multiple headers with the same name.

Previously the probes were using `headers.get()` which concats multiple headers into a single string, which results in the test not really checking if there are in fact multiple headers with the same name. Using `headers.raw()` allows us to properly test for that.

A couple of Python tests that were already checking for multiple `set-cookie` headers needed to be updated to match the full value, since the check now properly validates the full string match of each header (before it was basically just doing a `string.includes()` check).

This is a precursor for https://github.com/vercel/vercel/pull/9533.