### PR TITLE
[gatsby-plugin-vercel-builder] use --keep-names esbuild flag

### DIFF
--- a/.changeset/happy-nails-walk.md
+++ b/.changeset/happy-nails-walk.md
@@ -1,0 +1,5 @@
+---
+"@vercel/gatsby-plugin-vercel-builder": patch
+---
+
+[gatsby-plugin-vercel-builder] use --keep-names esbuild flag

--- a/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
@@ -35,7 +35,9 @@ export const writeHandler = async ({
       platform: 'node',
       bundle: true,
       minify: true,
-      keepNames: true,
+      // prevents renaming edge cases from causing failures like:
+      // https://github.com/node-fetch/node-fetch/issues/784 
+      keepNames: true, 
       define: {
         'process.env.NODE_ENV': "'production'",
         vercel_pathPrefix: JSON.stringify(prefix),

--- a/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
@@ -35,6 +35,7 @@ export const writeHandler = async ({
       platform: 'node',
       bundle: true,
       minify: true,
+      keepNames: true,
       define: {
         'process.env.NODE_ENV': "'production'",
         vercel_pathPrefix: JSON.stringify(prefix),

--- a/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/handlers/build.ts
@@ -36,8 +36,8 @@ export const writeHandler = async ({
       bundle: true,
       minify: true,
       // prevents renaming edge cases from causing failures like:
-      // https://github.com/node-fetch/node-fetch/issues/784 
-      keepNames: true, 
+      // https://github.com/node-fetch/node-fetch/issues/784
+      keepNames: true,
       define: {
         'process.env.NODE_ENV': "'production'",
         vercel_pathPrefix: JSON.stringify(prefix),


### PR DESCRIPTION
Some packages are very sensitive to minification.
For example: https://github.com/node-fetch/node-fetch/issues/784 which ends up in runtime error, and is hard to notice as they don't reproduce on local dev.

Setting `--keep-names` should prevent those edge cases: https://esbuild.github.io/api/#keep-names