### PR TITLE
Update placeholder for Nuxt to be correct command.

### DIFF
--- a/.changeset/grumpy-wasps-protect.md
+++ b/.changeset/grumpy-wasps-protect.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+Update placeholder for Nuxt to be correct command.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1456,8 +1456,8 @@ export const frameworks = [
           '`yarn install`, `pnpm install`, `npm install`, or `bun install`',
       },
       buildCommand: {
-        placeholder: '`npm run build` or `nuxt generate`',
-        value: 'nuxt generate',
+        placeholder: '`npm run build` or `nuxt build`',
+        value: 'nuxt build',
       },
       devCommand: {
         value: 'nuxt',


### PR DESCRIPTION
We are not running `nuxt generate`, but instead, `nuxt build`. This is important because it means you can take advantage of Nuxt server features, like SSR and ISR.