### PR TITLE
Add array type to functions schema (vercel.json)

### DIFF
--- a/.changeset/wet-days-doubt.md
+++ b/.changeset/wet-days-doubt.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Add array type to functions schema (vercel.json)

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -22,7 +22,7 @@ export const functionsSchema = {
           maximum: 900,
         },
         includeFiles: {
-          type: 'string',
+          type: ['string','array'],
           maxLength: 256,
         },
         excludeFiles: {


### PR DESCRIPTION
This PR adds array type to vercel.json's functions field to prevent errors like: 
![image](https://github.com/vercel/vercel/assets/83997633/480b1180-8070-46d1-b345-4430146016cf)
when vercel.json's content is:
```
"functions": {
    "api/get-installer-info.go": {
      "includeFiles": [
        "api/glib-2.0/**",
        "api/libmsi-1.0/**"
      ]
    }
  }
```

If I'm not wrong, array support has already been implemented, but array "type" is absent from the schema which is why it errors out.
`@vercel/go`: https://github.com/vercel/vercel/blob/main/packages/go/index.ts#L208-L219
`@vercel/node`: https://github.com/vercel/vercel/blob/main/packages/node/src/index.ts#L138-L155
`@vercel/ruby`: https://github.com/vercel/vercel/blob/main/packages/ruby/index.ts#L23-L42
`@vercel/python`: I wasn't able to understand the code, so it may/may not be implemented.