### PR TITLE
[next] fix 404 enoent for i18n

### DIFF
--- a/.changeset/pink-carpets-perform.md
+++ b/.changeset/pink-carpets-perform.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+fix 404 enoent for i18n

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -437,11 +437,19 @@ export async function serverBuild({
 
       if (i18n) {
         for (const locale of i18n.locales) {
-          const static404File =
-            staticPages[path.posix.join(entryDirectory, locale, '/404')] ||
-            new FileFsRef({
+          let static404File =
+            staticPages[path.posix.join(entryDirectory, locale, '/404')];
+
+          if (!static404File) {
+            static404File = new FileFsRef({
               fsPath: path.join(pagesDir, locale, '/404.html'),
             });
+            if (!fs.existsSync(static404File.fsPath)) {
+              static404File = new FileFsRef({
+                fsPath: path.join(pagesDir, '/404.html'),
+              });
+            }
+          }
           requiredFiles[path.relative(baseDir, static404File.fsPath)] =
             static404File;
         }


### PR DESCRIPTION
This PR fixes the following error:

```
Error: ENOENT: no such file or directory, open '/vercel/path0/.next/server/pages/en/404.html'
```

https://github.com/vercel/vercel/actions/runs/6030773334/job/16364078054?pr=10415#step:9:1352