### PR TITLE
[remix] Remove symlink creation warning

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -719,6 +719,7 @@ async function ensureSymlink(
   }
 
   await fs.symlink(relativeTarget, symlinkPath);
+  debug(`Created symlink for "${pkgName}"`);
 }
 
 async function writeEntrypointFile(

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -719,9 +719,6 @@ async function ensureSymlink(
   }
 
   await fs.symlink(relativeTarget, symlinkPath);
-  console.warn(
-    `WARN: Created symlink for "${pkgName}". To silence this warning, add "${pkgName}" to "dependencies" in your \`package.json\` file.`
-  );
 }
 
 async function writeEntrypointFile(

--- a/packages/remix/test/fixtures/03-with-pnpm/probes.json
+++ b/packages/remix/test/fixtures/03-with-pnpm/probes.json
@@ -2,13 +2,11 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "Welcome to Remix",
-      "logMustContain": "WARN: Created symlink for \"@remix-run/node\". To silence this warning, add \"@remix-run/node\" to \"dependencies\" in your `package.json` file"
+      "mustContain": "Welcome to Remix"
     },
     {
       "path": "/edge",
-      "mustContain": "Welcome to Remix@Edge",
-      "logMustContain": "WARN: Created symlink for \"@remix-run/server-runtime\". To silence this warning, add \"@remix-run/server-runtime\" to \"dependencies\" in your `package.json` file"
+      "mustContain": "Welcome to Remix@Edge"
     },
     { "path": "/b", "mustContain": "B page" },
     { "path": "/nested", "mustContain": "Nested index page" },

--- a/packages/remix/test/fixtures/04-with-npm9-linked/probes.json
+++ b/packages/remix/test/fixtures/04-with-npm9-linked/probes.json
@@ -2,13 +2,11 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "Welcome to Remix",
-      "logMustContain": "WARN: Created symlink for \"@remix-run/node\". To silence this warning, add \"@remix-run/node\" to \"dependencies\" in your `package.json` file"
+      "mustContain": "Welcome to Remix"
     },
     {
       "path": "/edge",
-      "mustContain": "Welcome to Remix@Edge",
-      "logMustContain": "WARN: Created symlink for \"@remix-run/server-runtime\". To silence this warning, add \"@remix-run/server-runtime\" to \"dependencies\" in your `package.json` file"
+      "mustContain": "Welcome to Remix@Edge"
     },
     { "path": "/b", "mustContain": "B page" },
     { "path": "/nested", "mustContain": "Nested index page" },


### PR DESCRIPTION
We're now going to encourage users to use `@vercel/remix` instead of `@remix-run/node`. So switch the symlink warning to a `debug()` call instead.