### PR TITLE
[frameworks] Update `saber.land` to `saber.egoist.dev`

### DIFF
--- a/.changeset/shy-pumas-dress.md
+++ b/.changeset/shy-pumas-dress.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": patch
+"examples": patch
+---
+
+[frameworks] Update `saber.land` to `saber.egoist.dev`

--- a/.changeset/shy-pumas-dress.md
+++ b/.changeset/shy-pumas-dress.md
@@ -1,6 +1,5 @@
 ---
 "@vercel/frameworks": patch
-"examples": patch
 ---
 
 [frameworks] Update `saber.land` to `saber.egoist.dev`

--- a/examples/saber/README.md
+++ b/examples/saber/README.md
@@ -2,7 +2,7 @@
 
 # Saber Example
 
-This directory is a brief example of a [Saber](https://saber.land) site that can be deployed to Vercel with zero configuration.
+This directory is a brief example of a [Saber](https://saber.egoist.dev) site that can be deployed to Vercel with zero configuration.
 
 ## Deploy Your Own
 

--- a/examples/saber/pages/about.md
+++ b/examples/saber/pages/about.md
@@ -5,4 +5,4 @@ layout: page
 
 This is the Saber port of the base Jekyll theme. Check out the [GitHub project](https://github.com/egoist/saber-theme-minima) for detailed usages.
 
-You can find out more info about customizing your theme, as well as basic Saber usage documentation at https://saber.land
+You can find out more info about customizing your theme, as well as basic Saber usage documentation at https://saber.egoist.dev

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1291,7 +1291,7 @@ export const frameworks = [
     tagline:
       'Saber is a framework for building static sites in Vue.js that supports data from any source.',
     description: 'A Saber site, created with npm init.',
-    website: 'https://saber.land/',
+    website: 'https://saber.egoist.dev',
     detectors: {
       every: [
         {


### PR DESCRIPTION
The website url for Saber changed

x-ref: [slack](https://vercel.slack.com/archives/C01RUTYJYHW/p1687900208904799)