### PR TITLE
[frameworks] Add `getOutputDirName` to Storybook definition

### DIFF
--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1962,6 +1962,7 @@ export const frameworks = [
       outputDirectory: {
         value: 'storybook-static',
       },
+      getOutputDirName: async () => 'storybook-static',
     },
   },
   {

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1962,8 +1962,8 @@ export const frameworks = [
       outputDirectory: {
         value: 'storybook-static',
       },
-      getOutputDirName: async () => 'storybook-static',
     },
+    getOutputDirName: async () => 'storybook-static',
   },
   {
     name: 'Other',


### PR DESCRIPTION
This was missing from the Storybook definition, causing deployment failures.