### PR TITLE
[cli] Added fetch dist-tags http status validation

### DIFF
--- a/packages/cli/src/util/get-latest-version/get-latest-worker.js
+++ b/packages/cli/src/util/get-latest-version/get-latest-worker.js
@@ -247,6 +247,14 @@ async function fetchDistTags(name) {
         });
         res.on('end', () => {
           try {
+            if (res.statusCode && res.statusCode >= 400) {
+              return reject(
+                new Error(
+                  `Fetch dist-tags failed ${res.statusCode} ${res.statusMessage}`
+                )
+              );
+            }
+
             resolve(JSON.parse(buf));
           } catch (err) {
             reject(err);


### PR DESCRIPTION
If for some reason the `get-latest-worker.js` fails to get the dist-tags, it doesn't check the status code and proceeds to `JSON.parse()` the response. If for example npm returns 401 Unauthorized, you get a cryptic JSON parse error message.