### PR TITLE
[cli] Pass `rootDirectory` setting to API during `vc link`

### DIFF
--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -197,6 +197,7 @@ export default async function setupAndLink(
         skipAutoDetectionConfirmation: false,
         projectSettings: {
           ...localConfigurationOverrides,
+          rootDirectory,
           sourceFilesOutsideRootDirectory,
         },
         autoAssignCustomDomains: true,
@@ -238,10 +239,6 @@ export default async function setupAndLink(
         autoConfirm,
         localConfigurationOverrides
       );
-    }
-
-    if (rootDirectory) {
-      settings.rootDirectory = rootDirectory;
     }
 
     const project = await createProject(client, {


### PR DESCRIPTION
When creating a new Project, `vc link` will issue an API call to the create deployment endpoint, where the API will attempt to detect which framework is used in the project. The detection does not currently work for monorepos, because the `rootDirectory` setting is not being sent to the API endpoint.