### PR TITLE
[fs-detectors] check turbo versions to allow for tags like "latest"

### DIFF
--- a/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
+++ b/packages/fs-detectors/src/monorepos/get-monorepo-default-settings.ts
@@ -22,6 +22,18 @@ export class MissingBuildTarget extends Error {
   }
 }
 
+function supportsRootCommand(turboSemVer: string | undefined) {
+  if (!turboSemVer) {
+    return false;
+  }
+
+  if (!semver.validRange(turboSemVer)) {
+    return false;
+  }
+
+  return !semver.intersects(turboSemVer, '<1.8.0');
+}
+
 type MonorepoDefaultSettings = {
   buildCommand?: string | null;
   installCommand?: string | null;
@@ -91,7 +103,7 @@ export async function getMonorepoDefaultSettings(
 
     let buildCommand = null;
     if (projectPath) {
-      if (turboSemVer && !semver.intersects(turboSemVer, '<1.8.0')) {
+      if (supportsRootCommand(turboSemVer)) {
         buildCommand = `turbo run build`;
       } else {
         // We don't know for sure if the local `turbo` supports inference.

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "turbo": "latest"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/packages/app-1/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/packages/app-1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-14",
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/turbo.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-latest/turbo.json
@@ -1,0 +1,2 @@
+// TEST COMMENT TO VERIFY JSON5 SUPPORT
+{ "pipeline": { "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] } } }

--- a/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
+++ b/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
@@ -31,6 +31,7 @@ describe('getMonorepoDefaultSettings', () => {
     ['turbo-package-config', 'turbo', false, 'app-13', false, false],
     ['turbo-npm', 'turbo', true, 'app-15', false, false],
     ['turbo-npm-root-proj', 'turbo', true, 'app-root-proj', true, false],
+    ['turbo-latest', 'turbo', false, 'app-14', false, false],
     ['nx', 'nx', false, 'app-12', false, false],
     ['nx-package-config', 'nx', false, 'app-11', false, false],
     ['nx-project-and-package-config-1', 'nx', false, 'app-10', false, false],


### PR DESCRIPTION
When a project depends on `turbo` at version `latest`, this code was breaking because `latest` is not a valid range for `semver.intersects`.