### PR TITLE
[cli] Clean up `project ls --deprecate`

### DIFF
--- a/.changeset/pink-coins-destroy.md
+++ b/.changeset/pink-coins-destroy.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove some debug statements and make log into warning

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -60,14 +60,13 @@ export default async function list(
     const upcomingDeprecationVersionsList = upcomingDeprecationVersions.map(
       nodeVersion => nodeVersion.range
     );
-    console.log(projectList);
     projectList = projectList.filter(
       project =>
         project.nodeVersion &&
         upcomingDeprecationVersionsList.includes(project.nodeVersion)
     );
 
-    output.log(
+    output.warn(
       `The following Node.js versions will be deprecated soon: ${upcomingDeprecationVersionsList.join(
         ', '
       )}. Upgrade your projects immediately.`

--- a/packages/cli/test/unit/commands/project.test.ts
+++ b/packages/cli/test/unit/commands/project.test.ts
@@ -55,8 +55,6 @@ describe('project', () => {
         nodeVersion: '16.x',
       });
 
-      console.log(project);
-
       client.setArgv('project', 'ls', '--deprecated');
       await projects(client);
 
@@ -67,7 +65,7 @@ describe('project', () => {
 
       line = await lines.next();
       expect(line.value).toEqual(
-        '> The following Node.js versions will be deprecated soon: 16.x. Upgrade your projects immediately.'
+        'WARN! The following Node.js versions will be deprecated soon: 16.x. Upgrade your projects immediately.'
       );
       line = await lines.next();
       expect(line.value).toEqual(


### PR DESCRIPTION
Follow up to #10919

Removes console.log statements and changes log into warning.