### PR TITLE
[build-utils] Fix `getPrefixedEnvVars()` to handle `VERCEL_BRANCH_URL`

### DIFF
--- a/.changeset/silver-items-retire.md
+++ b/.changeset/silver-items-retire.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Fix `getPrefixedEnvVars()` to handle `VERCEL_BRANCH_URL`

--- a/packages/build-utils/src/get-prefixed-env-vars.ts
+++ b/packages/build-utils/src/get-prefixed-env-vars.ts
@@ -14,7 +14,12 @@ export function getPrefixedEnvVars({
   envs: Envs;
 }): Envs {
   const vercelSystemEnvPrefix = 'VERCEL_';
-  const allowed = ['VERCEL_URL', 'VERCEL_ENV', 'VERCEL_REGION'];
+  const allowed = [
+    'VERCEL_URL',
+    'VERCEL_ENV',
+    'VERCEL_REGION',
+    'VERCEL_BRANCH_URL',
+  ];
   const newEnvs: Envs = {};
   if (envPrefix && envs.VERCEL_URL) {
     Object.keys(envs)

--- a/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
@@ -13,6 +13,8 @@ describe('Test `getPrefixedEnvVars()`', () => {
         envs: {
           VERCEL: '1',
           VERCEL_URL: 'example.vercel.sh',
+          VERCEL_ENV: 'production',
+          VERCEL_BRANCH_URL: 'example-git-main-acme.vercel.app',
           USER_ENV_VAR_NOT_VERCEL: 'example.com',
           VERCEL_ARTIFACTS_TOKEN: 'abc123',
           FOO: 'bar',
@@ -20,6 +22,8 @@ describe('Test `getPrefixedEnvVars()`', () => {
       },
       want: {
         NEXT_PUBLIC_VERCEL_URL: 'example.vercel.sh',
+        NEXT_PUBLIC_VERCEL_ENV: 'production',
+        NEXT_PUBLIC_VERCEL_BRANCH_URL: 'example-git-main-acme.vercel.app',
         TURBO_CI_VENDOR_ENV_KEY: 'NEXT_PUBLIC_VERCEL_',
       },
     },


### PR DESCRIPTION
- Fixes [NEXT-1500](https://linear.app/vercel/issue/NEXT-1500)
- See [documentation](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#framework-environment-variables)