### PR TITLE
[tests] fetch vercel.com cert before builds and after tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       - run: pnpm install
 
       - name: fetch ssl certificate before build
-        run: echo | openssl s_client -showcerts -servername 'vercel.com' -connect 76.76.21.21:443
+        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443
 
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --scope=${{matrix.packageName}} --include-dependencies --no-deps
@@ -93,7 +93,7 @@ jobs:
           FORCE_COLOR: '1'
 
       - name: fetch ssl certificate after tests
-        run: echo | openssl s_client -showcerts -servername 'vercel.com' -connect 76.76.21.21:443
+        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443
 
   conclusion:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,16 @@ jobs:
 
       - run: pnpm install
 
-      - name: fetch ssl certificate before build
+      - name: fetch ssl certificate before build (windows)
+        if: matrix.runner == 'windows-latest'
+        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443 > cert_chain_before_build.txt
+
+      - name: display certificate chain before build (windows)
+        if: matrix.runner == 'windows-latest'
+        run: type cert_chain_before_build.txt
+
+      - name: fetch ssl certificate before build (linux, os x)
+        if: matrix.runner != 'windows-latest'
         run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443
 
       - name: Build ${{matrix.packageName}} and all its dependencies
@@ -92,7 +101,16 @@ jobs:
           VERCEL_TEST_REGISTRATION_URL: ${{ secrets.VERCEL_TEST_REGISTRATION_URL }}
           FORCE_COLOR: '1'
 
-      - name: fetch ssl certificate after tests
+      - name: fetch ssl certificate after tests (windows)
+        if: matrix.runner == 'windows-latest'
+        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443 > cert_chain_after_tests.txt
+
+      - name: display certificate chain after tests (windows)
+        if: matrix.runner == 'windows-latest'
+        run: type cert_chain_after_tests.txt
+
+      - name: fetch ssl certificate after tests (linux, os x)
+        if: matrix.runner != 'windows-latest'
         run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443
 
   conclusion:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,9 @@ jobs:
 
       - run: pnpm install
 
+      - name: fetch ssl certificate before build
+        run: echo | openssl s_client -showcerts -servername 'vercel.com' -connect 76.76.21.21:443
+
       - name: Build ${{matrix.packageName}} and all its dependencies
         run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --scope=${{matrix.packageName}} --include-dependencies --no-deps
         env:
@@ -88,6 +91,9 @@ jobs:
           VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
           VERCEL_TEST_REGISTRATION_URL: ${{ secrets.VERCEL_TEST_REGISTRATION_URL }}
           FORCE_COLOR: '1'
+
+      - name: fetch ssl certificate after tests
+        run: echo | openssl s_client -showcerts -servername 'vercel.com' -connect 76.76.21.21:443
 
   conclusion:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,14 +76,6 @@ jobs:
 
       - run: pnpm install
 
-      - name: fetch ssl certificate before build (windows)
-        if: matrix.runner == 'windows-latest'
-        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443 > cert_chain_before_build.txt
-
-      - name: display certificate chain before build (windows)
-        if: matrix.runner == 'windows-latest'
-        run: type cert_chain_before_build.txt
-
       - name: fetch ssl certificate before build (linux, os x)
         if: matrix.runner != 'windows-latest'
         run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443
@@ -100,14 +92,6 @@ jobs:
           VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
           VERCEL_TEST_REGISTRATION_URL: ${{ secrets.VERCEL_TEST_REGISTRATION_URL }}
           FORCE_COLOR: '1'
-
-      - name: fetch ssl certificate after tests (windows)
-        if: matrix.runner == 'windows-latest'
-        run: echo | openssl s_client -showcerts -servername 'api.vercel.com' -connect 76.76.21.21:443 > cert_chain_after_tests.txt
-
-      - name: display certificate chain after tests (windows)
-        if: matrix.runner == 'windows-latest'
-        run: type cert_chain_after_tests.txt
 
       - name: fetch ssl certificate after tests (linux, os x)
         if: matrix.runner != 'windows-latest'


### PR DESCRIPTION
To debug intermittent connection errors when the tests make requests to [api.vercel.com], fetch the SSL certificate before builds and after tests.