### PR TITLE
[cli] Simplify `parseRepoUrl()` and fix edge case

### DIFF
--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -178,6 +178,7 @@ export default async function connect(
     gitOrg,
     repo,
   });
+
   if (typeof checkAndConnect === 'number') {
     return checkAndConnect;
   }

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -108,14 +108,15 @@ function getURL(input: string) {
 export function parseRepoUrl(originUrl: string): RepoInfo | null {
   const url = getURL(originUrl);
   if (!url) return null;
+
   const hostParts = url.hostname.split('.');
   if (hostParts.length < 2) return null;
   const provider = hostParts[hostParts.length - 2];
 
-  const pathParts = url.pathname.split('/');
-  if (pathParts.length !== 3) return null;
-  const org = pathParts[1];
-  const repo = pathParts[2].replace(/\.git$/, '');
+  const pathParts = url.pathname.split('/').filter(Boolean);
+  if (pathParts.length !== 2) return null;
+  const org = pathParts[0];
+  const repo = pathParts[1].replace(/\.git$/, '');
   return { url: originUrl, provider, org, repo };
 }
 

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -1,10 +1,11 @@
+import { URL } from 'url';
 import Client from '../client';
-import { Org } from '@vercel-internals/types';
 import chalk from 'chalk';
 import link from '../output/link';
 import { isAPIError } from '../errors-ts';
 import { Output } from '../output';
 import { Dictionary } from '@vercel/client';
+import type { Org } from '@vercel-internals/types';
 
 export interface RepoInfo {
   url: string;
@@ -86,40 +87,38 @@ export function formatProvider(type: string): string {
   }
 }
 
-export function parseRepoUrl(originUrl: string): RepoInfo | null {
-  const isSSH = originUrl.startsWith('git@');
-  // Matches all characters between (// or @) and (.com or .org)
-  // eslint-disable-next-line prefer-named-capture-group
-  const provider =
-    /(?<=(\/\/|@)).*(?=(\.com|\.org))/.exec(originUrl)?.[0] ||
-    originUrl.replace('www.', '').split('.')[0];
-  if (!provider) {
-    return null;
+function getURL(input: string) {
+  let url: URL | null = null;
+
+  try {
+    url = new URL(input);
+  } catch {}
+
+  if (!url) {
+    // Probably an SSH url, so mangle it into a
+    // format that the URL constructor works with.
+    try {
+      url = new URL(`ssh://${input.replace(':', '/')}`);
+    } catch {}
   }
 
-  let org;
-  let repo;
-
-  if (isSSH) {
-    org = originUrl.split(':')[1].split('/')[0];
-    repo = originUrl.split('/')[1]?.replace('.git', '');
-  } else {
-    // Assume https:// or git://
-    org = originUrl.replace('//', '').split('/')[1];
-    repo = originUrl.replace('//', '').split('/')[2]?.replace('.git', '');
-  }
-
-  if (!org || !repo) {
-    return null;
-  }
-
-  return {
-    url: originUrl,
-    provider,
-    org,
-    repo,
-  };
+  return url;
 }
+
+export function parseRepoUrl(originUrl: string): RepoInfo | null {
+  const url = getURL(originUrl);
+  if (!url) return null;
+  const hostParts = url.hostname.split('.');
+  if (hostParts.length < 2) return null;
+  const provider = hostParts[hostParts.length - 2];
+
+  const pathParts = url.pathname.split('/');
+  if (pathParts.length !== 3) return null;
+  const org = pathParts[1];
+  const repo = pathParts[2].replace(/\.git$/, '');
+  return { url: originUrl, provider, org, repo };
+}
+
 export function printRemoteUrls(
   output: Output,
   remoteUrls: Dictionary<string>

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -67,6 +67,13 @@ describe('parseRepoUrl', () => {
     const repoInfo = parseRepoUrl('https://github.com/borked');
     expect(repoInfo).toBeNull();
   });
+  it('should parse url with `.com` in the repo name', () => {
+    const repoInfo = parseRepoUrl('https://github.com/vercel/vercel.com.git');
+    expect(repoInfo).toBeDefined();
+    expect(repoInfo?.provider).toEqual('github');
+    expect(repoInfo?.org).toEqual('vercel');
+    expect(repoInfo?.repo).toEqual('vercel.com');
+  });
   it('should parse url with a period in the repo name', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/next.js');
     expect(repoInfo).toBeDefined();

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -69,49 +69,57 @@ describe('parseRepoUrl', () => {
   });
   it('should parse url with `.com` in the repo name', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/vercel.com.git');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('vercel.com');
   });
   it('should parse url with a period in the repo name', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/next.js');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('next.js');
   });
   it('should parse url that ends with .git', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/next.js.git');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('next.js');
   });
   it('should parse github https url', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/vercel.git');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('vercel');
   });
   it('should parse github https url without the .git suffix', () => {
     const repoInfo = parseRepoUrl('https://github.com/vercel/vercel');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('vercel');
   });
   it('should parse github git url', () => {
     const repoInfo = parseRepoUrl('git://github.com/vercel/vercel.git');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
+    expect(repoInfo?.provider).toEqual('github');
+    expect(repoInfo?.org).toEqual('vercel');
+    expect(repoInfo?.repo).toEqual('vercel');
+  });
+  it('should parse github git url with trailing slash', () => {
+    const repoInfo = parseRepoUrl('git://github.com/vercel/vercel.git/');
+    expect(repoInfo).toBeTruthy();
+    console.log(repoInfo);
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('vercel');
   });
   it('should parse github ssh url', () => {
     const repoInfo = parseRepoUrl('git@github.com:vercel/vercel.git');
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('github');
     expect(repoInfo?.org).toEqual('vercel');
     expect(repoInfo?.repo).toEqual('vercel');
@@ -121,7 +129,7 @@ describe('parseRepoUrl', () => {
     const repoInfo = parseRepoUrl(
       'https://gitlab.com/gitlab-examples/knative-kotlin-app.git'
     );
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('gitlab');
     expect(repoInfo?.org).toEqual('gitlab-examples');
     expect(repoInfo?.repo).toEqual('knative-kotlin-app');
@@ -130,7 +138,7 @@ describe('parseRepoUrl', () => {
     const repoInfo = parseRepoUrl(
       'git@gitlab.com:gitlab-examples/knative-kotlin-app.git'
     );
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('gitlab');
     expect(repoInfo?.org).toEqual('gitlab-examples');
     expect(repoInfo?.repo).toEqual('knative-kotlin-app');
@@ -140,7 +148,7 @@ describe('parseRepoUrl', () => {
     const repoInfo = parseRepoUrl(
       'https://bitbucket.org/atlassianlabs/maven-project-example.git'
     );
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('bitbucket');
     expect(repoInfo?.org).toEqual('atlassianlabs');
     expect(repoInfo?.repo).toEqual('maven-project-example');
@@ -149,7 +157,7 @@ describe('parseRepoUrl', () => {
     const repoInfo = parseRepoUrl(
       'git@bitbucket.org:atlassianlabs/maven-project-example.git'
     );
-    expect(repoInfo).toBeDefined();
+    expect(repoInfo).toBeTruthy();
     expect(repoInfo?.provider).toEqual('bitbucket');
     expect(repoInfo?.org).toEqual('atlassianlabs');
     expect(repoInfo?.repo).toEqual('maven-project-example');


### PR DESCRIPTION
Fixes an edge case in `parseRepoUrl()` when there is a `.com` in the repo name. The code was hard to refactor in its previous form so I refactored it to be simpler as well.