### PR TITLE
[node] fix: runs edge user code inside IIFE

### DIFF
--- a/.changeset/chilled-rabbits-walk.md
+++ b/.changeset/chilled-rabbits-walk.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+[node] fix: runs edge user code inside IIFE

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -88,7 +88,10 @@ async function compileUserCode(
       "use strict";var regeneratorRuntime;
 
       // user code
-      ${compiledFile.text};
+      (() => {
+        ${compiledFile.text};
+      })();
+
       const userModule = module.exports;
 
       // request metadata

--- a/packages/node/test/dev-fixtures/edge-self.js
+++ b/packages/node/test/dev-fixtures/edge-self.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-undef
+delete self.__listeners;
+export default async () => fetch('https://example.vercel.sh');
+export const config = { runtime: 'edge' };

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -148,6 +148,27 @@ function testForkDevServer(entrypoint: string) {
   }
 );
 
+test("user code doesn't interfer with runtime", async () => {
+  const child = testForkDevServer('./edge-self.js');
+  try {
+    const result = await readMessage(child);
+    if (result.state !== 'message') {
+      throw new Error('Exited. error: ' + JSON.stringify(result.value));
+    }
+
+    const { address, port } = result.value;
+    const response = await fetch(`http://${address}:${port}/api/edge-self`);
+
+    expect({
+      status: response.status,
+    }).toEqual({
+      status: 200,
+    });
+  } finally {
+    child.kill(9);
+  }
+});
+
 test('runs an edge function that uses `WebSocket`', async () => {
   const child = testForkDevServer('./edge-websocket.js');
   try {


### PR DESCRIPTION
In this way, `self` is isolated and modify it doesn't break some Edge Runtime internals

Originally reported by @jawj at https://github.com/jawj/neon-vercel-zapatos-minimal-crash