### PR TITLE
Use `worker.name` instead of edge function name to fix type error in `@vercel/next`

### DIFF
--- a/.changeset/rich-lemons-matter.md
+++ b/.changeset/rich-lemons-matter.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Use `worker.name` instead of edge function name to fix type error in `@vercel/next`

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2856,6 +2856,7 @@ export async function getMiddlewareBundle({
           return {
             type,
             page: edgeFunction.page,
+            name: edgeFunction.name,
             edgeFunction: (() => {
               const { source, map } = wrappedModuleSource.sourceAndMap();
               const transformedMap = stringifySourceMap(
@@ -2951,8 +2952,7 @@ export async function getMiddlewareBundle({
     };
 
     for (const worker of workerConfigs.values()) {
-      const edgeFile = worker.edgeFunction.name;
-      let shortPath = edgeFile;
+      let shortPath = worker.name;
 
       // Replacing the folder prefix for the page
       //


### PR DESCRIPTION
Uses another `name` property instead of the now deprecated one.

It is my understanding that the fixtures: https://github.com/vercel/vercel/tree/main/packages/next/test/fixtures/00-app-dir-edge (app dir) and https://github.com/vercel/vercel/tree/main/packages/next/test/fixtures/00-edge-runtime (pages) cover this code. 