### PR TITLE
[cli] rename global options in help output

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -5,6 +5,8 @@ import { getPkgName } from './util/pkg-name';
 export const help = () => `
   ${chalk.bold(`${logo} ${getPkgName()}`)} [options] <command | path>
 
+  ${chalk.dim('For deploy command help, run `vercel deploy --help`.')}
+
   ${chalk.dim('Commands:')}
 
     ${chalk.dim('Basic')}
@@ -40,7 +42,7 @@ export const help = () => `
       teams                            Manages your teams
       whoami                           Shows the username of the currently logged in user
 
-  ${chalk.dim('Options:')}
+  ${chalk.dim('Global Options:')}
 
     -h, --help                     Output usage information
     -v, --version                  Output the version number

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -5,7 +5,7 @@ import { getPkgName } from './util/pkg-name';
 export const help = () => `
   ${chalk.bold(`${logo} ${getPkgName()}`)} [options] <command | path>
 
-  ${chalk.dim('For deploy command help, run `vercel deploy --help`.')}
+  ${chalk.dim('For deploy command help, run `vercel deploy --help`')}
 
   ${chalk.dim('Commands:')}
 


### PR DESCRIPTION
Make the distinction between global and deploy options more clear.

The dim note about how to get `deploy`-specific help:

<img width="670" alt="Screenshot 2023-05-05 at 3 55 49 PM" src="https://user-images.githubusercontent.com/41545/236568356-10b9ce4f-2865-4267-a3eb-3488df88a133.png">
