### PR TITLE
[node] use `ws` instead of `undici.WebSocket`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -34,7 +34,6 @@
     "ts-morph": "12.0.0",
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
-    "undici": "5.22.0",
     "ws": "8.13.0"
   },
   "devDependencies": {

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -133,17 +133,8 @@ async function createEdgeRuntimeServer(params?: {
 
     const wasmBindings = await params.wasmAssets.getContext();
     const nodeCompatBindings = params.nodeCompatBindings.getContext();
-
-    let WebSocket: any;
-
-    // undici's WebSocket handling is only available in Node.js >= 18
-    // so fallback to using ws for v16
-    if (Number(process.version.split('.')[0].substring(1)) < 18) {
-      // @ts-ignore
-      WebSocket = (await import('ws')).WebSocket;
-    } else {
-      WebSocket = (await import('undici')).WebSocket;
-    }
+    // @ts-ignore
+    const WebSocket = (await import('ws')).WebSocket;
 
     const runtime = new EdgeRuntime({
       initialCode: params.userCode,
@@ -151,7 +142,6 @@ async function createEdgeRuntimeServer(params?: {
         Object.assign(context, {
           // This is required for esbuild wrapping logic to resolve
           module: {},
-
           WebSocket,
 
           // This is required for environment variable access.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,9 +1214,6 @@ importers:
       typescript:
         specifier: 4.9.5
         version: 4.9.5
-      undici:
-        specifier: 5.22.0
-        version: 5.22.0
       ws:
         specifier: 8.13.0
         version: 8.13.0
@@ -7821,13 +7818,6 @@ packages:
       esbuild: 0.14.54
       load-tsconfig: 0.2.3
     dev: true
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: false
 
   /byte-size@7.0.1:
     resolution: {integrity: sha512-crQdqyCwhokxwV1UyDzLZanhkugAgft7vt0qbbdt60C6Zf3CAiGmtUCylbtYwrU6loOUw3euGrNtW1J651ot1A==}
@@ -17037,11 +17027,6 @@ packages:
       stream-to-array: 2.3.0
     dev: true
 
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-    dev: false
-
   /string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
@@ -18047,13 +18032,6 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
     dev: true
-
-  /undici@5.22.0:
-    resolution: {integrity: sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      busboy: 1.6.0
-    dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
The `WebSocket` constructor exposed by `undici` is not working against some db connections.

That can be considered kind of expected since `undici` docs is saying it's experimental.

We're working into isolate the issue and report at `undici` repository, but for now, let's just use `ws` for all the node versions.