### PR TITLE
Revert "[next] Update rsc content-type test fixtures"

### DIFF
--- a/.changeset/purple-islands-rule.md
+++ b/.changeset/purple-islands-rule.md
@@ -1,5 +1,0 @@
----
-"@vercel/next": patch
----
-
-[next] Update rsc content-type test fixtures

--- a/.changeset/thin-zebras-rhyme.md
+++ b/.changeset/thin-zebras-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Revert "[next] Update rsc content-type test fixtures"

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2130,8 +2130,7 @@ export const onPrerenderRoute =
         routesManifest?.rsc?.varyHeader ||
         'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
       const rscContentTypeHeader =
-        routesManifest?.rsc?.contentTypeHeader ||
-        'text/x-component; charset=utf-8';
+        routesManifest?.rsc?.contentTypeHeader || 'text/x-component';
 
       let sourcePath: string | undefined;
       if (`/${outputPathPage}` !== srcRoute && srcRoute) {

--- a/packages/next/test/fixtures/00-app-dir-edge/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge/vercel.json
@@ -27,7 +27,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component; charset=utf-8"
+        "content-type": "text/x-component"
       }
     },
     {
@@ -51,7 +51,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component; charset=utf-8"
+        "content-type": "text/x-component"
       }
     }
   ]

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -30,7 +30,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component; charset=utf-8",
+        "content-type": "text/x-component",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -122,7 +122,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component; charset=utf-8",
+        "content-type": "text/x-component",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -141,7 +141,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component; charset=utf-8",
+        "content-type": "text/x-component",
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
       }
     },


### PR DESCRIPTION
Relies on https://github.com/vercel/next.js/pull/50472 this should only be merged after the Next.js PR is released to canary

Reverts vercel/vercel#10023