### PR TITLE
migrate `env` to command structure

### DIFF
--- a/.changeset/eighty-rockets-help.md
+++ b/.changeset/eighty-rockets-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Migrates the vc env command to the command data structure for use in the help output.

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -1,0 +1,140 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+import { getEnvTargetPlaceholder } from '../../util/env/env-target';
+
+const targetPlaceholder = getEnvTargetPlaceholder();
+
+export const envCommand: Command = {
+  name: 'env',
+  description: 'Interact with environment variables.',
+  arguments: [
+    {
+      name: 'command',
+      required: false,
+    },
+  ],
+  subcommands: [
+    {
+      name: 'ls',
+      description: 'Show all aliases.',
+      arguments: [],
+      options: [],
+      examples: [],
+    },
+    {
+      name: 'set',
+      description: 'Create a new alias',
+      arguments: [
+        {
+          name: 'deployment',
+          required: true,
+        },
+        {
+          name: 'alias',
+          required: true,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+    {
+      name: 'rm',
+      description: 'Remove an alias using its hostname.',
+      arguments: [
+        {
+          name: 'alias',
+          required: true,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+  ],
+  options: [
+    {
+      name: 'environment',
+      description:
+        'Set the Environment (development, preview, production) when pulling Environment Variables',
+      shorthand: null,
+      type: 'boolean',
+      deprecated: false,
+      multi: false,
+    },
+    {
+      name: 'git-branch',
+      description:
+        'Specify the Git branch to pull specific Environment Variables for',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+    {
+      name: 'yes',
+      description: 'Skip the confirmation prompt when removing an alias',
+      shorthand: 'y',
+      type: 'boolean',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Pull all Development Environment Variables down from the cloud',
+      value: [
+        `$ ${packageName} env pull <file>`,
+        `$ ${packageName} env pull .env.development.local`,
+      ],
+    },
+    {
+      name: 'Add a new variable to multiple Environments',
+      value: [
+        `$ ${packageName} env add <name>`,
+        `$ ${packageName} env add API_TOKEN`,
+      ],
+    },
+    {
+      name: 'Add a new variable for a specific Environment',
+      value: [
+        `$ ${packageName} env add <name> ${targetPlaceholder}`,
+        `$ ${packageName} env add DB_PASS production`,
+      ],
+    },
+    {
+      name: 'Add a new variable for a specific Environment and Git Branch',
+      value: [
+        `$ ${packageName} env add <name> ${targetPlaceholder} <gitbranch>`,
+        `$ ${packageName} env add DB_PASS preview feat1`,
+      ],
+    },
+    {
+      name: 'Add a new Environment Variable from stdin',
+      value: [
+        `$ cat <file> | ${packageName} env add <name> ${targetPlaceholder}`,
+        `$ cat ~/.npmrc | ${packageName} env add NPM_RC preview`,
+        `$ ${packageName} env add API_URL production < url.txt`,
+      ],
+    },
+    {
+      name: 'Remove a variable from multiple Environments',
+      value: [
+        `$ ${packageName} env rm <name>`,
+        `$ ${packageName} env rm API_TOKEN`,
+      ],
+    },
+    {
+      name: 'Remove a variable from a specific Environment',
+      value: [
+        `$ ${packageName} env rm <name> ${targetPlaceholder}`,
+        `$ ${packageName} env rm NPM_RC preview`,
+      ],
+    },
+    {
+      name: 'Remove a variable from a specific Environment and Git Branch',
+      value: [
+        `$ ${packageName} env rm <name> ${targetPlaceholder} <gitbranch>`,
+        `$ ${packageName} env rm NPM_RC preview feat1`,
+      ],
+    },
+  ],
+};

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -82,58 +82,58 @@ export const envCommand: Command = {
     {
       name: 'Pull all Development Environment Variables down from the cloud',
       value: [
-        `$ ${packageName} env pull <file>`,
-        `$ ${packageName} env pull .env.development.local`,
+        `${packageName} env pull <file>`,
+        `${packageName} env pull .env.development.local`,
       ],
     },
     {
       name: 'Add a new variable to multiple Environments',
       value: [
-        `$ ${packageName} env add <name>`,
-        `$ ${packageName} env add API_TOKEN`,
+        `${packageName} env add <name>`,
+        `${packageName} env add API_TOKEN`,
       ],
     },
     {
       name: 'Add a new variable for a specific Environment',
       value: [
-        `$ ${packageName} env add <name> ${targetPlaceholder}`,
-        `$ ${packageName} env add DB_PASS production`,
+        `${packageName} env add <name> ${targetPlaceholder}`,
+        `${packageName} env add DB_PASS production`,
       ],
     },
     {
       name: 'Add a new variable for a specific Environment and Git Branch',
       value: [
-        `$ ${packageName} env add <name> ${targetPlaceholder} <gitbranch>`,
-        `$ ${packageName} env add DB_PASS preview feat1`,
+        `${packageName} env add <name> ${targetPlaceholder} <gitbranch>`,
+        `${packageName} env add DB_PASS preview feat1`,
       ],
     },
     {
       name: 'Add a new Environment Variable from stdin',
       value: [
-        `$ cat <file> | ${packageName} env add <name> ${targetPlaceholder}`,
-        `$ cat ~/.npmrc | ${packageName} env add NPM_RC preview`,
-        `$ ${packageName} env add API_URL production < url.txt`,
+        `cat <file> | ${packageName} env add <name> ${targetPlaceholder}`,
+        `cat ~/.npmrc | ${packageName} env add NPM_RC preview`,
+        `${packageName} env add API_URL production < url.txt`,
       ],
     },
     {
       name: 'Remove a variable from multiple Environments',
       value: [
-        `$ ${packageName} env rm <name>`,
-        `$ ${packageName} env rm API_TOKEN`,
+        `${packageName} env rm <name>`,
+        `${packageName} env rm API_TOKEN`,
       ],
     },
     {
       name: 'Remove a variable from a specific Environment',
       value: [
-        `$ ${packageName} env rm <name> ${targetPlaceholder}`,
-        `$ ${packageName} env rm NPM_RC preview`,
+        `${packageName} env rm <name> ${targetPlaceholder}`,
+        `${packageName} env rm NPM_RC preview`,
       ],
     },
     {
       name: 'Remove a variable from a specific Environment and Git Branch',
       value: [
-        `$ ${packageName} env rm <name> ${targetPlaceholder} <gitbranch>`,
-        `$ ${packageName} env rm NPM_RC preview feat1`,
+        `${packageName} env rm <name> ${targetPlaceholder} <gitbranch>`,
+        `${packageName} env rm NPM_RC preview feat1`,
       ],
     },
   ],

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -16,22 +16,22 @@ export const envCommand: Command = {
   subcommands: [
     {
       name: 'ls',
-      description: 'Show all aliases.',
+      description: 'List all variables for the specified Environment',
       arguments: [],
       options: [],
       examples: [],
     },
     {
-      name: 'set',
-      description: 'Create a new alias',
+      name: 'add',
+      description: 'Add an Environment Variable (see examples below)',
       arguments: [
         {
-          name: 'deployment',
+          name: 'name',
           required: true,
         },
         {
-          name: 'alias',
-          required: true,
+          name: 'environment',
+          required: false,
         },
       ],
       options: [],
@@ -39,11 +39,28 @@ export const envCommand: Command = {
     },
     {
       name: 'rm',
-      description: 'Remove an alias using its hostname.',
+      description: 'Remove an Environment Variable (see examples below)',
       arguments: [
         {
-          name: 'alias',
+          name: 'name',
           required: true,
+        },
+        {
+          name: 'environment',
+          required: false,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+    {
+      name: 'pull',
+      description:
+        'Pull all Development Environment Variables from the cloud and write to a file [.env.local]',
+      arguments: [
+        {
+          name: 'filename',
+          required: false,
         },
       ],
       options: [],

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -8,99 +8,15 @@ import getArgs from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
 import handleError from '../../util/handle-error';
-import { getCommandName, packageName, logo } from '../../util/pkg-name';
+import { help } from '../help';
+import { getCommandName } from '../../util/pkg-name';
 import { getLinkedProject } from '../../util/projects/link';
+
 import add from './add';
 import ls from './ls';
 import pull from './pull';
 import rm from './rm';
-
-const help = () => {
-  const targetPlaceholder = getEnvTargetPlaceholder();
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} env`)} [options] <command>
-
-  ${chalk.dim('Commands:')}
-
-    ls      [environment] [gitbranch]         List all variables for the specified Environment
-    add     [name] [environment] [gitbranch]  Add an Environment Variable (see examples below)
-    rm      [name] [environment] [gitbranch]  Remove an Environment Variable (see examples below)
-    pull    [filename]                        Pull all Development Environment Variables from the cloud and write to a file [.env.local]
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                     Output usage information
-    --environment                  Set the Environment (development, preview, production) when pulling Environment Variables
-    --git-branch                   Specify the Git branch to pull specific Environment Variables for
-    -A ${chalk.bold.underline('FILE')}, --local-config=${chalk.bold.underline(
-    'FILE'
-  )}   Path to the local ${'`vercel.json`'} file
-    -Q ${chalk.bold.underline('DIR')}, --global-config=${chalk.bold.underline(
-    'DIR'
-  )}    Path to the global ${'`.vercel`'} directory
-    -d, --debug                    Debug mode [off]
-    --no-color                     No color mode [off]
-    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
-    'TOKEN'
-  )}        Login token
-    -y, --yes                      Skip the confirmation prompt when overwriting env file on pull or removing an env variable
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray(
-    '–'
-  )} Pull all Development Environment Variables down from the cloud
-
-      ${chalk.cyan(`$ ${packageName} env pull <file>`)}
-      ${chalk.cyan(`$ ${packageName} env pull .env.development.local`)}
-
-  ${chalk.gray('–')} Add a new variable to multiple Environments
-
-      ${chalk.cyan(`$ ${packageName} env add <name>`)}
-      ${chalk.cyan(`$ ${packageName} env add API_TOKEN`)}
-
-  ${chalk.gray('–')} Add a new variable for a specific Environment
-
-      ${chalk.cyan(`$ ${packageName} env add <name> ${targetPlaceholder}`)}
-      ${chalk.cyan(`$ ${packageName} env add DB_PASS production`)}
-
-  ${chalk.gray(
-    '–'
-  )} Add a new variable for a specific Environment and Git Branch
-
-      ${chalk.cyan(
-        `$ ${packageName} env add <name> ${targetPlaceholder} <gitbranch>`
-      )}
-      ${chalk.cyan(`$ ${packageName} env add DB_PASS preview feat1`)}
-
-  ${chalk.gray('–')} Add a new Environment Variable from stdin
-
-      ${chalk.cyan(
-        `$ cat <file> | ${packageName} env add <name> ${targetPlaceholder}`
-      )}
-      ${chalk.cyan(`$ cat ~/.npmrc | ${packageName} env add NPM_RC preview`)}
-      ${chalk.cyan(`$ ${packageName} env add API_URL production < url.txt`)}
-
-  ${chalk.gray('–')} Remove a variable from multiple Environments
-
-      ${chalk.cyan(`$ ${packageName} env rm <name>`)}
-      ${chalk.cyan(`$ ${packageName} env rm API_TOKEN`)}
-
-  ${chalk.gray('–')} Remove a variable from a specific Environment
-
-      ${chalk.cyan(`$ ${packageName} env rm <name> ${targetPlaceholder}`)}
-      ${chalk.cyan(`$ ${packageName} env rm NPM_RC preview`)}
-
-  ${chalk.gray(
-    '–'
-  )} Remove a variable from a specific Environment and Git Branch
-
-      ${chalk.cyan(
-        `$ ${packageName} env rm <name> ${targetPlaceholder} <gitbranch>`
-      )}
-      ${chalk.cyan(`$ ${packageName} env rm NPM_RC preview feat1`)}
-`);
-};
+import { envCommand } from './command';
 
 const COMMAND_CONFIG = {
   ls: ['ls', 'list'],
@@ -125,7 +41,7 @@ export default async function main(client: Client) {
   }
 
   if (argv['--help']) {
-    help();
+    client.output.print(help(envCommand, { columns: client.stderr.columns }));
     return 2;
   }
 
@@ -177,7 +93,9 @@ export default async function main(client: Client) {
         );
       default:
         output.error(getInvalidSubcommand(COMMAND_CONFIG));
-        help();
+        client.output.print(
+          help(envCommand, { columns: client.stderr.columns })
+        );
         return 2;
     }
   }


### PR DESCRIPTION
Migrates the `vc env` command to the command data structure for use in the help output.