### PR TITLE
handle undefined content type in `vc dev`

### DIFF
--- a/.changeset/sour-lies-pay.md
+++ b/.changeset/sour-lies-pay.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+handle undefined content type in `vc dev`

--- a/packages/node/src/serverless-functions/helpers.ts
+++ b/packages/node/src/serverless-functions/helpers.ts
@@ -27,10 +27,19 @@ class ApiError extends Error {
   }
 }
 
+function normalizeContentType(contentType: string | undefined) {
+  if (!contentType) {
+    return 'text/plain';
+  }
+
+  const { parse: parseContentType } = require('content-type');
+  const { type } = parseContentType(contentType);
+  return type;
+}
+
 function getBodyParser(body: Buffer, contentType: string | undefined) {
   return function parseBody(): VercelRequestBody {
-    const { parse: parseContentType } = require('content-type');
-    const { type } = parseContentType(contentType);
+    const type = normalizeContentType(contentType);
 
     if (type === 'application/json') {
       try {


### PR DESCRIPTION
When no content type header is sent to an API request during `vc dev`, the request fails:

```
/Users/smassa/source/vercel/vercel-2/node_modules/.pnpm/content-type@1.0.4/node_modules/content-type/index.js:108
    throw new TypeError('argument string is required')
          ^
TypeError: argument string is required
...
```

This comes from some runtime type validation happening in the `content-type` package, for which we do not have types, which is why typescript didn't catch this.