### PR TITLE
[build-utils][cli][fs-detectors] Upgrade minimatch to 3.1.2

### DIFF
--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -44,7 +44,7 @@
     "ignore": "4.0.6",
     "into-stream": "5.0.0",
     "js-yaml": "3.13.1",
-    "minimatch": "3.0.4",
+    "minimatch": "3.1.2",
     "multistream": "2.1.1",
     "node-fetch": "2.6.7",
     "semver": "6.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -135,7 +135,7 @@
     "line-async-iterator": "3.0.0",
     "load-json-file": "3.0.0",
     "mime-types": "2.1.24",
-    "minimatch": "3.0.4",
+    "minimatch": "3.1.2",
     "mri": "1.1.5",
     "ms": "2.1.2",
     "node-fetch": "2.6.7",

--- a/packages/cli/test/dev/fixtures/03-aurelia/package.json
+++ b/packages/cli/test/dev/fixtures/03-aurelia/package.json
@@ -44,7 +44,7 @@
     "jest-transform-stub": "2.0.0",
     "json-loader": "0.5.7",
     "mini-css-extract-plugin": "0.4.3",
-    "minimatch": "3.0.4",
+    "minimatch": "3.1.2",
     "promise-polyfill": "8.1.0",
     "regenerator-runtime": "0.13.2",
     "style-loader": "0.23.1",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -25,7 +25,7 @@
     "glob": "8.0.3",
     "js-yaml": "4.1.0",
     "json5": "2.2.2",
-    "minimatch": "3.0.4",
+    "minimatch": "3.1.2",
     "semver": "6.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
       ignore: 4.0.6
       into-stream: 5.0.0
       js-yaml: 3.13.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       multistream: 2.1.1
       node-fetch: 2.6.7
       semver: 6.1.1
@@ -186,7 +186,7 @@ importers:
       ignore: 4.0.6
       into-stream: 5.0.0
       js-yaml: 3.13.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       multistream: 2.1.1
       node-fetch: 2.6.7
       semver: 6.1.1
@@ -296,7 +296,7 @@ importers:
       line-async-iterator: 3.0.0
       load-json-file: 3.0.0
       mime-types: 2.1.24
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       mri: 1.1.5
       ms: 2.1.2
       node-fetch: 2.6.7
@@ -431,7 +431,7 @@ importers:
       line-async-iterator: 3.0.0
       load-json-file: 3.0.0
       mime-types: 2.1.24
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       mri: 1.1.5
       ms: 2.1.2
       node-fetch: 2.6.7
@@ -587,7 +587,7 @@ importers:
       glob: 8.0.3
       js-yaml: 4.1.0
       json5: 2.2.2
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       semver: 6.1.1
       typescript: 4.3.4
     dependencies:
@@ -597,7 +597,7 @@ importers:
       glob: 8.0.3
       js-yaml: 4.1.0
       json5: 2.2.2
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       semver: 6.1.1
     devDependencies:
       '@types/glob': 7.2.0
@@ -9912,7 +9912,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.1
       regexpp: 3.2.0
@@ -10907,7 +10907,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -10929,7 +10929,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -11454,7 +11454,7 @@ packages:
   /ignore-walk/3.0.3:
     resolution: {integrity: sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==}
     dependencies:
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /ignore-walk/5.0.1:


### PR DESCRIPTION
Minimatch 3.0.4 has a [ReDoS vulnerability](https://security.snyk.io/vuln/SNYK-JS-MINIMATCH-3050818). While not likely to be an issue for the packages that use it here, a simple version bump should prevent the issue and reduce vulnerability noise on audits. 3.1.2 is the latest version within the 3.x range, so prevents breaking changes.
