### PR TITLE
Add 'PUBLIC_' prefix to SvelteKit 1.0 framework

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1020,6 +1020,7 @@ export const frameworks = [
       'SvelteKit is a framework for building web applications of all sizes.',
     description: 'A SvelteKit app optimized Edge-first.',
     website: 'https://kit.svelte.dev',
+    envPrefix: 'PUBLIC_',
     detectors: {
       every: [
         {


### PR DESCRIPTION
With the SvelteKit 1.0 release, public environment variable prefix has been changed to `PUBLIC_` from `VITE_` [1].
Current Vercel build pipeline for SvelteKit exposes environment variable with no prefix [2], making it impossible to access from client-side code while build time.

This PR fixes it.

[1] https://kit.svelte.dev/docs/configuration#env
[2]
<img width="808" alt="image" src="https://user-images.githubusercontent.com/337728/230769952-a11d1d57-8777-44ac-90bb-04f3d2e87c15.png">
