### PR TITLE
Exclude Gatsby from default 404 error route

### DIFF
--- a/.changeset/metal-ears-battle.md
+++ b/.changeset/metal-ears-battle.md
@@ -1,7 +1,6 @@
 ---
+'@vercel/fs-detectors': patch
 '@vercel/gatsby-plugin-vercel-builder': patch
-'@vercel/routing-utils': patch
-'@vercel/static-build': patch
 ---
 
-Prioritize builder error routes before default error routes
+Exclude Gatsby from default 404 error route

--- a/.changeset/metal-ears-battle.md
+++ b/.changeset/metal-ears-battle.md
@@ -1,0 +1,7 @@
+---
+'@vercel/gatsby-plugin-vercel-builder': patch
+'@vercel/routing-utils': patch
+'@vercel/static-build': patch
+---
+
+Prioritize builder error routes before default error routes

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -992,7 +992,7 @@ function getRouteResult(
   const rewriteRoutes: Route[] = [];
   const errorRoutes: Route[] = [];
   const framework = frontendBuilder?.config?.framework || '';
-  const isGastby = framework === 'gatsby';
+  const isGatsby = framework === 'gatsby';
   const isNextjs =
     framework === 'nextjs' || isOfficialRuntime('next', frontendBuilder?.use);
   const ignoreRuntimes = slugToFramework.get(framework)?.ignoreRuntimes;
@@ -1072,8 +1072,8 @@ function getRouteResult(
     });
   }
 
