### PR TITLE
[frameworks][static-build] Add `ignorePackageJsonScript` configuration for Framework command settings

### DIFF
--- a/.changeset/sixty-buttons-listen.md
+++ b/.changeset/sixty-buttons-listen.md
@@ -1,0 +1,8 @@
+---
+'@vercel/frameworks': minor
+'@vercel/static-build': patch
+---
+
+Add `ignorePackageJsonScript` configuration for Framework command settings to ignore the `package.json` script.
+
+Enable this mode for Storybook's `buildCommand`, since it should not invoke the "build" script, which is most likely designated for the frontend app build.

--- a/packages/cli/test/fixtures/unit/commands/build/storybook-with-middleware/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/storybook-with-middleware/.vercel/project.json
@@ -2,8 +2,6 @@
   "orgId": ".",
   "projectId": ".",
   "settings": {
-    "framework": "storybook",
-    "buildCommand": "npm run build-storybook",
-    "outputDirectory": "storybook-static"
+    "framework": "storybook"
   }
 }

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1955,6 +1955,7 @@ export const frameworks = [
       },
       buildCommand: {
         value: 'storybook build',
+        ignorePackageJsonScript: true,
       },
       devCommand: {
         value: `storybook dev -p $PORT`,

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -46,7 +46,8 @@ export interface SettingValue {
    * When set to `true`, then the builder will not
    * invoke the equivalent script in `package.json`,
    * and instead will invoke the command specified in
-   * configuration setting directly.
+   * configuration setting directly. When this
+   * configuration is enabled, `value` must be a string.
    */
   ignorePackageJsonScript?: boolean;
 }

--- a/packages/frameworks/src/types.ts
+++ b/packages/frameworks/src/types.ts
@@ -32,11 +32,23 @@ export interface SettingPlaceholder {
 
 export interface SettingValue {
   /**
-   * A predefined setting for the detected framework
+   * A predefined setting for the detected framework.
    * @example "next dev --port $PORT"
    */
   value: string | null;
+  /**
+   * Placeholder text that may be shown in the UI when
+   * the user is configuring this setting value.
+   * @example "`npm run build` or `next build`"
+   */
   placeholder?: string;
+  /**
+   * When set to `true`, then the builder will not
+   * invoke the equivalent script in `package.json`,
+   * and instead will invoke the command specified in
+   * configuration setting directly.
+   */
+  ignorePackageJsonScript?: boolean;
 }
 
 export type Setting = SettingValue | SettingPlaceholder;

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -47,6 +47,19 @@ const SchemaSettings = {
         placeholder: {
           type: 'string',
         },
+      },
+    },
+    {
+      type: 'object',
+      required: ['value', 'ignorePackageJsonScript'],
+      additionalProperties: false,
+      properties: {
+        value: {
+          type: 'string',
+        },
+        placeholder: {
+          type: 'string',
+        },
         ignorePackageJsonScript: {
           type: 'boolean',
         },

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -47,6 +47,9 @@ const SchemaSettings = {
         placeholder: {
           type: 'string',
         },
+        ignorePackageJsonScript: {
+          type: 'boolean',
+        },
       },
     },
     {

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -137,7 +137,11 @@ function getCommand(
     return propValue;
   }
 
-  if (pkg) {
+  const ignorePackageJsonScript =
+    name === 'build' &&
+    framework?.settings.buildCommand.ignorePackageJsonScript;
+
+  if (pkg && !ignorePackageJsonScript) {
     const scriptName = getScriptName(pkg, name, config);
 
     if (hasScript(scriptName, pkg)) {


### PR DESCRIPTION
When this property is set to `true`, then the corresponding `package.json` script will not be invoked, allowing for the default setting value will be executed.

This is enabled for Storybook's `buildCommand`, since we do not want the "build" script to be invoked, since that would belong to the frontend application's build instead of Storybook's.