### PR TITLE
[node] add tests to getBodyParser helper

### DIFF
--- a/.changeset/chatty-papayas-protect.md
+++ b/.changeset/chatty-papayas-protect.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+add tests to getBodyParser helper

--- a/packages/node/src/serverless-functions/helpers.ts
+++ b/packages/node/src/serverless-functions/helpers.ts
@@ -1,6 +1,8 @@
 import type { ServerResponse, IncomingMessage } from 'http';
 import { serializeBody } from '../utils';
 import { PassThrough } from 'stream';
+import { parse as parseContentType } from 'content-type';
+import { parse as parseQS } from 'querystring';
 
 type VercelRequestCookies = { [key: string]: string };
 type VercelRequestQuery = { [key: string]: string | string[] };
@@ -32,12 +34,11 @@ function normalizeContentType(contentType: string | undefined) {
     return 'text/plain';
   }
 
-  const { parse: parseContentType } = require('content-type');
   const { type } = parseContentType(contentType);
   return type;
 }
 
-function getBodyParser(body: Buffer, contentType: string | undefined) {
+export function getBodyParser(body: Buffer, contentType: string | undefined) {
   return function parseBody(): VercelRequestBody {
     const type = normalizeContentType(contentType);
 
@@ -53,7 +54,6 @@ function getBodyParser(body: Buffer, contentType: string | undefined) {
     if (type === 'application/octet-stream') return body;
 
     if (type === 'application/x-www-form-urlencoded') {
-      const { parse: parseQS } = require('querystring');
       // note: querystring.parse does not produce an iterable object
       // https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options
       return parseQS(body.toString());

--- a/packages/node/test/unit/serverless-functions/helpers.test.ts
+++ b/packages/node/test/unit/serverless-functions/helpers.test.ts
@@ -1,0 +1,55 @@
+import { getBodyParser } from '../../../src/serverless-functions/helpers';
+
+describe('serverless-functions/helpers', () => {
+  describe('getBodyParser', () => {
+    it('content type undefined should return the original string', () => {
+      const rawBody = 'body content';
+      const body = Buffer.from(rawBody);
+      const result = getBodyParser(body, undefined)();
+      expect(result).toBe(rawBody);
+    });
+
+    it('content type "text/plain" should return the original string', () => {
+      const rawBody = 'body content';
+      const body = Buffer.from(rawBody);
+      const result = getBodyParser(body, 'text/plain')();
+      expect(result).toBe(rawBody);
+    });
+
+    it('content type "application/octet-stream" should return the body buffer', () => {
+      const rawBody = 'body content';
+      const body = Buffer.from(rawBody);
+      const result = getBodyParser(body, 'application/octet-stream')();
+      expect(result).toBe(body);
+    });
+
+    it('content type "application/x-www-form-urlencoded" should return the parsed query string', () => {
+      const rawBody = 'foo=bar&baz=zim';
+      const body = Buffer.from(rawBody);
+
+      const result = getBodyParser(body, 'application/x-www-form-urlencoded')();
+      expect(result).toEqual({
+        foo: 'bar',
+        baz: 'zim',
+      });
+    });
+
+    it('content type "application/json" should return the parsed object', () => {
+      const rawBody = '{"foo": "bar", "baz": "zim"}';
+      const body = Buffer.from(rawBody);
+      const result = getBodyParser(body, 'application/json')();
+      expect(result).toEqual({
+        foo: 'bar',
+        baz: 'zim',
+      });
+    });
+
+    it('content type "application/json" should throw when parsing bad json', () => {
+      const rawBody = 'not valid json';
+      const body = Buffer.from(rawBody);
+      expect(() => {
+        getBodyParser(body, 'application/json')();
+      }).toThrow('Invalid JSON');
+    });
+  });
+});


### PR DESCRIPTION
Add some tests to the `getBodyParser` helper to prevent future regressions.

Refactored away some dynamic requires for static imports, providing type safety. All new tests pass before and after the refactor.