### PR TITLE
add repo details for packages that are missing it

### DIFF
--- a/.changeset/lemon-trees-glow.md
+++ b/.changeset/lemon-trees-glow.md
@@ -1,0 +1,5 @@
+---
+"@vercel/gatsby-plugin-vercel-builder": patch
+---
+
+add repo details for gatsby-plugin-vercel-builder

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -6,6 +6,11 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/vercel.git",
+    "directory": "packages/frameworks"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",

--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -8,6 +8,11 @@
     "gatsby-node.js",
     "gatsby-node.js.map"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/vercel.git",
+    "directory": "packages/gatsby-plugin-vercel-builder"
+  },
   "scripts": {
     "build": "pnpm build:src && pnpm build:gatsby",
     "build:gatsby": "tsc -p tsconfig.gatsby.json",


### PR DESCRIPTION
The [changeset publish failed](https://github.com/vercel/vercel/actions/runs/5026353621/jobs/9014526785) because the `repository.url` value was missing. 

This PR adds those details for all packages that are missing it.