### PR TITLE
[remix] Ensure the symlink directory exists in `ensureSymlink()`

### DIFF
--- a/.changeset/weak-countries-pull.md
+++ b/.changeset/weak-countries-pull.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Ensure the symlink directory exists in `ensureSymlink()`

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -359,6 +359,7 @@ async function ensureSymlink(
     }
   }
 
+  await fs.mkdir(symlinkDir, { recursive: true });
   await fs.symlink(relativeTarget, symlinkPath);
   debug(`Created symlink for "${pkgName}"`);
 }

--- a/packages/remix/test/unit.ensure-resolvable.test.ts
+++ b/packages/remix/test/unit.ensure-resolvable.test.ts
@@ -17,4 +17,17 @@ describe('ensureResolvable()', () => {
       await fs.rm(start, { recursive: true });
     }
   });
+
+  it('should create a symlink when the node_modules directory does not exist', async () => {
+    const FIXTURE = join(FIXTURES_DIR, '00-pnpm');
+    const start = join(FIXTURE, 'apps/a');
+    try {
+      await fs.mkdir(start, { recursive: true });
+      await ensureResolvable(start, FIXTURE, 'ms');
+      const stat = await fs.lstat(join(start, 'node_modules/ms'));
+      expect(stat.isSymbolicLink()).toEqual(true);
+    } finally {
+      await fs.rm(start, { recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
Customer reported an edge case where (in a monorepo) their project's `package.json` did not list any dependencies (instead they are listed at the root-level `package.json`) and this caused the `node_modules` directory to not exist in the app subdirectory, causing `ensureSymlink()` to fail.