### PR TITLE
[next] fix lambda creation for i18n edge pages

### DIFF
--- a/.changeset/mighty-pens-teach.md
+++ b/.changeset/mighty-pens-teach.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] fix lambda creation for i18n edge pages

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2572,6 +2572,11 @@ export function normalizeEdgeFunctionPath(
       shortPath = 'index';
     }
   }
+
+  if (shortPath.startsWith('pages/')) {
+    shortPath = shortPath.replace(/^pages\//, '');
+  }
+
   return shortPath;
 }
 

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/index.test.js
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/index.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs-extra');
+const ms = require('ms');
+const path = require('path');
+const { build } = require('../../../../dist');
+const { FileFsRef } = require('@vercel/build-utils');
+
+jest.setTimeout(ms('6m'));
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should normalize routes in build results output', async () => {
+    // TODO: remove after bug with edge functions on Windows
+    // is resolved upstream in Next.js
+    if (process.platform === 'win32') {
+      const indexPage = path.join(__dirname, 'pages/index.tsx');
+      await fs.writeFile(
+        indexPage,
+        (
+          await fs.readFile(indexPage, 'utf8')
+        ).replace('runtime: ', '// runtime: ')
+      );
+    }
+
+    const files = [
+      'index.test.js',
+      'next.config.js',
+      'package.json',
+      'tsconfig.json',
+      'pages/index.tsx',
+    ].reduce((filesMap, file) => {
+      const fsPath = path.join(__dirname, file);
+      const { mode } = fs.statSync(fsPath);
+      filesMap[path] = new FileFsRef({ mode, fsPath });
+      return filesMap;
+    }, {});
+
+    const { output } = await build({
+      config: {},
+      entrypoint: 'package.json',
+      files,
+      meta: {
+        skipDownload: true,
+      },
+      repoRootPath: __dirname,
+      workPath: __dirname,
+    });
+
+    const lambdaPaths = [];
+
+    for (const key in output) {
+      if (output[key].type === 'Lambda') {
+        lambdaPaths.push(key);
+      }
+    }
+
+    expect(lambdaPaths).toEqual(
+      [],
+      `Unexpected paths with type "Lambda": ${lambdaPaths.join(', ')}`
+    );
+  });
+});

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/next-env.d.ts
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/next.config.js
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  i18n: {
+    locales: ['en', 'fr', 'nl'],
+    defaultLocale: 'en',
+  },
+};
+
+module.exports = nextConfig;

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/package.json
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "02-edge-function-basepath",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/pages/index.tsx
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/pages/index.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from 'next';
+
+const Home: NextPage = () => {
+  return <div>Home</div>;
+};
+
+export default Home;
+
+export const config = {
+  runtime: 'experimental-edge',
+};

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/tsconfig.json
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
An issue similar to https://github.com/vercel/next.js/issues/44381 exists whereby vercel creates lambda functions for edge pages when i18n is configured.

Fixes https://github.com/vercel/next.js/issues/42854