### PR TITLE
enable localePrefixed404 when i18n is available

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -217,10 +217,10 @@ export async function serverBuild({
       : undefined;
 
   if (!static404Page && i18n) {
+    localePrefixed404 = true;
     if (
       staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
     ) {
-      localePrefixed404 = true;
       static404Page = path.posix.join(
         entryDirectory,
         i18n.defaultLocale,


### PR DESCRIPTION
## Context
Upgrading to [vercel@31.1.0](https://github.com/vercel/vercel/releases/tag/vercel%4031.1.0) in a non-app router Next project that uses i18n gives the following error, when using `vercel build` command
```
Error: ENOENT: no such file or directory, open '/vercel/path1/.next/server/pages/404'
``` 

## Expected Outcome
This PR aims to fix the above build error by simply enabling back the flag `localePrefixed404` after if i18n is present in project