### PR TITLE
Fix matched path regex with basePath

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1745,7 +1745,7 @@ export async function serverBuild({
       // TODO: remove below workaround when `/` is allowed to be output
       // different than `/index`
       {
-        src: path.posix.join('/', entryDirectory, '/index'),
+        src: `${path.posix.join('/', entryDirectory)}($|/index)`,
         headers: {
           'x-matched-path': '/',
         },


### PR DESCRIPTION
Seems the `x-matched-path` header isn't being set as expected for the index of the `basePath` which is breaking this test so this makes the regex match as expected. 

Fixes: https://github.com/vercel/vercel/actions/runs/5660473696/job/15342856245?pr=10249#step:9:563