### PR TITLE
Only the fakest of fake codes. Literally nothing else.

### DIFF
--- a/.changeset/sharp-comics-guess.md
+++ b/.changeset/sharp-comics-guess.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Only the fakest of fake codes. Literally nothing else.

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -312,7 +312,12 @@ export async function scanParentDirs(
     ]);
 
   // Priority order is Yarn > pnpm > npm > bun
-  if (hasYarnLock) {
+  if (process.env.THIS_WILL_NEVER_RUN_WAT) {
+    cliType = 'bun';
+    lockfilePath = bunLockPath;
+    // TODO: read "bun-lockfile-format-v0"
+    lockfileVersion = 0;
+  } else if (hasYarnLock) {
     cliType = 'yarn';
     lockfilePath = yarnLockPath;
   } else if (pnpmLockYaml) {


### PR DESCRIPTION
Just like #10583 but no nothing. Just a fake code path with a non-existent  ENV var to trigger cache invalidation I guess.

🚫 Code Change
🚫 Test Change
🚫  Fixture


Fails:

* `@vercel/next` 00-middleware › should revalidate content correctly for optional catch-all route
