### PR TITLE
[python][ruby][cli] Remove deprecated `createLambda()` usage

### DIFF
--- a/.changeset/heavy-bananas-battle.md
+++ b/.changeset/heavy-bananas-battle.md
@@ -1,0 +1,6 @@
+---
+'@vercel/python': patch
+'@vercel/ruby': patch
+---
+
+Remove deprecated `createLambda()` usage

--- a/.changeset/khaki-items-juggle.md
+++ b/.changeset/khaki-items-juggle.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update `vc dev` to support `Lambda` instances without `zipBuffer`

--- a/packages/cli/src/util/dev/builder-worker.js
+++ b/packages/cli/src/util/dev/builder-worker.js
@@ -42,6 +42,18 @@ async function processMessage(message) {
   // structure to JSON" errors, so delete the property...
   delete result.childProcesses;
 
+  if (builder.version === 3) {
+    if (result.output.type === 'Lambda') {
+      result.output.zipBuffer = await result.output.createZip();
+    }
+  } else {
+    for (const output of Object.values(result.output)) {
+      if (output.type === 'Lambda') {
+        output.zipBuffer = await output.createZip();
+      }
+    }
+  }
+
   process.send({ type: 'buildResult', result });
 }
 

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -361,8 +361,10 @@ export async function executeBuild(
           await oldAsset.fn.destroy();
         }
 
+        const ZipFile = asset.zipBuffer || (await asset.createZip());
+
         asset.fn = await createFunction({
-          Code: { ZipFile: asset.zipBuffer },
+          Code: { ZipFile },
           Handler: asset.handler,
           Runtime: asset.runtime,
           MemorySize: asset.memory || 3008,


### PR DESCRIPTION
* Use `Lambda` constructor instead of `createLambda()`
* Return `FileBlob` instance for the entrypoint files, so that they do not get written to cwd
* In `vc dev`, support `Lambda` instances which do not have `zipBuffer` property