### PR TITLE
fix: missing experimental field

### DIFF
--- a/.changeset/swift-jobs-protect.md
+++ b/.changeset/swift-jobs-protect.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+fix: missing experimental field

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1170,6 +1170,7 @@ export async function serverBuild({
         maxDuration: group.maxDuration,
         isStreaming: group.isStreaming,
         nextVersion,
+        experimentalAllowBundling,
       };
 
       const lambda = await createLambdaFromPseudoLayers(options);


### PR DESCRIPTION
Ensures we pass this through properly when the flag is enabled