### PR TITLE
Add optional experimentalStreamingLambda field for prerender

### DIFF
--- a/.changeset/olive-trees-applaud.md
+++ b/.changeset/olive-trees-applaud.md
@@ -2,4 +2,4 @@
 '@vercel/build-utils': minor
 ---
 
-Add new optional prerender field: experimentalStreamingLambda
+Add new optional prerender field: experimentalStreamingLambdaPath

--- a/.changeset/olive-trees-applaud.md
+++ b/.changeset/olive-trees-applaud.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add new optional prerender field: experimentalStreamingLambda

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -12,7 +12,7 @@ interface PrerenderOptions {
   initialStatus?: number;
   passQuery?: boolean;
   sourcePath?: string;
-  experimentalSteramingLambda?: string;
+  experimentalStreamingLambda?: string;
 }
 
 export class Prerender {

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -12,7 +12,7 @@ interface PrerenderOptions {
   initialStatus?: number;
   passQuery?: boolean;
   sourcePath?: string;
-  experimentalStreamingLambda?: string;
+  experimentalStreamingLambdaPath?: string;
 }
 
 export class Prerender {
@@ -27,7 +27,7 @@ export class Prerender {
   public initialStatus?: number;
   public passQuery?: boolean;
   public sourcePath?: string;
-  public experimentalStreamingLambda?: string;
+  public experimentalStreamingLambdaPath?: string;
 
   constructor({
     expiration,
@@ -40,7 +40,7 @@ export class Prerender {
     initialStatus,
     passQuery,
     sourcePath,
-    experimentalStreamingLambda,
+    experimentalStreamingLambdaPath,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -134,6 +134,13 @@ export class Prerender {
       this.allowQuery = allowQuery;
     }
 
-    this.experimentalStreamingLambda = experimentalStreamingLambda;
+    if (experimentalStreamingLambdaPath !== undefined) {
+      if (typeof experimentalStreamingLambdaPath !== 'string') {
+        throw new Error(
+          'The `experimentalStreamingLambdaPath` argument for `Prerender` must be a string.'
+        );
+      }
+      this.experimentalStreamingLambdaPath = experimentalStreamingLambdaPath;
+    }
   }
 }

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -40,7 +40,7 @@ export class Prerender {
     initialStatus,
     passQuery,
     sourcePath,
-    experimentalSteramingLambda,
+    experimentalStreamingLambda,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -134,6 +134,6 @@ export class Prerender {
       this.allowQuery = allowQuery;
     }
 
-    this.experimentalStreamingLambda = experimentalSteramingLambda;
+    this.experimentalStreamingLambda = experimentalStreamingLambda;
   }
 }

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -12,6 +12,7 @@ interface PrerenderOptions {
   initialStatus?: number;
   passQuery?: boolean;
   sourcePath?: string;
+  experimentalSteramingLambda?: string;
 }
 
 export class Prerender {
@@ -26,6 +27,7 @@ export class Prerender {
   public initialStatus?: number;
   public passQuery?: boolean;
   public sourcePath?: string;
+  public experimentalStreamingLambda?: string;
 
   constructor({
     expiration,
@@ -38,6 +40,7 @@ export class Prerender {
     initialStatus,
     passQuery,
     sourcePath,
+    experimentalSteramingLambda,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -130,5 +133,7 @@ export class Prerender {
       }
       this.allowQuery = allowQuery;
     }
+
+    this.experimentalStreamingLambda = experimentalSteramingLambda;
   }
 }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -387,6 +387,42 @@ it('should support passQuery correctly', async () => {
   );
 });
 
+it('should support experimentalStreamingLambdaPath correctly', async () => {
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    experimentalStreamingLambdaPath: undefined,
+  });
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    experimentalStreamingLambdaPath: '/some/path/to/lambda',
+  });
+  new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+
+  expect(() => {
+    new Prerender({
+      expiration: 1,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      // @ts-expect-error testing invalid field
+      experimentalStreamingLambdaPath: 1,
+    });
+  }).toThrowError(
+    `The \`experimentalStreamingLambdaPath\` argument for \`Prerender\` must be a string.`
+  );
+});
+
 it('should support require by path for legacy builders', () => {
   const index = require('../');
 


### PR DESCRIPTION
This adds a new `experimentalStreamingLambda` field to Prerender outputs, allowing references to an optional streaming lambda path.
