### PR TITLE
Collect lockfileVersion for yarn

### DIFF
--- a/packages/build-utils/src/fs/read-config-file.ts
+++ b/packages/build-utils/src/fs/read-config-file.ts
@@ -30,7 +30,9 @@ export async function readConfigFile<T>(
     if (data) {
       const str = data.toString('utf8');
       try {
-        if (name.endsWith('.json')) {
+        if (name === 'yarn.lock') {
+          return yaml.safeLoad(str, { filename: name }) as T;
+        } else if (name.endsWith('.json')) {
           return JSON.parse(str) as T;
         } else if (name.endsWith('.toml')) {
           return toml.parse(str) as unknown as T;

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -299,9 +299,13 @@ export async function scanParentDirs(
   let lockfileVersion: number | undefined;
   let cliType: CliType = 'yarn';
 
-  const [hasYarnLock, packageLockJson, pnpmLockYaml, bunLockBin] =
+  const hasYarnLock = Boolean(yarnLockPath);
+
+  const [yarnLockYaml, packageLockJson, pnpmLockYaml, bunLockBin] =
     await Promise.all([
-      Boolean(yarnLockPath),
+      yarnLockPath
+        ? readConfigFile<{ __metadata: { version: number } }>(yarnLockPath)
+        : null,
       npmLockPath
         ? readConfigFile<{ lockfileVersion: number }>(npmLockPath)
         : null,
@@ -320,6 +324,7 @@ export async function scanParentDirs(
   } else if (hasYarnLock) {
     cliType = 'yarn';
     lockfilePath = yarnLockPath;
+    lockfileVersion = Number(yarnLockYaml.__metadata.version);
   } else if (pnpmLockYaml) {
     cliType = 'pnpm';
     lockfilePath = pnpmLockPath;


### PR DESCRIPTION
This PR gets the lockfile version from a `yarn.lock` into the returned value from `scanParentDirs`. This function is used by the Vercel build container for DD tracing, and we are currently missing the lockfileVersion when the package manager is yarn. 