### PR TITLE
[remix] Use `debug()` for warnings when reading config file

### DIFF
--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs } from 'fs';
 import { join, relative, resolve } from 'path';
 import { pathToRegexp, Key } from 'path-to-regexp';
-import { spawnAsync } from '@vercel/build-utils';
+import { debug, spawnAsync } from '@vercel/build-utils';
 import { readConfig } from '@remix-run/dev/dist/config';
 import type {
   ConfigRoute,
@@ -225,11 +225,15 @@ export async function chdirAndReadConfig(dir: string, packageJsonPath: string) {
     modifiedPackageJson = true;
   }
 
+  // Suppress any warnings emitted from `readConfig()` to avoid
+  // printing them > 1 time. They will already be printed during
+  // `remix build` when invoking the Build Command.
   const warn = console.warn;
+  console.warn = debug;
+
   let remixConfig: RemixConfig;
   try {
     process.chdir(dir);
-    console.warn = () => {};
     remixConfig = await readConfig(dir);
   } finally {
     console.warn = warn;


### PR DESCRIPTION
Follow-up to address this comment: https://github.com/vercel/vercel/pull/9888#discussion_r1182739621