### PR TITLE
[next] Ensure rewrites handle RSC requests

### DIFF
--- a/.changeset/empty-socks-change.md
+++ b/.changeset/empty-socks-change.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Ensure rewrites handle RSC requests

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -213,6 +213,25 @@ export async function serverBuild({
         value.contentType = rscContentTypeHeader;
       }
     }
+
+    for (const rewrite of afterFilesRewrites) {
+      if (rewrite.src && rewrite.dest) {
+        rewrite.src = rewrite.src.replace(
+          '(?:/)?',
+          '(?<rscsuff>(\\.prefetch)?\\.rsc)?(?:/)?'
+        );
+        let destQueryIndex = rewrite.dest.indexOf('?');
+
+        if (destQueryIndex === -1) {
+          destQueryIndex = rewrite.dest.length;
+        }
+
+        rewrite.dest =
+          rewrite.dest.substring(0, destQueryIndex) +
+          '$rscsuff' +
+          rewrite.dest.substring(destQueryIndex);
+      }
+    }
   }
 
   const isCorrectNotFoundRoutes = semver.gte(
@@ -1856,6 +1875,17 @@ export async function serverBuild({
       // These need to come before handle: miss or else they are grouped
       // with that routing section
       ...afterFilesRewrites,
+
+      // ensure non-normalized /.rsc from rewrites is handled
+      ...(appPathRoutesManifest
+        ? [
+            {
+              src: '/((\\.prefetch)?\\.rsc)$',
+              dest: '/index$1',
+              check: true,
+            },
+          ]
+        : []),
 
       { handle: 'resource' },
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1880,8 +1880,17 @@ export async function serverBuild({
       ...(appPathRoutesManifest
         ? [
             {
-              src: '/((\\.prefetch)?\\.rsc)$',
-              dest: '/index$1',
+              src: path.posix.join('/', entryDirectory, '/\\.prefetch\\.rsc$'),
+              dest: path.posix.join(
+                '/',
+                entryDirectory,
+                `/__index${RSC_PREFETCH_SUFFIX}`
+              ),
+              check: true,
+            },
+            {
+              src: path.posix.join('/', entryDirectory, '/\\.rsc$'),
+              dest: path.posix.join('/', entryDirectory, `/index.rsc`),
               check: true,
             },
           ]

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/next.config.js
@@ -9,6 +9,10 @@ module.exports = {
         source: '/rewritten-to-dashboard',
         destination: '/dashboard',
       },
+      {
+        source: '/rewritten-to-index',
+        destination: '/?fromRewrite=1',
+      },
     ];
   },
 };

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -18,6 +18,54 @@
     }
   ],
   "probes": [
+     {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": "html"
+    },
+    {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": "html"
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1
+      }
+    },
     {
       "path": "/catch-all",
       "status": 200,

--- a/packages/next/test/fixtures/00-app-dir-ppr/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr/next.config.js
@@ -10,6 +10,10 @@ module.exports = {
         source: '/rewritten-to-dashboard',
         destination: '/dashboard',
       },
+      {
+        source: '/rewritten-to-index',
+        destination: '/?fromRewrite=1',
+      },
     ];
   },
 };

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -19,6 +19,30 @@
   ],
   "probes": [
     {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": "html"
+    },
+    {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": ":{",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-dashboard",
+      "status": 200,
+      "mustContain": ":{",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1
+      }
+    },
+    {
       "path": "/catch-all",
       "status": 200,
       "mustContain": "html"

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -26,7 +26,7 @@
     {
       "path": "/rewritten-to-dashboard",
       "status": 200,
-      "mustContain": ":{",
+      "mustContain": ":",
       "mustNotContain": "<html",
       "headers": {
         "RSC": 1,
@@ -36,7 +36,31 @@
     {
       "path": "/rewritten-to-dashboard",
       "status": 200,
-      "mustContain": ":{",
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": "html"
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
+      "path": "/rewritten-to-index",
+      "status": 200,
+      "mustContain": ":",
       "mustNotContain": "<html",
       "headers": {
         "RSC": 1


### PR DESCRIPTION
This ensures we add handling for our internal `.rsc` suffixes for rewrites since this currently fail to match by default unless the user manually adds handling for this. Updated our test fixture to ensure this is tested properly. 