### PR TITLE
Revert "Use `pnpm publish -r` to publish packages (#10022)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm ci:version
-          publish: pnpm ci:publish
+          version: pnpm version:prepare
+          publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
-    "ci:publish": "pnpm publish -r"
+    "version:prepare": "changeset version && pnpm install --no-frozen-lockfile",
+    "release": "changeset publish"
   },
   "lint-staged": {
     "./{*,{api,packages,test,utils}/**/*}.{js,ts}": [


### PR DESCRIPTION
This reverts commit 1e47bbf32f21262c0d85fa0c1fe89cf59b67cd4c.

`changeset publish` also creates git tags, whereas `pnpm publish -r` does not. This causes the GitHub Releases to not be created.