### PR TITLE
Fix index normalizing for app outputs

### DIFF
--- a/.changeset/nasty-teachers-wave.md
+++ b/.changeset/nasty-teachers-wave.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix index normalizing for app outputs

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1130,7 +1130,7 @@ export async function serverBuild({
         }
         let outputName = path.posix.join(entryDirectory, pageNoExt);
 
-        if (!(group.isAppRouter || group.isAppRouteHandler)) {
+        if (!group.isAppRouter && !group.isAppRouteHandler) {
           outputName = normalizeIndexOutput(outputName, true);
         }
 

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1128,11 +1128,11 @@ export async function serverBuild({
             );
           });
         }
+        let outputName = path.posix.join(entryDirectory, pageNoExt);
 
-        let outputName = normalizeIndexOutput(
-          path.posix.join(entryDirectory, pageNoExt),
-          true
-        );
+        if (!(group.isAppRouter || group.isAppRouteHandler)) {
+          outputName = normalizeIndexOutput(outputName, true);
+        }
 
         // If this is a PPR page, then we should prefix the output name.
         if (isPPR) {
@@ -1443,9 +1443,10 @@ export async function serverBuild({
         continue;
       }
 
-      const pathname = normalizeIndexOutput(
-        path.posix.join('./', entryDirectory, route === '/' ? '/index' : route),
-        true
+      const pathname = path.posix.join(
+        './',
+        entryDirectory,
+        route === '/' ? '/index' : route
       );
 
       if (lambdas[pathname]) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2051,7 +2051,7 @@ export const onPrerenderRoute =
       } = pr);
     }
 
-    let isAppPathRoute = false;
+    let isAppPathRoute = !!experimentalPPR;
 
     // TODO: leverage manifest to determine app paths more accurately
     if (appDir && srcRoute && (!dataRoute || dataRoute?.endsWith('.rsc'))) {
@@ -2184,7 +2184,6 @@ export const onPrerenderRoute =
       if (routeKey !== '/index' && routeKey.endsWith('/index')) {
         routeKey = `${routeKey}/index`;
         routeFileNoExt = routeKey;
-        origRouteFileNoExt = routeKey;
       }
     }
 
@@ -2263,7 +2262,7 @@ export const onPrerenderRoute =
               srcRoute === '/' ? '/index' : srcRoute
             );
 
-      if (!isAppPathRoute) {
+      if (!isAppPathRoute && !experimentalPPR) {
         outputSrcPathPage = normalizeIndexOutput(
           outputSrcPathPage,
           isServerMode

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2051,7 +2051,12 @@ export const onPrerenderRoute =
       } = pr);
     }
 
-    let isAppPathRoute = !!experimentalPPR;
+    let isAppPathRoute = false;
+
+    // experimentalPPR signals app path route
+    if (appDir && experimentalPPR) {
+      isAppPathRoute = true;
+    }
 
     // TODO: leverage manifest to determine app paths more accurately
     if (appDir && srcRoute && (!dataRoute || dataRoute?.endsWith('.rsc'))) {
@@ -2262,7 +2267,7 @@ export const onPrerenderRoute =
               srcRoute === '/' ? '/index' : srcRoute
             );
 
-      if (!isAppPathRoute && !experimentalPPR) {
+      if (!isAppPathRoute) {
         outputSrcPathPage = normalizeIndexOutput(
           outputSrcPathPage,
           isServerMode

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2255,15 +2255,20 @@ export const onPrerenderRoute =
       const lambdaId = pageLambdaMap[outputSrcPathPage];
       lambda = lambdas[lambdaId];
     } else {
-      const outputSrcPathPage = normalizeIndexOutput(
+      let outputSrcPathPage =
         srcRoute == null
           ? outputPathPageOrig
           : path.posix.join(
               entryDirectory,
               srcRoute === '/' ? '/index' : srcRoute
-            ),
-        isServerMode
-      );
+            );
+
+      if (!isAppPathRoute) {
+        outputSrcPathPage = normalizeIndexOutput(
+          outputSrcPathPage,
+          isServerMode
+        );
+      }
 
       lambda = lambdas[outputSrcPathPage];
     }
@@ -2464,10 +2469,17 @@ export const onPrerenderRoute =
             routesManifest,
             locale
           );
-          const localeOutputPathPage = normalizeIndexOutput(
-            path.posix.join(entryDirectory, localeRouteFileNoExt),
-            isServerMode
+          let localeOutputPathPage = path.posix.join(
+            entryDirectory,
+            localeRouteFileNoExt
           );
+
+          if (!isAppPathRoute) {
+            localeOutputPathPage = normalizeIndexOutput(
+              localeOutputPathPage,
+              isServerMode
+            );
+          }
 
           const origPrerenderPage = prerenders[outputPathPage];
           prerenders[localeOutputPathPage] = {
@@ -2969,14 +2981,17 @@ export async function getMiddlewareBundle({
       }
 
       if (routesManifest?.basePath) {
-        shortPath = normalizeIndexOutput(
-          path.posix.join(
-            './',
-            routesManifest?.basePath,
-            shortPath.replace(/^\//, '')
-          ),
-          true
+        const isAppPathRoute = !!appPathRoutesManifest[shortPath];
+
+        shortPath = path.posix.join(
+          './',
+          routesManifest?.basePath,
+          shortPath.replace(/^\//, '')
         );
+
+        if (!isAppPathRoute) {
+          shortPath = normalizeIndexOutput(shortPath, true);
+        }
       }
 
       worker.edgeFunction.name = shortPath;

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic-index/[slug]/index/page.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic-index/[slug]/index/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <p>dynamic-index</p>
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -18,7 +18,22 @@
     }
   ],
   "probes": [
-     {
+    {
+      "path": "/dynamic-index/hello/index",
+      "status": 200,
+      "mustContain": "dynamic-index"
+    },
+    {
+      "path": "/dynamic-index/hello/index",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
       "path": "/rewritten-to-dashboard",
       "status": 200,
       "mustContain": "html"

--- a/packages/next/test/fixtures/00-app-dir-ppr/app/dynamic-index/[slug]/index/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr/app/dynamic-index/[slug]/index/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <p>dynamic-index</p>
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -19,6 +19,21 @@
   ],
   "probes": [
     {
+      "path": "/dynamic-index/hello/index",
+      "status": 200,
+      "mustContain": "dynamic-index"
+    },
+    {
+      "path": "/dynamic-index/hello/index",
+      "status": 200,
+      "mustContain": ":",
+      "mustNotContain": "<html",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
       "path": "/rewritten-to-dashboard",
       "status": 200,
       "mustContain": "html"


### PR DESCRIPTION
This ensures we don't apply the index output normalizing for app paths which was previously already gated for prerenders but not all routes. 

