### PR TITLE
Fix changeset lint for forks

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-      - run: git checkout ${{ github.event.pull_request.head.ref }}
+      - run: git fetch origin ${{ github.event.pull_request.head.sha }}:pr-${{ github.event.pull_request.number }}
+      - run: git checkout pr-${{ github.event.pull_request.number }}
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
       - run: pnpm install


### PR DESCRIPTION
When a PR is created from a fork then the `Lint` / `Enforce Changeset` step will always fail because of how we try to check out the PR branch that will only exist on the forked repo but not in this origin repo.

The error I get is this:
```
The Lint / Enforce Changeset workflow is failing with error: pathspec 'skip-error-only-page-group' did not match any file(s) known to git
```
(via https://github.com/vercel/vercel/actions/runs/6545130867/job/17772970043?pr=10726)

This PR adds a fix for this by checking out the PR head by sha instead of the ref that only exists in the forked repo.

This will not affect `main` since this check is only run for PRs:
```
if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
```
(via https://github.com/vercel/vercel/blob/main/.github/workflows/test-lint.yml#L25)