### PR TITLE
[cli] Enable TS path alias (doesn't work)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,8 +11,6 @@ packages/cli/@types
 packages/cli/download
 packages/cli/dist
 packages/cli/test/dev/fixtures
-packages/cli/bin
-packages/cli/link
 packages/cli/src/util/dev/templates/*.ts
 
 # client

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,55 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module",
+    "modules": true
+  },
+  "plugins": ["jest"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "env": {
+    "node": true,
+    "jest": true,
+    "es6": true
+  },
+  "rules": {
+    "no-restricted-syntax": [
+      "warn",
+      "WithStatement",
+      {
+        "message": "substr() is deprecated, use slice() or substring() instead",
+        "selector": "MemberExpression > Identifier[name='substr']"
+      }
+    ],
+    "no-dupe-keys": 2,
+    "require-atomic-updates": 0,
+    "@typescript-eslint/ban-ts-comment": 0,
+    "@typescript-eslint/camelcase": 0,
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/no-empty-function": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-non-null-assertion": 0,
+    "@typescript-eslint/no-unused-vars": 2,
+    "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/no-var-requires": 0,
+    "jest/no-disabled-tests": 2,
+    "jest/no-focused-tests": 2
+  },
+  "overrides": [
+    {
+      "files": ["packages/client/**/*"],
+      "rules": {
+        "prefer-const": 0,
+        "require-atomic-updates": 0,
+        "@typescript-eslint/ban-ts-ignore": 0,
+        "@typescript-eslint/no-explicit-any": 0
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lerna": "5.6.2"
   },
   "devDependencies": {
+    "@limegrass/eslint-plugin-import-alias": "1.0.6",
     "@types/node": "14.18.33",
     "@typescript-eslint/eslint-plugin": "5.21.0",
     "@typescript-eslint/parser": "5.21.0",
@@ -70,83 +71,5 @@
     "trailingComma": "es5",
     "singleQuote": true,
     "arrowParens": "avoid"
-  },
-  "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaVersion": 2018,
-      "sourceType": "module",
-      "modules": true
-    },
-    "plugins": [
-      "jest"
-    ],
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "prettier"
-    ],
-    "env": {
-      "node": true,
-      "jest": true,
-      "es6": true
-    },
-    "rules": {
-      "no-restricted-syntax": [
-        "warn",
-        "WithStatement",
-        {
-          "message": "substr() is deprecated, use slice() or substring() instead",
-          "selector": "MemberExpression > Identifier[name='substr']"
-        }
-      ],
-      "no-dupe-keys": 2,
-      "require-atomic-updates": 0,
-      "@typescript-eslint/ban-ts-comment": 0,
-      "@typescript-eslint/camelcase": 0,
-      "@typescript-eslint/explicit-module-boundary-types": 0,
-      "@typescript-eslint/no-empty-function": 0,
-      "@typescript-eslint/no-explicit-any": 0,
-      "@typescript-eslint/no-non-null-assertion": 0,
-      "@typescript-eslint/no-unused-vars": 2,
-      "@typescript-eslint/no-use-before-define": 0,
-      "@typescript-eslint/no-var-requires": 0,
-      "jest/no-disabled-tests": 2,
-      "jest/no-focused-tests": 2
-    },
-    "overrides": [
-      {
-        "files": [
-          "packages/cli/**/*"
-        ],
-        "rules": {
-          "lines-between-class-members": 0,
-          "no-async-promise-executor": 0,
-          "no-control-regex": 0,
-          "no-empty": 0,
-          "prefer-const": 0,
-          "prefer-destructuring": 0,
-          "@typescript-eslint/ban-types": 0,
-          "@typescript-eslint/consistent-type-assertions": 0,
-          "@typescript-eslint/member-delimiter-style": 0,
-          "@typescript-eslint/no-empty-function": 0,
-          "@typescript-eslint/no-explicit-any": 0,
-          "@typescript-eslint/no-inferrable-types": 0
-        }
-      },
-      {
-        "files": [
-          "packages/client/**/*"
-        ],
-        "rules": {
-          "prefer-const": 0,
-          "require-atomic-updates": 0,
-          "@typescript-eslint/ban-ts-ignore": 0,
-          "@typescript-eslint/no-explicit-any": 0
-        }
-      }
-    ]
   }
 }

