### PR TITLE
[cli] Ignore `vc build` subdirectory warning on vercel

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -281,7 +281,12 @@ const main = async () => {
       GLOBAL_COMMANDS.has(targetOrSubcommand) ||
       commands.has(targetOrSubcommand);
 
-    if (targetPathExists && subcommandExists && !argv['--cwd']) {
+    if (
+      targetPathExists &&
+      subcommandExists &&
+      !argv['--cwd'] &&
+      !process.env.NOW_BUILDER
+    ) {
       output.warn(
         `Did you mean to deploy the subdirectory "${targetOrSubcommand}"? ` +
           `Use \`vc --cwd ${targetOrSubcommand}\` instead.`


### PR DESCRIPTION
This warning is only relevant when running `vc build` locally so we can hide it for Vercel deployments.

I noticed this in the build logs here:

<img width="862" alt="image" src="https://user-images.githubusercontent.com/229881/225774670-9b4aecf5-d020-489f-819f-7b55ce96f877.png">
