### PR TITLE
Add vercel/otel package

### DIFF
--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@vercel/otel",
+  "version": "0.0.1",
+  "description": "Vercel wrapper around OpenTelemetry APIs",
+  "exports": {
+    ".": {
+      "edge": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "edge-light": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "worker": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "workerd": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "import": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      },
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/vercel.git",
+    "directory": "packages/otel"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/fs-extra": "^8.0.0",
+    "@types/node": "14.18.33",
+    "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.34.0",
+    "@opentelemetry/resources": "^1.0.0",
+    "@opentelemetry/sdk-trace-base": "^1.0.0",
+    "@opentelemetry/sdk-trace-node": "^1.0.0",
+    "@opentelemetry/semantic-conventions": "^1.0.0"
+  }
+}

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -41,7 +41,10 @@
     "directory": "packages/otel"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "pnpm build:node",
+    "build:node": "tsc --project tsconfig.node.json",
+    "build:edge": "tsc --project tsconfig.edge.json",
+    "build:browser": "tsc --project tsconfig.browser.json"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -50,12 +50,10 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.34.0",
-    "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/sdk-trace-node": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.35.1",
+    "@opentelemetry/resources": "1.9.1",
+    "@opentelemetry/sdk-trace-node": "1.9.1",
+    "@opentelemetry/semantic-conventions": "1.9.1"
   }
 }

--- a/packages/otel/src/index.browser.ts
+++ b/packages/otel/src/index.browser.ts
@@ -1,0 +1,4 @@
+export const register = (serviceName: string) => {
+  void serviceName;
+  // We don't support OpenTelemetry on client-side yet.
+};

--- a/packages/otel/src/index.edge.ts
+++ b/packages/otel/src/index.edge.ts
@@ -1,0 +1,4 @@
+export const register = (serviceName: string) => {
+  void serviceName;
+  // We don't support OpenTelemetry on edge.
+};

--- a/packages/otel/src/index.node.ts
+++ b/packages/otel/src/index.node.ts
@@ -17,7 +17,9 @@ export const register = (serviceName: string) => {
     }),
   });
 
+  provider.register();
+
   provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter({})));
 
-  provider.register();
+  return provider;
 };

--- a/packages/otel/src/index.node.ts
+++ b/packages/otel/src/index.node.ts
@@ -1,0 +1,23 @@
+export * from '@opentelemetry/api';
+export * from '@opentelemetry/semantic-conventions';
+
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+export const register = (serviceName: string) => {
+  const provider = new NodeTracerProvider({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    }),
+  });
+
+  provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter({})));
+
+  provider.register();
+};

--- a/packages/otel/tsconfig.browser.json
+++ b/packages/otel/tsconfig.browser.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["./src/index.edge.ts"]
+}

--- a/packages/otel/tsconfig.edge.json
+++ b/packages/otel/tsconfig.edge.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["./src/index.edge.ts"]
+}

