### PR TITLE
[next] Fix interception routes PPR route handling

### DIFF
--- a/.changeset/tricky-moose-hear.md
+++ b/.changeset/tricky-moose-hear.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix interception routes PPR route handling

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1588,10 +1588,19 @@ export async function serverBuild({
 
       if (lambdas[pathname]) {
         lambdas[`${pathname}.rsc`] = lambdas[pathname];
+
+        if (experimental.ppr) {
+          lambdas[`${pathname}${RSC_PREFETCH_SUFFIX}`] = lambdas[pathname];
+        }
       }
 
       if (edgeFunctions[pathname]) {
         edgeFunctions[`${pathname}.rsc`] = edgeFunctions[pathname];
+
+        if (experimental.ppr) {
+          edgeFunctions[`${pathname}${RSC_PREFETCH_SUFFIX}`] =
+            edgeFunctions[pathname];
+        }
       }
     }
   }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/(.)cart/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/(.)cart/page.js
@@ -1,0 +1,5 @@
+export default function Modal() {
+  return (
+    <p>cart modal!!</p>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/(.)cart/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/(.)cart/page.js
@@ -1,5 +1,10 @@
+import Link from 'next/link'
+
 export default function Modal() {
   return (
-    <p>cart modal!!</p>
+    <>
+      <p>cart modal!!</p>
+      <Link href='/'>to index</Link>
+    </>
   )
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/default.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/@modal/default.js
@@ -1,0 +1,3 @@
+export default function Modal() {
+  return null
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/cart/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/cart/page.js
@@ -1,0 +1,7 @@
+export default function Cart() {
+  return (
+    <>
+      <p>normal cart page</p>
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/cart/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/cart/page.js
@@ -1,7 +1,10 @@
+import Link from 'next/link'
+
 export default function Cart() {
   return (
     <>
       <p>normal cart page</p>
+      <Link href='/'>to index</Link>
     </>
   )
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/(store)/layout.js
@@ -1,0 +1,8 @@
+export default function Layout({ modal, children }) {
+  return (
+    <>
+      {modal}
+      {children}
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/page.jsx
@@ -1,10 +1,14 @@
+import Link from 'next/link'
 import React, { Suspense } from 'react'
 import { Dynamic } from '../components/dynamic'
 
 export default () => {
   return (
-    <Suspense fallback={<Dynamic pathname="/" fallback />}>
-      <Dynamic pathname="/" />
-    </Suspense>
+    <>
+      <Suspense fallback={<Dynamic pathname="/" fallback />}>
+        <Dynamic pathname="/" />
+      </Suspense>
+      <Link href='/cart'>to /cart</Link>
+    </>
   )
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/components/links.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/components/links.jsx
@@ -19,14 +19,6 @@ const links = [
   { href: '/no-suspense/nested/c', tag: 'no suspense, on-demand' },
   { href: '/dynamic/force-dynamic', tag: "dynamic = 'force-dynamic'" },
   { href: '/dynamic/force-static', tag: "dynamic = 'force-static'" },
-  { href: '/edge/suspense', tag: 'edge, pre-generated' },
-  { href: '/edge/suspense/a', tag: 'edge, pre-generated' },
-  { href: '/edge/suspense/b', tag: 'edge, on-demand' },
-  { href: '/edge/suspense/c', tag: 'edge, on-demand' },
-  { href: '/edge/no-suspense', tag: 'edge, no suspense, pre-generated' },
-  { href: '/edge/no-suspense/a', tag: 'edge, no suspense, pre-generated' },
-  { href: '/edge/no-suspense/b', tag: 'edge, no suspense, on-demand' },
-  { href: '/edge/no-suspense/c', tag: 'edge, no suspense, on-demand' },
 ];
 
 export const Links = () => {

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -45,6 +45,45 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
   });
 
   describe('dynamic pages should resume', () => {
+    it('should handle interception route properly', async () => {
+      const res = await fetch(`${ctx.deploymentUrl}/cart`)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('normal cart page')
+      
+      const res2 = await fetch(`${ctx.deploymentUrl}/cart`, {
+        headers: {
+          RSC: '1'
+        }
+      })
+      const res2Body = await res2.text()
+      expect(res2.status).toBe(200)
+      expect(res2Body).toContain(':')
+      expect(res2Body).not.toContain('<html')
+      
+      const res3 = await fetch(`${ctx.deploymentUrl}/cart`, {
+        headers: {
+          RSC: '1',
+          'Next-Url': '/cart',
+          'Next-Router-Prefetch': '1'
+        }
+      })
+      const res3Body = await res3.text()
+      expect(res3.status).toBe(200)
+      expect(res3Body).toContain(':')
+      expect(res3Body).not.toContain('<html')
+      
+      const res4 = await fetch(`${ctx.deploymentUrl}/cart`, {
+        headers: {
+          RSC: '1',
+          'Next-Url': '/cart',
+        }
+      })
+      const res4Body = await res4.text()
+      expect(res4.status).toBe(200)
+      expect(res4Body).toContain(':')
+      expect(res4Body).not.toContain('<html')
+    })
+    
     it.each(pages.filter(p => p.dynamic === true))(
       'should resume $pathname',
       async ({ pathname }) => {

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -44,46 +44,46 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     Object.assign(ctx, info);
   });
 
+  it('should handle interception route properly', async () => {
+    const res = await fetch(`${ctx.deploymentUrl}/cart`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('normal cart page');
+
+    const res2 = await fetch(`${ctx.deploymentUrl}/cart`, {
+      headers: {
+        RSC: '1',
+      },
+    });
+    const res2Body = await res2.text();
+    expect(res2.status).toBe(200);
+    expect(res2Body).toContain(':');
+    expect(res2Body).not.toContain('<html');
+
+    const res3 = await fetch(`${ctx.deploymentUrl}/cart`, {
+      headers: {
+        RSC: '1',
+        'Next-Url': '/cart',
+        'Next-Router-Prefetch': '1',
+      },
+    });
+    const res3Body = await res3.text();
+    expect(res3.status).toBe(200);
+    expect(res3Body).toContain(':');
+    expect(res3Body).not.toContain('<html');
+
+    const res4 = await fetch(`${ctx.deploymentUrl}/cart`, {
+      headers: {
+        RSC: '1',
+        'Next-Url': '/cart',
+      },
+    });
+    const res4Body = await res4.text();
+    expect(res4.status).toBe(200);
+    expect(res4Body).toContain(':');
+    expect(res4Body).not.toContain('<html');
+  });
+
   describe('dynamic pages should resume', () => {
-    it('should handle interception route properly', async () => {
-      const res = await fetch(`${ctx.deploymentUrl}/cart`)
-      expect(res.status).toBe(200)
-      expect(await res.text()).toContain('normal cart page')
-      
-      const res2 = await fetch(`${ctx.deploymentUrl}/cart`, {
-        headers: {
-          RSC: '1'
-        }
-      })
-      const res2Body = await res2.text()
-      expect(res2.status).toBe(200)
-      expect(res2Body).toContain(':')
-      expect(res2Body).not.toContain('<html')
-      
-      const res3 = await fetch(`${ctx.deploymentUrl}/cart`, {
-        headers: {
-          RSC: '1',
-          'Next-Url': '/cart',
-          'Next-Router-Prefetch': '1'
-        }
-      })
-      const res3Body = await res3.text()
-      expect(res3.status).toBe(200)
-      expect(res3Body).toContain(':')
-      expect(res3Body).not.toContain('<html')
-      
-      const res4 = await fetch(`${ctx.deploymentUrl}/cart`, {
-        headers: {
-          RSC: '1',
-          'Next-Url': '/cart',
-        }
-      })
-      const res4Body = await res4.text()
-      expect(res4.status).toBe(200)
-      expect(res4Body).toContain(':')
-      expect(res4Body).not.toContain('<html')
-    })
-    
     it.each(pages.filter(p => p.dynamic === true))(
       'should resume $pathname',
       async ({ pathname }) => {


### PR DESCRIPTION
This ensures we properly create `.prefetch.rsc` output aliases for non-prerender outputs when PPR is enabled so that we can properly route which handles the interception route case as that is always dynamic so was missing it's `.prefetch.rsc` output causing the prefetch request to 404 unexpectedly. 

x-ref: [slack thread](https://vercel.slack.com/archives/C070ZMMKVU7/p1714511126337289) 