### PR TITLE
migrate dev command structure for help output

### DIFF
--- a/.changeset/modern-avocados-double.md
+++ b/.changeset/modern-avocados-double.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+migrate dev command structure for help output

--- a/packages/cli/src/commands/dev/command.ts
+++ b/packages/cli/src/commands/dev/command.ts
@@ -1,0 +1,34 @@
+import { Command } from '../help';
+import { packageName } from '../../util/pkg-name';
+
+export const devCommand: Command = {
+  name: 'dev',
+  description: `Starts the \`${packageName} dev\` server.`,
+  arguments: [
+    {
+      name: 'dir',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'listen',
+      description: 'Specify a URI endpoint on which to listen [0.0.0.0:3000]',
+      argument: 'uri',
+      shorthand: null,
+      type: 'string',
+      deprecated: false,
+      multi: false,
+    },
+  ],
+  examples: [
+    {
+      name: `Start the \`${packageName} dev\` server on port 8080`,
+      value: `${packageName} dev --listen 8080`,
+    },
+    {
+      name: 'Make the `vercel dev` server bind to localhost on port 5000',
+      value: `${packageName} dev --listen 127.0.0.1:5000 `,
+    },
+  ],
+};

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -12,41 +12,14 @@ import highlight from '../../util/output/highlight';
 import dev from './dev';
 import readConfig from '../../util/config/read-config';
 import readJSONFile from '../../util/read-json-file';
-import { packageName, getCommandName, logo } from '../../util/pkg-name';
+import { packageName, getCommandName } from '../../util/pkg-name';
 import { CantParseJSONFile } from '../../util/errors-ts';
 import { isErrnoException } from '@vercel/error-utils';
+import { help } from '../help';
+import { devCommand } from './command';
 
 const COMMAND_CONFIG = {
   dev: ['dev'],
-};
-
-const help = () => {
-  console.log(`
-  ${chalk.bold(`${logo} ${packageName} dev`)} [options] <dir>
-
-  Starts the \`${packageName} dev\` server.
-
-  ${chalk.dim('Options:')}
-
-    -h, --help             Output usage information
-    -d, --debug            Debug mode [off]
-    --no-color             No color mode [off]
-    -l, --listen  [uri]    Specify a URI endpoint on which to listen [0.0.0.0:3000]
-    -t, --token   [token]  Specify an Authorization Token
-    -y, --yes              Skip questions when setting up new project using default scope and settings
-
-  ${chalk.dim('Examples:')}
-
-  ${chalk.gray('–')} Start the \`${packageName} dev\` server on port 8080
-
-      ${chalk.cyan(`$ ${packageName} dev --listen 8080`)}
-
-  ${chalk.gray(
-    '–'
-  )} Make the \`vercel dev\` server bind to localhost on port 5000
-
-      ${chalk.cyan(`$ ${packageName} dev --listen 127.0.0.1:5000`)}
-  `);
 };
 
 export default async function main(client: Client) {
@@ -100,7 +73,7 @@ export default async function main(client: Client) {
   }
 
   if (argv['--help']) {
-    help();
+    client.output.print(help(devCommand, { columns: client.stderr.columns }));
     return 2;
   }
 

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -292,7 +292,7 @@ test('[vc dev] should print help from `vc develop --help`', async () => {
   );
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(2);
-  expect(stdout).toMatch(/▲ vercel dev/gm);
+  expect(stderr).toMatch(/▲ vercel dev/gm);
 });
 
 test('default command should deploy directory', async () => {


### PR DESCRIPTION
Migrates the `vc dev` command to the command data structure for use in the help output.

---

<img width="1891" alt="Screenshot 2023-08-31 at 1 35 07 PM" src="https://github.com/vercel/vercel/assets/41545/d3d63faa-9427-49e8-8137-a76d4c208cb3">
