### PR TITLE
[remix] Inject Edge entrypoint into `@remix-run/vercel` during Edge Function creation

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -654,42 +654,6 @@ async function doBuild(
       emoji('success')
     )}\n`
   );
-
-  console.log(
-    await fs.readdir(join(outputDir, 'functions/edge.func/node_modules'))
-  );
-  console.log(
-    await fs.readdir(
-      join(outputDir, 'functions/edge.func/node_modules/@remix-run')
-    )
-  );
-  console.log(
-    await fs.readFile(
-      join(outputDir, 'functions/edge.func/build/index.js'),
-      'utf8'
-    )
-  );
-  console.log(
-    await fs.readdir(
-      join(outputDir, 'functions/edge.func/node_modules/@remix-run/vercel')
-    )
-  );
-  console.log(
-    await fs.readJSON(
-      join(
-        outputDir,
-        'functions/edge.func/node_modules/@remix-run/vercel/package.json'
-      )
-    )
-  );
-  console.log(
-    await fs.pathExists(
-      join(
-        outputDir,
-        'functions/edge.func/node_modules/@remix-run/vercel/dist/edge.js'
-      )
-    )
-  );
 }
 
 async function getFramework(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -664,6 +664,11 @@ async function doBuild(
     )
   );
   console.log(
+    await fs.readFile(
+      join(outputDir, 'functions/edge.func/dist/index.js', 'utf8')
+    )
+  );
+  console.log(
     await fs.readdir(
       join(outputDir, 'functions/edge.func/node_modules/@remix-run/vercel')
     )

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -654,6 +654,36 @@ async function doBuild(
       emoji('success')
     )}\n`
   );
