### PR TITLE
[next] Run e2e tests against Next.js v13.4.12

### DIFF
--- a/packages/next/test/integration/404-getstaticprops-i18n/package.json
+++ b/packages/next/test/integration/404-getstaticprops-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/custom-error-lambda/package.json
+++ b/packages/next/test/integration/custom-error-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/edge-app-dir-basepath/package.json
+++ b/packages/next/test/integration/edge-app-dir-basepath/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/gip-gsp-404/package.json
+++ b/packages/next/test/integration/gip-gsp-404/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/middleware-dynamic/package.json
+++ b/packages/next/test/integration/middleware-dynamic/package.json
@@ -4,7 +4,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/middleware-eval/package.json
+++ b/packages/next/test/integration/middleware-eval/package.json
@@ -4,7 +4,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/server-build/package.json
+++ b/packages/next/test/integration/server-build/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/serverless-config-object/package.json
+++ b/packages/next/test/integration/serverless-config-object/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/serverless-no-config/package.json
+++ b/packages/next/test/integration/serverless-no-config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/standard/package.json
+++ b/packages/next/test/integration/standard/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/static-site/package.json
+++ b/packages/next/test/integration/static-site/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/test-limit-exceeded-404-static-files/package.json
+++ b/packages/next/test/integration/test-limit-exceeded-404-static-files/package.json
@@ -5,7 +5,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/test-limit-exceeded-internal-files-server-build/package.json
+++ b/packages/next/test/integration/test-limit-exceeded-internal-files-server-build/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chrome-aws-lambda": "8.0.0",
     "firebase": "8.3.0",
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/test-limit-exceeded-server-build/package.json
+++ b/packages/next/test/integration/test-limit-exceeded-server-build/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chrome-aws-lambda": "8.0.0",
     "firebase": "8.3.0",
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/packages/next/test/integration/test-limit-large-uncompressed-files/package.json
+++ b/packages/next/test/integration/test-limit-large-uncompressed-files/package.json
@@ -5,7 +5,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "13.4.12",
     "react": "latest",
     "react-dom": "latest"
   },


### PR DESCRIPTION
## Do not merge - Just for running tests against CI