### PR TITLE
[remix] Fixes for Remix v2

### DIFF
--- a/.changeset/weak-carrots-tickle.md
+++ b/.changeset/weak-carrots-tickle.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fixes for Remix v2

--- a/packages/remix/defaults/server-node.mjs
+++ b/packages/remix/defaults/server-node.mjs
@@ -1,20 +1,20 @@
 import {
-  AbortController as NodeAbortController,
   createRequestHandler as createRemixRequestHandler,
-  Headers as NodeHeaders,
-  Request as NodeRequest,
   writeReadableStreamToWritable,
   installGlobals,
 } from '@remix-run/node';
 
 installGlobals();
 
-import build from '@remix-run/dev/server-build';
+import * as build from '@remix-run/dev/server-build';
 
-const handleRequest = createRemixRequestHandler(build, process.env.NODE_ENV);
+const handleRequest = createRemixRequestHandler(
+  build.default || build,
+  process.env.NODE_ENV
+);
 
 function createRemixHeaders(requestHeaders) {
-  const headers = new NodeHeaders();
+  const headers = new Headers();
 
   for (const key in requestHeaders) {
     const header = requestHeaders[key];
@@ -37,7 +37,7 @@ function createRemixRequest(req, res) {
   const url = new URL(req.url, `${protocol}://${host}`);
 
   // Abort action/loaders once we can no longer write a response
-  const controller = new NodeAbortController();
+  const controller = new AbortController();
   res.on('close', () => controller.abort());
 
   const init = {
@@ -50,7 +50,7 @@ function createRemixRequest(req, res) {
     init.body = req;
   }
 
-  return new NodeRequest(url.href, init);
+  return new Request(url.href, init);
 }
 
 async function sendRemixResponse(res, nodeResponse) {

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -141,9 +141,10 @@ export const build: BuildV2 = async ({
     await runNpmInstall(entrypointFsDirname, [], spawnOpts, meta, nodeVersion);
   }
 
-  const isHydrogen2 =
+  const isHydrogen2 = Boolean(
     pkg.dependencies?.['@shopify/remix-oxygen'] ||
-    pkg.devDependencies?.['@shopify/remix-oxygen'];
+      pkg.devDependencies?.['@shopify/remix-oxygen']
+  );
 
   // Determine the version of Remix based on the `@remix-run/dev`
   // package version.
@@ -167,7 +168,7 @@ export const build: BuildV2 = async ({
 
   const depsToAdd: string[] = [];
 
-  const remixRunDevPkgVersion =
+  const remixRunDevPkgVersion: string | undefined =
     pkg.dependencies?.['@remix-run/dev'] ||
     pkg.devDependencies?.['@remix-run/dev'];
 
@@ -176,7 +177,7 @@ export const build: BuildV2 = async ({
   if (
     !isHydrogen2 &&
     remixRunDevPkg.name !== '@vercel/remix-run-dev' &&
-    !remixRunDevPkgVersion.startsWith('https:')
+    !remixRunDevPkgVersion?.startsWith('https:')
   ) {
     const remixDevForkVersion = resolveSemverMinMax(
       REMIX_RUN_DEV_MIN_VERSION,

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -167,9 +167,17 @@ export const build: BuildV2 = async ({
 
   const depsToAdd: string[] = [];
 
+  const remixRunDevPkgVersion =
+    pkg.dependencies?.['@remix-run/dev'] ||
+    pkg.devDependencies?.['@remix-run/dev'];
+
   // Override the official `@remix-run/dev` package with the
   // Vercel fork, which supports the `serverBundles` config
-  if (!isHydrogen2 && remixRunDevPkg.name !== '@vercel/remix-run-dev') {
+  if (
+    !isHydrogen2 &&
+    remixRunDevPkg.name !== '@vercel/remix-run-dev' &&
+    !remixRunDevPkgVersion.startsWith('https:')
+  ) {
     const remixDevForkVersion = resolveSemverMinMax(
       REMIX_RUN_DEV_MIN_VERSION,
       REMIX_RUN_DEV_MAX_VERSION,
@@ -308,7 +316,7 @@ export const build: BuildV2 = async ({
           renamedRemixConfigPath
         )}';
 config.serverBuildTarget = undefined;
-config.serverModuleFormat = 'cjs';
+config.serverModuleFormat = '${pkg.type === 'module' ? 'esm' : 'cjs'}';
 config.serverPlatform = 'node';
 config.serverBuildPath = undefined;
 config.serverBundles = ${JSON.stringify(serverBundles)};
@@ -318,7 +326,7 @@ export default config;`;
           renamedRemixConfigPath
         )}');
 config.serverBuildTarget = undefined;
-config.serverModuleFormat = 'cjs';
+config.serverModuleFormat = '${pkg.type === 'module' ? 'esm' : 'cjs'}';
 config.serverPlatform = 'node';
 config.serverBuildPath = undefined;
 config.serverBundles = ${JSON.stringify(serverBundles)};

--- a/packages/remix/test/unit.resolve-semver-min-max.test.ts
+++ b/packages/remix/test/unit.resolve-semver-min-max.test.ts
@@ -10,6 +10,9 @@ describe('resolveSemverMinMax()', () => {
     { min: '1.0.0', max: '1.15.0', version: '1.16.0', expected: '1.15.0' },
     { min: '1.0.0', max: '1.15.0', version: '^1.12.0', expected: '^1.12.0' },
     { min: '1.0.0', max: '1.15.0', version: '0.x.x', expected: '1.0.0' },
+    { min: '1.0.0', max: '2.0.0', version: '1.x.x', expected: '1.x.x' },
+    { min: '1.0.0', max: '2.0.0', version: '2.x.x', expected: '2.x.x' },
+    { min: '1.0.0', max: '2.0.0', version: '^2.0.0', expected: '^2.0.0' },
   ])(
     'Should return "$expected" for version "$version" (min=$min, max=$max)',
     ({ min, max, version, expected }) => {


### PR DESCRIPTION
The Remix v2 template now uses `"type": "module"` by default, so adjust our bundling logic to account for that possibility.