### PR TITLE
migrate `init` command structure for help output

### DIFF
--- a/.changeset/lucky-roses-pump.md
+++ b/.changeset/lucky-roses-pump.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+migrate `inti` command structure for help output

--- a/packages/cli/src/commands/init/command.ts
+++ b/packages/cli/src/commands/init/command.ts
@@ -1,0 +1,47 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+
+export const initCommand: Command = {
+  name: 'init',
+  description: 'Initialize example Vercel Projects',
+  arguments: [
+    {
+      name: 'example',
+      required: false,
+    },
+    {
+      name: 'dir',
+      required: false,
+    },
+  ],
+  subcommands: undefined,
+  options: [
+    {
+      name: 'force',
+      description: 'Overwrite destination directory if exists [off]',
+      argument: undefined,
+      shorthand: 'f',
+      type: 'boolean',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Choose from all available examples',
+      value: `${packageName} init`,
+    },
+    {
+      name: 'Initialize example project into a new directory',
+      value: `${packageName} init <example>`,
+    },
+    {
+      name: 'Initialize example project into specified directory',
+      value: `${packageName} <example> <dir>`,
+    },
+    {
+      name: 'Initialize example project without checking',
+      value: `${packageName} init <example> --force`,
+    },
+  ],
+};

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,46 +1,14 @@
-import chalk from 'chalk';
-
 import getArgs from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import Client from '../../util/client';
 import handleError from '../../util/handle-error';
 import init from './init';
-import { packageName, logo } from '../../util/pkg-name';
 import { isError } from '@vercel/error-utils';
+import { help } from '../help';
+import { initCommand } from './command';
 
 const COMMAND_CONFIG = {
   init: ['init'],
-};
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} init`)} [example] [dir] [-f | --force]
-
-  ${chalk.dim('Options:')}
-
-    -h, --help        Output usage information
-    -d, --debug       Debug mode [off]
-    --no-color        No color mode [off]
-    -f, --force       Overwrite destination directory if exists [off]
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray('–')}  Choose from all available examples
-
-      ${chalk.cyan(`$ ${packageName} init`)}
-
-  ${chalk.gray('–')}  Initialize example project into a new directory
-
-      ${chalk.cyan(`$ ${packageName} init <example>`)}
-
-  ${chalk.gray('–')}  Initialize example project into specified directory
-
-      ${chalk.cyan(`$ ${packageName} init <example> <dir>`)}
-
-  ${chalk.gray('–')}  Initialize example project without checking
-
-      ${chalk.cyan(`$ ${packageName} init <example> --force`)}
-  `);
 };
 
 export default async function main(client: Client) {
@@ -60,7 +28,7 @@ export default async function main(client: Client) {
   }
 
   if (argv['--help']) {
-    help();
+    client.output.print(help(initCommand, { columns: client.stderr.columns }));
     return 2;
   }
 


### PR DESCRIPTION
Migrates the `vc init` command to the command data structure for use in the help output.

---

<img width="1891" alt="Screenshot 2023-08-31 at 11 36 37 AM" src="https://github.com/vercel/vercel/assets/41545/1caeb203-470f-49a5-86b2-273b04bc0489">
