### PR TITLE
Fix rewrite RSC handling with trailingSlash

### DIFF
--- a/.changeset/thirty-pears-whisper.md
+++ b/.changeset/thirty-pears-whisper.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix rewrite RSC handling with trailingSlash

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -217,7 +217,7 @@ export async function serverBuild({
     for (const rewrite of afterFilesRewrites) {
       if (rewrite.src && rewrite.dest) {
         rewrite.src = rewrite.src.replace(
-          '(?:/)?',
+          /\/?\(\?:\/\)\?/,
           '(?<rscsuff>(\\.prefetch)?\\.rsc)?(?:/)?'
         );
         let destQueryIndex = rewrite.dest.indexOf('?');

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/next.config.js
@@ -6,7 +6,11 @@ module.exports = {
   rewrites: async () => {
     return [
       {
-        source: '/rewritten-to-dashboard',
+        source: '/rewritten-to-dashboard/',
+        destination: '/dashboard/',
+      },
+      {
+        source: '/:locale/t/size-chart/:chart/',
         destination: '/dashboard',
       },
     ];

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -7,6 +7,30 @@
   ],
   "probes": [
     {
+      "path": "/en-us/t/size-chart/mens/",
+      "status": 200,
+      "mustContain": "hello from app/dashboard"
+    },
+    {
+      "path": "/en-us/t/size-chart/mens/",
+      "status": 200,
+       "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      },
+      "mustContain": ":{",
+      "mustNotContain": ".prefetch"
+    },
+    {
+      "path": "/en-us/t/size-chart/mens/",
+      "status": 200,
+       "headers": {
+        "RSC": 1
+      },
+      "mustContain": ":{",
+      "mustNotContain": ".rsc"
+    },
+    {
       "path": "/dynamic/category-1/id-1/",
       "status": 200,
       "headers": {


### PR DESCRIPTION
This ensures our rewrite patching to handle RSC requests handles a trailing slash being present with added regression tests. 

