### PR TITLE
[fs-detectors] Resolve symlinks in `LocalFileSystemDetector#readdir()`

### DIFF
--- a/.changeset/modern-shirts-check.md
+++ b/.changeset/modern-shirts-check.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Resolve symlinks in `LocalFileSystemDetector#readdir()`

--- a/packages/fs-detectors/src/detectors/local-file-system-detector.ts
+++ b/packages/fs-detectors/src/detectors/local-file-system-detector.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises';
-import type { Dirent } from 'fs';
-import path from 'path';
+import { join, relative } from 'path';
 import { DetectorFilesystem, DetectorFilesystemStat } from './filesystem';
 import { isErrnoException } from '@vercel/error-utils';
 
@@ -33,25 +32,27 @@ export class LocalFileSystemDetector extends DetectorFilesystem {
     return stat.isFile();
   }
 
-  async _readdir(name: string): Promise<DetectorFilesystemStat[]> {
-    const dirPath = this.getFilePath(name);
-    const dir = await fs.readdir(dirPath, {
-      withFileTypes: true,
-    });
-    const getType = (dirent: Dirent) => {
-      if (dirent.isFile()) {
-        return 'file';
-      } else if (dirent.isDirectory()) {
-        return 'dir';
-      } else {
-        throw new Error(`Dirent was neither file nor directory`);
-      }
-    };
-    return dir.map(dirent => ({
-      name: dirent.name,
-      path: path.join(this.getRelativeFilePath(name), dirent.name),
-      type: getType(dirent),
-    }));
+  async _readdir(dir: string): Promise<DetectorFilesystemStat[]> {
+    const dirPath = this.getFilePath(dir);
+    const files = await fs.readdir(dirPath);
+    return Promise.all(
+      files.map(async name => {
+        const absPath = join(this.rootPath, dir, name);
+        const path = join(this.getRelativeFilePath(dir), name);
+
+        const stat = await fs.stat(absPath);
+        let type: DetectorFilesystemStat['type'];
+        if (stat.isFile()) {
+          type = 'file';
+        } else if (stat.isDirectory()) {
+          type = 'dir';
+        } else {
+          throw new Error(`Dirent was neither file nor directory: ${path}`);
+        }
+
+        return { name, path, type };
+      })
+    );
   }
 
   _chdir(name: string): DetectorFilesystem {
@@ -60,11 +61,11 @@ export class LocalFileSystemDetector extends DetectorFilesystem {
 
   private getRelativeFilePath(name: string) {
     return name.startsWith(this.rootPath)
-      ? path.relative(this.rootPath, name)
+      ? relative(this.rootPath, name)
       : name;
   }
 
   private getFilePath(name: string) {
-    return path.join(this.rootPath, this.getRelativeFilePath(name));
+    return join(this.rootPath, this.getRelativeFilePath(name));
   }
 }

--- a/packages/fs-detectors/test/fixtures/35-no-monorepo/symlink
+++ b/packages/fs-detectors/test/fixtures/35-no-monorepo/symlink
@@ -1,0 +1,1 @@
+package.json

--- a/packages/fs-detectors/test/unit.get-workspaces.test.ts
+++ b/packages/fs-detectors/test/unit.get-workspaces.test.ts
@@ -35,7 +35,6 @@ describe.each<[string, Workspace[]]>([
 
   it(testName, async () => {
     const fixture = path.join(__dirname, 'fixtures', fixturePath);
-    console.log(fixture);
     const fs = new LocalFileSystemDetector(fixture);
 
     const actualWorkspaces = await getWorkspaces({ fs });

--- a/packages/fs-detectors/test/unit.get-workspaces.test.ts
+++ b/packages/fs-detectors/test/unit.get-workspaces.test.ts
@@ -23,6 +23,7 @@ describe.each<[string, Workspace[]]>([
     ],
   ],
   ['22-pnpm', []],
+  ['35-no-monorepo', []],
 ])('`getWorkspaces()`', (fixturePath, workspaces) => {
   const expectedImplementations = workspaces.map(({ type }) => type);
   const testName =
@@ -34,6 +35,7 @@ describe.each<[string, Workspace[]]>([
 
   it(testName, async () => {
     const fixture = path.join(__dirname, 'fixtures', fixturePath);
+    console.log(fixture);
     const fs = new LocalFileSystemDetector(fixture);
 
     const actualWorkspaces = await getWorkspaces({ fs });


### PR DESCRIPTION
`LocalFileSystemDetector#readdir()` was throwing an error when a symlink was encountered, due to `fs.readdir()` `withFileTypes: true` option performing an lstat instead of a stat operation.

So re-implement the `readdir()` logic to use `fs.stat()` so that the symlink is resolved (only "dir" and "file" types are expected in the result).