### PR TITLE
[cli] Optimize write build result for vc build

### DIFF
--- a/.changeset/loud-teachers-hug.md
+++ b/.changeset/loud-teachers-hug.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Optimize write build result for vc build

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -131,6 +131,9 @@ async function writeBuildResultV2(
 
   const lambdas = new Map<Lambda, string>();
   const overrides: Record<string, PathOverride> = {};
+
+  const isBuildContainer = !!process.env.VERCEL;
+
   for (const [path, output] of Object.entries(buildResult.output)) {
     const normalizedPath = stripDuplicateSlashes(path);
     if (isLambda(output)) {
@@ -159,8 +162,8 @@ async function writeBuildResultV2(
 
         // if we're in the build container and fallback is already
         // on the disk just move it to avoid duplicating output
-        if (process.env.VERCEL && 'fsPath' in fallback) {
-          await fs.move(fallback.fsPath, fallbackPath);
+        if (isBuildContainer && 'fsPath' in fallback) {
+          await fs.link(fallback.fsPath, fallbackPath);
         } else {
           const stream = fallback.toStream();
           await pipe(

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -163,7 +163,8 @@ async function writeBuildResultV2(
         let usedHardLink = false;
         if ('fsPath' in fallback) {
           try {
-            return await fs.link(fallback.fsPath, fallbackPath);
+            await fs.link(fallback.fsPath, fallbackPath);
+            usedHardLink = true;
           } catch (_) {
             // if link fails we continue attempting to copy
           }


### PR DESCRIPTION
As noticed this is copying all fallback files from output even if they are already on the disk in the build container which should be able to be considered a "pure" environment. This copying can cause disk space/perf issues when there are massive amounts of fallback files generated e.g. 8000 outputs at 200KB/output is already 1.6GB of copying needing to be done that could just be a move operation. 


x-ref: [slack thread](https://vercel.slack.com/archives/C03F2CMNGKG/p1687969734598509?thread_ts=1687963253.178369&cid=C03F2CMNGKG)
x-ref: [slack thread](https://vercel.slack.com/archives/C02SM2K2UM9/p1687970267370669)
x-ref: [slack thread](https://vercel.slack.com/archives/C03DQ3QFV7C/p1687338157228459)
