### PR TITLE
[next] Update test fixture 00-app-dir-edge to use `export const runtime`

### DIFF
--- a/packages/next/test/fixtures/00-app-dir-edge/app/edge/page.js
+++ b/packages/next/test/fixtures/00-app-dir-edge/app/edge/page.js
@@ -2,6 +2,4 @@ export default function Page() {
   return <p>edge</p>;
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-};
+export const runtime = 'edge';

--- a/packages/next/test/fixtures/00-app-dir-edge/app/index/page.js
+++ b/packages/next/test/fixtures/00-app-dir-edge/app/index/page.js
@@ -2,6 +2,4 @@ export default function page() {
   return 'index/page';
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-};
+export const runtime = 'edge';

--- a/packages/next/test/fixtures/00-app-dir-edge/app/page.js
+++ b/packages/next/test/fixtures/00-app-dir-edge/app/page.js
@@ -2,6 +2,4 @@ export default function page() {
   return 'page';
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-};
+export const runtime = 'edge';


### PR DESCRIPTION
This test has started to fail consistently:

https://github.com/vercel/vercel/actions/runs/4792497815/jobs/8524784756