### PR TITLE
[cli] Support pnpm in `getUpdateCommand()`

### DIFF
--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -84,7 +84,14 @@ export default async function getUpdateCommand(): Promise<string> {
   const tag = isCanary() ? 'canary' : 'latest';
   const pkgAndVersion = `${getPkgName()}@${tag}`;
 
-  const { cliType } = await scanParentDirs(dirname(dirname(process.argv[1])));
+  const entrypoint = await realpath(process.argv[1]);
+  let { cliType, lockfilePath } = await scanParentDirs(
+    dirname(dirname(entrypoint))
+  );
+  if (!lockfilePath) {
+    // Global installs for npm do not have a lockfile
+    cliType = 'npm';
+  }
   const yarn = cliType === 'yarn';
 
   let install = yarn ? 'add' : 'i';

--- a/packages/cli/src/util/get-update-command.ts
+++ b/packages/cli/src/util/get-update-command.ts
@@ -1,30 +1,8 @@
-import { Stats } from 'fs';
+import { readFile, realpath } from 'fs-extra';
 import { sep, dirname, join, resolve } from 'path';
-import { lstat, readlink, readFile, realpath } from 'fs-extra';
+import { scanParentDirs } from '@vercel/build-utils';
 import { isCanary } from './is-canary';
 import { getPkgName } from './pkg-name';
-
-async function isYarn(): Promise<boolean> {
-  let s: Stats;
-  let binPath = process.argv[1];
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    s = await lstat(binPath);
-    if (s.isSymbolicLink()) {
-      binPath = resolve(dirname(binPath), await readlink(binPath));
-    } else {
-      break;
-    }
-  }
-  const pkgPath = join(dirname(binPath), '..', 'package.json');
-  /*
-   * Generally, pkgPath looks like:
-   * "/Users/username/.config/yarn/global/node_modules/vercel/package.json"
-   * "/usr/local/share/.config/yarn/global/node_modules/vercel/package.json"
-   */
-  return pkgPath.includes(join('yarn', 'global'));
-}
 
 async function getConfigPrefix() {
   const paths = [
@@ -76,6 +54,10 @@ async function isGlobal() {
       return true;
     }
 
+    if (installPath.includes(['', 'pnpm', 'global', ''].join(sep))) {
+      return true;
+    }
+
     if (installPath.includes(['', 'fnm', 'node-versions', ''].join(sep))) {
       return true;
     }
@@ -102,13 +84,17 @@ export default async function getUpdateCommand(): Promise<string> {
   const tag = isCanary() ? 'canary' : 'latest';
   const pkgAndVersion = `${getPkgName()}@${tag}`;
 
+  const { cliType } = await scanParentDirs(dirname(dirname(process.argv[1])));
+  const yarn = cliType === 'yarn';
+
+  let install = yarn ? 'add' : 'i';
   if (await isGlobal()) {
-    return (await isYarn())
-      ? `yarn global add ${pkgAndVersion}`
-      : `npm i -g ${pkgAndVersion}`;
+    if (yarn) {
+      install = 'global add';
+    } else {
+      install = 'i -g';
+    }
   }
 
-  return (await isYarn())
-    ? `yarn add ${pkgAndVersion}`
-    : `npm i ${pkgAndVersion}`;
+  return `${cliType} ${install} ${pkgAndVersion}`;
 }

--- a/packages/cli/test/unit/util/get-update-command.test.ts
+++ b/packages/cli/test/unit/util/get-update-command.test.ts
@@ -5,7 +5,7 @@ describe('getUpdateCommand', () => {
   it('should detect update command', async () => {
     const updateCommand = await getUpdateCommand();
     expect(updateCommand).toEqual(
-      `npm i vercel@${isCanary() ? 'canary' : 'latest'}`
+      `pnpm i vercel@${isCanary() ? 'canary' : 'latest'}`
     );
   });
 });


### PR DESCRIPTION
We're currently showing bad instructions when CLI was installed via pnpm:

![image](https://user-images.githubusercontent.com/71256/232131890-ecc1c2c1-ace6-48b3-bd6f-8631cf7be087.png)

This adds support for it by leveraging our existing `scanParentDirs()` logic from build-utils.