### PR TITLE
[cli] replace `--deprecated` with `--update-required` in `vc project ls`

### DIFF
--- a/.changeset/sweet-cougars-judge.md
+++ b/.changeset/sweet-cougars-judge.md
@@ -1,0 +1,5 @@
+---
+"vercel": major
+---
+
+[cli] replace `--deprecated` with `--update-required` in `vc project ls`

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -17,9 +17,9 @@ export const projectCommand: Command = {
       arguments: [],
       options: [
         {
-          name: 'deprecated',
-          description: 'A list of projects affected by a deprecation',
-          argument: 'deprecated',
+          name: 'update-required',
+          description: 'A list of projects affected by an upcoming deprecation',
+          argument: 'update-required',
           shorthand: null,
           type: 'boolean',
           deprecated: false,

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -23,7 +23,7 @@ export default async function main(client: Client) {
     argv = getArgs(client.argv.slice(2), {
       '--next': Number,
       '-N': '--next',
-      '--deprecated': Boolean,
+      '--update-required': Boolean,
     });
   } catch (error) {
     handleError(error);

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -30,7 +30,7 @@ export default async function list(
 
   let projectsUrl = `/v4/projects/?limit=20`;
 
-  const deprecated = argv['--deprecated'] || false;
+  const deprecated = argv['--update-required'] || false;
   if (deprecated) {
     projectsUrl += `&deprecated=${deprecated}`;
   }
@@ -69,7 +69,7 @@ export default async function list(
     output.warn(
       `The following Node.js versions will be deprecated soon: ${upcomingDeprecationVersionsList.join(
         ', '
-      )}. Upgrade your projects immediately.`
+      )}. Please upgrade your projects immediately.`
     );
     output.log(
       `For more information visit: https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#node.js-version`

--- a/packages/cli/test/unit/commands/project.test.ts
+++ b/packages/cli/test/unit/commands/project.test.ts
@@ -55,7 +55,7 @@ describe('project', () => {
         nodeVersion: '16.x',
       });
 
-      client.setArgv('project', 'ls', '--deprecated');
+      client.setArgv('project', 'ls', '--update-required');
       await projects(client);
 
       const lines = createLineIterator(client.stderr);
@@ -65,7 +65,7 @@ describe('project', () => {
 
       line = await lines.next();
       expect(line.value).toEqual(
-        'WARN! The following Node.js versions will be deprecated soon: 16.x. Upgrade your projects immediately.'
+        'WARN! The following Node.js versions will be deprecated soon: 16.x. Please upgrade your projects immediately.'
       );
       line = await lines.next();
       expect(line.value).toEqual(


### PR DESCRIPTION
Replaces the new `--deprecated` option with `--update-required` in the `vc project ls` command.