### PR TITLE
[cli] refactor help output around default and deploy commands

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -53,7 +53,6 @@ export const help = () => `
 )}    Path to the global ${'`.vercel`'} directory
     -d, --debug                    Debug mode [off]
     --no-color                     No color mode [off]
-    -f, --force                    Force a new deployment even if nothing has changed
     -S, --scope                    Set a custom scope
     -t ${chalk.underline('TOKEN')}, --token=${chalk.underline(
   'TOKEN'

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,81 @@
+import chalk from 'chalk';
+import logo from './util/output/logo';
+import { getPkgName } from './util/pkg-name';
+
+export const help = () => `
+  ${chalk.bold(`${logo} ${getPkgName()}`)} [options] <command | path>
+
+  ${chalk.dim('Commands:')}
+
+    ${chalk.dim('Basic')}
+
+      deploy               [path]      Performs a deployment ${chalk.bold(
+        '(default)'
+      )}
+      dev                              Start a local development server
+      env                              Manages the Environment Variables for your current Project
+      git                              Manage Git provider repository for your current Project
+      help                 [cmd]       Displays complete help for [cmd]
+      init                 [example]   Initialize an example project
+      inspect              [id]        Displays information related to a deployment
+      link                 [path]      Link local directory to a Vercel Project
+      ls | list            [app]       Lists deployments
+      login                [email]     Logs into your account or creates a new one
+      logout                           Logs out of your account
+      pull                 [path]      Pull your Project Settings from the cloud
+      rollback             [url|id]    Quickly revert back to a previous deployment [beta]
+      switch               [scope]     Switches between teams and your personal account
+
+    ${chalk.dim('Advanced')}
+
+      alias                [cmd]       Manages your domain aliases
+      bisect                           Use binary search to find the deployment that introduced a bug
+      certs                [cmd]       Manages your SSL certificates
+      dns                  [name]      Manages your DNS records
+      domains              [name]      Manages your domain names
+      logs                 [url]       Displays the logs for a deployment
+      projects                         Manages your Projects
+      rm | remove          [id]        Removes a deployment
+      secrets              [name]      Manages your global Secrets, for use in Environment Variables
+      teams                            Manages your teams
+      whoami                           Shows the username of the currently logged in user
+
+  ${chalk.dim('Options:')}
+
+    -h, --help                     Output usage information
+    -v, --version                  Output the version number
+    --cwd                          Current working directory
+    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
+  'FILE'
+)}   Path to the local ${'`vercel.json`'} file
+    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
+  'DIR'
+)}    Path to the global ${'`.vercel`'} directory
+    -d, --debug                    Debug mode [off]
+    --no-color                     No color mode [off]
+    -f, --force                    Force a new deployment even if nothing has changed
+    -S, --scope                    Set a custom scope
+    -t ${chalk.underline('TOKEN')}, --token=${chalk.underline(
+  'TOKEN'
+)}        Login token
+
+  ${chalk.dim('Examples:')}
+
+  ${chalk.gray('–')} Deploy the current directory
+
+    ${chalk.cyan(`$ ${getPkgName()}`)}
+
+  ${chalk.gray('–')} Deploy a custom path
+
+    ${chalk.cyan(`$ ${getPkgName()} /usr/src/project`)}
+
+  ${chalk.gray('–')} Deploy with Environment Variables
+
+    ${chalk.cyan(`$ ${getPkgName()} -e NODE_ENV=production`)}
+
+  ${chalk.gray('–')} Show the usage information for the sub command ${chalk.dim(
+  '`list`'
+)}
+
+    ${chalk.cyan(`$ ${getPkgName()} help list`)}
+`;

--- a/packages/cli/src/commands/deploy/args.ts
+++ b/packages/cli/src/commands/deploy/args.ts
@@ -2,80 +2,27 @@ import chalk from 'chalk';
 import logo from '../../util/output/logo';
 import { getPkgName } from '../../util/pkg-name';
 
-export const help = () => `
-  ${chalk.bold(`${logo} ${getPkgName()}`)} [options] <command | path>
+export const help = () => {
+  return `
+  ${chalk.bold(`${logo} ${getPkgName()} [deploy]`)} [path-to-project] [options]
 
-  ${chalk.dim('Commands:')}
-
-    ${chalk.dim('Basic')}
-
-      deploy               [path]      Performs a deployment ${chalk.bold(
-        '(default)'
-      )}
-      dev                              Start a local development server
-      env                              Manages the Environment Variables for your current Project
-      git                              Manage Git provider repository for your current Project
-      help                 [cmd]       Displays complete help for [cmd]
-      init                 [example]   Initialize an example project
-      inspect              [id]        Displays information related to a deployment
-      link                 [path]      Link local directory to a Vercel Project
-      ls | list            [app]       Lists deployments
-      login                [email]     Logs into your account or creates a new one
-      logout                           Logs out of your account
-      pull                 [path]      Pull your Project Settings from the cloud
-      rollback             [url|id]    Quickly revert back to a previous deployment [beta]
-      switch               [scope]     Switches between teams and your personal account
-
-    ${chalk.dim('Advanced')}
-
-      alias                [cmd]       Manages your domain aliases
-      bisect                           Use binary search to find the deployment that introduced a bug
-      certs                [cmd]       Manages your SSL certificates
-      dns                  [name]      Manages your DNS records
-      domains              [name]      Manages your domain names
-      logs                 [url]       Displays the logs for a deployment
-      projects                         Manages your Projects
-      rm | remove          [id]        Removes a deployment
-      secrets              [name]      Manages your global Secrets, for use in Environment Variables
-      teams                            Manages your teams
-      whoami                           Shows the username of the currently logged in user
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                     Output usage information
-    -v, --version                  Output the version number
-    --cwd                          Current working directory
-    -V, --platform-version         Set the platform version to deploy to
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-  'FILE'
-)}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-  'DIR'
-)}    Path to the global ${'`.vercel`'} directory
-    -d, --debug                    Debug mode [off]
-    --no-color                     No color mode [off]
-    -f, --force                    Force a new deployment even if nothing has changed
-    --with-cache                   Retain build cache when using "--force"
-    -t ${chalk.underline('TOKEN')}, --token=${chalk.underline(
-  'TOKEN'
-)}        Login token
-    -p, --public                   Deployment is public (${chalk.dim(
-      '`/_src`'
-    )} is exposed)
-    -e, --env                      Include an env var during run time (e.g.: ${chalk.dim(
-      '`-e KEY=value`'
-    )}). Can appear many times.
-    -b, --build-env                Similar to ${chalk.dim(
-      '`--env`'
-    )} but for build time only.
-    -m, --meta                     Add metadata for the deployment (e.g.: ${chalk.dim(
-      '`-m KEY=value`'
-    )}). Can appear many times.
-    --no-wait                      Don't wait for the deployment to finish
-    -S, --scope                    Set a custom scope
-    --regions                      Set default regions to enable the deployment on
-    --prod                         Create a production deployment
-    -y, --yes                      Skip questions when setting up new project using default scope and settings
+  --prod                         Create a production deployment
+  -p, --public                   Deployment is public (${chalk.dim(
+    '`/_src`'
+  )} is exposed)
+  -e, --env                      Include an env var during run time (e.g.: ${chalk.dim(
+    '`-e KEY=value`'
+  )}). Can appear many times.
+  -b, --build-env                Similar to ${chalk.dim(
+    '`--env`'
+  )} but for build time only.
+  -m, --meta                     Add metadata for the deployment (e.g.: ${chalk.dim(
+    '`-m KEY=value`'
+  )}). Can appear many times.
+  --no-wait                      Don't wait for the deployment to finish
+  -f, --force                    Force a new deployment even if nothing has changed
+  --with-cache                   Retain build cache when using "--force"
+  --regions                      Set default regions to enable the deployment on
 
   ${chalk.dim('Examples:')}
 
@@ -89,14 +36,15 @@ export const help = () => `
 
   ${chalk.gray('–')} Deploy with Environment Variables
 
-    ${chalk.cyan(
-      `$ ${getPkgName()} -e NODE_ENV=production -e SECRET=@mysql-secret`
-    )}
+    ${chalk.cyan(`$ ${getPkgName()} -e NODE_ENV=production`)}
 
-  ${chalk.gray('–')} Show the usage information for the sub command ${chalk.dim(
-  '`list`'
-)}
+  ${chalk.gray('–')} Deploy with prebuilt outputs
 
-    ${chalk.cyan(`$ ${getPkgName()} help list`)}
+    ${chalk.cyan(`$ ${getPkgName()} build`)}
+    ${chalk.cyan(`$ ${getPkgName()} deploy --prebuilt`)}
 
+  ${chalk.gray('–')} Save reference to Deployment URL
+
+    ${chalk.cyan(`$ ${getPkgName()} > deployment-url.txt`)}
 `;
+};

--- a/packages/cli/src/commands/deploy/args.ts
+++ b/packages/cli/src/commands/deploy/args.ts
@@ -43,7 +43,7 @@ export const help = () => {
     ${chalk.cyan(`$ ${getPkgName()} build`)}
     ${chalk.cyan(`$ ${getPkgName()} deploy --prebuilt`)}
 
-  ${chalk.gray('–')} Save reference to Deployment URL
+  ${chalk.gray('–')} Write Deployment URL to a file
 
     ${chalk.cyan(`$ ${getPkgName()} > deployment-url.txt`)}
 `;

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -52,7 +52,7 @@ export default async function main(client: Client) {
   try {
     argv = getArgs(client.argv.slice(2), {
       '--force': Boolean,
-      '-f': Boolean,
+      '-f': '--force',
     });
     args = getSubcommand(argv._.slice(1), COMMAND_CONFIG).args;
   } catch (err) {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -35,7 +35,7 @@ export default async function init(
 ) {
   const { output } = client;
   const [name, dir] = args;
-  const force = opts['-f'] || opts['--force'];
+  const force = opts['--force'];
 
   const examples = await fetchExampleList(client);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,6 +54,7 @@ import type { AuthConfig, GlobalConfig } from '@vercel-internals/types';
 import { VercelConfig } from '@vercel/client';
 import box from './util/output/box';
 import { ProxyAgent } from 'proxy-agent';
+import { help } from './args';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -152,6 +153,7 @@ const main = async () => {
   //  * a path to deploy (as in: `vercel path/`)
   //  * a subcommand (as in: `vercel ls`)
   const targetOrSubcommand = argv._[2];
+  const subSubCommand = argv._[3];
 
   // Currently no beta commands - add here as needed
   const betaCommands: string[] = ['rollback'];
@@ -171,6 +173,14 @@ const main = async () => {
   if (!targetOrSubcommand && argv['--version']) {
     console.log(pkg.version);
     return 0;
+  }
+
+  // Handle bare `-h` directly
+  const bareHelpOption = !targetOrSubcommand && argv['--help'];
+  const bareHelpSubcommand = targetOrSubcommand === 'help' && !subSubCommand;
+  if (bareHelpOption || bareHelpSubcommand) {
+    output.print(help());
+    return 2;
   }
 
   // Ensure that the Vercel global configuration directory exists
@@ -300,7 +310,7 @@ const main = async () => {
   }
 
   if (subcommand === 'help') {
-    subcommand = argv._[3] || 'deploy';
+    subcommand = subSubCommand || 'deploy';
     client.argv.push('-h');
   }
 
@@ -411,7 +421,7 @@ const main = async () => {
     targetCommand !== 'login' &&
     targetCommand !== 'dev' &&
     targetCommand !== 'build' &&
-    !(targetCommand === 'teams' && argv._[3] !== 'invite')
+    !(targetCommand === 'teams' && subSubCommand !== 'invite')
   ) {
     let user = null;
 

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -2,9 +2,6 @@ const ARG_COMMON = {
   '--help': Boolean,
   '-h': '--help',
 
-  '--platform-version': Number,
-  '-V': '--platform-version',
-
   '--debug': Boolean,
   '-d': '--debug',
 
@@ -28,6 +25,10 @@ const ARG_COMMON = {
   '--api': String,
 
   '--cwd': String,
+
+  // Deprecated
+  '--platform-version': Number,
+  '-V': '--platform-version',
 };
 
 export default () => ARG_COMMON;


### PR DESCRIPTION
When getting help output for the default command `vc --help`, you get a list of commands. When you specify the `deploy` command with `vc deploy --help`, you get the same list of commands.

This PR makes a distinction between an explicit `deploy` command and a default one for the purposes of help output.

Should show CLI help:

- `vc -h`
- `vc --help`
- `vc help`

Should show `deploy` command help:

- `vc deploy -h`
- `vc deploy --help`
- `vc help deploy`
