### PR TITLE
[build-utils] Trigger release of `@vercel/build-utils`

### DIFF
--- a/.changeset/strange-wolves-wave.md
+++ b/.changeset/strange-wolves-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Trigger release


### PR DESCRIPTION
PR #11305 didn't include this package as part of its changeset, so there was no new release even though it is exporting a new function. Adding this changeset so that the package is properly published.

Closes #11464.