### PR TITLE
[cli] Fix `link` subcommand unit tests on Windows

### DIFF
--- a/packages/cli/test/helpers/setup-unit-fixture.ts
+++ b/packages/cli/test/helpers/setup-unit-fixture.ts
@@ -34,16 +34,19 @@ export function setupUnitFixture(fixtureName: string) {
     );
   }
 
+  const cwd = setupTmpDir(fixtureName);
+  fs.copySync(fixturePath, cwd);
+  return cwd;
+}
+
+export function setupTmpDir(fixtureName?: string) {
   if (!tempRoot) {
     // Create a shared root temp directory for fixture files
     tempRoot = tmp.dirSync({ unsafeCleanup: true }); // clean up even if files are left
   }
 
-  const cwd = path.join(tempRoot.name, String(tempNumber++), fixtureName);
-
+  const cwd = path.join(tempRoot.name, String(tempNumber++), fixtureName ?? '');
   fs.mkdirpSync(cwd);
-  fs.copySync(fixturePath, cwd);
-
   return cwd;
 }
 

--- a/packages/cli/test/unit/commands/link.test.ts
+++ b/packages/cli/test/unit/commands/link.test.ts
@@ -1,5 +1,5 @@
 import { basename, join } from 'path';
-import { mkdtemp, readJSON, remove } from 'fs-extra';
+import { readJSON } from 'fs-extra';
 import link from '../../../src/commands/link';
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
@@ -9,112 +9,100 @@ import {
   useProject,
   useUnknownProject,
 } from '../../mocks/project';
-import { tmpdir } from 'os';
+import { setupTmpDir } from '../../helpers/setup-unit-fixture';
 
 describe('link', () => {
   it('should prompt for link', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    const cwd = setupTmpDir();
+    const user = useUser();
+    useTeams('team_dummy');
+    const { project } = useProject({
+      ...defaultProject,
+      id: basename(cwd),
+      name: basename(cwd),
+    });
+    useUnknownProject();
+
     client.cwd = cwd;
-    try {
-      const user = useUser();
-      useTeams('team_dummy');
-      const { project } = useProject({
-        ...defaultProject,
-        id: basename(cwd),
-        name: basename(cwd),
-      });
-      useUnknownProject();
+    const exitCodePromise = link(client);
 
-      const exitCodePromise = link(client);
+    await expect(client.stderr).toOutput('Set up');
+    client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput('Set up');
-      client.stdin.write('y\n');
+    await expect(client.stderr).toOutput(
+      'Which scope should contain your project?'
+    );
+    client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput(
-        'Which scope should contain your project?'
-      );
-      client.stdin.write('y\n');
+    await expect(client.stderr).toOutput('Link to it?');
+    client.stdin.write('y\n');
 
-      await expect(client.stderr).toOutput('Link to it?');
-      client.stdin.write('y\n');
+    await expect(client.stderr).toOutput(
+      `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+    );
 
-      await expect(client.stderr).toOutput(
-        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
-      );
+    await expect(exitCodePromise).resolves.toEqual(0);
 
-      await expect(exitCodePromise).resolves.toEqual(0);
-
-      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
-      expect(projectJson.orgId).toEqual(user.id);
-      expect(projectJson.projectId).toEqual(project.id);
-    } finally {
-      await remove(cwd);
-    }
+    const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+    expect(projectJson.orgId).toEqual(user.id);
+    expect(projectJson.projectId).toEqual(project.id);
   });
 
   it('should allow specifying `--project` flag', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    const cwd = setupTmpDir();
+    const user = useUser();
+    useTeams('team_dummy');
+    const { project } = useProject({
+      ...defaultProject,
+      id: basename(cwd),
+      name: basename(cwd),
+    });
+    useUnknownProject();
+
     client.cwd = cwd;
-    try {
-      const user = useUser();
-      useTeams('team_dummy');
-      const { project } = useProject({
-        ...defaultProject,
-        id: basename(cwd),
-        name: basename(cwd),
-      });
-      useUnknownProject();
+    client.setArgv('--project', project.name!, '--yes');
+    const exitCodePromise = link(client);
 
-      client.setArgv('--project', project.name!, '--yes');
-      const exitCodePromise = link(client);
+    await expect(client.stderr).toOutput(
+      `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+    );
 
-      await expect(client.stderr).toOutput(
-        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
-      );
+    await expect(exitCodePromise).resolves.toEqual(0);
 
-      await expect(exitCodePromise).resolves.toEqual(0);
-
-      const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
-      expect(projectJson.orgId).toEqual(user.id);
-      expect(projectJson.projectId).toEqual(project.id);
-    } finally {
-      await remove(cwd);
-    }
+    const projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+    expect(projectJson.orgId).toEqual(user.id);
+    expect(projectJson.projectId).toEqual(project.id);
   });
 
   it('should allow overwriting existing link', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'cli-'));
+    const cwd = setupTmpDir();
+    const user = useUser();
+    useTeams('team_dummy');
+    const { project: proj1 } = useProject({
+      ...defaultProject,
+      id: 'one',
+      name: 'one',
+    });
+    const { project: proj2 } = useProject({
+      ...defaultProject,
+      id: 'two',
+      name: 'two',
+    });
+    useUnknownProject();
+
     client.cwd = cwd;
-    try {
-      const user = useUser();
-      useTeams('team_dummy');
-      const { project: proj1 } = useProject({
-        ...defaultProject,
-        id: 'one',
-        name: 'one',
-      });
-      const { project: proj2 } = useProject({
-        ...defaultProject,
-        id: 'two',
-        name: 'two',
-      });
-      useUnknownProject();
+    client.setArgv('--project', proj1.name!, '--yes');
+    await expect(link(client)).resolves.toEqual(0);
 
-      client.setArgv('--project', proj1.name!, '--yes');
-      await expect(link(client)).resolves.toEqual(0);
+    let projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+    expect(projectJson.orgId).toEqual(user.id);
+    expect(projectJson.projectId).toEqual(proj1.id);
 
-      let projectJson = await readJSON(join(cwd, '.vercel/project.json'));
-      expect(projectJson.orgId).toEqual(user.id);
-      expect(projectJson.projectId).toEqual(proj1.id);
+    client.setArgv('--project', proj2.name!, '--yes');
+    await expect(link(client)).resolves.toEqual(0);
 
-      client.setArgv('--project', proj2.name!, '--yes');
-      await expect(link(client)).resolves.toEqual(0);
-
-      projectJson = await readJSON(join(cwd, '.vercel/project.json'));
-      expect(projectJson.orgId).toEqual(user.id);
-      expect(projectJson.projectId).toEqual(proj2.id);
-    } finally {
-      await remove(cwd);
-    }
+    projectJson = await readJSON(join(cwd, '.vercel/project.json'));
+    expect(projectJson.orgId).toEqual(user.id);
+    expect(projectJson.projectId).toEqual(proj2.id);
   });
 });


### PR DESCRIPTION
Follow-up to #10031 which broke the `link` unit tests on Windows.

For some reason Kodiak was a bad bot and merged the PR with failing tests <picture data-single-emoji=":rarityannoyed:" title=":rarityannoyed:"><img class="emoji" src="https://emoji.slack-edge.com/T0CAQ00TU/rarityannoyed/b62f8c87a5fb7239.png" alt=":rarityannoyed:" width="20" height="auto" align="absmiddle"></picture> 

_Note:_ Probably easier to review with [whitespace hidden](https://github.com/vercel/vercel/pull/10033/files?w=1).