### PR TITLE
Use Svelte's changelog generator and don't delete `CHANGELOG.md`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@svitejs/changesets-changelog-github-compact",
+    { "repo": "vercel/vercel" }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile && rm -f packages/*/CHANGELOG.md",
+    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile",
     "release": "changeset publish"
   },
   "lint-staged": {


### PR DESCRIPTION
Partial revert of #9932, since apparently [that didn't work](https://github.com/vercel/vercel/actions/runs/4941266637/jobs/8833725828).

We can investigate that more later, but this gets it working again properly at least.

Also use Svelte's changelog generator, since it includes the PR numbers which Sean wanted.