### PR TITLE
[cli] respect install command

### DIFF
--- a/.changeset/mighty-pants-pull.md
+++ b/.changeset/mighty-pants-pull.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[cli] respect install command


### PR DESCRIPTION
Although I have this setting in my project:

![CleanShot 2023-12-08 at 13 27 52@2x](https://github.com/vercel/vercel/assets/2096101/b8bbab46-a398-4167-8993-1586469c447b)

pnpm will be never used unless my project doesn't have a lockfile present. Although I can understand the decision there, it's totally fine to run pnpm without lockfile (in fact, my build is failing because it's using yarn, but working flawless installing via pnpm), but even better, it allows any user to run the desired package manager without being vendorlocking to yarn.