### PR TITLE
[cli] Serialize duplicate `EdgeFunction` references as symlinks in `vc build`

### DIFF
--- a/.changeset/large-baboons-train.md
+++ b/.changeset/large-baboons-train.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Serialize duplicate `EdgeFunction` references as symlinks in `vc build`

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -330,6 +330,11 @@ async function writeStaticFile(
  * If the `fn` Lambda or Edge function has already been written to
  * the filesystem at a different location, then create a symlink
  * to the previous location instead of copying the files again.
+ *
+ * @param outputPath The path of the `.vercel/output` directory
+ * @param dest The path of destination function's `.func` directory
+ * @param fn The Lambda or EdgeFunction instance to create the symlink for
+ * @param existingFunctions Map of `Lambda`/`EdgeFunction` instances that have previously been written
  */
 async function writeFunctionSymlink(
   outputDir: string,
@@ -353,8 +358,10 @@ async function writeFunctionSymlink(
 /**
  * Serializes the `EdgeFunction` instance to the file system.
  *
+ * @param outputPath The path of the `.vercel/output` directory
  * @param edgeFunction The `EdgeFunction` instance
  * @param path The URL path where the `EdgeFunction` can be accessed from
+ * @param existingFunctions (optional) Map of `Lambda`/`EdgeFunction` instances that have previously been written
  */
 async function writeEdgeFunction(
   outputDir: string,
@@ -401,9 +408,11 @@ async function writeEdgeFunction(
 /**
  * Writes the file references from the `Lambda` instance to the file system.
  *
+ * @param outputPath The path of the `.vercel/output` directory
  * @param lambda The `Lambda` instance
  * @param path The URL path where the `Lambda` can be accessed from
- * @param existingFunctions (optional) Map of `Lambda` instances that have previously been written
+ * @param functionConfiguration (optional) Extra configuration to apply to the function's `.vc-config.json` file
+ * @param existingFunctions (optional) Map of `Lambda`/`EdgeFunction` instances that have previously been written
  */
 async function writeLambda(
   outputDir: string,

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/main.js
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/main.js
@@ -1,0 +1,21 @@
+const { Lambda, EdgeFunction } = require('@vercel/build-utils');
+
+exports.build = async () => {
+    const lambda = new Lambda({
+        files: {},
+        runtime: 'provided',
+        handler: 'example.js'
+    });
+    const edge = new EdgeFunction({
+      files: {},
+      deploymentTarget: 'v8-worker',
+      entrypoint: 'example.js'
+    });
+    const output = {
+      lambda,
+      lambda2: lambda,
+      edge,
+      edge2: edge
+    };
+    return { output };
+};

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "functions-symlink",
+  "private": true,
+  "version": "0.0.0",
+  "main": "main.js"
+}

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "functions-symlink-test",
+  "private": true
+}

--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/vercel.json
@@ -1,0 +1,3 @@
+{
+  "builds": [{ "src": "package.json", "use": "functions-symlink@0.0.0" }]
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1248,3 +1248,42 @@ describe('build', () => {
     ).toEqual('marketing');
   });
 });
+
+it('should create symlinks for duplicate references to Lambda / EdgeFunction instances', async () => {
+  if (process.platform === 'win32') {
+    console.log('Skipping test on Windows');
+    return;
+  }
+  const cwd = fixture('functions-symlink');
+  const output = join(cwd, '.vercel/output');
+  client.cwd = cwd;
+  const exitCode = await build(client);
+  expect(exitCode).toEqual(0);
+
+  // "functions" directory has output Functions
+  const functions = await fs.readdir(join(output, 'functions'));
+  expect(functions.sort()).toEqual([
+    'edge.func',
+    'edge2.func',
+    'lambda.func',
+    'lambda2.func',
+  ]);
+  expect(
+    fs.lstatSync(join(output, 'functions/lambda.func')).isDirectory()
+  ).toEqual(true);
+  expect(
+    fs.lstatSync(join(output, 'functions/edge.func')).isDirectory()
+  ).toEqual(true);
+  expect(
+    fs.lstatSync(join(output, 'functions/lambda2.func')).isSymbolicLink()
+  ).toEqual(true);
+  expect(
+    fs.lstatSync(join(output, 'functions/edge2.func')).isSymbolicLink()
+  ).toEqual(true);
+  expect(fs.readlinkSync(join(output, 'functions/lambda2.func'))).toEqual(
+    'lambda.func'
+  );
+  expect(fs.readlinkSync(join(output, 'functions/edge2.func'))).toEqual(
+    'edge.func'
+  );
+});


### PR DESCRIPTION
Enables the symlink optimization that currently exists for `Lambda` instances, but now for `EdgeFunction` instances as well. This will be particularly beneficial for Remix applications which use edge functions for many routes, since they will now all be represented by the same underling function in production.