### PR TITLE
[next] Ensure un-necessary rsc routes are not added

### DIFF
--- a/.changeset/eleven-pumpkins-breathe.md
+++ b/.changeset/eleven-pumpkins-breathe.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Ensure un-necessary rsc routes are not added

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -65,6 +65,13 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
       }
     }
 
+    expect(
+      buildResult.routes.some(
+        route =>
+          route.src?.includes('_next/data') && route.src?.includes('.rsc')
+      )
+    ).toBeFalsy();
+
     expect(lambdas.size).toBe(3);
     expect(buildResult.output['dashboard']).toBeDefined();
     expect(buildResult.output['dashboard/another']).toBeDefined();


### PR DESCRIPTION
These routes aren't needed for RSC as `_next/data` isn't used for routing app paths. 

x-ref: [slack thread](https://vercel.slack.com/archives/C058FQFKAGH/p1684272340654679?thread_ts=1684271538.503259&cid=C058FQFKAGH)