### PR TITLE
[node-bridge]: remove API Gateway normalization

### DIFF
--- a/packages/node-bridge/bridge.js
+++ b/packages/node-bridge/bridge.js
@@ -84,17 +84,12 @@ function normalizeProxyEvent(event) {
 }
 
 /**
- * @param {import('./types').VercelProxyEvent | import('aws-lambda').APIGatewayProxyEvent} event
- * @return {import('./types').VercelProxyRequest | undefined }
+ * @param {import('./types').VercelProxyEvent } event
+ * @return {import('./types').VercelProxyRequest }
  */
 function normalizeEvent(event) {
-  if ('Action' in event) {
-    if (event.Action === 'Invoke') {
-      return normalizeProxyEvent(event);
-    } else {
-      throw new Error(`Unexpected event.Action: ${event.Action}`);
-    }
-  }
+  if (event.Action === 'Invoke') return normalizeProxyEvent(event);
+  throw new Error(`Unexpected event.Action: ${event.Action}`);
 }
 
 class Bridge {
@@ -174,7 +169,7 @@ class Bridge {
 
   /**
    *
-   * @param {import('./types').VercelProxyEvent | import('aws-lambda').APIGatewayProxyEvent} event
+   * @param {import('./types').VercelProxyEvent} event
    * @param {import('aws-lambda').Context} context
    * @return {Promise<import('./types').VercelProxyResponse>}
    */

--- a/packages/node-bridge/bridge.js
+++ b/packages/node-bridge/bridge.js
@@ -84,39 +84,8 @@ function normalizeProxyEvent(event) {
 }
 
 /**
- * @param {import('aws-lambda').APIGatewayProxyEvent} event
- */
-function normalizeAPIGatewayProxyEvent(event) {
-  let bodyBuffer;
-  const { httpMethod: method, path, headers, body } = event;
-
-  if (body) {
-    if (event.isBase64Encoded) {
-      bodyBuffer = Buffer.from(body, 'base64');
-    } else {
-      bodyBuffer = Buffer.from(body);
-    }
-  } else {
-    bodyBuffer = Buffer.alloc(0);
-  }
-
-  return {
-    body: bodyBuffer,
-    headers,
-    isApiGateway: true,
-    method,
-    path,
-    responseCallbackCipher: undefined,
-    responseCallbackCipherIV: undefined,
-    responseCallbackCipherKey: undefined,
-    responseCallbackStream: undefined,
-    responseCallbackUrl: undefined,
-  };
-}
-
-/**
  * @param {import('./types').VercelProxyEvent | import('aws-lambda').APIGatewayProxyEvent} event
- * @return {import('./types').VercelProxyRequest}
+ * @return {import('./types').VercelProxyRequest | undefined }
  */
 function normalizeEvent(event) {
   if ('Action' in event) {
@@ -125,8 +94,6 @@ function normalizeEvent(event) {
     } else {
       throw new Error(`Unexpected event.Action: ${event.Action}`);
     }
-  } else {
-    return normalizeAPIGatewayProxyEvent(event);
   }
 }
 

--- a/packages/node-bridge/launcher.js
+++ b/packages/node-bridge/launcher.js
@@ -153,17 +153,17 @@ function getAwsLauncher({ entrypointPath, awsLambdaHandler = '' }) {
   }
 
   /**
-   * @param {import('aws-lambda').APIGatewayProxyEvent} e
+   * @param {import('aws-lambda').APIGatewayProxyEvent} event
    * @param {import('aws-lambda').Context} context
    * @param {() => void} callback
    */
-  function internal(e, context, callback) {
+  function internal(event, context, callback) {
     const {
       path,
       method: httpMethod,
       body,
       headers,
-    } = JSON.parse(e.body || '{}');
+    } = JSON.parse(event.body || '{}');
     const { query } = parse(path, true);
     /**
      * @type {{[key: string]: string}}

--- a/packages/node-bridge/test/bridge.test.js
+++ b/packages/node-bridge/test/bridge.test.js
@@ -19,39 +19,6 @@ test('port binding', async () => {
   server.close();
 });
 
-test('`APIGatewayProxyEvent` normalizing', async () => {
-  const server = new Server((req, res) =>
-    res.end(
-      JSON.stringify({
-        method: req.method,
-        path: req.url,
-        headers: req.headers,
-      })
-    )
-  );
-  const bridge = new Bridge(server);
-  bridge.listen();
-  const context = {};
-  const result = await bridge.launcher(
-    {
-      httpMethod: 'GET',
-      headers: { foo: 'bar' },
-      path: '/apigateway',
-      body: null,
-    },
-    context
-  );
-  assert.strictEqual(result.encoding, 'base64');
-  assert.strictEqual(result.statusCode, 200);
-  const body = JSON.parse(Buffer.from(result.body, 'base64').toString());
-  assert.strictEqual(body.method, 'GET');
-  assert.strictEqual(body.path, '/apigateway');
-  assert.strictEqual(body.headers.foo, 'bar');
-  assert.strictEqual(context.callbackWaitsForEmptyEventLoop, false);
-
-  server.close();
-});
-
 test('`NowProxyEvent` normalizing', async () => {
   const server = new Server((req, res) =>
     res.end(

--- a/packages/node/src/dev-server.ts
+++ b/packages/node/src/dev-server.ts
@@ -93,7 +93,7 @@ async function main() {
     handleEvent = await createEventHandler(entrypoint!, config, {
       shouldAddHelpers,
     });
-  } catch (error) {
+  } catch (error: any) {
     logError(error);
     handlerEventError = error;
   }
@@ -132,7 +132,7 @@ export async function onDevRequest(
       }
     }
     res.end(Buffer.from(result.body, result.encoding));
-  } catch (error) {
+  } catch (error: any) {
     res.statusCode = 500;
     res.end(error.stack);
   }


### PR DESCRIPTION
We no longer use since a long time ago