### PR TITLE
[next] Update allowQuery test

### DIFF
--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -158,7 +158,7 @@ it('should build using server build', async () => {
   expect(output['dynamic/[slug]'].operationType).toBe('SSR');
 
   expect(output['fallback/[slug]'].type).toBe('Prerender');
-  expect(output['fallback/[slug]'].allowQuery).toEqual(['slug']);
+  expect(output['fallback/[slug]'].allowQuery).toEqual(['nextParamslug']);
   expect(output['fallback/[slug]'].lambda.operationType).toBe('ISR');
   expect(output['fallback/[slug]'].sourcePath).toBe(undefined);
 
@@ -167,7 +167,7 @@ it('should build using server build', async () => {
   );
   expect(
     output['_next/data/testing-build-id/fallback/[slug].json'].allowQuery
-  ).toEqual(['slug']);
+  ).toEqual(['nextParamslug']);
   expect(
     output['_next/data/testing-build-id/fallback/[slug].json'].lambda
       .operationType


### PR DESCRIPTION
These values are now expected to be prefixed so we can isolate them from normal query params. 

x-ref: https://github.com/vercel/vercel/actions/runs/4624385719/jobs/8179201620?pr=9719#step:8:2982