### PR TITLE
[docs] fix edge IP_HEADER_NAME header typedoc typo

### DIFF
--- a/packages/edge/docs/README.md
+++ b/packages/edge/docs/README.md
@@ -70,7 +70,7 @@ Unicode characters for emoji flags start at this number, and run up to 127469.
 
 • `Const` **IP_HEADER_NAME**: `"x-real-ip"`
 
-Client IP as calcualted by Vercel Proxy.
+Client IP as calculated by Vercel Proxy.
 
 #### Defined in
 

--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -7,7 +7,7 @@ export const CITY_HEADER_NAME = 'x-vercel-ip-city';
  */
 export const COUNTRY_HEADER_NAME = 'x-vercel-ip-country';
 /**
- * Client IP as calcualted by Vercel Proxy.
+ * Client IP as calculated by Vercel Proxy.
  */
 export const IP_HEADER_NAME = 'x-real-ip';
 /**


### PR DESCRIPTION
Fix small typo in the `IP_HEADER_NAME` description.

<img width="362" alt="Screenshot 2024-01-08 at 7 25 34 PM" src="https://github.com/vercel/vercel/assets/762112/db4d684a-5a12-45d0-8428-981bf2489999">
