### PR TITLE
Run "Enforce Changeset" job for additional commits on a pull request

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -22,7 +22,7 @@ jobs:
   enforce-changeset:
     name: Enforce Changeset
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
+    if: github.event.pull_request && github.event.pull_request.title != 'Version Packages'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The "Enforce Changeset" job executes for new Pull Requests, but is canceled upon additional pushes to the PR. Checking for the `github.event.pull_request` property instead of checking the event name should remedy that.