### PR TITLE
Add matchUnescapedFirst to routing doc

### DIFF
--- a/.changeset/chilled-plums-sparkle.md
+++ b/.changeset/chilled-plums-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@vercel/routing-utils": patch
+---
+
+Add matchUnescapedFirst to routing doc

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -116,6 +116,9 @@ export const routesSchema = {
           isInternal: {
             type: 'boolean',
           },
+          matchUnescapedFirst: {
+            type: 'boolean',
+          },
           status: {
             type: 'integer',
             minimum: 100,


### PR DESCRIPTION
Adds a new field to routing API to allow optionally matching on an unescaped path first