### PR TITLE
[cli] Use new `deprecated` query param in projects api for `vc project ls --deprecated`

### DIFF
--- a/.changeset/clever-peaches-allow.md
+++ b/.changeset/clever-peaches-allow.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Use new `deprecated` query param in projects api for `vc project ls --deprecated`

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -28,11 +28,12 @@ export default async function list(
 
   output.spinner(`Fetching projects in ${chalk.bold(contextName)}`);
 
-  const deprecated = argv['--deprecated'] || false;
+  let projectsUrl = `/v4/projects/?limit=20`;
 
-  // use a larger limit when `--deprecated`
-  // because client-side filtering produces fewer results
-  let projectsUrl = `/v4/projects/?limit=${deprecated ? 40 : 20}`;
+  const deprecated = argv['--deprecated'] || false;
+  if (deprecated) {
+    projectsUrl += `&deprecated=${deprecated}`;
+  }
 
   const next = argv['--next'] || false;
   if (next) {

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -55,19 +55,16 @@ export default async function list(
   const elapsed = ms(Date.now() - start);
 
   if (deprecated) {
-    const upcomingDeprecationVersions = NODE_VERSIONS.filter(
-      nodeVersion =>
+    const upcomingDeprecationVersionsList = [];
+
+    for (const nodeVersion of NODE_VERSIONS) {
+      if (
         nodeVersion.discontinueDate &&
         nodeVersion.discontinueDate.valueOf() > Date.now()
-    );
-    const upcomingDeprecationVersionsList = upcomingDeprecationVersions.map(
-      nodeVersion => nodeVersion.range
-    );
-    projectList = projectList.filter(
-      project =>
-        project.nodeVersion &&
-        upcomingDeprecationVersionsList.includes(project.nodeVersion)
-    );
+      ) {
+        upcomingDeprecationVersionsList.push(nodeVersion.range);
+      }
+    }
 
     output.warn(
       `The following Node.js versions will be deprecated soon: ${upcomingDeprecationVersionsList.join(


### PR DESCRIPTION
Uses the new `deprecated` query param for the GET /projects API instead of client-side filtering.

This enables a better UX so that results are properly paginated. 

Here are some example runs:

Pagination works as expected:
<img width="831" alt="Screenshot 2023-12-12 at 20 59 57" src="https://github.com/vercel/vercel/assets/16144158/c592752d-bf49-41a0-8dae-8b8e233052f8">

Usage without the flag results in different output (as expected!)
<img width="830" alt="Screenshot 2023-12-12 at 21 04 52" src="https://github.com/vercel/vercel/assets/16144158/c65461e0-b4a0-4725-aaae-a63739e6c8e9">
