### PR TITLE
Rework prefetch route handling

### DIFF
--- a/.changeset/tricky-rules-sin.md
+++ b/.changeset/tricky-rules-sin.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Rework prefetch route handling

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1642,7 +1642,7 @@ export async function serverBuild({
                     dest: path.posix.join(
                       '/',
                       entryDirectory,
-                      `/__$1${RSC_PREFETCH_SUFFIX}`
+                      `/$1${RSC_PREFETCH_SUFFIX}`
                     ),
                     headers: { vary: rscVaryHeader },
                     continue: true,
@@ -1737,7 +1737,7 @@ export async function serverBuild({
               src: `^${path.posix.join(
                 '/',
                 entryDirectory,
-                `/__(.+?)${RSC_PREFETCH_SUFFIX}(?:/)?$`
+                `/(.+?)${RSC_PREFETCH_SUFFIX}(?:/)?$`
               )}`,
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
               has: [

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3127,8 +3127,12 @@ export function normalizePrefetches(prefetches: Record<string, FileFsRef>) {
   const updatedPrefetches: Record<string, FileFsRef> = {};
 
   for (const key in prefetches) {
-    const newKey = key.replace(/([^/]+\.prefetch\.rsc)$/, '__$1');
-    updatedPrefetches[newKey] = prefetches[key];
+    if (key === 'index.prefetch.rsc') {
+      const newKey = key.replace(/([^/]+\.prefetch\.rsc)$/, '__$1');
+      updatedPrefetches[newKey] = prefetches[key];
+    } else {
+      updatedPrefetches[key] = prefetches[key];
+    }
   }
 
   return updatedPrefetches;

--- a/packages/next/test/fixtures/00-app-dir-root-catch-all/app/[[...slug]]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-root-catch-all/app/[[...slug]]/page.js
@@ -15,9 +15,10 @@ export function generateStaticParams() {
     {
       slug: [''],
     },
-    {
-      slug: ['index'],
-    },
+    // this case is not supported
+    // {
+    //   slug: ['index'],
+    // },
     {
       slug: ['first'],
     },

--- a/packages/next/test/fixtures/00-app-dir-root-catch-all/app/nested/[[...slug]]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-root-catch-all/app/nested/[[...slug]]/page.js
@@ -15,9 +15,10 @@ export function generateStaticParams() {
     {
       slug: [''],
     },
-    {
-      slug: ['index'],
-    },
+    // not supported
+    // {
+    //   slug: ['index'],
+    // },
     {
       slug: ['first'],
     },

--- a/packages/next/test/fixtures/00-app-dir-root-catch-all/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-root-catch-all/vercel.json
@@ -26,25 +26,6 @@
       "mustContain": "catch-all"
     },
     {
-      "path": "/index",
-      "status": 200,
-      "mustContain": "html"
-    },
-    {
-      "path": "/index",
-      "status": 200,
-      "mustContain": "catch-all"
-    },
-    {
-      "path": "/index",
-      "status": 200,
-      "headers": {
-        "RSC": 1
-      },
-      "mustNotContain": "<html",
-      "mustContain": "catch-all"
-    },
-    {
       "path": "/nested",
       "status": 200,
       "mustContain": "html"
@@ -56,25 +37,6 @@
     },
     {
       "path": "/nested",
-      "status": 200,
-      "headers": {
-        "RSC": 1
-      },
-      "mustNotContain": "<html",
-      "mustContain": "catch-all"
-    },
-    {
-      "path": "/nested/index",
-      "status": 200,
-      "mustContain": "html"
-    },
-    {
-      "path": "/nested/index",
-      "status": 200,
-      "mustContain": "catch-all"
-    },
-    {
-      "path": "/nested/index",
       "status": 200,
       "headers": {
         "RSC": 1

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -452,15 +452,7 @@ it('Should throw when package.json or next.config.js is not the "src"', async ()
 });
 
 it('Should build the serverless-config-async example', async () => {
-  let error = null;
-
-  try {
-    await runBuildLambda(path.join(__dirname, '..', 'serverless-config-async'));
-  } catch (err) {
-    error = err;
-  }
-
-  expect(error).toBe(null);
+  await runBuildLambda(path.join(__dirname, 'serverless-config-async'));
 });
 
 describe('Middleware simple project', () => {

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -451,6 +451,18 @@ it('Should throw when package.json or next.config.js is not the "src"', async ()
   }
 });
 
+it('Should build the serverless-config-async example', async () => {
+  let error = null;
+
+  try {
+    await runBuildLambda(path.join(__dirname, '..', 'serverless-config-async'));
+  } catch (err) {
+    error = err;
+  }
+
+  expect(error).toBe(null);
+});
+
 describe('Middleware simple project', () => {
   const ctx = {};
 

--- a/packages/next/test/integration/legacy/integration-legacy.test.js
+++ b/packages/next/test/integration/legacy/integration-legacy.test.js
@@ -247,18 +247,6 @@ it('Should opt-out of shared lambdas when routes are detected', async () => {
   expect(hasUnderScoreErrorStaticFile).toBeTruthy();
 });
 
-it('Should build the serverless-config-async example', async () => {
-  let error = null;
-
-  try {
-    await runBuildLambda(path.join(__dirname, '..', 'serverless-config-async'));
-  } catch (err) {
-    error = err;
-  }
-
-  expect(error).toBe(null);
-});
-
 it('Should provide lambda info when limit is hit (shared lambdas)', async () => {
   let logs = '';
 

--- a/packages/next/test/unit/utils.test.ts
+++ b/packages/next/test/unit/utils.test.ts
@@ -426,10 +426,10 @@ describe('normalizePrefetches', () => {
 
     expect(Object.keys(updatedPrefetches)).toEqual([
       '__index.prefetch.rsc',
-      'index/__index.prefetch.rsc',
-      '__foo.prefetch.rsc',
-      'foo/__index.prefetch.rsc',
-      'foo/bar/__baz.prefetch.rsc',
+      'index/index.prefetch.rsc',
+      'foo.prefetch.rsc',
+      'foo/index.prefetch.rsc',
+      'foo/bar/baz.prefetch.rsc',
     ]);
   });
 });


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/10750 this removes the underscore prefetching from all prefetch outputs and instead only applies it to the index route itself as this causes issues with PPR making these outputs prerenders and being able to interpolate the route param values. 

There is the edge case of a user returning the literal value `index` from `generateStaticParams` but we can tolerate that more than ppr not working as expected. 