### PR TITLE
[cli] fix domains access permission issues

### DIFF
--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -90,6 +90,7 @@ export interface Team {
       state: string;
     };
   };
+  createdDirectToHobby?: boolean;
 }
 
 export type Domain = {

--- a/packages/cli/src/util/certs/issue-cert.ts
+++ b/packages/cli/src/util/certs/issue-cert.ts
@@ -13,6 +13,9 @@ export default async function issueCert(client: Client, cns: string[]) {
         return await client.fetch<Cert>('/v3/now/certs', {
           method: 'POST',
           body: { domains: cns },
+          useCurrentTeam: client.authContext.enableFallbackDomainsAccess
+            ? false
+            : true,
         });
       } catch (err: unknown) {
         if (isAPIError(err) && err.code === 'configuration_error') {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -54,6 +54,11 @@ export interface ClientOptions extends Stdio {
   agent?: Agent;
 }
 
+export interface AuthContext {
+  isCanonicalHobbyTeam?: boolean;
+  enableFallbackDomainsAccess?: boolean;
+}
+
 export const isJSONObject = (v: any): v is JSONObject => {
   return v && typeof v == 'object' && v.constructor === Object;
 };
@@ -72,6 +77,7 @@ export default class Client extends EventEmitter implements Stdio {
   localConfigPath?: string;
   requestIdCounter: number;
   input;
+  authContext: AuthContext = {};
 
   constructor(opts: ClientOptions) {
     super();

--- a/packages/cli/src/util/deploy/generate-cert-for-deploy.ts
+++ b/packages/cli/src/util/deploy/generate-cert-for-deploy.ts
@@ -4,6 +4,7 @@ import Client from '../client';
 import createCertForCns from '../certs/create-cert-for-cns';
 import setupDomain from '../domains/setup-domain';
 import { InvalidDomain } from '../errors-ts';
+import getScope from '../../util/get-scope';
 
 export default async function generateCertForDeploy(
   client: Client,
@@ -11,6 +12,8 @@ export default async function generateCertForDeploy(
   deployURL: string
 ) {
   const { output } = client;
+  await getScope(client);
+
   const parsedDomain = psl.parse(deployURL);
   if (parsedDomain.error) {
     return new InvalidDomain(deployURL, parsedDomain.error.message);

--- a/packages/cli/src/util/domains/get-domain-by-name.ts
+++ b/packages/cli/src/util/domains/get-domain-by-name.ts
@@ -25,9 +25,34 @@ export default async function getDomainByName(
     );
   }
   try {
-    const { domain } = await client.fetch<Response>(
-      `/v4/domains/${encodeURIComponent(domainName)}`
-    );
+    const { domain } = await client
+      .fetch<Response>(`/v4/domains/${encodeURIComponent(domainName)}`)
+      .catch(async err => {
+        // NOTE: to maintain backwards compatibility after northstar migration
+        // we fallback to personal account if the team is a canonical hobby team
+        if (isAPIError(err)) {
+          if (
+            client.authContext.isCanonicalHobbyTeam === true &&
+            err.status === 403
+          ) {
+            return await client
+              .fetch<Response>(
+                `/v4/domains/${encodeURIComponent(domainName)}`,
+                {
+                  useCurrentTeam: false,
+                }
+              )
+              .then(domain => {
+                // setting the flag so subsuquent requests to related resources (e.g., issue cert)
+                // are also made with the personal account auth context to avoid similar auth errors
+                client.authContext.enableFallbackDomainsAccess = true;
+                return domain;
+              });
+          }
+        }
+
+        throw err;
+      });
     return domain;
   } catch (err: unknown) {
     if (isAPIError(err)) {

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -35,7 +35,7 @@ export default async function getScope(
    * A user may have multiple Hobby teams (e.g., Pro Trial downgrade), but can have only one canonical Hobby team.
    */
   const isCanonicalHobbyTeam =
-    (team?.billing.plan === 'hobby' &&
+    (team?.billing?.plan === 'hobby' &&
       team.createdDirectToHobby &&
       team.creatorId === user.id) ??
     false;

--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -29,5 +29,19 @@ export default async function getScope(
     contextName = team.slug;
   }
 
+  /**
+   * isCanonicalHobbyTeam is true, if the Hobby team is the canonical team of the user account.
+   * Canonical Hoby team is the team that was created "automatically" upon new signups or by Northstar migration.
+   * A user may have multiple Hobby teams (e.g., Pro Trial downgrade), but can have only one canonical Hobby team.
+   */
+  const isCanonicalHobbyTeam =
+    (team?.billing.plan === 'hobby' &&
+      team.createdDirectToHobby &&
+      team.creatorId === user.id) ??
+    false;
+  if (isCanonicalHobbyTeam) {
+    client.authContext.isCanonicalHobbyTeam = true;
+  }
+
   return { contextName, team, user };
 }


### PR DESCRIPTION
Also related: https://github.com/vercel/api/pull/27464

After the Hobby plan [migration](https://vercel.com/changelog/2024-01-account-changes), several CLI commands stopped working for migrated users due to domains access check.

The main issue is, after the migration, we basically kept all domain resources (Apex zones, the account-level domains) under a personal account and created a new Hobby team, where all other resources (e.g., projects) were moved over. So, those domains are technically under a different account than their new Hobby team, and hence, access/permission checks started failing.

To work around it, currently, users need to explicitly move domains from their personal account to their Hobby team, which is considered to be a breaking change in UX.

To maintain the backward compatibility of this workflow, this PR adds fallback logic to fetch domains from personal account.