### PR TITLE
[build-utils] Change `debug()` to accept a single string param

### DIFF
--- a/packages/build-utils/src/debug.ts
+++ b/packages/build-utils/src/debug.ts
@@ -1,9 +1,6 @@
-import { getPlatformEnv } from './get-platform-env';
-
-export default function debug(message: string, ...additional: any[]) {
-  if (getPlatformEnv('BUILDER_DEBUG')) {
-    console.log(message, ...additional);
-  } else if (process.env.VERCEL_DEBUG_PREFIX) {
-    console.log(`${process.env.VERCEL_DEBUG_PREFIX}${message}`, ...additional);
+export default function debug(message: string) {
+  if (process.env.VERCEL_DEBUG_PREFIX) {
+    const line = message.replace(/\r?\n/g, ' ');
+    console.log(`${process.env.VERCEL_DEBUG_PREFIX}${line}`);
   }
 }

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -540,7 +540,6 @@ export async function runCustomInstallCommand({
     nodeVersion,
     env: spawnOpts?.env || {},
   });
-  debug(`Running with $PATH:`, env?.PATH || '');
   await execCommand(installCommand, {
     ...spawnOpts,
     env,

--- a/packages/build-utils/test/unit.debug.test.ts
+++ b/packages/build-utils/test/unit.debug.test.ts
@@ -1,0 +1,55 @@
+import { debug } from '../src';
+
+describe('Test `debug()`', () => {
+  let logMessages: string[];
+  const originalConsoleLog = console.log;
+
+  beforeEach(() => {
+    logMessages = [];
+    console.log = m => {
+      logMessages.push(m);
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+  });
+
+  it('should not log when env var is not assigned', async () => {
+    debug('Hello world');
+    expect(logMessages.length).toBe(0);
+  });
+
+  it('should log when env var is assigned', async () => {
+    const original = process.env.VERCEL_DEBUG_PREFIX;
+    try {
+      process.env.VERCEL_DEBUG_PREFIX = 'HELLO: ';
+      debug('world');
+    } finally {
+      process.env.VERCEL_DEBUG_PREFIX = original;
+    }
+    expect(logMessages[0]).toBe('HELLO: world');
+  });
+
+  it('should replace newline with space', async () => {
+    const original = process.env.VERCEL_DEBUG_PREFIX;
+    try {
+      process.env.VERCEL_DEBUG_PREFIX = 'DEBUG: ';
+      debug('Hello\nwith\nnew\nlines');
+    } finally {
+      process.env.VERCEL_DEBUG_PREFIX = original;
+    }
+    expect(logMessages[0]).toBe('DEBUG: Hello with new lines');
+  });
+
+  it('should replace carriage return and newline with space', async () => {
+    const original = process.env.VERCEL_DEBUG_PREFIX;
+    try {
+      process.env.VERCEL_DEBUG_PREFIX = 'DEBUG: ';
+      debug('Hello\r\nwith\r\ncarriage\r\nreturns');
+    } finally {
+      process.env.VERCEL_DEBUG_PREFIX = original;
+    }
+    expect(logMessages[0]).toBe('DEBUG: Hello with carriage returns');
+  });
+});

--- a/packages/go/go-helpers.ts
+++ b/packages/go/go-helpers.ts
@@ -39,7 +39,7 @@ export async function getAnalyzedEntrypoint(
   filePath: string,
   modulePath: string
 ) {
-  debug('Analyzing entrypoint %o with modulePath %o', filePath, modulePath);
+  debug(`Analyzing entrypoint ${filePath} with modulePath ${modulePath}`);
   const bin = join(__dirname, `analyze${OUT_EXTENSION}`);
 
   const isAnalyzeExist = await pathExists(bin);
@@ -52,7 +52,7 @@ export async function getAnalyzedEntrypoint(
   const args = [`-modpath=${modulePath}`, filePath];
 
   const analyzed = await execa.stdout(bin, args);
-  debug('Analyzed entrypoint %o', analyzed);
+  debug(`Analyzed entrypoint ${analyzed}`);
   return analyzed;
 }
 
@@ -60,7 +60,7 @@ export async function getAnalyzedEntrypoint(
 // Without this, `go` won't recognize the `$GOPATH`.
 function createGoPathTree(goPath: string, platform: string, arch: string) {
   const tuple = `${getPlatform(platform)}_${getArch(arch)}`;
-  debug('Creating GOPATH directory structure for %o (%s)', goPath, tuple);
+  debug(`Creating GOPATH directory structure for ${goPath} (${tuple})`);
   return Promise.all([
     mkdirp(join(goPath, 'bin')),
     mkdirp(join(goPath, 'pkg', tuple)),
@@ -81,7 +81,7 @@ class GoWrapper {
 
   private execute(...args: string[]) {
     const { opts, env } = this;
-    debug('Exec %o', `go ${args.join(' ')}`);
+    debug(`Executing go ${args.join(' ')}`);
     return execa('go', args, { stdio: 'pipe', ...opts, env });
   }
 
@@ -92,16 +92,16 @@ class GoWrapper {
   get(src?: string) {
     const args = ['get'];
     if (src) {
-      debug('Fetching `go` dependencies for file %o', src);
+      debug(`Fetching go dependencies for file ${src}`);
       args.push(src);
     } else {
-      debug('Fetching `go` dependencies for cwd %o', this.opts.cwd);
+      debug(`Fetching go dependencies for cwd ${this.opts.cwd}`);
     }
     return this.execute(...args);
   }
 
   build(src: string | string[], dest: string) {
-    debug('Building optimized `go` binary %o -> %o', src, dest);
+    debug(`Building optimized go binary ${src} -> ${dest}`);
     const sources = Array.isArray(src) ? src : [src];
 
     const flags = process.env.GO_BUILD_FLAGS
@@ -145,16 +145,15 @@ export async function downloadGo(workPath: string, modulePath: string) {
   const { failed, stdout } = await execa('go', ['version'], { reject: false });
 
   if (!failed && parseInt(stdout.split('.')[1]) >= GO_MIN_VERSION) {
-    debug('Using system installed version of `go`: %o', stdout.trim());
+    debug(`Using system installed version of go: ${stdout.trim()}`);
     return createGo(workPath, dir, platform, arch);
   }
 
   // Check `go` bin in cacheDir
   const isGoExist = await pathExists(join(dir, 'bin'));
   if (!isGoExist) {
-    debug('Installing `go` v%s to %o for %s %s', version, dir, platform, arch);
     const url = getGoUrl(version, platform, arch);
-    debug('Downloading `go` URL: %o', url);
+    debug(`Downloading go URL: ${url}`);
     const res = await fetch(url);
 
     if (!res.ok) {
@@ -189,7 +188,7 @@ async function parseGoVersion(modulePath: string): Promise<string> {
     } else {
       console.log(`Warning: Unknown Go version in ${file}`);
     }
-  } catch (err) {
+  } catch (err: any) {
     if (err.code === 'ENOENT') {
       debug(`File not found: ${file}`);
     } else {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -221,21 +221,6 @@ export const build: BuildV2 = async ({
   // setting that can't be triggered with vercel.json
   const baseDir = repoRootPath || workPath;
 
-  debug(
-    JSON.stringify(
-      {
-        repoRootPath,
-        baseDir,
-        workPath,
-        entryPath,
-        entryDirectory,
-        outputDirectory,
-      },
-      null,
-      2
-    )
-  );
-
   const prefixedEnvs = getPrefixedEnvVars({
     envPrefix: 'NEXT_PUBLIC_',
     envs: process.env,
@@ -293,7 +278,6 @@ export const build: BuildV2 = async ({
 
     debug('Normalizing package.json');
     pkg = normalizePackageJson(pkg);
-    debug('Normalized package.json result: ', pkg);
     await writePackageJson(entryPath, pkg);
   }
 
@@ -1538,7 +1522,7 @@ export const build: BuildV2 = async ({
         );
         assetKeys.forEach(assetFile => debug(`\t${assetFile}`));
         debug(
-          '\nPlease upgrade to Next.js 9.1 to leverage modern asset handling.'
+          'Please upgrade to Next.js 9.1 to leverage modern asset handling.'
         );
       }
     }

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -469,14 +469,10 @@ export async function serverBuild({
     }, 0);
 
     debug(
-      JSON.stringify(
-        {
-          uncompressedInitialSize,
-          compressedInitialSize: initialPseudoLayer.pseudoLayerBytes,
-        },
-        null,
-        2
-      )
+      JSON.stringify({
+        uncompressedInitialSize,
+        compressedInitialSize: initialPseudoLayer.pseudoLayerBytes,
+      })
     );
 
     if (
@@ -756,33 +752,6 @@ export async function serverBuild({
       group.isApiLambda = true;
     }
 
-    debug(
-      JSON.stringify(
-        {
-          apiLambdaGroups: apiLambdaGroups.map(group => ({
-            pages: group.pages,
-            isPrerender: group.isPrerenders,
-            pseudoLayerBytes: group.pseudoLayerBytes,
-            uncompressedLayerBytes: group.pseudoLayerUncompressedBytes,
-          })),
-          pageLambdaGroups: pageLambdaGroups.map(group => ({
-            pages: group.pages,
-            isPrerender: group.isPrerenders,
-            pseudoLayerBytes: group.pseudoLayerBytes,
-            uncompressedLayerBytes: group.pseudoLayerUncompressedBytes,
-          })),
-          streamingPageLambdaGroups: streamingPageLambdaGroups.map(group => ({
-            pages: group.pages,
-            isPrerender: group.isPrerenders,
-            pseudoLayerBytes: group.pseudoLayerBytes,
-            uncompressedLayerBytes: group.pseudoLayerUncompressedBytes,
-          })),
-          nextServerLayerSize: initialPseudoLayer.pseudoLayerBytes,
-        },
-        null,
-        2
-      )
-    );
     const combinedGroups = [
       ...pageLambdaGroups,
       ...streamingPageLambdaGroups,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -8,7 +8,6 @@ import {
   Lambda,
   Prerender,
   getLambdaOptionsFromFunction,
-  getPlatformEnv,
   streamToBuffer,
   NowBuildError,
   isSymbolicLink,
@@ -1594,12 +1593,7 @@ export const detectLambdaLimitExceeding = async (
       group.pseudoLayerBytes > COMPRESSED_SIZE_LIMIT_CLOSE ||
       group.pseudoLayerUncompressedBytes > UNCOMPRESSED_SIZE_LIMIT_CLOSE;
 
-    if (
-      closeToLimit ||
-      exceededLimit ||
-      getPlatformEnv('BUILDER_DEBUG') ||
-      process.env.NEXT_DEBUG_FUNCTION_SIZE
-    ) {
+    if (closeToLimit || exceededLimit || process.env.NEXT_DEBUG_FUNCTION_SIZE) {
       if (exceededLimit) {
         numExceededLimit += 1;
       }

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -180,12 +180,10 @@ export const build = async ({
 
   const originalPyPath = join(__dirname, '..', 'vc_init.py');
   const originalHandlerPyContents = await readFile(originalPyPath, 'utf8');
-  debug('Entrypoint is', entrypoint);
   const moduleName = entrypoint.replace(/\//g, '.').replace(/\.py$/, '');
   // Since `vercel dev` renames source files, we must reference the original
   const suffix = meta.isDev && !entrypoint.endsWith('.py') ? '.py' : '';
   const entrypointWithSuffix = `${entrypoint}${suffix}`;
-  debug('Entrypoint with suffix is', entrypointWithSuffix);
   const handlerPyContents = originalHandlerPyContents
     .replace(/__VC_HANDLER_MODULE_NAME/g, moduleName)
     .replace(/__VC_HANDLER_ENTRYPOINT/g, entrypointWithSuffix);

--- a/packages/ruby/index.ts
+++ b/packages/ruby/index.ts
@@ -160,7 +160,6 @@ export async function build({
 
   // will be used on `require_relative '$here'` or for loading rack config.ru file
   // for example, `require_relative 'api/users'`
-  debug('entrypoint is', entrypoint);
   const userHandlerFilePath = entrypoint.replace(/\.rb$/, '');
   const nowHandlerRbContents = originalHandlerRbContents.replace(
     /__VC_HANDLER_FILENAME/g,

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -565,9 +565,9 @@ export const build: BuildV2 = async ({
 
       if (typeof devPort === 'number') {
         debug(
-          '`%s` server already running for %j',
-          devCommand || devScript,
-          entrypoint
+          `"${
+            devCommand || devScript
+          }" server already running for ${entrypoint}`
         );
       } else {
         // Run the `now-dev` or `dev` script out-of-bounds, since it is assumed that
@@ -598,7 +598,7 @@ export const build: BuildV2 = async ({
           );
         }
 
-        debug('Detected dev server for %j', entrypoint);
+        debug('Detected dev server for ' + entrypoint);
       }
 
       let srcBase = mountpoint.replace(/^\.\/?/, '');


### PR DESCRIPTION
This is technically a semver major change but will improve our logging because we can optionally turn on debugging in the build container.

- Before: `debug(obj)`
- After: `debug(JSON.stringify(obj))`

If there are any newlines then they will be replaced to avoid accidentally printing when you don't intend to.