### PR TITLE
[node][next][redwood][remix] bump `@vercel/nft@0.26.4`

### DIFF
--- a/.changeset/strange-deers-complain.md
+++ b/.changeset/strange-deers-complain.md
@@ -1,0 +1,8 @@
+---
+"@vercel/next": patch
+"@vercel/node": patch
+"@vercel/redwood": patch
+"@vercel/remix-builder": patch
+---
+
+bump `@vercel/nft@0.26.4`

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@vercel/nft": "0.26.3"
+    "@vercel/nft": "0.26.4"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.19",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,7 @@
     "@types/node": "14.18.33",
     "@vercel/build-utils": "7.7.0",
     "@vercel/error-utils": "2.0.2",
-    "@vercel/nft": "0.26.3",
+    "@vercel/nft": "0.26.4",
     "@vercel/static-config": "3.0.0",
     "async-listen": "3.0.0",
     "cjs-module-lexer": "1.2.3",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/nft": "0.26.3",
+    "@vercel/nft": "0.26.4",
     "@vercel/routing-utils": "3.1.0",
     "semver": "6.3.1"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -21,7 +21,7 @@
     "defaults"
   ],
   "dependencies": {
-    "@vercel/nft": "0.26.3",
+    "@vercel/nft": "0.26.4",
     "@vercel/static-config": "3.0.0",
     "ts-morph": "12.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,8 +1082,8 @@ importers:
   packages/next:
     dependencies:
       '@vercel/nft':
-        specifier: 0.26.3
-        version: 0.26.3
+        specifier: 0.26.4
+        version: 0.26.4
     devDependencies:
       '@types/aws-lambda':
         specifier: 8.10.19
@@ -1221,8 +1221,8 @@ importers:
         specifier: 2.0.2
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 0.26.3
-        version: 0.26.3
+        specifier: 0.26.4
+        version: 0.26.4
       '@vercel/static-config':
         specifier: 3.0.0
         version: link:../static-config
@@ -1348,8 +1348,8 @@ importers:
   packages/redwood:
     dependencies:
       '@vercel/nft':
-        specifier: 0.26.3
-        version: 0.26.3
+        specifier: 0.26.4
+        version: 0.26.4
       '@vercel/routing-utils':
         specifier: 3.1.0
         version: link:../routing-utils
@@ -1382,8 +1382,8 @@ importers:
   packages/remix:
     dependencies:
       '@vercel/nft':
-        specifier: 0.26.3
-        version: 0.26.3
+        specifier: 0.26.4
+        version: 0.26.4
       '@vercel/static-config':
         specifier: 3.0.0
         version: link:../static-config
@@ -5393,8 +5393,8 @@ packages:
       - supports-color
     dev: false
 
-  /@vercel/nft@0.26.3:
-    resolution: {integrity: sha512-h1z/NN9ppS4YOKwSgBoopJlhm7tS2Qb/9Ld1HXjDpvvTE7mY0xVD8nllXs+RihD9uTGJISOIMzp18Eg0EApaMA==}
+  /@vercel/nft@0.26.4:
+    resolution: {integrity: sha512-j4jCOOXke2t8cHZCIxu1dzKLHLcFmYzC3yqAK6MfZznOL1QIJKd0xcFsXK3zcqzU7ScsE2zWkiMMNHGMHgp+FA==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
- Release https://github.com/vercel/nft/releases/tag/0.26.4