### PR TITLE
[frameworks] validate getOutputDirName and other missing values on framework entries

### DIFF
--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -297,7 +297,7 @@ function getValidator() {
 
   ajv.addKeyword('isFunction', {
     compile: shouldMatch => data => {
-      const matches = data instanceof Function;
+      const matches = typeof data === 'function';
       return (shouldMatch && matches) || (!shouldMatch && !matches);
     },
   });

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -62,10 +62,25 @@ const SchemaSettings = {
   ],
 };
 
+const RouteSchema = {
+  type: 'array',
+  items: {
+    properties: {
+      src: { type: 'string' },
+      dest: { type: 'string' },
+      status: { type: 'number' },
+      handle: { type: 'string' },
+      headers: { type: 'object' },
+      continue: { type: 'boolean' },
+    },
+  },
+};
+
 const Schema = {
   type: 'array',
   items: {
     type: 'object',
+    additionalProperties: false,
     required: [
       'name',
       'slug',
@@ -79,6 +94,8 @@ const Schema = {
       slug: { type: ['string', 'null'] },
       sort: { type: 'number' },
       logo: { type: 'string' },
+      darkModeLogo: { type: 'string' },
+      screenshot: { type: 'string' },
       demo: { type: 'string' },
       tagline: { type: 'string' },
       website: { type: 'string' },
@@ -125,6 +142,23 @@ const Schema = {
       },
       getOutputDirName: {
         isFunction: true,
+      },
+      defaultRoutes: {
+        oneOf: [{ isFunction: true }, RouteSchema],
+      },
+      defaulHeaders: {
+        type: 'array',
+        items: {
+          properties: {
+            source: { type: 'string' },
+            regex: { type: 'string' },
+            headers: { type: 'object' },
+            continue: { type: 'boolean' },
+          },
+        },
+      },
+      disableRootMiddleware: {
+        type: 'boolean',
       },
       recommendedIntegrations: {
         type: 'array',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -66,7 +66,14 @@ const Schema = {
   type: 'array',
   items: {
     type: 'object',
-    required: ['name', 'slug', 'logo', 'description', 'settings'],
+    required: [
+      'name',
+      'slug',
+      'logo',
+      'description',
+      'settings',
+      'getOutputDirName',
+    ],
     properties: {
       name: { type: 'string' },
       slug: { type: ['string', 'null'] },
@@ -115,6 +122,9 @@ const Schema = {
           devCommand: SchemaSettings,
           outputDirectory: SchemaSettings,
         },
+      },
+      getOutputDirName: {
+        isFunction: true,
       },
       recommendedIntegrations: {
         type: 'array',
@@ -167,7 +177,8 @@ describe('frameworks', () => {
   });
 
   it('ensure schema', async () => {
-    const ajv = new Ajv();
+    const ajv = getValidator();
+
     const result = ajv.validate(Schema, frameworkList);
 
     if (ajv.errors) {
@@ -246,3 +257,16 @@ describe('frameworks', () => {
     );
   });
 });
+
+function getValidator() {
+  const ajv = new Ajv();
+
+  ajv.addKeyword('isFunction', {
+    compile: shouldMatch => data => {
+      const matches = data instanceof Function;
+      return (shouldMatch && matches) || (!shouldMatch && !matches);
+    },
+  });
+
+  return ajv;
+}


### PR DESCRIPTION
Covers the validation in Framework entries over function properties and other missing holes.