### PR TITLE
[build-utils] Add getOutputPath and isDirectory

### DIFF
--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @vercel/build-utils
 
+## 7.0.1
+
+- Added `getOutputPath` to abstract the logic of determining the output folder. It will return a string which ought to be the path to the output folder.
+- Added `isDirectoryPath` which is the helper function used to determine whether a path is a directory, or not when it is a file or doesn't exist at all. It will return a boolean.
+
 ## 7.0.0
 
 ### Major Changes

--- a/packages/build-utils/src/fs/is-directory-path.ts
+++ b/packages/build-utils/src/fs/is-directory-path.ts
@@ -1,0 +1,17 @@
+import { stat } from 'fs-extra';
+
+/**
+ * Returns `true` if "path" is a directory on the filesystem.
+ * Returns `false` if "path" does not exist or is a file.
+ */
+export async function isDirectoryPath(dir: string): Promise<boolean> {
+  try {
+    const s = await stat(dir);
+    return s.isDirectory();
+  } catch (err) {
+    if ((err as undefined | { code: string })?.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+  return false;
+}

--- a/packages/build-utils/src/get-output-path.ts
+++ b/packages/build-utils/src/get-output-path.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import { isDirectoryPath } from './fs/is-directory-path';
+
+// This may end up being the output folder if it is indeed a prebuilt build
+export const PREBUILT_OUTPUT_DIR = '.vercel/output';
+
+const outputDirPrefix = process.env.HOME || '';
+if (!outputDirPrefix) {
+  throw new Error('Expected `HOME` environment variable to be set');
+}
+
+// This core logic was ported from vc-build/build.ts
+export async function getOutputPath(
+  workPath: string,
+  rootPath: string
+): Promise<string> {
+  let cwd = workPath;
+  let outputDir: string;
+  let isPrebuilt = await isDirectoryPath(path.join(cwd, PREBUILT_OUTPUT_DIR));
+
+  if (!isPrebuilt && rootPath && rootPath !== workPath) {
+    cwd = rootPath;
+    isPrebuilt = await isDirectoryPath(path.join(cwd, PREBUILT_OUTPUT_DIR));
+  }
+
+  if (isPrebuilt) {
+    // This ends up something like `/vercel/path0/.vercel/output` (TODO: verify)
+    outputDir = path.join(cwd, PREBUILT_OUTPUT_DIR);
+  } else {
+    // The Build Output API contents will be located at `$HOME/output`.
+    // Note, this currently ends up being `/vercel/output`
+    outputDir = path.join(outputDirPrefix, 'output');
+  }
+
+  return outputDir;
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -12,6 +12,8 @@ import download, {
 } from './fs/download';
 import getWriteableDirectory from './fs/get-writable-directory';
 import glob, { GlobOptions } from './fs/glob';
+import { isDirectoryPath } from './fs/is-directory-path';
+import { getOutputPath } from './get-output-path';
 import rename from './fs/rename';
 import {
   spawnAsync,
@@ -80,6 +82,7 @@ export {
   getNodeVersion,
   getLatestNodeVersion,
   getDiscontinuedNodeVersions,
+  getOutputPath,
   getSpawnOptions,
   getPlatformEnv,
   getPrefixedEnvVars,
@@ -87,6 +90,7 @@ export {
   debug,
   isSymbolicLink,
   isDirectory,
+  isDirectoryPath,
   getLambdaOptionsFromFunction,
   scanParentDirs,
   getIgnoreFilter,


### PR DESCRIPTION
Ported from vc build. Need this logic in the build container too.
The logic was ported from vc-build/build.ts
