### PR TITLE
[next] Update rsc content-type test fixtures

### DIFF
--- a/.changeset/purple-islands-rule.md
+++ b/.changeset/purple-islands-rule.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] Update rsc content-type test fixtures

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2099,7 +2099,8 @@ export const onPrerenderRoute =
         routesManifest?.rsc?.varyHeader ||
         'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
       const rscContentTypeHeader =
-        routesManifest?.rsc?.contentTypeHeader || 'text/x-component';
+        routesManifest?.rsc?.contentTypeHeader ||
+        'text/x-component; charset=utf-8';
 
       let sourcePath: string | undefined;
       if (`/${outputPathPage}` !== srcRoute && srcRoute) {

--- a/packages/next/test/fixtures/00-app-dir-edge/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge/vercel.json
@@ -27,7 +27,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component; charset=utf-8"
       }
     },
     {
@@ -51,7 +51,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component; charset=utf-8"
       }
     }
   ]

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -30,7 +30,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
+        "content-type": "text/x-component; charset=utf-8",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -122,7 +122,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
+        "content-type": "text/x-component; charset=utf-8",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -141,7 +141,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
+        "content-type": "text/x-component; charset=utf-8",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },


### PR DESCRIPTION
This updates the tests to the latest expected content-type header for RSC responses. 

x-ref: https://github.com/vercel/next.js/pull/50314