### PR TITLE
[next] ensure function configs apply to route groups

### DIFF
--- a/.changeset/eighty-sheep-beam.md
+++ b/.changeset/eighty-sheep-beam.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+ensure function configs work for paths inside of route groups

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,11 @@ jobs:
         if: matrix.runner == 'macos-latest'
         run: curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.56.0/hugo_0.56.0_macOS-64bit.tar.gz && tar -xzf hugo_0.56.0_macOS-64bit.tar.gz && mv ./hugo packages/cli/test/dev/fixtures/08-hugo/
 
+      # yarn 1.22.21 introduced a Corepack bug when running tests.
+      # this can be removed once https://github.com/yarnpkg/yarn/issues/9015 is resolved
+      - name: install yarn@1.22.19
+        run: npm i -g yarn@1.22.19
+
       - name: install pnpm@8.3.1
         run: npm i -g pnpm@8.3.1
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -875,6 +875,7 @@ export async function serverBuild({
       initialPseudoLayerUncompressed: uncompressedInitialSize,
       internalPages,
       pageExtensions,
+      inversedAppPathManifest,
     });
 
     const appRouteHandlersLambdaGroups = await getPageLambdaGroups({
@@ -892,6 +893,7 @@ export async function serverBuild({
       initialPseudoLayerUncompressed: uncompressedInitialSize,
       internalPages,
       pageExtensions,
+      inversedAppPathManifest,
     });
 
     for (const group of appRouterLambdaGroups) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1501,6 +1501,7 @@ export async function getPageLambdaGroups({
   lambdaCompressedByteLimit,
   internalPages,
   pageExtensions,
+  inversedAppPathManifest,
 }: {
   entryPath: string;
   config: Config;
@@ -1522,6 +1523,7 @@ export async function getPageLambdaGroups({
   lambdaCompressedByteLimit: number;
   internalPages: string[];
   pageExtensions?: string[];
+  inversedAppPathManifest?: Record<string, string>;
 }) {
   const groups: Array<LambdaGroup> = [];
 
@@ -1541,9 +1543,15 @@ export async function getPageLambdaGroups({
     }
 
     if (config && config.functions) {
+      // `pages` are normalized without route groups (e.g., /app/(group)/page.js).
+      // we keep track of that mapping in `inversedAppPathManifest`
+      // `getSourceFilePathFromPage` needs to use the path from source to properly match the config
+      const pageFromManifest = inversedAppPathManifest?.[routeName];
       const sourceFile = await getSourceFilePathFromPage({
         workPath: entryPath,
-        page,
+        // since this function is used by both `pages` and `app`, the manifest might not be provided
+        // so fallback to normal behavior of just checking the `page`.
+        page: pageFromManifest ?? page,
         pageExtensions,
       });
 

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/api/hello-again/with-group/(group)/route.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/api/hello-again/with-group/(group)/route.js
@@ -1,0 +1,4 @@
+export const GET = req => {
+  console.log(req.url);
+  return new Response('hello world');
+};

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic-group/[slug]/(group)/page.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic-group/[slug]/(group)/page.js
@@ -1,0 +1,11 @@
+export default function Page({params}) {
+  return (
+    <>
+      <p>
+        Catch All Page. Params:{' '}
+        <span id="catch-all-page-params">{JSON.stringify(params)}</span>
+      </p>
+      {children}
+    </>
+  );  
+}

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -91,6 +91,8 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
       'api/hello',
       // app dir route handler
       'api/hello-again',
+      // app dir route handler inside of a group
+      'api/hello-again/with-group',
       // server component inside of a group
       'dynamic-group/[slug]',
       'dynamic-group/[slug].rsc',

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -85,15 +85,25 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
     expect(buildResult.output['dashboard/changelog']).toBeDefined();
     expect(buildResult.output['dashboard/deployments/[id]']).toBeDefined();
 
-    expect(buildResult.output['api/hello']).toBeDefined();
-    expect(buildResult.output['api/hello'].type).toBe('Lambda');
-    expect(buildResult.output['api/hello'].memory).toBe(512);
-    expect(buildResult.output['api/hello'].maxDuration).toBe(5);
+    // ensure that function configs are properly applied across pages & app dir outputs
+    [
+      // pages dir route handler
+      'api/hello',
+      // app dir route handler
+      'api/hello-again',
+      // server component inside of a group
+      'dynamic-group/[slug]',
+      'dynamic-group/[slug].rsc',
+      // server component
+      'dynamic/[category]/[id]',
+      'dynamic/[category]/[id].rsc',
+    ].forEach(fnKey => {
+      expect(buildResult.output[fnKey]).toBeDefined();
+      expect(buildResult.output[fnKey].type).toBe('Lambda');
+      expect(buildResult.output[fnKey].memory).toBe(512);
+      expect(buildResult.output[fnKey].maxDuration).toBe(5);
+    });
 
-    expect(buildResult.output['api/hello-again']).toBeDefined();
-    expect(buildResult.output['api/hello-again'].type).toBe('Lambda');
-    expect(buildResult.output['api/hello-again'].memory).toBe(512);
-    expect(buildResult.output['api/hello-again'].maxDuration).toBe(5);
     expect(
       buildResult.output['api/hello-again'].supportsResponseStreaming
     ).toBe(true);


### PR DESCRIPTION
`getSourceFilePathFromPage` attempts to match patterns found in `vercel.json` with source files. However, the `page` argument to this function is stripped of route groups, so these files are erroneously skipped and function settings are not applied. 

For app-dir routes which might contain route groups, this checks an internal mapping which maps the "normalized" paths (e.g. `app/dashboard/[slug]/page.js`) to the file-system path (e.g. `app/dashboard/[slug]/(group)/page.js`)