### PR TITLE
[cli] remove unused source map pkg

### DIFF
--- a/.changeset/beige-rockets-remember.md
+++ b/.changeset/beige-rockets-remember.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+remove unused source map pkg

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
     "node": ">= 16"
   },
   "dependencies": {
-    "chokidar": "3.3.1",
     "@vercel/build-utils": "7.2.1",
     "@vercel/fun": "1.1.0",
     "@vercel/go": "3.0.2",
@@ -41,7 +40,8 @@
     "@vercel/redwood": "2.0.3",
     "@vercel/remix-builder": "2.0.8",
     "@vercel/ruby": "2.0.2",
-    "@vercel/static-build": "2.0.7"
+    "@vercel/static-build": "2.0.7",
+    "chokidar": "3.3.1"
   },
   "devDependencies": {
     "@alex_neo/jest-expect-message": "1.0.5",
@@ -93,7 +93,6 @@
     "@vercel/frameworks": "2.0.2",
     "@vercel/fs-detectors": "5.1.0",
     "@vercel/routing-utils": "3.0.0",
-    "@zeit/source-map-support": "0.6.2",
     "ajv": "6.12.2",
     "alpha-sort": "2.0.1",
     "ansi-escapes": "4.3.2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,6 @@ try {
 
 import { join } from 'path';
 import { existsSync } from 'fs';
-import sourceMap from '@zeit/source-map-support';
 import { mkdirp } from 'fs-extra';
 import chalk from 'chalk';
 import epipebomb from 'epipebomb';
@@ -65,8 +64,6 @@ const VERCEL_AUTH_CONFIG_PATH = configFiles.getAuthConfigFilePath();
 const GLOBAL_COMMANDS = new Set(['help']);
 
 epipebomb();
-
-sourceMap.install();
 
 // Configure the error reporting system
 Sentry.init({

--- a/packages/cli/types/zeit__source-map-support/index.d.ts
+++ b/packages/cli/types/zeit__source-map-support/index.d.ts
@@ -1,3 +1,0 @@
-declare module '@zeit/source-map-support' {
-  function install(): void;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,9 +490,6 @@ importers:
       '@vercel/routing-utils':
         specifier: 3.0.0
         version: link:../routing-utils
-      '@zeit/source-map-support':
-        specifier: 0.6.2
-        version: 0.6.2
       ajv:
         specifier: 6.12.2
         version: 6.12.2
@@ -5601,12 +5598,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@zeit/source-map-support@0.6.2:
-    resolution: {integrity: sha512-hSGbAEUxKhrE6DAWe5cPVdlRxtpjOnNdeMI5kNIHOvJxYrWUrIdIDeTbM7hpoz0R/SSWYFxKjPJRSLs74ffVIQ==}
-    dependencies:
-      source-map: 0.6.1
-    dev: true
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -13756,6 +13747,7 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: true
 
   /source-map@0.7.3:


### PR DESCRIPTION
This PR removes a [deprecated package](https://www.npmjs.com/package/@zeit/source-map-support) that was originally added in PR https://github.com/vercel/vercel/pull/1205

The comment said:

```js
// we only enable source maps while developing, since
// they have a small performance hit. for this, we
// look for `pkg`, which is only present in the final bin
```

Some time along the way this was changed from development only, to always being installed.

However, no longer need this package because we can enable source maps for development by using [`--enable-source-map`](https://nodejs.org/docs/latest-v18.x/api/cli.html#--enable-source-maps) which has been available since Node.js 12