### PR TITLE
Project limits error handling

### DIFF
--- a/.changeset/nasty-bikes-beam.md
+++ b/.changeset/nasty-bikes-beam.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Handle `TooManyProjects` error in places where projects are created

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -428,7 +428,8 @@ export type ProjectLinkedError = {
     | 'TEAM_DELETED'
     | 'PATH_IS_FILE'
     | 'INVALID_ROOT_DIRECTORY'
-    | 'MISSING_PROJECT_SETTINGS';
+    | 'MISSING_PROJECT_SETTINGS'
+    | 'TOO_MANY_PROJECTS';
 };
 
 export type ProjectLinkResult =

--- a/packages/cli/src/commands/project/add.ts
+++ b/packages/cli/src/commands/project/add.ts
@@ -3,6 +3,7 @@ import ms from 'ms';
 import Client from '../../util/client';
 import { isAPIError } from '../../util/errors-ts';
 import { getCommandName } from '../../util/pkg-name';
+import createProject from '../../util/projects/create-project';
 
 export default async function add(
   client: Client,
@@ -32,12 +33,14 @@ export default async function add(
   const start = Date.now();
 
   const [name] = args;
+
   try {
-    await client.fetch('/projects', {
-      method: 'POST',
-      body: { name },
-    });
+    await createProject(client, { name });
   } catch (err: unknown) {
+    if (isAPIError(err) && err.code === 'too_many_projects') {
+      output.prettyError(err);
+      return 1;
+    }
     if (isAPIError(err) && err.status === 409) {
       // project already exists, so we can
       // show a success message

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -21,6 +21,7 @@ import createProject from '../projects/create-project';
 import { detectProjects } from '../projects/detect-projects';
 import { repoInfoToUrl } from '../git/repo-info-to-url';
 import { connectGitProvider, parseRepoUrl } from '../git/connect-git-provider';
+import { isAPIError } from '../errors-ts';
 
 const home = homedir();
 
@@ -283,24 +284,31 @@ export async function ensureRepoLink(
       output.spinner(`Creating new Project: ${orgAndName}`);
       delete selection.newProject;
       if (!selection.rootDirectory) delete selection.rootDirectory;
-      const project = (selected[i] = await createProject(client, {
-        ...selection,
-        framework: selection.framework.slug,
-      }));
-      await connectGitProvider(
-        client,
-        org,
-        project.id,
-        parsedRepoUrl.provider,
-        `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
-      );
-      output.log(
-        `Created new Project: ${output.link(
-          orgAndName,
-          `https://vercel.com/${orgAndName}`,
-          { fallback: false }
-        )}`
-      );
+      try {
+        const project = (selected[i] = await createProject(client, {
+          ...selection,
+          framework: selection.framework.slug,
+        }));
+        await connectGitProvider(
+          client,
+          org,
+          project.id,
+          parsedRepoUrl.provider,
+          `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
+        );
+        output.log(
+          `Created new Project: ${output.link(
+            orgAndName,
+            `https://vercel.com/${orgAndName}`,
+            { fallback: false }
+          )}`
+        );
+      } catch (err) {
+        if (isAPIError(err) && err.code === 'too_many_projects') {
+          output.prettyError(err);
+          return;
+        }
+      }
     }
 
     repoConfig = {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -263,6 +263,10 @@ export default async function setupAndLink(
 
     return { status: 'linked', org, project };
   } catch (err) {
+    if (isAPIError(err) && err.code === 'too_many_projects') {
+      output.prettyError(err);
+      return { status: 'error', exitCode: 1, reason: 'TOO_MANY_PROJECTS' };
+    }
     handleError(err);
 
     return { status: 'error', exitCode: 1 };

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -357,7 +357,7 @@ export function useProject(
       pagination: null,
     });
   });
-  client.scenario.post(`/projects`, (req, res) => {
+  client.scenario.post(`/v1/projects`, (req, res) => {
     const { name } = req.body;
     if (name === project.name) {
       res.json(project);


### PR DESCRIPTION
This PR adds improved error handling for the 200 project limit error that will start being returned for free tier teams/accounts.  The following changes have been made:
- improve error message format by using `client.output.prettyError` so that the docs link (https://vercel.com/docs/limits/overview#general-limits) returned with the error response is included with the error message 
- add explicit error handling of this error from any places where `createProject` is called, which includes the following commands:
  - `vc project add`
  - `vc link` (indirectly called via `ensureLink`)
  - `vc list` (indirectly called via `ensureLink`)
  - `vc git connect` (indirectly called via `ensureLink`)

### Testing
- sign in to a vercel account that is associated with your work email (ends in `@vercel.com`), this is necessary for creating a team with the proper conditions to artificially trigger the error message
- create a Pro Trial team and make sure to prefix the name with: `vtest314 too many projects `, for example `vtest314 too many projects test 1`
- check out this branch and cd to `vercel/vercel/packages/cli`
- run: `pnpm dev add [project-name] --cwd=/path/to/some/project`
- the project should fail to be created and you should see the expected error message (screenshot below) in the terminal output

**Screenshot of error message when attempting to add project from cli**
<img width="798" alt="image" src="https://github.com/vercel/vercel/assets/14896430/43e6ac2c-ae1c-4367-8d57-0aeb7fbddf33">