### PR TITLE
[cli] Do not remove in-progress deployments in safe mode

### DIFF
--- a/.changeset/improve-safe-remove.md
+++ b/.changeset/improve-safe-remove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Do not remove in-progress deployments in safe mode

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -155,7 +155,11 @@ export default async function remove(client: Client) {
   }
 
   deployments = deployments.filter((match, i) => {
-    if (safe && aliases[i].length > 0) {
+    if (
+      safe &&
+      (aliases[i].length > 0 ||
+        ['QUEUED', 'INITIALIZING', 'BUILDING'].includes(match.status))
+    ) {
       return false;
     }
 


### PR DESCRIPTION
The `remove` command currently removes in-progress deployments when invoked in a safe mode (with `--safe` parameter). It can be totally unexpected that "safe" removal process deletes an in-progress deployment that is about to become production one. This PR addresses this use case by filtering out in-progress deployments.