### PR TITLE
[node] add support for regions in nodejs runtime functions

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -38,6 +38,7 @@ import {
   debug,
   isSymbolicLink,
   walkParentDirs,
+  NowBuildError,
 } from '@vercel/build-utils';
 import type {
   File,
@@ -497,6 +498,14 @@ export const build: BuildV3 = async ({
         ? true
         : undefined;
 
+    if (staticConfig?.regions && !Array.isArray(staticConfig.regions)) {
+      throw new NowBuildError({
+        code: 'NODEJS_FUNCTION_CONFIG_REGIONS',
+        message: 'Regions must be a string array when using the nodejs runtime',
+        link: 'https://vercel.com/docs/edge-network/regions#region-list',
+      });
+    }
+
     output = new NodejsLambda({
       files: preparedFiles,
       handler,
@@ -505,6 +514,7 @@ export const build: BuildV3 = async ({
       shouldAddSourcemapSupport,
       awsLambdaHandler,
       supportsResponseStreaming,
+      regions: staticConfig?.regions as string[],
       maxDuration: staticConfig?.maxDuration,
     });
   }

--- a/packages/static-config/src/index.ts
+++ b/packages/static-config/src/index.ts
@@ -20,6 +20,7 @@ export const BaseFunctionConfigSchema = {
       oneOf: [
         {
           type: 'array',
+          minItems: 1,
           items: { type: 'string' },
         },
         {

--- a/packages/static-config/test/fixtures/node.js
+++ b/packages/static-config/test/fixtures/node.js
@@ -4,6 +4,7 @@ export const config = {
   runtime: 'nodejs',
   memory: 1024,
   maxDuration: 60,
+  regions: ['fra1'],
 };
 
 export default function (req, res) {

--- a/packages/static-config/test/index.test.ts
+++ b/packages/static-config/test/index.test.ts
@@ -11,6 +11,9 @@ describe('getConfig()', () => {
       {
         "maxDuration": 60,
         "memory": 1024,
+        "regions": [
+          "fra1",
+        ],
         "runtime": "nodejs",
       }
     `);
@@ -44,12 +47,12 @@ describe('getConfig()', () => {
   it('should throw an error upon schema validation failure', () => {
     const project = new Project();
     const sourcePath = join(__dirname, 'fixtures/invalid-schema.js');
-    let err;
+    let err: Error | undefined;
     try {
       getConfig(project, sourcePath);
     } catch (_err) {
-      err = _err;
+      err = _err as unknown as Error;
     }
-    expect(err.message).toEqual('Invalid data');
+    expect(err?.message).toEqual('Invalid data');
   });
 });

--- a/packages/static-config/test/swc.test.ts
+++ b/packages/static-config/test/swc.test.ts
@@ -58,6 +58,9 @@ describe('getConfig for swc', () => {
       {
         "maxDuration": 60,
         "memory": 1024,
+        "regions": [
+          "fra1",
+        ],
         "runtime": "nodejs",
       }
     `);


### PR DESCRIPTION
We already support this in build output api, but we were missing logic to output regions when running `vc build` for `nodejs` functions.