### PR TITLE
Create release PR as "github-actions" bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           version: pnpm version:prepare
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}


### PR DESCRIPTION
There's no need to run the tests for the release PR, so create the PR as "github-bot" instead of "vercel-release-bot", which will prevent Actions from being executed on the release PR. The consequence of this is that we will have to force-merge since the required tests will not be passing.

This reverts commit 5825e3070046f090cbca998b82a8e01261559e79 (#9932).