### PR TITLE
[docs] mention nodejs20.x in LambdaRuntime

### DIFF
--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -385,6 +385,7 @@ This is a [class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refere
 
 This is an abstract enumeration type that is implemented by one of the following possible `String` values:
 
+- `nodejs20.x`
 - `nodejs18.x`
 - `nodejs16.x`
 - `go1.x`


### PR DESCRIPTION
The error message when trying to deploy with an invalid runtime value leads you there, where `nodejs20.x` is missing currently