### PR TITLE
[build-utils] Remove Node v20 env var check

### DIFF
--- a/.changeset/little-readers-explain.md
+++ b/.changeset/little-readers-explain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Remove Node.js v20 env var check

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -8,6 +8,7 @@ export type NodeVersionMajor = ReturnType<typeof getOptions>[number]['major'];
 
 function getOptions() {
   const options = [
+    { major: 20, range: '20.x', runtime: 'nodejs20.x' },
     { major: 18, range: '18.x', runtime: 'nodejs18.x' },
     {
       major: 16,
@@ -40,12 +41,6 @@ function getOptions() {
       discontinueDate: new Date('2020-01-06'),
     },
   ] as const;
-  if (process.env.VERCEL_ALLOW_NODEJS20 === '1') {
-    return [
-      { major: 20, range: '20.x', runtime: 'nodejs20.x' },
-      ...options,
-    ] as const;
-  }
   return options;
 }
 
@@ -64,8 +59,8 @@ export function getAvailableNodeVersions(): NodeVersionMajor[] {
     .map(n => n.major);
 }
 
-function getHint(isAuto = false) {
-  const { major, range } = getLatestNodeVersion();
+function getHint(isAuto = false, availableVersions?: NodeVersionMajor[]) {
+  const { major, range } = getLatestNodeVersion(availableVersions);
   return isAuto
     ? `Please set Node.js Version to ${range} in your Project Settings to use Node.js ${major}.`
     : `Please set "engines": { "node": "${range}" } in your \`package.json\` file to use Node.js ${major}.`;
@@ -119,7 +114,8 @@ export async function getSupportedNodeVersion(
         code: 'BUILD_UTILS_NODE_VERSION_INVALID',
         link: 'http://vercel.link/node-version',
         message: `Found invalid Node.js Version: "${engineRange}". ${getHint(
-          isAuto
+          isAuto,
+          availableVersions
         )}`,
       });
     }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -60,7 +60,7 @@ it('should only match supported node versions, otherwise throw an error', async 
   );
 
   const autoMessage =
-    'Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.';
+    'Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.';
   await expectBuilderError(
     getSupportedNodeVersion('8.11.x', true),
     autoMessage
@@ -80,7 +80,7 @@ it('should only match supported node versions, otherwise throw an error', async 
   );
 
   const foundMessage =
-    'Please set "engines": { "node": "18.x" } in your `package.json` file to use Node.js 18.';
+    'Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.';
   await expectBuilderError(
     getSupportedNodeVersion('8.11.x', false),
     foundMessage
@@ -101,8 +101,8 @@ it('should match all semver ranges', async () => {
   // See https://docs.npmjs.com/files/package.json#engines
   expect(await getSupportedNodeVersion('16.0.0')).toHaveProperty('major', 16);
   expect(await getSupportedNodeVersion('16.x')).toHaveProperty('major', 16);
-  expect(await getSupportedNodeVersion('>=10')).toHaveProperty('major', 18);
-  expect(await getSupportedNodeVersion('>=10.3.0')).toHaveProperty('major', 18);
+  expect(await getSupportedNodeVersion('>=10')).toHaveProperty('major', 20);
+  expect(await getSupportedNodeVersion('>=10.3.0')).toHaveProperty('major', 20);
   expect(await getSupportedNodeVersion('16.5.0 - 16.9.0')).toHaveProperty(
     'major',
     16
@@ -120,11 +120,17 @@ it('should match all semver ranges', async () => {
 });
 
 it('should allow nodejs18.x', async () => {
-  expect(getLatestNodeVersion()).toHaveProperty('major', 18);
   expect(await getSupportedNodeVersion('18.x')).toHaveProperty('major', 18);
   expect(await getSupportedNodeVersion('18')).toHaveProperty('major', 18);
   expect(await getSupportedNodeVersion('18.1.0')).toHaveProperty('major', 18);
-  expect(await getSupportedNodeVersion('>=16')).toHaveProperty('major', 18);
+});
+
+it('should allow nodejs20.x', async () => {
+  expect(getLatestNodeVersion()).toHaveProperty('major', 20);
+  expect(await getSupportedNodeVersion('20.x')).toHaveProperty('major', 20);
+  expect(await getSupportedNodeVersion('20')).toHaveProperty('major', 20);
+  expect(await getSupportedNodeVersion('20.1.0')).toHaveProperty('major', 20);
+  expect(await getSupportedNodeVersion('>=18')).toHaveProperty('major', 20);
 });
 
 it('should not allow nodejs20.x when not available', async () => {
@@ -138,14 +144,9 @@ it('should not allow nodejs20.x when not available', async () => {
 
 it('should not allow nodejs18.x when not available', async () => {
   // Simulates AL2023 build-container
-  try {
-    process.env.VERCEL_ALLOW_NODEJS20 = '1';
-    await expect(getSupportedNodeVersion('18.x', true, [20])).rejects.toThrow(
-      'Found invalid Node.js Version: "18.x". Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.'
-    );
-  } finally {
-    delete process.env.VERCEL_ALLOW_NODEJS20;
-  }
+  await expect(getSupportedNodeVersion('18.x', true, [20])).rejects.toThrow(
+    'Found invalid Node.js Version: "18.x". Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.'
+  );
 });
 
 it('should ignore node version in vercel dev getNodeVersion()', async () => {
@@ -214,7 +215,7 @@ it('should warn when package.json engines is greater than', async () => {
       {},
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '20.x');
   expect(warningMessages).toStrictEqual([
     'Warning: Detected "engines": { "node": ">=16" } in your `package.json` that will automatically upgrade when a new major Node.js Version is released. Learn More: http://vercel.link/node-version',
   ]);
@@ -253,7 +254,7 @@ it('should not warn when package.json engines matches project setting from confi
 });
 
 it('should get latest node version', async () => {
-  expect(getLatestNodeVersion()).toHaveProperty('major', 18);
+  expect(getLatestNodeVersion()).toHaveProperty('major', 20);
 });
 
 it('should get latest node version with Node 18.x in build-container', async () => {
@@ -263,12 +264,7 @@ it('should get latest node version with Node 18.x in build-container', async () 
 
 it('should get latest node version with Node 20.x in build-container', async () => {
   // Simulates AL2023 build-container
-  try {
-    process.env.VERCEL_ALLOW_NODEJS20 = '1';
-    expect(getLatestNodeVersion([20])).toHaveProperty('major', 20);
-  } finally {
-    delete process.env.VERCEL_ALLOW_NODEJS20;
-  }
+  expect(getLatestNodeVersion([20])).toHaveProperty('major', 20);
 });
 
 it('should throw for discontinued versions', async () => {
@@ -336,34 +332,17 @@ it('should warn for deprecated versions, soon to be discontinued', async () => {
     16
   );
   expect(warningMessages).toStrictEqual([
-    'Error: Node.js version 10.x has reached End-of-Life. Deployments created on or after 2021-04-20 will fail to build. Please set "engines": { "node": "18.x" } in your `package.json` file to use Node.js 18.',
-    'Error: Node.js version 10.x has reached End-of-Life. Deployments created on or after 2021-04-20 will fail to build. Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.',
-    'Error: Node.js version 12.x has reached End-of-Life. Deployments created on or after 2022-10-03 will fail to build. Please set "engines": { "node": "18.x" } in your `package.json` file to use Node.js 18.',
-    'Error: Node.js version 12.x has reached End-of-Life. Deployments created on or after 2022-10-03 will fail to build. Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.',
-    'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set "engines": { "node": "18.x" } in your `package.json` file to use Node.js 18.',
-    'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.',
-    'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2024-02-06 will fail to build. Please set "engines": { "node": "18.x" } in your `package.json` file to use Node.js 18.',
-    'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2024-02-06 will fail to build. Please set Node.js Version to 18.x in your Project Settings to use Node.js 18.',
+    'Error: Node.js version 10.x has reached End-of-Life. Deployments created on or after 2021-04-20 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
+    'Error: Node.js version 10.x has reached End-of-Life. Deployments created on or after 2021-04-20 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
+    'Error: Node.js version 12.x has reached End-of-Life. Deployments created on or after 2022-10-03 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
+    'Error: Node.js version 12.x has reached End-of-Life. Deployments created on or after 2022-10-03 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
+    'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
+    'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
+    'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2024-02-06 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
+    'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2024-02-06 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
   ]);
 
   global.Date.now = realDateNow;
-});
-
-it('should only allow nodejs20.x when env var is set', async () => {
-  try {
-    expect(getLatestNodeVersion()).toHaveProperty('major', 18);
-    await expect(getSupportedNodeVersion('20.x')).rejects.toThrow();
-
-    process.env.VERCEL_ALLOW_NODEJS20 = '1';
-
-    expect(getLatestNodeVersion()).toHaveProperty('major', 20);
-    expect(await getSupportedNodeVersion('20.x')).toHaveProperty('major', 20);
-    expect(await getSupportedNodeVersion('20')).toHaveProperty('major', 20);
-    expect(await getSupportedNodeVersion('20.1.0')).toHaveProperty('major', 20);
-    expect(await getSupportedNodeVersion('>=16')).toHaveProperty('major', 20);
-  } finally {
-    delete process.env.VERCEL_ALLOW_NODEJS20;
-  }
 });
 
 it('should support initialHeaders and initialStatus correctly', async () => {


### PR DESCRIPTION
It's safe to remove this env var check, because #10822 makes it explicit on which versions of Node are actually present in the build environment.