### PR TITLE
[error-utils] fix `files` in package.json to use `dist`

### DIFF
--- a/.changeset/fuzzy-yaks-judge.md
+++ b/.changeset/fuzzy-yaks-judge.md
@@ -1,0 +1,5 @@
+---
+"@vercel/error-utils": patch
+---
+
+fix `files` in package.json to use `dist`

--- a/internals/constants/package.json
+++ b/internals/constants/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.4",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/internals/get-package-json/package.json
+++ b/internals/get-package-json/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "files": [
-    "dist/*"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",

--- a/internals/types/package.json
+++ b/internals/types/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.7",
   "types": "index.d.ts",
   "main": "index.d.ts",
+  "files": [
+    "*.d.ts"
+  ],
   "dependencies": {
     "@types/node": "14.14.31",
     "@vercel-internals/constants": "1.0.4",

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -4,6 +4,9 @@
   "description": "A collection of error utilities for vercel/vercel",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/vercel.git",


### PR DESCRIPTION
These packages were publishing unnecessary files to npm so we can reduce to only the `dist` directory.

- Example: https://unpkg.com/browse/@vercel/error-utils@2.0.0/
- Docs: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files