### PR TITLE
Updated port number of localhost in README.md

### DIFF
--- a/examples/remix/README.md
+++ b/examples/remix/README.md
@@ -35,4 +35,4 @@ Afterwards, start the Remix development server like so:
 npm run dev
 ```
 
-Open up [http://localhost:3000](http://localhost:3000) and you should be ready to go!
+Open up [http://localhost:5173](http://localhost:5173) and you should be ready to go!


### PR DESCRIPTION
With Remix's migration to Vite as its bundler, the default localhost port has changed from 3000 to 5173.