### PR TITLE
[next] fix feature flag detection

### DIFF
--- a/.changeset/late-impalas-nail.md
+++ b/.changeset/late-impalas-nail.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix feature flag detection

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -313,7 +313,7 @@ export async function serverBuild({
 
     const useBundledServer =
       semver.gte(nextVersion, BUNDLED_SERVER_NEXT_VERSION) &&
-      process.env.VERCEL_NEXT_BUNDLED_SERVER;
+      process.env.VERCEL_NEXT_BUNDLED_SERVER === '1';
 
     if (useBundledServer) {
       debug('Using bundled Next.js server');


### PR DESCRIPTION
For feature flags, we use the string `1` for enabled and the string `0` for disabled.

So we need to check the value of the env var, not the presence of the env var.