### PR TITLE
allow Vercel to be run while offline

### DIFF
--- a/.changeset/chilly-clouds-relate.md
+++ b/.changeset/chilly-clouds-relate.md
@@ -1,0 +1,6 @@
+---
+'@vercel-internals/types': patch
+'vercel': patch
+---
+
+Allow dev command to be ran while offline

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -409,6 +409,13 @@ export type ProjectLinked = {
   org: Org;
   project: Project;
   repoRoot?: string;
+  offline: false;
+};
+
+export type ProjectOfflineMode = {
+  status: 'linked';
+  repoRoot?: string;
+  offline: true;
 };
 
 export type ProjectNotLinked = {
@@ -432,7 +439,8 @@ export type ProjectLinkedError = {
 export type ProjectLinkResult =
   | ProjectLinked
   | ProjectNotLinked
-  | ProjectLinkedError;
+  | ProjectLinkedError
+  | ProjectOfflineMode;
 
 /**
  * @deprecated - `RollbackJobStatus` has been replace by `LastAliasRequest['jobStatus']`.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -58,7 +58,7 @@ export default async function dev(
   let projectSettings: ProjectSettings | undefined;
   let envValues: Record<string, string> = {};
   let repoRoot: string | undefined;
-  if (link.status === 'linked') {
+  if (link.status === 'linked' && !link.offline) {
     const { project, org } = link;
 
     // If repo linked, update `cwd` to the repo root


### PR DESCRIPTION
# Summary

Right now, you need to be connected to the internet in order to use the Vercel dev command, although everything is spun locally. This change will simply skip the constant linking and allow users to work offline as long as they have setup the project before. 