### PR TITLE
require `--yes` flag to promote preview deployment

### DIFF
--- a/.changeset/green-badgers-reflect.md
+++ b/.changeset/green-badgers-reflect.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-require force to promote preview deployment
+require `--yes` to promote preview deployment

--- a/.changeset/green-badgers-reflect.md
+++ b/.changeset/green-badgers-reflect.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+require force to promote preview deployment

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -30,7 +30,6 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
-    --force                        Force promote of a preview deployment
     --timeout=${chalk.bold.underline(
       'TIME'
     )}                 Time to wait for promotion completion [3m]
@@ -61,7 +60,6 @@ export default async (client: Client): Promise<number> => {
   try {
     argv = getArgs(client.argv.slice(2), {
       '--timeout': String,
-      '--force': Boolean,
       '--yes': Boolean,
       '-y': '--yes',
     });
@@ -75,7 +73,7 @@ export default async (client: Client): Promise<number> => {
     return 2;
   }
 
-  const force = argv['--force'] ?? false;
+  const yes = argv['--yes'] ?? false;
 
   // validate the timeout
   let timeout = argv['--timeout'];
@@ -107,7 +105,7 @@ export default async (client: Client): Promise<number> => {
       client,
       deployId: actionOrDeployId,
       timeout,
-      force,
+      yes,
     });
   } catch (err) {
     if (isErrnoException(err)) {

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -60,6 +60,7 @@ export default async (client: Client): Promise<number> => {
   try {
     argv = getArgs(client.argv.slice(2), {
       '--timeout': String,
+      '--force': Boolean,
       '--yes': Boolean,
       '-y': '--yes',
     });
@@ -72,6 +73,8 @@ export default async (client: Client): Promise<number> => {
     help();
     return 2;
   }
+
+  const force = argv['--force'] ?? false;
 
   // validate the timeout
   let timeout = argv['--timeout'];
@@ -103,6 +106,7 @@ export default async (client: Client): Promise<number> => {
       client,
       deployId: actionOrDeployId,
       timeout,
+      force,
     });
   } catch (err) {
     if (isErrnoException(err)) {

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -30,6 +30,7 @@ const help = () => {
     -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
     'TOKEN'
   )}        Login token
+    --force                        Force promote of a preview deployment
     --timeout=${chalk.bold.underline(
       'TIME'
     )}                 Time to wait for promotion completion [3m]

--- a/packages/cli/src/commands/promote/request-promote.ts
+++ b/packages/cli/src/commands/promote/request-promote.ts
@@ -35,12 +35,10 @@ export default async function requestPromote({
   if (deployment.target !== 'production' && !yes) {
     const question =
       'This deployment does not target production, therefore promotion will not apply production environment variables. Are you sure you want to continue?';
-    const answer = await confirm(client, question, true);
+    const answer = await confirm(client, question, false);
     if (!answer) {
-      output.error(
-        'User declined to promote a deployment that did not target production.'
-      );
-      return 1;
+      output.error('Canceled');
+      return 0;
     }
   }
 

--- a/packages/cli/src/commands/promote/request-promote.ts
+++ b/packages/cli/src/commands/promote/request-promote.ts
@@ -16,10 +16,12 @@ export default async function requestPromote({
   client,
   deployId,
   timeout,
+  force,
 }: {
   client: Client;
   deployId: string;
   timeout?: string;
+  force: boolean;
 }): Promise<number> {
   const { output } = client;
 
@@ -28,6 +30,13 @@ export default async function requestPromote({
     deployId,
     output: client.output,
   });
+
+  if (deployment.target !== 'production' && !force) {
+    output.error(
+      'Cannot promote deployment that does not target "production". If you are sure you want to do this, add `--force`.'
+    );
+    return 1;
+  }
 
   // request the promotion
   await client.fetch(`/v9/projects/${project.id}/promote/${deployment.id}`, {

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -18,6 +18,7 @@ export function useDeployment({
   state = 'READY',
   createdAt,
   project = defaultProject,
+  target = 'production',
 }: {
   creator: Pick<User, 'id' | 'email' | 'name' | 'username'>;
   state?:
@@ -29,6 +30,7 @@ export function useDeployment({
     | 'CANCELED';
   createdAt?: number;
   project: any; // FIX ME: Use `Project` once PR #9956 is merged
+  target?: Deployment['target'];
 }) {
   setupDeploymentEndpoints();
 
@@ -63,7 +65,7 @@ export function useDeployment({
     regions: [],
     routes: [],
     status: state,
-    target: 'production',
+    target,
     type: 'LAMBDAS',
     url: url.hostname,
     version: 2,

--- a/packages/cli/test/unit/commands/promote.test.ts
+++ b/packages/cli/test/unit/commands/promote.test.ts
@@ -119,6 +119,10 @@ describe('promote', () => {
     // say "no" to the prompt
     client.stdin.write('n\n');
 
+    await expect(client.stderr).toOutput(
+      'User declined to promote a deployment that did not target production.'
+    );
+
     await expect(exitCodePromise).resolves.toEqual(1);
   });
 

--- a/packages/cli/test/unit/commands/promote.test.ts
+++ b/packages/cli/test/unit/commands/promote.test.ts
@@ -119,11 +119,9 @@ describe('promote', () => {
     // say "no" to the prompt
     client.stdin.write('n\n');
 
-    await expect(client.stderr).toOutput(
-      'User declined to promote a deployment that did not target production.'
-    );
+    await expect(client.stderr).toOutput('Error: Canceled');
 
-    await expect(exitCodePromise).resolves.toEqual(1);
+    await expect(exitCodePromise).resolves.toEqual(0);
   });
 
   it('should promote a preview deployment when user says yes', async () => {

--- a/packages/cli/test/unit/commands/promote.test.ts
+++ b/packages/cli/test/unit/commands/promote.test.ts
@@ -112,7 +112,6 @@ describe('promote', () => {
     await expect(client.stderr).toOutput(
       `Fetching deployment "${previousDeployment.url}" in ${previousDeployment.creator?.username}`
     );
-    await expect(client.stderr).toOutput('Promote in progress');
     await expect(client.stderr).toOutput(
       'Error: Cannot promote deployment that does not target "production". If you are sure you want to do this, add `--force`.'
     );

--- a/packages/cli/test/unit/commands/promote.test.ts
+++ b/packages/cli/test/unit/commands/promote.test.ts
@@ -116,7 +116,7 @@ describe('promote', () => {
       'Error: Cannot promote deployment that does not target "production". If you are sure you want to do this, add `--force`.'
     );
 
-    await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(exitCodePromise).resolves.toEqual(1);
   });
 
   it('should promote a preview deployment with --force', async () => {


### PR DESCRIPTION
In order to promote a preview deployment, we want to make sure the user knows that this is not typical. Now the `--yes` flag is required to make this work.