### PR TITLE
Clear revert out of changelog

### DIFF
--- a/.changeset/friendly-mangos-type.md
+++ b/.changeset/friendly-mangos-type.md
@@ -1,5 +1,0 @@
----
-"vercel": patch
----
-
-Revert "[cli] Add support for `vc pull` command with repo link"


### PR DESCRIPTION
Get rid of the changelog entry for a revert of a PR that was never published.