### PR TITLE
[cli][node] upgrade `async-listen` to 3.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -100,7 +100,7 @@
     "ansi-escapes": "4.3.2",
     "ansi-regex": "5.0.1",
     "arg": "5.0.0",
-    "async-listen": "1.2.0",
+    "async-listen": "3.0.0",
     "async-retry": "1.1.3",
     "async-sema": "2.1.4",
     "bytes": "3.0.0",

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import fetch from 'node-fetch';
 import plural from 'pluralize';
 import rawBody from 'raw-body';
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import minimatch from 'minimatch';
 import httpProxy from 'http-proxy';
 import { randomBytes } from 'crypto';
@@ -860,7 +860,7 @@ export default class DevServer {
     let address: string | null = null;
     while (typeof address !== 'string') {
       try {
-        address = await listen(this.server, ...listenSpec);
+        address = (await listen(this.server, ...listenSpec)).toString();
       } catch (err: unknown) {
         if (isErrnoException(err)) {
           this.output.debug(`Got listen error: ${err.code}`);

--- a/packages/cli/src/util/login/oauth.ts
+++ b/packages/cli/src/util/login/oauth.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import open from 'open';
 import { URL } from 'url';
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import isDocker from 'is-docker';
 import Client from '../client';
 import prompt, { readInput } from './prompt';
@@ -64,8 +64,7 @@ async function getVerificationTokenInBand(
 ) {
   const { output } = client;
   const server = http.createServer();
-  const address = await listen(server, 0, '127.0.0.1');
-  const { port } = new URL(address);
+  const { port } = await listen(server, 0, '127.0.0.1');
   url.searchParams.set('next', `http://localhost:${port}`);
 
   output.log(`Please visit the following URL in your web browser:`);

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import url from 'url';
 import fs from 'fs-extra';
 import { join } from 'path';
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import stripAnsi from 'strip-ansi';
 import { createServer } from 'http';
 

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { PassThrough } from 'stream';
 import { createServer, Server } from 'http';
 import express, { Express, Router } from 'express';
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import Client from '../../src/util/client';
 import { Output } from '../../src/util/output';
 

--- a/packages/cli/test/unit/util/client.test.ts
+++ b/packages/cli/test/unit/util/client.test.ts
@@ -1,4 +1,4 @@
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import { createProxy } from 'proxy';
 import { ProxyAgent } from 'proxy-agent';
 import { client } from '../../mocks/client';
@@ -12,7 +12,7 @@ describe('Client', () => {
     it('should respect the `HTTPS_PROXY` env var', async () => {
       let connectCount = 0;
       const proxy = createProxy();
-      const proxyUrl = new URL(await listen(proxy));
+      const proxyUrl = await listen(proxy);
       proxy.on('connect', () => {
         connectCount++;
       });

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import listen from 'async-listen';
+import { listen } from 'async-listen';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import type { JSONValue } from '@vercel-internals/types';
 import {
@@ -22,7 +22,7 @@ describe('responseError()', () => {
 
   beforeAll(async () => {
     server = createServer((req, res) => handler(req, res));
-    url = await listen(server);
+    url = (await listen(server)).toString();
   });
 
   afterAll(() => {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -25,7 +25,7 @@
     "@vercel/build-utils": "6.7.2",
     "@vercel/error-utils": "1.0.8",
     "@vercel/static-config": "2.0.17",
-    "async-listen": "1.2.0",
+    "async-listen": "3.0.0",
     "edge-runtime": "2.1.4",
     "esbuild": "0.14.47",
     "exit-hook": "2.2.1",

--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -15,9 +15,7 @@ import { createServerlessEventHandler } from './serverless-functions/serverless-
 import { isEdgeRuntime, logError, validateConfiguredRuntime } from './utils.js';
 import { getConfig } from '@vercel/static-config';
 import { Project } from 'ts-morph';
-import asyncListen from 'async-listen';
-
-const { default: listen } = asyncListen;
+import { listen } from 'async-listen';
 
 const parseConfig = (entryPointPath: string) =>
   getConfig(new Project(), entryPointPath);

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -4,14 +4,12 @@ import { serializeBody } from '../utils.js';
 import { streamToBuffer } from '@vercel/build-utils';
 import exitHook from 'exit-hook';
 import fetch from 'node-fetch';
-import asyncListen from 'async-listen';
+import { listen } from 'async-listen';
 import { isAbsolute } from 'path';
 import { pathToFileURL } from 'url';
 import type { ServerResponse, IncomingMessage } from 'http';
 import type { VercelProxyResponse } from '../types.js';
 import type { VercelRequest, VercelResponse } from './helpers.js';
-
-const { default: listen } = asyncListen;
 
 type ServerlessServerOptions = {
   shouldAddHelpers: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,8 +508,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0
       async-listen:
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 3.0.0
+        version: 3.0.0
       async-retry:
         specifier: 1.1.3
         version: 1.1.3
@@ -1194,8 +1194,8 @@ importers:
         specifier: 2.0.17
         version: link:../static-config
       async-listen:
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 3.0.0
+        version: 3.0.0
       edge-runtime:
         specifier: 2.1.4
         version: 2.1.4
@@ -7390,11 +7390,16 @@ packages:
 
   /async-listen@1.2.0:
     resolution: {integrity: sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==}
+    dev: true
 
   /async-listen@2.0.3:
     resolution: {integrity: sha512-WVLi/FGIQaXyfYyNvmkwKT1RZbkzszLLnmW/gFCc5lbVvN/0QQCWpBwRBk2OWSdkkmKRBc8yD6BrKsjA3XKaSw==}
     engines: {node: '>= 14'}
     dev: false
+
+  /async-listen@3.0.0:
+    resolution: {integrity: sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==}
+    engines: {node: '>= 14'}
 
   /async-retry@1.1.3:
     resolution: {integrity: sha512-fiAB2uaoAoUS5Ua75XFGoMKF4hmQ5H4u4gsINUjwPNof5dygJS1zyL9mh0SOmIkzAwGijwG4ybLNc8yG2OGpEQ==}


### PR DESCRIPTION
The `async-listen@3.0.0` is ESM ready and always returns a `URL` instance; That helps us to unify code.