### PR TITLE
migrate `promote` command structure for help output

### DIFF
--- a/.changeset/small-points-type.md
+++ b/.changeset/small-points-type.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+migrate `promote` command structure for help output

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -12,6 +12,7 @@ export interface CommandOption {
   argument?: string;
   deprecated: boolean;
   description?: string;
+  /** supports multiple entries */
   multi: boolean;
 }
 export interface CommandArgument {

--- a/packages/cli/src/commands/promote/command.ts
+++ b/packages/cli/src/commands/promote/command.ts
@@ -1,0 +1,53 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+
+export const promoteCommand: Command = {
+  name: 'promote',
+  description: 'Promote an existing deployment to current.',
+  arguments: [
+    {
+      name: 'deployment id/url',
+      required: false,
+    },
+  ],
+  subcommands: [
+    {
+      name: 'status',
+      description: 'Show the status of any current pending promotions',
+      arguments: [
+        {
+          name: 'project',
+          required: false,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+  ],
+  options: [
+    {
+      name: 'timeout',
+      description: 'Time to wait for promotion completion [3m]',
+      argument: 'timeout',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the status of any current pending promotions',
+      value: [
+        `${packageName} promote`,
+        `${packageName} promote status`,
+        `${packageName} promote status <project>`,
+        `${packageName} promote status --timeout 30s`,
+      ],
+    },
+    {
+      name: 'Promote a deployment using id or url',
+      value: `${packageName} promote <deployment id/url>`,
+    },
+  ],
+};

--- a/packages/cli/src/commands/promote/command.ts
+++ b/packages/cli/src/commands/promote/command.ts
@@ -7,7 +7,7 @@ export const promoteCommand: Command = {
   arguments: [
     {
       name: 'deployment id/url',
-      required: false,
+      required: true,
     },
   ],
   subcommands: [

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -1,53 +1,13 @@
-import chalk from 'chalk';
 import type Client from '../../util/client';
 import getArgs from '../../util/get-args';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
-import { packageName, logo } from '../../util/pkg-name';
 import handleError from '../../util/handle-error';
 import { isErrnoException } from '@vercel/error-utils';
 import ms from 'ms';
 import requestPromote from './request-promote';
 import promoteStatus from './status';
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} promote`)} [deployment id/url]
-
-  Promote an existing deployment to current.
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                     Output usage information
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-    'FILE'
-  )}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-    'DIR'
-  )}    Path to the global ${'`.vercel`'} directory
-    -d, --debug                    Debug mode [off]
-    --no-color                     No color mode [off]
-    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
-    'TOKEN'
-  )}        Login token
-    --timeout=${chalk.bold.underline(
-      'TIME'
-    )}                 Time to wait for promotion completion [3m]
-    -y, --yes                      Skip questions when setting up new project using default scope and settings
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray('–')} Show the status of any current pending promotions
-
-    ${chalk.cyan(`$ ${packageName} promote`)}
-    ${chalk.cyan(`$ ${packageName} promote status`)}
-    ${chalk.cyan(`$ ${packageName} promote status <project>`)}
-    ${chalk.cyan(`$ ${packageName} promote status --timeout 30s`)}
-
-  ${chalk.gray('–')} Promote a deployment using id or url
-
-    ${chalk.cyan(`$ ${packageName} promote <deployment id/url>`)}
-`);
-};
+import { promoteCommand } from './command';
+import { help } from '../help';
 
 /**
  * `vc promote` command
@@ -68,7 +28,9 @@ export default async (client: Client): Promise<number> => {
   }
 
   if (argv['--help'] || argv._[0] === 'help') {
-    help();
+    client.output.print(
+      help(promoteCommand, { columns: client.stderr.columns })
+    );
     return 2;
   }
 


### PR DESCRIPTION
Migrates the `vc promote` command to the command data structure for use in the help output.

---

<img width="1878" alt="Screenshot 2023-08-31 at 11 04 32 AM" src="https://github.com/vercel/vercel/assets/41545/b79c6aec-af03-4685-8ee4-9c0d89b2f236">

