### PR TITLE
Removes a leftover `console.log` in the new `help` method

### DIFF
--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -222,7 +222,6 @@ export interface HelpOptions {
 }
 
 export function help(command: Command, options: HelpOptions) {
-  console.log(options);
   return buildHelpOutput(command, {
     columns: options.columns ?? 80,
   });


### PR DESCRIPTION
Removes a leftover `console.log` in the new `help` method. Whoops!