### PR TITLE
Update CODEOWNERS to ensure Zero Config can always approve

### DIFF
--- a/.changeset/bright-trees-smash.md
+++ b/.changeset/bright-trees-smash.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update CODEOWNERS to ensure Zero Config can always approve

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,13 @@
 *                                        @TooTallNate @EndangeredMassa @trek
 /.github/workflows                       @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @agadzik @chloetedder
-/packages/next                           @TooTallNate @EndangeredMassa @trek @Ethan-Arrowood @ijjk @ztanner
+/packages/next                           @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood
 /packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/static-build                   @TooTallNate @EndangeredMassa @trek
 /packages/edge                           @TooTallNate @EndangeredMassa @trek @vercel/compute
 /examples                                @TooTallNate @EndangeredMassa @trek @leerob
 /examples/create-react-app               @TooTallNate @EndangeredMassa @trek @Timer
-/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi
+/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood
 /packages/node                           @TooTallNate @EndangeredMassa @trek @Kikobeats
 
 # Unrestricted Paths

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,13 @@
 *                                        @TooTallNate @EndangeredMassa @trek
 /.github/workflows                       @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @agadzik @chloetedder
-/packages/next                           @TooTallNate @EndangeredMassa @Ethan-Arrowood @trek @ijjk @ztanner
+/packages/next                           @TooTallNate @EndangeredMassa @trek @Ethan-Arrowood @ijjk @ztanner
 /packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/static-build                   @TooTallNate @EndangeredMassa @trek
-/packages/edge                           @vercel/compute @TooTallNate @EndangeredMassa @trek
-/examples                                @leerob
-/examples/create-react-app               @Timer
-/examples/nextjs                         @timneutkens @ijjk @ztanner @huozhi
+/packages/edge                           @TooTallNate @EndangeredMassa @trek @vercel/compute
+/examples                                @TooTallNate @EndangeredMassa @trek @leerob
+/examples/create-react-app               @TooTallNate @EndangeredMassa @trek @Timer
+/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi
 /packages/node                           @TooTallNate @EndangeredMassa @trek @Kikobeats
 
 # Unrestricted Paths

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,13 @@
 *                                        @TooTallNate @EndangeredMassa @trek
 /.github/workflows                       @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @agadzik @chloetedder
-/packages/next                           @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood
+/packages/next                           @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
 /packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @ijjk
 /packages/static-build                   @TooTallNate @EndangeredMassa @trek
 /packages/edge                           @TooTallNate @EndangeredMassa @trek @vercel/compute
 /examples                                @TooTallNate @EndangeredMassa @trek @leerob
 /examples/create-react-app               @TooTallNate @EndangeredMassa @trek @Timer
-/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood
+/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
 /packages/node                           @TooTallNate @EndangeredMassa @trek @Kikobeats
 
 # Unrestricted Paths

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,17 @@
 # https://help.github.com/en/articles/about-code-owners
 
 # Restricted Paths
-*                                        @TooTallNate @EndangeredMassa @trek
-/.github/workflows                       @TooTallNate @EndangeredMassa @trek @ijjk
-/packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @agadzik @chloetedder
-/packages/next                           @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
-/packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @ijjk
-/packages/static-build                   @TooTallNate @EndangeredMassa @trek
-/packages/edge                           @TooTallNate @EndangeredMassa @trek @vercel/compute
-/examples                                @TooTallNate @EndangeredMassa @trek @leerob
-/examples/create-react-app               @TooTallNate @EndangeredMassa @trek @Timer
-/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
-/packages/node                           @TooTallNate @EndangeredMassa @trek @Kikobeats
+*                                        @TooTallNate @EndangeredMassa @trek @onsclom
+/.github/workflows                       @TooTallNate @EndangeredMassa @trek @onsclom @ijjk
+/packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @onsclom @agadzik @chloetedder
+/packages/next                           @TooTallNate @EndangeredMassa @trek @onsclom @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
+/packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @onsclom @ijjk
+/packages/static-build                   @TooTallNate @EndangeredMassa @trek @onsclom
+/packages/edge                           @TooTallNate @EndangeredMassa @trek @onsclom @vercel/compute
+/examples                                @TooTallNate @EndangeredMassa @trek @onsclom @leerob
+/examples/create-react-app               @TooTallNate @EndangeredMassa @trek @onsclom @Timer
+/examples/nextjs                         @TooTallNate @EndangeredMassa @trek @onsclom @timneutkens @ijjk @ztanner @huozhi @Ethan-Arrowood @styfle
+/packages/node                           @TooTallNate @EndangeredMassa @trek @onsclom @Kikobeats
 
 # Unrestricted Paths
 .changeset/


### PR DESCRIPTION
I tagged everyone for review that might be impacted. I removed no one, but added Zero Config to each section.

This allows Zero Config to make uncontroversial tweaks as needed. For any significant changes to these areas, we'd of course still wait for other teams' reviews.