### PR TITLE
[cli] Add support for `vc deploy --prebuilt` command with repo link

### DIFF
--- a/.changeset/mighty-grapes-whisper.md
+++ b/.changeset/mighty-grapes-whisper.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add support for `vc deploy --prebuilt` command with repo link

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -203,56 +203,6 @@ export default async (client: Client): Promise<number> => {
     return target;
   }
 
-  // build `--prebuilt`
-  if (argv['--prebuilt']) {
-    const prebuiltExists = await fs.pathExists(join(cwd, '.vercel/output'));
-    if (!prebuiltExists) {
-      error(
-        `The ${param(
-          '--prebuilt'
-        )} option was used, but no prebuilt output found in ".vercel/output". Run ${getCommandName(
-          'build'
-        )} to generate a local build.`
-      );
-      return 1;
-    }
-
-    const prebuiltBuild = await getPrebuiltJson(cwd);
-
-    // Ensure that there was not a build error
-    const prebuiltError =
-      prebuiltBuild?.error ||
-      prebuiltBuild?.builds?.find(build => 'error' in build)?.error;
-    if (prebuiltError) {
-      output.log(
-        `Prebuilt deployment cannot be created because ${getCommandName(
-          'build'
-        )} failed with error:\n`
-      );
-      prettyError(prebuiltError);
-      return 1;
-    }
-
-    // Ensure that the deploy target matches the build target
-    const assumedTarget = target || 'preview';
-    if (prebuiltBuild?.target && prebuiltBuild.target !== assumedTarget) {
-      let specifyTarget = '';
-      if (prebuiltBuild.target === 'production') {
-        specifyTarget = ` --prod`;
-      }
-
-      prettyError({
-        message: `The ${param(
-          '--prebuilt'
-        )} option was used with the target environment "${assumedTarget}", but the prebuilt output found in ".vercel/output" was built with target environment "${
-          prebuiltBuild.target
-        }". Please run ${getCommandName(`--prebuilt${specifyTarget}`)}.`,
-        link: 'https://vercel.link/prebuilt-environment-mismatch',
-      });
-      return 1;
-    }
-  }
-
   const archive = argv['--archive'];
   if (typeof archive === 'string' && !isValidArchive(archive)) {
     output.error(`Format must be one of: ${VALID_ARCHIVE_FORMATS.join(', ')}`);
@@ -353,6 +303,67 @@ export default async (client: Client): Promise<number> => {
   // At this point `org` should be populated
   if (!org) {
     throw new Error(`"org" is not defined`);
+  }
+
+  // build `--prebuilt`
+  if (argv['--prebuilt']) {
+    // For repo-style linking, update `cwd` to be the Project
+    // subdirectory when `rootDirectory` setting is defined
+    if (
+      link.status === 'linked' &&
+      link.repoRoot &&
+      link.project.rootDirectory
+    ) {
+      cwd = join(cwd, link.project.rootDirectory);
+    }
+    console.log({ cwd });
+
+    const prebuiltExists = await fs.pathExists(join(cwd, '.vercel/output'));
+    if (!prebuiltExists) {
+      error(
+        `The ${param(
+          '--prebuilt'
+        )} option was used, but no prebuilt output found in ".vercel/output". Run ${getCommandName(
+          'build'
+        )} to generate a local build.`
+      );
+      return 1;
+    }
+
+    const prebuiltBuild = await getPrebuiltJson(cwd);
+
+    // Ensure that there was not a build error
+    const prebuiltError =
+      prebuiltBuild?.error ||
+      prebuiltBuild?.builds?.find(build => 'error' in build)?.error;
+    if (prebuiltError) {
+      output.log(
+        `Prebuilt deployment cannot be created because ${getCommandName(
+          'build'
+        )} failed with error:\n`
+      );
+      prettyError(prebuiltError);
+      return 1;
+    }
+
+    // Ensure that the deploy target matches the build target
+    const assumedTarget = target || 'preview';
+    if (prebuiltBuild?.target && prebuiltBuild.target !== assumedTarget) {
+      let specifyTarget = '';
+      if (prebuiltBuild.target === 'production') {
+        specifyTarget = ` --prod`;
+      }
+
+      prettyError({
+        message: `The ${param(
+          '--prebuilt'
+        )} option was used with the target environment "${assumedTarget}", but the prebuilt output found in ".vercel/output" was built with target environment "${
+          prebuiltBuild.target
+        }". Please run ${getCommandName(`--prebuilt${specifyTarget}`)}.`,
+        link: 'https://vercel.link/prebuilt-environment-mismatch',
+      });
+      return 1;
+    }
   }
 
   // Set the `contextName` and `currentTeam` as specified by the

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -316,7 +316,6 @@ export default async (client: Client): Promise<number> => {
     ) {
       cwd = join(cwd, link.project.rootDirectory);
     }
-    console.log({ cwd });
 
     const prebuiltExists = await fs.pathExists(join(cwd, '.vercel/output'));
     if (!prebuiltExists) {

--- a/packages/cli/test/fixtures/unit/build-output-api-failed-before-builds/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/build-output-api-failed-before-builds/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+    "orgId": "team_dummy",
+    "projectId": "build-output-api-failed-before-builds"
+}

--- a/packages/cli/test/fixtures/unit/build-output-api-failed-within-build/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/build-output-api-failed-within-build/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+    "orgId": "team_dummy",
+    "projectId": "build-output-api-failed-within-build"
+}

--- a/packages/cli/test/fixtures/unit/build-output-api-preview/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/build-output-api-preview/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+    "orgId": "team_dummy",
+    "projectId": "build-output-api-preview"
+}

