### PR TITLE
[tests] Add "Summary" Step to release workflow

### DIFF
--- a/.changeset/big-crews-happen.md
+++ b/.changeset/big-crews-happen.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+[tests] Add "Summary" Step to release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
     name: Summary
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always()
     needs:
       - release
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,13 @@ jobs:
           script: |
             const script = require('./utils/update-latest-release.js')
             await script({ github, context })
+  summary:
+    name: Summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - release
+    steps:
+      - name: Check All
+        run: echo OK


### PR DESCRIPTION
There's some confusion around out workflows and branch protection. We had some mechanism of protecting merges to main that went away. Maybe? Looking at past PRs we can't see any "(Required)" labels so this might be a live rather than cached representation (although adding a new required check doesn't changed these older lists either?).

All very confusing.

Adding a required check for the "Summary" step works to restore the desired behavior on code change PRs, but makes merging [Version Packages](https://github.com/vercel/vercel/pull/10935) PRs unmergeable. Possibly we worked around this before by having admin powers, but @Ethan-Arrowood  (who has such powers) was not able to merge.

Again, all very confusing.

This PR  adds a "Summary" step to https://github.com/vercel/vercel/blob/main/.github/workflows/release.yml that always passes. If this resolves the issue, we can move on with our lives. If not, I'll keep digging.