### PR TITLE
[cli] Add `expect` dev dependency to fix type error in `toOutput`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -119,6 +119,7 @@
     "escape-html": "1.0.3",
     "esm": "3.1.4",
     "execa": "3.2.0",
+    "expect": "29.5.0",
     "express": "4.17.1",
     "fast-deep-equal": "3.1.3",
     "find-up": "4.1.0",

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -56,7 +56,7 @@ export async function toOutput(
       resolve({
         pass: false,
         message() {
-          return `${hint}Timed out waiting ${timeout} ms for output`;
+          return `${hint}Timed out waiting ${timeout} ms for output.\n\nExpected: "${test}"\nReceived: "${output}"`;
         },
       });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,6 +569,9 @@ importers:
       execa:
         specifier: 3.2.0
         version: 3.2.0
+      expect:
+        specifier: 29.5.0
+        version: 29.5.0
       express:
         specifier: 4.17.1
         version: 4.17.1
@@ -3774,13 +3777,6 @@ packages:
       jest-mock: 29.5.0
     dev: true
 
-  /@jest/expect-utils@29.3.1:
-    resolution: {integrity: sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.2.0
-    dev: true
-
   /@jest/expect-utils@29.5.0:
     resolution: {integrity: sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5036,14 +5032,14 @@ packages:
   /@types/jest@29.2.1:
     resolution: {integrity: sha512-nKixEdnGDqFOZkMTF74avFNr3yRqB1ZJ6sRZv5/28D5x2oLN14KApv7F9mfDT/vUic0L3tRCsh3XWpWjtJisUQ==}
     dependencies:
-      expect: 29.3.1
+      expect: 29.5.0
       pretty-format: 29.3.1
     dev: true
 
   /@types/jest@29.5.0:
     resolution: {integrity: sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==}
     dependencies:
-      expect: 29.3.1
+      expect: 29.5.0
       pretty-format: 29.3.1
     dev: true
 
@@ -9561,17 +9557,6 @@ packages:
       - supports-color
     dev: true
 
-  /expect@29.3.1:
-    resolution: {integrity: sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/expect-utils': 29.3.1
-      jest-get-type: 29.2.0
-      jest-matcher-utils: 29.3.1
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
-    dev: true
-
   /expect@29.5.0:
     resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11792,21 +11777,6 @@ packages:
       graceful-fs: 4.2.11
       micromatch: 4.0.5
       pretty-format: 28.1.3
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    dev: true
-
-  /jest-message-util@29.3.1:
-    resolution: {integrity: sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@jest/types': 29.5.0
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.0
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      pretty-format: 29.5.0
       slash: 3.0.0
       stack-utils: 2.0.6
     dev: true


### PR DESCRIPTION
Also make the timeout print what was buffered to help with debugging failed tests.