### PR TITLE
Add handling to leverage RSC prefetch outputs

### DIFF
--- a/.changeset/slimy-comics-serve.md
+++ b/.changeset/slimy-comics-serve.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Add handling to leverage RSC prefetch outputs

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -168,12 +168,15 @@ export async function serverBuild({
     }
   }
 
+  const APP_PREFETCH_SUFFIX = '.prefetch.rsc';
+  let appRscPrefetches: UnwrapPromise<ReturnType<typeof glob>> = {};
   let appBuildTraces: UnwrapPromise<ReturnType<typeof glob>> = {};
   let appDir: string | null = null;
 
   if (appPathRoutesManifest) {
     appDir = path.join(pagesDir, '../app');
     appBuildTraces = await glob('**/*.js.nft.json', appDir);
+    appRscPrefetches = await glob(`**/*${APP_PREFETCH_SUFFIX}`, appDir);
   }
 
   const isCorrectNotFoundRoutes = semver.gte(
@@ -1225,6 +1228,7 @@ export async function serverBuild({
   }
 
   const rscHeader = routesManifest.rsc?.header?.toLowerCase() || '__rsc__';
+  const rscPrefetchHeader = routesManifest.rsc?.prefetchHeader?.toLowerCase();
   const rscVaryHeader =
     routesManifest?.rsc?.varyHeader ||
     'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
@@ -1236,6 +1240,7 @@ export async function serverBuild({
     output: {
       ...publicDirectoryFiles,
       ...lambdas,
+      ...appRscPrefetches,
       // Prerenders may override Lambdas -- this is an intentional behavior.
       ...prerenders,
       ...staticPages,
@@ -1475,6 +1480,49 @@ export async function serverBuild({
 
       ...(appDir
         ? [
+            ...(rscPrefetchHeader
+              ? [
+                  {
+                    src: `^${path.posix.join('/', entryDirectory, '/')}`,
+                    has: [
+                      {
+                        type: 'header',
+                        key: rscPrefetchHeader,
+                      },
+                    ],
+                    dest: path.posix.join(
+                      '/',
+                      entryDirectory,
+                      '/index.prefetch.rsc'
+                    ),
+                    headers: { vary: rscVaryHeader },
+                    continue: true,
+                    override: true,
+                  },
+                  {
+                    src: `^${path.posix.join(
+                      '/',
+                      entryDirectory,
+                      '/((?!.+\\.rsc).+?)(?:/)?$'
+                    )}`,
+                    has: [
+                      {
+                        type: 'header',
+                        key: rscPrefetchHeader,
+                      },
+                    ],
+                    dest: path.posix.join(
+                      '/',
+                      entryDirectory,
+                      `/$1${APP_PREFETCH_SUFFIX}`
+                    ),
+                    headers: { vary: rscVaryHeader },
+                    continue: true,
+                    override: true,
+                  },
+                ]
+              : []),
+
             {
               src: `^${path.posix.join('/', entryDirectory, '/')}`,
               has: [
@@ -1535,6 +1583,43 @@ export async function serverBuild({
               src: path.posix.join('/', entryDirectory, '_next/data/(.*)'),
               dest: path.posix.join('/', entryDirectory, '_next/data/$1'),
               check: true,
+            },
+          ]
+        : []),
+
+      ...(rscPrefetchHeader
+        ? [
+            {
+              src: path.posix.join(
+                '/',
+                entryDirectory,
+                `/index${APP_PREFETCH_SUFFIX}`
+              ),
+              dest: `^${path.posix.join('/', entryDirectory, '/index.rsc')}`,
+              has: [
+                {
+                  type: 'header',
+                  key: rscPrefetchHeader,
+                },
+              ],
+              check: true,
+              override: true,
+            },
+            {
+              src: `^${path.posix.join(
+                '/',
+                entryDirectory,
+                `/(.+?)${APP_PREFETCH_SUFFIX}(?:/)?$`
+              )}`,
+              has: [
+                {
+                  type: 'header',
+                  key: rscPrefetchHeader,
+                },
+              ],
+              dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
+              check: true,
+              override: true,
             },
           ]
         : []),

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1595,14 +1595,14 @@ export async function serverBuild({
                 entryDirectory,
                 `/index${APP_PREFETCH_SUFFIX}`
               ),
-              dest: `^${path.posix.join('/', entryDirectory, '/index.rsc')}`,
+              dest: path.posix.join('/', entryDirectory, '/index.rsc'),
               has: [
                 {
                   type: 'header',
                   key: rscPrefetchHeader,
                 },
               ],
-              check: true,
+              continue: true,
               override: true,
             },
             {
@@ -1611,14 +1611,14 @@ export async function serverBuild({
                 entryDirectory,
                 `/(.+?)${APP_PREFETCH_SUFFIX}(?:/)?$`
               )}`,
+              dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
               has: [
                 {
                   type: 'header',
                   key: rscPrefetchHeader,
                 },
               ],
-              dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
-              check: true,
+              continue: true,
               override: true,
             },
           ]
@@ -1637,8 +1637,18 @@ export async function serverBuild({
                   key: rscHeader,
                 },
               ],
+              ...(rscPrefetchHeader
+                ? {
+                    missing: [
+                      {
+                        type: 'header',
+                        key: rscPrefetchHeader,
+                      },
+                    ],
+                  }
+                : {}),
               check: true,
-            },
+            } as Route,
           ]
         : []),
 
@@ -1650,7 +1660,11 @@ export async function serverBuild({
         ? [
             // rewrite route back to `.rsc`, but skip checking fs
             {
-              src: `^${path.posix.join('/', entryDirectory, '/(.*)$')}`,
+              src: `^${path.posix.join(
+                '/',
+                entryDirectory,
+                '/((?!.+\\.rsc).+?)(?:/)?$'
+              )}`,
               has: [
                 {
                   type: 'header',

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -236,6 +236,7 @@ type RoutesManifestOld = {
   rsc?: {
     header: string;
     varyHeader: string;
+    prefetchHeader?: string;
     contentTypeHeader: string;
   };
   skipMiddlewareUrlNormalize?: boolean;

--- a/packages/next/test/fixtures/00-app-dir/app/client-nested/page.js
+++ b/packages/next/test/fixtures/00-app-dir/app/client-nested/page.js
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 export default function ClientPage() {
   return (
     <>

--- a/packages/next/test/fixtures/00-app-dir/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir/vercel.json
@@ -38,11 +38,40 @@
       "mustNotContain": "<html"
     },
     {
+      "path": "/dynamic/category-1/id-1",
+      "status": 200,
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      },
+      "mustContain": ":",
+      "mustNotContain": "<html"
+    },
+    {
       "path": "/ssg",
       "status": 200,
       "mustContain": "hello from /ssg",
       "responseHeaders": {
         "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url"
+      }
+    },
+    {
+      "path": "/client-nested",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "Next-Router-Prefetch": "1",
+        "RSC": "1"
+      }
+    },
+    {
+      "path": "/client-nested",
+      "status": 200,
+      "mustContain": "hello",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": "1"
       }
     },
     {
@@ -53,6 +82,19 @@
       },
       "headers": {
         "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/ssg",
+      "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url"
+      },
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
       },
       "mustContain": ":{",
       "mustNotContain": "<html"


### PR DESCRIPTION
Implements handling for the RSC prefetch outputs when available that were added in https://github.com/vercel/next.js/pull/54403