+
+  console.log(
+    await fs.readdir(join(outputDir, 'functions/edge.func/node_modules'))
+  );
+  console.log(
+    await fs.readdir(
+      join(outputDir, 'functions/edge.func/node_modules/@remix-run')
+    )
+  );
+  console.log(
+    await fs.readdir(
+      join(outputDir, 'functions/edge.func/node_modules/@remix-run/vercel')
+    )
+  );
+  console.log(
+    await fs.readJSON(
+      join(
+        outputDir,
+        'functions/edge.func/node_modules/@remix-run/vercel/package.json'
+      )
+    )
+  );
+  console.log(
+    await fs.pathExists(
+      join(
+        outputDir,
+        'functions/edge.func/node_modules/@remix-run/vercel/dist/edge.js'
+      )
+    )
+  );
 }
 
 async function getFramework(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -665,7 +665,7 @@ async function doBuild(
   );
   console.log(
     await fs.readFile(
-      join(outputDir, 'functions/edge.func/dist/index.js'),
+      join(outputDir, 'functions/edge.func/build/index.js'),
       'utf8'
     )
   );

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -665,7 +665,8 @@ async function doBuild(
   );
   console.log(
     await fs.readFile(
-      join(outputDir, 'functions/edge.func/dist/index.js', 'utf8')
+      join(outputDir, 'functions/edge.func/dist/index.js'),
+      'utf8'
     )
   );
   console.log(

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -18,7 +18,8 @@
   "files": [
     "dist",
     "server-node.mjs",
-    "server-edge.mjs"
+    "server-edge.mjs",
+    "vercel-edge-entrypoint.js"
   ],
   "dependencies": {
     "@remix-run/dev": "1.13.0",

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -359,7 +359,6 @@ async function createRenderEdgeFunction(
   let remixRunVercelPkgJson: string | undefined;
 
   // Trace the handler with `@vercel/nft`
-  console.log({ handlerPath });
   const trace = await nodeFileTrace([handlerPath], {
     base: rootDir,
     processCwd: entrypointDir,
@@ -383,7 +382,6 @@ async function createRenderEdgeFunction(
         // is used. This is a temporary stop gap until this PR is merged:
         // https://github.com/remix-run/remix/pull/5537
         if (pkgJson.name === '@remix-run/vercel') {
-          console.log('detected @remix-run/vercel');
           pkgJson.browser = 'dist/edge.js';
           pkgJson.dependencies['@remix-run/server-runtime'] =
             pkgJson.dependencies['@remix-run/node'];
@@ -423,19 +421,15 @@ async function createRenderEdgeFunction(
   });
 
   for (const warning of trace.warnings) {
-    console.log(`Warning from trace: ${warning.message}`);
+    debug(`Warning from trace: ${warning.message}`);
   }
 
   for (const file of trace.fileList) {
-    console.log(file);
     if (
       remixRunVercelPkgJson &&
       file.endsWith(`@remix-run${sep}vercel${sep}package.json`)
     ) {
       // Use the modified `@remix-run/vercel` package.json which contains "browser" field
-      console.log(
-        'Use the modified `@remix-run/vercel` package.json which contains "browser" field'
-      );
       files[file] = new FileBlob({ data: remixRunVercelPkgJson });
     } else {
       files[file] = await FileFsRef.fromFsPath({ fsPath: join(rootDir, file) });

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -359,6 +359,7 @@ async function createRenderEdgeFunction(
   let remixRunVercelPkgJson: string | undefined;
 
   // Trace the handler with `@vercel/nft`
+  console.log({ handlerPath });
   const trace = await nodeFileTrace([handlerPath], {
     base: rootDir,
     processCwd: entrypointDir,
@@ -382,6 +383,7 @@ async function createRenderEdgeFunction(
         // is used. This is a temporary stop gap until this PR is merged:
         // https://github.com/remix-run/remix/pull/5537
         if (pkgJson.name === '@remix-run/vercel') {
+          console.log('detected @remix-run/vercel');
           pkgJson.browser = 'dist/edge.js';
           pkgJson.dependencies['@remix-run/server-runtime'] =
             pkgJson.dependencies['@remix-run/node'];
@@ -421,15 +423,19 @@ async function createRenderEdgeFunction(
   });
 
   for (const warning of trace.warnings) {
-    debug(`Warning from trace: ${warning.message}`);
+    console.log(`Warning from trace: ${warning.message}`);
   }
 
   for (const file of trace.fileList) {
+    console.log(file);
     if (
       remixRunVercelPkgJson &&
       file.endsWith(`@remix-run${sep}vercel${sep}package.json`)
     ) {
       // Use the modified `@remix-run/vercel` package.json which contains "browser" field
+      console.log(
+        'Use the modified `@remix-run/vercel` package.json which contains "browser" field'
+      );
       files[file] = new FileBlob({ data: remixRunVercelPkgJson });
     } else {
       files[file] = await FileFsRef.fromFsPath({ fsPath: join(rootDir, file) });

--- a/packages/remix/test/fixtures/02-remix-basics-mjs/app/routes/edge.tsx
+++ b/packages/remix/test/fixtures/02-remix-basics-mjs/app/routes/edge.tsx
@@ -1,0 +1,9 @@
+export const config = { runtime: 'edge' };
+
+export default function Edge() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix@Edge</h1>
+    </div>
+  );
+}

--- a/packages/remix/test/fixtures/02-remix-basics-mjs/app/routes/load-context.tsx
+++ b/packages/remix/test/fixtures/02-remix-basics-mjs/app/routes/load-context.tsx
@@ -1,4 +1,4 @@
-import { json, LoaderFunction } from "@remix-run/node";
+import { json, LoaderFunction } from "@remix-run/server-runtime";
 
 export const loader: LoaderFunction = ({ context }) => {
     return json(context);

--- a/packages/remix/test/fixtures/02-remix-basics-mjs/vercel.json
+++ b/packages/remix/test/fixtures/02-remix-basics-mjs/vercel.json
@@ -11,6 +11,7 @@
   ],
   "probes": [
     { "path": "/", "mustContain": "Welcome to Remix" },
+    { "path": "/edge", "mustContain": "Welcome to Remix@Edge" },
     { "path": "/load-context", "mustContain": "{\"nodeLoadContext\":true}" }
   ]
 }

--- a/packages/remix/vercel-edge-entrypoint.js
+++ b/packages/remix/vercel-edge-entrypoint.js
@@ -1,0 +1,21 @@
+/**
+ * Edge runtime entrypoint for `@remix-run/vercel`.
+ */
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var serverRuntime = require('@remix-run/server-runtime');
+
+/**
+ * Returns a request handler for the Vercel Edge runtime that serves
+ * the Remix SSR response.
+ */
+function createRequestHandler({ build, mode }) {
+  let handleRequest = serverRuntime.createRequestHandler(build, mode);
+  return request => {
+    return handleRequest(request);
+  };
+}
+
+exports.createRequestHandler = createRequestHandler;


### PR DESCRIPTION
There's [a PR](https://github.com/remix-run/remix/pull/5537) opened on Remix to add an Edge compatible entrypoint to `@remix-run/vercel`. This is only really needed specifically for projects that have a custom server.js entrypoint file, which is not strictly necessary anymore, but there are some edge cases where a project might still want to have one. So this PR is necessary for those kinds of projects to be able to use Edge runtime.

Even when they merge the PR, it would be good to leave this injection code around for some time to continue support for older `@remix-run/vercel` versions in existing projects.