### PR TITLE
[next] Fix pages and app router i18n handling

### DIFF
--- a/.changeset/plenty-rings-dress.md
+++ b/.changeset/plenty-rings-dress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix pages and app router i18n handling

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -967,6 +967,7 @@ export async function serverBuild({
         if (
           i18n &&
           !isPrerender &&
+          !group.isAppRouter &&
           (!isCorrectLocaleAPIRoutes ||
             !(pageNoExt === 'api' || pageNoExt.startsWith('api/')))
         ) {
@@ -1070,7 +1071,8 @@ export async function serverBuild({
       prerenderManifest,
       routesManifest,
       true,
-      isCorrectLocaleAPIRoutes
+      isCorrectLocaleAPIRoutes,
+      inversedAppPathManifest
     )
   );
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -207,6 +207,7 @@ export async function serverBuild({
 
   const { i18n } = routesManifest;
   const hasPages404 = routesManifest.pages404;
+  let localePrefixed404 = false;
 
   let static404Page =
     staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
@@ -216,11 +217,16 @@ export async function serverBuild({
       : undefined;
 
   if (!static404Page && i18n) {
-    static404Page = staticPages[
-      path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-    ]
-      ? path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-      : undefined;
+    if (
+      staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
+    ) {
+      localePrefixed404 = true;
+      static404Page = path.posix.join(
+        entryDirectory,
+        i18n.defaultLocale,
+        '404'
+      );
+    }
   }
 
   if (!hasStatic500 && i18n) {
@@ -1005,6 +1011,7 @@ export async function serverBuild({
     isSharedLambdas: false,
     canUsePreviewMode,
     static404Page,
+    localePrefixed404,
     hasPages404: routesManifest.pages404,
     isCorrectNotFoundRoutes,
     isEmptyAllowQueryForPrendered,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1986,7 +1986,7 @@ export const onPrerenderRoute =
                 : pagesDir,
               `${
                 isOmittedOrNotFound
-                  ? static404Page
+                  ? `${static404Page}.html`
                   : isAppPathRoute
                   ? dataRoute
                   : routeFileNoExt + '.json'

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1799,6 +1799,7 @@ export const onPrerenderRouteInitial = (
 type OnPrerenderRouteArgs = {
   appDir: string | null;
   pagesDir: string;
+  localePrefixed404?: boolean;
   static404Page?: string;
   hasPages404: boolean;
   entryDirectory: string;
@@ -1836,6 +1837,7 @@ export const onPrerenderRoute =
       appDir,
       pagesDir,
       static404Page,
+      localePrefixed404,
       entryDirectory,
       prerenderManifest,
       isSharedLambdas,
@@ -1970,7 +1972,11 @@ export const onPrerenderRoute =
                   : // Otherwise, the route itself should exist as a static HTML
                     // file.
                     `${
-                      isOmittedOrNotFound ? static404Page : routeFileNoExt
+                      isOmittedOrNotFound
+                        ? localePrefixed404
+                          ? addLocaleOrDefault('/404', routesManifest, locale)
+                          : '/404'
+                        : routeFileNoExt
                     }.html`
               ),
             });
@@ -1986,7 +1992,9 @@ export const onPrerenderRoute =
                 : pagesDir,
               `${
                 isOmittedOrNotFound
-                  ? `${static404Page}.html`
+                  ? localePrefixed404
+                    ? addLocaleOrDefault('/404.html', routesManifest, locale)
+                    : '/404.html'
                   : isAppPathRoute
                   ? dataRoute
                   : routeFileNoExt + '.json'

--- a/packages/next/test/fixtures/00-app-dir-i18n/app/api/hello-app/route.js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/app/api/hello-app/route.js
@@ -1,0 +1,3 @@
+export function GET(req) {
+  return new Response('hello world')
+}

--- a/packages/next/test/fixtures/00-app-dir-i18n/app/dynamic/[slug]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/app/dynamic/[slug]/page.js
@@ -1,0 +1,16 @@
+export default function Page({ params: { slug } }) {
+  return (
+    <p>dynamic page {slug}</p>
+  )
+}
+
+export function generateStaticParams() {
+  return [
+    {
+      slug: 'first',
+    },
+    {
+      slug: 'second'
+    }
+  ]
+}

--- a/packages/next/test/fixtures/00-app-dir-i18n/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
     appDir: true,
   },
   i18n: {
-    locales: ['en'],
+    locales: ['en', 'fr', 'de'],
     defaultLocale: 'en',
   },
 };

--- a/packages/next/test/fixtures/00-app-dir-i18n/pages/another.js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/pages/another.js
@@ -1,0 +1,5 @@
+export default function Page() {
+  return <>
+    <p>pages/another.js</p>
+  </>
+}

--- a/packages/next/test/fixtures/00-app-dir-i18n/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.end('hello world')
+}

--- a/packages/next/test/fixtures/00-app-dir-i18n/pages/blog/[slug].js
+++ b/packages/next/test/fixtures/00-app-dir-i18n/pages/blog/[slug].js
@@ -1,0 +1,18 @@
+export default function Page() {
+  return <p>dynamic pages page</p>;
+}
+
+export function getStaticProps() {
+  return {
+    props: {
+      now: Date.now(),
+    },
+  };
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { slug: "first" } }, { params: { slug: "second" } }],
+    fallback: "blocking",
+  };
+}

--- a/packages/next/test/fixtures/00-app-dir-i18n/probes.json
+++ b/packages/next/test/fixtures/00-app-dir-i18n/probes.json
@@ -35,6 +35,42 @@
       "path": "/en/other",
       "status": 200,
       "mustContain": "My Other Page"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/dynamic/first",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/dynamic/third",
+      "status": 200,
+      "mustContain": "dynamic page"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/another",
+      "status": 200,
+      "mustContain": "pages/another"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/fr/another",
+      "status": 200,
+      "mustContain": "pages/another"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/api/hello",
+      "status": 200,
+      "mustContain": "hello world"
+    },
+    {
+      "fetchOptions": { "redirect": "manual" },
+      "path": "/api/hello-app",
+      "status": 200,
+      "mustContain": "hello world"
     }
   ]
 }


### PR DESCRIPTION
Ensures app router paths are handled properly when i18n is configured for pages directory. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1687565759424049)
x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1687565759424049)
x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1672781549860349?thread_ts=1671393204.073649&cid=C03KAR5DCKC)

[VCCLI-780](https://linear.app/vercel/issue/VCCLI-780/add-404i18n-invariant-case-in-nextjs-builder)