--- a/packages/otel/tsconfig.json
+++ b/packages/otel/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "./dist",
+    "types": ["node"],
+    "strict": true,
+    "sourceMap": true,
+    "target": "ES2020"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/otel/tsconfig.node.json
+++ b/packages/otel/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // There is a bug in OTEL that requires us to add dom types: https://github.com/open-telemetry/opentelemetry-js/issues/3580
+    "lib": ["ES2020", "dom"]
+  },
+  "files": ["./src/index.node.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,30 @@ importers:
       test-listen: 1.1.0
       typescript: 4.3.4
 
+  packages/otel:
+    specifiers:
+      '@opentelemetry/api': ^1.0.0
+      '@opentelemetry/core': ^1.0.0
+      '@opentelemetry/exporter-trace-otlp-http': ^0.34.0
+      '@opentelemetry/resources': ^1.0.0
+      '@opentelemetry/sdk-trace-base': ^1.0.0
+      '@opentelemetry/sdk-trace-node': ^1.0.0
+      '@opentelemetry/semantic-conventions': ^1.0.0
+      '@types/fs-extra': ^8.0.0
+      '@types/node': 14.18.33
+      typescript: ^4.8.4
+    devDependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.34.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-node': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.10.1
+      '@types/fs-extra': 8.0.0
+      '@types/node': 14.18.33
+      typescript: 4.9.5
+
   packages/python:
     specifiers:
       '@types/execa': ^0.9.0
@@ -987,7 +1011,7 @@ importers:
     dependencies:
       path-to-regexp: 6.1.0
     optionalDependencies:
-      ajv: 6.12.2
+      ajv: 6.12.6
     devDependencies:
       '@types/jest': 27.4.1
       '@types/node': 14.18.33
@@ -4252,6 +4276,180 @@ packages:
       '@octokit/openapi-types': 14.0.0
     dev: false
 
+  /@opentelemetry/api/1.4.1:
+    resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
+  /@opentelemetry/context-async-hooks/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-6CC9sWOZDkUkKrAR957fmxXXlaK3uiBu5xVnuNEQ7hI7VqkUC/r0mNYIql0ouRInLz5o0HwmDuga1eXgQU7KNQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+    dev: true
+
+  /@opentelemetry/core/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/semantic-conventions': 1.10.1
+    dev: true
+
+  /@opentelemetry/core/1.8.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.4.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/semantic-conventions': 1.8.0
+    dev: true
+
+  /@opentelemetry/exporter-trace-otlp-http/0.34.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-MBtUwMvgpdoRo9iqK2eDJ8SP2xKYWeBCSu99s4cc1kg4HKKOpenXLE/6daGsSZ+QTPwd8j+9xMSd+hhBg+Bvzw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-exporter-base': 0.34.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-transformer': 0.34.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.8.0_@opentelemetry+api@1.4.1
+    dev: true
+
+  /@opentelemetry/otlp-exporter-base/0.34.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+    dev: true
+
+  /@opentelemetry/otlp-transformer/0.34.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.4.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-metrics': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.8.0_@opentelemetry+api@1.4.1
+    dev: true
+
+  /@opentelemetry/propagator-b3/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-YrWqU93PH8RyCmqGhtDZgyk64D+cp8XIjQsLhEgOPcOsxvxSSGXnGt46rx9Z8+WdIbJgj13Q4nV/xuh36k+O+A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+    dev: true
+
+  /@opentelemetry/propagator-jaeger/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-qvwFfDPoBw2YQW/OsGHdLdD/rqNRGBRLz5UZR/akO21C4qwIK+lQcXbSi5ve0p2eLHnFshhNFqDmgQclOYBcmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+    dev: true
+
+  /@opentelemetry/resources/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.10.1
+    dev: true
+
+  /@opentelemetry/resources/1.8.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.4.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.8.0
+    dev: true
+
+  /@opentelemetry/sdk-metrics/1.8.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.4.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
+      lodash.merge: 4.6.2
+    dev: true
+
+  /@opentelemetry/sdk-trace-base/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.10.1
+    dev: true
+
+  /@opentelemetry/sdk-trace-base/1.8.0_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.4.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.8.0
+    dev: true
+
+  /@opentelemetry/sdk-trace-node/1.10.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-/y+s1j8rPTaKnPnbrsbYv3ygTb4hjx/1H32zqobFr85cvWX+Tt1RWmcZ51TaPAfq5uJobGFhhLh6ADI2RDvk5Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/context-async-hooks': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-b3': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-jaeger': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.10.1_@opentelemetry+api@1.4.1
+      semver: 7.3.8
+    dev: true
+
+  /@opentelemetry/semantic-conventions/1.10.1:
+    resolution: {integrity: sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /@opentelemetry/semantic-conventions/1.8.0:
+    resolution: {integrity: sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@parcel/watcher/2.0.4:
     resolution: {integrity: sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==}
     engines: {node: '>= 10.0.0'}
@@ -6207,7 +6405,7 @@ packages:
     dependencies:
       path-to-regexp: 6.1.0
     optionalDependencies:
-      ajv: 6.12.2
+      ajv: 6.12.6
     dev: false
 
   /@vercel/style-guide/4.0.2:
@@ -6482,6 +6680,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+    dev: true
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -6490,7 +6689,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
 
   /ajv/8.6.3:
     resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
@@ -9363,7 +9561,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_typescript@4.9.4
+      '@typescript-eslint/parser': 5.54.1
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.3_5rfvta7qn57kxm7ir36ta6fixq
@@ -9391,7 +9589,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_typescript@4.9.4
+      '@typescript-eslint/parser': 5.54.1
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -9508,7 +9706,7 @@ packages:
       eslint-plugin-jest:
         optional: true
     dependencies:
-      eslint-plugin-jest: 27.2.1_6xo4tvwzjwdi6xwjpxfe6jodqe
+      eslint-plugin-jest: 27.2.1_j7aytffwn6h2xuxtcd36dokff4
     dev: true
 
   /eslint-plugin-react-hooks/4.6.0:
@@ -9646,7 +9844,7 @@ packages:
     dependencies:
       '@eslint/eslintrc': 1.4.1
       '@humanwhocodes/config-array': 0.9.5
-      ajv: 6.12.2
+      ajv: 6.12.6
       chalk: 4.1.0
       cross-spawn: 7.0.3
       debug: 4.3.4
@@ -17764,7 +17962,6 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /ufo/1.0.1:
     resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,24 +890,21 @@ importers:
 
   packages/otel:
     specifiers:
-      '@opentelemetry/api': ^1.0.0
-      '@opentelemetry/core': ^1.0.0
-      '@opentelemetry/exporter-trace-otlp-http': ^0.34.0
-      '@opentelemetry/resources': ^1.0.0
-      '@opentelemetry/sdk-trace-base': ^1.0.0
-      '@opentelemetry/sdk-trace-node': ^1.0.0
-      '@opentelemetry/semantic-conventions': ^1.0.0
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.35.1
+      '@opentelemetry/resources': 1.9.1
+      '@opentelemetry/sdk-trace-node': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.9.1
       '@types/fs-extra': ^8.0.0
       '@types/node': 14.18.33
       typescript: ^4.8.4
-    devDependencies:
+    dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/exporter-trace-otlp-http': 0.34.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-trace-base': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-trace-node': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/semantic-conventions': 1.10.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.35.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-node': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    devDependencies:
       '@types/fs-extra': 8.0.0
       '@types/node': 14.18.33
       typescript: 4.9.5
@@ -4279,176 +4276,138 @@ packages:
   /@opentelemetry/api/1.4.1:
     resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
     engines: {node: '>=8.0.0'}
-    dev: true
+    dev: false
 
-  /@opentelemetry/context-async-hooks/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-6CC9sWOZDkUkKrAR957fmxXXlaK3uiBu5xVnuNEQ7hI7VqkUC/r0mNYIql0ouRInLz5o0HwmDuga1eXgQU7KNQ==}
+  /@opentelemetry/context-async-hooks/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-HmycxnnIm00gdmxfD5OkDotL15bGqazLYqQJdcv1uNt22OSc5F/a3Paz3yznmf+/gWdPG8nlq/zd9H0mNXJnGg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-    dev: true
+    dev: false
 
-  /@opentelemetry/core/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==}
+  /@opentelemetry/core/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/semantic-conventions': 1.10.1
-    dev: true
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
 
-  /@opentelemetry/core/1.8.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.4.0'
-    dependencies:
-      '@opentelemetry/api': 1.4.1
-      '@opentelemetry/semantic-conventions': 1.8.0
-    dev: true
-
-  /@opentelemetry/exporter-trace-otlp-http/0.34.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-MBtUwMvgpdoRo9iqK2eDJ8SP2xKYWeBCSu99s4cc1kg4HKKOpenXLE/6daGsSZ+QTPwd8j+9xMSd+hhBg+Bvzw==}
+  /@opentelemetry/exporter-trace-otlp-http/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-EJgAsrvscKsqb/GzF1zS74vM+Z/aQRhrFE7hs/1GK1M9bLixaVyMGwg2pxz1wdYdjxS1mqpHMhXU+VvMvFCw1w==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/otlp-exporter-base': 0.34.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/otlp-transformer': 0.34.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-trace-base': 1.8.0_@opentelemetry+api@1.4.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-exporter-base': 0.35.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-transformer': 0.35.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
 
