### PR TITLE
[next] Remove extra env variables

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -410,7 +410,6 @@ export const build: BuildV2 = async ({
 
   const env: typeof process.env = { ...spawnOpts.env };
   env.NEXT_EDGE_RUNTIME_PROVIDER = 'vercel';
-  env.NEXT_PUBLIC_EDGE_RUNTIME_PROVIDER = env.NEXT_EDGE_RUNTIME_PROVIDER;
 
   if (target) {
     // Since version v10.0.8-canary.15 of Next.js the NEXT_PRIVATE_TARGET env
@@ -418,13 +417,11 @@ export const build: BuildV2 = async ({
     // this helps us catch cases where we can't locate the next.config.js
     // correctly
     env.NEXT_PRIVATE_TARGET = target;
-    env.NEXT_PUBLIC_TARGET = target;
   }
   // Only NEXT_PUBLIC_ is considered for turbo/nx cache keys
   // and caches may not have the correct trace root so we
   // need to ensure this included in the cache key
   env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = baseDir;
-  env.NEXT_PUBLIC_OUTPUT_TRACE_ROOT = baseDir;
 
   if (isServerMode) {
     // when testing with jest NODE_ENV will be set to test so ensure


### PR DESCRIPTION
These env variables were temporarily added to bust turbo/nx cache although this should no longer be needed as a proper fix has been landed in Next.js itself. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04Q0GWSB8W/p1679518040946589)