### PR TITLE
[gatsby-plugin-vercel-builder] Add support for "rewrites"

### DIFF
--- a/.changeset/sixty-drinks-exist.md
+++ b/.changeset/sixty-drinks-exist.md
@@ -1,0 +1,5 @@
+---
+'@vercel/gatsby-plugin-vercel-builder': patch
+---
+
+Add support for "rewrites"

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -1,4 +1,8 @@
-import { getTransformedRoutes } from '@vercel/routing-utils';
+import {
+  getTransformedRoutes,
+  type Redirect,
+  type Rewrite,
+} from '@vercel/routing-utils';
 import { writeJson } from 'fs-extra';
 import { validateGatsbyState } from './schemas';
 import {
@@ -31,7 +35,7 @@ export async function generateVercelBuildOutputAPI3Output({
   if (validateGatsbyState.Check(state)) {
     console.log('▲ Creating Vercel build output');
 
-    const { pages, redirects, functions, config: gatsbyConfig } = state;
+    const { pages, functions, config: gatsbyConfig } = state;
     const { pathPrefix = '' } = gatsbyConfig;
 
     const ssrRoutes = pages
@@ -60,14 +64,36 @@ export async function generateVercelBuildOutputAPI3Output({
       trailingSlash = false;
     }
 
-    const routes =
-      getTransformedRoutes({
-        trailingSlash,
-        redirects: redirects.map(({ fromPath, toPath, isPermanent }) => ({
+    const redirects: Redirect[] = [];
+    const rewrites: Rewrite[] = [];
+
+    for (const {
+      fromPath,
+      toPath,
+      isPermanent,
+      statusCode,
+    } of state.redirects) {
+      if (statusCode === 200) {
+        // A statusCode of 200 on createRedirect creates a rewrite (i.e. a reverse proxy)
+        // https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/#rewrites-and-reverse-proxies
+        rewrites.push({
+          source: fromPath,
+          destination: toPath,
+        });
+      } else {
+        redirects.push({
           source: fromPath,
           destination: toPath,
           permanent: isPermanent,
-        })),
+        });
+      }
+    }
+
+    const routes =
+      getTransformedRoutes({
+        trailingSlash,
+        redirects,
+        rewrites,
       }).routes || [];
 
     routes.push({

--- a/packages/gatsby-plugin-vercel-builder/src/index.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/index.ts
@@ -74,7 +74,7 @@ export async function generateVercelBuildOutputAPI3Output({
       statusCode,
     } of state.redirects) {
       if (statusCode === 200) {
-        // A statusCode of 200 on createRedirect creates a rewrite (i.e. a reverse proxy)
+        // A `statusCode` of 200 on `createRedirect()` creates a rewrite (i.e. a reverse proxy)
         // https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/#rewrites-and-reverse-proxies
         rewrites.push({
           source: fromPath,

--- a/packages/gatsby-plugin-vercel-builder/src/schemas.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/schemas.ts
@@ -31,6 +31,7 @@ const GatsbyRedirectSchema = Type.Object({
   fromPath: Type.String(),
   toPath: Type.String(),
   isPermanent: Type.Optional(Type.Boolean()),
+  statusCode: Type.Optional(Type.Number()),
 });
 export type GatsbyRedirect = Static<typeof GatsbyRedirectSchema>;
 

--- a/packages/static-build/test/fixtures/gatsby-v4/gatsby-node.js
+++ b/packages/static-build/test/fixtures/gatsby-v4/gatsby-node.js
@@ -1,7 +1,13 @@
 const fs = require('fs');
 
 exports.createPages = async ({ actions }) => {
-  const { createPage } = actions;
+  const { createPage, createRedirect } = actions;
+        console.log('createPages');
+
+    createRedirect({
+        fromPath: `/blog`,
+        toPath: `/using-ssr`,
+    });
   createPage({
     path: '/using-dsg',
     component: require.resolve('./src/templates/using-dsg.js'),

--- a/packages/static-build/test/fixtures/gatsby-v4/gatsby-node.js
+++ b/packages/static-build/test/fixtures/gatsby-v4/gatsby-node.js
@@ -2,12 +2,19 @@ const fs = require('fs');
 
 exports.createPages = async ({ actions }) => {
   const { createPage, createRedirect } = actions;
-        console.log('createPages');
 
-    createRedirect({
-        fromPath: `/blog`,
-        toPath: `/using-ssr`,
-    });
+  createRedirect({
+    fromPath: `/redirect`,
+    toPath: `/using-ssr`,
+  });
+
+  // This is a "rewrite"
+  createRedirect({
+    fromPath: `/rewrite`,
+    toPath: `https://vercel.com/`,
+    statusCode: 200,
+  });
+
   createPage({
     path: '/using-dsg',
     component: require.resolve('./src/templates/using-dsg.js'),

--- a/packages/static-build/test/fixtures/gatsby-v4/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/probes.json
@@ -28,10 +28,7 @@
     {
       "fetchOptions": { "redirect": "manual" },
       "path": "/redirect",
-      "status": 307,
-      "responseHeaders": {
-        "location": "/using-ssr"
-      }
+      "status": 307
     },
     {
       "path": "/rewrite",

--- a/packages/static-build/test/fixtures/gatsby-v4/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/probes.json
@@ -26,11 +26,11 @@
       "mustContain": "{\"message\":\"A ok!\"}"
     },
     {
-      "path": "/redirect/",
+      "path": "/redirect",
       "status": "307"
     },
     {
-      "path": "/rewrite/",
+      "path": "/rewrite",
       "mustContain": "Vercel"
     }
   ]

--- a/packages/static-build/test/fixtures/gatsby-v4/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/probes.json
@@ -24,6 +24,14 @@
     {
       "path": "/api/hello",
       "mustContain": "{\"message\":\"A ok!\"}"
+    },
+    {
+      "path": "/redirect/",
+      "status": "307"
+    },
+    {
+      "path": "/rewrite/",
+      "mustContain": "Vercel"
     }
   ]
 }

--- a/packages/static-build/test/fixtures/gatsby-v4/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/probes.json
@@ -26,8 +26,12 @@
       "mustContain": "{\"message\":\"A ok!\"}"
     },
     {
+      "fetchOptions": { "redirect": "manual" },
       "path": "/redirect",
-      "status": "307"
+      "status": "307",
+      "responseHeaders": {
+        "location": "/using-ssr"
+      }
     },
     {
       "path": "/rewrite",

--- a/packages/static-build/test/fixtures/gatsby-v4/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v4/probes.json
@@ -28,7 +28,7 @@
     {
       "fetchOptions": { "redirect": "manual" },
       "path": "/redirect",
-      "status": "307",
+      "status": 307,
       "responseHeaders": {
         "location": "/using-ssr"
       }

--- a/packages/static-build/test/fixtures/gatsby-v5/gatsby-node.js
+++ b/packages/static-build/test/fixtures/gatsby-v5/gatsby-node.js
@@ -1,0 +1,15 @@
+exports.createPages = async ({ actions }) => {
+  const { createRedirect } = actions;
+
+  createRedirect({
+    fromPath: `/redirect/`,
+    toPath: `/ssr`,
+  });
+
+  // This is a "rewrite"
+  createRedirect({
+    fromPath: `/rewrite/`,
+    toPath: `https://vercel.com/`,
+    statusCode: 200,
+  });
+};

--- a/packages/static-build/test/fixtures/gatsby-v5/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/probes.json
@@ -22,8 +22,12 @@
       "mustContain": "<h1>Page not found</h1>"
     },
     {
-      "path": "/foo/bar/ssr/",
-      "mustContain": "<h1>This page is <!-- -->rendered server side (nested)</h1>"
+      "path": "/redirect/",
+      "status": "307"
+    },
+    {
+      "path": "/rewrite/",
+      "mustContain": "Vercel"
     }
   ]
 }

--- a/packages/static-build/test/fixtures/gatsby-v5/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/probes.json
@@ -22,8 +22,12 @@
       "mustContain": "<h1>Page not found</h1>"
     },
     {
+      "fetchOptions": { "redirect": "manual" },
       "path": "/redirect/",
-      "status": "307"
+      "status": "307",
+      "responseHeaders": {
+        "location": "/using-ssr"
+      }
     },
     {
       "path": "/rewrite/",

--- a/packages/static-build/test/fixtures/gatsby-v5/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/probes.json
@@ -24,10 +24,7 @@
     {
       "fetchOptions": { "redirect": "manual" },
       "path": "/redirect/",
-      "status": 307,
-      "responseHeaders": {
-        "location": "/using-ssr"
-      }
+      "status": 307
     },
     {
       "path": "/rewrite/",

--- a/packages/static-build/test/fixtures/gatsby-v5/probes.json
+++ b/packages/static-build/test/fixtures/gatsby-v5/probes.json
@@ -24,7 +24,7 @@
     {
       "fetchOptions": { "redirect": "manual" },
       "path": "/redirect/",
-      "status": "307",
+      "status": 307,
       "responseHeaders": {
         "location": "/using-ssr"
       }


### PR DESCRIPTION
As per the [Gatsby docs](https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/#rewrites-and-reverse-proxies):

> Whenever you set a statusCode of 200 on createRedirect you create a rewrite or a reverse proxy.

This adds support for that, and also adds tests for the regular redirect case, since we didn't have tests for that previously.