### PR TITLE
[remix] Fix support for optional path params

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -337,7 +337,7 @@ module.exports = config;`;
     // Layout routes don't get a function / route added
     if (isLayoutRoute(route.id, remixRoutes)) continue;
 
-    const path = getPathFromRoute(route, remixConfig.routes);
+    const { path, rePath } = getPathFromRoute(route, remixConfig.routes);
 
     // If the route is a pathless layout route (at the root level)
     // and doesn't have any sub-routes, then a function should not be created.
@@ -367,7 +367,7 @@ module.exports = config;`;
         : func;
 
     // If this is a dynamic route then add a Vercel route
-    const re = getRegExpFromPath(path);
+    const re = getRegExpFromPath(rePath);
     if (re) {
       routes.push({
         src: re.source,

--- a/packages/remix/test/unit.get-path-from-route.test.ts
+++ b/packages/remix/test/unit.get-path-from-route.test.ts
@@ -80,24 +80,84 @@ describe('getPathFromRoute()', () => {
       parentId: 'root',
       file: 'routes/nested/index.tsx',
     },
+    'routes/($lang)/index': {
+      path: ':lang?',
+      index: true,
+      caseSensitive: undefined,
+      id: 'routes/($lang)/index',
+      parentId: 'root',
+      file: 'routes/($lang)/index.tsx',
+    },
+    'routes/($lang)/other': {
+      path: ':lang?/other',
+      index: undefined,
+      caseSensitive: undefined,
+      id: 'routes/($lang)/other',
+      parentId: 'root',
+      file: 'routes/($lang)/other.tsx',
+    },
+    'routes/($lang)/$pid': {
+      path: ':lang?/:pid',
+      index: undefined,
+      caseSensitive: undefined,
+      id: 'routes/($lang)/$pid',
+      parentId: 'root',
+      file: 'routes/($lang)/$pid.tsx',
+    },
   };
 
   it.each([
-    { id: 'root', expected: 'index' },
-    { id: 'routes/__pathless', expected: '' },
-    { id: 'routes/index', expected: 'index' },
-    { id: 'routes/api.hello', expected: 'api/hello' },
-    { id: 'routes/nested/index', expected: 'nested' },
-    { id: 'routes/projects', expected: 'projects' },
-    { id: 'routes/projects/__pathless', expected: 'projects' },
-    { id: 'routes/projects/index', expected: 'projects' },
-    { id: 'routes/projects/create', expected: 'projects/create' },
-    { id: 'routes/projects/$', expected: 'projects/*' },
-    { id: 'routes/$foo.$bar.$baz', expected: ':foo/:bar/:baz' },
-    { id: 'routes/node', expected: 'node' },
-    { id: 'routes/$', expected: '*' },
+    { id: 'root', expected: { path: 'index', rePath: '/index' } },
+    { id: 'routes/__pathless', expected: { path: '', rePath: '/' } },
+    { id: 'routes/index', expected: { path: 'index', rePath: '/index' } },
+    {
+      id: 'routes/api.hello',
+      expected: { path: 'api/hello', rePath: '/api/hello' },
+    },
+    {
+      id: 'routes/nested/index',
+      expected: { path: 'nested', rePath: '/nested' },
+    },
+    {
+      id: 'routes/projects',
+      expected: { path: 'projects', rePath: '/projects' },
+    },
+    {
+      id: 'routes/projects/__pathless',
+      expected: { path: 'projects', rePath: '/projects' },
+    },
+    {
+      id: 'routes/projects/index',
+      expected: { path: 'projects', rePath: '/projects' },
+    },
+    {
+      id: 'routes/projects/create',
+      expected: { path: 'projects/create', rePath: '/projects/create' },
+    },
+    {
+      id: 'routes/projects/$',
+      expected: { path: 'projects/*', rePath: '/projects/:params+' },
+    },
+    {
+      id: 'routes/$foo.$bar.$baz',
+      expected: { path: ':foo/:bar/:baz', rePath: '/:foo/:bar/:baz' },
+    },
+    { id: 'routes/node', expected: { path: 'node', rePath: '/node' } },
+    { id: 'routes/$', expected: { path: '*', rePath: '/:params+' } },
+    {
+      id: 'routes/($lang)/index',
+      expected: { path: '(:lang)', rePath: '/:lang?' },
+    },
+    {
+      id: 'routes/($lang)/other',
+      expected: { path: '(:lang)/other', rePath: '/:lang?/other' },
+    },
+    {
+      id: 'routes/($lang)/$pid',
+      expected: { path: '(:lang)/:pid', rePath: '/:lang?/:pid' },
+    },
   ])('should return `$expected` for "$id" route', ({ id, expected }) => {
     const route = routes[id];
-    expect(getPathFromRoute(route, routes)).toEqual(expected);
+    expect(getPathFromRoute(route, routes)).toMatchObject(expected);
   });
 });

--- a/packages/remix/test/unit.get-regexp-from-path.test.ts
+++ b/packages/remix/test/unit.get-regexp-from-path.test.ts
@@ -2,17 +2,18 @@ import { getRegExpFromPath } from '../src/utils';
 
 describe('getRegExpFromPath()', () => {
   describe('paths without parameters', () => {
-    it.each([{ path: 'index' }, { path: 'api/hello' }, { path: 'projects' }])(
-      'should return `false` for "$path"',
-      ({ path }) => {
-        expect(getRegExpFromPath(path)).toEqual(false);
-      }
-    );
+    it.each([
+      { path: '/index' },
+      { path: '/api/hello' },
+      { path: '/projects' },
+    ])('should return `false` for "$path"', ({ path }) => {
+      expect(getRegExpFromPath(path)).toEqual(false);
+    });
   });
 
   describe.each([
     {
-      path: '*',
+      path: '/:params+',
       urls: [
         {
           url: '/',
@@ -37,7 +38,7 @@ describe('getRegExpFromPath()', () => {
       ],
     },
     {
-      path: 'projects/*',
+      path: '/projects/:params+',
       urls: [
         {
           url: '/',
@@ -58,7 +59,7 @@ describe('getRegExpFromPath()', () => {
       ],
     },
     {
-      path: ':foo',
+      path: '/:foo',
       urls: [
         {
           url: '/',
@@ -79,7 +80,7 @@ describe('getRegExpFromPath()', () => {
       ],
     },
     {
-      path: 'blog/:id/edit',
+      path: '/blog/:id/edit',
       urls: [
         {
           url: '/',
@@ -103,6 +104,65 @@ describe('getRegExpFromPath()', () => {
         },
         {
           url: '/blog/123/another',
+          expected: false,
+        },
+      ],
+    },
+    {
+      path: '/:lang?',
+      urls: [
+        {
+          url: '/',
+          expected: true,
+        },
+        {
+          url: '/en',
+          expected: true,
+        },
+        {
+          url: '/en/other',
+          expected: false,
+        },
+      ],
+    },
+    {
+      path: '/:lang?/other',
+      urls: [
+        {
+          url: '/other',
+          expected: true,
+        },
+        {
+          url: '/en/other',
+          expected: true,
+        },
+        {
+          url: '/',
+          expected: false,
+        },
+        {
+          url: '/another',
+          expected: false,
+        },
+      ],
+    },
+    {
+      path: '/:lang?/:pid',
+      urls: [
+        {
+          url: '/123',
+          expected: true,
+        },
+        {
+          url: '/en/123',
+          expected: true,
+        },
+        {
+          url: '/',
+          expected: false,
+        },
+        {
+          url: '/en/foo/bar',
           expected: false,
         },
       ],


### PR DESCRIPTION
Changes the way that routes with optional params are stored on Vercel to not use `?` in the name, because it's not possible to have a route destination with a `?` that's pointing to a function.

So instead of the function with a name such as `:lang?`, it will be stored on Vercel with a name like `(:lang)`, which can be routed to.