### PR TITLE
[remix] Fix issue where `npm install` was not properly injecting forked compiler

### DIFF
--- a/.changeset/fast-glasses-wonder.md
+++ b/.changeset/fast-glasses-wonder.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fix issue where `npm install` was not properly injecting forked compiler

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -225,6 +225,7 @@ export const build: BuildV2 = async ({
     // Remove the env vars that will cause pnpm to consider
     // as CI, which enables `--frozen-lockfile` enforcement
     const nonCiEnv = { ...spawnOpts.env };
+    console.log(nonCiEnv);
     delete nonCiEnv.VERCEL;
     delete nonCiEnv.NOW_BUILDER;
 

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -222,13 +222,22 @@ export const build: BuildV2 = async ({
   if (depsModified) {
     await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
 
+    // Remove the env vars that will cause pnpm to consider
+    // as CI, which enables `--frozen-lockfile` enforcement
+    const nonCiEnv = { ...spawnOpts.env };
+    delete nonCiEnv.VERCEL;
+    delete nonCiEnv.NOW_BUILDER;
+
     // Purposefully not passing `meta` here to avoid
     // the optimization that prevents `npm install`
     // from running a second time
     await runNpmInstall(
       entrypointFsDirname,
       [],
-      spawnOpts,
+      {
+        ...spawnOpts,
+        env: nonCiEnv,
+      },
       undefined,
       nodeVersion
     );

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -222,13 +222,12 @@ export const build: BuildV2 = async ({
   if (depsModified) {
     await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
 
-    // Remove the env vars that will cause pnpm to consider
-    // as CI, which enables `--frozen-lockfile` enforcement
+    // Bypass `--frozen-lockfile` enforcement by removing
+    // env vars that are considered to be CI
     const nonCiEnv = { ...spawnOpts.env };
     delete nonCiEnv.CI;
     delete nonCiEnv.VERCEL;
     delete nonCiEnv.NOW_BUILDER;
-    console.log(nonCiEnv);
 
     // Purposefully not passing `meta` here to avoid
     // the optimization that prevents `npm install`

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -40,7 +40,6 @@ import {
   ResolvedEdgeRouteConfig,
   findEntry,
   chdirAndReadConfig,
-  addDependencies,
   resolveSemverMinMax,
   ensureResolvable,
   isESM,
@@ -166,7 +165,7 @@ export const build: BuildV2 = async ({
   const { serverEntryPoint, appDirectory } = remixConfig;
   const remixRoutes = Object.values(remixConfig.routes);
 
-  const depsToAdd: string[] = [];
+  let depsModified = false;
 
   const remixRunDevPkgVersion: string | undefined =
     pkg.dependencies?.['@remix-run/dev'] ||
@@ -184,9 +183,15 @@ export const build: BuildV2 = async ({
       REMIX_RUN_DEV_MAX_VERSION,
       remixVersion
     );
-    depsToAdd.push(
-      `@remix-run/dev@npm:@vercel/remix-run-dev@${remixDevForkVersion}`
-    );
+    // Remove `@remix-run/dev`, add `@vercel/remix-run-dev`
+    if (pkg.devDependencies['@remix-run/dev']) {
+      delete pkg.devDependencies['@remix-run/dev'];
+      pkg.devDependencies['@vercel/remix-run-dev'] = remixDevForkVersion;
+    } else {
+      delete pkg.dependencies['@remix-run/dev'];
+      pkg.dependencies['@vercel/remix-run-dev'] = remixDevForkVersion;
+    }
+    depsModified = true;
   }
 
   // `app/entry.server.tsx` and `app/entry.client.tsx` are optional in Remix,
@@ -209,15 +214,24 @@ export const build: BuildV2 = async ({
         REMIX_RUN_DEV_MAX_VERSION,
         remixVersion
       );
-      depsToAdd.push(`@vercel/remix@${vercelRemixVersion}`);
+      pkg.dependencies['@vercel/remix'] = vercelRemixVersion;
+      depsModified = true;
     }
   }
 
-  if (depsToAdd.length) {
-    await addDependencies(cliType, depsToAdd, {
-      ...spawnOpts,
-      cwd: entrypointFsDirname,
-    });
+  if (depsModified) {
+    await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+
+    // Purposefully not passing `meta` here to avoid
+    // the optimization that prevents `npm install`
+    // from running a second time
+    await runNpmInstall(
+      entrypointFsDirname,
+      [],
+      spawnOpts,
+      undefined,
+      nodeVersion
+    );
   }
 
   const userEntryClientFile = findEntry(

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -225,9 +225,10 @@ export const build: BuildV2 = async ({
     // Remove the env vars that will cause pnpm to consider
     // as CI, which enables `--frozen-lockfile` enforcement
     const nonCiEnv = { ...spawnOpts.env };
-    console.log(nonCiEnv);
+    delete nonCiEnv.CI;
     delete nonCiEnv.VERCEL;
     delete nonCiEnv.NOW_BUILDER;
+    console.log(nonCiEnv);
 
     // Purposefully not passing `meta` here to avoid
     // the optimization that prevents `npm install`


### PR DESCRIPTION
User reported a scenario in which npm was ignoring the second `npm install` command to replace the Remix compiler with our forked version. This seems like a bug in npm. Workaround that seems to work is to remove `@remix-run/dev` entirely and install our forked version as a "standard" dependency (instead of using the `npm:` syntax). The `bin` entry for `remix` should at that point be our forked compiler.