### PR TITLE
[cli] do not force auto-assign value on deployments

### DIFF
--- a/.changeset/fluffy-socks-refuse.md
+++ b/.changeset/fluffy-socks-refuse.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] do not force auto-assign value on deployments

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -521,7 +521,8 @@ export default async (client: Client): Promise<number> => {
   }
 
   try {
-    const autoAssignCustomDomains = !argv['--skip-domain'];
+    // if this flag is not set, use `undefined` to allow the project setting to be used
+    const autoAssignCustomDomains = argv['--skip-domain'] ? false : undefined;
 
     const createArgs: CreateOptions = {
       name,

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -50,7 +50,7 @@ export interface CreateOptions {
   projectSettings?: any;
   skipAutoDetectionConfirmation?: boolean;
   noWait?: boolean;
-  autoAssignCustomDomains: boolean;
+  autoAssignCustomDomains?: boolean;
 }
 
 export interface RemoveOptions {


### PR DESCRIPTION
When `vc deploy` happens, it was forcing a `true`/`false` value for `autoAssignCustomDomains`. This overwrites the project setting in some cases, which is not what we want.

If a CLI command or API call explicitly wants to force `autoAssignCustomDomains` on or off, it can. Otherwise, the project setting value should be used.

This PR only sets `autoAssignCustomDomains` to `false` when the `--skip-domain` flag is passed. Otherwise, the value is `undefined` so that the project setting can take effect.