### PR TITLE
disable eslint for a few files to mitigate flakey linting

### DIFF
--- a/.changeset/chatty-pets-hear.md
+++ b/.changeset/chatty-pets-hear.md
@@ -1,0 +1,4 @@
+---
+---
+
+disable eslint for a few files

--- a/packages/node/test/dev-fixtures/edge-buffer.js
+++ b/packages/node/test/dev-fixtures/edge-buffer.js
@@ -1,4 +1,4 @@
-/* global Response */
+/* eslint-disable */
 
 import B from 'node:buffer';
 import { Buffer } from 'buffer';

--- a/packages/node/test/dev-fixtures/edge-waituntil.js
+++ b/packages/node/test/dev-fixtures/edge-waituntil.js
@@ -1,4 +1,4 @@
-/* global Response */
+/* eslint-disable -- flakey application of `global Response` eslint directive */
 
 export const config = { runtime: 'edge' };
 

--- a/packages/node/test/dev-fixtures/edge-websocket.js
+++ b/packages/node/test/dev-fixtures/edge-websocket.js
@@ -1,4 +1,4 @@
-/*global TextEncoderStream, ReadableStream, Response, WebSocket */
+/* eslint-disable -- flakey application of `global TextEncoderStream, ReadableStream, Response, WebSocket` eslint directive */
 
 export const config = { runtime: 'edge' };
 

--- a/packages/node/test/dev-fixtures/web-handlers-edge.js
+++ b/packages/node/test/dev-fixtures/web-handlers-edge.js
@@ -1,4 +1,4 @@
-/* global ReadableStream, TextEncoderStream, Response */
+/* eslint-disable -- flakey application of `global ReadableStream, TextEncoderStream, Response` eslint directive */
 
 export const config = { runtime: 'edge' };
 

--- a/packages/node/test/dev-fixtures/web-handlers-node.js
+++ b/packages/node/test/dev-fixtures/web-handlers-node.js
@@ -1,4 +1,4 @@
-/* global ReadableStream, TextEncoderStream, Response */
+/* eslint-disable -- flakey application of `global ReadableStream, TextEncoderStream, Response` eslint directive */
 
 const DEFER_MS = 10;
 


### PR DESCRIPTION
Sometimes, we get errors from eslint saying that we're duplicating the definition of a global, like `Response`. But then later, with no obvious changes, that linting rule will be fine.

This PR eslint ignores the specific files, which seems like a fine tradeoff for this problem.