### PR TITLE
[remix] Fix functions without a output path edge case

### DIFF
--- a/.changeset/long-hats-argue.md
+++ b/.changeset/long-hats-argue.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fix functions without a output path edge case

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -148,7 +148,9 @@ export function getPathFromRoute(
 ): ResolvedRoutePaths {
   if (
     route.id === 'root' ||
-    (route.parentId === 'root' && !route.path && route.index)
+    (route.parentId === 'root' &&
+      (!route.path || route.path === '/') &&
+      route.index)
   ) {
     return { path: 'index', rePath: '/index' };
   }

--- a/packages/remix/test/unit.get-path-from-route.test.ts
+++ b/packages/remix/test/unit.get-path-from-route.test.ts
@@ -112,10 +112,19 @@ describe('getPathFromRoute()', () => {
       parentId: 'root',
       file: 'routes/admin.(lol).tsx',
     },
+    manual: {
+      path: '/',
+      index: true,
+      caseSensitive: undefined,
+      id: 'manual',
+      parentId: 'root',
+      file: 'manual.tsx',
+    },
   };
 
   it.each([
     { id: 'root', expected: { path: 'index', rePath: '/index' } },
+    { id: 'manual', expected: { path: 'index', rePath: '/index' } },
     { id: 'routes/__pathless', expected: { path: '', rePath: '/' } },
     { id: 'routes/index', expected: { path: 'index', rePath: '/index' } },
     {


### PR DESCRIPTION
Fixes an edge case where a route without a path was causing the build to fail. Reproducible with this `remix.config.js` file:

```js
export default {
    ignoredRouteFiles: ["**/.*"],
    routes(defineRoutes) {
        return defineRoutes((route) => {
            route("/", "foo.tsx", { index: true });
        });
    },
};
```