### PR TITLE
[next] Skip broken Next.js tests

### DIFF
--- a/packages/next/test/fixtures/00-i18n-404-lambda/index.test.js
+++ b/packages/next/test/fixtures/00-i18n-404-lambda/index.test.js
@@ -2,7 +2,8 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -97,7 +97,8 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
   });
 }
 
-it('should build using server build', async () => {
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('should build using server build', async () => {
   const origLog = console.log;
   const origError = console.error;
   const caughtLogs = [];


### PR DESCRIPTION
This PR skips some tests that are breaking because they are running Next.js canary.