### PR TITLE
[release] Promote `vercel` CLI release to "latest"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,15 @@ jobs:
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+      - name: Set latest Release to `vercel` (if a Publish Happened)
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          script: |
+            const script = require('./utils/update-latest-release.js')
+            await script({ github, context })
+
       - name: Trigger Update (if a Publish Happened)
         if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v6

--- a/utils/update-latest-release.js
+++ b/utils/update-latest-release.js
@@ -1,0 +1,24 @@
+module.exports = async ({ github, context }) => {
+  const { owner, repo } = context.repo;
+  const response = await github.repos.listReleases({ owner, repo });
+
+  function isVercelCliRelease(release) {
+    return release.tag_name.startsWith('vercel@');
+  }
+
+  const latestRelease = response.data[0];
+  if (isVercelCliRelease(latestRelease)) {
+    console.log(`Latest release is "${latestRelease.tag_name}" - skipping`);
+    return;
+  }
+
+  const latestVercelRelease = response.data.find(isVercelCliRelease);
+  console.log(`Promoting "${latestVercelRelease.tag_name}" to latest release`);
+
+  await github.repos.updateRelease({
+    owner,
+    repo,
+    release_id: latestVercelRelease.id,
+    make_latest: true,
+  });
+};


### PR DESCRIPTION
It's possible that changesets will promote a release to latest that is not the Vercel CLI release. This script ensures that a `vercel@` release is always the latest after a publish happens.