--- a/packages/cli/test/fixtures/unit/build-output-api-production/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/build-output-api-production/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+    "orgId": "team_dummy",
+    "projectId": "build-output-api-production"
+}

--- a/packages/cli/test/unit/commands/deploy.test.ts
+++ b/packages/cli/test/unit/commands/deploy.test.ts
@@ -45,6 +45,14 @@ describe('deploy', () => {
   it('should reject deploying when `--prebuilt` is used and `vc build` failed before Builders', async () => {
     const cwd = setupUnitFixture('build-output-api-failed-before-builds');
 
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'build-output-api-failed-before-builds',
+      name: 'build-output-api-failed-before-builds',
+    });
+
     client.setArgv('deploy', cwd, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
@@ -56,6 +64,14 @@ describe('deploy', () => {
   it('should reject deploying when `--prebuilt` is used and `vc build` failed within a Builder', async () => {
     const cwd = setupUnitFixture('build-output-api-failed-within-build');
 
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'build-output-api-failed-within-build',
+      name: 'build-output-api-failed-within-build',
+    });
+
     client.setArgv('deploy', cwd, '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
@@ -65,7 +81,16 @@ describe('deploy', () => {
   });
 
   it('should reject deploying a directory that does not contain ".vercel/output" when `--prebuilt` is used', async () => {
-    client.setArgv('deploy', __dirname, '--prebuilt');
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      name: 'static',
+      id: 'static',
+    });
+
+    client.cwd = setupUnitFixture('commands/deploy/static');
+    client.setArgv('deploy', '--prebuilt');
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
       'Error: The "--prebuilt" option was used, but no prebuilt output found in ".vercel/output". Run `vercel build` to generate a local build.\n'
@@ -102,8 +127,8 @@ describe('deploy', () => {
     useTeams('team_dummy');
     useProject({
       ...defaultProject,
-      id: 'build-output-api-preview',
-      name: 'build-output-api-preview',
+      id: 'build-output-api-production',
+      name: 'build-output-api-production',
     });
 
     client.setArgv('deploy', cwd, '--prebuilt');


### PR DESCRIPTION
When repo linked, `vc deploy --prebuilt` will change working directory to the Project root directory, instead of the repo root, so that the project's local `.vercel/output` directory is what gets uploaded + deployed.