### PR TITLE
[next] Support pre-generated pages without fallbacks with Partial Prerendering

### DIFF
--- a/.changeset/calm-terms-dance.md
+++ b/.changeset/calm-terms-dance.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Enable partial prerendering support for pre-generated pages

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1143,9 +1143,8 @@ export const build: BuildV2 = async ({
     });
 
     /**
-     * Originally, you had to have a `pages/api` route in order to add a preview
-     * mode cookie. This isn't the case with app router, as it can be done
-     * dynamically via a Server Action or a App Route.
+     * This is a detection for preview mode that's required for the pages
+     * router.
      */
     const canUsePreviewMode = Object.keys(pages).some(page =>
       isApiPage(pages[page].fsPath)

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2143,6 +2143,7 @@ export const build: BuildV2 = async ({
       appPathRoutesManifest,
       isSharedLambdas,
       canUsePreviewMode,
+      omittedPrerenderRoutes,
     });
 
     Object.keys(prerenderManifest.staticRoutes).forEach(route =>

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1318,29 +1318,31 @@ export async function serverBuild({
     omittedPrerenderRoutes,
   });
 
-  const prerenderParameters: Array<Parameters<typeof prerenderRoute>> = [];
-
-  for (const route of Object.keys(prerenderManifest.staticRoutes)) {
-    prerenderParameters.push([route, {}]);
-  }
-
-  for (const route of Object.keys(prerenderManifest.fallbackRoutes)) {
-    prerenderParameters.push([route, { isFallback: true }]);
-  }
-
-  for (const route of Object.keys(prerenderManifest.blockingFallbackRoutes)) {
-    prerenderParameters.push([route, { isBlocking: true }]);
-  }
-
-  if (static404Page && canUsePreviewMode) {
-    for (const route of Array.from(omittedPrerenderRoutes)) {
-      prerenderParameters.push([route, { isOmitted: true }]);
-    }
-  }
+  await Promise.all(
+    Object.keys(prerenderManifest.staticRoutes).map(route =>
+      prerenderRoute(route, {})
+    )
+  );
 
   await Promise.all(
-    prerenderParameters.map(parameters => prerenderRoute(...parameters))
+    Object.keys(prerenderManifest.fallbackRoutes).map(route =>
+      prerenderRoute(route, { isFallback: true })
+    )
   );
+
+  await Promise.all(
+    Object.keys(prerenderManifest.blockingFallbackRoutes).map(route =>
+      prerenderRoute(route, { isBlocking: true })
+    )
+  );
+
+  if (static404Page && canUsePreviewMode) {
+    await Promise.all(
+      Array.from(omittedPrerenderRoutes).map(route =>
+        prerenderRoute(route, { isOmitted: true })
+      )
+    );
+  }
 
   prerenderRoutes.forEach(route => {
     if (experimentalPPRRoutes.has(route)) return;

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2407,6 +2407,10 @@ export const onPrerenderRoute =
           );
         }
 
+        // If a source route exists, and it's not listed as an omitted route,
+        // then use the src route as the basis for the experimental streaming
+        // lambda path. If the route doesn't have a source route or it's not
+        // omitted, then use the more specific `routeKey` as the basis.
         if (srcRoute && !omittedPrerenderRoutes.has(srcRoute)) {
           experimentalStreamingLambdaPath =
             experimentalStreamingLambdaPaths.get(

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -304,19 +304,31 @@ export async function getRoutesManifest(
   return routesManifest;
 }
 
-export async function getDynamicRoutes(
-  entryPath: string,
-  entryDirectory: string,
-  dynamicPages: ReadonlyArray<string>,
-  isDev?: boolean,
-  routesManifest?: RoutesManifest,
-  omittedRoutes?: ReadonlySet<string>,
-  canUsePreviewMode?: boolean,
-  bypassToken?: string,
-  isServerMode?: boolean,
-  dynamicMiddlewareRouteMap?: ReadonlyMap<string, RouteWithSrc>,
-  experimentalPPR?: boolean
-): Promise<RouteWithSrc[]> {
+export async function getDynamicRoutes({
+  entryPath,
+  entryDirectory,
+  dynamicPages,
+  isDev,
+  routesManifest,
+  omittedRoutes,
+  canUsePreviewMode,
+  bypassToken,
+  isServerMode,
+  dynamicMiddlewareRouteMap,
+  experimentalPPRRoutes,
+}: {
+  entryPath: string;
+  entryDirectory: string;
+  dynamicPages: string[];
+  isDev?: boolean;
+  routesManifest?: RoutesManifest;
+  omittedRoutes?: ReadonlySet<string>;
+  canUsePreviewMode?: boolean;
+  bypassToken?: string;
+  isServerMode?: boolean;
+  dynamicMiddlewareRouteMap?: ReadonlyMap<string, RouteWithSrc>;
+  experimentalPPRRoutes: ReadonlySet<string>;
+}): Promise<RouteWithSrc[]> {
   if (routesManifest) {
     switch (routesManifest.version) {
       case 1:
@@ -389,7 +401,7 @@ export async function getDynamicRoutes(
             ];
           }
 
-          if (experimentalPPR) {
+          if (experimentalPPRRoutes.has(page)) {
             let dest = route.dest?.replace(/($|\?)/, '.prefetch.rsc$1');
 
             if (page === '/' || page === '/index') {
@@ -919,6 +931,10 @@ export type NextPrerenderedRoutes = {
     };
   };
 
+  /**
+   * Routes that have their fallback behavior is disabled. All routes would've
+   * been provided in the top-level `routes` key (`staticRoutes`).
+   */
   omittedRoutes: {
     [route: string]: {
       routeRegex: string;
@@ -1298,8 +1314,6 @@ export async function getPrerenderManifest(
             prefetchDataRouteRegex,
           };
         } else {
-          // Fallback behavior is disabled, all routes would've been provided
-          // in the top-level `routes` key (`staticRoutes`).
           ret.omittedRoutes[lazyRoute] = {
             experimentalBypassFor,
             experimentalPPR,

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/no-fallback/[slug]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/no-fallback/[slug]/page.jsx
@@ -1,0 +1,18 @@
+import React, { Suspense } from 'react'
+import { Dynamic } from '../../../components/dynamic'
+
+export const dynamicParams = false;
+
+const slugs = ['a', 'b', 'c'];
+
+export function generateStaticParams() {
+  return slugs.map((slug) => ({  slug  }));
+}
+
+export default function NoFallbackPage({ params: { slug } }) {
+  return (
+    <Suspense fallback={<Dynamic pathname={`/no-fallback/${slug}`} fallback />}>
+      <Dynamic pathname={`/no-fallback/${slug}`} />
+    </Suspense>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -19,6 +19,9 @@ const pages = [
   { pathname: '/no-suspense/nested/a', dynamic: true },
   { pathname: '/no-suspense/nested/b', dynamic: true },
   { pathname: '/no-suspense/nested/c', dynamic: true },
+  { pathname: '/no-fallback/a', dynamic: true },
+  { pathname: '/no-fallback/b', dynamic: true },
+  { pathname: '/no-fallback/c', dynamic: true },
   // TODO: uncomment when we've fixed the 404 case for force-dynamic pages
   // { pathname: '/dynamic/force-dynamic', dynamic: 'force-dynamic' },
   { pathname: '/dynamic/force-static', dynamic: 'force-static' },

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -27,6 +27,15 @@ const pages = [
   { pathname: '/dynamic/force-static', dynamic: 'force-static' },
 ];
 
+const cases = {
+  404: [
+    // For routes that do not support fallback (they had `dynamicParams` set to
+    // `false`), we shouldn't see any fallback behavior for routes not defined
+    // in `getStaticParams`.
+    { pathname: '/no-fallback/non-existent' },
+  ],
+};
+
 const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
@@ -50,6 +59,14 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         const html = await res.text();
         expect(html).toContain(expected);
         expect(html).toContain('</html>');
+      }
+    );
+
+    it.each(cases[404])(
+      'should return 404 for $pathname',
+      async ({ pathname }) => {
+        const res = await fetch(`${ctx.deploymentUrl}${pathname}`);
+        expect(res.status).toEqual(404);
       }
     );
   });
@@ -91,6 +108,16 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         }
       }
     );
+
+    it.each(cases[404])(
+      'should return 404 for $pathname',
+      async ({ pathname }) => {
+        const res = await fetch(`${ctx.deploymentUrl}${pathname}`, {
+          headers: { RSC: 1, 'Next-Router-Prefetch': '1' },
+        });
+        expect(res.status).toEqual(404);
+      }
+    );
   });
 
   describe('dynamic RSC payloads should return', () => {
@@ -125,5 +152,15 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         expect(text).not.toContain(expected);
       }
     });
+
+    it.each(cases[404])(
+      'should return 404 for $pathname',
+      async ({ pathname }) => {
+        const res = await fetch(`${ctx.deploymentUrl}${pathname}`, {
+          headers: { RSC: 1 },
+        });
+        expect(res.status).toEqual(404);
+      }
+    );
   });
 });

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/package.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "next": "canary",
-    "react": "experimental",
-    "react-dom": "experimental"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "ignoreNextjsUpdates": true
 }


