### PR TITLE
[cli] stops warning Next.js users about legacy Speed Insights

### DIFF
--- a/.changeset/cold-carrots-kick.md
+++ b/.changeset/cold-carrots-kick.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Stops warning about legacy Speed Insights for Next.js apps

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -257,9 +257,6 @@ export default async function main(client: Client): Promise<number> {
     if (project.settings.analyticsId) {
       envToUnset.add('VERCEL_ANALYTICS_ID');
       process.env.VERCEL_ANALYTICS_ID = project.settings.analyticsId;
-      output.warn(
-        'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
-      );
     }
 
     // Some build processes use these env vars to platform detect Vercel

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -785,7 +785,7 @@ describe('build', () => {
     expect(files.sort()).toEqual(['index.html', 'package.json']);
   });
 
-  it('should set `VERCEL_ANALYTICS_ID` environment variable and warn users', async () => {
+  it('should set `VERCEL_ANALYTICS_ID` environment variable', async () => {
     const cwd = fixture('vercel-analytics');
     const output = join(cwd, '.vercel/output');
     client.cwd = cwd;
@@ -794,9 +794,6 @@ describe('build', () => {
 
     const env = await fs.readJSON(join(output, 'static', 'env.json'));
     expect(Object.keys(env).includes('VERCEL_ANALYTICS_ID')).toEqual(true);
-    await expect(client.stderr).toOutput(
-      'Vercel Speed Insights auto-injection is deprecated in favor of @vercel/speed-insights package. Learn more: https://vercel.link/upgrate-to-speed-insights-package'
-    );
   });
 
   it('should load environment variables from `.vercel/.env.preview.local`', async () => {


### PR DESCRIPTION
### 🧐 What's in there?

Vercel's Speed Insights legacy injection is deprecated in favor of `@vercel/speed-insights` package.
CLI has a couple places where it warns users running `vc build` locally (or on their CI).

Some users complained about seeing the warning while they are already using the package.

This PR removes the message

### ❗ Note to reviewers

@tobiaslins, @timolins and I had a long discussion on the approach here.

This warning is issued because during `vc pull`, the project API on Vercel returns a legacy analytics.id field, [which is stored](https://github.com/vercel/vercel/blame/main/packages/cli/src/util/projects/project-settings.ts#L35) in `.vercel/project.json`.
While it is legit for users who never used `@vercel/speed-insights` package, it also appear for users who migrated from legacy.

Besides setting the warning, `VERCEL_ANALYTICS_ID` is set, which triggers auto-injection in Next.js, and is useful during self-hosting.

We first considered removing the legacy id from `project.json`, but it would break self-hosting.
We also considered printing the warning only if the application never used the package (which the project API on Vercel knows). 
In the end, we realized that vercel.com Speed Insights dashboard has plenty of disclaimer and incentives to use the new package. Having it in the CLI doesn't worth the annoyance.