### PR TITLE
[next] fix ENOENT on /404.html when `fallback: false` w/ `basePath`

### DIFF
--- a/.changeset/nice-lies-sip.md
+++ b/.changeset/nice-lies-sip.md
@@ -1,0 +1,6 @@
+---
+"@vercel/next": patch
+"api": patch
+---
+
+fix ENOENT on /404.html when `fallback: false` w/ `basePath`

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1321,11 +1321,7 @@ export const build: BuildV2 = async ({
       const localePrefixed404 = !!(
         routesManifest.i18n &&
         originalStaticPages[
-          path.posix.join(
-            entryDirectory,
-            routesManifest.i18n.defaultLocale,
-            '404.html'
-          )
+          path.posix.join('.', routesManifest.i18n.defaultLocale, '404.html')
         ]
       );
 

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/index.test.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/next.config.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  basePath: '/docs',
+  i18n: {
+    locales: ['en', 'fr', 'nl'],
+    defaultLocale: 'en',
+  },
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/package.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/404.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/404.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return 'not found page';
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/_app.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/_app.js
@@ -1,0 +1,13 @@
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export const getStaticProps = ({ locale }) => ({
+  props: {
+    locale
+  }
+});
+
+export default MyApp;
+

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/another.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/another.js
@@ -1,0 +1,11 @@
+export default function Another() {
+  return 'another page';
+}
+
+export const getStaticProps = ({ locale }) => ({
+  props: {
+    locale,
+    hello: 'world',
+  },
+  revalidate: 1,
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/blog/[slug].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/blog/[slug].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.json({ slug: req.query.slug });
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/catchall/[...rest].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/catchall/[...rest].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.json({ rest: req.query.rest.join('/') });
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/api/hello.js
@@ -1,0 +1,6 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  res.statusCode = 200;
+  res.json({ name: 'John Doe' });
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/foo/[slug].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/foo/[slug].js
@@ -1,0 +1,25 @@
+export default function Page() {
+  return 'Hello World';
+}
+
+export const getStaticProps = async ({ locale, params }) => {
+  const id = params?.['slug'];
+  if (!id) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      locale,
+    },
+  };
+};
+
+export const getStaticPaths = async () => {
+  return {
+    paths: [{ params: { slug: 'test' } }],
+    fallback: false,
+  };
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/hello.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/hello.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'hello page';
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/index.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/pages/index.js
@@ -1,0 +1,11 @@
+export default function Home() {
+  return 'index page';
+}
+
+export const getServerSideProps = ({ locale }) => ({
+  props: {
+    locale,
+    hello: 'world',
+    gsspData: true,
+  },
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/probes.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/probes.json
@@ -1,0 +1,84 @@
+{
+  "probes": [
+    {
+      "path": "/docs/non-existent",
+      "status": 404,
+      "mustContain": "not found page"
+    },
+    {
+      "path": "/docs/non-existent",
+      "status": 404,
+      "mustContain": "lang=\"en\""
+    },
+    {
+      "path": "/docs/fr/non-existent",
+      "status": 404,
+      "mustContain": "not found page"
+    },
+    {
+      "path": "/docs/fr/non-existent",
+      "status": 404,
+      "mustContain": "lang=\"fr\""
+    },
+    {
+      "path": "/docs",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/docs/fr",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/docs/another",
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/docs/fr/another",
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/docs/fr/another",
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+    {
+      "path": "/docs/hello",
+      "status": 200,
+      "mustContain": "hello page"
+    },
+    {
+      "path": "/docs/hello",
+      "status": 200,
+      "mustContain": "lang=\"en\""
+    },
+    {
+      "path": "/docs/fr/hello",
+      "status": 200,
+      "mustContain": "hello page"
+    },
+    {
+      "path": "/docs/fr/hello",
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+    {
+      "path": "/docs/api/hello",
+      "status": 200,
+      "mustContain": "John Doe"
+    },
+    {
+      "path": "/docs/api/blog/first",
+      "status": 200,
+      "mustContain": "\"slug\":\"first\""
+    },
+    {
+      "path": "/docs/api/catchall/hello/world",
+      "status": 200,
+      "mustContain": "\"rest\":\"hello/world\""
+    }
+  ]
+}


### PR DESCRIPTION
The following error occurs during build when `basePath` is present in conjunction with `fallback: false` in `getStaticPaths`:

> Error: ENOENT: no such file or directory, open '/vercel/path0/.next/server/pages/404.html'

`localePrefixed404` was incorrectly being set to `false` because it was looking for `/<basePath>/<locale>/404.html` (when it's actually `/<locale>/404.html`)

This meant that inside `onPrerenderRoute`, `htmlFsRef` was pointing to `/404.html` rather than `/en/404.html`.