-  /@opentelemetry/otlp-exporter-base/0.34.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==}
+  /@opentelemetry/otlp-exporter-base/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-Sc0buJIs8CfUeQCL/12vDDjBREgsqHdjboBa/kPQDgMf008OBJSM02Ijj6T1TH+QVHl/VHBBEVJF+FTf0EH9Vg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
 
-  /@opentelemetry/otlp-transformer/0.34.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==}
+  /@opentelemetry/otlp-transformer/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-c0HXcJ49MKoWSaA49J8PXlVx48CeEFpL0odP6KBkVT+Bw6kAe8JlI3mIezyN05VCDJGtS2I5E6WEsE+DJL1t9A==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.4.0'
+      '@opentelemetry/api': '>=1.3.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-metrics': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-trace-base': 1.8.0_@opentelemetry+api@1.4.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-metrics': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
 
-  /@opentelemetry/propagator-b3/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-YrWqU93PH8RyCmqGhtDZgyk64D+cp8XIjQsLhEgOPcOsxvxSSGXnGt46rx9Z8+WdIbJgj13Q4nV/xuh36k+O+A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.5.0'
-    dependencies:
-      '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-    dev: true
-
-  /@opentelemetry/propagator-jaeger/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-qvwFfDPoBw2YQW/OsGHdLdD/rqNRGBRLz5UZR/akO21C4qwIK+lQcXbSi5ve0p2eLHnFshhNFqDmgQclOYBcmg==}
+  /@opentelemetry/propagator-b3/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-V+/ufHnZSr0YlbNhPg4PIQAZOhP61fVwL0JZJ6qnl9i0jgaZBSAtV99ZvHMxMy0Z1tf+oGj1Hk+S6jRRXL+j1Q==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
 
