### PR TITLE
Fix redeploy target

### DIFF
--- a/.changeset/silver-mirrors-unite.md
+++ b/.changeset/silver-mirrors-unite.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Redeploy command no longer redeploys preview deployments to production

--- a/packages/cli/src/commands/redeploy.ts
+++ b/packages/cli/src/commands/redeploy.ts
@@ -108,7 +108,7 @@ export default async (client: Client): Promise<number> => {
           action: 'redeploy',
         },
         name: fromDeployment.name,
-        target: fromDeployment.target || 'production',
+        target: fromDeployment.target,
       },
       method: 'POST',
     });

--- a/packages/cli/test/unit/commands/redeploy.test.ts
+++ b/packages/cli/test/unit/commands/redeploy.test.ts
@@ -5,6 +5,7 @@ import { setupUnitFixture } from '../../helpers/setup-unit-fixture';
 import { useDeployment } from '../../mocks/deployment';
 import { useTeams } from '../../mocks/team';
 import { useUser } from '../../mocks/user';
+import { Deployment } from '@vercel-internals/types';
 
 describe('redeploy', () => {
   it('should error if missing deployment url', async () => {
@@ -77,9 +78,20 @@ describe('redeploy', () => {
 
     await expect(exitCodePromise).resolves.toEqual(0);
   });
+
+  it('should redeploy to preview', async () => {
+    const { fromDeployment } = initRedeployTest({ target: null });
+    client.setArgv('rollback', fromDeployment.id);
+    const exitCodePromise = redeploy(client);
+    await expect(client.stderr).toOutput(
+      `Fetching deployment "${fromDeployment.id}" in ${fromDeployment.creator?.username}`
+    );
+    await expect(client.stderr).toOutput('Preview');
+    await expect(exitCodePromise).resolves.toEqual(0);
+  });
 });
 
-function initRedeployTest() {
+function initRedeployTest({ target }: { target?: Deployment['target'] } = {}) {
   setupUnitFixture('commands/redeploy/simple-static');
   const user = useUser();
   useTeams('team_dummy');
@@ -88,8 +100,8 @@ function initRedeployTest() {
     id: 'vercel-redeploy',
     name: 'vercel-redeploy',
   });
-  const fromDeployment = useDeployment({ creator: user });
-  const toDeployment = useDeployment({ creator: user });
+  const fromDeployment = useDeployment({ creator: user, target });
+  const toDeployment = useDeployment({ creator: user, target });
 
   client.scenario.post(`/v13/deployments`, (req, res) => {
     res.json(toDeployment);


### PR DESCRIPTION
This PR fixes customer issue https://github.com/vercel/customer-issues/issues/1310 which identified an issue with the `redeploy` command. 

`redeploy` should not default the `target` to `'production'` as an `undefined` target is meant to mean `'preview'`.