### PR TITLE
Revert "Default ruby to only currently supported version (3.2.0)"

### DIFF
--- a/.changeset/fair-years-share.md
+++ b/.changeset/fair-years-share.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": minor
+"@vercel/static-build": minor
+---
+
+Revert "Default ruby to only currently supported version (3.2.0)"

--- a/packages/build-utils/test/integration.test.ts
+++ b/packages/build-utils/test/integration.test.ts
@@ -23,8 +23,6 @@ const skipFixtures: string[] = [
   '23-pnpm-workspaces',
   '41-nx-monorepo',
   '42-npm-workspace-with-nx',
-  'jekyll-v4',
-  'middleman-v4',
 ];
 
 // eslint-disable-next-line no-restricted-syntax

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -46,7 +46,6 @@ import {
   LocalFileSystemDetector,
 } from '@vercel/fs-detectors';
 
-const SUPPORTED_RUBY_VERSION = '3.2.0';
 const sleep = (n: number) => new Promise(resolve => setTimeout(resolve, n));
 
 const DEV_SERVER_PORT_BIND_TIMEOUT = ms('5m');
@@ -542,9 +541,12 @@ export const build: BuildV2 = async ({
       pathList.push(vendorBin); // Add `./vendor/bin`
       debug(`Added "${vendorBin}" to PATH env because a Gemfile was found`);
       const dir = path.join(workPath, 'vendor', 'bundle', 'ruby');
-      const rubyVersion = SUPPORTED_RUBY_VERSION;
+      const rubyVersion =
+        existsSync(dir) && statSync(dir).isDirectory()
+          ? readdirSync(dir)[0]
+          : '';
       if (rubyVersion) {
-        gemHome = path.join(dir, rubyVersion);
+        gemHome = path.join(dir, rubyVersion); // Add `./vendor/bundle/ruby/2.7.0`
         debug(`Set GEM_HOME="${gemHome}" because a Gemfile was found`);
       }
     }

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -38,14 +38,8 @@ module.exports = function setupTests(groupIndex) {
     console.log('testing group', groupIndex, fixtures);
   }
 
-  const fixturesToSkip = ['jekyll-v3', 'jekyll-v4', 'middleman-v4'];
-
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fixtures) {
-    if (fixturesToSkip.includes(fixture)) {
-      continue;
-    }
-
     const errMsg = testsThatFailToBuild.get(fixture);
     if (errMsg) {
       // eslint-disable-next-line no-loop-func


### PR DESCRIPTION
This reverts commit de63e356223467447cda539ddc435a892303afc7 / #11104. We had no great way to test this without release but we have other things we'd like to deploy today. Will revert the revert when we're closer to fixing just this issue.