### PR TITLE
[CLI] Fix team URL on `vercel help switch` 

### DIFF
--- a/.changeset/chilly-chefs-shake.md
+++ b/.changeset/chilly-chefs-shake.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix team URL on `vercel help switch` 

--- a/packages/cli/src/commands/teams/command.ts
+++ b/packages/cli/src/commands/teams/command.ts
@@ -58,7 +58,7 @@ export const teamsCommand: Command = {
   ],
   examples: [
     {
-      name: "Switch to a team. If your team's url is 'vercel.com/teams/name', then 'name' is the slug. If the slug is omitted, you can choose interactively.",
+      name: "Switch to a team. If your team's url is 'vercel.com/name', then 'name' is the slug. If the slug is omitted, you can choose interactively.",
       value: `${packageName} teams switch <slug>`,
     },
     {


### PR DESCRIPTION
In `vercel help switch`, it suggests that team URL is of the format `vercel.com/teams/name`, but this will be 404. It should be `vercel.com/name`.