### PR TITLE
[next] fix next.js edge functions that use the instrumentation hook

### DIFF
--- a/.changeset/bright-timers-remember.md
+++ b/.changeset/bright-timers-remember.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix the instrumentation hook on Next.js Edge Functions

--- a/packages/next/src/edge-function-source/get-edge-function-source.ts
+++ b/packages/next/src/edge-function-source/get-edge-function-source.ts
@@ -30,7 +30,7 @@ export async function getNextjsEdgeFunctionSource(
   outputDir: string,
   wasm?: { filePath: string; name: string }[]
 ): Promise<Source> {
-  const chunks = new ConcatSource(raw(`let _ENTRIES = {};`));
+  const chunks = new ConcatSource(raw(`globalThis._ENTRIES = {};`));
   for (const filePath of filePaths) {
     const fullFilePath = join(outputDir, filePath);
     const content = await readFile(fullFilePath, 'utf8');

--- a/packages/next/test/fixtures/36-instrumentation-hook/app/api/edge/route.js
+++ b/packages/next/test/fixtures/36-instrumentation-hook/app/api/edge/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge'
+
+export async function GET(request) {
+  return NextResponse.json({
+    runtime: 'edge',
+    payload: `isOdd: ${globalThis.isOdd ? globalThis.isOdd(2) : 'unknown'}`,
+  })
+}

--- a/packages/next/test/fixtures/36-instrumentation-hook/app/api/node/route.js
+++ b/packages/next/test/fixtures/36-instrumentation-hook/app/api/node/route.js
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request) {
+  return NextResponse.json({
+    runtime: 'node',
+    payload: `isOdd: ${globalThis.isOdd ? globalThis.isOdd(2) : 'unknown'}`,
+  })
+}

--- a/packages/next/test/fixtures/36-instrumentation-hook/app/edge/page.jsx
+++ b/packages/next/test/fixtures/36-instrumentation-hook/app/edge/page.jsx
@@ -1,0 +1,15 @@
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
+
+export default async function EdgePage() {
+  const { props } = await getServerSideProps();
+  return `(edge) isOdd: ${props.isOdd}`;
+}
+
+async function getServerSideProps() {
+  return {
+    props: {
+      isOdd: globalThis.isOdd ? globalThis.isOdd(2) : 'unknown',
+    },
+  };
+}

--- a/packages/next/test/fixtures/36-instrumentation-hook/app/layout.jsx
+++ b/packages/next/test/fixtures/36-instrumentation-hook/app/layout.jsx
@@ -1,0 +1,9 @@
+export default function RootLayout({
+  children,
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/next/test/fixtures/36-instrumentation-hook/app/node/page.jsx
+++ b/packages/next/test/fixtures/36-instrumentation-hook/app/node/page.jsx
@@ -1,0 +1,14 @@
+export const dynamic = 'force-dynamic';
+
+export default async function NodePage() {
+  const { props } = await getServerSideProps();
+  return `(node) isOdd: ${props.isOdd}`;
+}
+
+async function getServerSideProps() {
+  return {
+    props: {
+      isOdd: globalThis.isOdd ? globalThis.isOdd(2) : 'unknown',
+    },
+  };
+}

--- a/packages/next/test/fixtures/36-instrumentation-hook/index.test.js
+++ b/packages/next/test/fixtures/36-instrumentation-hook/index.test.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { deployAndTest } = require('../../utils');
 const { describe } = require('node:test');
+const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 const ctx = {};
 

--- a/packages/next/test/fixtures/36-instrumentation-hook/index.test.js
+++ b/packages/next/test/fixtures/36-instrumentation-hook/index.test.js
@@ -1,8 +1,55 @@
 const path = require('path');
 const { deployAndTest } = require('../../utils');
+const { describe } = require('node:test');
+
+const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
+  // this test needs to run first to set ctx.deploymentUrl
   it('should deploy and pass probe checks', async () => {
-    await deployAndTest(__dirname);
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+
+  it('node: should be able to use the instrumentation code in a app router page', async () => {
+    const endpoint = `${ctx.deploymentUrl}/node`;
+    console.log(endpoint)
+    const res = await fetch(endpoint);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain(`(node) isOdd: false`);
+  });
+
+  it('node: should be able to use the instrumentation code in a route handler', async () => {
+    const endpoint = `${ctx.deploymentUrl}/api/node`;
+    console.log(endpoint)
+    const res = await fetch(endpoint);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      runtime: 'node',
+      payload: 'isOdd: false',
+    });
+  });
+
+  it('edge: should be able to use the instrumentation code in a app router page', async () => {
+    const endpoint = `${ctx.deploymentUrl}/edge`;
+    console.log(endpoint)
+    const res = await fetch(endpoint);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain(`(edge) isOdd: false`);
+  });
+
+  it('edge: should be able to use the instrumentation code in a route handler', async () => {
+    const endpoint = `${ctx.deploymentUrl}/api/edge`;
+    console.log(endpoint)
+    const res = await fetch(endpoint);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      runtime: 'edge',
+      payload: 'isOdd: false',
+    });
   });
 });

--- a/packages/next/test/fixtures/36-instrumentation-hook/pages/index.js
+++ b/packages/next/test/fixtures/36-instrumentation-hook/pages/index.js
@@ -5,7 +5,7 @@ export default function Home(props) {
 export async function getServerSideProps() {
   return {
     props: {
-      isOdd: globalThis.isOdd(2),
+      isOdd: globalThis.isOdd ? globalThis.isOdd(2) : 'unknown',
     },
   };
 }


### PR DESCRIPTION
Fixes a issue when a Next.js app uses app router + edge runtime + instrumentation hook deployed out on Vercel.  The issue is that the code to register the instrumentation hook in Next.js expects `_ENTRIES` to be defined on `globalThis`.

```ts
async function registerInstrumentation() {
  console.log("'_ENTRIES' in globalThis:", '_ENTRIES' in globalThis)
  console.log(
    '_ENTRIES.middleware_instrumentation:',
    Boolean(_ENTRIES.middleware_instrumentation)
  )
  console.log(
    '_ENTRIES.middleware_instrumentation.register:',
    Boolean(_ENTRIES.middleware_instrumentation.register)
  )

  if (
    '_ENTRIES' in globalThis &&
    _ENTRIES.middleware_instrumentation &&
    _ENTRIES.middleware_instrumentation.register
  ) {
    try {
      console.log('registering middleware instrumentation...')
      await _ENTRIES.middleware_instrumentation.register()
      console.log('registered middleware instrumentation!')
    } catch (err: any) {
      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
      console.error(err)
      throw err
    }
  }
}
```

produced the following output,

![image](https://github.com/vercel/vercel/assets/1278714/d0a3a536-5579-4a63-a726-2e34a575e713)

This PR fixes this by changing `let _ENTRIES = {}'` to `globalThis._ENTRIES = {};`

![image](https://github.com/vercel/vercel/assets/1278714/7ba558ac-7364-4d91-869e-920662161022)
