### PR TITLE
Use production deploys for testing

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -85,7 +85,7 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
 
   for (let i = 0; i < 750; i += 1) {
     const deployment = await deploymentGet(deploymentId);
-    const { readyState } = deployment;
+    const { readyState, readySubstate } = deployment;
     if (readyState === 'ERROR') {
       logWithinTest('state is ERROR, throwing');
       const error = new Error(
@@ -94,7 +94,8 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
       error.deployment = deployment;
       throw error;
     }
-    if (readyState === 'READY') {
+    // ensure production alias is assigned properly
+    if (readyState === 'READY' && readySubstate === 'PROMOTED') {
       logWithinTest(`State of https://${deploymentUrl} is READY, moving on`);
       break;
     }

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -71,7 +71,6 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
 
   {
     const json = await deploymentPost(nowDeployPayload, opts);
-    console.log(JSON.stringify(json, null, 2));
 
     if (json.error && json.error.code === 'missing_files')
       throw new Error('Missing files');

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -305,10 +305,14 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
 }
 
 async function testDeployment(fixturePath, opts) {
-  const projectName = path
-    .basename(fixturePath)
-    .toLowerCase()
-    .replace(/(_|\.)/g, '-');
+  const projectName =
+    path
+      .basename(fixturePath)
+      .toLowerCase()
+      .replace(/(_|\.)/g, '-') +
+    '-' +
+    Date.now();
+
   logWithinTest(`testDeployment "${projectName}"`);
   const globResult = await glob(`${fixturePath}/**`, {
     nodir: true,

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -312,8 +312,8 @@ async function testDeployment(fixturePath, opts) {
       .replace(/(_|\.)/g, '-') +
     '-' +
     Date.now() +
-    '-';
-  Math.round(Math.random() * 1000);
+    '-' +
+    Math.round(Math.random() * 1000);
 
   logWithinTest(`testDeployment "${projectName}"`);
   const globResult = await glob(`${fixturePath}/**`, {

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -311,7 +311,9 @@ async function testDeployment(fixturePath, opts) {
       .toLowerCase()
       .replace(/(_|\.)/g, '-') +
     '-' +
-    Date.now();
+    Date.now() +
+    '-';
+  Math.round(Math.random() * 1000);
 
   logWithinTest(`testDeployment "${projectName}"`);
   const globResult = await glob(`${fixturePath}/**`, {


### PR DESCRIPTION
Alternative to https://github.com/vercel/vercel/pull/11061 this uses production deploys for testing by default which avoids the need for disabling deployment protection for every test project and hopefully reduces flakiness in tests. 

x-ref: https://github.com/vercel/vercel/actions/runs/7563953104/job/20597320056?pr=11059
x-ref: https://github.com/vercel/vercel/actions/runs/7563953104/job/20597322078?pr=11059