### PR TITLE
Add retry handling when hitting SSO

### DIFF
--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -23,7 +23,7 @@ async function fetchRetry(url, ...rest) {
               requestIds.push(res.headers.get('x-vercel-id'));
               if (i === 0) {
                 console.error(
-                  `request ids: `,
+                  `Failed request ids (because of 401s): `,
                   JSON.stringify(requestIds, null, 2)
                 );
                 throw new Error(

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -14,7 +14,7 @@ async function fetchRetry(url, ...rest) {
       try {
         const res = await fetch(url, ...rest);
 
-        if (res.status === 401 && retryIndex < 2) {
+        if (res.status === 401 && retryIndex < 4) {
           const error = new Error('sso error');
           error.type = 'sso-error';
           throw error;
@@ -43,7 +43,7 @@ async function fetchRetry(url, ...rest) {
         throw error;
       }
     },
-    { factor: 2, retries: 3 }
+    { factor: 2, retries: 5 }
   );
 }
 

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -1,5 +1,4 @@
 const fetch = require('node-fetch');
-const { disableSSO } = require('./now-deploy.js');
 const retryBailByDefault = require('./retry-bail-by-default.js');
 
 const ABSOLUTE_URL_PATTERN = /^https?:\/\//i;
@@ -27,11 +26,6 @@ async function fetchRetry(url, ...rest) {
                 `Failed to fetch ${url}, received 401 status for over 1 minute`
               );
             }
-
-            if (i % 10 === 0) {
-              await disableSSO(url);
-            }
-
             await new Promise(resolve => setTimeout(resolve, 1000));
           } else {
             return res;

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -59,7 +59,7 @@ async function fetchRetry(url, ...rest) {
         throw error;
       }
     },
-    { factor: 2, retries: 5 }
+    { factor: 2, retries: 3 }
   );
 }
 

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -16,15 +16,20 @@ async function fetchRetry(url, ...rest) {
           const res = await fetch(url, ...rest);
 
           if (res.status === 401) {
-            requestIds.push(res.headers.get('x-vercel-id'));
-            if (i === 0) {
-              console.error(
-                `request ids: `,
-                JSON.stringify(requestIds, null, 2)
-              );
-              throw new Error(
-                `Failed to fetch ${url}, received 401 status for over 1 minute`
-              );
+            const clonedRes = res.clone();
+            const body = await clonedRes.text();
+
+            if (body.includes('https://vercel.com/sso-api')) {
+              requestIds.push(res.headers.get('x-vercel-id'));
+              if (i === 0) {
+                console.error(
+                  `request ids: `,
+                  JSON.stringify(requestIds, null, 2)
+                );
+                throw new Error(
+                  `Failed to fetch ${url}, received 401 status for over 1 minute`
+                );
+              }
             }
             await new Promise(resolve => setTimeout(resolve, 1000));
           } else {

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -30,6 +30,8 @@ async function fetchRetry(url, ...rest) {
                   `Failed to fetch ${url}, received 401 status for over 1 minute`
                 );
               }
+            } else {
+              return res;
             }
             await new Promise(resolve => setTimeout(resolve, 1000));
           } else {

--- a/test/lib/deployment/fetch-retry.js
+++ b/test/lib/deployment/fetch-retry.js
@@ -7,24 +7,27 @@ async function fetchRetry(url, ...rest) {
   if (!ABSOLUTE_URL_PATTERN.test(url)) {
     throw new Error(`fetch url must be absolute: "${url}"`);
   }
-  let retryIndex = 0;
 
   return await retryBailByDefault(
     async canRetry => {
       try {
-        const res = await fetch(url, ...rest);
+        for (let i = 60; i >= 0; i--) {
+          const res = await fetch(url, ...rest);
 
-        if (res.status === 401 && retryIndex < 4) {
-          const error = new Error('sso error');
-          error.type = 'sso-error';
-          throw error;
+          if (res.status === 401) {
+            if (i === 0) {
+              throw new Error(
+                `Failed to fetch ${url}, received 401 statu for over 1 minute`
+              );
+            }
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          } else {
+            return res;
+          }
         }
-        return res;
       } catch (error) {
         if (error.type === 'request-timeout') {
           // FetchError: network timeout at: ...
-          throw canRetry(error);
-        } else if (error.type === 'sso-error') {
           throw canRetry(error);
         } else if (error.code === 'ENOTFOUND') {
           // getaddrinfo ENOTFOUND api.vercel.com like some transient dns issue

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -8,8 +8,6 @@ const fileModeSymbol = Symbol('fileMode');
 const { logWithinTest } = require('./log');
 const ms = require('ms');
 
-console.error({ fetch });
-
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -149,10 +149,14 @@ async function disableSSO(deploymentId, useTeam = true) {
   );
 
   if (settingRes.ok) {
-    for (let i = 0; i < 5; i++) {
-      const res = await fetch(`https://${deploymentUrl}`);
-      if (res.status !== 401) {
-        break;
+    for (let i = 0; i < 10; i++) {
+      try {
+        const res = await _fetch(`https://${deploymentUrl}`);
+        if (res.status !== 401) {
+          break;
+        }
+      } catch (err) {
+        console.error(err);
       }
       await new Promise(resolve => setTimeout(resolve, 5 * 1000));
     }

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -150,13 +150,9 @@ async function disableSSO(deploymentId, useTeam = true) {
 
   if (settingRes.ok) {
     for (let i = 0; i < 10; i++) {
-      try {
-        const res = await fetch(`https://${deploymentUrl}`);
-        if (res.status !== 401) {
-          break;
-        }
-      } catch (err) {
-        console.error(err);
+      const res = await fetch(`https://${deploymentUrl}`);
+      if (res.status !== 401) {
+        break;
       }
       await new Promise(resolve => setTimeout(resolve, 5 * 1000));
     }

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -3,10 +3,12 @@ const assert = require('assert');
 const { createHash } = require('crypto');
 const path = require('path');
 const _fetch = require('node-fetch');
-const fetch = require('./fetch-retry.js');
+const fetch = require('./fetch-retry');
 const fileModeSymbol = Symbol('fileMode');
 const { logWithinTest } = require('./log');
 const ms = require('ms');
+
+console.error({ fetch });
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -151,7 +153,7 @@ async function disableSSO(deploymentId, useTeam = true) {
   if (settingRes.ok) {
     for (let i = 0; i < 10; i++) {
       try {
-        const res = await _fetch(`https://${deploymentUrl}`);
+        const res = await fetch(`https://${deploymentUrl}`);
         if (res.status !== 401) {
           break;
         }


### PR DESCRIPTION
This aims to reduce flakiness when SSO disabling for a test project is still disabling/propagating. 

x-ref: https://github.com/vercel/vercel/actions/runs/7563953104/job/20597320056?pr=11059
x-ref: https://github.com/vercel/vercel/actions/runs/7563953104/job/20597322078?pr=11059