### PR TITLE
[tests] remove eslint from fixture

### DIFF
--- a/packages/remix/test/fixtures/07-turborepo/apps/remix-app/.eslintrc.js
+++ b/packages/remix/test/fixtures/07-turborepo/apps/remix-app/.eslintrc.js
@@ -1,4 +1,0 @@
-/** @type {import('eslint').Linter.Config} */
-module.exports = {
-  extends: ["@remix-run/eslint-config", "@remix-run/eslint-config/node"],
-};

--- a/packages/remix/test/fixtures/07-turborepo/apps/remix-app/package.json
+++ b/packages/remix/test/fixtures/07-turborepo/apps/remix-app/package.json
@@ -18,11 +18,9 @@
   },
   "devDependencies": {
     "@remix-run/dev": "*",
-    "@remix-run/eslint-config": "*",
     "@remix-run/serve": "*",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
-    "eslint": "^8.27.0",
     "typescript": "^4.8.4"
   },
   "engines": {


### PR DESCRIPTION
In a previous PR https://github.com/vercel/vercel/pull/9622/files#diff-508a8f08333e1f42e2b2f02e99081c181802b6b2e7baa4e75c18e51e1e703ce4, this fixture was added which contained an eslint config file. We do have these fixtures eslint ignored, but it seems the presence of this config file re-enables it. This causes eslint failures inside the fixture to bubble up and fail lint checks.

This PR removes eslint from the fixture.