### PR TITLE
[cli] support `build -y` shorthand

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -157,6 +157,7 @@ export default async function main(client: Client): Promise<number> {
     '--output': String,
     '--prod': Boolean,
     '--yes': Boolean,
+    '-y': '--yes',
   });
 
   if (argv['--help']) {


### PR DESCRIPTION
The `build` command wasn't supporting the `-y` shorthand for `--yes`. Now it does.

I looked at the other uses and they all seem fine.