--- a/packages/cli/.eslintignore
+++ b/packages/cli/.eslintignore
@@ -1,0 +1,5 @@
+@types
+download
+dist
+test/dev/fixtures
+src/util/dev/templates/*.ts

--- a/packages/cli/.eslintrc.json
+++ b/packages/cli/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "plugins": ["@limegrass/import-alias"],
+  "rules": {
+    "@limegrass/import-alias/import-alias": [
+      "warn",
+      {
+        "aliasConfigPath": "./packages/cli/tsconfig.json"
+      }
+    ],
+    "lines-between-class-members": 0,
+    "no-async-promise-executor": 0,
+    "no-control-regex": 0,
+    "no-empty": 0,
+    "prefer-const": 0,
+    "prefer-destructuring": 0,
+    "@typescript-eslint/ban-types": 0,
+    "@typescript-eslint/consistent-type-assertions": 0,
+    "@typescript-eslint/member-delimiter-style": 0,
+    "@typescript-eslint/no-empty-function": 0,
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-inferrable-types": 0
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,41 +18,41 @@ import sourceMap from '@zeit/source-map-support';
 import { mkdirp } from 'fs-extra';
 import chalk from 'chalk';
 import epipebomb from 'epipebomb';
-import getLatestVersion from './util/get-latest-version';
+import getLatestVersion from '~/util/get-latest-version';
 import { URL } from 'url';
 import * as Sentry from '@sentry/node';
-import hp from './util/humanize-path';
-import commands from './commands';
-import pkg from './util/pkg';
-import { Output } from './util/output';
-import cmd from './util/output/cmd';
-import info from './util/output/info';
-import error from './util/output/error';
-import param from './util/output/param';
-import highlight from './util/output/highlight';
-import getArgs from './util/get-args';
-import getUser from './util/get-user';
-import getTeams from './util/teams/get-teams';
-import Client from './util/client';
-import { handleError } from './util/error';
-import reportError from './util/report-error';
-import getConfig from './util/get-config';
-import * as configFiles from './util/config/files';
-import getGlobalPathConfig from './util/config/global-path';
+import hp from '~/util/humanize-path';
+import commands from '~/commands';
+import pkg from '~/util/pkg';
+import { Output } from '~/util/output';
+import cmd from '~/util/output/cmd';
+import info from '~/util/output/info';
+import error from '~/util/output/error';
+import param from '~/util/output/param';
+import highlight from '~/util/output/highlight';
+import getArgs from '~/util/get-args';
+import getUser from '~/util/get-user';
+import getTeams from '~/util/teams/get-teams';
+import Client from '~/util/client';
+import { handleError } from '~/util/error';
+import reportError from '~/util/report-error';
+import getConfig from '~/util/get-config';
+import * as configFiles from '~/util/config/files';
+import getGlobalPathConfig from '~/util/config/global-path';
 import {
   defaultAuthConfig,
   defaultGlobalConfig,
-} from './util/config/get-default';
-import * as ERRORS from './util/errors-ts';
-import { APIError } from './util/errors-ts';
-import { SENTRY_DSN } from './util/constants';
-import getUpdateCommand from './util/get-update-command';
-import { metrics, shouldCollectMetrics } from './util/metrics';
-import { getCommandName, getTitleName } from './util/pkg-name';
-import doLoginPrompt from './util/login/prompt';
+} from '~/util/config/get-default';
+import * as ERRORS from '~/util/errors-ts';
+import { APIError } from '~/util/errors-ts';
+import { SENTRY_DSN } from '~/util/constants';
+import getUpdateCommand from '~/util/get-update-command';
+import { metrics, shouldCollectMetrics } from '~/util/metrics';
+import { getCommandName, getTitleName } from '~/util/pkg-name';
+import doLoginPrompt from '~/util/login/prompt';
 import { AuthConfig, GlobalConfig } from '@vercel-internals/types';
 import { VercelConfig } from '@vercel/client';
-import box from './util/output/box';
+import box from '~/util/output/box';
 
 const isCanary = pkg.version.includes('canary');
 
@@ -483,76 +483,76 @@ const main = async () => {
     let func: any;
     switch (targetCommand) {
       case 'alias':
-        func = require('./commands/alias').default;
+        func = require('~/commands/alias').default;
         break;
       case 'bisect':
-        func = require('./commands/bisect').default;
+        func = require('~/commands/bisect').default;
         break;
       case 'build':
-        func = require('./commands/build').default;
+        func = require('~/commands/build').default;
         break;
       case 'certs':
-        func = require('./commands/certs').default;
+        func = require('~/commands/certs').default;
         break;
       case 'deploy':
-        func = require('./commands/deploy').default;
+        func = require('~/commands/deploy').default;
         break;
       case 'dev':
-        func = require('./commands/dev').default;
+        func = require('~/commands/dev').default;
         break;
       case 'dns':
-        func = require('./commands/dns').default;
+        func = require('~/commands/dns').default;
         break;
       case 'domains':
-        func = require('./commands/domains').default;
+        func = require('~/commands/domains').default;
         break;
       case 'env':
-        func = require('./commands/env').default;
+        func = require('~/commands/env').default;
         break;
       case 'git':
-        func = require('./commands/git').default;
+        func = require('~/commands/git').default;
         break;
       case 'init':
-        func = require('./commands/init').default;
+        func = require('~/commands/init').default;
         break;
       case 'inspect':
-        func = require('./commands/inspect').default;
+        func = require('~/commands/inspect').default;
         break;
       case 'link':
-        func = require('./commands/link').default;
+        func = require('~/commands/link').default;
         break;
       case 'list':
-        func = require('./commands/list').default;
+        func = require('~/commands/list').default;
         break;
       case 'logs':
-        func = require('./commands/logs').default;
+        func = require('~/commands/logs').default;
         break;
       case 'login':
-        func = require('./commands/login').default;
+        func = require('~/commands/login').default;
         break;
       case 'logout':
-        func = require('./commands/logout').default;
+        func = require('~/commands/logout').default;
         break;
       case 'project':
-        func = require('./commands/project').default;
+        func = require('~/commands/project').default;
         break;
       case 'pull':
-        func = require('./commands/pull').default;
+        func = require('~/commands/pull').default;
         break;
       case 'remove':
-        func = require('./commands/remove').default;
+        func = require('~/commands/remove').default;
         break;
       case 'rollback':
-        func = require('./commands/rollback').default;
+        func = require('~/commands/rollback').default;
         break;
       case 'secrets':
-        func = require('./commands/secrets').default;
+        func = require('~/commands/secrets').default;
         break;
       case 'teams':
-        func = require('./commands/teams').default;
+        func = require('~/commands/teams').default;
         break;
       case 'whoami':
-        func = require('./commands/whoami').default;
+        func = require('~/commands/whoami').default;
         break;
       default:
         func = null;

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -5,13 +5,13 @@ import { URL } from 'url';
 import { VercelConfig } from '@vercel/client';
 import retry, { RetryFunction, Options as RetryOptions } from 'async-retry';
 import fetch, { BodyInit, Headers, RequestInit, Response } from 'node-fetch';
-import ua from './ua';
-import { Output } from './output/create-output';
-import responseError from './response-error';
-import printIndications from './print-indications';
-import reauthenticate from './login/reauthenticate';
-import { SAMLError } from './login/types';
-import { writeToAuthConfigFile } from './config/files';
+import ua from '~/util/ua';
+import { Output } from '~/util/output/create-output';
+import responseError from '~/util/response-error';
+import printIndications from '~/util/print-indications';
+import reauthenticate from '~/util/login/reauthenticate';
+import { SAMLError } from '~/util/login/types';
+import { writeToAuthConfigFile } from '~/util/config/files';
 import type {
   AuthConfig,
   GlobalConfig,
@@ -20,8 +20,8 @@ import type {
   ReadableTTY,
   WritableTTY,
 } from '@vercel-internals/types';
-import { sharedPromise } from './promise';
-import { APIError } from './errors-ts';
+import { sharedPromise } from '~/util/promise';
+import { APIError } from '~/util/errors-ts';
 import { normalizeError } from '@vercel/error-utils';
 
 const isSAMLError = (v: any): v is SAMLError => {

--- a/packages/cli/test/unit/util/projects/get-vercel-directory.test.ts
+++ b/packages/cli/test/unit/util/projects/get-vercel-directory.test.ts
@@ -1,5 +1,5 @@
 import { basename, join } from 'path';
-import { getVercelDirectory } from '../../../../src/util/projects/link';
+import { getVercelDirectory } from '~/util/projects/link';
 
 const fixture = (name: string) =>
   join(__dirname, '../../../fixtures/unit', name);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,7 +12,11 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types"],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["./types", "src/**/*"],
   "ts-node": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ importers:
 
   .:
     specifiers:
