### PR TITLE
Fetch git tags during Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Follow-up to #10044. The git tags need to be present for `changeset tag` to work properly.