### PR TITLE
[node] Improve edge-handler-template error handling

### DIFF
--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -105,7 +105,7 @@ test('[vercel dev] throws an error when an edge function has no response', async
     expect(await res.status).toBe(500);
     expect(await res.text()).toMatch('FUNCTION_INVOCATION_FAILED');
     expect(stdout).toMatch(
-      /Error from API Route \/api\/edge-no-response: Edge Function "api\/edge-no-response.js" did not return a response./g
+      /Error from API Route \/api\/edge-no-response: Edge Function did not return a response./g
     );
   } finally {
     await dev.kill();

--- a/packages/node/src/edge-functions/edge-handler-template.js
+++ b/packages/node/src/edge-functions/edge-handler-template.js
@@ -2,21 +2,18 @@
 /* global addEventListener */
 
 function buildUrl(requestDetails) {
+  const host = requestDetails.headers['x-forwarded-host'] || '127.0.0.1';
+  const path = requestDetails.url || '/';
+
   const allProtocols = requestDetails.headers['x-forwarded-proto'];
-  const host = requestDetails.headers['x-forwarded-host'];
-  const path = requestDetails.url;
-
-  if (!allProtocols) {
-    throw new Error('missing header "x-forwarded-proto"');
-  }
-  if (!host) {
-    throw new Error('missing header "x-forwarded-host"');
-  }
-  if (!path) {
-    throw new Error('missing url');
+  let proto;
+  if (allProtocols) {
+    // handle multi-protocol like: https,http://...
+    proto = allProtocols.split(/\b/).shift();
+  } else {
+    proto = 'http';
   }
 
-  const proto = allProtocols.split(/\b/).shift(); // handling multi-protocol like https,http://...
   return `${proto}://${host}${path}`;
 }
 

--- a/packages/node/src/edge-functions/edge-handler-template.js
+++ b/packages/node/src/edge-functions/edge-handler-template.js
@@ -57,7 +57,7 @@ async function respond(
         },
       });
     } else {
-      throw new Error(`Execution did not return a response.`);
+      throw new Error(`Edge Function did not return a response.`);
     }
   }
   return response;
@@ -69,8 +69,7 @@ function toResponseError(error, entrypointLabel, Response) {
   const msg = error.cause
     ? error.message + ': ' + (error.cause.message || error.cause)
     : error.message;
-  const fullMessage = `Edge Function "${entrypointLabel}" failed: ${msg}`;
-  return new Response(fullMessage, {
+  return new Response(msg, {
     status: 500,
     headers: {
       'x-vercel-failed': 'edge-wrapper',

--- a/packages/node/src/edge-functions/edge-handler-template.js
+++ b/packages/node/src/edge-functions/edge-handler-template.js
@@ -63,7 +63,7 @@ async function respond(
   return response;
 }
 
-function toResponseError(error, entrypointLabel, Response) {
+function toResponseError(error, Response) {
   // we can't easily show a meaningful stack trace
   // so, stick to just the error message for now
   const msg = error.cause
@@ -98,10 +98,7 @@ function registerFetchListener(userEdgeHandler, options, dependencies) {
       );
       return event.respondWith(response);
     } catch (error) {
-      const { entrypointLabel } = options;
-      event.respondWith(
-        toResponseError(error, entrypointLabel, dependencies.Response)
-      );
+      event.respondWith(toResponseError(error, dependencies.Response));
     }
   });
 }

--- a/packages/node/test/unit/edge-functions/edge-handler-template.test.ts
+++ b/packages/node/test/unit/edge-functions/edge-handler-template.test.ts
@@ -28,6 +28,42 @@ describe('edge-handler-template', () => {
       });
       expect(url).toBe('https://somewhere.com/api/add');
     });
+
+    test('fails with missing proto header', async () => {
+      expect(() => {
+        buildUrl({
+          url: '/api/add',
+          headers: {
+            // missing 'x-forwarded-proto'
+            'x-forwarded-host': 'somewhere.com',
+          },
+        });
+      }).toThrowError('missing header "x-forwarded-proto"');
+    });
+
+    test('fails with missing host header', async () => {
+      expect(() => {
+        buildUrl({
+          url: '/api/add',
+          headers: {
+            'x-forwarded-proto': 'https,http',
+            // missing 'x-forwarded-host'
+          },
+        });
+      }).toThrowError('missing header "x-forwarded-host"');
+    });
+
+    test('fails with missing proto header', async () => {
+      expect(() => {
+        buildUrl({
+          // missing url
+          headers: {
+            'x-forwarded-proto': 'https,http',
+            'x-forwarded-host': 'somewhere.com',
+          },
+        });
+      }).toThrowError('missing url');
+    });
   });
 
   describe('respond()', () => {

--- a/packages/node/test/unit/edge-functions/edge-handler-template.test.ts
+++ b/packages/node/test/unit/edge-functions/edge-handler-template.test.ts
@@ -29,40 +29,37 @@ describe('edge-handler-template', () => {
       expect(url).toBe('https://somewhere.com/api/add');
     });
 
-    test('fails with missing proto header', async () => {
-      expect(() => {
-        buildUrl({
-          url: '/api/add',
-          headers: {
-            // missing 'x-forwarded-proto'
-            'x-forwarded-host': 'somewhere.com',
-          },
-        });
-      }).toThrowError('missing header "x-forwarded-proto"');
+    test('url falls back to `/`', async () => {
+      const url = buildUrl({
+        // missing url
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'somewhere.com',
+        },
+      });
+      expect(url).toBe('https://somewhere.com/');
     });
 
-    test('fails with missing host header', async () => {
-      expect(() => {
-        buildUrl({
-          url: '/api/add',
-          headers: {
-            'x-forwarded-proto': 'https,http',
-            // missing 'x-forwarded-host'
-          },
-        });
-      }).toThrowError('missing header "x-forwarded-host"');
+    test('host header falls back to `127.0.0.1`', async () => {
+      const url = buildUrl({
+        url: '/api/add',
+        headers: {
+          'x-forwarded-proto': 'https',
+          // missing 'x-forwarded-host'
+        },
+      });
+      expect(url).toBe('https://127.0.0.1/api/add');
     });
 
-    test('fails with missing proto header', async () => {
-      expect(() => {
-        buildUrl({
-          // missing url
-          headers: {
-            'x-forwarded-proto': 'https,http',
-            'x-forwarded-host': 'somewhere.com',
-          },
-        });
-      }).toThrowError('missing url');
+    test('proto header falls back to `http`', async () => {
+      const url = buildUrl({
+        url: '/api/add',
+        headers: {
+          // missing 'x-forwarded-proto'
+          'x-forwarded-host': 'somewhere.com',
+        },
+      });
+      expect(url).toBe('http://somewhere.com/api/add');
     });
   });
 


### PR DESCRIPTION
When passing the `Request` into the user's edge handler, the url is constructed from proxy headers from the edge runtime. There are cases where these headers can be overridden (like using cloudflare tunnel). To protect for those cases, this PR updates the url construction to fall back to likely good values.

* host: `127.0.0.1`
* path: `/`
* proto: `http`