### PR TITLE
[cli] Fix redeploy target to be `undefined` when `null`

### DIFF
--- a/.changeset/fresh-monkeys-speak.md
+++ b/.changeset/fresh-monkeys-speak.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix redeploy target to be undefined when null

--- a/packages/cli/src/commands/redeploy.ts
+++ b/packages/cli/src/commands/redeploy.ts
@@ -108,7 +108,7 @@ export default async (client: Client): Promise<number> => {
           action: 'redeploy',
         },
         name: fromDeployment.name,
-        target: fromDeployment.target,
+        target: fromDeployment.target ?? undefined,
       },
       method: 'POST',
     });

--- a/packages/cli/test/unit/commands/redeploy.test.ts
+++ b/packages/cli/test/unit/commands/redeploy.test.ts
@@ -104,6 +104,14 @@ function initRedeployTest({ target }: { target?: Deployment['target'] } = {}) {
   const toDeployment = useDeployment({ creator: user, target });
 
   client.scenario.post(`/v13/deployments`, (req, res) => {
+    const { target } = req.body;
+    if (target !== undefined && typeof target !== 'string') {
+      res.status(400).json({
+        message: 'Invalid request: `target` should be string',
+      });
+      return;
+    }
+
     res.json(toDeployment);
   });
 


### PR DESCRIPTION
When redeploying an existing deployment, the target can be `null` and `null` will get sent, however the API only allows a string or `undefined`.