### PR TITLE
[cli] Added line return at end of help output

### DIFF
--- a/.changeset/tame-ads-swim.md
+++ b/.changeset/tame-ads-swim.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Added trailing new line at end of help output

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -212,6 +212,7 @@ export function buildHelpOutput(
     buildCommandOptionLines(command, options),
     '',
     buildCommandExampleLines(command),
+    '',
   ];
 
   return outputArrayToString(outputArray);

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -121,7 +121,8 @@ Deploy your project to Vercel. The \`deploy\` command is the default command for
 
   [90m-[39m Write Deployment URL to a file
 
-    [36m$ vercel > deployment-url.txt[39m"
+    [36m$ vercel > deployment-url.txt[39m
+"
 `;
 
 exports[`help command help output snapshots column width 80 1`] = `
@@ -182,7 +183,8 @@ Deploy your project to Vercel. The \`deploy\` command is the default command for
 
   [90m-[39m Write Deployment URL to a file
 
-    [36m$ vercel > deployment-url.txt[39m"
+    [36m$ vercel > deployment-url.txt[39m
+"
 `;
 
 exports[`help command help output snapshots column width 120 1`] = `
@@ -237,5 +239,6 @@ Deploy your project to Vercel. The \`deploy\` command is the default command for
 
   [90m-[39m Write Deployment URL to a file
 
-    [36m$ vercel > deployment-url.txt[39m"
+    [36m$ vercel > deployment-url.txt[39m
+"
 `;


### PR DESCRIPTION
I noticed the help output doesn't render a line return at the end.

<img width="290" alt="image" src="https://github.com/vercel/vercel/assets/97262/8aea6be0-9620-4445-b05d-62b838cefb07">
