### PR TITLE
[next] Ensure all static routes have static streaming lambda path

### DIFF
--- a/.changeset/brave-parrots-walk.md
+++ b/.changeset/brave-parrots-walk.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Ensure that static PPR pages have static streaming lambda paths.

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2142,7 +2142,6 @@ export const build: BuildV2 = async ({
       appPathRoutesManifest,
       isSharedLambdas,
       canUsePreviewMode,
-      omittedPrerenderRoutes,
     });
 
     await Promise.all(

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1229,34 +1229,31 @@ export async function serverBuild({
             // We want to add the `experimentalStreamingLambdaPath` to this
             // output.
             experimentalStreamingLambdaPaths.set(outputName, key);
-          } else {
-            // As this is an omitted page, we should generate the experimental
-            // partial prerendering resume route for each of these routes that
-            // support partial prerendering. This is because the routes that
-            // haven't been omitted will have rewrite rules in place to rewrite
-            // the original request `/blog/my-slug` to the dynamic path
-            // `/blog/[slug]?nxtPslug=my-slug`.
-            for (const [
-              routePathname,
-              { srcRoute, experimentalPPR },
-            ] of Object.entries(prerenderManifest.staticRoutes)) {
-              // If the srcRoute doesn't match or this doesn't support
-              // experimental partial prerendering, then we can skip this route.
-              if (srcRoute !== pagePathname || !experimentalPPR) continue;
+          }
 
-              // If this route is the same as the page route, then we can skip
-              // it, because we've already added the lambda to the output.
-              if (routePathname === pagePathname) continue;
+          // For each static route that was generated, we should generate a
+          // specific partial prerendering resume route. This is because any
+          // static route that is matched will not hit the rewrite rules.
+          for (const [
+            routePathname,
+            { srcRoute, experimentalPPR },
+          ] of Object.entries(prerenderManifest.staticRoutes)) {
+            // If the srcRoute doesn't match or this doesn't support
+            // experimental partial prerendering, then we can skip this route.
+            if (srcRoute !== pagePathname || !experimentalPPR) continue;
 
-              const key = getPostponeResumePathname(
-                entryDirectory,
-                routePathname
-              );
-              lambdas[key] = lambda;
+            // If this route is the same as the page route, then we can skip
+            // it, because we've already added the lambda to the output.
+            if (routePathname === pagePathname) continue;
 
-              outputName = path.posix.join(entryDirectory, routePathname);
-              experimentalStreamingLambdaPaths.set(outputName, key);
-            }
+            const key = getPostponeResumePathname(
+              entryDirectory,
+              routePathname
+            );
+            lambdas[key] = lambda;
+
+            outputName = path.posix.join(entryDirectory, routePathname);
+            experimentalStreamingLambdaPaths.set(outputName, key);
           }
 
           continue;
@@ -1314,7 +1311,6 @@ export async function serverBuild({
     hasPages404: routesManifest.pages404,
     isCorrectNotFoundRoutes,
     isEmptyAllowQueryForPrendered,
-    omittedPrerenderRoutes,
   });
 
   await Promise.all(

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/components/dynamic.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/components/dynamic.jsx
@@ -20,7 +20,11 @@ export const Dynamic = ({ pathname, fallback }) => {
         {pathname && (
           <>
             <dt>Pathname</dt>
-            <dd>{pathname}</dd>
+            {/* We're encoding this using the following format so that even if
+                the HTML is sent as flight data, it will still retain the same
+                content, and can be inspected without having to run the
+                javascript. */}
+            <dd data-pathname={`data-pathname=${pathname}`}>{pathname}</dd>
           </>
         )}
         {messages.map(({ name, value }) => (

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -59,6 +59,9 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         const html = await res.text();
         expect(html).toContain(expected);
         expect(html).toContain('</html>');
+
+        // Validate that the loaded URL is correct.
+        expect(html).toContain(`data-pathname=${pathname}`);
       }
     );
 


### PR DESCRIPTION
When there's a match for a prerender, the dynamic query parameters will not be provided via the `x-now-route-matches`. This ensures that when generating any static route that the static streaming lambda path is used if it's provided, ensuring that when a page is generated via `generateStaticParams`:

```tsx
// app/blog/[slug]/page.tsx

type Props = {
  params: {
    slug: string
  }
}

export function generateStaticParams() {
  return [{ slug: "one" }, { slug: "two" }, { slug: "three" }]
}

export default function BlogPage({ slug }: Props) {
  // ...
}
```

That we use the specific routes (`/blog/one`, `/blog/two`, and `/blog/three`) for the partial prerendering streaming path instead of the paramatarized pathname (`/blog/[slug]`) as the rewrites won't be matched once a match for a prerender has been found.

This additionally updates the tests to ensure that the correct pathname is observed (this was previously silently failing).