### PR TITLE
[next] Populate middlewareRawSrc using middleware originalSource

### DIFF
--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2362,6 +2362,7 @@ interface EdgeFunctionMatcher {
   regexp: string;
   has?: HasField;
   missing?: HasField;
+  originalSource?: string;
 }
 
 export async function getMiddlewareBundle({
@@ -2579,6 +2580,9 @@ export async function getMiddlewareBundle({
         };
 
         route.middlewarePath = shortPath;
+        route.middlewareRawSrc = matcher.originalSource
+          ? [matcher.originalSource]
+          : [];
         if (isCorrectMiddlewareOrder) {
           route.override = true;
         }
@@ -2701,6 +2705,7 @@ function getRouteMatchers(
   return info.matchers.map(matcher => {
     const m: EdgeFunctionMatcher = {
       regexp: getRegexp(matcher.regexp),
+      originalSource: matcher.originalSource,
     };
     if (matcher.has) {
       m.has = normalizeHas(matcher.has);

--- a/packages/next/test/unit/middleware-routes.test.js
+++ b/packages/next/test/unit/middleware-routes.test.js
@@ -20,6 +20,7 @@ describe('middleware routes', () => {
       {
         continue: true,
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',
@@ -51,6 +52,7 @@ describe('middleware routes', () => {
       {
         continue: true,
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',
@@ -94,6 +96,7 @@ describe('middleware routes', () => {
       {
         continue: true,
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',
@@ -114,6 +117,7 @@ describe('middleware routes', () => {
           },
         ],
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',
@@ -161,6 +165,7 @@ describe('middleware routes', () => {
           },
         ],
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',
@@ -193,6 +198,7 @@ describe('middleware routes', () => {
       {
         continue: true,
         middlewarePath: 'middleware',
+        middlewareRawSrc: [],
         missing: [
           {
             key: 'x-prerender-revalidate',


### PR DESCRIPTION
Next.js will pass the original middleware matching routes through to the middleware manifest once https://github.com/vercel/next.js/pull/46753 lands. This PR will take those original values and put them in the middleware route `middlewareRawSrc` property.

NOTE: The tests will need to be updated once the Next.js version is updated in the fixtures.