### PR TITLE
ensure cleanup after the gatsby plugin runs

### DIFF
--- a/.changeset/odd-elephants-reply.md
+++ b/.changeset/odd-elephants-reply.md
@@ -1,0 +1,5 @@
+---
+"@vercel/static-build": patch
+---
+
+ensure cleanup after gatsby plugin runs

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -655,7 +655,7 @@ export const build: BuildV2 = async ({
         }
       } finally {
         if (framework?.slug === 'gatsby') {
-          await GatsbyUtils.cleanupGatsbyFiles(entrypointDir);
+          GatsbyUtils.cleanupGatsbyFiles(entrypointDir);
         }
       }
 

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -375,12 +375,12 @@ function tryReadFileSync(filePath: string) {
   try {
     return fs.readFileSync(filePath, 'utf-8');
   } catch (error: unknown) {
-    if (!isErrnoException(error)) {
-      console.error(error);
-    } else {
+    if (isErrnoException(error)) {
       if (error.code !== 'ENOENT') {
         console.error(error);
       }
+    } else {
+      console.error(error);
     }
 
     return undefined;

--- a/packages/static-build/src/utils/gatsby.ts
+++ b/packages/static-build/src/utils/gatsby.ts
@@ -33,6 +33,10 @@ export async function injectPlugins(
     const version = semver.coerce(detectedVersion);
     if (version && semver.satisfies(version, '>=4.0.0')) {
       plugins.add('@vercel/gatsby-plugin-vercel-builder');
+
+      process.on('exit', async () => {
+        await cleanupGatsbyFiles(dir);
+      });
     }
   }
 

--- a/packages/static-build/test/gatsby.test.ts
+++ b/packages/static-build/test/gatsby.test.ts
@@ -359,7 +359,7 @@ describe('gatsby utilities', () => {
       );
 
       expect((await fs.readdir(dir)).length).toBe(6);
-      await cleanupGatsbyFiles(dir);
+      cleanupGatsbyFiles(dir);
       expect((await fs.readdir(dir)).length).toBe(0);
     });
   });
@@ -393,7 +393,7 @@ describe('gatsby utilities', () => {
     );
 
     expect((await fs.readdir(dir)).length).toBe(12);
-    await cleanupGatsbyFiles(dir);
+    cleanupGatsbyFiles(dir);
     const afterDelete = await fs.readdir(dir);
     expect(afterDelete.length).toBe(6);
     expect(afterDelete.sort()).toEqual(files.sort());


### PR DESCRIPTION
There is an issue where you can interrupt a gatsby project build and the temporary files are not cleaned up. If you try to build again, it will get stuck in an infinite loop.

This PR adds an exit hook to make sure the cleanup happens.