### PR TITLE
Revert "[build-utils] Allow file-ref sema to be controlled through env flag"

### DIFF
--- a/.changeset/dry-hotels-worry.md
+++ b/.changeset/dry-hotels-worry.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Revert "[build-utils] Allow file-ref sema to be controlled through env flag"

--- a/packages/build-utils/src/file-fs-ref.ts
+++ b/packages/build-utils/src/file-fs-ref.ts
@@ -5,13 +5,7 @@ import path from 'path';
 import Sema from 'async-sema';
 import { FileBase } from './types';
 
-const DEFAULT_SEMA = 20;
-const semaToPreventEMFILE = new Sema(
-  parseInt(
-    process.env.VERCEL_INTERNAL_FILE_FS_REF_SEMA || String(DEFAULT_SEMA),
-    10
-  ) || DEFAULT_SEMA
-);
+const semaToPreventEMFILE = new Sema(20);
 
 interface FileFsRefOptions {
   mode?: number;

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -12,13 +12,7 @@ interface FileRefOptions {
   mutable?: boolean;
 }
 
-const DEFAULT_SEMA = 5;
-const semaToDownloadFromS3 = new Sema(
-  parseInt(
-    process.env.VERCEL_INTERNAL_FILE_REF_SEMA || String(DEFAULT_SEMA),
-    10
-  ) || DEFAULT_SEMA
-);
+const semaToDownloadFromS3 = new Sema(5);
 
 class BailableError extends Error {
   public bail: boolean;


### PR DESCRIPTION
Reverts vercel/vercel#8681

We ran an experiment here a while ago but it had flaky results.

This PR cleans up the experiment code, and reverts to the previous behavior.