### PR TITLE
[node] Explicitly set 'set-cookie' header

### DIFF
--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -109,10 +109,8 @@ async function onDevRequest(
     for (const [key, value] of headers as unknown as Headers) {
       // node-fetch does not support headers.getSetCookie(), so we need to
       // manually set the raw value which can be an array of strings
-      if (key === 'set-cookie') {
-        res.setHeader(key, headers.raw()[key]); // jam it in there
-      } else if (value !== undefined) {
-        res.setHeader(key, value);
+      if (value !== undefined) {
+        res.setHeader(key, key === 'set-cookie' ? headers.raw()[key] : value);
       }
     }
 

--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -105,8 +105,13 @@ async function onDevRequest(
   try {
     const { headers, body, status } = await handleEvent(req);
     res.statusCode = status;
+
     for (const [key, value] of headers as unknown as Headers) {
-      if (value !== undefined) {
+      // node-fetch does not support headers.getSetCookie(), so we need to
+      // manually set the raw value which can be an array of strings
+      if (key === 'set-cookie') {
+        res.setHeader(key, headers.raw()[key]); // jam it in there
+      } else if (value !== undefined) {
         res.setHeader(key, value);
       }
     }


### PR DESCRIPTION
When looping over the response headers returned by `node-fetch`, it will join `set-cookie` header value into a single string. The whatwg calls for a `headers.getSetCookie()` function to handle the `set-cookie` special case, but `node-fetch@2.x` doesn't support it.

As a workaround, we need to grab the raw `set-cookie` header value.