### PR TITLE
[build-utils] Fix system env var detection for prefixed env vars

### DIFF
--- a/packages/build-utils/src/get-prefixed-env-vars.ts
+++ b/packages/build-utils/src/get-prefixed-env-vars.ts
@@ -14,10 +14,11 @@ export function getPrefixedEnvVars({
   envs: Envs;
 }): Envs {
   const vercelSystemEnvPrefix = 'VERCEL_';
+  const allowed = ['VERCEL_URL', 'VERCEL_ENV', 'VERCEL_REGION'];
   const newEnvs: Envs = {};
   if (envPrefix && envs.VERCEL_URL) {
     Object.keys(envs)
-      .filter(key => key.startsWith(vercelSystemEnvPrefix))
+      .filter(key => allowed.includes(key) || key.startsWith('VERCEL_GIT_'))
       .forEach(key => {
         const newKey = `${envPrefix}${key}`;
         if (!(newKey in envs)) {

--- a/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
@@ -14,6 +14,7 @@ describe('Test `getPrefixedEnvVars()`', () => {
           VERCEL: '1',
           VERCEL_URL: 'example.vercel.sh',
           USER_ENV_VAR_NOT_VERCEL: 'example.com',
+          VERCEL_ARTIFACTS_TOKEN: 'abc123',
           FOO: 'bar',
         },
       },
@@ -28,6 +29,7 @@ describe('Test `getPrefixedEnvVars()`', () => {
         envPrefix: 'GATSBY_',
         envs: {
           USER_ENV_VAR_NOT_VERCEL: 'example.com',
+          VERCEL_ARTIFACTS_TOKEN: 'abc123',
           FOO: 'bar',
           VERCEL_URL: 'example.vercel.sh',
           VERCEL_ENV: 'production',
@@ -51,6 +53,7 @@ describe('Test `getPrefixedEnvVars()`', () => {
           USER_ENV_VAR_NOT_VERCEL: 'example.com',
           FOO: 'bar',
           BLARG_VERCEL_THING: 'fake',
+          VERCEL_ARTIFACTS_TOKEN: 'abc123',
         },
       },
       want: {},


### PR DESCRIPTION
This PR fixes a bug that was causing too many env vars to be exposed to the frontend by adding the framework `envPrefix`.

Some frameworks, such as CRA, will include all of these in the frontend even if not explicitly used so we must only prefix known [System Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables).

This PR adds an allowlist to ensure this is handle properly.

- Fixes https://linear.app/vercel/issue/VCCLI-639