### PR TITLE
[remix] Sort dynamic routes by precedence

### DIFF
--- a/.changeset/quick-snakes-whisper.md
+++ b/.changeset/quick-snakes-whisper.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Sort dynamic routes by precedence

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -571,10 +571,10 @@ module.exports = config;`;
     output[path] = func;
 
     // If this is a dynamic route then add a Vercel route
-    const re = getRegExpFromPath(rePath);
-    if (re) {
+    const result = getRegExpFromPath(rePath);
+    if (result) {
       routes.push({
-        src: re.source,
+        src: result.re.source,
         dest: path,
       });
     }

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -194,10 +194,13 @@ export function getPathFromRoute(
   return { path, rePath };
 }
 
-export function getRegExpFromPath(rePath: string): RegExp | false {
+export function getRegExpFromPath(
+  rePath: string
+): { re: RegExp; keys: Key[] } | false {
   const keys: Key[] = [];
   const re = pathToRegexp(rePath, keys);
-  return keys.length > 0 ? re : false;
+  if (!keys.length) return false;
+  return { re, keys };
 }
 
 /**

--- a/packages/remix/test/fixtures-vite/02-interactive-remix-routing-v2/probes.json
+++ b/packages/remix/test/fixtures-vite/02-interactive-remix-routing-v2/probes.json
@@ -61,6 +61,10 @@
       "mustContain": "authRegister Page"
     },
     {
+      "path": "/products/fr",
+      "mustContain": "ProductsPage"
+    },
+    {
       "path": "/products/en/american-flag-speedo",
       "status": 200,
       "mustContain": "ProductPage"

--- a/packages/remix/test/unit.get-regexp-from-path.test.ts
+++ b/packages/remix/test/unit.get-regexp-from-path.test.ts
@@ -197,7 +197,11 @@ describe('getRegExpFromPath()', () => {
       ],
     },
   ])('with path "$path"', ({ path, urls }) => {
-    const re = getRegExpFromPath(path) as RegExp;
+    const result = getRegExpFromPath(path);
+    if (!result) {
+      throw new Error('Expected truthy');
+    }
+    const { re } = result;
 
     it('should return RegExp', () => {
       expect(re).toBeInstanceOf(RegExp);


### PR DESCRIPTION
Ensure routes are sorted so that more specific routes come before more permissive routes. For example, given two pages:

* `products.($lang).$productId.tsx`
* `products.($lang).categories.tsx`

In this example, the `categories` route should come first in the routes array, because it is more specific than the dynamic `$productId` parameter. If the `$productId` route is first, then it would erroneously match against "categories" and end up serving the wrong content upon server render, which would cause a hydration mismatch warning on the client-side.