### PR TITLE
Enforce a changeset file to be present

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -33,3 +33,6 @@ jobs:
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run prettier-check
+
+      # Enforce a changeset file to be present
+      - run: changeset status --since=main

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -40,11 +40,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - run: git fetch origin main
+      - run: git branch
+      # Enforce a changeset file to be present
+      - run: pnpm exec changeset status --since=main
+
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run prettier-check
-
-      # Enforce a changeset file to be present
-      - run: pnpm exec changeset status --since=main

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -29,7 +29,6 @@ jobs:
           fetch-depth: 0
           ref: main
       - run: git checkout ${{ github.event.pull_request.head.ref }}
-      - run: git branch
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -19,31 +19,32 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  enforce-changeset:
+    name: Enforce Changeset
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+      - run: git checkout ${{ github.event.pull_request.head.ref }}
+      - run: git branch
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+      - run: pnpm install
+      # Enforce a changeset file to be present
+      - run: pnpm exec changeset status --since=main
+
   test:
     name: Lint
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name == 'pull_request'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - uses: actions/checkout@v3
-        if: github.event_name == 'push'
-        with:
-          fetch-depth: 0
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - run: git fetch origin main
-      - run: git branch
-      # Enforce a changeset file to be present
-      - run: pnpm exec changeset status --since=main
-
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -35,4 +35,4 @@ jobs:
       - run: pnpm run prettier-check
 
       # Enforce a changeset file to be present
-      - run: changeset status --since=main
+      - run: pnpm exec changeset status --since=main

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -25,9 +25,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: actions/checkout@v3
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+
       - run: git fetch origin main
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - run: git fetch origin main
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -778,4 +778,3 @@ Run ${chalk.cyan(cmd(await getUpdateCommand()))} to update.${errorMsg}`
     process.exitCode = exitCode;
   })
   .catch(handleUnexpected);
-// test

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -778,3 +778,4 @@ Run ${chalk.cyan(cmd(await getUpdateCommand()))} to update.${errorMsg}`
     process.exitCode = exitCode;
   })
   .catch(handleUnexpected);
+// test


### PR DESCRIPTION
Based off of these setup instructions:
https://github.com/changesets/changesets/blob/main/docs/automating-changesets.md#blocking

If a commit should really not publish a release, you can run `changeset --empty`.

In a follow-up PR we can add logic to enforce that the changeset updates specific package(s) based off of the diff.