### PR TITLE
[frameworks] Check for `remix.config.mjs` for "remix" auto-detection

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -202,11 +202,12 @@ export const frameworks = [
     useRuntime: { src: 'package.json', use: '@vercel/remix' },
     ignoreRuntimes: ['@vercel/node'],
     detectors: {
-      every: [
-        // Intentionally does not detect a package name
-        // https://github.com/vercel/vercel/pull/7761
+      some: [
         {
           path: 'remix.config.js',
+        },
+        {
+          path: 'remix.config.mjs',
         },
       ],
     },


### PR DESCRIPTION
Moving this to a separate PR based on this comment: https://github.com/vercel/vercel/pull/9556#discussion_r1117939290

This will need to be merged and released before the relevant E2E test in #9556 will pass.