### PR TITLE
[cli] Add `client.cwd` to unify all working directory related logic

### DIFF
--- a/.changeset/thin-planets-unite.md
+++ b/.changeset/thin-planets-unite.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `--cwd` flag with a relative path for `env`, `link`, `promote`, and `rollback` subcommands

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -133,7 +133,7 @@ const help = () => {
 };
 
 export default async function main(client: Client): Promise<number> {
-  const { output } = client;
+  const { cwd, output } = client;
 
   // Ensure that `vc build` is not being invoked recursively
   if (process.env.__VERCEL_BUILD_RUNNING) {
@@ -164,8 +164,6 @@ export default async function main(client: Client): Promise<number> {
     help();
     return 2;
   }
-
-  const cwd = process.cwd();
 
   // Build `target` influences which environment variables will be used
   const target = argv['--prod'] ? 'production' : 'preview';

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -130,10 +130,9 @@ export default async function main(client: Client) {
     return 2;
   }
 
-  const cwd = argv['--cwd'] || process.cwd();
   const subArgs = argv._.slice(1);
   const { subcommand, args } = getSubcommand(subArgs, COMMAND_CONFIG);
-  const { output, config } = client;
+  const { cwd, output, config } = client;
 
   const target = argv['--environment']?.toLowerCase() || 'development';
   if (!isValidEnvTarget(target)) {

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -90,7 +90,7 @@ export default async function main(client: Client) {
       )} instead`
     );
   } else {
-    cwd = process.cwd();
+    cwd = client.cwd;
   }
 
   if (argv['--repo']) {

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -88,7 +88,7 @@ export default async (client: Client): Promise<number> => {
         autoConfirm: Boolean(argv['--yes']),
         client,
         commandName: 'promote',
-        cwd: argv['--cwd'] || process.cwd(),
+        cwd: client.cwd,
         projectNameOrId: argv._[2],
       });
 

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -88,7 +88,7 @@ export default async (client: Client): Promise<number> => {
         autoConfirm: Boolean(argv['--yes']),
         client,
         commandName: 'promote',
-        cwd: argv['--cwd'] || process.cwd(),
+        cwd: client.cwd,
         projectNameOrId: argv._[2],
       });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -144,12 +144,6 @@ const main = async () => {
     return 1;
   }
 
-  let cwd = argv['--cwd'];
-  if (cwd) {
-    process.chdir(cwd);
-  }
-  cwd = process.cwd();
-
   // The second argument to the command can be:
   //
   //  * a path to deploy (as in: `vercel path/`)
@@ -276,6 +270,12 @@ const main = async () => {
     localConfigPath,
     argv: process.argv,
   });
+
+  // The `--cwd` flag is respected for all sub-commands
+  if (argv['--cwd']) {
+    client.cwd = argv['--cwd'];
+  }
+  const { cwd } = client;
 
   // Gets populated to the subcommand name when a built-in is
   // provided, otherwise it remains undefined for an extension

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -207,4 +207,12 @@ export default class Client extends EventEmitter implements Stdio {
       output: this.stderr as NodeJS.WriteStream,
     });
   }
+
+  get cwd(): string {
+    return process.cwd();
+  }
+
+  set cwd(v: string) {
+    process.chdir(v);
+  }
 }

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -1,3 +1,5 @@
+const originalCwd = process.cwd();
+
 // Register Jest matcher extensions for CLI unit tests
 import './matchers';
 
@@ -73,6 +75,8 @@ export class MockClient extends Client {
     });
 
     this.scenario = Router();
+
+    this.reset();
   }
 
   reset() {
@@ -99,11 +103,14 @@ export class MockClient extends Client {
     };
     this.config = {};
     this.localConfig = {};
+    this.localConfigPath = undefined;
 
     this.scenario = Router();
 
     this.agent?.destroy();
     this.agent = undefined;
+
+    this.cwd = originalCwd;
   }
 
   async startMockServer() {
@@ -156,7 +163,7 @@ beforeAll(async () => {
   await client.startMockServer();
 });
 
-beforeEach(() => {
+afterEach(() => {
   client.reset();
 });
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -982,6 +982,8 @@ describe('build', () => {
     let output: string;
 
     beforeAll(async function () {
+      delete process.env.__VERCEL_BUILD_RUNNING;
+
       const cwd = fixture('import-from-main-keys');
       output = join(cwd, '.vercel/output');
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -14,134 +14,121 @@ const fixture = (name: string) =>
   join(__dirname, '../../../fixtures/unit/commands/build', name);
 
 describe('build', () => {
-  const originalCwd = process.cwd();
+  beforeEach(() => {
+    delete process.env.__VERCEL_BUILD_RUNNING;
+  });
 
   it('should build with `@vercel/static`', async () => {
     const cwd = fixture('static');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/static" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            src: '**',
-            use: '@vercel/static',
-          },
-        ],
-      });
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // "static" directory contains static files
-      const files = await fs.readdir(join(output, 'static'));
-      expect(files.sort()).toEqual(['index.html']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // `builds.json` says that "@vercel/static" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          src: '**',
+          use: '@vercel/static',
+        },
+      ],
+    });
+
+    // "static" directory contains static files
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files.sort()).toEqual(['index.html']);
   });
 
   it('should build with `@now/static`', async () => {
     const cwd = fixture('now-static');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@now/static',
-            apiVersion: 2,
-            src: 'www/index.html',
-            use: '@now/static',
-          },
-        ],
-      });
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@now/static',
+          apiVersion: 2,
+          src: 'www/index.html',
+          use: '@now/static',
+        },
+      ],
+    });
 
-      const files = await fs.readdir(join(output, 'static'));
-      expect(files).toEqual(['www']);
-      const www = await fs.readdir(join(output, 'static', 'www'));
-      expect(www).toEqual(['index.html']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files).toEqual(['www']);
+    const www = await fs.readdir(join(output, 'static', 'www'));
+    expect(www).toEqual(['index.html']);
   });
 
   it('should build with `@vercel/node`', async () => {
     const cwd = fixture('node');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    // `builds.json` says that "@vercel/node" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'api/es6.js',
+          config: { zeroConfig: true },
+        },
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'api/index.js',
+          config: { zeroConfig: true },
+        },
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'api/mjs.mjs',
+          config: { zeroConfig: true },
+        },
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'api/typescript.ts',
+          config: { zeroConfig: true },
+        },
+      ],
+    });
 
-      // `builds.json` says that "@vercel/node" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'api/es6.js',
-            config: { zeroConfig: true },
-          },
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'api/index.js',
-            config: { zeroConfig: true },
-          },
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'api/mjs.mjs',
-            config: { zeroConfig: true },
-          },
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'api/typescript.ts',
-            config: { zeroConfig: true },
-          },
-        ],
-      });
+    // "static" directory is empty
+    const hasStaticFiles = await fs.pathExists(join(output, 'static'));
+    expect(
+      hasStaticFiles,
+      'Expected ".vercel/output/static" to not exist'
+    ).toEqual(false);
 
-      // "static" directory is empty
-      const hasStaticFiles = await fs.pathExists(join(output, 'static'));
-      expect(
-        hasStaticFiles,
-        'Expected ".vercel/output/static" to not exist'
-      ).toEqual(false);
-
-      // "functions/api" directory has output Functions
-      const functions = await fs.readdir(join(output, 'functions/api'));
-      expect(functions.sort()).toEqual([
-        'es6.func',
-        'index.func',
-        'mjs.func',
-        'typescript.func',
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions/api" directory has output Functions
+    const functions = await fs.readdir(join(output, 'functions/api'));
+    expect(functions.sort()).toEqual([
+      'es6.func',
+      'index.func',
+      'mjs.func',
+      'typescript.func',
+    ]);
   });
 
   it('should handle symlinked static files', async () => {
@@ -157,220 +144,198 @@ describe('build', () => {
       return;
     }
 
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/static" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            src: '**',
-            use: '@vercel/static',
-          },
-        ],
-      });
+    // `builds.json` says that "@vercel/static" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          src: '**',
+          use: '@vercel/static',
+        },
+      ],
+    });
 
-      // "static" directory contains static files
-      const files = await fs.readdir(join(output, 'static'));
-      expect(files.sort()).toEqual(['foo.html', 'index.html']);
-      expect(
-        (await fs.lstat(join(output, 'static', 'foo.html'))).isSymbolicLink()
-      ).toEqual(true);
-      expect(
-        (await fs.lstat(join(output, 'static', 'index.html'))).isSymbolicLink()
-      ).toEqual(false);
-    } finally {
-      await fs.unlink(join(cwd, 'foo.html'));
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "static" directory contains static files
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files.sort()).toEqual(['foo.html', 'index.html']);
+    expect(
+      (await fs.lstat(join(output, 'static', 'foo.html'))).isSymbolicLink()
+    ).toEqual(true);
+    expect(
+      (await fs.lstat(join(output, 'static', 'index.html'))).isSymbolicLink()
+    ).toEqual(false);
   });
 
   it('should normalize "src" path in `vercel.json`', async () => {
     const cwd = fixture('normalize-src');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    // `builds.json` says that "@vercel/node" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'server.js',
+        },
+      ],
+    });
 
-      // `builds.json` says that "@vercel/node" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'server.js',
-          },
-        ],
-      });
+    // `config.json` includes "route" from `vercel.json`
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toMatchObject({
+      version: 3,
+      routes: [
+        {
+          src: '^/(.*)$',
+          dest: '/server.js',
+        },
+      ],
+    });
 
-      // `config.json` includes "route" from `vercel.json`
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toMatchObject({
-        version: 3,
-        routes: [
-          {
-            src: '^/(.*)$',
-            dest: '/server.js',
-          },
-        ],
-      });
+    // "static" directory is empty
+    const hasStaticFiles = await fs.pathExists(join(output, 'static'));
+    expect(
+      hasStaticFiles,
+      'Expected ".vercel/output/static" to not exist'
+    ).toEqual(false);
 
-      // "static" directory is empty
-      const hasStaticFiles = await fs.pathExists(join(output, 'static'));
-      expect(
-        hasStaticFiles,
-        'Expected ".vercel/output/static" to not exist'
-      ).toEqual(false);
-
-      // "functions" directory has output Function
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions.sort()).toEqual(['server.js.func']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions" directory has output Function
+    const functions = await fs.readdir(join(output, 'functions'));
+    expect(functions.sort()).toEqual(['server.js.func']);
   });
 
   it('should build with 3rd party Builder', async () => {
     const cwd = fixture('third-party-builder');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "txt-builder" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: 'txt-builder',
-            apiVersion: 3,
-            use: 'txt-builder@0.0.0',
-            src: 'api/foo.txt',
-            config: {
-              zeroConfig: true,
-              functions: {
-                'api/*.txt': {
-                  runtime: 'txt-builder@0.0.0',
-                },
+    // `builds.json` says that "txt-builder" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: 'txt-builder',
+          apiVersion: 3,
+          use: 'txt-builder@0.0.0',
+          src: 'api/foo.txt',
+          config: {
+            zeroConfig: true,
+            functions: {
+              'api/*.txt': {
+                runtime: 'txt-builder@0.0.0',
               },
             },
           },
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            use: '@vercel/static',
-            src: '!{api/**,package.json,middleware.[jt]s}',
-            config: {
-              zeroConfig: true,
-            },
+        },
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          use: '@vercel/static',
+          src: '!{api/**,package.json,middleware.[jt]s}',
+          config: {
+            zeroConfig: true,
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      // "static" directory is empty
-      const hasStaticFiles = await fs.pathExists(join(output, 'static'));
-      expect(
-        hasStaticFiles,
-        'Expected ".vercel/output/static" to not exist'
-      ).toEqual(false);
+    // "static" directory is empty
+    const hasStaticFiles = await fs.pathExists(join(output, 'static'));
+    expect(
+      hasStaticFiles,
+      'Expected ".vercel/output/static" to not exist'
+    ).toEqual(false);
 
-      // "functions/api" directory has output Functions
-      const functions = await fs.readdir(join(output, 'functions/api'));
-      expect(functions.sort()).toEqual(['foo.func']);
+    // "functions/api" directory has output Functions
+    const functions = await fs.readdir(join(output, 'functions/api'));
+    expect(functions.sort()).toEqual(['foo.func']);
 
-      const vcConfig = await fs.readJSON(
-        join(output, 'functions/api/foo.func/.vc-config.json')
-      );
-      expect(vcConfig).toMatchObject({
-        handler: 'api/foo.txt',
-        runtime: 'provided',
-        environment: {},
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const vcConfig = await fs.readJSON(
+      join(output, 'functions/api/foo.func/.vc-config.json')
+    );
+    expect(vcConfig).toMatchObject({
+      handler: 'api/foo.txt',
+      runtime: 'provided',
+      environment: {},
+    });
   });
 
   it('should serialize `EdgeFunction` output in version 3 Builder', async () => {
     const cwd = fixture('edge-function');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      client.setArgv('build', '--prod');
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    client.setArgv('build', '--prod');
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "edge-function" Builder was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'production',
-        builds: [
-          {
-            require: 'edge-function',
-            apiVersion: 3,
-            use: 'edge-function@0.0.0',
-            src: 'api/edge.js',
-            config: {
-              zeroConfig: true,
-              functions: {
-                'api/*.js': {
-                  runtime: 'edge-function@0.0.0',
-                },
+    // `builds.json` says that "edge-function" Builder was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'production',
+      builds: [
+        {
+          require: 'edge-function',
+          apiVersion: 3,
+          use: 'edge-function@0.0.0',
+          src: 'api/edge.js',
+          config: {
+            zeroConfig: true,
+            functions: {
+              'api/*.js': {
+                runtime: 'edge-function@0.0.0',
               },
             },
           },
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            use: '@vercel/static',
-            src: '!{api/**,package.json,middleware.[jt]s}',
-            config: {
-              zeroConfig: true,
-            },
+        },
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          use: '@vercel/static',
+          src: '!{api/**,package.json,middleware.[jt]s}',
+          config: {
+            zeroConfig: true,
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      // "static" directory is empty
-      const hasStaticFiles = await fs.pathExists(join(output, 'static'));
-      expect(
-        hasStaticFiles,
-        'Expected ".vercel/output/static" to not exist'
-      ).toEqual(false);
+    // "static" directory is empty
+    const hasStaticFiles = await fs.pathExists(join(output, 'static'));
+    expect(
+      hasStaticFiles,
+      'Expected ".vercel/output/static" to not exist'
+    ).toEqual(false);
 
-      // "functions/api" directory has output Functions
-      const functions = await fs.readdir(join(output, 'functions/api'));
-      expect(functions.sort()).toEqual(['edge.func']);
+    // "functions/api" directory has output Functions
+    const functions = await fs.readdir(join(output, 'functions/api'));
+    expect(functions.sort()).toEqual(['edge.func']);
 
-      const vcConfig = await fs.readJSON(
-        join(output, 'functions/api/edge.func/.vc-config.json')
-      );
-      expect(vcConfig).toMatchObject({
-        runtime: 'edge',
-        name: 'api/edge.js',
-        deploymentTarget: 'v8-worker',
-        entrypoint: 'api/edge.js',
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const vcConfig = await fs.readJSON(
+      join(output, 'functions/api/edge.func/.vc-config.json')
+    );
+    expect(vcConfig).toMatchObject({
+      runtime: 'edge',
+      name: 'api/edge.js',
+      deploymentTarget: 'v8-worker',
+      entrypoint: 'api/edge.js',
+    });
   });
 
   it('should pull "preview" env vars by default', async () => {
@@ -388,7 +353,7 @@ describe('build', () => {
       join(cwd, '.vercel/project.json')
     );
     try {
-      process.chdir(cwd);
+      client.cwd = cwd;
       client.setArgv('build', '--yes');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
@@ -401,8 +366,6 @@ describe('build', () => {
     } finally {
       await fs.remove(envFilePath);
       await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
     }
   });
 
@@ -421,7 +384,7 @@ describe('build', () => {
       join(cwd, '.vercel/project.json')
     );
     try {
-      process.chdir(cwd);
+      client.cwd = cwd;
       client.setArgv('build', '--yes', '--prod');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
@@ -438,211 +401,194 @@ describe('build', () => {
     } finally {
       await fs.remove(envFilePath);
       await fs.writeJSON(projectJsonPath, originalProjectJson, { spaces: 2 });
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
     }
   });
 
   it('should build root-level `middleware.js` and exclude from static files', async () => {
     const cwd = fixture('middleware');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/node" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'middleware.js',
-            config: {
-              zeroConfig: true,
-              middleware: true,
-            },
+    // `builds.json` says that "@vercel/node" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'middleware.js',
+          config: {
+            zeroConfig: true,
+            middleware: true,
           },
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            use: '@vercel/static',
-            src: '!{api/**,package.json,middleware.[jt]s}',
-            config: {
-              zeroConfig: true,
-            },
+        },
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          use: '@vercel/static',
+          src: '!{api/**,package.json,middleware.[jt]s}',
+          config: {
+            zeroConfig: true,
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      // `config.json` includes the "middlewarePath" route
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toMatchObject({
-        version: 3,
-        routes: [
-          {
-            src: '^/.*$',
-            middlewarePath: 'middleware',
-            middlewareRawSrc: [],
-            override: true,
-            continue: true,
-          },
-          { handle: 'error' },
-          { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
-        ],
-      });
+    // `config.json` includes the "middlewarePath" route
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toMatchObject({
+      version: 3,
+      routes: [
+        {
+          src: '^/.*$',
+          middlewarePath: 'middleware',
+          middlewareRawSrc: [],
+          override: true,
+          continue: true,
+        },
+        { handle: 'error' },
+        { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
+      ],
+    });
 
-      // "static" directory contains `index.html`, but *not* `middleware.js`
-      const staticFiles = await fs.readdir(join(output, 'static'));
-      expect(staticFiles.sort()).toEqual(['index.html']);
+    // "static" directory contains `index.html`, but *not* `middleware.js`
+    const staticFiles = await fs.readdir(join(output, 'static'));
+    expect(staticFiles.sort()).toEqual(['index.html']);
 
-      // "functions" directory contains `middleware.func`
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions.sort()).toEqual(['middleware.func']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions" directory contains `middleware.func`
+    const functions = await fs.readdir(join(output, 'functions'));
+    expect(functions.sort()).toEqual(['middleware.func']);
   });
 
   it('should build root-level `middleware.js` with "Root Directory" setting', async () => {
     const cwd = fixture('middleware-root-directory');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/static" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'middleware.js',
-            config: {
-              zeroConfig: true,
-              middleware: true,
-            },
+    // `builds.json` says that "@vercel/static" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'middleware.js',
+          config: {
+            zeroConfig: true,
+            middleware: true,
           },
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            use: '@vercel/static',
-            src: '!{api/**,package.json,middleware.[jt]s}',
-            config: {
-              zeroConfig: true,
-            },
+        },
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          use: '@vercel/static',
+          src: '!{api/**,package.json,middleware.[jt]s}',
+          config: {
+            zeroConfig: true,
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      // `config.json` includes the "middlewarePath" route
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toMatchObject({
-        version: 3,
-        routes: [
-          {
-            src: '^/.*$',
-            middlewarePath: 'middleware',
-            middlewareRawSrc: [],
-            override: true,
-            continue: true,
-          },
-          { handle: 'error' },
-          { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
-        ],
-      });
+    // `config.json` includes the "middlewarePath" route
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toMatchObject({
+      version: 3,
+      routes: [
+        {
+          src: '^/.*$',
+          middlewarePath: 'middleware',
+          middlewareRawSrc: [],
+          override: true,
+          continue: true,
+        },
+        { handle: 'error' },
+        { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
+      ],
+    });
 
-      // "static" directory contains `index.html`, but *not* `middleware.js`
-      const staticFiles = await fs.readdir(join(output, 'static'));
-      expect(staticFiles.sort()).toEqual(['index.html']);
+    // "static" directory contains `index.html`, but *not* `middleware.js`
+    const staticFiles = await fs.readdir(join(output, 'static'));
+    expect(staticFiles.sort()).toEqual(['index.html']);
 
-      // "functions" directory contains `middleware.func`
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions.sort()).toEqual(['middleware.func']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions" directory contains `middleware.func`
+    const functions = await fs.readdir(join(output, 'functions'));
+    expect(functions.sort()).toEqual(['middleware.func']);
   });
 
   it('should build root-level `middleware.js` with "matcher" config', async () => {
     const cwd = fixture('middleware-with-matcher');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/node" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/node',
-            apiVersion: 3,
-            use: '@vercel/node',
-            src: 'middleware.js',
-            config: {
-              zeroConfig: true,
-              middleware: true,
-            },
+    // `builds.json` says that "@vercel/node" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/node',
+          apiVersion: 3,
+          use: '@vercel/node',
+          src: 'middleware.js',
+          config: {
+            zeroConfig: true,
+            middleware: true,
           },
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            use: '@vercel/static',
-            src: '!{api/**,package.json,middleware.[jt]s}',
-            config: {
-              zeroConfig: true,
-            },
+        },
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          use: '@vercel/static',
+          src: '!{api/**,package.json,middleware.[jt]s}',
+          config: {
+            zeroConfig: true,
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      // `config.json` includes the "middlewarePath" route
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toMatchObject({
-        version: 3,
-        routes: [
-          {
-            src: '^\\/about(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$|^\\/dashboard(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$',
-            middlewarePath: 'middleware',
-            middlewareRawSrc: ['/about/:path*', '/dashboard/:path*'],
-            override: true,
-            continue: true,
-          },
-          { handle: 'error' },
-          { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
-        ],
-      });
+    // `config.json` includes the "middlewarePath" route
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toMatchObject({
+      version: 3,
+      routes: [
+        {
+          src: '^\\/about(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$|^\\/dashboard(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$',
+          middlewarePath: 'middleware',
+          middlewareRawSrc: ['/about/:path*', '/dashboard/:path*'],
+          override: true,
+          continue: true,
+        },
+        { handle: 'error' },
+        { status: 404, src: '^(?!/api).*$', dest: '/404.html' },
+      ],
+    });
 
-      // "static" directory contains `index.html`, but *not* `middleware.js`
-      const staticFiles = await fs.readdir(join(output, 'static'));
-      expect(staticFiles.sort()).toEqual(['index.html']);
+    // "static" directory contains `index.html`, but *not* `middleware.js`
+    const staticFiles = await fs.readdir(join(output, 'static'));
+    expect(staticFiles.sort()).toEqual(['index.html']);
 
-      // "functions" directory contains `middleware.func`
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions.sort()).toEqual(['middleware.func']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions" directory contains `middleware.func`
+    const functions = await fs.readdir(join(output, 'functions'));
+    expect(functions.sort()).toEqual(['middleware.func']);
   });
 
   it('should support `--output` parameter', async () => {
     const cwd = fixture('static');
     const output = await getWriteableDirectory();
     try {
-      process.chdir(cwd);
+      client.cwd = cwd;
       client.setArgv('build', '--output', output);
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
@@ -666,8 +612,6 @@ describe('build', () => {
       expect(files.sort()).toEqual(['index.html']);
     } finally {
       await fs.remove(output);
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
     }
   });
 
@@ -676,114 +620,99 @@ describe('build', () => {
   it("should support Builder that doesn't export `version`", async () => {
     const cwd = fixture('versionless-builder');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "versionless-builder" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: 'versionless-builder',
-            src: 'package.json',
-            use: 'versionless-builder@0.0.0',
-          },
-        ],
-      });
+    // `builds.json` says that "versionless-builder" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: 'versionless-builder',
+          src: 'package.json',
+          use: 'versionless-builder@0.0.0',
+        },
+      ],
+    });
 
-      // "static" directory contains static files
-      const files = await fs.readdir(join(output, 'static'));
-      expect(files.sort()).toEqual(['file']);
+    // "static" directory contains static files
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files.sort()).toEqual(['file']);
 
-      expect(await fs.readFile(join(output, 'static/file'), 'utf8')).toEqual(
-        'file contents'
-      );
+    expect(await fs.readFile(join(output, 'static/file'), 'utf8')).toEqual(
+      'file contents'
+    );
 
-      // "functions" directory has output Functions
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions.sort()).toEqual(['withTrailingSlash.func']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "functions" directory has output Functions
+    const functions = await fs.readdir(join(output, 'functions'));
+    expect(functions.sort()).toEqual(['withTrailingSlash.func']);
   });
 
   it('should store `detectBuilders()` error in `builds.json`', async () => {
     const cwd = fixture('error-vercel-json-validation');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(1);
 
-      // Error gets printed to the terminal
-      await expect(client.stderr).toOutput(
-        'Error: Function must contain at least one property.'
-      );
+    // Error gets printed to the terminal
+    await expect(client.stderr).toOutput(
+      'Error: Function must contain at least one property.'
+    );
 
-      // `builds.json` contains top-level "error" property
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds.builds).toBeUndefined();
+    // `builds.json` contains top-level "error" property
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds.builds).toBeUndefined();
 
-      expect(builds.error.code).toEqual('invalid_function');
-      expect(builds.error.message).toEqual(
-        'Function must contain at least one property.'
-      );
+    expect(builds.error.code).toEqual('invalid_function');
+    expect(builds.error.message).toEqual(
+      'Function must contain at least one property.'
+    );
 
-      // `config.json` contains `version`
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson.version).toBe(3);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // `config.json` contains `version`
+    const configJson = await fs.readJSON(join(output, 'config.json'));
+    expect(configJson.version).toBe(3);
   });
 
   it('should store Builder error in `builds.json`', async () => {
     const cwd = fixture('node-error');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(1);
 
-      // Error gets printed to the terminal
-      await expect(client.stderr).toOutput("Duplicate identifier 'res'.");
+    // Error gets printed to the terminal
+    await expect(client.stderr).toOutput("Duplicate identifier 'res'.");
 
-      // `builds.json` contains "error" build
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds.builds).toHaveLength(4);
+    // `builds.json` contains "error" build
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds.builds).toHaveLength(4);
 
-      const errorBuilds = builds.builds.filter((b: any) => 'error' in b);
-      expect(errorBuilds).toHaveLength(1);
+    const errorBuilds = builds.builds.filter((b: any) => 'error' in b);
+    expect(errorBuilds).toHaveLength(1);
 
-      expect(errorBuilds[0].error).toEqual({
-        name: 'Error',
-        message: expect.stringContaining('TS1005'),
-        stack: expect.stringContaining('api/typescript.ts'),
-        hideStackTrace: true,
-        code: 'NODE_TYPESCRIPT_ERROR',
-      });
+    expect(errorBuilds[0].error).toEqual({
+      name: 'Error',
+      message: expect.stringContaining('TS1005'),
+      stack: expect.stringContaining('api/typescript.ts'),
+      hideStackTrace: true,
+      code: 'NODE_TYPESCRIPT_ERROR',
+    });
 
-      // top level "error" also contains the same error
-      expect(builds.error).toEqual({
-        name: 'Error',
-        message: expect.stringContaining('TS1005'),
-        stack: expect.stringContaining('api/typescript.ts'),
-        hideStackTrace: true,
-        code: 'NODE_TYPESCRIPT_ERROR',
-      });
+    // top level "error" also contains the same error
+    expect(builds.error).toEqual({
+      name: 'Error',
+      message: expect.stringContaining('TS1005'),
+      stack: expect.stringContaining('api/typescript.ts'),
+      hideStackTrace: true,
+      code: 'NODE_TYPESCRIPT_ERROR',
+    });
 
-      // `config.json` contains `version`
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson.version).toBe(3);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // `config.json` contains `version`
+    const configJson = await fs.readJSON(join(output, 'config.json'));
+    expect(configJson.version).toBe(3);
   });
 
   it('should error when "functions" has runtime that emits discontinued "nodejs12.x"', async () => {
@@ -793,210 +722,139 @@ describe('build', () => {
     }
     const cwd = fixture('discontinued-nodejs12.x');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(1);
 
-      // Error gets printed to the terminal
-      await expect(client.stderr).toOutput(
-        'The Runtime "vercel-php@0.1.0" is using "nodejs12.x", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.'
-      );
+    // Error gets printed to the terminal
+    await expect(client.stderr).toOutput(
+      'The Runtime "vercel-php@0.1.0" is using "nodejs12.x", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.'
+    );
 
-      // `builds.json` contains "error" build
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      const errorBuilds = builds.builds.filter((b: any) => 'error' in b);
-      expect(errorBuilds).toHaveLength(1);
-      expect(errorBuilds[0].error).toEqual({
-        name: 'Error',
-        message: expect.stringContaining('Please upgrade your Runtime'),
-        stack: expect.stringContaining('Please upgrade your Runtime'),
-        hideStackTrace: true,
-        code: 'NODEJS_DISCONTINUED_VERSION',
-        link: 'https://github.com/vercel/vercel/blob/main/DEVELOPING_A_RUNTIME.md#lambdaruntime',
-      });
+    // `builds.json` contains "error" build
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    const errorBuilds = builds.builds.filter((b: any) => 'error' in b);
+    expect(errorBuilds).toHaveLength(1);
+    expect(errorBuilds[0].error).toEqual({
+      name: 'Error',
+      message: expect.stringContaining('Please upgrade your Runtime'),
+      stack: expect.stringContaining('Please upgrade your Runtime'),
+      hideStackTrace: true,
+      code: 'NODEJS_DISCONTINUED_VERSION',
+      link: 'https://github.com/vercel/vercel/blob/main/DEVELOPING_A_RUNTIME.md#lambdaruntime',
+    });
 
-      // top level "error" also contains the same error
-      expect(builds.error).toEqual({
-        name: 'Error',
-        message: expect.stringContaining('Please upgrade your Runtime'),
-        stack: expect.stringContaining('Please upgrade your Runtime'),
-        hideStackTrace: true,
-        code: 'NODEJS_DISCONTINUED_VERSION',
-        link: 'https://github.com/vercel/vercel/blob/main/DEVELOPING_A_RUNTIME.md#lambdaruntime',
-      });
+    // top level "error" also contains the same error
+    expect(builds.error).toEqual({
+      name: 'Error',
+      message: expect.stringContaining('Please upgrade your Runtime'),
+      stack: expect.stringContaining('Please upgrade your Runtime'),
+      hideStackTrace: true,
+      code: 'NODEJS_DISCONTINUED_VERSION',
+      link: 'https://github.com/vercel/vercel/blob/main/DEVELOPING_A_RUNTIME.md#lambdaruntime',
+    });
 
-      // `config.json` contains `version`
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson.version).toBe(3);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // `config.json` contains `version`
+    const configJson = await fs.readJSON(join(output, 'config.json'));
+    expect(configJson.version).toBe(3);
   });
-
-  /* Skipping because this legacy builder is causing something to break with cwd
-  it('should error when builder returns result without "output" such as @now/node-server', async () => {
-    const cwd = join(os.tmpdir(), 'now-node-server');
-    const output = join(cwd, '.vercel/output');
-    try {
-      // Copy to a temp directory to avoid breaking other tests
-      await fs.copy(fixture('now-node-server'), cwd);
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
-
-      // Error gets printed to the terminal
-      const message =
-        'The build result from "@now/node-server" is missing the "output" property. Please update from "@now" to "@vercel" in your `vercel.json` file.';
-      await expect(client.stderr).toOutput(message);
-
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-
-      // top level "error" also contains the same error
-      expect(builds.error).toEqual({
-        name: 'Error',
-        message,
-        stack: expect.stringContaining(message),
-      });
-
-      // `config.json` contains `version`
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson.version).toBe(3);
-    } finally {
-      await fs.remove(cwd);
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
-  });
-  */
 
   it('should allow for missing "build" script', async () => {
     const cwd = fixture('static-with-pkg');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `builds.json` says that "@vercel/static" was run
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds).toMatchObject({
-        target: 'preview',
-        builds: [
-          {
-            require: '@vercel/static',
-            apiVersion: 2,
-            src: '**',
-            use: '@vercel/static',
-          },
-        ],
-      });
+    // `builds.json` says that "@vercel/static" was run
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds).toMatchObject({
+      target: 'preview',
+      builds: [
+        {
+          require: '@vercel/static',
+          apiVersion: 2,
+          src: '**',
+          use: '@vercel/static',
+        },
+      ],
+    });
 
-      // "static" directory contains static files
-      const files = await fs.readdir(join(output, 'static'));
-      expect(files.sort()).toEqual(['index.html', 'package.json']);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // "static" directory contains static files
+    const files = await fs.readdir(join(output, 'static'));
+    expect(files.sort()).toEqual(['index.html', 'package.json']);
   });
 
   it('should set `VERCEL_ANALYTICS_ID` environment variable', async () => {
     const cwd = fixture('vercel-analytics');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const env = await fs.readJSON(join(output, 'static', 'env.json'));
-      expect(Object.keys(env).includes('VERCEL_ANALYTICS_ID')).toEqual(true);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(Object.keys(env).includes('VERCEL_ANALYTICS_ID')).toEqual(true);
   });
 
   it('should load environment variables from `.vercel/.env.preview.local`', async () => {
     const cwd = fixture('env-from-vc-pull');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const env = await fs.readJSON(join(output, 'static', 'env.json'));
-      expect(env['ENV_FILE']).toEqual('preview');
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(env['ENV_FILE']).toEqual('preview');
   });
 
   it('should load environment variables from `.vercel/.env.production.local`', async () => {
     const cwd = fixture('env-from-vc-pull');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      client.setArgv('build', '--prod');
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    client.setArgv('build', '--prod');
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const env = await fs.readJSON(join(output, 'static', 'env.json'));
-      expect(env['ENV_FILE']).toEqual('production');
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(env['ENV_FILE']).toEqual('production');
   });
 
   it('should NOT load environment variables from `.env`', async () => {
     const cwd = fixture('env-root-level');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const env = await fs.readJSON(join(output, 'static', 'env.json'));
-      // The `.env` in this fixture has `ENV_FILE=root"`,
-      // so if that's not defined then we're good
-      expect(env['ENV_FILE']).toBeUndefined();
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    // The `.env` in this fixture has `ENV_FILE=root"`,
+    // so if that's not defined then we're good
+    expect(env['ENV_FILE']).toBeUndefined();
   });
 
   it('should apply function configuration from "vercel.json" to Serverless Functions', async () => {
     const cwd = fixture('lambda-with-128-memory');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // "functions/api" directory has output Functions
-      const functions = await fs.readdir(join(output, 'functions/api'));
-      expect(functions.sort()).toEqual(['memory.func']);
+    // "functions/api" directory has output Functions
+    const functions = await fs.readdir(join(output, 'functions/api'));
+    expect(functions.sort()).toEqual(['memory.func']);
 
-      const vcConfig = await fs.readJSON(
-        join(output, 'functions/api/memory.func/.vc-config.json')
-      );
-      expect(vcConfig).toMatchObject({
-        handler: 'api/memory.js',
-        memory: 128,
-        environment: {},
-        launcherType: 'Nodejs',
-        shouldAddHelpers: true,
-        shouldAddSourcemapSupport: false,
-        awsLambdaHandler: '',
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const vcConfig = await fs.readJSON(
+      join(output, 'functions/api/memory.func/.vc-config.json')
+    );
+    expect(vcConfig).toMatchObject({
+      handler: 'api/memory.js',
+      memory: 128,
+      environment: {},
+      launcherType: 'Nodejs',
+      shouldAddHelpers: true,
+      shouldAddSourcemapSupport: false,
+      awsLambdaHandler: '',
+    });
   });
 
   it('should apply project settings overrides from "vercel.json"', async () => {
@@ -1008,148 +866,116 @@ describe('build', () => {
 
     const cwd = fixture('project-settings-override');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // The `buildCommand` override in "vercel.json" outputs "3" to the
-      // index.txt file, so verify that that was produced in the build output
-      const contents = await fs.readFile(
-        join(output, 'static/index.txt'),
-        'utf8'
-      );
-      expect(contents.trim()).toEqual('3');
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // The `buildCommand` override in "vercel.json" outputs "3" to the
+    // index.txt file, so verify that that was produced in the build output
+    const contents = await fs.readFile(
+      join(output, 'static/index.txt'),
+      'utf8'
+    );
+    expect(contents.trim()).toEqual('3');
   });
 
   it('should set VERCEL_PROJECT_SETTINGS_ environment variables', async () => {
     const cwd = fixture('project-settings-env-vars');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      const contents = await fs.readJSON(join(output, 'static/env.json'));
-      expect(contents).toMatchObject({
-        VERCEL_PROJECT_SETTINGS_BUILD_COMMAND: `node build.cjs`,
-        VERCEL_PROJECT_SETTINGS_INSTALL_COMMAND: '',
-        VERCEL_PROJECT_SETTINGS_OUTPUT_DIRECTORY: 'out',
-        VERCEL_PROJECT_SETTINGS_NODE_VERSION: '18.x',
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const contents = await fs.readJSON(join(output, 'static/env.json'));
+    expect(contents).toMatchObject({
+      VERCEL_PROJECT_SETTINGS_BUILD_COMMAND: `node build.cjs`,
+      VERCEL_PROJECT_SETTINGS_INSTALL_COMMAND: '',
+      VERCEL_PROJECT_SETTINGS_OUTPUT_DIRECTORY: 'out',
+      VERCEL_PROJECT_SETTINGS_NODE_VERSION: '18.x',
+    });
   });
 
   it('should apply "images" configuration from `vercel.json`', async () => {
     const cwd = fixture('images');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      // `config.json` includes "images" from `vercel.json`
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson).toMatchObject({
-        images: {
-          sizes: [256, 384, 600, 1000],
-          domains: [],
-          minimumCacheTTL: 60,
-          formats: ['image/avif', 'image/webp'],
-          contentDispositionType: 'attachment',
-        },
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    // `config.json` includes "images" from `vercel.json`
+    const configJson = await fs.readJSON(join(output, 'config.json'));
+    expect(configJson).toMatchObject({
+      images: {
+        sizes: [256, 384, 600, 1000],
+        domains: [],
+        minimumCacheTTL: 60,
+        formats: ['image/avif', 'image/webp'],
+        contentDispositionType: 'attachment',
+      },
+    });
   });
 
   it('should fail with invalid "rewrites" configuration from `vercel.json`', async () => {
     const cwd = fixture('invalid-rewrites');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput(
-        'Error: Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?' +
-          '\n' +
-          'View Documentation: https://vercel.com/docs/concepts/projects/project-configuration#rewrites'
-      );
-      const builds = await fs.readJSON(join(output, 'builds.json'));
-      expect(builds.builds).toBeUndefined();
-      expect(builds.error).toEqual({
-        name: 'Error',
-        message:
-          'Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?',
-        stack: expect.stringContaining('at validateConfig'),
-        hideStackTrace: true,
-        code: 'INVALID_VERCEL_CONFIG',
-        link: 'https://vercel.com/docs/concepts/projects/project-configuration#rewrites',
-        action: 'View Documentation',
-      });
-      const configJson = await fs.readJSON(join(output, 'config.json'));
-      expect(configJson.version).toBe(3);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Error: Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?' +
+        '\n' +
+        'View Documentation: https://vercel.com/docs/concepts/projects/project-configuration#rewrites'
+    );
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds.builds).toBeUndefined();
+    expect(builds.error).toEqual({
+      name: 'Error',
+      message:
+        'Invalid vercel.json - `rewrites[2]` should NOT have additional property `src`. Did you mean `source`?',
+      stack: expect.stringContaining('at validateConfig'),
+      hideStackTrace: true,
+      code: 'INVALID_VERCEL_CONFIG',
+      link: 'https://vercel.com/docs/concepts/projects/project-configuration#rewrites',
+      action: 'View Documentation',
+    });
+    const configJson = await fs.readJSON(join(output, 'config.json'));
+    expect(configJson.version).toBe(3);
   });
 
   it('should include crons property in build output', async () => {
     const cwd = fixture('with-cron');
     const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
 
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toBe(0);
-
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toHaveProperty('crons', [
-        {
-          path: '/api/cron-job',
-          schedule: '0 0 * * *',
-        },
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toHaveProperty('crons', [
+      {
+        path: '/api/cron-job',
+        schedule: '0 0 * * *',
+      },
+    ]);
   });
 
   it('should merge crons property from build output with vercel.json crons property', async () => {
     const cwd = fixture('with-cron-merge');
     const output = join(cwd, '.vercel', 'output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toBe(0);
 
-    try {
-      process.chdir(cwd);
-      const exitCode = await build(client);
-      expect(exitCode).toBe(0);
-
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toHaveProperty('crons', [
-        {
-          path: '/api/cron-job',
-          schedule: '0 0 * * *',
-        },
-        {
-          path: '/api/cron-job-build-output',
-          schedule: '0 0 * * *',
-        },
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    const config = await fs.readJSON(join(output, 'config.json'));
+    expect(config).toHaveProperty('crons', [
+      {
+        path: '/api/cron-job',
+        schedule: '0 0 * * *',
+      },
+      {
+        path: '/api/cron-job-build-output',
+        schedule: '0 0 * * *',
+      },
+    ]);
   });
 
   describe('should find packages with different main/module/browser keys', function () {
@@ -1159,7 +985,7 @@ describe('build', () => {
       const cwd = fixture('import-from-main-keys');
       output = join(cwd, '.vercel/output');
 
-      process.chdir(cwd);
+      client.cwd = cwd;
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
@@ -1174,11 +1000,6 @@ describe('build', () => {
         'use-main.func',
         'use-module.func',
       ]);
-    });
-
-    afterAll(function () {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
     });
 
     it('use-classic', async function () {
@@ -1269,50 +1090,41 @@ describe('build', () => {
   it('should use --local-config over default vercel.json', async () => {
     const cwd = fixture('local-config');
     const output = join(cwd, '.vercel/output');
-    try {
-      process.chdir(cwd);
-      let exitCode = await build(client);
-      delete process.env.__VERCEL_BUILD_RUNNING;
-      expect(exitCode).toEqual(0);
+    client.cwd = cwd;
+    let exitCode = await build(client);
+    delete process.env.__VERCEL_BUILD_RUNNING;
+    expect(exitCode).toEqual(0);
 
-      let config = await fs.readJSON(join(output, 'config.json'));
-      expect(config.routes).toContainEqual({
-        src: '^/another-main$',
-        dest: '/main.html',
-      });
-      expect(config.routes).not.toContainEqual({
-        src: '^/another-test$',
-        dest: '/test.html',
-      });
+    let config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.routes).toContainEqual({
+      src: '^/another-main$',
+      dest: '/main.html',
+    });
+    expect(config.routes).not.toContainEqual({
+      src: '^/another-test$',
+      dest: '/test.html',
+    });
 
-      client.localConfigPath = 'vercel-test.json';
-      exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+    client.localConfigPath = 'vercel-test.json';
+    exitCode = await build(client);
+    expect(exitCode).toEqual(0);
 
-      config = await fs.readJSON(join(output, 'config.json'));
-      expect(config.routes).not.toContainEqual({
-        src: '^/another-main$',
-        dest: '/main.html',
-      });
-      expect(config.routes).toContainEqual({
-        src: '^/another-test$',
-        dest: '/test.html',
-      });
-    } finally {
-      process.chdir(originalCwd);
-      delete client.localConfigPath;
-      delete process.env.__VERCEL_BUILD_RUNNING;
-    }
+    config = await fs.readJSON(join(output, 'config.json'));
+    expect(config.routes).not.toContainEqual({
+      src: '^/another-main$',
+      dest: '/main.html',
+    });
+    expect(config.routes).toContainEqual({
+      src: '^/another-test$',
+      dest: '/test.html',
+    });
   });
 
   it('should build Storybook project and ignore middleware', async () => {
     const cwd = fixture('storybook-with-middleware');
     const output = join(cwd, '.vercel/output');
     try {
-      client.stdout.pipe(process.stdout);
-      client.stderr.pipe(process.stderr);
-
-      process.chdir(cwd);
+      client.cwd = cwd;
       process.env.STORYBOOK_DISABLE_TELEMETRY = '1';
       execSync('yarn');
 
@@ -1337,8 +1149,6 @@ describe('build', () => {
       // we should NOT see `functions` because that means `middleware.ts` was processed
       expect(files.sort()).toEqual(['builds.json', 'config.json', 'static']);
     } finally {
-      process.chdir(originalCwd);
-      delete process.env.__VERCEL_BUILD_RUNNING;
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;
     }
   });

--- a/packages/cli/test/unit/commands/deploy.test.ts
+++ b/packages/cli/test/unit/commands/deploy.test.ts
@@ -141,232 +141,206 @@ describe('deploy', () => {
   });
 
   it('should send a tgz file when `--archive=tgz`', async () => {
-    const cwd = setupUnitFixture('commands/deploy/static');
-    const originalCwd = process.cwd();
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
 
-      const user = useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        name: 'static',
-        id: 'static',
+    let body: any;
+    client.scenario.post(`/v13/deployments`, (req, res) => {
+      body = req.body;
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
       });
+    });
+    client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
+    client.scenario.get(`/v10/now/deployments/dpl_archive_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
 
-      let body: any;
-      client.scenario.post(`/v13/deployments`, (req, res) => {
-        body = req.body;
-        res.json({
-          creator: {
-            uid: user.id,
-            username: user.username,
-          },
-          id: 'dpl_archive_test',
-        });
-      });
-      client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
-        res.json({
-          creator: {
-            uid: user.id,
-            username: user.username,
-          },
-          id: 'dpl_archive_test',
-          readyState: 'READY',
-          aliasAssigned: true,
-          alias: [],
-        });
-      });
-      client.scenario.get(
-        `/v10/now/deployments/dpl_archive_test`,
-        (req, res) => {
-          res.json({
-            creator: {
-              uid: user.id,
-              username: user.username,
-            },
-            id: 'dpl_archive_test',
-            readyState: 'READY',
-            aliasAssigned: true,
-            alias: [],
-          });
-        }
-      );
-
-      client.setArgv('deploy', '--archive=tgz');
-      const exitCode = await deploy(client);
-      expect(exitCode).toEqual(0);
-      expect(body?.files?.length).toEqual(1);
-      expect(body?.files?.[0].file).toEqual('.vercel/source.tgz');
-    } finally {
-      process.chdir(originalCwd);
-    }
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.setArgv('deploy', '--archive=tgz');
+    const exitCode = await deploy(client);
+    expect(exitCode).toEqual(0);
+    expect(body?.files?.length).toEqual(1);
+    expect(body?.files?.[0].file).toEqual('.vercel/source.tgz');
   });
 
   it('should pass flag to skip custom domain assignment', async () => {
-    const cwd = setupUnitFixture('commands/deploy/static');
-    const originalCwd = process.cwd();
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
 
-      const user = useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        name: 'static',
-        id: 'static',
+    let body: any;
+    client.scenario.post(`/v13/deployments`, (req, res) => {
+      body = req.body;
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
       });
+    });
+    client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
 
-      let body: any;
-      client.scenario.post(`/v13/deployments`, (req, res) => {
-        body = req.body;
-        res.json({
-          creator: {
-            uid: user.id,
-            username: user.username,
-          },
-          id: 'dpl_archive_test',
-        });
-      });
-      client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
-        res.json({
-          creator: {
-            uid: user.id,
-            username: user.username,
-          },
-          id: 'dpl_archive_test',
-          readyState: 'READY',
-          aliasAssigned: true,
-          alias: [],
-        });
-      });
-
-      client.setArgv('deploy', '--prod', '--skip-domain');
-      const exitCode = await deploy(client);
-      expect(exitCode).toEqual(0);
-      expect(body).toMatchObject({
-        target: 'production',
-        source: 'cli',
-        autoAssignCustomDomains: false,
-        version: 2,
-      });
-    } finally {
-      process.chdir(originalCwd);
-    }
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.setArgv('deploy', '--prod', '--skip-domain');
+    const exitCode = await deploy(client);
+    expect(exitCode).toEqual(0);
+    expect(body).toMatchObject({
+      target: 'production',
+      source: 'cli',
+      autoAssignCustomDomains: false,
+      version: 2,
+    });
   });
 
   it('should upload missing files', async () => {
     const cwd = setupUnitFixture('commands/deploy/static');
-    const originalCwd = process.cwd();
+    client.cwd = cwd;
 
     // Add random 1mb file
     await fs.writeFile(join(cwd, 'data'), randomBytes(bytes('1mb')));
 
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
 
-      const user = useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        name: 'static',
-        id: 'static',
-      });
-
-      let body: any;
-      let fileUploaded = false;
-      client.scenario.post(`/v13/deployments`, (req, res) => {
-        if (fileUploaded) {
-          body = req.body;
-          res.json({
-            creator: {
-              uid: user.id,
-              username: user.username,
-            },
-            id: 'dpl_archive_test',
-          });
-        } else {
-          const sha = req.body.files[0].sha;
-          res.status(400).json({
-            error: {
-              code: 'missing_files',
-              message: 'Missing files',
-              missing: [sha],
-            },
-          });
-        }
-      });
-      client.scenario.post('/v2/files', (req, res) => {
-        // Wait for file to be finished uploading
-        req.on('data', () => {
-          // Noop
-        });
-        req.on('end', () => {
-          fileUploaded = true;
-          res.end();
-        });
-      });
-      client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
+    let body: any;
+    let fileUploaded = false;
+    client.scenario.post(`/v13/deployments`, (req, res) => {
+      if (fileUploaded) {
+        body = req.body;
         res.json({
           creator: {
             uid: user.id,
             username: user.username,
           },
           id: 'dpl_archive_test',
-          readyState: 'READY',
-          aliasAssigned: true,
-          alias: [],
         });
+      } else {
+        const sha = req.body.files[0].sha;
+        res.status(400).json({
+          error: {
+            code: 'missing_files',
+            message: 'Missing files',
+            missing: [sha],
+          },
+        });
+      }
+    });
+    client.scenario.post('/v2/files', (req, res) => {
+      // Wait for file to be finished uploading
+      req.on('data', () => {
+        // Noop
       });
-      client.scenario.get(
-        `/v10/now/deployments/dpl_archive_test`,
-        (req, res) => {
-          res.json({
-            creator: {
-              uid: user.id,
-              username: user.username,
-            },
-            id: 'dpl_archive_test',
-            readyState: 'READY',
-            aliasAssigned: true,
-            alias: [],
-          });
-        }
-      );
-
-      // When stderr is not a TTY we expect 5 progress lines to be printed
-      client.stderr.isTTY = false;
-
-      client.setArgv('deploy', '--archive=tgz');
-      const uploadingLines: string[] = [];
-      client.stderr.on('data', data => {
-        if (data.startsWith('Uploading [')) {
-          uploadingLines.push(data);
-        }
+      req.on('end', () => {
+        fileUploaded = true;
+        res.end();
       });
-      client.stderr.resume();
-      const exitCode = await deploy(client);
-      expect(exitCode).toEqual(0);
-      expect(body?.files?.length).toEqual(1);
-      expect(body?.files?.[0].file).toEqual('.vercel/source.tgz');
-      expect(uploadingLines.length).toEqual(5);
-      expect(
-        uploadingLines[0].startsWith('Uploading [--------------------]')
-      ).toEqual(true);
-      expect(
-        uploadingLines[1].startsWith('Uploading [=====---------------]')
-      ).toEqual(true);
-      expect(
-        uploadingLines[2].startsWith('Uploading [==========----------]')
-      ).toEqual(true);
-      expect(
-        uploadingLines[3].startsWith('Uploading [===============-----]')
-      ).toEqual(true);
-      expect(
-        uploadingLines[4].startsWith('Uploading [====================]')
-      ).toEqual(true);
-    } finally {
-      process.chdir(originalCwd);
-    }
+    });
+    client.scenario.get(`/v13/deployments/dpl_archive_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
+    client.scenario.get(`/v10/now/deployments/dpl_archive_test`, (req, res) => {
+      res.json({
+        creator: {
+          uid: user.id,
+          username: user.username,
+        },
+        id: 'dpl_archive_test',
+        readyState: 'READY',
+        aliasAssigned: true,
+        alias: [],
+      });
+    });
+
+    // When stderr is not a TTY we expect 5 progress lines to be printed
+    client.stderr.isTTY = false;
+
+    client.setArgv('deploy', '--archive=tgz');
+    const uploadingLines: string[] = [];
+    client.stderr.on('data', data => {
+      if (data.startsWith('Uploading [')) {
+        uploadingLines.push(data);
+      }
+    });
+    client.stderr.resume();
+    const exitCode = await deploy(client);
+    expect(exitCode).toEqual(0);
+    expect(body?.files?.length).toEqual(1);
+    expect(body?.files?.[0].file).toEqual('.vercel/source.tgz');
+    expect(uploadingLines.length).toEqual(5);
+    expect(
+      uploadingLines[0].startsWith('Uploading [--------------------]')
+    ).toEqual(true);
+    expect(
+      uploadingLines[1].startsWith('Uploading [=====---------------]')
+    ).toEqual(true);
+    expect(
+      uploadingLines[2].startsWith('Uploading [==========----------]')
+    ).toEqual(true);
+    expect(
+      uploadingLines[3].startsWith('Uploading [===============-----]')
+    ).toEqual(true);
+    expect(
+      uploadingLines[4].startsWith('Uploading [====================]')
+    ).toEqual(true);
   });
 });

--- a/packages/cli/test/unit/commands/env.test.ts
+++ b/packages/cli/test/unit/commands/env.test.ts
@@ -11,7 +11,6 @@ import { useUser } from '../../mocks/user';
 describe('env', () => {
   describe('pull', () => {
     it('should handle pulling', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -19,7 +18,9 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
-      client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes');
       const exitCodePromise = env(client);
       await expect(client.stderr).toOutput(
         'Downloading `development` Environment Variables for Project vercel-env-pull'
@@ -35,7 +36,6 @@ describe('env', () => {
     });
 
     it('should handle pulling from Preview env vars', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -43,15 +43,9 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
-      client.setArgv(
-        'env',
-        'pull',
-        '--yes',
-        '--cwd',
-        cwd,
-        '--environment',
-        'preview'
-      );
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes', '--environment', 'preview');
       const exitCodePromise = env(client);
       await expect(client.stderr).toOutput(
         'Downloading `preview` Environment Variables for Project vercel-env-pull'
@@ -70,7 +64,6 @@ describe('env', () => {
     });
 
     it('should handle pulling from specific Git branch', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -78,12 +71,12 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
       client.setArgv(
         'env',
         'pull',
         '--yes',
-        '--cwd',
-        cwd,
         '--environment',
         'preview',
         '--git-branch',
@@ -114,7 +107,6 @@ describe('env', () => {
     });
 
     it('should handle alternate filename', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -122,7 +114,9 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
-      client.setArgv('env', 'pull', 'other.env', '--yes', '--cwd', cwd);
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', 'other.env', '--yes');
       const exitCodePromise = env(client);
       await expect(client.stderr).toOutput(
         'Downloading `development` Environment Variables for Project vercel-env-pull'
@@ -138,7 +132,6 @@ describe('env', () => {
     });
 
     it('should use given environment', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -146,15 +139,9 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
-
-      client.setArgv(
-        'env',
-        'pull',
-        '--environment',
-        'production',
-        '--cwd',
-        cwd
-      );
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--environment', 'production');
       const exitCodePromise = env(client);
       await expect(client.stderr).toOutput(
         `Downloading \`production\` Environment Variables for Project vercel-env-pull`
@@ -172,7 +159,6 @@ describe('env', () => {
     });
 
     it('should throw an error when it does not recognize given environment', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -180,15 +166,14 @@ describe('env', () => {
         id: 'vercel-env-pull',
         name: 'vercel-env-pull',
       });
-
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
       client.setArgv(
         'env',
         'pull',
         '.env.production',
         '--environment',
-        'something-invalid',
-        '--cwd',
-        cwd
+        'something-invalid'
       );
 
       const exitCodePromise = env(client);
@@ -200,7 +185,6 @@ describe('env', () => {
     });
 
     it('should expose production system env variables', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -209,8 +193,9 @@ describe('env', () => {
         name: 'vercel-env-pull',
         autoExposeSystemEnvs: true,
       });
-
-      client.setArgv('env', 'pull', 'other.env', '--yes', '--cwd', cwd);
+      const cwd = setupUnitFixture('vercel-env-pull');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', 'other.env', '--yes');
       const exitCodePromise = env(client);
       await expect(client.stderr).toOutput(
         'Downloading `development` Environment Variables for Project vercel-env-pull'
@@ -228,6 +213,7 @@ describe('env', () => {
 
     it('should show a delta string', async () => {
       const cwd = setupUnitFixture('vercel-env-pull-delta');
+      client.cwd = cwd;
       try {
         useUser();
         useTeams('team_dummy');
@@ -237,7 +223,7 @@ describe('env', () => {
           name: 'env-pull-delta',
         });
 
-        client.setArgv('env', 'add', 'NEW_VAR', '--cwd', cwd);
+        client.setArgv('env', 'add', 'NEW_VAR');
         const addPromise = env(client);
 
         await expect(client.stderr).toOutput('What’s the value of NEW_VAR?');
@@ -253,7 +239,7 @@ describe('env', () => {
 
         await expect(addPromise).resolves.toEqual(0);
 
-        client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'pull', '--yes');
         const pullPromise = env(client);
         await expect(client.stderr).toOutput(
           'Downloading `development` Environment Variables for Project env-pull-delta'
@@ -265,13 +251,12 @@ describe('env', () => {
 
         await expect(pullPromise).resolves.toEqual(0);
       } finally {
-        client.setArgv('env', 'rm', 'NEW_VAR', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
         await env(client);
       }
     });
 
     it('should not show a delta string when it fails to read a file', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull-delta-corrupt');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -279,15 +264,15 @@ describe('env', () => {
         id: 'env-pull-delta-corrupt',
         name: 'env-pull-delta-corrupt',
       });
-
-      client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
+      const cwd = setupUnitFixture('vercel-env-pull-delta-corrupt');
+      client.cwd = cwd;
+      client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput('Updated .env.local file');
       await expect(pullPromise).resolves.toEqual(0);
     });
 
     it('should show that no changes were found', async () => {
-      const cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -295,8 +280,8 @@ describe('env', () => {
         id: 'env-pull-delta-no-changes',
         name: 'env-pull-delta-no-changes',
       });
-
-      client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
+      client.cwd = setupUnitFixture('vercel-env-pull-delta-no-changes');
+      client.setArgv('env', 'pull', '--yes');
       const pullPromise = env(client);
       await expect(client.stderr).toOutput('> No changes found.');
       await expect(client.stderr).toOutput('Updated .env.local file');
@@ -305,6 +290,7 @@ describe('env', () => {
 
     it('should correctly render delta string when env variable has quotes', async () => {
       const cwd = setupUnitFixture('vercel-env-pull-delta-quotes');
+      client.cwd = cwd;
       try {
         useUser();
         useTeams('team_dummy');
@@ -329,7 +315,7 @@ describe('env', () => {
           ]
         );
 
-        client.setArgv('env', 'pull', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'pull', '--yes');
         const pullPromise = env(client);
         await expect(client.stderr).toOutput(
           'Downloading `development` Environment Variables for Project env-pull-delta'
@@ -339,13 +325,14 @@ describe('env', () => {
 
         await expect(pullPromise).resolves.toEqual(0);
       } finally {
-        client.setArgv('env', 'rm', 'NEW_VAR', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
         await env(client);
       }
     });
 
     it('should correctly render delta string when local env variable has quotes', async () => {
       const cwd = setupUnitFixture('vercel-env-pull-delta-quotes');
+      client.cwd = cwd;
       try {
         useUser();
         useTeams('team_dummy');
@@ -370,7 +357,7 @@ describe('env', () => {
           ]
         );
 
-        client.setArgv('env', 'pull', '.env.testquotes', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'pull', '.env.testquotes', '--yes');
         const pullPromise = env(client);
         await expect(client.stderr).toOutput(
           'Downloading `development` Environment Variables for Project env-pull-delta'
@@ -380,7 +367,7 @@ describe('env', () => {
 
         await expect(pullPromise).resolves.toEqual(0);
       } finally {
-        client.setArgv('env', 'rm', 'NEW_VAR', '--yes', '--cwd', cwd);
+        client.setArgv('env', 'rm', 'NEW_VAR', '--yes');
         await env(client);
       }
     });

--- a/packages/cli/test/unit/commands/git.test.ts
+++ b/packages/cli/test/unit/commands/git.test.ts
@@ -9,14 +9,13 @@ import type { Project } from '@vercel-internals/types';
 
 describe('git', () => {
   describe('connect', () => {
-    const originalCwd = process.cwd();
     const fixture = (name: string) =>
       join(__dirname, '../../fixtures/unit/commands/git/connect', name);
 
     it('connects an unlinked project', async () => {
       const cwd = fixture('unlinked');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -62,13 +61,12 @@ describe('git', () => {
         });
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('connects an unlinked project with a remote url', async () => {
       const cwd = fixture('unlinked');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -119,34 +117,28 @@ describe('git', () => {
         });
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should fail when there is no git config', async () => {
-      const cwd = fixture('no-git-config');
-      try {
-        process.chdir(cwd);
-        useUser();
-        useTeams('team_dummy');
-        useProject({
-          ...defaultProject,
-          id: 'no-git-config',
-          name: 'no-git-config',
-        });
-        client.setArgv('git', 'connect', '--yes');
-        const exitCode = await git(client);
-        expect(exitCode).toEqual(1);
-        await expect(client.stderr).toOutput(
-          `Error: No local Git repository found. Run \`git clone <url>\` to clone a remote Git repository first.\n`
-        );
-      } finally {
-        process.chdir(originalCwd);
-      }
+      client.cwd = fixture('no-git-config');
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'no-git-config',
+        name: 'no-git-config',
+      });
+      client.setArgv('git', 'connect', '--yes');
+      const exitCode = await git(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        `Error: No local Git repository found. Run \`git clone <url>\` to clone a remote Git repository first.\n`
+      );
     });
     it('should fail when there is no remote url', async () => {
       const cwd = fixture('no-remote-url');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -163,13 +155,12 @@ describe('git', () => {
         );
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should fail when the remote url is bad', async () => {
       const cwd = fixture('bad-remote-url');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -190,13 +181,12 @@ describe('git', () => {
         );
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should connect a repo to a project that is not already connected', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -232,13 +222,12 @@ describe('git', () => {
         });
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should replace an old connection with a new one', async () => {
       const cwd = fixture('existing-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -285,13 +274,12 @@ describe('git', () => {
         });
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should exit when an already-connected repo is connected', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -324,13 +312,12 @@ describe('git', () => {
         expect(exitCode).toEqual(1);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should fail when it cannot find the repository', async () => {
       const cwd = fixture('invalid-repo');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -354,13 +341,12 @@ describe('git', () => {
         expect(exitCode).toEqual(1);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should connect the default option of multiple remotes', async () => {
       const cwd = fixture('multiple-remotes');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -404,19 +390,17 @@ describe('git', () => {
         });
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
   });
   describe('disconnect', () => {
-    const originalCwd = process.cwd();
     const fixture = (name: string) =>
       join(__dirname, '../../fixtures/unit/commands/git/connect', name);
 
     it('should disconnect a repository', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -453,13 +437,12 @@ describe('git', () => {
         expect(exitCode).toEqual(0);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should fail if there is no repository to disconnect', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -480,13 +463,12 @@ describe('git', () => {
         expect(exitCode).toEqual(1);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should connect a given repository', async () => {
       const cwd = fixture('no-remote-url');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -522,13 +504,12 @@ describe('git', () => {
         await expect(gitPromise).resolves.toEqual(0);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should prompt when it finds a repository', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -571,13 +552,12 @@ describe('git', () => {
         await expect(gitPromise).resolves.toEqual(0);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should prompt when it finds multiple remotes', async () => {
       const cwd = fixture('multiple-remotes');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -621,13 +601,12 @@ describe('git', () => {
         await expect(gitPromise).resolves.toEqual(0);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
     it('should continue as normal when input matches single git remote', async () => {
       const cwd = fixture('new-connection');
+      client.cwd = cwd;
       try {
-        process.chdir(cwd);
         await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
         useUser();
         useTeams('team_dummy');
@@ -663,7 +642,6 @@ describe('git', () => {
         await expect(gitPromise).resolves.toEqual(0);
       } finally {
         await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-        process.chdir(originalCwd);
       }
     });
   });

--- a/packages/cli/test/unit/commands/link.test.ts
+++ b/packages/cli/test/unit/commands/link.test.ts
@@ -12,12 +12,10 @@ import {
 import { tmpdir } from 'os';
 
 describe('link', () => {
-  const origCwd = process.cwd();
-
   it('should prompt for link', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    client.cwd = cwd;
     try {
-      process.chdir(cwd);
       const user = useUser();
       useTeams('team_dummy');
       const { project } = useProject({
@@ -50,15 +48,14 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(project.id);
     } finally {
-      process.chdir(origCwd);
       await remove(cwd);
     }
   });
 
   it('should allow specifying `--project` flag', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    client.cwd = cwd;
     try {
-      process.chdir(cwd);
       const user = useUser();
       useTeams('team_dummy');
       const { project } = useProject({
@@ -81,15 +78,14 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(project.id);
     } finally {
-      process.chdir(origCwd);
       await remove(cwd);
     }
   });
 
   it('should allow overwriting existing link', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    client.cwd = cwd;
     try {
-      process.chdir(cwd);
       const user = useUser();
       useTeams('team_dummy');
       const { project: proj1 } = useProject({
@@ -118,7 +114,6 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(proj2.id);
     } finally {
-      process.chdir(origCwd);
       await remove(cwd);
     }
   });

--- a/packages/cli/test/unit/commands/list.test.ts
+++ b/packages/cli/test/unit/commands/list.test.ts
@@ -18,179 +18,160 @@ const fixture = (name: string) =>
   join(__dirname, '../../fixtures/unit/commands/list', name);
 
 describe('list', () => {
-  const originalCwd = process.cwd();
   let teamSlug: string;
 
   it('should get deployments from a project linked by a directory', async () => {
-    const cwd = fixture('with-team');
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    const team = useTeams('team_dummy');
+    teamSlug = team[0].slug;
+    useProject({
+      ...defaultProject,
+      id: 'with-team',
+      name: 'with-team',
+    });
+    const deployment = useDeployment({ creator: user });
 
-      const user = useUser();
-      const team = useTeams('team_dummy');
-      teamSlug = team[0].slug;
-      useProject({
-        ...defaultProject,
-        id: 'with-team',
-        name: 'with-team',
-      });
-      const deployment = useDeployment({ creator: user });
+    client.cwd = fixture('with-team');
+    await list(client);
 
-      await list(client);
+    const lines = createLineIterator(client.stderr);
 
-      const lines = createLineIterator(client.stderr);
+    let line = await lines.next();
+    expect(line.value).toEqual('Retrieving project…');
 
-      let line = await lines.next();
-      expect(line.value).toEqual('Retrieving project…');
+    line = await lines.next();
+    expect(line.value).toEqual(`Fetching deployments in ${team[0].slug}`);
 
-      line = await lines.next();
-      expect(line.value).toEqual(`Fetching deployments in ${team[0].slug}`);
+    line = await lines.next();
+    const { org } = pluckIdentifiersFromDeploymentList(line.value!);
+    expect(org).toEqual(team[0].slug);
 
-      line = await lines.next();
-      const { org } = pluckIdentifiersFromDeploymentList(line.value!);
-      expect(org).toEqual(team[0].slug);
+    // skip next line
+    await lines.next();
 
-      // skip next line
-      await lines.next();
+    line = await lines.next();
+    expect(line.value).toEqual('');
 
-      line = await lines.next();
-      expect(line.value).toEqual('');
+    line = await lines.next();
+    const header = parseSpacedTableRow(line.value!);
+    expect(header).toEqual([
+      'Age',
+      'Deployment',
+      'Status',
+      'Duration',
+      'Username',
+    ]);
 
-      line = await lines.next();
-      const header = parseSpacedTableRow(line.value!);
-      expect(header).toEqual([
-        'Age',
-        'Deployment',
-        'Status',
-        'Duration',
-        'Username',
-      ]);
-
-      line = await lines.next();
-      const data = parseSpacedTableRow(line.value!);
-      data.shift();
-      expect(data).toEqual([
-        `https://${deployment.url}`,
-        stateString(deployment.state || ''),
-        getDeploymentDuration(deployment),
-        user.username,
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-    }
+    line = await lines.next();
+    const data = parseSpacedTableRow(line.value!);
+    data.shift();
+    expect(data).toEqual([
+      `https://${deployment.url}`,
+      stateString(deployment.state || ''),
+      getDeploymentDuration(deployment),
+      user.username,
+    ]);
   });
 
   it('should get deployments for linked project where the scope is a user', async () => {
-    const cwd = fixture('with-team');
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'with-team',
+      name: 'with-team',
+    });
+    const deployment = useDeployment({ creator: user });
 
-      const user = useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'with-team',
-        name: 'with-team',
-      });
-      const deployment = useDeployment({ creator: user });
+    client.cwd = fixture('with-team');
+    client.setArgv('-S', user.username);
+    await list(client);
 
-      client.setArgv('-S', user.username);
-      await list(client);
+    const lines = createLineIterator(client.stderr);
 
-      const lines = createLineIterator(client.stderr);
+    let line = await lines.next();
+    expect(line.value).toEqual('Retrieving project…');
 
-      let line = await lines.next();
-      expect(line.value).toEqual('Retrieving project…');
+    line = await lines.next();
+    expect(line.value).toEqual(`Fetching deployments in ${user.username}`);
 
-      line = await lines.next();
-      expect(line.value).toEqual(`Fetching deployments in ${user.username}`);
+    line = await lines.next();
+    const { org } = pluckIdentifiersFromDeploymentList(line.value!);
+    expect(org).toEqual(user.username);
 
-      line = await lines.next();
-      const { org } = pluckIdentifiersFromDeploymentList(line.value!);
-      expect(org).toEqual(user.username);
+    // skip next line
+    await lines.next();
 
-      // skip next line
-      await lines.next();
+    line = await lines.next();
+    expect(line.value).toEqual('');
 
-      line = await lines.next();
-      expect(line.value).toEqual('');
+    line = await lines.next();
+    const header = parseSpacedTableRow(line.value!);
+    expect(header).toEqual(['Age', 'Deployment', 'Status', 'Duration']);
 
-      line = await lines.next();
-      const header = parseSpacedTableRow(line.value!);
-      expect(header).toEqual(['Age', 'Deployment', 'Status', 'Duration']);
+    line = await lines.next();
+    const data = parseSpacedTableRow(line.value!);
+    data.shift();
 
-      line = await lines.next();
-      const data = parseSpacedTableRow(line.value!);
-      data.shift();
-
-      expect(data).toEqual([
-        'https://' + deployment.url,
-        stateString(deployment.state || ''),
-        getDeploymentDuration(deployment),
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-    }
+    expect(data).toEqual([
+      'https://' + deployment.url,
+      stateString(deployment.state || ''),
+      getDeploymentDuration(deployment),
+    ]);
   });
 
   it('should get the deployments for a specified project', async () => {
-    const cwd = fixture('with-team');
-    try {
-      process.chdir(cwd);
+    const user = useUser();
+    const team = useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'with-team',
+      name: 'with-team',
+    });
+    const deployment = useDeployment({ creator: user });
 
-      const user = useUser();
-      const team = useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'with-team',
-        name: 'with-team',
-      });
-      const deployment = useDeployment({ creator: user });
+    client.cwd = fixture('with-team');
+    client.setArgv(deployment.name);
+    await list(client);
 
-      client.setArgv(deployment.name);
-      await list(client);
+    const lines = createLineIterator(client.stderr);
 
-      const lines = createLineIterator(client.stderr);
+    let line = await lines.next();
+    expect(line.value).toEqual('Retrieving project…');
 
-      let line = await lines.next();
-      expect(line.value).toEqual('Retrieving project…');
+    line = await lines.next();
+    expect(line.value).toEqual(
+      `Fetching deployments in ${teamSlug || team[0].slug}`
+    );
 
-      line = await lines.next();
-      expect(line.value).toEqual(
-        `Fetching deployments in ${teamSlug || team[0].slug}`
-      );
+    line = await lines.next();
+    const { org } = pluckIdentifiersFromDeploymentList(line.value!);
+    expect(org).toEqual(teamSlug || team[0].slug);
 
-      line = await lines.next();
-      const { org } = pluckIdentifiersFromDeploymentList(line.value!);
-      expect(org).toEqual(teamSlug || team[0].slug);
+    // skip next line
+    await lines.next();
 
-      // skip next line
-      await lines.next();
+    line = await lines.next();
+    expect(line.value).toEqual('');
 
-      line = await lines.next();
-      expect(line.value).toEqual('');
+    line = await lines.next();
+    const header = parseSpacedTableRow(line.value!);
+    expect(header).toEqual([
+      'Age',
+      'Deployment',
+      'Status',
+      'Duration',
+      'Username',
+    ]);
 
-      line = await lines.next();
-      const header = parseSpacedTableRow(line.value!);
-      expect(header).toEqual([
-        'Age',
-        'Deployment',
-        'Status',
-        'Duration',
-        'Username',
-      ]);
-
-      line = await lines.next();
-      const data = parseSpacedTableRow(line.value!);
-      data.shift();
-      expect(data).toEqual([
-        `https://${deployment.url}`,
-        stateString(deployment.state || ''),
-        getDeploymentDuration(deployment),
-        user.username,
-      ]);
-    } finally {
-      process.chdir(originalCwd);
-    }
+    line = await lines.next();
+    const data = parseSpacedTableRow(line.value!);
+    data.shift();
+    expect(data).toEqual([
+      `https://${deployment.url}`,
+      stateString(deployment.state || ''),
+      getDeploymentDuration(deployment),
+      user.username,
+    ]);
   });
 });

--- a/packages/cli/test/unit/commands/promote.test.ts
+++ b/packages/cli/test/unit/commands/promote.test.ts
@@ -13,20 +13,10 @@ import sleep from '../../../src/util/sleep';
 jest.setTimeout(60000);
 
 describe('promote', () => {
-  it('should error if cwd is invalid', async () => {
-    client.setArgv('promote', '--cwd', __filename);
-    const exitCodePromise = promote(client);
-
-    await expect(client.stderr).toOutput(
-      'Error: Support for single file deployments has been removed.'
-    );
-
-    await expect(exitCodePromise).resolves.toEqual(1);
-  });
-
   it('should error if timeout is invalid', async () => {
     const { cwd } = initPromoteTest();
-    client.setArgv('promote', '--yes', '--cwd', cwd, '--timeout', 'foo');
+    client.cwd = cwd;
+    client.setArgv('promote', '--yes', '--timeout', 'foo');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput('Error: Invalid timeout "foo"');
@@ -35,7 +25,8 @@ describe('promote', () => {
 
   it('should error if invalid deployment ID', async () => {
     const { cwd } = initPromoteTest();
-    client.setArgv('promote', '????', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', '????', '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -46,7 +37,8 @@ describe('promote', () => {
 
   it('should error if deployment not found', async () => {
     const { cwd } = initPromoteTest();
-    client.setArgv('promote', 'foo', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', 'foo', '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput('Fetching deployment "foo" in ');
@@ -59,7 +51,8 @@ describe('promote', () => {
 
   it('should show status when not promoting', async () => {
     const { cwd } = initPromoteTest();
-    client.setArgv('promote', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -72,7 +65,8 @@ describe('promote', () => {
 
   it('should promote by deployment id', async () => {
     const { cwd, previousDeployment } = initPromoteTest();
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -90,7 +84,8 @@ describe('promote', () => {
 
   it('should promote by deployment url', async () => {
     const { cwd, previousDeployment } = initPromoteTest();
-    client.setArgv('promote', previousDeployment.url, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.url, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -110,16 +105,17 @@ describe('promote', () => {
     const { cwd, previousDeployment, project } = initPromoteTest({
       promotePollCount: 10,
     });
+    client.cwd = cwd;
 
     // start the promote
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.setArgv('promote', previousDeployment.id, '--yes');
     promote(client);
 
     // need to wait for the promote request to be accepted
     await sleep(300);
 
     // get the status
-    client.setArgv('promote', '--yes', '--cwd', cwd);
+    client.setArgv('promote', '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -139,8 +135,8 @@ describe('promote', () => {
       promotePollCount: 10,
       promoteStatusCode: 500,
     });
-
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -157,7 +153,8 @@ describe('promote', () => {
     const { cwd, previousDeployment } = initPromoteTest({
       promoteJobStatus: 'failed',
     });
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -185,7 +182,8 @@ describe('promote', () => {
       ],
       promoteJobStatus: 'failed',
     });
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -209,15 +207,8 @@ describe('promote', () => {
     const { cwd, previousDeployment } = initPromoteTest({
       promotePollCount: 10,
     });
-    client.setArgv(
-      'promote',
-      previousDeployment.id,
-      '--yes',
-      '--cwd',
-      cwd,
-      '--timeout',
-      '1'
-    );
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes', '--timeout', '1');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -236,15 +227,8 @@ describe('promote', () => {
 
   it('should immediately exit after requesting promote', async () => {
     const { cwd, previousDeployment } = initPromoteTest();
-    client.setArgv(
-      'promote',
-      previousDeployment.id,
-      '--yes',
-      '--cwd',
-      cwd,
-      '--timeout',
-      '0'
-    );
+    client.cwd = cwd;
+    client.setArgv('promote', previousDeployment.id, '--yes', '--timeout', '0');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(
@@ -261,12 +245,13 @@ describe('promote', () => {
 
   it('should error if deployment belongs to different team', async () => {
     const { cwd, previousDeployment } = initPromoteTest();
+    client.cwd = cwd;
     previousDeployment.team = {
       id: 'abc',
       name: 'abc',
       slug: 'abc',
     };
-    client.setArgv('promote', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.setArgv('promote', previousDeployment.id, '--yes');
     const exitCodePromise = promote(client);
 
     await expect(client.stderr).toOutput(

--- a/packages/cli/test/unit/commands/rollback.test.ts
+++ b/packages/cli/test/unit/commands/rollback.test.ts
@@ -13,20 +13,10 @@ import sleep from '../../../src/util/sleep';
 jest.setTimeout(60000);
 
 describe('rollback', () => {
-  it('should error if cwd is invalid', async () => {
-    client.setArgv('rollback', '--cwd', __filename);
-    const exitCodePromise = rollback(client);
-
-    await expect(client.stderr).toOutput(
-      'Error: Support for single file deployments has been removed.'
-    );
-
-    await expect(exitCodePromise).resolves.toEqual(1);
-  });
-
   it('should error if timeout is invalid', async () => {
     const { cwd } = initRollbackTest();
-    client.setArgv('rollback', '--yes', '--cwd', cwd, '--timeout', 'foo');
+    client.cwd = cwd;
+    client.setArgv('rollback', '--yes', '--timeout', 'foo');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput('Error: Invalid timeout "foo"');
@@ -35,7 +25,8 @@ describe('rollback', () => {
 
   it('should error if invalid deployment ID', async () => {
     const { cwd } = initRollbackTest();
-    client.setArgv('rollback', '????', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', '????', '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -46,7 +37,8 @@ describe('rollback', () => {
 
   it('should error if deployment not found', async () => {
     const { cwd } = initRollbackTest();
-    client.setArgv('rollback', 'foo', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', 'foo', '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -58,7 +50,8 @@ describe('rollback', () => {
 
   it('should show status when not rolling back', async () => {
     const { cwd } = initRollbackTest();
-    client.setArgv('rollback', '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -71,7 +64,8 @@ describe('rollback', () => {
 
   it('should rollback by deployment id', async () => {
     const { cwd, previousDeployment } = initRollbackTest();
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -89,7 +83,8 @@ describe('rollback', () => {
 
   it('should rollback by deployment url', async () => {
     const { cwd, previousDeployment } = initRollbackTest();
-    client.setArgv('rollback', previousDeployment.url, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.url, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -109,16 +104,17 @@ describe('rollback', () => {
     const { cwd, previousDeployment, project } = initRollbackTest({
       rollbackPollCount: 10,
     });
+    client.cwd = cwd;
 
     // start the rollback
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     rollback(client);
 
     // need to wait for the rollback request to be accepted
     await sleep(300);
 
     // get the status
-    client.setArgv('rollback', '--yes', '--cwd', cwd);
+    client.setArgv('rollback', '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -138,8 +134,9 @@ describe('rollback', () => {
       rollbackPollCount: 10,
       rollbackStatusCode: 500,
     });
+    client.cwd = cwd;
 
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -155,7 +152,8 @@ describe('rollback', () => {
     const { cwd, previousDeployment } = initRollbackTest({
       rollbackJobStatus: 'failed',
     });
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -183,7 +181,8 @@ describe('rollback', () => {
       ],
       rollbackJobStatus: 'failed',
     });
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(
@@ -207,12 +206,11 @@ describe('rollback', () => {
     const { cwd, previousDeployment } = initRollbackTest({
       rollbackPollCount: 10,
     });
+    client.cwd = cwd;
     client.setArgv(
       'rollback',
       previousDeployment.id,
       '--yes',
-      '--cwd',
-      cwd,
       '--timeout',
       '1'
     );
@@ -233,12 +231,11 @@ describe('rollback', () => {
 
   it('should immediately exit after requesting rollback', async () => {
     const { cwd, previousDeployment } = initRollbackTest();
+    client.cwd = cwd;
     client.setArgv(
       'rollback',
       previousDeployment.id,
       '--yes',
-      '--cwd',
-      cwd,
       '--timeout',
       '0'
     );
@@ -263,7 +260,8 @@ describe('rollback', () => {
       name: 'abc',
       slug: 'abc',
     };
-    client.setArgv('rollback', previousDeployment.id, '--yes', '--cwd', cwd);
+    client.cwd = cwd;
+    client.setArgv('rollback', previousDeployment.id, '--yes');
     const exitCodePromise = rollback(client);
 
     await expect(client.stderr).toOutput(

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -306,10 +306,9 @@ describe('createGitMeta', () => {
     }
   });
   it('uses the repo url for a connected project', async () => {
-    const originalCwd = process.cwd();
     const directory = fixture('connected-repo');
+    client.cwd = directory;
     try {
-      process.chdir(directory);
       await fs.rename(join(directory, 'git'), join(directory, '.git'));
 
       useUser();
@@ -343,7 +342,6 @@ describe('createGitMeta', () => {
       });
     } finally {
       await fs.rename(join(directory, '.git'), join(directory, 'git'));
-      process.chdir(originalCwd);
     }
   });
 });


### PR DESCRIPTION
A few commands were still checking on `--cwd` explicitly, which is incorrect since the entrypoint file already handles the directory change.

The new `client.cwd` property is a helper to make writing tests easier. Tests no longer need to `chdir()` explicitly and then revert afterwards.