### PR TITLE
Create release PR as "Vercel Bot" and remove `CHANGELOG.md` files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           version: pnpm version:prepare
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           NPM_CONFIG_PROVENANCE: 'true'
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile",
+    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile && rm -f packages/*/CHANGELOG.md",
     "release": "changeset publish"
   },
   "lint-staged": {


### PR DESCRIPTION
* Have changesets create the release PR as "Vercel Bot", so that the tests run.
* Remove the `CHANGELOG.md` files. They are redundant with the GH Releases which contain the same information.