### PR TITLE
migrate `git` command structure for help output

### DIFF
--- a/.changeset/stupid-vans-leave.md
+++ b/.changeset/stupid-vans-leave.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+migrate `git` command structure for help output

--- a/packages/cli/src/commands/git/command.ts
+++ b/packages/cli/src/commands/git/command.ts
@@ -1,0 +1,50 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+
+export const gitCommand: Command = {
+  name: 'git',
+  description: 'Manage your Git provider connections.',
+  arguments: [
+    {
+      name: 'command',
+      required: true,
+    },
+  ],
+  subcommands: [
+    {
+      name: 'connect',
+      description:
+        'Connect your Vercel Project to your Git repository or provide the remote URL to your Git repository',
+      arguments: [
+        {
+          name: 'git url',
+          required: false,
+        },
+      ],
+      options: [],
+      examples: [],
+    },
+    {
+      name: 'disconnect',
+      description: 'Disconnect the Git provider repository from your project',
+      arguments: [],
+      options: [],
+      examples: [],
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Connect your Vercel Project to your Git repository defined in your local .git config',
+      value: `${packageName} git connect`,
+    },
+    {
+      name: 'Connect your Vercel Project to a Git repository using the remote URL',
+      value: `${packageName} git connect https://github.com/user/repo.git`,
+    },
+    {
+      name: 'Disconnect the Git provider repository',
+      value: `${packageName} git disconnect`,
+    },
+  ],
+};

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -1,51 +1,12 @@
-import chalk from 'chalk';
 import Client from '../../util/client';
 import { ensureLink } from '../../util/link/ensure-link';
 import getArgs from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import handleError from '../../util/handle-error';
-import { packageName, logo } from '../../util/pkg-name';
 import connect from './connect';
 import disconnect from './disconnect';
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} git`)} <command>
-
-  ${chalk.dim('Commands:')}
-
-    connect [url]             Connect your Vercel Project to your Git repository or provide the remote URL to your Git repository
-    disconnect                Disconnect the Git provider repository from your project
-
-  ${chalk.dim('Options:')}
-
-    -h, --help                Output usage information
-    -t ${chalk.bold.underline('TOKEN')}, --token=${chalk.bold.underline(
-    'TOKEN'
-  )}   Login token
-    -y, --yes                 Skip confirmation when connecting a Git provider
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray(
-    '–'
-  )} Connect your Vercel Project to your Git repository defined in your local .git config
-
-    ${chalk.cyan(`$ ${packageName} git connect`)}
-
-  ${chalk.gray(
-    '–'
-  )} Connect your Vercel Project to a Git repository using the remote URL
-
-    ${chalk.cyan(
-      `$ ${packageName} git connect https://github.com/user/repo.git`
-    )}
-
-  ${chalk.gray('–')} Disconnect the Git provider repository
-
-    ${chalk.cyan(`$ ${packageName} git disconnect`)}
-`);
-};
+import { help } from '../help';
+import { gitCommand } from './command';
 
 const COMMAND_CONFIG = {
   connect: ['connect'],
@@ -71,7 +32,7 @@ export default async function main(client: Client) {
   }
 
   if (argv['--help']) {
-    help();
+    client.output.print(help(gitCommand, { columns: client.stderr.columns }));
     return 2;
   }
 
@@ -96,7 +57,7 @@ export default async function main(client: Client) {
       return await disconnect(client, args, project, org);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
-      help();
+      client.output.print(help(gitCommand, { columns: client.stderr.columns }));
       return 2;
   }
 }


### PR DESCRIPTION
Migrates the `vc git` command to the command data structure for use in the help output.

---

<img width="1891" alt="Screenshot 2023-08-31 at 11 36 37 AM" src="https://github.com/vercel/vercel/assets/41545/3cacaad6-f32f-4bc6-8113-59ef4d34b4f5">
