### PR TITLE
[next] use "Page" instead of "SSR" for `operationType`

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1089,7 +1089,7 @@ export const build: BuildV2 = async ({
           handler: '___next_launcher.cjs',
           runtime: nodeVersion.runtime,
           ...lambdaOptions,
-          operationType: 'SSR', // always SSR because we're in legacy mode
+          operationType: 'Page', // always Page because we're in legacy mode
           shouldAddHelpers: false,
           shouldAddSourcemapSupport: false,
           supportsMultiPayloads: !!process.env.NEXT_PRIVATE_MULTI_PAYLOAD,
@@ -1842,7 +1842,7 @@ export const build: BuildV2 = async ({
                 path.relative(baseDir, entryPath),
                 '___next_launcher.cjs'
               ),
-              operationType: getOperationType({ pageFileName }), // can only be API or SSR
+              operationType: getOperationType({ pageFileName }), // can only be API or Page
               runtime: nodeVersion.runtime,
               nextVersion,
               ...lambdaOptions,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2784,7 +2784,7 @@ export function getOperationType({
     }
   }
 
-  return 'SSR';
+  return 'Page'; // aka SSR
 }
 
 export function isApiPage(page: string | undefined) {

--- a/packages/next/test/integration/index.test.js
+++ b/packages/next/test/integration/index.test.js
@@ -144,18 +144,18 @@ it('should build using server build', async () => {
   expect(output['index'].allowQuery).toBe(undefined);
   expect(output['index'].memory).toBe(512);
   expect(output['index'].maxDuration).toBe(5);
-  expect(output['index'].operationType).toBe('SSR');
+  expect(output['index'].operationType).toBe('Page');
 
   expect(output['another'].type).toBe('Lambda');
   expect(output['another'].memory).toBe(512);
   expect(output['another'].maxDuration).toBe(5);
   expect(output['another'].allowQuery).toBe(undefined);
-  expect(output['another'].operationType).toBe('SSR');
+  expect(output['another'].operationType).toBe('Page');
 
   expect(output['dynamic/[slug]'].type).toBe('Lambda');
   expect(output['dynamic/[slug]'].memory).toBe(undefined);
   expect(output['dynamic/[slug]'].maxDuration).toBe(5);
-  expect(output['dynamic/[slug]'].operationType).toBe('SSR');
+  expect(output['dynamic/[slug]'].operationType).toBe('Page');
 
   expect(output['fallback/[slug]'].type).toBe('Prerender');
   expect(output['fallback/[slug]'].allowQuery).toEqual(['nextParamslug']);


### PR DESCRIPTION
Update the `operationType` from "SSR" to "Page" for display in build outputs.