### PR TITLE
[cli] vc env pull should add `.env*.local` to `.gitignore`

### DIFF
--- a/.changeset/blue-rats-know.md
+++ b/.changeset/blue-rats-know.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] vc env pull should add `.env*.local` to `.gitignore`

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -167,6 +167,7 @@ export default async function main(client: Client) {
       case 'pull':
         return pull(
           client,
+          link,
           project,
           target,
           argv,

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -2,7 +2,11 @@ import chalk from 'chalk';
 import { outputFile } from 'fs-extra';
 import { closeSync, openSync, readSync } from 'fs';
 import { resolve } from 'path';
-import type { Project, ProjectEnvTarget } from '@vercel-internals/types';
+import type {
+  Project,
+  ProjectEnvTarget,
+  ProjectLinked,
+} from '@vercel-internals/types';
 import Client from '../../util/client';
 import { emoji, prependEmoji } from '../../util/emoji';
 import confirm from '../../util/input/confirm';
@@ -20,7 +24,6 @@ import {
 } from '../../util/env/diff-env-files';
 import { isErrnoException } from '@vercel/error-utils';
 import { addToGitIgnore } from '../../util/link/add-to-gitignore';
-import { getRepoLink } from '../../util/link/repo';
 
 const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
@@ -53,6 +56,7 @@ function tryReadHeadSync(path: string, length: number) {
 
 export default async function pull(
   client: Client,
+  link: ProjectLinked,
   project: Project,
   environment: ProjectEnvTarget,
   opts: Partial<Options>,
@@ -145,8 +149,7 @@ export default async function pull(
     // We use '.env*.local' to match the default .gitignore from
     // create-next-app template. See:
     // https://github.com/vercel/next.js/blob/06abd634899095b6cc28e6e8315b1e8b9c8df939/packages/create-next-app/templates/app/js/gitignore#L28
-    const repoLink = await getRepoLink(cwd);
-    const rootPath = repoLink?.rootPath ?? cwd;
+    const rootPath = link.repoRoot ?? cwd;
     isGitIgnoreUpdated = await addToGitIgnore(rootPath, '.env*.local');
   }
 

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,7 +1,11 @@
 import chalk from 'chalk';
 import { join } from 'path';
 import Client from '../util/client';
-import type { Project, ProjectEnvTarget } from '@vercel-internals/types';
+import type {
+  Project,
+  ProjectEnvTarget,
+  ProjectLinked,
+} from '@vercel-internals/types';
 import { emoji, prependEmoji } from '../util/emoji';
 import getArgs from '../util/get-args';
 import logo from '../util/output/logo';
@@ -82,6 +86,7 @@ function parseArgs(client: Client) {
 async function pullAllEnvFiles(
   environment: ProjectEnvTarget,
   client: Client,
+  link: ProjectLinked,
   project: Project,
   argv: ReturnType<typeof processArgs>,
   cwd: string
@@ -89,6 +94,7 @@ async function pullAllEnvFiles(
   const environmentFile = `.env.${environment}.local`;
   return envPull(
     client,
+    link,
     project,
     environment,
     argv,
@@ -136,6 +142,7 @@ export default async function main(client: Client) {
   const pullResultCode = await pullAllEnvFiles(
     environment,
     client,
+    link,
     project,
     argv,
     cwd

--- a/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.gitignore
+++ b/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.gitignore
@@ -1,0 +1,4 @@
+.next
+yarn.lock
+!.vercel
+.env*.local

--- a/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/vercel-env-pull-with-gitignore/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_dummy",
+  "projectId": "vercel-env-pull-with-gitignore"
+}


### PR DESCRIPTION
This is a follow up to PR #9892 which changed the default to `.env.local`.

Now that we know local files should never be committed to git, we can automatically add `.env*.local` to `.gitignore`. Note that this is the same ignore pattern that ships with create-next-app [as seen here](https://github.com/vercel/next.js/blob/06abd634899095b6cc28e6e8315b1e8b9c8df939/packages/create-next-app/templates/app/js/gitignore#L28), so most Next.js users won't see anything change.

See the related [Linear ticket](https://linear.app/vercel/issue/VCCLI-461/)