### PR TITLE
[build-utils] Select Node.js version based on what's available in build-container

### DIFF
--- a/.changeset/cuddly-squids-cough.md
+++ b/.changeset/cuddly-squids-cough.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Select Node.js version based on what's available in build-container

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -9,7 +9,11 @@ import { deprecate } from 'util';
 import debug from '../debug';
 import { NowBuildError } from '../errors';
 import { Meta, PackageJson, NodeVersion, Config } from '../types';
-import { getSupportedNodeVersion, getLatestNodeVersion } from './node-version';
+import {
+  getSupportedNodeVersion,
+  getLatestNodeVersion,
+  getAvailableNodeVersions,
+} from './node-version';
 import { readConfigFile } from './read-config-file';
 import { cloneEnv } from '../clone-env';
 
@@ -238,9 +242,10 @@ export async function getNodeVersion(
   destPath: string,
   nodeVersionFallback = process.env.VERCEL_PROJECT_SETTINGS_NODE_VERSION,
   config: Config = {},
-  meta: Meta = {}
+  meta: Meta = {},
+  availableVersions = getAvailableNodeVersions()
 ): Promise<NodeVersion> {
-  const latest = getLatestNodeVersion();
+  const latest = getLatestNodeVersion(availableVersions);
   if (meta.isDev) {
     // Use the system-installed version of `node` in PATH for `vercel dev`
     return { ...latest, runtime: 'nodejs' };
@@ -266,7 +271,7 @@ export async function getNodeVersion(
     nodeVersion = node;
     isAuto = false;
   }
-  return getSupportedNodeVersion(nodeVersion, isAuto);
+  return getSupportedNodeVersion(nodeVersion, isAuto, availableVersions);
 }
 
 export async function scanParentDirs(

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -127,6 +127,27 @@ it('should allow nodejs18.x', async () => {
   expect(await getSupportedNodeVersion('>=16')).toHaveProperty('major', 18);
 });
 
+it('should not allow nodejs20.x when not available', async () => {
+  // Simulates AL2 build-container
+  await expect(
+    getSupportedNodeVersion('20.x', true, [14, 16, 18])
+  ).rejects.toThrow(
+    'Found invalid Node.js Version: "20.x". Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.'
+  );
+});
+
+it('should not allow nodejs18.x when not available', async () => {
+  // Simulates AL2023 build-container
+  try {
+    process.env.VERCEL_ALLOW_NODEJS20 = '1';
+    await expect(getSupportedNodeVersion('18.x', true, [20])).rejects.toThrow(
+      'Found invalid Node.js Version: "18.x". Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.'
+    );
+  } finally {
+    delete process.env.VERCEL_ALLOW_NODEJS20;
+  }
+});
+
 it('should ignore node version in vercel dev getNodeVersion()', async () => {
   expect(
     await getNodeVersion(
@@ -233,6 +254,21 @@ it('should not warn when package.json engines matches project setting from confi
 
 it('should get latest node version', async () => {
   expect(getLatestNodeVersion()).toHaveProperty('major', 18);
+});
+
+it('should get latest node version with Node 18.x in build-container', async () => {
+  // Simulates AL2 build-container
+  expect(getLatestNodeVersion([14, 16, 18])).toHaveProperty('major', 18);
+});
+
+it('should get latest node version with Node 20.x in build-container', async () => {
+  // Simulates AL2023 build-container
+  try {
+    process.env.VERCEL_ALLOW_NODEJS20 = '1';
+    expect(getLatestNodeVersion([20])).toHaveProperty('major', 20);
+  } finally {
+    delete process.env.VERCEL_ALLOW_NODEJS20;
+  }
 });
 
 it('should throw for discontinued versions', async () => {


### PR DESCRIPTION
Makes `getLatestNodeVersion()` and `getSupportedNodeVersion()` (and thus by extension - `getNodeVersion()`) be aware of the available Node.js versions when running inside the build-container. This is to address the situation with the new AL2023 build-container image which has different Node versions installed compared to the existing AL2 build image.

### Project Settings `20.x` with package.json `"engines": "18.x"`

If the Project Settings Node Version is set to `20.x`, but the package.json has `"engines": "18.x"`, then the build will fail like so, because Node 18 is not present on the AL2023 build image:

<img width="1044" alt="Screenshot 2023-11-09 at 1 25 41 PM" src="https://github.com/vercel/vercel/assets/71256/572c544b-6574-4eb1-98f7-787075a60000">

### Project Settings `18.x` with package.json `"engines": "20.x"`

If the Project Settings Node Version is set to `18.x`, but the package.json has `"engines": "20.x"`, then the build will fail like so, because Node 20 is not present on the AL2 build image:

<img width="1042" alt="Screenshot 2023-11-09 at 1 34 43 PM" src="https://github.com/vercel/vercel/assets/71256/c6a2d955-9453-4ef5-a99d-b49a6d9af766">

### Project Settings `18.x` with no package.json `"engines"`

If Project Settings Node Version is set to `18.x`, but the package.json has no "engines" (and thus wants "latest"), then the latest available Node version in the build-container, which would be Node 18.
