### PR TITLE
[routing-utils] Add missing 'middlewareRawSrc' to route schema

### DIFF
--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -155,7 +155,12 @@ export const routesSchema = {
           },
           middleware: { type: 'number' },
           middlewarePath: { type: 'string' },
-          middlewareRawSrc: { type: 'string' },
+          middlewareRawSrc: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
           has: hasSchema,
           missing: hasSchema,
         },

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -155,6 +155,7 @@ export const routesSchema = {
           },
           middleware: { type: 'number' },
           middlewarePath: { type: 'string' },
+          middlewareRawSrc: { type: 'string' },
           has: hasSchema,
           missing: hasSchema,
         },


### PR DESCRIPTION
Need to add `middlewareRawSrc` to route schema so the build container will accept the new property.

This PR blocks https://github.com/vercel/vercel/pull/9435.

Linear: https://linear.app/vercel/issue/VCCLI-411/display-uncompressed-edge-middleware-matcher-show-the-list-of-matches