### PR TITLE
Fix regression: traverse parent folders as long as the path matches

### DIFF
--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -428,14 +428,20 @@ module.exports = config;`;
       : null,
   ]);
 
-  const staticDir = join(
-    remixConfig.assetsBuildDirectory,
-    ...remixConfig.publicPath
-      .replace(/^\/|\/$/g, '')
-      .split('/')
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .map(_ => '..')
-  );
+  const assetsBuildDirectory = remixConfig.assetsBuildDirectory
+    .replace(/^\/|\/$/g, '')
+    .split('/');
+  const publicPath = remixConfig.publicPath.replace(/^\/|\/$/g, '').split('/');
+
+  // Remove matching segments at end of paths only (e.g. `/project/build/` compared to `/public/build/`)
+  while (
+    assetsBuildDirectory.length &&
+    assetsBuildDirectory[assetsBuildDirectory.length - 1] === publicPath.pop()
+  ) {
+    assetsBuildDirectory.pop();
+  }
+
+  const staticDir = join(...assetsBuildDirectory);
   const [staticFiles, ...functions] = await Promise.all([
     glob('**', staticDir),
     ...serverBundles.map(bundle => {


### PR DESCRIPTION
Addresses regression in #10305 related to my [comments](https://github.com/vercel/vercel/pull/10305/files#r1346756667).

This update will assume the asset build path and the public path are related, as long as the end of the paths match. This _should_ address the use case in #10305 as well as the original intent of `publicPath` in Remix, which is to specify a path in the browser to an asset -- unrelated to the filesystem.

An example might be:
- `assetsBuildDirectory: /project/public/build/`
- `publicPath: /apps/my-app/build/`

The end of those paths match `/build/` and would result in the Remix build script traversing to the parent `/project/public` folder on the filesystem and regard that as the root.

Given, this might be a contrived example, but I would presume this addresses the use case in #10305 as well as preserves the original intent of the `publicPath`.