### PR TITLE
Update Next.js screenshot preview

### DIFF
--- a/.changeset/gentle-penguins-warn.md
+++ b/.changeset/gentle-penguins-warn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+This new screenshot matches the template. It removes the version number so this screenshot will not go stale.

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -66,7 +66,7 @@ export const frameworks = [
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/next-dark.svg',
     screenshot:
-      'https://assets.vercel.com/image/upload/v1673027027/front/import/nextjs.png',
+      'https://assets.vercel.com/image/upload/v1701461207/front/import/nextjs.png',
     tagline:
       'Next.js makes you productive with React instantly — whether you want to build static or dynamic sites.',
     description: 'A Next.js app and a Serverless Function API.',


### PR DESCRIPTION
This new screenshot matches the template. It removes the version number so this screenshot will not go stale.