### PR TITLE
[frameworks] Update dev command for Sanity v3

### DIFF
--- a/.changeset/nervous-icons-wait.md
+++ b/.changeset/nervous-icons-wait.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Update dev command for Sanity v3

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1914,7 +1914,7 @@ export const frameworks = [
         value: 'sanity build',
       },
       devCommand: {
-        value: 'sanity start --port $PORT',
+        value: 'sanity dev --port $PORT',
       },
       outputDirectory: {
         value: 'dist',


### PR DESCRIPTION
Sanity v2 is now deprecated, and [Sanity v3](https://www.sanity.io/help/studio-v2-vs-v3) prefers a new `sanity dev` command. `sanity start` results in following error/warning:

```
▶ vc dev
Vercel CLI 30.0.0
> Running Dev Command “sanity start --port $PORT”
╭───────────────────────────────────────────────────────────╮
│                                                           │
│  You're running Sanity Studio v3. In this version the     │
│  [start] command is used to preview static builds.        |
│                                                           │
│  To run a development server, use the [npm run dev] or    |
│  [npx sanity dev] command instead. For more information,  │
│  see https://www.sanity.io/help/studio-v2-vs-v3           │
│                                                           │
╰───────────────────────────────────────────────────────────╯

Could not find a production build in the '[Sanity project root]/dist' directory.
Try building your studio app with 'sanity build' before starting the preview server.
```

**But before anyone merges: would changing this retroactively change the dev command for all existing Sanity-detected projects on Vercel?** That would break Sanity v2 projects and I'd need to split into Sanity v2 and Sanity v3 frameworks.

Or does framework detection only run once on new project creation?