### PR TITLE
[next] Fix edge runtime for route groups

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1024,6 +1024,7 @@ export async function serverBuild({
     isCorrectMiddlewareOrder,
     prerenderBypassToken: prerenderManifest.bypassToken || '',
     nextVersion,
+    appPathRoutesManifest: appPathRoutesManifest || {},
   });
 
   const isNextDataServerResolving =

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2378,6 +2378,7 @@ export async function getMiddlewareBundle({
   isCorrectMiddlewareOrder,
   prerenderBypassToken,
   nextVersion,
+  appPathRoutesManifest,
 }: {
   config: Config;
   entryPath: string;
@@ -2386,6 +2387,7 @@ export async function getMiddlewareBundle({
   routesManifest: RoutesManifest;
   isCorrectMiddlewareOrder: boolean;
   nextVersion: string;
+  appPathRoutesManifest: Record<string, string>;
 }): Promise<{
   staticRoutes: Route[];
   dynamicRouteMap: Map<string, RouteWithSrc>;
@@ -2550,9 +2552,15 @@ export async function getMiddlewareBundle({
         shortPath.startsWith('app/') &&
         (shortPath.endsWith('/page') || shortPath.endsWith('/route'))
       ) {
-        shortPath =
-          shortPath.replace(/^app\//, '').replace(/(^|\/)(page|route)$/, '') ||
-          'index';
+        const ogRoute = shortPath.replace(/^app\//, '/');
+        shortPath = (
+          appPathRoutesManifest[ogRoute] ||
+          shortPath.replace(/(^|\/)(page|route)$/, '')
+        ).replace(/^\//, '');
+
+        if (!shortPath || shortPath === '/') {
+          shortPath = 'index';
+        }
       }
 
       if (routesManifest?.basePath) {

--- a/packages/next/test/fixtures/00-app-dir/app/(newroot)/dashboard/another-edge/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/(newroot)/dashboard/another-edge/page.js
@@ -1,0 +1,9 @@
+export const runtime = 'experimental-edge'
+
+export default function AnotherPage(props) {
+  return (
+    <>
+      <p>hello from newroot/dashboard/another</p>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -7,6 +7,11 @@
   ],
   "probes": [
     {
+      "path": "/dashboard/another-edge",
+      "status": 200,
+      "mustContain": "hello from newroot/dashboard/another"
+    },
+    {
       "path": "/dynamic/category-1/id-1",
       "status": 200,
       "headers": {

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -78,7 +78,7 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     expect(edgeFunctions.size).toBe(3);
     expect(buildResult.output['edge']).toBeDefined();
     expect(buildResult.output['index']).toBeDefined();
-    expect(buildResult.output['index/index']).toBeDefined();
+    // expect(buildResult.output['index/index']).toBeDefined();
   });
 
   it('should show error from basePath with legacy monorepo build', async () => {


### PR DESCRIPTION
This ensures we use the correct short name when generating edge functions with route groups from app directory. 

Example deployment with fix can be seen here https://next-debug-edge-runtime-1ar7agbjh-vtest314-ijjk-testing.vercel.app/group-no-layout

Fixes: https://github.com/vercel/next.js/issues/43458
