### PR TITLE
[node] fix decompress mismatching

### DIFF
--- a/.changeset/fluffy-bikes-battle.md
+++ b/.changeset/fluffy-bikes-battle.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+[node] fix decompress mismatching

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -7,6 +7,7 @@ import fetch from 'node-fetch';
 import { listen } from 'async-listen';
 import { isAbsolute } from 'path';
 import { pathToFileURL } from 'url';
+import zlib from 'zlib';
 import type { ServerResponse, IncomingMessage } from 'http';
 import type { VercelProxyResponse } from '../types.js';
 import type { VercelRequest, VercelResponse } from './helpers.js';
@@ -33,6 +34,27 @@ const HTTP_METHODS = [
   'DELETE',
   'PATCH',
 ];
+
+function compress(body: Buffer, encoding: string): Buffer {
+  switch (encoding) {
+    case 'br':
+      return zlib.brotliCompressSync(body, {
+        params: {
+          [zlib.constants.BROTLI_PARAM_QUALITY]: 0,
+        },
+      });
+    case 'gzip':
+      return zlib.gzipSync(body, {
+        level: zlib.constants.Z_BEST_SPEED,
+      });
+    case 'deflate':
+      return zlib.deflateSync(body, {
+        level: zlib.constants.Z_BEST_SPEED,
+      });
+    default:
+      throw new Error(`encoding '${encoding}' not supported`);
+  }
+}
 
 async function createServerlessServer(userCode: ServerlessFunctionSignature) {
   const server = createServer(userCode);
@@ -78,12 +100,14 @@ export async function createServerlessEventHandler(
 ): Promise<(request: IncomingMessage) => Promise<VercelProxyResponse>> {
   const userCode = await compileUserCode(entrypointPath, options);
   const server = await createServerlessServer(userCode);
+  const isStreaming = options.mode === 'streaming';
 
   return async function (request: IncomingMessage) {
     const url = new URL(request.url ?? '/', server.url);
     // @ts-expect-error
     const response = await fetch(url, {
       body: await serializeBody(request),
+      compress: isStreaming,
       headers: {
         ...request.headers,
         host: request.headers['x-forwarded-host'],
@@ -93,12 +117,22 @@ export async function createServerlessEventHandler(
     });
 
     let body;
-    if (options.mode === 'streaming') {
+    if (isStreaming) {
       body = response.body;
     } else {
       body = await streamToBuffer(response.body);
+
+      const contentEncoding = response.headers.get('content-encoding');
+      if (contentEncoding) {
+        body = compress(body, contentEncoding);
+        response.headers.set('content-length', Buffer.byteLength(body));
+      }
+
+      /**
+       * `transfer-encoding` is related to streaming chunks.
+       * Since we are buffering the response.body, it should be stripped.
+       */
       response.headers.delete('transfer-encoding');
-      response.headers.set('content-length', body.length);
     }
 
     return {

--- a/packages/node/test/dev-fixtures/serverless-fetch.js
+++ b/packages/node/test/dev-fixtures/serverless-fetch.js
@@ -1,0 +1,10 @@
+const baseUrl = ({ headers }) =>
+  `${headers.get('x-forwarded-proto')}://${headers.get('x-forwarded-host')}`;
+
+export function GET(request) {
+  const { searchParams } = new URL(request.url, baseUrl(request));
+  const url = searchParams.get('url');
+  const encoding = searchParams.get('encoding');
+  const serverUrl = `${url}?encoding=${encoding}`;
+  return fetch(serverUrl);
+}

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -64,7 +64,7 @@ function testForkDevServer(entrypoint: string) {
   }
 );
 
-(NODE_MAJOR < 18 ? test.skip : test.only)(
+(NODE_MAJOR < 18 ? test.skip : test)(
   'buffer fetch response correctly',
   async () => {
     const child = testForkDevServer('./serverless-fetch.js');

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -1,6 +1,9 @@
 import { forkDevServer, readMessage } from '../../src/fork-dev-server';
 import { resolve, extname } from 'path';
 import fetch from 'node-fetch';
+import { createServer } from 'http';
+import { listen } from 'async-listen';
+import zlib from 'zlib';
 
 jest.setTimeout(20 * 1000);
 
@@ -29,7 +32,7 @@ function testForkDevServer(entrypoint: string) {
 (NODE_MAJOR < 18 ? test.skip : test)(
   'runs an serverless function that exports GET',
   async () => {
-    const child = testForkDevServer('./serverless-web.js');
+    const child = testForkDevServer('./serverless-response.js');
     try {
       const result = await readMessage(child);
       if (result.state !== 'message') {
@@ -40,7 +43,7 @@ function testForkDevServer(entrypoint: string) {
 
       {
         const response = await fetch(
-          `http://${address}:${port}/api/serverless-web?name=Vercel`
+          `http://${address}:${port}/api/serverless-response?name=Vercel`
         );
         expect({
           status: response.status,
@@ -50,12 +53,96 @@ function testForkDevServer(entrypoint: string) {
 
       {
         const response = await fetch(
-          `http://${address}:${port}/api/serverless-web?name=Vercel`,
+          `http://${address}:${port}/api/serverless-response?name=Vercel`,
           { method: 'HEAD' }
         );
         expect({ status: response.status }).toEqual({ status: 405 });
       }
     } finally {
+      child.kill(9);
+    }
+  }
+);
+
+(NODE_MAJOR < 18 ? test.skip : test.only)(
+  'buffer fetch response correctly',
+  async () => {
+    const child = testForkDevServer('./serverless-fetch.js');
+
+    const server = createServer((req, res) => {
+      res.setHeader('Content-Encoding', 'br');
+      const searchParams = new URLSearchParams(req.url!.substring(1));
+      const encoding = searchParams.get('encoding') ?? 'identity';
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'content-encoding': encoding,
+      });
+      let payload = Buffer.from('Greetings, Vercel');
+
+      if (encoding === 'br') {
+        payload = zlib.brotliCompressSync(payload, {
+          params: {
+            [zlib.constants.BROTLI_PARAM_QUALITY]: 0,
+          },
+        });
+      } else if (encoding === 'gzip') {
+        payload = zlib.gzipSync(payload, {
+          level: zlib.constants.Z_BEST_SPEED,
+        });
+      } else if (encoding === 'deflate') {
+        payload = zlib.deflateSync(payload, {
+          level: zlib.constants.Z_BEST_SPEED,
+        });
+      }
+
+      res.end(payload);
+    });
+
+    const serverUrl = (await listen(server)).toString();
+
+    try {
+      const result = await readMessage(child);
+      if (result.state !== 'message') {
+        throw new Error('Exited. error: ' + JSON.stringify(result.value));
+      }
+
+      const { address, port } = result.value;
+
+      {
+        const response = await fetch(
+          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=br`
+        );
+        expect(response.headers.get('content-encoding')).toBe('br');
+        expect(response.headers.get('content-length')).toBe('21');
+        expect({
+          status: response.status,
+          body: await response.text(),
+        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
+      }
+      {
+        const response = await fetch(
+          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=gzip`
+        );
+        expect(response.headers.get('content-encoding')).toBe('gzip');
+        expect(response.headers.get('content-length')).toBe('37');
+        expect({
+          status: response.status,
+          body: await response.text(),
+        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
+      }
+      {
+        const response = await fetch(
+          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=deflate`
+        );
+        expect(response.headers.get('content-encoding')).toBe('deflate');
+        expect(response.headers.get('content-length')).toBe('25');
+        expect({
+          status: response.status,
+          body: await response.text(),
+        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
+      }
+    } finally {
+      server.close();
       child.kill(9);
     }
   }


### PR DESCRIPTION
This PR disabled `node-fetch` default compression handling when the response is not streamed.

The default behavior in node-fetch is to handle the compression. That's great if you interact with node-fetch as user, but bad if you use it as intermediate proxy server, since it's creating a mismatching related with the body format and length expectations.

Instead, we disable compression, get the buffered response and compress it again if needed.