### PR TITLE
[cli] Remove `mri` workaround

### DIFF
--- a/.changeset/metal-ties-shop.md
+++ b/.changeset/metal-ties-shop.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove mri workaround

--- a/packages/cli/src/commands/secrets.js
+++ b/packages/cli/src/commands/secrets.js
@@ -334,7 +334,6 @@ async function run({ output, contextName, currentTeam, client }) {
     }
 
     const [name, value] = args;
-    let value = parsedValue;
 
     if (typeof value === 'boolean') {
       const example = chalk.cyan(

--- a/packages/cli/src/commands/secrets.js
+++ b/packages/cli/src/commands/secrets.js
@@ -333,7 +333,7 @@ async function run({ output, contextName, currentTeam, client }) {
       return 1;
     }
 
-    const [name, parsedValue] = args;
+    const [name, value] = args;
     let value = parsedValue;
 
     if (typeof value === 'boolean') {

--- a/packages/cli/src/commands/secrets.js
+++ b/packages/cli/src/commands/secrets.js
@@ -334,18 +334,7 @@ async function run({ output, contextName, currentTeam, client }) {
     }
 
     const [name, parsedValue] = args;
-    const [originalName, originalValue] = client.argv.slice(-2);
-
     let value = parsedValue;
-    if (
-      name === originalName &&
-      typeof parsedValue === 'boolean' &&
-      parsedValue !== originalValue
-    ) {
-      // Corner case where `mri` transforms the secret value into a boolean because
-      // it starts with a `-` so it thinks its a flag, so we use the original value instead.
-      value = originalValue;
-    }
 
     if (typeof value === 'boolean') {
       const example = chalk.cyan(


### PR DESCRIPTION
As of https://github.com/vercel/vercel/pull/10389 the `mri` package is no longer used and this workaround can be removed.