### PR DESCRIPTION
When using App Router, you can declare a route that has dynamic path segments using the `[param]` syntax in the folder structure. These can be either handled dynamically (the default), statically, or both. When these static parameters are provided statically, it could look something like this:

```typescript
// app/blog/[slug]/page.tsx
import { getBlogPosts, getBlogPost } from "@/db"

// 🔬 This is the important bit
export const dynamicParams = false;

type Props = {
  params: {
    slug: string
  }
}

export async function generateStaticParams() {
  const posts = await getBlogPosts()
  return posts.map(({ slug }) => ({ slug }))
}

export default async function BlogPage({ params: { slug } }: Props) {
  const post = await getBlogPost(slug)
  return <div>My Blog Post: {post.title}</div>
}
```

By setting `dynamicParams = false`, you're telling Next.js that you shouldn't support new blog posts that aren't defined in the `generateStaticParams`. When Partial Prerendering has been enabled, we have a bit of a problem. The previous code assumed that if you had pre-generated the routes, and that there was no fallback, that no additional rewrites should be added to support dynamic routes (as the routes themselves have been pre-generated).

This pull request fixes this by creating outputs for each of the statically generated routes when they have dynamic parameters turned off. This creates N*2 more outputs/routes for each statically generated route, as it requires an output for the Partial Prerendering Resume route as well as the Dynamic RSC route. This ensures that no other route match can be hit if `dynamicParams` is set to `false`.