### PR TITLE
[vc dev] Automatically expose framework system env vars

### DIFF
--- a/packages/cli/test/dev/fixtures/10a-nextjs-routes/pages/api/env.js
+++ b/packages/cli/test/dev/fixtures/10a-nextjs-routes/pages/api/env.js
@@ -1,0 +1,3 @@
+export default (_req, res) => {
+  res.send(process.env);
+};

--- a/packages/cli/test/dev/fixtures/10a-nextjs-routes/pages/env.js
+++ b/packages/cli/test/dev/fixtures/10a-nextjs-routes/pages/env.js
@@ -1,0 +1,14 @@
+function Env() {
+  return (
+    <main>
+      <p>
+        NEXT_PUBLIC_VERCEL_ENV: {process.env.NEXT_PUBLIC_VERCEL_ENV}
+      </p>
+      <p>
+        NEXT_PUBLIC_VERCEL_URL: {process.env.NEXT_PUBLIC_VERCEL_URL}
+      </p>
+    </main>
+  );
+}
+
+export default Env;

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -143,13 +143,20 @@ test('[vercel dev] framework system env vars should be exposed automatically', a
   try {
     await readyResolver;
     {
-      const res = await fetch(`http://localhost:${port}/api/env`);
-      validateResponseHeaders(res);
-      const body = await res.json();
-      expect(body.VERCEL_ENV).toBe('development');
-      expect(body.NEXT_PUBLIC_VERCEL_ENV).toBe('development');
-      expect(body.VERCEL_URL).toBe(`localhost:${port}`);
-      expect(body.NEXT_PUBLIC_VERCEL_URL).toBe(`localhost:${port}`);
+      const apiRes = await fetch(`http://localhost:${port}/api/env`);
+      validateResponseHeaders(apiRes);
+      const apiJson = await apiRes.json();
+      expect(apiJson.VERCEL_ENV).toBe('development');
+      expect(apiJson.NEXT_PUBLIC_VERCEL_ENV).toBe('development');
+      expect(apiJson.VERCEL_URL).toBe(`localhost:${port}`);
+      expect(apiJson.NEXT_PUBLIC_VERCEL_URL).toBe(`localhost:${port}`);
+
+      const homeRes = await fetch(`http://localhost:${port}/env`);
+      const homeText = await homeRes.text();
+      expect(homeText).toContain('NEXT_PUBLIC_VERCEL_ENV: <!-- -->development');
+      expect(homeText).toContain(
+        `NEXT_PUBLIC_VERCEL_URL: <!-- -->localhost:${port}`
+      );
     }
   } finally {
     await dev.kill();

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -136,6 +136,26 @@ test(
   })
 );
 
+test('[vercel dev] framework system env vars should be exposed automatically', async () => {
+  const dir = fixture('10a-nextjs-routes');
+  const { dev, port, readyResolver } = await testFixture(dir);
+
+  try {
+    await readyResolver;
+    {
+      const res = await fetch(`http://localhost:${port}/api/env`);
+      validateResponseHeaders(res);
+      const body = await res.json();
+      expect(body.VERCEL_ENV).toBe('development');
+      expect(body.NEXT_PUBLIC_VERCEL_ENV).toBe('development');
+      expect(body.VERCEL_URL).toBe(`localhost:${port}`);
+      expect(body.NEXT_PUBLIC_VERCEL_URL).toBe(`localhost:${port}`);
+    }
+  } finally {
+    await dev.kill();
+  }
+});
+
 test(
   '[vercel dev] 12-polymer-node',
   testFixtureStdio(


### PR DESCRIPTION
Exposing `VERCEL_ENV` and `VERCEL_URL` to `vc dev`, alnong with their framework aliases.

- Related to #7009 