### PR TITLE
[next] Ensure app functions are detected/separated properly

### DIFF
--- a/.changeset/tiny-melons-bow.md
+++ b/.changeset/tiny-melons-bow.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] Ensure app functions are detected/separated properly

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -407,14 +407,10 @@ export async function serverBuild({
         dynamicPages.push(normalizedPathname);
       }
 
-      if (pageMatchesApi(page)) {
-        apiPages.push(page);
-      } else if (
-        (appPathRoutesManifest?.[`${normalizedPathname}/page`] ||
-          appPathRoutesManifest?.[`${normalizedPathname}/route`]) &&
-        lambdaAppPaths[page]
-      ) {
+      if (lambdaAppPaths[page]) {
         appRouterPages.push(page);
+      } else if (pageMatchesApi(page)) {
+        apiPages.push(page);
       } else {
         nonApiPages.push(page);
       }

--- a/packages/next/test/fixtures/00-app-dir/app/(rootonly)/dashboard/hello/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/(rootonly)/dashboard/hello/page.js
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 export default function HelloPage(props) {
   return (
     <>

--- a/packages/next/test/fixtures/00-app-dir/app/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/page.js
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 export default function Page() {
-  return <p>index app page</p>;
+  return <p>index app page {Date.now()}</p>;
 }

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -19,6 +19,11 @@
   ],
   "probes": [
     {
+      "path": "/dashboard/hello",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/rootonly/hello"
+    },
+    {
       "path": "/dashboard/another-edge",
       "status": 200,
       "mustContain": "hello from newroot/dashboard/another"


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/9974 this uses the `lambdaAppPaths` as the source of truth instead of the manifest which is more accurate for separating/detecting. Also adds additional test cases for new root and index app functions. 

x-ref: https://github.com/vercel/next.js/issues/49169