### PR TITLE
[cli] Display actual deployment's 'target'

### DIFF
--- a/.changeset/unlucky-wasps-ring.md
+++ b/.changeset/unlucky-wasps-ring.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Display actual deployment's 'target'

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -185,7 +185,7 @@ export default async function processDeployment({
 
         printInspectUrl(output, deployment.inspectorUrl, deployStamp);
 
-        const isProdDeployment = requestBody.target === 'production';
+        const isProdDeployment = deployment.target === 'production';
         const previewUrl = `https://${deployment.url}`;
 
         output.print(

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -750,7 +750,7 @@ test('deploys with only vercel.json and README.md', async () => {
 
   // assert timing order of showing URLs vs status updates
   expect(stderr).toMatch(
-    /Inspect.*\nPreview.*\nQueued.*\nBuilding.*\nCompleting/
+    /Inspect.*\nProduction.*\nQueued.*\nBuilding.*\nCompleting/
   );
 
   const { host } = new URL(stdout);


### PR DESCRIPTION
The CLI renders the deploy URL with the "Preview" label on first deploy because the CLI treats deploys as previews unless `--prod` is set. However the first deploy for a new project is always production, so the CLI needs to render the deploy URL based on the actual deployment's `target`.