### PR TITLE
fix monorepo linking path to vercel dir readme

### DIFF
--- a/.changeset/serious-lobsters-peel.md
+++ b/.changeset/serious-lobsters-peel.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+fix monorepo linking path to vercel dir readme

--- a/.changeset/serious-lobsters-peel.md
+++ b/.changeset/serious-lobsters-peel.md
@@ -1,5 +1,0 @@
----
-"vercel": patch
----
-
-fix monorepo linking path to vercel dir readme

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -195,7 +195,10 @@ export async function ensureRepoLink(
 
     await writeFile(
       join(rootPath, VERCEL_DIR, VERCEL_DIR_README),
-      await readFile(join(__dirname, 'VERCEL_DIR_README.txt'), 'utf8')
+      await readFile(
+        join(__dirname, '..', 'projects', 'VERCEL_DIR_README.txt'),
+        'utf8'
+      )
     );
 
     // update .gitignore


### PR DESCRIPTION
Linking a monorepo fails when it looks for the vercel dir readme text file. This PR fixes the issue.

```
$  vc link --repo
Vercel CLI 30.1.2
WARN! The `--repo` flag is in alpha, please report issues
? Link Git repository at “~/source/demo/vercel-cli-monorepo-test” to your Project(s)? [Y/n] y
? Which scope should contain your Project(s)? Uncurated Tests
> Projects linked to https://github.com/uncurated-tests/vercel-cli-monorepo-test.git under uncurated-tests:
  * uncurated-tests/vercel-cli-monorepo-test-one
  * uncurated-tests/vercel-cli-monorepo-test-two
? Link to these 2 Projects? [Y/n] y
Error: ENOENT: no such file or directory, open '/Users/smassa/source/vercel/vercel-2/packages/cli/src/util/link/VERCEL_DIR_README.txt'
 ELIFECYCLE  Command failed with exit code 1.
```