### PR TITLE
[build-utils] Handle error during `readConfigFile()`

### DIFF
--- a/packages/build-utils/src/fs/read-config-file.ts
+++ b/packages/build-utils/src/fs/read-config-file.ts
@@ -25,12 +25,16 @@ export async function readConfigFile<T>(
 
     if (data) {
       const str = data.toString('utf8');
-      if (name.endsWith('.json')) {
-        return JSON.parse(str) as T;
-      } else if (name.endsWith('.toml')) {
-        return (toml.parse(str) as unknown) as T;
-      } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
-        return yaml.safeLoad(str, { filename: name }) as T;
+      try {
+        if (name.endsWith('.json')) {
+          return JSON.parse(str) as T;
+        } else if (name.endsWith('.toml')) {
+          return toml.parse(str) as unknown as T;
+        } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
+          return yaml.safeLoad(str, { filename: name }) as T;
+        }
+      } catch (error: unknown) {
+        console.log(`Error while parsing config file: "${name}"`);
       }
     }
   }

--- a/packages/build-utils/test/unit.read-config-file.test.ts
+++ b/packages/build-utils/test/unit.read-config-file.test.ts
@@ -1,0 +1,77 @@
+import { join } from 'path';
+import { writeFile, rm } from 'fs/promises';
+import { readConfigFile } from '../src';
+
+describe('Test `readConfigFile()`', () => {
+  let logMessages: string[];
+  const originalConsoleLog = console.log;
+
+  beforeEach(() => {
+    logMessages = [];
+    console.log = m => {
+      logMessages.push(m);
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+  });
+
+  const doesnotexist = join(__dirname, 'does-not-exist.json');
+  const tsconfig = join(__dirname, '../tsconfig.json');
+  const invalid = join(__dirname, 'invalid.json');
+
+  it('should return null when file does not exist', async () => {
+    expect(await readConfigFile(doesnotexist)).toBeNull();
+    expect(logMessages).toEqual([]);
+  });
+
+  it('should return parsed object when file exists', async () => {
+    expect(await readConfigFile(tsconfig)).toMatchObject({
+      compilerOptions: {
+        strict: true,
+      },
+    });
+    expect(logMessages).toEqual([]);
+  });
+
+  it('should return parsed object when at least one file exists', async () => {
+    const files = [doesnotexist, tsconfig];
+    expect(await readConfigFile(files)).toMatchObject({
+      compilerOptions: {
+        strict: true,
+      },
+    });
+    expect(logMessages).toEqual([]);
+  });
+
+  it('should return null when parse fails', async () => {
+    try {
+      await writeFile(invalid, 'borked');
+      expect(await readConfigFile(invalid)).toBeNull();
+    } finally {
+      await rm(invalid);
+    }
+    expect(logMessages.length).toBe(1);
+    expect(logMessages[0]).toMatch(
+      /^Error while parsing config file.+invalid.json/
+    );
+  });
+
+  it('should return parsed object when at least one file is valid', async () => {
+    try {
+      await writeFile(invalid, 'borked');
+      expect(await readConfigFile([invalid, tsconfig])).toMatchObject({
+        compilerOptions: {
+          strict: true,
+        },
+      });
+    } finally {
+      await rm(invalid);
+    }
+    expect(logMessages.length).toBe(1);
+    expect(logMessages[0]).toMatch(
+      /^Error while parsing config file.+invalid.json/
+    );
+  });
+});


### PR DESCRIPTION
This fixes a confusing error:

```
$ vercel build
Vercel CLI 28.16.6
Error: duplicated mapping key in "/vercel/path0/pnpm-lock.yaml" at line 1215, column -164:
      /@react-dnd/asap/4.0.1:
      ^
```