-  /@opentelemetry/resources/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==}
+  /@opentelemetry/propagator-jaeger/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-xjG5HnOgu/1f9+GphWr8lqxaU51iFL9HgFdnSQBSFqhM2OeMuzpFt6jmkpZJBAK3oqQ9BG52fHfCdYlw3GOkVQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/semantic-conventions': 1.10.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
 
-  /@opentelemetry/resources/1.8.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==}
+  /@opentelemetry/resources/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.4.0'
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/semantic-conventions': 1.8.0
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
 
-  /@opentelemetry/sdk-metrics/1.8.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==}
+  /@opentelemetry/sdk-metrics/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-AyhKDcA8NuV7o1+9KvzRMxNbATJ8AcrutKilJ6hWSo9R5utnzxgffV4y+Hp4mJn84iXxkv+CBb99GOJ2A5OMzA==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.4.0'
+      '@opentelemetry/api': '>=1.3.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
       lodash.merge: 4.6.2
-    dev: true
+    dev: false
 
-  /@opentelemetry/sdk-trace-base/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==}
+  /@opentelemetry/sdk-trace-base/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/semantic-conventions': 1.10.1
-    dev: true
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
 
-  /@opentelemetry/sdk-trace-base/1.8.0_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.4.0'
-    dependencies:
-      '@opentelemetry/api': 1.4.1
-      '@opentelemetry/core': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/resources': 1.8.0_@opentelemetry+api@1.4.1
-      '@opentelemetry/semantic-conventions': 1.8.0
-    dev: true
-
-  /@opentelemetry/sdk-trace-node/1.10.1_@opentelemetry+api@1.4.1:
-    resolution: {integrity: sha512-/y+s1j8rPTaKnPnbrsbYv3ygTb4hjx/1H32zqobFr85cvWX+Tt1RWmcZ51TaPAfq5uJobGFhhLh6ADI2RDvk5Q==}
+  /@opentelemetry/sdk-trace-node/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-wwwCM2G/A0LY3oPLDyO31uRnm9EMNkhhjSxL9cmkK2kM+F915em8K0pXkPWFNGWu0OHkGALWYwH6Oz0P5nVcHA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.5.0'
     dependencies:
       '@opentelemetry/api': 1.4.1
-      '@opentelemetry/context-async-hooks': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/core': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/propagator-b3': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/propagator-jaeger': 1.10.1_@opentelemetry+api@1.4.1
-      '@opentelemetry/sdk-trace-base': 1.10.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/context-async-hooks': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-b3': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-jaeger': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
       semver: 7.3.8
-    dev: true
+    dev: false
 
-  /@opentelemetry/semantic-conventions/1.10.1:
-    resolution: {integrity: sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==}
+  /@opentelemetry/semantic-conventions/1.9.1:
+    resolution: {integrity: sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==}
     engines: {node: '>=14'}
-    dev: true
-
-  /@opentelemetry/semantic-conventions/1.8.0:
-    resolution: {integrity: sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==}
-    engines: {node: '>=14'}
-    dev: true
+    dev: false
 
   /@parcel/watcher/2.0.4:
     resolution: {integrity: sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==}
@@ -13516,7 +13475,6 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
 
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}


### PR DESCRIPTION
We are working on OpenTelemetry support for Next.js, and because open telemetry API is convoluted and complex, we wanted to make it easier for users to get started.

Usually, when using OTEL, you need to set up how you want to export your traces (`register` function), and you need a bunch of dependencies here. You need a bunch of dependencies here, and this is the most complex part.

Also without this package dependencies need to be conditionally required based on the environment which is also needlessly complex when don't know that concept.

The instrumentation is relatively easy since you need only `@opentelemetry/api` (and sometimes `@opentelemetry/resources`, but that's only for advanced instrumentation).
We reexport those two packages so that `@vercel/otel` is the only hotel package that you need.