### PR TITLE
[tests] Add dependabot for fixture updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 1
+    reviewers:
+      - 'trek'
+      - 'TooTallNate'
+      - 'EndangeredMassa'
+    commit-message:
+      prefix: '[framework-fixtures]'
+    package-ecosystem: 'npm'
+    directory: /packages/static-build/test/fixtures/angular-v17
+    allow:
+      - dependency-name: '@angular*'
+    groups:
+      core:
+        patterns:
+          - '@angular*'
+        update-types:
+          - 'minor'


### PR DESCRIPTION
Gradually adding dependabot updaters to avoid the problem of getting hundreds of individual updates:

* Using the new `groups` key (new as of [~September 2023](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/)).
* Focused only to "core" dependencies of the framework.
* Tested on [separate repo](https://github.com/trek/test-dependabot/pull/5) to avoid PR spam.