-  if (options.featHandleMiss && !isNextjs && !isGastby) {
-    // Exclude Next.js to avoid overriding custom error page
+  if (options.featHandleMiss && !isNextjs && !isGatsby) {
+    // Exclude Next.js (and Gatsby) to avoid overriding custom error page
     // https://nextjs.org/docs/advanced-features/custom-error-page
     errorRoutes.push({
       status: 404,

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -992,6 +992,7 @@ function getRouteResult(
   const rewriteRoutes: Route[] = [];
   const errorRoutes: Route[] = [];
   const framework = frontendBuilder?.config?.framework || '';
+  const isGastby = framework === 'gatsby';
   const isNextjs =
     framework === 'nextjs' || isOfficialRuntime('next', frontendBuilder?.use);
   const ignoreRuntimes = slugToFramework.get(framework)?.ignoreRuntimes;
@@ -1071,7 +1072,7 @@ function getRouteResult(
     });
   }
 
-  if (options.featHandleMiss && !isNextjs) {
+  if (options.featHandleMiss && !isNextjs && !isGastby) {
     // Exclude Next.js to avoid overriding custom error page
     // https://nextjs.org/docs/advanced-features/custom-error-page
     errorRoutes.push({

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -6,7 +6,6 @@ import {
   createAPIRoutes,
 } from './helpers/functions';
 import { createStaticDir } from './helpers/static';
-import { pathExists } from 'fs-extra';
 import { join } from 'path';
 import type { Config } from './types';
 
@@ -71,16 +70,16 @@ export async function generateVercelBuildOutputAPI3Output({
         })),
       }).routes || [];
 
-    if (pathPrefix && (await pathExists(join('public', '404.html')))) {
-      routes.push({
+    routes.push(
+      {
         handle: 'error',
-      });
-      routes.push({
+      },
+      {
         status: 404,
         src: '^(?!/api).*$',
-        dest: join(pathPrefix, '404.html'),
-      });
-    }
+        dest: pathPrefix ? join(pathPrefix, '404.html') : '404.html',
+      }
+    );
 
     const config: Config = {
       version: 3,

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -70,16 +70,21 @@ export async function generateVercelBuildOutputAPI3Output({
         })),
       }).routes || [];
 
-    routes.push(
-      {
-        handle: 'error',
-      },
-      {
+    routes.push({
+      handle: 'error',
+    });
+    if (pathPrefix) {
+      routes.push({
         status: 404,
         src: '^(?!/api).*$',
-        dest: pathPrefix ? join(pathPrefix, '404.html') : '404.html',
-      }
-    );
+        dest: join(pathPrefix, '404.html'),
+      });
+    }
+    routes.push({
+      status: 404,
+      src: '^(?!/api).*$',
+      dest: '404.html',
+    });
 
     const config: Config = {
       version: 3,

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -6,6 +6,8 @@ import {
   createAPIRoutes,
 } from './helpers/functions';
 import { createStaticDir } from './helpers/static';
+import { pathExists } from 'fs-extra';
+import { join } from 'path';
 import type { Config } from './types';
 
 export interface GenerateVercelBuildOutputAPI3OutputOptions {
@@ -59,14 +61,26 @@ export async function generateVercelBuildOutputAPI3Output({
       trailingSlash = false;
     }
 
-    const { routes } = getTransformedRoutes({
-      trailingSlash,
-      redirects: redirects.map(({ fromPath, toPath, isPermanent }) => ({
-        source: fromPath,
-        destination: toPath,
-        permanent: isPermanent,
-      })),
-    });
+    const routes =
+      getTransformedRoutes({
+        trailingSlash,
+        redirects: redirects.map(({ fromPath, toPath, isPermanent }) => ({
+          source: fromPath,
+          destination: toPath,
+          permanent: isPermanent,
+        })),
+      }).routes || [];
+
+    if (pathPrefix && (await pathExists(join('public', '404.html')))) {
+      routes.push({
+        handle: 'error',
+      });
+      routes.push({
+        status: 404,
+        src: '^(?!/api).*$',
+        dest: join(pathPrefix, '404.html'),
+      });
+    }
 
     const config: Config = {
       version: 3,

--- a/packages/routing-utils/src/merge.ts
+++ b/packages/routing-utils/src/merge.ts
@@ -82,6 +82,17 @@ export function mergeRoutes({ userRoutes, builds }: MergeRoutesProps): Route[] {
           if (!routes) {
             builderHandleMap.set(builderPrevHandle, [route]);
           } else {
+            if (
+              builderPrevHandle === 'error' &&
+              (route.status === 404 || route.status === 500)
+            ) {
+              // insert 404 and 500 routes before `/` root error handlers
+              const p = routes.findIndex(r => r.status === route.status);
+              if (p !== -1) {
+                routes.splice(p, 0, route);
+                return;
+              }
+            }
             routes.push(route);
           }
         }

--- a/packages/routing-utils/src/merge.ts
+++ b/packages/routing-utils/src/merge.ts
@@ -82,17 +82,6 @@ export function mergeRoutes({ userRoutes, builds }: MergeRoutesProps): Route[] {
           if (!routes) {
             builderHandleMap.set(builderPrevHandle, [route]);
           } else {
-            if (
-              builderPrevHandle === 'error' &&
-              (route.status === 404 || route.status === 500)
-            ) {
-              // insert 404 and 500 routes before `/` root error handlers
-              const p = routes.findIndex(r => r.status === route.status);
-              if (p !== -1) {
-                routes.splice(p, 0, route);
-                return;
-              }
-            }
             routes.push(route);
           }
         }

--- a/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/probes.json
@@ -8,6 +8,10 @@
     {
       "path": "/foo/dsg/",
       "mustContain": "This page is <b>DSG</b>"
+    },
+    {
+      "path": "/foo/x/y/z",
+      "mustContain": "This is a custom 404 page"
     }
   ]
 }

--- a/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/src/pages/404.js
+++ b/packages/static-build/test/fixtures/gatsby-v5-pathPrefix/src/pages/404.js
@@ -15,13 +15,6 @@ const headingStyles = {
 const paragraphStyles = {
   marginBottom: 48,
 };
-const codeStyles = {
-  color: '#8A6534',
-  padding: 4,
-  backgroundColor: '#FFF4DB',
-  fontSize: '1.25rem',
-  borderRadius: 4,
-};
 
 const NotFoundPage = () => {
   return (
@@ -30,13 +23,7 @@ const NotFoundPage = () => {
       <p style={paragraphStyles}>
         Sorry 😔, we couldn’t find what you were looking for.
         <br />
-        {process.env.NODE_ENV === 'development' ? (
-          <>
-            <br />
-            Try creating a page in <code style={codeStyles}>src/pages/</code>.
-            <br />
-          </>
-        ) : null}
+        This is a custom 404 page.
         <br />
         <Link to="/">Go home</Link>.
       </p>


### PR DESCRIPTION
All static builds (except Next.js) have a default 404 error route. This PR add the exclusion of Gatsby from being assigned a 404 error route. The error routes are now introduced by the `gatsby-plugin-vercel-builder`.

Linear: https://linear.app/vercel/issue/VCCLI-749/fix-gatsby-404500-pages-directory-listing-bug