### PR TITLE
[fs-detectors] fix: Next.js builds not always excluding Node.js middleware builder

### DIFF
--- a/.changeset/lazy-parrots-guess.md
+++ b/.changeset/lazy-parrots-guess.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fix Next.js apps not excluding the Node.js builder for middleware when `framework` is `undefined` in the project settings.

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -312,7 +312,7 @@ export async function detectBuilders(
   // we need to check if it's a Next.js app here again for the case where
   // `projectSettings.framework == null`.
   if (
-    framework === null &&
+    framework == null &&
     frontendBuilder?.use === '@vercel/next' &&
     apiBuilders.length > 0
   ) {

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -2359,6 +2359,26 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
   });
 
+  it('should not add middleware builder when building "nextjs" + undefined project settings', async () => {
+    const files = ['package.json', 'pages/index.ts', 'middleware.ts'];
+    const pkg = {
+      scripts: { build: 'next build' },
+      dependencies: { next: '12.2.0' },
+    };
+    const { builders } = await detectBuilders(files, pkg, {
+      featHandleMiss,
+    });
+    expect(builders).toEqual([
+      {
+        use: '@vercel/next',
+        src: 'package.json',
+        config: {
+          zeroConfig: true,
+        },
+      },
+    ]);
+  });
+
   it('should add middleware builder with "remix" framework preset', async () => {
     const files = ['package.json', 'app/routes/index.ts', 'middleware.ts'];
     const projectSettings = {


### PR DESCRIPTION
This PR does the following:
- Fixes the null equality check for Next.js builds when middleware is present and the project settings `framework` option is `undefined`.
- Adds a test for the fix.