### PR TITLE
[cli] Respond with "Redirecting..." to match production behavior

### DIFF
--- a/.changeset/polite-experts-jam.md
+++ b/.changeset/polite-experts-jam.md
@@ -1,0 +1,5 @@
+---
+'vercel': major
+---
+
+Update `vc dev` redirect response to match production behavior

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -1131,7 +1131,7 @@ export default class DevServer {
       body = redirectTemplate({ location, statusCode });
     } else {
       res.setHeader('content-type', 'text/plain; charset=utf-8');
-      body = `Redirecting to ${location} (${statusCode})\n`;
+      body = `Redirecting...\n`;
     }
     res.end(body);
   }

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -88,10 +88,10 @@ test(
     async (testPath: any) => {
       const vcRobots = `https://vercel.com/robots.txt`;
       await testPath(200, '/rewrite', /User-Agent: \*/m);
-      await testPath(308, '/redirect', `Redirecting to ${vcRobots} (308)`, {
+      await testPath(308, '/redirect', `Redirecting...`, {
         Location: vcRobots,
       });
-      await testPath(307, '/tempRedirect', `Redirecting to ${vcRobots} (307)`, {
+      await testPath(307, '/tempRedirect', `Redirecting...`, {
         Location: vcRobots,
       });
     }
@@ -103,10 +103,10 @@ test(
   testFixtureStdio('test-routing-case-sensitive', async (testPath: any) => {
     await testPath(200, '/Path', 'UPPERCASE');
     await testPath(200, '/path', 'lowercase');
-    await testPath(308, '/GoTo', 'Redirecting to /upper.html (308)', {
+    await testPath(308, '/GoTo', 'Redirecting...', {
       Location: '/upper.html',
     });
-    await testPath(308, '/goto', 'Redirecting to /lower.html (308)', {
+    await testPath(308, '/goto', 'Redirecting...', {
       Location: '/lower.html',
     });
   })

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -233,7 +233,7 @@ test(
         expect(res.headers.get('location')).toBe(
           `http://localhost:${port}/?foo=bar`
         );
-        expect(body).toBe('Redirecting to /?foo=bar (301)\n');
+        expect(body).toBe('Redirecting...\n');
       }
 
       {

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -197,21 +197,18 @@ test(
     await testPath(200, '/sub', 'Sub Index Page');
     await testPath(200, '/sub/another', 'Sub Another Page');
     await testPath(200, '/style.css', 'body { color: green }');
-    await testPath(308, '/index.html', 'Redirecting to / (308)', {
+    await testPath(308, '/index.html', 'Redirecting...', {
       Location: '/',
     });
-    await testPath(308, '/about.html', 'Redirecting to /about (308)', {
+    await testPath(308, '/about.html', 'Redirecting...', {
       Location: '/about',
     });
-    await testPath(308, '/sub/index.html', 'Redirecting to /sub (308)', {
+    await testPath(308, '/sub/index.html', 'Redirecting...', {
       Location: '/sub',
     });
-    await testPath(
-      308,
-      '/sub/another.html',
-      'Redirecting to /sub/another (308)',
-      { Location: '/sub/another' }
-    );
+    await testPath(308, '/sub/another.html', 'Redirecting...', {
+      Location: '/sub/another',
+    });
   })
 );
 
@@ -225,21 +222,18 @@ test(
       await testPath(200, '/sub', 'Sub Index Page');
       await testPath(200, '/sub/another', 'Sub Another Page');
       await testPath(200, '/style.css', 'body { color: green }');
-      await testPath(308, '/index.html', 'Redirecting to / (308)', {
+      await testPath(308, '/index.html', 'Redirecting...', {
         Location: '/',
       });
-      await testPath(308, '/about.html', 'Redirecting to /about (308)', {
+      await testPath(308, '/about.html', 'Redirecting...', {
         Location: '/about',
       });
-      await testPath(308, '/sub/index.html', 'Redirecting to /sub (308)', {
+      await testPath(308, '/sub/index.html', 'Redirecting...', {
         Location: '/sub',
       });
-      await testPath(
-        308,
-        '/sub/another.html',
-        'Redirecting to /sub/another (308)',
-        { Location: '/sub/another' }
-      );
+      await testPath(308, '/sub/another.html', 'Redirecting...', {
+        Location: '/sub/another',
+      });
     }
   )
 );
@@ -264,21 +258,16 @@ test(
     await testPath(200, '/sub/another/', 'Sub Another Page');
     await testPath(200, '/style.css', 'body { color: green }');
     //TODO: fix this test so that location is `/` instead of `//`
-    //await testPath(308, '/index.html', 'Redirecting to / (308)', { Location: '/' });
-    await testPath(308, '/about.html', 'Redirecting to /about/ (308)', {
+    //await testPath(308, '/index.html', 'Redirecting...', { Location: '/' });
+    await testPath(308, '/about.html', 'Redirecting...', {
       Location: '/about/',
     });
-    await testPath(308, '/sub/index.html', 'Redirecting to /sub/ (308)', {
+    await testPath(308, '/sub/index.html', 'Redirecting...', {
       Location: '/sub/',
     });
-    await testPath(
-      308,
-      '/sub/another.html',
-      'Redirecting to /sub/another/ (308)',
-      {
-        Location: '/sub/another/',
-      }
-    );
+    await testPath(308, '/sub/another.html', 'Redirecting...', {
+      Location: '/sub/another/',
+    });
   })
 );
 
@@ -315,13 +304,13 @@ test(
     await testPath(200, '/sub/index.html', 'Sub Index Page');
     await testPath(200, '/sub/another.html', 'Sub Another Page');
     await testPath(200, '/style.css', 'body { color: green }');
-    await testPath(308, '/about.html/', 'Redirecting to /about.html (308)', {
+    await testPath(308, '/about.html/', 'Redirecting...', {
       Location: '/about.html',
     });
-    await testPath(308, '/style.css/', 'Redirecting to /style.css (308)', {
+    await testPath(308, '/style.css/', 'Redirecting...', {
       Location: '/style.css',
     });
-    await testPath(308, '/sub', 'Redirecting to /sub/ (308)', {
+    await testPath(308, '/sub', 'Redirecting...', {
       Location: '/sub/',
     });
   })
@@ -347,20 +336,15 @@ test(
     await testPath(200, '/sub/index.html', 'Sub Index Page');
     await testPath(200, '/sub/another.html', 'Sub Another Page');
     await testPath(200, '/style.css', 'body { color: green }');
-    await testPath(308, '/about.html/', 'Redirecting to /about.html (308)', {
+    await testPath(308, '/about.html/', 'Redirecting...', {
       Location: '/about.html',
     });
-    await testPath(308, '/sub/', 'Redirecting to /sub (308)', {
+    await testPath(308, '/sub/', 'Redirecting...', {
       Location: '/sub',
     });
-    await testPath(
-      308,
-      '/sub/another.html/',
-      'Redirecting to /sub/another.html (308)',
-      {
-        Location: '/sub/another.html',
-      }
-    );
+    await testPath(308, '/sub/another.html/', 'Redirecting...', {
+      Location: '/sub/another.html',
+    });
   })
 );
 


### PR DESCRIPTION
Production was recently changed to make redirect responses return the text "Redirecting..." without the destination nor status code in the text.

This caused some tests to start failing, so update `vc dev` to match this new behavior and update the relevant tests.