### PR TITLE
Remove usage of `env` from Edge Functions and Middleware

### DIFF
--- a/.changeset/warm-coins-poke.md
+++ b/.changeset/warm-coins-poke.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"@vercel/next": patch
+---
+
+Remove usage of `env` from Edge Functions and Middleware

--- a/packages/build-utils/src/edge-function.ts
+++ b/packages/build-utils/src/edge-function.ts
@@ -28,12 +28,6 @@ export class EdgeFunction {
   files: Files;
 
   /**
-   * Extra environment variables in use for the user code, to be
-   * assigned to the edge function.
-   */
-  envVarsInUse?: string[];
-
-  /**
    * Extra binary files to be included in the edge function
    */
   assets?: { name: string; path: string }[];
@@ -50,7 +44,6 @@ export class EdgeFunction {
     this.deploymentTarget = params.deploymentTarget;
     this.entrypoint = params.entrypoint;
     this.files = params.files;
-    this.envVarsInUse = params.envVarsInUse;
     this.assets = params.assets;
     this.regions = params.regions;
     this.framework = params.framework;

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2376,7 +2376,6 @@ interface MiddlewareManifestV2 {
 type Regions = 'home' | 'global' | 'auto' | string[] | 'all' | 'default';
 
 interface BaseEdgeFunctionInfo {
-  env: string[];
   files: string[];
   name: string;
   page: string;
@@ -2586,7 +2585,6 @@ export async function getMiddlewareBundle({
                   ? normalizeRegions(edgeFunction.regions)
                   : undefined,
                 entrypoint: 'index.js',
-                envVarsInUse: edgeFunction.env,
                 assets: (edgeFunction.assets ?? []).map(({ name }) => {
                   return {
                     name,


### PR DESCRIPTION
This PR removes `envVarsInUse` from `build-utils` and ignores `.env` in Next.js manifest
