### PR TITLE
[next] fix 404 page in edge runtime

### DIFF
--- a/.changeset/rich-days-deliver.md
+++ b/.changeset/rich-days-deliver.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] fix 404 page in edge runtime

--- a/.changeset/rich-days-deliver.md
+++ b/.changeset/rich-days-deliver.md
@@ -2,4 +2,4 @@
 "@vercel/next": patch
 ---
 
-[next] fix 404 page in edge runtime
+Fix 404 page in edge runtime

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1223,6 +1223,7 @@ export async function serverBuild({
   const rscVaryHeader =
     routesManifest?.rsc?.varyHeader ||
     'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
+  const appNotFoundPath = path.posix.join('.', entryDirectory, '_not-found');
 
   return {
     wildcard: wildcardConfig,
@@ -1755,6 +1756,7 @@ export async function serverBuild({
       { handle: 'error' } as RouteWithHandle,
 
       // Custom Next.js 404 page
+
       ...(i18n && (static404Page || hasIsr404Page || lambdaPages['404.js'])
         ? [
             {
@@ -1789,6 +1791,10 @@ export async function serverBuild({
                   hasIsr404Page ||
                   lambdas[path.posix.join(entryDirectory, '404')]
                   ? '/404'
+                  : appPathRoutesManifest &&
+                    (middleware.edgeFunctions[appNotFoundPath] ||
+                      lambdas[appNotFoundPath])
+                  ? '/_not-found'
                   : '/_error'
               ),
               status: 404,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2685,7 +2685,9 @@ export async function getMiddlewareBundle({
         shortPath = shortPath.replace(/^pages\//, '');
       } else if (
         shortPath.startsWith('app/') &&
-        (shortPath.endsWith('/page') || shortPath.endsWith('/route'))
+        (shortPath.endsWith('/page') ||
+          shortPath.endsWith('/route') ||
+          shortPath === 'app/_not-found')
       ) {
         const ogRoute = shortPath.replace(/^app\//, '/');
         shortPath = (

--- a/packages/next/test/fixtures/00-app-dir-edge-404/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/app/layout.js
@@ -1,0 +1,12 @@
+export const runtime = 'edge'
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head>
+        <title>Hello World</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found.js
@@ -1,0 +1,9 @@
+export default function Page() {
+  return (
+    <>
+      <h1>This Is The Not Found Page</h1>
+
+      <div id="timestamp">{Date.now()}</div>
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found/not-found.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found/not-found.js
@@ -1,0 +1,3 @@
+export default function notFound() {
+  return <h1>custom not found</h1>
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found/page.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/app/not-found/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>I'm still a valid page</h1>
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/app/page.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>My page</h1>
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-edge-404/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+    runtime: 'nodejs',
+  },
+  rewrites: async () => {
+    return [
+      {
+        source: '/rewritten-to-dashboard',
+        destination: '/dashboard',
+      },
+    ];
+  },
+};

--- a/packages/next/test/fixtures/00-app-dir-edge-404/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/next.config.js
@@ -1,14 +1,5 @@
 module.exports = {
   experimental: {
     appDir: true,
-    runtime: 'nodejs',
-  },
-  rewrites: async () => {
-    return [
-      {
-        source: '/rewritten-to-dashboard',
-        destination: '/dashboard',
-      },
-    ];
   },
 };

--- a/packages/next/test/fixtures/00-app-dir-edge-404/package.json
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "experimental",
+    "react-dom": "experimental"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/fixtures/00-app-dir-edge-404/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-edge-404/vercel.json
@@ -1,0 +1,20 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "My page"
+    },
+    {
+      "path": "/not-found-page",
+      "status": 404,
+      "mustContain": "This Is The Not Found Page"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes Next builder to handle edge runtime on 404 pages

[Related Next.js PR](https://github.com/vercel/next.js/pull/52754)
[slack x-ref](https://vercel.slack.com/archives/C03S8ED1DKM/p1689312606770609)