### PR TITLE
Be looser with mock server URLs

### DIFF
--- a/.changeset/rare-toys-develop.md
+++ b/.changeset/rare-toys-develop.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Be looser in tests with mock server urls

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -144,7 +144,7 @@ export const defaultProject: Project = {
  */
 export function useUnknownProject() {
   let project: Project;
-  client.scenario.get(`/v8/projects/:projectNameOrId`, (_req, res) => {
+  client.scenario.get(`/:version/projects/:projectNameOrId`, (_req, res) => {
     res.status(404).send();
   });
   client.scenario.post(`/:version/projects`, (req, res) => {


### PR DESCRIPTION
Attempting to add tests to unblock a contributor https://github.com/vercel/vercel/pull/10236#issuecomment-1664183891 and running into places where the hardcoded version `8` isn't being called by the client. Other mock endpoints simply specify `:version`, so I updated the offending mock to use this pattern as well.