### PR TITLE
migrate `rollback` command structure for help output

### DIFF
--- a/.changeset/happy-rivers-rule.md
+++ b/.changeset/happy-rivers-rule.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+migrate `rollback` command structure for help output

--- a/packages/cli/src/commands/rollback/command.ts
+++ b/packages/cli/src/commands/rollback/command.ts
@@ -1,0 +1,53 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+
+export const rollbackCommand: Command = {
+  name: 'rollback',
+  description: 'Quickly revert back to a previous deployment.',
+  arguments: [
+    {
+      name: 'deployment id/url',
+      required: true,
+    },
+  ],
+  subcommands: [
+    {
+      name: 'status',
+      description: 'Show the status of any current pending rollbacks',
+      arguments: [
+        {
+          name: 'project',
+          required: false,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+  ],
+  options: [
+    {
+      name: 'timeout',
+      description: 'Time to wait for rollback completion [3m]',
+      argument: 'timeout',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the status of any current pending rollbacks',
+      value: [
+        `${packageName} rollback`,
+        `${packageName} rollback status`,
+        `${packageName} rollback status <project>`,
+        `${packageName} rollback status --timeout 30s`,
+      ],
+    },
+    {
+      name: 'Rollback a deployment using id or url',
+      value: `${packageName} rollback <deployment id/url>`,
+    },
+  ],
+};

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -1,53 +1,13 @@
-import chalk from 'chalk';
 import type Client from '../../util/client';
 import getArgs from '../../util/get-args';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
-import { packageName, logo } from '../../util/pkg-name';
 import handleError from '../../util/handle-error';
 import { isErrnoException } from '@vercel/error-utils';
 import ms from 'ms';
 import requestRollback from './request-rollback';
 import rollbackStatus from './status';
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} rollback`)} [deployment id/url]
-
-  Quickly revert back to a previous deployment.
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                     Output usage information
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-    'FILE'
-  )}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-    'DIR'
-  )}    Path to the global ${'`.vercel`'} directory
-    -d, --debug                    Debug mode [off]
-    --no-color                     No color mode [off]
-    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
-    'TOKEN'
-  )}        Login token
-    --timeout=${chalk.bold.underline(
-      'TIME'
-    )}                 Time to wait for rollback completion [3m]
-    -y, --yes                      Skip questions when setting up new project using default scope and settings
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray('–')} Show the status of any current pending rollbacks
-
-    ${chalk.cyan(`$ ${packageName} rollback`)}
-    ${chalk.cyan(`$ ${packageName} rollback status`)}
-    ${chalk.cyan(`$ ${packageName} rollback status <project>`)}
-    ${chalk.cyan(`$ ${packageName} rollback status --timeout 30s`)}
-
-  ${chalk.gray('–')} Rollback a deployment using id or url
-
-    ${chalk.cyan(`$ ${packageName} rollback <deployment id/url>`)}
-`);
-};
+import { help } from '../help';
+import { rollbackCommand } from './command';
 
 /**
  * `vc rollback` command
@@ -68,7 +28,9 @@ export default async (client: Client): Promise<number> => {
   }
 
   if (argv['--help'] || argv._[0] === 'help') {
-    help();
+    client.output.print(
+      help(rollbackCommand, { columns: client.stderr.columns })
+    );
     return 2;
   }
 


### PR DESCRIPTION
Migrates the `vc rollback` command to the command data structure for use in the help output.

---

<img width="1891" alt="Screenshot 2023-08-31 at 11 25 49 AM" src="https://github.com/vercel/vercel/assets/41545/a6d802ac-3851-4641-b950-764fc65fa9d2">
