### PR TITLE
[error-utils] fix jest coverage issue

### DIFF
--- a/.changeset/mean-tips-provide.md
+++ b/.changeset/mean-tips-provide.md
@@ -1,0 +1,4 @@
+---
+---
+
+[error-utils] fix jest coverage issue

--- a/packages/error-utils/tsconfig.json
+++ b/packages/error-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
+    "sourceMap": true,
     "types": ["node", "jest"]
   },
   "extends": "../../tsconfig.base.json",


### PR DESCRIPTION
Due to a recent change to the error-utils package, our CI is finally running those tests (https://github.com/vercel/vercel/actions/runs/6711642045/job/18239491622) and it was discovered that Jest's coverage is broken due to another change made many weeks ago: https://github.com/vercel/vercel/pull/10667

Enabling `sourceMap` option in the package's tsconfig fixes this known Jest bug (https://github.com/kulshekhar/ts-jest/issues/378)