### PR TITLE
[cli] refactor to use create deployment param type

### DIFF
--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -280,7 +280,7 @@ export default async (client: Client): Promise<number> => {
   let { org, project, status } = link;
 
   let newProjectName = null;
-  let rootDirectory = project?.rootDirectory || undefined;
+  let rootDirectory = project?.rootDirectory;
   let sourceFilesOutsideRootDirectory: boolean | undefined = true;
 
   if (status === 'not_linked') {
@@ -335,11 +335,10 @@ export default async (client: Client): Promise<number> => {
 
     if (typeof projectOrNewProjectName === 'string') {
       newProjectName = projectOrNewProjectName;
-      rootDirectory =
-        (await inputRootDirectory(client, path, autoConfirm)) ?? undefined;
+      rootDirectory = await inputRootDirectory(client, path, autoConfirm);
     } else {
       project = projectOrNewProjectName;
-      rootDirectory = project.rootDirectory ?? undefined;
+      rootDirectory = project.rootDirectory;
       sourceFilesOutsideRootDirectory = project.sourceFilesOutsideRootDirectory;
 
       // we can already link the project

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -529,7 +529,7 @@ export default async (client: Client): Promise<number> => {
       prebuilt: argv['--prebuilt'],
       rootDirectory,
       quiet,
-      wantsPublic: (argv['--public'] || localConfig.public) ?? false,
+      wantsPublic: Boolean(argv['--public'] || localConfig.public),
       nowConfig: {
         ...localConfig,
         // `images` is allowed in "vercel.json" and processed

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -511,7 +511,9 @@ export default async (client: Client): Promise<number> => {
 
   const name = project ? project.name : newProjectName;
   if (!name) {
-    throw new Error();
+    throw new Error(
+      '`name` not found on project or provided by existing project'
+    );
   }
 
   try {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -75,7 +75,8 @@ function compactObject<T>(dict: Record<string, T>) {
   const newDict: Record<string, NonNullable<T>> = {};
   for (const [key, value] of Object.entries(dict)) {
     if (typeof value !== 'undefined' && value !== null) {
-      newDict[key] = value;
+      // TS should know this is already NonNullable<T>, but oh well
+      newDict[key] = value as NonNullable<T>;
     }
   }
   return newDict;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -71,17 +71,6 @@ import { parseEnv } from '../../util/parse-env';
 import { errorToString, isErrnoException, isError } from '@vercel/error-utils';
 import { pickOverrides } from '../../util/projects/project-settings';
 
-function compactObject<T>(dict: Record<string, T>) {
-  const newDict: Record<string, NonNullable<T>> = {};
-  for (const [key, value] of Object.entries(dict)) {
-    if (typeof value !== 'undefined' && value !== null) {
-      // TS should know this is already NonNullable<T>, but oh well
-      newDict[key] = value as NonNullable<T>;
-    }
-  }
-  return newDict;
-}
-
 export default async (client: Client): Promise<number> => {
   const { output } = client;
 
@@ -481,17 +470,17 @@ export default async (client: Client): Promise<number> => {
   const gitMetadata = await createGitMeta(path, output, project);
 
   // Merge dotenv config, `env` from vercel.json, and `--env` / `-e` arguments
-  const deploymentEnv = compactObject(
-    Object.assign({}, parseEnv(localConfig.env), parseEnv(argv['--env']))
+  const deploymentEnv = Object.assign(
+    {},
+    parseEnv(localConfig.env),
+    parseEnv(argv['--env'])
   );
 
   // Merge build env out of  `build.env` from vercel.json, and `--build-env` args
-  const deploymentBuildEnv = compactObject(
-    Object.assign(
-      {},
-      parseEnv(localConfig.build && localConfig.build.env),
-      parseEnv(argv['--build-env'])
-    )
+  const deploymentBuildEnv = Object.assign(
+    {},
+    parseEnv(localConfig.build && localConfig.build.env),
+    parseEnv(argv['--build-env'])
   );
 
   // If there's any undefined values, then inherit them from this process

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -280,7 +280,7 @@ export default async (client: Client): Promise<number> => {
   let { org, project, status } = link;
 
   let newProjectName = null;
-  let rootDirectory = project?.rootDirectory;
+  let rootDirectory = project ? project.rootDirectory : null;
   let sourceFilesOutsideRootDirectory: boolean | undefined = true;
 
   if (status === 'not_linked') {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -95,7 +95,6 @@ export default async (client: Client): Promise<number> => {
       '--env': [String],
       '--build-env': [String],
       '--meta': [String],
-      '--no-alias': Boolean,
       // This is not an array in favor of matching
       // the config property name.
       '--regions': String,

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -52,7 +52,7 @@ export default async function processDeployment({
   archive?: ArchiveFormat;
   skipAutoDetectionConfirmation?: boolean;
   cwd?: string;
-  rootDirectory?: string;
+  rootDirectory?: string | null;
 }) {
   let {
     now,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -36,7 +36,7 @@ export interface CreateOptions {
   project?: string;
   wantsPublic: boolean;
   prebuilt?: boolean;
-  rootDirectory?: string;
+  rootDirectory?: string | null;
   meta: Dictionary<string>;
   gitMetadata?: GitMetadata;
   regions?: string[];

--- a/packages/cli/src/util/parse-env.ts
+++ b/packages/cli/src/util/parse-env.ts
@@ -12,9 +12,10 @@ export const parseEnv = (env?: string | string[] | Dictionary<string>) => {
   }
 
   if (Array.isArray(env)) {
+    const startingDict: Dictionary<string> = {};
     return env.reduce((o, e) => {
-      let key;
-      let value;
+      let key: string | undefined;
+      let value: string | undefined;
       const equalsSign = e.indexOf('=');
 
       if (equalsSign === -1) {
@@ -24,9 +25,12 @@ export const parseEnv = (env?: string | string[] | Dictionary<string>) => {
         value = e.slice(equalsSign + 1);
       }
 
-      o[key] = value;
+      if (typeof value !== 'undefined') {
+        o[key] = value;
+      }
+
       return o;
-    }, {} as Dictionary<string | undefined>);
+    }, startingDict);
   }
 
   // assume it's already an Object

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -24,7 +24,7 @@ export interface VercelClientOptions {
   apiUrl?: string;
   force?: boolean;
   prebuilt?: boolean;
-  rootDirectory?: string;
+  rootDirectory?: string | null;
   withCache?: boolean;
   userAgent?: string;
   defaultName?: string;


### PR DESCRIPTION
Small refactor to provide type safety to this invocation of `createDeploy`.