### PR TITLE
[frameworks] Updated default Hugo command to not publish draft pages

### DIFF
--- a/.changeset/moody-crabs-fix.md
+++ b/.changeset/moody-crabs-fix.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Updated default Hugo command to not publish draft pages

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1520,8 +1520,8 @@ export const frameworks = [
         placeholder: 'None',
       },
       buildCommand: {
-        placeholder: '`npm run build` or `hugo -D --gc`',
-        value: 'hugo -D --gc',
+        placeholder: '`npm run build` or `hugo --gc`',
+        value: 'hugo --gc',
       },
       devCommand: {
         value: 'hugo server -D -w -p $PORT',


### PR DESCRIPTION
We should not publish Hugo draft pages during deployments.

Linear: https://linear.app/vercel/issue/VCCLI-319/create-hugo-migration-to-set-default-build-command