### PR TITLE
[frameworks] move some `devDependencies` to `dependencies`

### DIFF
--- a/.changeset/cyan-trains-sneeze.md
+++ b/.changeset/cyan-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+move some frameworks deps to dependencies

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -19,15 +19,15 @@
   },
   "dependencies": {
     "@iarna/toml": "2.2.3",
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.13.1",
+    "@vercel/error-utils": "2.0.0",
+    "@vercel/routing-utils": "3.0.0"
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
     "@types/js-yaml": "3.12.1",
     "@types/node": "14.18.33",
     "@types/node-fetch": "2.5.8",
-    "@vercel/error-utils": "2.0.0",
-    "@vercel/routing-utils": "3.0.0",
     "ajv": "6.12.2",
     "jest-junit": "16.0.0",
     "typescript": "4.9.5"

--- a/packages/frameworks/package.json
+++ b/packages/frameworks/package.json
@@ -20,14 +20,14 @@
   "dependencies": {
     "@iarna/toml": "2.2.3",
     "js-yaml": "3.13.1",
-    "@vercel/error-utils": "2.0.0",
-    "@vercel/routing-utils": "3.0.0"
+    "@vercel/error-utils": "2.0.0"
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
     "@types/js-yaml": "3.12.1",
     "@types/node": "14.18.33",
     "@types/node-fetch": "2.5.8",
+    "@vercel/routing-utils": "3.0.0",
     "ajv": "6.12.2",
     "jest-junit": "16.0.0",
     "typescript": "4.9.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,9 +860,6 @@ importers:
       '@vercel/error-utils':
         specifier: 2.0.0
         version: link:../error-utils
-      '@vercel/routing-utils':
-        specifier: 3.0.0
-        version: link:../routing-utils
       js-yaml:
         specifier: 3.13.1
         version: 3.13.1
@@ -879,6 +876,9 @@ importers:
       '@types/node-fetch':
         specifier: 2.5.8
         version: 2.5.8
+      '@vercel/routing-utils':
+        specifier: 3.0.0
+        version: link:../routing-utils
       ajv:
         specifier: 6.12.2
         version: 6.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,12 @@ importers:
       '@iarna/toml':
         specifier: 2.2.3
         version: 2.2.3
+      '@vercel/error-utils':
+        specifier: 2.0.0
+        version: link:../error-utils
+      '@vercel/routing-utils':
+        specifier: 3.0.0
+        version: link:../routing-utils
       js-yaml:
         specifier: 3.13.1
         version: 3.13.1
@@ -873,12 +879,6 @@ importers:
       '@types/node-fetch':
         specifier: 2.5.8
         version: 2.5.8
-      '@vercel/error-utils':
-        specifier: 2.0.0
-        version: link:../error-utils
-      '@vercel/routing-utils':
-        specifier: 3.0.0
-        version: link:../routing-utils
       ajv:
         specifier: 6.12.2
         version: 6.12.2


### PR DESCRIPTION
Because `frameworks` isn't bundled with `ncc`, we need the runtime dependencies to exist in the `dependencies` section of `package.json`.