### PR TITLE
[gatsby-plugin-vercel-builder] Log validation errors

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -76,8 +76,18 @@ export async function generateVercelBuildOutputAPI3Output({
     await writeJson('.vercel/output/config.json', config);
     console.log('Vercel output has been generated');
   } else {
+    const errors = [...validateGatsbyState.Errors(state)];
     throw new Error(
-      'Gatsby state validation error. Please file an issue https://vercel.com/help#issues'
+      `Gatsby state validation failed:\n${errors
+        .map(
+          err =>
+            `  - ${err.message}, got ${typeof err.value} (${JSON.stringify(
+              err.value
+            )}) at path "${err.path}"\n`
+        )
+        .join(
+          ''
+        )}Please check your Gatsby configuration files, or file an issue at https://vercel.com/help#issues`
     );
   }
 }


### PR DESCRIPTION
Log state validation errors, because they can be user error.

Example:

```
error "gatsby-node.js" threw an error while running the onPostBuild lifecycle:

Gatsby state validation failed:
  - Expected boolean, got string ("true") at path "/redirects/0/isPermanent"
Please check your Gatsby configuration files, or file an issue at https://vercel.com/help#issues

  3 |
  4 | export const onPostBuild = async ({ store }: { store: any }) => {
> 5 |   await generateVercelBuildOutputAPI3Output({
    |         ^
  6 |     // validated by `pluginOptionSchema`
  7 |     gatsbyStoreState: store.getState(),
  8 |   });
```