### PR TITLE
[remix] Don't install Remix fork when not using split configuration

### DIFF
--- a/.changeset/cool-buttons-suffer.md
+++ b/.changeset/cool-buttons-suffer.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Don't install Remix fork when not using split configuration

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -239,7 +239,7 @@ export const build: BuildV2 = async ({
 
   // If the project is not relying on split configuration,
   // then don't inject the `@vercel/remix-run-dev` fork
-  if (serverBundles.length === 1) {
+  if (!isHydrogen2 && serverBundles.length === 1) {
     // `serverBuildTarget` and `serverBuildPath` are undefined with
     // our remix config modifications, so use the default build path
     serverBundles[0].serverBuildPath = 'build/index.js';

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -249,7 +249,7 @@ export const build: BuildV2 = async ({
   // Override the official `@remix-run/dev` package with the
   // Vercel fork, which supports the `serverBundles` config
   if (
-    serverBundles.length > 0 &&
+    serverBundles.length > 1 &&
     !isHydrogen2 &&
     remixRunDevPkg.name !== '@vercel/remix-run-dev' &&
     !remixRunDevPkgVersion?.startsWith('https:')

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -236,7 +236,6 @@ export const build: BuildV2 = async ({
       routes: routes.map(r => r.id),
     };
   });
-  console.log(remixConfig);
 
   // If the project is not relying on split configuration,
   // then don't inject the `@vercel/remix-run-dev` fork
@@ -246,7 +245,6 @@ export const build: BuildV2 = async ({
       remixConfig.serverBuildPath
     );
   }
-  console.log(serverBundles);
 
   // Override the official `@remix-run/dev` package with the
   // Vercel fork, which supports the `serverBundles` config

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -237,16 +237,18 @@ export const build: BuildV2 = async ({
     };
   });
 
-  // If the project is not relying on split configuration,
-  // then don't inject the `@vercel/remix-run-dev` fork
+  // If the project is *not* relying on split configurations, then set
+  // the `serverBuildPath` to the default Remix path, since the forked
+  // Remix compiler will not be used
   if (!isHydrogen2 && serverBundles.length === 1) {
     // `serverBuildTarget` and `serverBuildPath` are undefined with
     // our remix config modifications, so use the default build path
     serverBundles[0].serverBuildPath = 'build/index.js';
   }
 
-  // Override the official `@remix-run/dev` package with the
-  // Vercel fork, which supports the `serverBundles` config
+  // If the project is relying on split configurations, then override
+  // the official `@remix-run/dev` package with the Vercel fork,
+  // which supports the `serverBundles` config
   if (
     serverBundles.length > 1 &&
     !isHydrogen2 &&

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -240,16 +240,9 @@ export const build: BuildV2 = async ({
   // If the project is not relying on split configuration,
   // then don't inject the `@vercel/remix-run-dev` fork
   if (serverBundles.length === 1) {
-    // The legacy `serverBuildTarget: 'vercel'` config gets wiped away with
-    // out remix config modifications, so use the default path if that's set
-    let serverBuildPath = 'build/index.js';
-    if (!(remixConfig as any).serverBuildTarget) {
-      serverBuildPath = relative(
-        entrypointFsDirname,
-        remixConfig.serverBuildPath
-      );
-    }
-    serverBundles[0].serverBuildPath = serverBuildPath;
+    // `serverBuildTarget` and `serverBuildPath` are undefined with
+    // our remix config modifications, so use the default build path
+    serverBundles[0].serverBuildPath = 'build/index.js';
   }
 
   // Override the official `@remix-run/dev` package with the

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -240,10 +240,16 @@ export const build: BuildV2 = async ({
   // If the project is not relying on split configuration,
   // then don't inject the `@vercel/remix-run-dev` fork
   if (serverBundles.length === 1) {
-    serverBundles[0].serverBuildPath = relative(
-      entrypointFsDirname,
-      remixConfig.serverBuildPath
-    );
+    // The legacy `serverBuildTarget: 'vercel'` config gets wiped away with
+    // out remix config modifications, so use the default path if that's set
+    let serverBuildPath = 'build/index.js';
+    if (!(remixConfig as any).serverBuildTarget) {
+      serverBuildPath = relative(
+        entrypointFsDirname,
+        remixConfig.serverBuildPath
+      );
+    }
+    serverBundles[0].serverBuildPath = serverBuildPath;
   }
 
   // Override the official `@remix-run/dev` package with the

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -174,7 +174,6 @@ export const build: BuildV2 = async ({
     pkg.dependencies?.['@remix-run/dev'] ||
     pkg.devDependencies?.['@remix-run/dev'];
 
-  // These get populated inside the try/catch below
   const serverBundlesMap = new Map<string, ConfigRoute[]>();
   const resolvedConfigsMap = new Map<ConfigRoute, ResolvedRouteConfig>();
 

--- a/packages/remix/src/build.ts
+++ b/packages/remix/src/build.ts
@@ -174,9 +174,85 @@ export const build: BuildV2 = async ({
     pkg.dependencies?.['@remix-run/dev'] ||
     pkg.devDependencies?.['@remix-run/dev'];
 
+  // These get populated inside the try/catch below
+  const serverBundlesMap = new Map<string, ConfigRoute[]>();
+  const resolvedConfigsMap = new Map<ConfigRoute, ResolvedRouteConfig>();
+
+  // Read the `export const config` (if any) for each route
+  const project = new Project();
+  const staticConfigsMap = new Map<ConfigRoute, BaseFunctionConfig | null>();
+  for (const route of remixRoutes) {
+    const routePath = join(remixConfig.appDirectory, route.file);
+    let staticConfig = getConfig(project, routePath);
+    if (staticConfig && isHydrogen2) {
+      console.log(
+        'WARN: `export const config` is currently not supported for Hydrogen v2 apps'
+      );
+      staticConfig = null;
+    }
+    staticConfigsMap.set(route, staticConfig);
+  }
+
+  for (const route of remixRoutes) {
+    const config = getResolvedRouteConfig(
+      route,
+      remixConfig.routes,
+      staticConfigsMap,
+      isHydrogen2
+    );
+    resolvedConfigsMap.set(route, config);
+  }
+
+  // Figure out which routes belong to which server bundles
+  // based on having common static config properties
+  for (const route of remixRoutes) {
+    if (isLayoutRoute(route.id, remixRoutes)) continue;
+
+    const config = resolvedConfigsMap.get(route);
+    if (!config) {
+      throw new Error(`Expected resolved config for "${route.id}"`);
+    }
+    const hash = calculateRouteConfigHash(config);
+
+    let routesForHash = serverBundlesMap.get(hash);
+    if (!Array.isArray(routesForHash)) {
+      routesForHash = [];
+      serverBundlesMap.set(hash, routesForHash);
+    }
+
+    routesForHash.push(route);
+  }
+
+  const serverBundles: ServerBundle[] = Array.from(
+    serverBundlesMap.entries()
+  ).map(([hash, routes]) => {
+    const runtime = resolvedConfigsMap.get(routes[0])?.runtime ?? 'nodejs';
+    return {
+      serverBuildPath: isHydrogen2
+        ? relative(entrypointFsDirname, remixConfig.serverBuildPath)
+        : `${relative(
+            entrypointFsDirname,
+            dirname(remixConfig.serverBuildPath)
+          )}/build-${runtime}-${hash}.js`,
+      routes: routes.map(r => r.id),
+    };
+  });
+  console.log(remixConfig);
+
+  // If the project is not relying on split configuration,
+  // then don't inject the `@vercel/remix-run-dev` fork
+  if (serverBundles.length === 1) {
+    serverBundles[0].serverBuildPath = relative(
+      entrypointFsDirname,
+      remixConfig.serverBuildPath
+    );
+  }
+  console.log(serverBundles);
+
   // Override the official `@remix-run/dev` package with the
   // Vercel fork, which supports the `serverBundles` config
   if (
+    serverBundles.length > 0 &&
     !isHydrogen2 &&
     remixRunDevPkg.name !== '@vercel/remix-run-dev' &&
     !remixRunDevPkgVersion?.startsWith('https:')
@@ -266,72 +342,7 @@ export const build: BuildV2 = async ({
     ? `${remixConfigPath}.original${extname(remixConfigPath)}`
     : undefined;
 
-  // These get populated inside the try/catch below
-  let serverBundles: ServerBundle[];
-  const serverBundlesMap = new Map<string, ConfigRoute[]>();
-  const resolvedConfigsMap = new Map<ConfigRoute, ResolvedRouteConfig>();
-
   try {
-    // Read the `export const config` (if any) for each route
-    const project = new Project();
-    const staticConfigsMap = new Map<ConfigRoute, BaseFunctionConfig | null>();
-    for (const route of remixRoutes) {
-      const routePath = join(remixConfig.appDirectory, route.file);
-      let staticConfig = getConfig(project, routePath);
-      if (staticConfig && isHydrogen2) {
-        console.log(
-          'WARN: `export const config` is currently not supported for Hydrogen v2 apps'
-        );
-        staticConfig = null;
-      }
-      staticConfigsMap.set(route, staticConfig);
-    }
-
-    for (const route of remixRoutes) {
-      const config = getResolvedRouteConfig(
-        route,
-        remixConfig.routes,
-        staticConfigsMap,
-        isHydrogen2
-      );
-      resolvedConfigsMap.set(route, config);
-    }
-
-    // Figure out which routes belong to which server bundles
-    // based on having common static config properties
-    for (const route of remixRoutes) {
-      if (isLayoutRoute(route.id, remixRoutes)) continue;
-
-      const config = resolvedConfigsMap.get(route);
-      if (!config) {
-        throw new Error(`Expected resolved config for "${route.id}"`);
-      }
-      const hash = calculateRouteConfigHash(config);
-
-      let routesForHash = serverBundlesMap.get(hash);
-      if (!Array.isArray(routesForHash)) {
-        routesForHash = [];
-        serverBundlesMap.set(hash, routesForHash);
-      }
-
-      routesForHash.push(route);
-    }
-
-    serverBundles = Array.from(serverBundlesMap.entries()).map(
-      ([hash, routes]) => {
-        const runtime = resolvedConfigsMap.get(routes[0])?.runtime ?? 'nodejs';
-        return {
-          serverBuildPath: isHydrogen2
-            ? relative(entrypointFsDirname, remixConfig.serverBuildPath)
-            : `${relative(
-                entrypointFsDirname,
-                dirname(remixConfig.serverBuildPath)
-              )}/build-${runtime}-${hash}.js`,
-          routes: routes.map(r => r.id),
-        };
-      }
-    );
-
     // We need to patch the `remix.config.js` file to force some values necessary
     // for a build that works on either Node.js or the Edge runtime
     if (!isHydrogen2 && remixConfigPath && renamedRemixConfigPath) {


### PR DESCRIPTION
The fork of the Remix compiler is only necessary when the project is utilizing split configurations in their routes (i.e. mixing Node.js and Edge functions).

However, the injecting of the forked compiler has proven to be brittle and has many edge cases which cause the fork to not be present. Considering that the more common case is to _not_ use split configuration, skip the fork entirely when that is the case.

This is somewhat of a band-aid / hold over for the "old" Remix. With the Remix + Vite configuration, the fork will be entirely unnecessary.