### PR TITLE
[cli] Sort keys in `vc env pull`

### DIFF
--- a/.changeset/quiet-avocados-pretend.md
+++ b/.changeset/quiet-avocados-pretend.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Sort environment variables alphabetically in `vercel env pull`

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -122,8 +122,9 @@ export default async function pull(
 
   const contents =
     CONTENTS_PREFIX +
-    Object.entries(records)
-      .map(([key, value]) => `${key}="${escapeValue(value)}"`)
+    Object.keys(records)
+      .sort()
+      .map(key => `${key}="${escapeValue(records[key])}"`)
       .join('\n') +
     '\n';
 

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -33,6 +33,16 @@ const envs: ProjectEnvVariable[] = [
   },
   {
     type: 'encrypted',
+    id: '781dt89g8r2h789g',
+    key: 'ANOTHER',
+    value: 'one',
+    target: ['preview'],
+    configurationId: null,
+    updatedAt: 1557241361455,
+    createdAt: 1557241361455,
+  },
+  {
+    type: 'encrypted',
     id: 'r124t6frtu25df16',
     key: 'SQL_CONNECTION_STRING',
     value: 'Server=sql.example.com;Database=app;Uid=root;Pwd=P455W0RD;',

--- a/packages/cli/test/unit/commands/env.test.ts
+++ b/packages/cli/test/unit/commands/env.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { parse } from 'dotenv';
 import env from '../../../src/commands/env';
 import { setupUnitFixture } from '../../helpers/setup-unit-fixture';
 import { client } from '../../mocks/client';
@@ -103,6 +104,13 @@ describe('env', () => {
       expect(rawDevEnv).toContain(
         'BRANCH_ENV_VAR="env var for a specific branch"'
       );
+
+      const parsed = parse(rawDevEnv);
+      const keys = Object.keys(parsed);
+      expect(keys).toHaveLength(3);
+      expect(keys[0]).toEqual('ANOTHER');
+      expect(keys[1]).toEqual('BRANCH_ENV_VAR');
+      expect(keys[2]).toEqual('REDIS_CONNECTION_STRING');
     });
 
     it('should handle alternate filename', async () => {


### PR DESCRIPTION
Makes sense to have the output be deterministic. Alphabetical sort seems like a logical choice.