### PR TITLE
Fix promoting CLI release to "latest" GH Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,6 @@ jobs:
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Set latest Release to `vercel` (if a Publish Happened)
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
-          script: |
-            const script = require('./utils/update-latest-release.js')
-            await script({ github, context })
-
       - name: Trigger Update (if a Publish Happened)
         if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v6
@@ -72,4 +63,13 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           script: |
             const script = require('./utils/trigger-update-workflow.js')
+            await script({ github, context })
+
+      - name: Set latest Release to `vercel` (if a Publish Happened)
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          script: |
+            const script = require('./utils/update-latest-release.js')
             await script({ github, context })

--- a/utils/update-latest-release.js
+++ b/utils/update-latest-release.js
@@ -1,24 +1,28 @@
+function isVercelCliRelease(release) {
+  return release.tag_name.startsWith('vercel@');
+}
+
 module.exports = async ({ github, context }) => {
   const { owner, repo } = context.repo;
-  const response = await github.rest.repos.listReleases({ owner, repo });
 
-  function isVercelCliRelease(release) {
-    return release.tag_name.startsWith('vercel@');
-  }
+  const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+    owner,
+    repo,
+  });
 
-  const latestRelease = response.data[0];
   if (isVercelCliRelease(latestRelease)) {
     console.log(`Latest release is "${latestRelease.tag_name}" - skipping`);
     return;
   }
 
-  const latestVercelRelease = response.data.find(isVercelCliRelease);
-  console.log(`Promoting "${latestVercelRelease.tag_name}" to latest release`);
+  const response = await github.rest.repos.listReleases({ owner, repo });
+  const latestCliRelease = response.data.find(isVercelCliRelease);
+  console.log(`Promoting "${latestCliRelease.tag_name}" to latest release`);
 
   await github.rest.repos.updateRelease({
     owner,
     repo,
-    release_id: latestVercelRelease.id,
+    release_id: latestCliRelease.id,
     make_latest: true,
   });
 };


### PR DESCRIPTION
The logic to retrieve the latest release was not working correctly, so use the `getLatestRelease()` function instead of assuming that `release[0]` is tagged as the latest.