### PR TITLE
[cli] Migrate `login` command to new structure

### DIFF
--- a/.changeset/moody-socks-serve.md
+++ b/.changeset/moody-socks-serve.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Migrate login command to new structure

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -1,0 +1,49 @@
+import { Command } from '../help';
+import { getPkgName } from '../../util/pkg-name';
+
+export const loginCommand: Command = {
+  name: 'login',
+  description: 'Authenticate a email or team.',
+  arguments: [
+    {
+      name: 'email or team',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'github',
+      description: 'Log in with github',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+    {
+      name: 'oob',
+      description: 'Log in with "out of band" authentication',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Log into the Vercel platform',
+      value: `${getPkgName()} login`,
+    },
+    {
+      name: 'Log in using a specific email address',
+      value: `${getPkgName()} login username@example.com`,
+    },
+    {
+      name: 'Log in using a specific team "slug" for SAML Single Sign-On',
+      value: `${getPkgName()} login acme`,
+    },
+    {
+      name: 'Log in using GitHub in "out-of-band" mode',
+      value: `${getPkgName()} login --github --oob`,
+    },
+  ],
+};

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -6,7 +6,7 @@ export const loginCommand: Command = {
   description: 'Authenticate a email or team.',
   arguments: [
     {
-      name: 'email or team',
+      name: 'email or team id',
       required: false,
     },
   ],

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -13,7 +13,7 @@ export const loginCommand: Command = {
   options: [
     {
       name: 'github',
-      description: 'Log in with github',
+      description: 'Log in with GitHub',
       shorthand: null,
       type: 'string',
       deprecated: false,

--- a/packages/cli/src/commands/login/command.ts
+++ b/packages/cli/src/commands/login/command.ts
@@ -3,7 +3,7 @@ import { getPkgName } from '../../util/pkg-name';
 
 export const loginCommand: Command = {
   name: 'login',
-  description: 'Authenticate a email or team.',
+  description: 'Authenticate using your email or team id.',
   arguments: [
     {
       name: 'email or team id',

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -1,55 +1,24 @@
 import { validate as validateEmail } from 'email-validator';
 import chalk from 'chalk';
-import hp from '../util/humanize-path';
-import getArgs from '../util/get-args';
-import logo from '../util/output/logo';
-import prompt from '../util/login/prompt';
-import doSamlLogin from '../util/login/saml';
-import doEmailLogin from '../util/login/email';
-import doGithubLogin from '../util/login/github';
-import doGitlabLogin from '../util/login/gitlab';
-import doBitbucketLogin from '../util/login/bitbucket';
-import { prependEmoji, emoji } from '../util/emoji';
-import { getCommandName, getPkgName } from '../util/pkg-name';
-import getGlobalPathConfig from '../util/config/global-path';
-import { writeToAuthConfigFile, writeToConfigFile } from '../util/config/files';
-import Client from '../util/client';
-import { LoginResult } from '../util/login/types';
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${getPkgName()} login`)} <email or team>
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                     Output usage information
-    --no-color                     No color mode [off]
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-    'FILE'
-  )}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-    'DIR'
-  )}    Path to the global ${'`.vercel`'} directory
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray('–')} Log into the Vercel platform
-
-    ${chalk.cyan(`$ ${getPkgName()} login`)}
-
-  ${chalk.gray('–')} Log in using a specific email address
-
-    ${chalk.cyan(`$ ${getPkgName()} login john@doe.com`)}
-
-  ${chalk.gray('–')} Log in using a specific team "slug" for SAML Single Sign-On
-
-    ${chalk.cyan(`$ ${getPkgName()} login acme`)}
-
-  ${chalk.gray('–')} Log in using GitHub in "out-of-band" mode
-
-    ${chalk.cyan(`$ ${getPkgName()} login --github --oob`)}
-`);
-};
+import hp from '../../util/humanize-path';
+import getArgs from '../../util/get-args';
+import prompt from '../../util/login/prompt';
+import doSamlLogin from '../../util/login/saml';
+import doEmailLogin from '../../util/login/email';
+import doGithubLogin from '../../util/login/github';
+import doGitlabLogin from '../../util/login/gitlab';
+import doBitbucketLogin from '../../util/login/bitbucket';
+import { prependEmoji, emoji } from '../../util/emoji';
+import { getCommandName } from '../../util/pkg-name';
+import getGlobalPathConfig from '../../util/config/global-path';
+import {
+  writeToAuthConfigFile,
+  writeToConfigFile,
+} from '../../util/config/files';
+import Client from '../../util/client';
+import { LoginResult } from '../../util/login/types';
+import { help } from '../help';
+import { loginCommand } from './command';
 
 export default async function login(client: Client): Promise<number> {
   const { output } = client;
@@ -62,7 +31,7 @@ export default async function login(client: Client): Promise<number> {
   });
 
   if (argv['--help']) {
-    help();
+    output.print(help(loginCommand, { columns: client.stderr.columns }));
     return 2;
   }
 


### PR DESCRIPTION
We currently incorrectly specify the argument is required with `<>`, but the examples show you can do `vercel login` without an argument, so I've corrected that as part of this migration.

Before:
<img width="549" alt="CleanShot 2023-07-31 at 09 44 28@2x" src="https://github.com/vercel/vercel/assets/9736/f1b1a328-69e0-4d61-b65c-d2739c81f61c">


After:
<img width="684" alt="CleanShot 2023-07-31 at 09 44 43@2x" src="https://github.com/vercel/vercel/assets/9736/e2bb28bf-e3d8-4d89-ad7e-864dd091ec3d">
