### PR TITLE
[frameworks][fs-detectors] Use correct "license" field in `package.json`

### DIFF
--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist"
   ],
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",
     "test": "jest --env node --verbose --runInBand --bail",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/vercel/vercel.git",
     "directory": "packages/fs-detectors"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",
     "test": "jest --env node --verbose --runInBand --bail test/unit.*test.*",


### PR DESCRIPTION
👋 We're hoping to use the `@vercel/frameworks` and `@vercel/fs-detectors` package for Sanity, but I encountered some irregularities in the licenses for these:

- The `@vercel/frameworks` package is published with a license file indicating it is Apache 2 licensed, but the `license` field in `package.json` says it is `UNLICENSED`, which according to npm is used "if you do not wish to grant others the right to use a private or unpublished package under any terms"
- The `@vercel/fs-detectors` package is published with a license file indicating it is Apache 2 licensed, but the `license` field in `package.json` says it is `MIT`.

It would be great to have these irregularities cleared up!
