### PR TITLE
[cli] Fix error message when token is invalid

### DIFF
--- a/.changeset/tall-lions-grin.md
+++ b/.changeset/tall-lions-grin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] Fix error message when token is invalid

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -246,7 +246,7 @@ export async function getLinkedProject(
     if (isAPIError(err) && err.status === 403) {
       output.stopSpinner();
 
-      if (err.missingToken) {
+      if (err.missingToken || err.invalidToken) {
         throw new InvalidToken();
       } else {
         throw new NowBuildError({

--- a/packages/cli/test/mocks/team.ts
+++ b/packages/cli/test/mocks/team.ts
@@ -5,9 +5,11 @@ export function useTeams(
   teamId?: string,
   options: {
     failMissingToken?: boolean;
+    failInvalidToken?: boolean;
     failNoAccess?: boolean;
   } = {
     failMissingToken: false,
+    failInvalidToken: false,
     failNoAccess: false,
   }
 ) {
@@ -31,6 +33,15 @@ export function useTeams(
           message: 'The request is missing an authentication token',
           code: 'forbidden',
           missingToken: true,
+        });
+        return;
+      }
+      if (options.failInvalidToken) {
+        res.statusCode = 403;
+        res.json({
+          message: 'Not authorized',
+          code: 'forbidden',
+          invalidToken: true,
         });
         return;
       }

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -41,6 +41,35 @@ describe('getLinkedProject', () => {
     );
   });
 
+  it('should fail to return a link when token is invalid', async () => {
+    const cwd = fixture('vercel-pull-next');
+
+    useUser();
+    useTeams('team_dummy', { failInvalidToken: true });
+    useProject({
+      ...defaultProject,
+      id: 'vercel-pull-next',
+      name: 'vercel-pull-next',
+    });
+
+    let link: UnPromisify<ReturnType<typeof getLinkedProject>> | undefined;
+    let error: Error | undefined;
+    try {
+      link = await getLinkedProject(client, cwd);
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(link).toBeUndefined();
+
+    if (!error) {
+      throw new Error(`Expected an error to be thrown.`);
+    }
+    expect(error.message).toBe(
+      'The specified token is not valid. Use `vercel login` to generate a new token.'
+    );
+  });
+
   it('should fail to return a link when no access to team', async () => {
     const cwd = fixture('vercel-pull-next');
 


### PR DESCRIPTION
This changes the error when a token is invalid or expired from

```
Error: Could not retrieve Project Settings. To link your Project, remove the `.vercel` directory and deploy again.
Learn More: https://vercel.link/cannot-load-project-settings
```

to a better error

```
Error: The specified token is not valid. Use `vercel login` to generate a new token.
```

- This could be considered a follow up to https://github.com/vercel/vercel/pull/7794