+      '@limegrass/eslint-plugin-import-alias': 1.0.6
       '@types/node': 14.18.33
       '@typescript-eslint/eslint-plugin': 5.21.0
       '@typescript-eslint/parser': 5.21.0
@@ -33,6 +34,7 @@ importers:
     dependencies:
       lerna: 5.6.2
     devDependencies:
+      '@limegrass/eslint-plugin-import-alias': 1.0.6_eslint@8.14.0
       '@types/node': 14.18.33
       '@typescript-eslint/eslint-plugin': 5.21.0_5yvnzvdwzksrnum37j3gumwy4y
       '@typescript-eslint/parser': 5.21.0_eslint@8.14.0
@@ -4247,6 +4249,19 @@ packages:
       npmlog: 6.0.2
       write-file-atomic: 4.0.2
     dev: false
+
+  /@limegrass/eslint-plugin-import-alias/1.0.6_eslint@8.14.0:
+    resolution: {integrity: sha512-BtPmdHbL4NmkVh2wMnOboyOCrdLOpBqwwtBIsB0/giTiALw/UTHD9TyH4vVnbDOuWPZQgE6kKloJ9G77FApt7w==}
+    peerDependencies:
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    dependencies:
+      eslint: 8.14.0
+      find-up: 5.0.0
+      fs-extra: 10.1.0
+      micromatch: 4.0.5
+      slash: 3.0.0
+      tsconfig-paths: 3.14.2
+    dev: true
 
   /@mapbox/node-pre-gyp/1.0.10:
     resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
@@ -8636,7 +8651,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     dev: true
 
   /debug/4.1.1:
@@ -9806,7 +9821,7 @@ packages:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.11.0
-      resolve: 1.22.1
+      resolve: 1.22.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9892,7 +9907,7 @@ packages:
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.6
-      resolve: 1.22.1
+      resolve: 1.22.2
       semver: 6.3.0
       tsconfig-paths: 3.14.2
     transitivePeerDependencies:
@@ -10699,7 +10714,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: false
 
   /flat-cache/3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
@@ -10816,6 +10830,15 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
+
+  /fs-extra/10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
 
   /fs-extra/11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
@@ -11678,7 +11701,7 @@ packages:
   /humanize-ms/1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     dev: false
 
   /husky/7.0.4:
@@ -13504,7 +13527,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: false
 
   /lodash.camelcase/4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -14442,7 +14464,6 @@ packages:
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /multimatch/5.0.0:
     resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
@@ -15111,7 +15132,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: false
 
   /p-map-series/2.1.0:
     resolution: {integrity: sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q==}


### PR DESCRIPTION
Attempt at enabling path alias for Vercel CLI. Unfortunately it seems like this doesn't work because path aliases are not currently supported by ncc.