### PR TITLE
[remix] Disable `prepareCache()` npm install for Remix + Vite

### DIFF
--- a/.changeset/five-bags-trade.md
+++ b/.changeset/five-bags-trade.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Disable `prepareCache()` npm install for Remix + Vite

--- a/packages/remix/src/prepare-cache.ts
+++ b/packages/remix/src/prepare-cache.ts
@@ -5,8 +5,8 @@ import {
   runNpmInstall,
 } from '@vercel/build-utils';
 import { dirname, join, relative } from 'path';
-import { require_, chdirAndReadConfig } from './utils';
-import type { PrepareCache } from '@vercel/build-utils';
+import { require_, chdirAndReadConfig, isVite } from './utils';
+import type { Files, PrepareCache } from '@vercel/build-utils';
 
 export const prepareCache: PrepareCache = async ({
   entrypoint,
@@ -17,45 +17,49 @@ export const prepareCache: PrepareCache = async ({
   const root = repoRootPath || workPath;
   const mountpoint = dirname(entrypoint);
   const entrypointFsDirname = join(workPath, mountpoint);
+  let cacheDirFiles: Files | undefined;
 
-  // Because the `node_modules` directory was modified to install
-  // the forked Remix compiler, re-install to the "fresh" dependencies
-  // state before the cache gets created.
-  const nodeVersion = await getNodeVersion(
-    entrypointFsDirname,
-    undefined,
-    config
-  );
-  const spawnOpts = getSpawnOptions({}, nodeVersion);
-  await runNpmInstall(
-    entrypointFsDirname,
-    [],
-    {
-      ...spawnOpts,
-      stdio: 'ignore',
-    },
-    undefined,
-    nodeVersion
-  );
+  if (!isVite(workPath)) {
+    // Because the `node_modules` directory was modified to install
+    // the forked Remix compiler, re-install to the "fresh" dependencies
+    // state before the cache gets created.
+    const nodeVersion = await getNodeVersion(
+      entrypointFsDirname,
+      undefined,
+      config
+    );
+    const spawnOpts = getSpawnOptions({}, nodeVersion);
+    await runNpmInstall(
+      entrypointFsDirname,
+      [],
+      {
+        ...spawnOpts,
+        stdio: 'ignore',
+      },
+      undefined,
+      nodeVersion
+    );
 
-  const packageJsonPath = join(entrypointFsDirname, 'package.json');
-  const remixRunDevPath = dirname(
-    require_.resolve('@remix-run/dev/package.json', {
-      paths: [entrypointFsDirname],
-    })
-  );
-  const remixConfig = await chdirAndReadConfig(
-    remixRunDevPath,
-    entrypointFsDirname,
-    packageJsonPath
-  );
-  const [nodeModulesFiles, cacheDirFiles] = await Promise.all([
-    // Cache `node_modules`
-    glob('**/node_modules/**', root),
-
+    const packageJsonPath = join(entrypointFsDirname, 'package.json');
+    const remixRunDevPath = dirname(
+      require_.resolve('@remix-run/dev/package.json', {
+        paths: [entrypointFsDirname],
+      })
+    );
+    const remixConfig = await chdirAndReadConfig(
+      remixRunDevPath,
+      entrypointFsDirname,
+      packageJsonPath
+    );
     // Cache the Remix "cacheDirectory" (typically `.cache`)
-    glob(relative(root, join(remixConfig.cacheDirectory, '**')), root),
-  ]);
+    cacheDirFiles = await glob(
+      relative(root, join(remixConfig.cacheDirectory, '**')),
+      root
+    );
+  }
+
+  // Cache `node_modules`
+  const nodeModulesFiles = await glob('**/node_modules/**', root);
 
   return { ...nodeModulesFiles, ...cacheDirFiles };
 };


### PR DESCRIPTION
In legacy Remix apps, we were running `npm install` once again before globbing the `node_modules` dir due to the injecting of the forked Remix compiler which would cause a cache miss without that happening.

For Vite, we are no longer mucking about `node_modules` at build-time, so there is no need to run `npm install` in the `prepareCache()` function.

There is also no "cacheDirectory" setting so the globbing of the legacy cache directory is also moved into the legacy-only logic.

**tl;dr** For Remix + Vite apps, the only thing that needs to be cached is `node_modules`.