### PR TITLE
fix release script

### DIFF
--- a/utils/update-latest-release.js
+++ b/utils/update-latest-release.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context }) => {
   const { owner, repo } = context.repo;
-  const response = await github.repos.listReleases({ owner, repo });
+  const response = await github.rest.repos.listReleases({ owner, repo });
 
   function isVercelCliRelease(release) {
     return release.tag_name.startsWith('vercel@');
@@ -15,7 +15,7 @@ module.exports = async ({ github, context }) => {
   const latestVercelRelease = response.data.find(isVercelCliRelease);
   console.log(`Promoting "${latestVercelRelease.tag_name}" to latest release`);
 
-  await github.repos.updateRelease({
+  await github.rest.repos.updateRelease({
     owner,
     repo,
     release_id: latestVercelRelease.id,


### PR DESCRIPTION
The [previous PR](https://github.com/vercel/vercel/pull/9942) used `github.repos`, but I think this needs to be `github.rest.repos`.

- [Docs](https://octokit.github.io/rest.js/v19#repos)
- [Failed GH Action](https://github.com/vercel/vercel/actions/runs/4994578940/jobs/8945329301)