### PR TITLE
[node] Add log message about compiling ESM to CJS

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -337,7 +337,7 @@ async function compile(
       if (!meta.compiledToCommonJS) {
         meta.compiledToCommonJS = true;
         console.warn(
-          'Warning: Node.js functions will be compiled from ESM to CommonJS. If this was not intended, add "type": "module" to your package.json file.'
+          'Warning: Node.js functions are compiled from ESM to CommonJS. If this is not intended, add "type": "module" to your package.json file.'
         );
       }
       console.log(`Compiling "${filename}" from ESM to CommonJS...`);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -119,6 +119,7 @@ async function compile(
   baseDir: string,
   entrypointPath: string,
   config: Config,
+  meta: Meta,
   nodeVersion: NodeVersion,
   isEdgeFunction: boolean
 ): Promise<{
@@ -333,7 +334,13 @@ async function compile(
         stream: preparedFiles[path].toStream(),
       });
 
-      console.log(`Compiling "${filename}" from ESM to CommonJS modules...`);
+      if (!meta.compiledToCommonJS) {
+        meta.compiledToCommonJS = true;
+        console.log(
+          'Warning: Node.js functions will be compiled from ESM to CommonJS. If this was not intended, add "type": "module" to your package.json file.'
+        );
+      }
+      console.log(`Compiling "${filename}" from ESM to CommonJS...`);
       const { code, map } = babelCompile(filename, source);
       shouldAddSourcemapSupport = true;
       preparedFiles[path] = new FileBlob({
@@ -423,6 +430,7 @@ export const build: BuildV3 = async ({
     baseDir,
     entrypointPath,
     config,
+    meta,
     nodeVersion,
     isEdgeFunction
   );

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -336,7 +336,7 @@ async function compile(
 
       if (!meta.compiledToCommonJS) {
         meta.compiledToCommonJS = true;
-        console.log(
+        console.warn(
           'Warning: Node.js functions will be compiled from ESM to CommonJS. If this was not intended, add "type": "module" to your package.json file.'
         );
       }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -333,6 +333,7 @@ async function compile(
         stream: preparedFiles[path].toStream(),
       });
 
+      console.log(`Compiling "${filename}" from ESM to CommonJS modules...`);
       const { code, map } = babelCompile(filename, source);
       shouldAddSourcemapSupport = true;
       preparedFiles[path] = new FileBlob({


### PR DESCRIPTION
When `@vercel/node` was created 5 or so years ago, Node.js didn't support ESM out of the box. So to create a zero configuration experience, babel was introduce to compile the authored ESM into the runtime CJS.

Today, Node.js supports ESM but you have to opt in using `type: module` in package.json or the `.mjs` file extension.

Indeed `@vercel/node` detects ESM and skips babel compilation. However, there is a case where the source code is ESM and a dependency supports both ESM and CJS via `imports` in package.json. This case will break because `@vercel/nft` traces the source file as ESM and assumes the dependency will be resolved as ESM too. But after `@vercel/nft` traces the source file, `@vercel/node` will compile to CJS and thus the trace will be incorrect and fail at runtime.

So this PR adds a warning when babel compiles ESM to CJS because it is no longer expected in 2023.

