### PR TITLE
[error-utils] use Node.js `util.types.isNativeError` for `isError` method

### DIFF
--- a/.changeset/purple-crews-type.md
+++ b/.changeset/purple-crews-type.md
@@ -1,0 +1,5 @@
+---
+"@vercel/error-utils": patch
+---
+
+use Node.js `util.types.isNativeError` for `isError` method

--- a/packages/error-utils/src/index.ts
+++ b/packages/error-utils/src/index.ts
@@ -1,3 +1,5 @@
+import util from 'node:util';
+
 export interface SpawnError extends NodeJS.ErrnoException {
   spawnargs: string[];
 }
@@ -13,22 +15,9 @@ export const isObject = (obj: unknown): obj is Record<string, unknown> =>
 /**
  * A type guard for `try...catch` errors.
  *
- * This function is based on:
- * https://github.com/stdlib-js/assert-is-error
  */
 export const isError = (error: unknown): error is Error => {
-  if (!isObject(error)) return false;
-
-  // Check for `Error` objects instantiated within the current global context.
-  if (error instanceof Error) return true;
-
-  // Walk the prototype tree until we find a matching object.
-  while (error) {
-    if (Object.prototype.toString.call(error) === '[object Error]') return true;
-    error = Object.getPrototypeOf(error);
-  }
-
-  return false;
+  return util.types.isNativeError(error);
 };
 
 export const isErrnoException = (

--- a/packages/error-utils/src/index.ts
+++ b/packages/error-utils/src/index.ts
@@ -14,7 +14,7 @@ export const isObject = (obj: unknown): obj is Record<string, unknown> =>
 
 /**
  * A type guard for `try...catch` errors.
- *
+ * @deprecated use `require('node:util').types.isNativeError(error)` instead
  */
 export const isError = (error: unknown): error is Error => {
   return util.types.isNativeError(error);


### PR DESCRIPTION
I recently learned about https://nodejs.org/api/util.html#utiltypesisnativeerrorvalue which is pretty great. It will return `true` for all errors including subclasses (`class MyError extends Error {}`)