### PR TITLE
Add `id-token: write` permissions to enable npm publish provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Was previously added in https://github.com/vercel/vercel/pull/9583, was missed in the changesets switchover.