### PR TITLE
[static-build] Add changeset for `SUPPORTED_RUBY_VERSION` revert

### DIFF
--- a/.changeset/clean-badgers-sit.md
+++ b/.changeset/clean-badgers-sit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/static-build': patch
+---
+
+Revert `SUPPORTED_RUBY_VERSION` change to fix Ruby site generators on AL2 build image


### PR DESCRIPTION
A changeset should have been included for https://github.com/vercel/vercel/pull/11518. Adding that here.