### PR TITLE
[node] Support import alias on serverless functions

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,10 +36,11 @@
     "esbuild": "0.14.47",
     "etag": "1.8.1",
     "node-fetch": "2.6.9",
-    "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
     "path-to-regexp": "6.1.0",
+    "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
     "ts-morph": "12.0.0",
     "ts-node": "10.9.1",
+    "tsconfig-paths": "4.2.0",
     "typescript": "4.9.5",
     "undici": "5.28.4"
   },

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'module';
 import { relative, basename, dirname } from 'path';
 import { NowBuildError } from '@vercel/build-utils';
+import { register as registerTsConfigPaths } from 'tsconfig-paths';
 import type _ts from 'typescript';
 
 /*
@@ -197,6 +198,14 @@ export function register(opts: Options = {}): Register {
 
     const outFiles = new Map<string, SourceOutput>();
     const config = readConfig(configFileName);
+
+    // Since we early return the cached output, this should run only once.
+    if (config.options?.baseUrl || config.options?.paths) {
+      registerTsConfigPaths({
+        baseUrl: config.options?.baseUrl || '',
+        paths: config.options?.paths || {},
+      });
+    }
 
     /**
      * Create the basic function for transpile only (ts-node --transpileOnly)

--- a/packages/node/test/fixtures/63-absolute-import/api/index.ts
+++ b/packages/node/test/fixtures/63-absolute-import/api/index.ts
@@ -1,0 +1,5 @@
+import { FOO } from 'src/foo';
+
+export default req => {
+  return new Response(`FOO:${FOO}`);
+};

--- a/packages/node/test/fixtures/63-absolute-import/probes.json
+++ b/packages/node/test/fixtures/63-absolute-import/probes.json
@@ -1,0 +1,8 @@
+{
+  "probes": [
+    {
+      "path": "/api",
+      "status": 500
+    }
+  ]
+}

--- a/packages/node/test/fixtures/63-absolute-import/probes.json
+++ b/packages/node/test/fixtures/63-absolute-import/probes.json
@@ -2,7 +2,8 @@
   "probes": [
     {
       "path": "/api",
-      "status": 500
+      "status": 200,
+      "mustContain": "FOO:FOO"
     }
   ]
 }

--- a/packages/node/test/fixtures/63-absolute-import/src/foo.ts
+++ b/packages/node/test/fixtures/63-absolute-import/src/foo.ts
@@ -1,0 +1,1 @@
+export const FOO = 'FOO';

--- a/packages/node/test/fixtures/63-absolute-import/tsconfig.json
+++ b/packages/node/test/fixtures/63-absolute-import/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "baseUrl": ".",
+  }
+}

--- a/packages/node/test/fixtures/63-absolute-import/vercel.json
+++ b/packages/node/test/fixtures/63-absolute-import/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/index.ts", "use": "@vercel/node" }]
+}

--- a/packages/node/test/fixtures/64-module-aliases/api/index.ts
+++ b/packages/node/test/fixtures/64-module-aliases/api/index.ts
@@ -1,0 +1,5 @@
+import { FOO } from '@/foo';
+
+export default req => {
+  return new Response(`FOO:${FOO}`);
+};

--- a/packages/node/test/fixtures/64-module-aliases/probes.json
+++ b/packages/node/test/fixtures/64-module-aliases/probes.json
@@ -1,0 +1,8 @@
+{
+  "probes": [
+    {
+      "path": "/api",
+      "status": 500
+    }
+  ]
+}

--- a/packages/node/test/fixtures/64-module-aliases/probes.json
+++ b/packages/node/test/fixtures/64-module-aliases/probes.json
@@ -2,7 +2,8 @@
   "probes": [
     {
       "path": "/api",
-      "status": 500
+      "status": 200,
+      "mustContain": "FOO:FOO"
     }
   ]
 }

--- a/packages/node/test/fixtures/64-module-aliases/src/foo.ts
+++ b/packages/node/test/fixtures/64-module-aliases/src/foo.ts
@@ -1,0 +1,1 @@
+export const FOO = 'FOO';

--- a/packages/node/test/fixtures/64-module-aliases/tsconfig.json
+++ b/packages/node/test/fixtures/64-module-aliases/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/node/test/fixtures/64-module-aliases/vercel.json
+++ b/packages/node/test/fixtures/64-module-aliases/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "api/index.ts", "use": "@vercel/node" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1364,6 +1364,9 @@ importers:
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@swc/core@1.2.218)(@types/node@14.18.33)(typescript@5.7.3)
+      tsconfig-paths:
+        specifier: 4.2.0
+        version: 4.2.0
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -8105,7 +8108,7 @@ packages:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 5.4.11(@types/node@14.18.33)
+      vite: 5.4.11(@types/node@16.18.11)
     dev: true
 
   /@vitest/pretty-format@2.0.3:
@@ -10671,7 +10674,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.9
@@ -10702,7 +10705,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.3
@@ -10850,7 +10853,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.24.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.24.0):
@@ -13428,7 +13431,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -16031,7 +16033,6 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-    dev: true
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -16600,6 +16601,15 @@ packages:
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: true
+
+  /tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
This PR added `tsconfig-paths` in order to resolve import aliases if both `baseUrl` and `paths` are given in tsconfig.json.

Fixes #10717
Fixes #10139