### PR TITLE
[client] More helpful error message when `vc deploy --prebuilt` has missing files

### DIFF
--- a/.changeset/popular-bulldogs-sip.md
+++ b/.changeset/popular-bulldogs-sip.md
@@ -1,0 +1,5 @@
+---
+"@vercel/client": patch
+---
+
+More helpful error message when `vc deploy --prebuilt` has missing files

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@vercel/build-utils": "7.5.1",
+    "@vercel/error-utils": "2.0.2",
     "@vercel/routing-utils": "3.1.0",
     "@zeit/fetch": "5.2.0",
     "async-retry": "1.2.3",

--- a/packages/client/src/create-deployment.ts
+++ b/packages/client/src/create-deployment.ts
@@ -1,5 +1,5 @@
 import { lstatSync } from 'fs-extra';
-import { isAbsolute, join, relative } from 'path';
+import { isAbsolute, join, relative, sep } from 'path';
 import { hash, hashes, mapToObject } from './utils/hashes';
 import { upload } from './upload';
 import { buildFileTree, createDebug } from './utils';
@@ -90,27 +90,38 @@ export default function buildCreateDeployment() {
 
     let files;
 
-    if (clientOptions.archive === 'tgz') {
-      debug('Packing tarball');
-      const tarStream = tar
-        .pack(workPath, {
-          entries: fileList.map(file => relative(workPath, file)),
-        })
-        .pipe(createGzip());
-      const tarBuffer = await streamToBuffer(tarStream);
-      debug('Packed tarball');
-      files = new Map([
-        [
-          hash(tarBuffer),
-          {
-            names: [join(workPath, '.vercel/source.tgz')],
-            data: tarBuffer,
-            mode: 0o666,
-          },
-        ],
-      ]);
-    } else {
-      files = await hashes(fileList);
+    try {
+      if (clientOptions.archive === 'tgz') {
+        debug('Packing tarball');
+        const tarStream = tar
+          .pack(workPath, {
+            entries: fileList.map(file => relative(workPath, file)),
+          })
+          .pipe(createGzip());
+        const tarBuffer = await streamToBuffer(tarStream);
+        debug('Packed tarball');
+        files = new Map([
+          [
+            hash(tarBuffer),
+            {
+              names: [join(workPath, '.vercel/source.tgz')],
+              data: tarBuffer,
+              mode: 0o666,
+            },
+          ],
+        ]);
+      } else {
+        files = await hashes(fileList);
+      }
+    } catch (err: any) {
+      if (clientOptions.prebuilt && err.code === 'ENOENT') {
+        const errPath = relative(workPath, err.path);
+        err.message = `File does not exist: "${relative(workPath, errPath)}"`;
+        if (errPath.split(sep).includes('node_modules')) {
+          err.message = `Please ensure project dependencies have been installed:\n${err.message}`;
+        }
+      }
+      throw err;
     }
 
     debug(`Yielding a 'hashes-calculated' event with ${files.size} hashes`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -724,6 +724,9 @@ importers:
       '@vercel/build-utils':
         specifier: 7.5.1
         version: link:../build-utils
+      '@vercel/error-utils':
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/routing-utils':
         specifier: 3.1.0
         version: link:../routing-utils


### PR DESCRIPTION
Print a more helpful error message for the scenario the user encountered here: https://github.com/orgs/vercel/discussions/5612

What was happening in they were running `vc build` in one GH Action job, and then `vc deploy --prebuilt` in a different job. The later job was does not have `node_modules` populated, causing the deploy command to fail:

<img width="1374" alt="Screenshot 2024-01-29 at 6 31 19 PM" src="https://github.com/vercel/vercel/assets/71256/0402c2fb-35bb-435c-bf4c-10368a27f3ee">

The updated error message hints to the user that the `node_modules` should be installed for the command to succeed:

<img width="813" alt="Screenshot 2024-01-29 at 6 30 54 PM" src="https://github.com/vercel/vercel/assets/71256/2c095e61-9b8a-4dac-9eb7-56363a8b89b8">
