### PR TITLE
[next] Ensure RSC paths handle basePath

### DIFF
--- a/.changeset/strong-coins-teach.md
+++ b/.changeset/strong-coins-teach.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] Ensure RSC paths handle basePath

--- a/packages/next/.gitignore
+++ b/packages/next/.gitignore
@@ -1,2 +1,3 @@
 /dist
 test/builder-info.json
+test/fixtures/**/tmp-contents

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1198,7 +1198,11 @@ export async function serverBuild({
       if (ogRoute.endsWith('/route')) {
         continue;
       }
-      route = path.posix.join('./', route === '/' ? '/index' : route);
+      route = path.posix.join(
+        './',
+        entryDirectory,
+        route === '/' ? '/index' : route
+      );
 
       if (lambdas[route]) {
         lambdas[`${route}.rsc`] = lambdas[route];

--- a/packages/next/test/fixtures/00-app-dir-base-path/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-base-path/index.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+const path = require('path');
+const fs = require('fs-extra');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  const fixtureDir = path.join(__dirname, 'tmp-contents');
+
+  afterAll(() => fs.remove(fixtureDir));
+
+  it('should deploy and pass probe checks', async () => {
+    await fs.copy(path.join(__dirname, '../00-app-dir'), fixtureDir);
+    const nextConfigPath = path.join(fixtureDir, 'next.config.js');
+
+    await fs.writeFile(
+      nextConfigPath,
+      (
+        await fs.readFile(nextConfigPath, 'utf8')
+      ).replace('experimental:', 'basePath: "/hello/world",experimental:')
+    );
+
+    await fs.copy(
+      path.join(__dirname, 'vercel.json'),
+      path.join(fixtureDir, 'vercel.json')
+    );
+
+    const info = await deployAndTest(fixtureDir);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
@@ -1,0 +1,198 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next",
+      "config": {
+        "functions": {
+          "app/**/*": {
+            "maxDuration": 5,
+            "memory": 512
+          },
+          "pages/api/**/*": {
+            "maxDuration": 5,
+            "memory": 512
+          }
+        }
+      }
+    }
+  ],
+  "probes": [
+    {
+      "path": "/hello/world/dashboard/hello",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/rootonly/hello"
+    },
+    {
+      "path": "/hello/world/dashboard/another-edge",
+      "status": 200,
+      "mustContain": "hello from newroot/dashboard/another"
+    },
+    {
+      "path": "/hello/world/dynamic/category-1/id-1",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/hello/world/ssg",
+      "status": 200,
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/hello/world/ssg",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/hello/world/ssg?override=1",
+      "status": 307,
+      "responseHeaders": {
+        "location": "/overridden/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/hello/world/ssg?override=1",
+      "status": 307,
+      "responseHeaders": {
+        "location": "/overridden/"
+      },
+      "fetchOptions": {
+        "redirect": "manual"
+      }
+    },
+    {
+      "path": "/hello/world/dashboard/deployments/123/settings",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/hello/world/dashboard/deployments/123/settings",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/hello/world/dashboard/deployments/catchall/something",
+      "status": 200,
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/hello/world/dashboard/deployments/catchall/something",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      },
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/hello/world/dashboard",
+      "status": 200,
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/hello/world/dashboard",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/hello/world/dashboard",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "responseHeaders": {
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch"
+      }
+    },
+    {
+      "path": "/hello/world/dashboard/another",
+      "status": 200,
+      "mustContain": "hello from newroot/dashboard/another"
+    },
+    {
+      "path": "/hello/world/dashboard/deployments/123",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/deployments/[id]. ID is: <!-- -->123"
+    },
+    {
+      "path": "/hello/world/",
+      "status": 200,
+      "mustContain": "index app page"
+    },
+    {
+      "path": "/hello/world/blog/123",
+      "status": 200,
+      "mustContain": "hello from pages/blog/[slug]"
+    },
+    {
+      "path": "/hello/world/blog-ssr/123",
+      "status": 200,
+      "mustContain": "hello from pages/blog-ssr/[slug]"
+    },
+    {
+      "path": "/hello/world/blog-ssr/321",
+      "status": 200,
+      "mustContain": "hello context"
+    },
+    {
+      "path": "/hello/world/dynamic/category-1/id-1",
+      "status": 200,
+      "mustContain": "{&quot;category&quot;:&quot;category-1&quot;,&quot;id&quot;:&quot;id-1&quot;}"
+    },
+    {
+      "path": "/hello/world/dashboard/changelog",
+      "status": 200,
+      "mustContain": "hello from app/dashboard/changelog"
+    },
+    {
+      "path": "/hello/world/",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    }
+  ]
+}


### PR DESCRIPTION
This ensures we properly create the `.rsc` variant of outputs when `basePath` is configured and adds a regression test for this. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1687944744404289)
Fixes: https://github.com/vercel/next.js/issues/48305