### PR TITLE
[tests] make prettier ignore .changeset

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ packages/gatsby-plugin-vercel-analytics
 node_modules
 dist
 pnpm-lock.yaml
+.changeset
 .vscode
 .DS_Store
 .next


### PR DESCRIPTION
You will get a lint failure if prettier runs on `.changeset/*` files. This PR prevents that.