### PR TITLE
[cli] Add support for `vc dev` command with repo link

### DIFF
--- a/.changeset/mean-windows-cheer.md
+++ b/.changeset/mean-windows-cheer.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add support for `vc dev` command with repo link

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -58,7 +58,13 @@ export default async function dev(
   let projectSettings: ProjectSettings | undefined;
   let envValues: Record<string, string> = {};
   if (link.status === 'linked') {
-    const { project, org } = link;
+    const { project, org, repoRoot } = link;
+
+    // If repo linked, update `cwd` to the repo root
+    if (repoRoot) {
+      cwd = repoRoot;
+    }
+
     client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
     projectSettings = project;


### PR DESCRIPTION
When repo linked, `vc dev` already works fine when run from the root of the repo. This change makes it so that `vc dev` also works as expected when executed within a project subdirectory.