### PR TITLE
Update CODEOWNERS for `.changeset/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
+# Restricted Paths
 *                                        @TooTallNate @EndangeredMassa @styfle @cb1kenobi @Ethan-Arrowood
 /.github/workflows                       @TooTallNate @EndangeredMassa @styfle @cb1kenobi @Ethan-Arrowood @ijjk
 /packages/fs-detectors                   @TooTallNate @EndangeredMassa @styfle @cb1kenobi @Ethan-Arrowood @agadzik @chloetedder
@@ -14,3 +15,6 @@
 /examples/jekyll                         @styfle
 /examples/zola                           @styfle
 /packages/node                           @TooTallNate @EndangeredMassa @styfle @cb1kenobi @Ethan-Arrowood @Kikobeats
+
+# Unrestricted Paths
+.changeset/


### PR DESCRIPTION
The `.changeset` directory currently falls under the wildcard code owner pattern, which effectively invalidates the rest of the codeowners file whenever a changeset file is in a PR. This PR sets `.changeset/` as an unrestricted path.

Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners