### PR TITLE
[cli] Move readme copy logic to a helper function for `vc link`

### DIFF
--- a/.changeset/perfect-gorillas-film.md
+++ b/.changeset/perfect-gorillas-film.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Move readme copy logic to a helper function for `vc link`

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -3,14 +3,10 @@ import pluralize from 'pluralize';
 import { homedir } from 'os';
 import { join, normalize } from 'path';
 import { normalizePath } from '@vercel/build-utils';
-import { lstat, readJSON, outputJSON, writeFile, readFile } from 'fs-extra';
+import { lstat, readJSON, outputJSON } from 'fs-extra';
 import confirm from '../input/confirm';
 import toHumanPath from '../humanize-path';
-import {
-  VERCEL_DIR,
-  VERCEL_DIR_README,
-  VERCEL_DIR_REPO,
-} from '../projects/link';
+import { VERCEL_DIR, VERCEL_DIR_REPO, writeReadme } from '../projects/link';
 import { getRemoteUrls } from '../create-git-meta';
 import link from '../output/link';
 import { emoji, prependEmoji } from '../emoji';
@@ -193,13 +189,7 @@ export async function ensureRepoLink(
     };
     await outputJSON(repoConfigPath, repoConfig, { spaces: 2 });
 
-    await writeFile(
-      join(rootPath, VERCEL_DIR, VERCEL_DIR_README),
-      await readFile(
-        join(__dirname, '..', 'projects', 'VERCEL_DIR_README.txt'),
-        'utf8'
-      )
-    );
+    await writeReadme(rootPath);
 
     // update .gitignore
     const isGitIgnoreUpdated = await addToGitIgnore(rootPath);

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -285,6 +285,13 @@ export async function getLinkedProject(
   return { status: 'linked', org, project, repoRoot: link.repoRoot };
 }
 
+export async function writeReadme(path: string) {
+  await writeFile(
+    join(path, VERCEL_DIR, VERCEL_DIR_README),
+    await readFile(join(__dirname, 'VERCEL_DIR_README.txt'), 'utf8')
+  );
+}
+
 export async function linkFolderToProject(
   client: Client,
   path: string,
@@ -314,10 +321,7 @@ export async function linkFolderToProject(
     JSON.stringify(projectLink)
   );
 
-  await writeFile(
-    join(path, VERCEL_DIR, VERCEL_DIR_README),
-    await readFile(join(__dirname, 'VERCEL_DIR_README.txt'), 'utf8')
-  );
+  await writeReadme(path);
 
   // update .gitignore
   const isGitIgnoreUpdated = await addToGitIgnore(path);


### PR DESCRIPTION
ncc has an issue with detecting + rewriting this file path for some reason. Moving to a helper function should work around that issue.

Fixing:

```
Error: ENOENT: no such file or directory, open '/node_modules/vercel/projects/VERCEL_DIR_README.txt'
```