### PR TITLE
Revert "[go] Set Lambda runtime to `provided.al2`"

### DIFF
--- a/.changeset/thirty-birds-decide.md
+++ b/.changeset/thirty-birds-decide.md
@@ -1,5 +1,0 @@
----
-'@vercel/go': patch
----
-
-Set Lambda runtime to "provided.al2"

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -388,13 +388,13 @@ This is an abstract enumeration type that is implemented by one of the following
 - `nodejs20.x`
 - `nodejs18.x`
 - `nodejs16.x`
+- `go1.x`
 - `java11`
 - `python3.9`
 - `dotnet6`
 - `dotnetcore3.1`
 - `ruby2.7`
 - `provided.al2`
-- `provided.al2023`
 
 ## `@vercel/build-utils` Helper Functions
 

--- a/packages/go/src/index.ts
+++ b/packages/go/src/index.ts
@@ -50,7 +50,7 @@ export { shouldServe };
 // we need our `main.go` to be called something else
 const MAIN_GO_FILENAME = 'main__vc__go__.go';
 
-const HANDLER_FILENAME = `bootstrap${OUT_EXTENSION}`;
+const HANDLER_FILENAME = `handler${OUT_EXTENSION}`;
 
 interface PortInfo {
   port: number;
@@ -252,7 +252,7 @@ export async function build({
     const lambda = new Lambda({
       files: { ...(await glob('**', outDir)), ...includedFiles },
       handler: HANDLER_FILENAME,
-      runtime: 'provided.al2',
+      runtime: 'go1.x',
       supportsWrapper: true,
       environment: {},
     });


### PR DESCRIPTION
This reverts commit 4b8b4992c4524eb8bb97e90a72c137e329dbbeb1.

We'll re-land this after Thanksgiving.