### PR TITLE
[deps] Change use of isbot next version

### DIFF
--- a/examples/hydrogen-2/app/entry.server.tsx
+++ b/examples/hydrogen-2/app/entry.server.tsx
@@ -1,6 +1,6 @@
 import type {EntryContext} from '@shopify/remix-oxygen';
 import {RemixServer} from '@remix-run/react';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import {renderToReadableStream} from 'react-dom/server';
 
 export default async function handleRequest(

--- a/examples/hydrogen-2/package.json
+++ b/examples/hydrogen-2/package.json
@@ -20,7 +20,7 @@
     "@shopify/remix-oxygen": "^1.1.3",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
-    "isbot": "^3.6.6",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -16,7 +16,7 @@
     "@remix-run/serve": "^2.0.0",
     "@vercel/analytics": "^1.0.2",
     "@vercel/remix": "^2.0.0",
-    "isbot": "^3.6.8",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -229,7 +229,7 @@ export async function chdirAndReadConfig(
   const pkgRaw = await fs.readFile(packageJsonPath, 'utf8');
   const pkg = JSON.parse(pkgRaw);
   if (!pkg.dependencies?.['isbot']) {
-    pkg.dependencies.isbot = 'latest';
+    pkg.dependencies.isbot = '^4.0.0';
     await fs.writeFile(packageJsonPath, JSON.stringify(pkg));
     modifiedPackageJson = true;
   }

--- a/packages/remix/test/fixtures/10-hydrogen-2/app/entry.server.tsx
+++ b/packages/remix/test/fixtures/10-hydrogen-2/app/entry.server.tsx
@@ -1,6 +1,6 @@
 import type {EntryContext} from '@shopify/remix-oxygen';
 import {RemixServer} from '@remix-run/react';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import {renderToReadableStream} from 'react-dom/server';
 
 export default async function handleRequest(

--- a/packages/remix/test/fixtures/10-hydrogen-2/package.json
+++ b/packages/remix/test/fixtures/10-hydrogen-2/package.json
@@ -19,7 +19,7 @@
     "@shopify/remix-oxygen": "^1.1.1",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
-    "isbot": "^3.6.6",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/remix/test/fixtures/11-hydrogen-2-js/app/entry.server.jsx
+++ b/packages/remix/test/fixtures/11-hydrogen-2-js/app/entry.server.jsx
@@ -1,5 +1,5 @@
 import {RemixServer} from '@remix-run/react';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import {renderToReadableStream} from 'react-dom/server';
 
 export default async function handleRequest(

--- a/packages/remix/test/fixtures/11-hydrogen-2-js/package.json
+++ b/packages/remix/test/fixtures/11-hydrogen-2-js/package.json
@@ -18,7 +18,7 @@
     "@shopify/remix-oxygen": "^1.1.1",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
-    "isbot": "^3.6.6",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/remix/test/fixtures/12-remix-v2/package.json
+++ b/packages/remix/test/fixtures/12-remix-v2/package.json
@@ -15,7 +15,7 @@
     "@remix-run/react": "^2.0.0",
     "@remix-run/serve": "^2.0.0",
     "@vercel/remix": "^2.0.0",
-    "isbot": "^3.6.8",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/remix/test/fixtures/13-remix-v2-public-path/site/package-lock.json
+++ b/packages/remix/test/fixtures/13-remix-v2-public-path/site/package-lock.json
@@ -11,7 +11,7 @@
         "@remix-run/react": "^2.2.0",
         "@remix-run/serve": "^2.2.0",
         "@vercel/remix": "^2.2.0",
-        "isbot": "^3.7.1",
+        "isbot": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1688,7 +1688,7 @@
       "dependencies": {
         "@remix-run/node": "2.2.0",
         "@remix-run/server-runtime": "2.2.0",
-        "isbot": "^3.6.8"
+        "isbot": "^4.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9111,7 +9111,7 @@
       "requires": {
         "@remix-run/node": "2.2.0",
         "@remix-run/server-runtime": "2.2.0",
-        "isbot": "^3.6.8"
+        "isbot": "^4.0.0"
       }
     },
     "@web3-storage/multipart-parser": {
@@ -10589,9 +10589,12 @@
       "dev": true
     },
     "isbot": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.7.1.tgz",
-      "integrity": "sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-4.0.0.tgz",
+      "integrity": "sha512-OoqchG4A/FngRcbxTRgdqFbSE/FS/DMWpRP4T+8Jar/8Cwlwm91jxSE20XGxrb8AgaDnmvnO3fwhlBus3kY6hQ==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "isexe": {
       "version": "2.0.0",

--- a/packages/remix/test/fixtures/13-remix-v2-public-path/site/package.json
+++ b/packages/remix/test/fixtures/13-remix-v2-public-path/site/package.json
@@ -15,7 +15,7 @@
     "@remix-run/react": "^2.2.0",
     "@remix-run/serve": "^2.2.0",
     "@vercel/remix": "^2.2.0",
-    "isbot": "^3.7.1",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/static-build/test/fixtures/hydrogen-v2023/app/entry.server.jsx
+++ b/packages/static-build/test/fixtures/hydrogen-v2023/app/entry.server.jsx
@@ -1,5 +1,5 @@
 import {RemixServer} from '@remix-run/react';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import {renderToReadableStream} from 'react-dom/server';
 import {createContentSecurityPolicy} from '@shopify/hydrogen';
 

--- a/packages/static-build/test/fixtures/hydrogen-v2023/package-lock.json
+++ b/packages/static-build/test/fixtures/hydrogen-v2023/package-lock.json
@@ -15,7 +15,7 @@
         "@shopify/remix-oxygen": "^1.1.5",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
-        "isbot": "^3.6.6",
+        "isbot": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -31413,9 +31413,12 @@
       "dev": true
     },
     "isbot": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.7.0.tgz",
-      "integrity": "sha512-9BcjlI89966BqWJmYdTnRub85sit931MyCthSIPtgoOsTjoW7A2MVa09HzPpYE2+G4vyAxfDvR0AbUGV0FInQg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-4.0.0.tgz",
+      "integrity": "sha512-OoqchG4A/FngRcbxTRgdqFbSE/FS/DMWpRP4T+8Jar/8Cwlwm91jxSE20XGxrb8AgaDnmvnO3fwhlBus3kY6hQ==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "iserror": {
       "version": "0.0.2",

--- a/packages/static-build/test/fixtures/hydrogen-v2023/package.json
+++ b/packages/static-build/test/fixtures/hydrogen-v2023/package.json
@@ -19,7 +19,7 @@
     "@shopify/remix-oxygen": "^1.1.5",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
-    "isbot": "^3.6.6",
+    "isbot": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Instead of using "latest", using a specific major version can prevent future breakages.

[isbot](https://github.com/omrilotan/isbot/blob/next/CHANGELOG.md#400) version 4 aims to be more performant at load time, better for tree-shaking and Typescript friendly. The default import was replaced with a named import.