### PR TITLE
[build-utils] Allow corepack resolution without lockfiles

### DIFF
--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -392,7 +392,9 @@ export async function runNpmInstall(
   try {
     await runNpmInstallSema.acquire();
     const { cliType, packageJsonPath, lockfileVersion } = await scanParentDirs(
-      destPath
+      destPath,
+      true,
+      spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK === '1'
     );
 
     // Only allow `runNpmInstall()` to run once per `package.json`
@@ -568,7 +570,11 @@ export async function runCustomInstallCommand({
   spawnOpts?: SpawnOptions;
 }) {
   console.log(`Running "install" command: \`${installCommand}\`...`);
-  const { cliType, lockfileVersion } = await scanParentDirs(destPath);
+  const { cliType, lockfileVersion } = await scanParentDirs(
+    destPath,
+    true,
+    spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK === '1'
+  );
   const env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
@@ -592,7 +598,8 @@ export async function runPackageJsonScript(
 
   const { packageJson, cliType, lockfileVersion } = await scanParentDirs(
     destPath,
-    true
+    true,
+    spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK === '1'
   );
   const scriptName = getScriptName(
     packageJson,

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -259,7 +259,7 @@ export async function scanParentDirs(
     predicate: fullpath => {
       const data = fs.readFileSync(fullpath, 'utf-8');
       const json = JSON.parse(data);
-      return json.packageManager != undefined;
+      return type json.packageManager === 'string';
     },
   });
   const packageJson: PackageJson | undefined =

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -333,7 +333,7 @@ export async function walkParentDirs({
   base,
   start,
   filename,
-  predicate = () => true,
+  predicate = (fullPath: string) => true,
 }: WalkParentDirsProps): Promise<string | null> {
   assert(path.isAbsolute(base), 'Expected "base" to be absolute path');
   assert(path.isAbsolute(start), 'Expected "start" to be absolute path');

--- a/packages/build-utils/test/fixtures/29-corepack-without-lockfile/package.json
+++ b/packages/build-utils/test/fixtures/29-corepack-without-lockfile/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir -p public && (printf \"pnpm version: \" && pnpm -v) > public/index.txt"
+  },
+  "dependencies": {
+    "once": "^1.4.0"
+  },
+  "packageManager": "pnpm@8.0.0"
+}

--- a/packages/build-utils/test/fixtures/29-corepack-without-lockfile/package.json
+++ b/packages/build-utils/test/fixtures/29-corepack-without-lockfile/package.json
@@ -3,8 +3,5 @@
   "scripts": {
     "build": "mkdir -p public && (printf \"pnpm version: \" && pnpm -v) > public/index.txt"
   },
-  "dependencies": {
-    "once": "^1.4.0"
-  },
   "packageManager": "pnpm@8.0.0"
 }

--- a/packages/build-utils/test/fixtures/29-corepack-without-lockfile/probes.json
+++ b/packages/build-utils/test/fixtures/29-corepack-without-lockfile/probes.json
@@ -1,0 +1,8 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "pnpm version: 8"
+    }
+  ]
+}

--- a/packages/build-utils/test/fixtures/29-corepack-without-lockfile/vercel.json
+++ b/packages/build-utils/test/fixtures/29-corepack-without-lockfile/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "ENABLE_EXPERIMENTAL_COREPACK": "1"
+    }
+  }
+}

--- a/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/app/package.json
+++ b/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/app/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "30-nested-corepack-without-lockfile-app"
+}

--- a/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/package.json
+++ b/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "mkdir -p public && (printf \"pnpm version: \" && pnpm -v) > public/index.txt"
+  },
+  "packageManager": "pnpm@8.0.0"
+}

--- a/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/pnpm-workspace.yaml
+++ b/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'app'

--- a/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/probes.json
+++ b/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/probes.json
@@ -1,0 +1,8 @@
+{
+  "probes": [
+    {
+      "path": "/",
+      "mustContain": "pnpm version: 8"
+    }
+  ]
+}

--- a/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/vercel.json
+++ b/packages/build-utils/test/fixtures/30-nested-corepack-without-lockfile/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rootDirectory": "app",
+  "build": {
+    "env": {
+      "ENABLE_EXPERIMENTAL_COREPACK": "1"
+    }
+  }
+}

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -51,7 +51,9 @@ export const build: BuildV2 = async ({
   );
 
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
-  const { cliType, lockfileVersion } = await scanParentDirs(entrypointDir);
+  const { cliType, lockfileVersion } = await scanParentDirs(entrypointDir, {
+    spawnOpts,
+  });
 
   spawnOpts.env = getEnvForPackageManager({
     cliType,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -259,7 +259,9 @@ export const build: BuildV2 = async ({
   const nextVersionRange = await getNextVersionRange(entryPath);
   const nodeVersion = await getNodeVersion(entryPath, undefined, config, meta);
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
-  const { cliType, lockfileVersion } = await scanParentDirs(entryPath);
+  const { cliType, lockfileVersion } = await scanParentDirs(entryPath, {
+    spawnOpts,
+  });
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -79,7 +79,8 @@ export const build: BuildV2 = async ({
     spawnOpts.env = {};
   }
   const { cliType, lockfileVersion } = await scanParentDirs(
-    entrypointFsDirname
+    entrypointFsDirname,
+    { spawnOpts }
   );
 
   spawnOpts.env = getEnvForPackageManager({

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -89,8 +89,11 @@ export const build: BuildV2 = async ({
     meta
   );
 
+  const spawnOpts = getSpawnOptions(meta, nodeVersion);
+
   const { cliType, packageJsonPath, lockfileVersion } = await scanParentDirs(
-    entrypointFsDirname
+    entrypointFsDirname,
+    { spawnOpts }
   );
 
   if (!packageJsonPath) {
@@ -100,7 +103,6 @@ export const build: BuildV2 = async ({
   const pkgRaw = await fs.readFile(packageJsonPath, 'utf8');
   const pkg = JSON.parse(pkgRaw);
 
-  const spawnOpts = getSpawnOptions(meta, nodeVersion);
   if (!spawnOpts.env) {
     spawnOpts.env = {};
   }

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -435,7 +435,9 @@ export const build: BuildV2 = async ({
       spawnOpts.env.CI = 'false';
     }
 
-    const { cliType, lockfileVersion } = await scanParentDirs(entrypointDir);
+    const { cliType, lockfileVersion } = await scanParentDirs(entrypointDir, {
+      spawnOpts,
+    });
 
     spawnOpts.env = getEnvForPackageManager({
       cliType,


### PR DESCRIPTION
Adds support for determining package manager using corepack without a lockfile existing.