### PR TITLE
Use `pnpm publish -r` to publish packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version:prepare
-          publish: pnpm release
+          version: pnpm ci:version
+          publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile",
-    "release": "changeset publish"
+    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
+    "ci:publish": "pnpm publish -r"
   },
   "lint-staged": {
     "./{*,{api,packages,test,utils}/**/*}.{js,ts}": [


### PR DESCRIPTION
Following the instructions here: https://pnpm.io/using-changesets

This should ensure that packages are published in the correct order (see related issue: https://github.com/changesets/changesets/issues/238).