### PR TITLE
[next] skip lambda creation for error-only page groups

### DIFF
--- a/.changeset/shiny-birds-collect.md
+++ b/.changeset/shiny-birds-collect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+[next] skip lambda creation for error-only page groups

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -981,6 +981,14 @@ export async function serverBuild({
     );
 
     for (const group of combinedGroups) {
+      // Skip group that only has an _error page
+      if (
+        group.pages &&
+        group.pages.length === 1 &&
+        group.pages[0] === '_error.js'
+      ) {
+        continue;
+      }
       const groupPageFiles: { [key: string]: PseudoFile } = {};
 
       for (const page of [...group.pages, ...internalPages]) {

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/pages/_error.tsx
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/pages/_error.tsx
@@ -1,0 +1,19 @@
+import { NextPageContext } from 'next';
+import { ErrorProps } from 'next/error';
+
+function Error({ statusCode }: ErrorProps) {
+  return (
+    <p>
+      {statusCode
+        ? `An error ${statusCode} occurred on server`
+        : 'An error occurred on client'}
+    </p>
+  );
+}
+
+Error.getInitialProps = ({ res, err }: NextPageContext) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;


### PR DESCRIPTION
Using i18n with the edge runtime results in an uneccessary _error functions generated.

Fixes https://github.com/vercel/next.js/issues/48490