### PR TITLE
[next] reduce `.action` rewrites

### DIFF
--- a/.changeset/forty-bottles-train.md
+++ b/.changeset/forty-bottles-train.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] reduce `.action` rewrites

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1409,7 +1409,9 @@ export async function serverBuild({
     isDev: false,
     routesManifest,
     omittedRoutes: omittedPrerenderRoutes,
+    prerenderManifest,
     canUsePreviewMode,
+    canUseActionRewrite: hasActionOutputSupport,
     bypassToken: prerenderManifest.bypassToken || '',
     isServerMode: true,
     dynamicMiddlewareRouteMap: middleware.dynamicRouteMap,
@@ -2204,7 +2206,10 @@ export async function serverBuild({
           // all dynamic routes including non-SSG/SSP so that the priority
           // is correct
           dynamicRoutes
-            .filter(route => !route.src.includes('.rsc'))
+            .filter(
+              route =>
+                !route.src.includes('.rsc') && !route.src.includes('.action')
+            )
             .map(route => {
               route = Object.assign({}, route);
               let normalizedSrc = route.src;

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -315,8 +315,10 @@ export async function getDynamicRoutes({
   dynamicPages,
   isDev,
   routesManifest,
+  prerenderManifest,
   omittedRoutes,
   canUsePreviewMode,
+  canUseActionRewrite,
   bypassToken,
   isServerMode,
   dynamicMiddlewareRouteMap,
@@ -327,8 +329,10 @@ export async function getDynamicRoutes({
   dynamicPages: string[];
   isDev?: boolean;
   routesManifest?: RoutesManifest;
+  prerenderManifest?: NextPrerenderedRoutes;
   omittedRoutes?: ReadonlySet<string>;
   canUsePreviewMode?: boolean;
+  canUseActionRewrite?: boolean;
   bypassToken?: string;
   isServerMode?: boolean;
   dynamicMiddlewareRouteMap?: ReadonlyMap<string, RouteWithSrc>;
@@ -432,14 +436,21 @@ export async function getDynamicRoutes({
             dest: route.dest?.replace(/($|\?)/, '.rsc$1'),
           });
 
-          routes.push({
-            ...route,
-            src: route.src.replace(
-              new RegExp(escapeStringRegexp('(?:/)?$')),
-              '(?:\\.action)(?:/)?$'
-            ),
-            dest: route.dest?.replace(/($|\?)/, '.action$1'),
-          });
+          // push .action rewrites for dynamic routes if support is available
+          // and the dynamic route is in the prerender manifest
+          if (
+            canUseActionRewrite &&
+            prerenderManifest?.blockingFallbackRoutes[page]
+          ) {
+            routes.push({
+              ...route,
+              src: route.src.replace(
+                new RegExp(escapeStringRegexp('(?:/)?$')),
+                '(?:\\.action)(?:/)?$'
+              ),
+              dest: route.dest?.replace(/($|\?)/, '.action$1'),
+            });
+          }
 
           routes.push(route);
         }


### PR DESCRIPTION
- copies existing .rsc handling to ignore `/_next/data` routes since those aren't relevant in app dir
- only push dynamic route rewrites if on a supported version & the route exists in the prerender manifest (need to verify that `blockingFallbackRoutes` is the correct place to check)