### PR TITLE
[next] Fix pages/404 gsp + i18n case

### DIFF
--- a/.changeset/lovely-donuts-buy.md
+++ b/.changeset/lovely-donuts-buy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix pages/404 gsp + i18n case

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1139,8 +1139,9 @@ export const build: BuildV2 = async ({
     const canUsePreviewMode = Object.keys(pages).some(page =>
       isApiPage(pages[page].fsPath)
     );
+    const originalStaticPages = await glob('**/*.html', pagesDir);
     staticPages = await filterStaticPages(
-      await glob('**/*.html', pagesDir),
+      originalStaticPages,
       dynamicPages,
       entryDirectory,
       htmlContentType,
@@ -1316,6 +1317,17 @@ export const build: BuildV2 = async ({
         );
       }
 
+      const localePrefixed404 = !!(
+        routesManifest.i18n &&
+        originalStaticPages[
+          path.posix.join(
+            entryDirectory,
+            routesManifest.i18n.defaultLocale,
+            '404.html'
+          )
+        ]
+      );
+
       return serverBuild({
         config,
         functionsConfigManifest,
@@ -1325,6 +1337,7 @@ export const build: BuildV2 = async ({
         dynamicPages,
         canUsePreviewMode,
         staticPages,
+        localePrefixed404,
         lambdaPages: pages,
         lambdaAppPaths,
         omittedPrerenderRoutes,

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -217,7 +217,11 @@ export async function serverBuild({
       ? path.posix.join(entryDirectory, '_errors/404')
       : undefined;
 
-  if (!static404Page && i18n) {
+  if (
+    !static404Page &&
+    i18n &&
+    staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
+  ) {
     static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
   }
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -91,6 +91,7 @@ export async function serverBuild({
   routesManifest,
   staticPages,
   lambdaPages,
+  localePrefixed404,
   nextVersion,
   lambdaAppPaths,
   canUsePreviewMode,
@@ -112,6 +113,7 @@ export async function serverBuild({
   baseDir: string;
   canUsePreviewMode: boolean;
   omittedPrerenderRoutes: Set<string>;
+  localePrefixed404: boolean;
   staticPages: { [key: string]: FileFsRef };
   lambdaAppPaths: { [key: string]: FileFsRef };
   lambdaPages: { [key: string]: FileFsRef };
@@ -207,7 +209,6 @@ export async function serverBuild({
 
   const { i18n } = routesManifest;
   const hasPages404 = routesManifest.pages404;
-  let localePrefixed404 = false;
 
   let static404Page =
     staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
@@ -217,16 +218,7 @@ export async function serverBuild({
       : undefined;
 
   if (!static404Page && i18n) {
-    if (
-      staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
-    ) {
-      localePrefixed404 = true;
-      static404Page = path.posix.join(
-        entryDirectory,
-        i18n.defaultLocale,
-        '404'
-      );
-    }
+    static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
   }
 
   if (!hasStatic500 && i18n) {

--- a/packages/next/test/fixtures/00-i18n-404-revalidate/pages/blog/[slug].js
+++ b/packages/next/test/fixtures/00-i18n-404-revalidate/pages/blog/[slug].js
@@ -1,0 +1,38 @@
+import { useRouter } from "next/router"
+
+export default function Page(props) {
+  const router = useRouter()
+  
+  return (
+    <>
+      <p>/blog/[slug]</p>
+      <p>{JSON.stringify(router.query)}</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  if (params.slug === 'second') {
+    return {
+      notFound: true
+    }
+  }
+  
+  return {
+    props: {
+      now: Date.now(),
+      params
+    }
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      { params: { slug: 'first' } },
+      { params: { slug: 'second' } },
+    ],
+    fallback: 'blocking'
+  }
+}


### PR DESCRIPTION
This ensures we detect the locale prefixed 404 when it uses `getStaticProps` correctly. 

- x-ref: [slack thread](https://vercel.slack.com/archives/C05JTC58AQJ)
- Closes https://github.com/vercel/vercel/pull/10248