### PR TITLE
[next] Remove .prefetch.rsc rewrites for non-PPR

### DIFF
--- a/.changeset/lovely-books-protect.md
+++ b/.changeset/lovely-books-protect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Remove .prefetch.rsc rewrites for non-PPR

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1903,7 +1903,7 @@ export async function serverBuild({
 
       ...(appDir
         ? [
-            ...(rscPrefetchHeader
+            ...(rscPrefetchHeader && experimental.ppr
               ? [
                   {
                     src: `^${path.posix.join('/', entryDirectory, '/')}`,
@@ -2041,47 +2041,6 @@ export async function serverBuild({
               src: path.posix.join('/', entryDirectory, '_next/data/(.*)'),
               dest: path.posix.join('/', entryDirectory, '_next/data/$1'),
               check: true,
-            },
-          ]
-        : []),
-
-      ...(rscPrefetchHeader && !experimental.ppr
-        ? [
-            {
-              src: path.posix.join(
-                '/',
-                entryDirectory,
-                `/__index${RSC_PREFETCH_SUFFIX}`
-              ),
-              dest: path.posix.join('/', entryDirectory, '/index.rsc'),
-              has: [
-                {
-                  type: 'header',
-                  key: rscPrefetchHeader,
-                },
-              ],
-              continue: true,
-              override: true,
-            },
-            {
-              src: `^${path.posix.join(
-                '/',
-                entryDirectory,
-                `/(.+?)${RSC_PREFETCH_SUFFIX}(?:/)?$`
-              )}`,
-              dest: path.posix.join(
-                '/',
-                entryDirectory,
-                `/$1${experimental.ppr ? RSC_PREFETCH_SUFFIX : '.rsc'}`
-              ),
-              has: [
-                {
-                  type: 'header',
-                  key: rscPrefetchHeader,
-                },
-              ],
-              continue: true,
-              override: true,
             },
           ]
         : []),

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -251,7 +251,7 @@ export async function serverBuild({
       if (rewrite.src && rewrite.dest) {
         rewrite.src = rewrite.src.replace(
           /\/?\(\?:\/\)\?/,
-          '(?<rscsuff>(\\.prefetch)?\\.rsc)?(?:/)?'
+          `(?<rscsuff>${experimental.ppr ? '(\\.prefetch)?' : ''}\\.rsc)?(?:/)?`
         );
         let destQueryIndex = rewrite.dest.indexOf('?');
 

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/products/[productId]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/products/[productId]/page.jsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      product page
+    </>
+  )
+}

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/next.config.js
@@ -13,6 +13,10 @@ module.exports = {
         source: '/rewritten-to-index',
         destination: '/?fromRewrite=1',
       },
+      {
+        source: '/to-product/:productId.html',
+        destination: '/products/:productId',
+      },
     ];
   },
 };

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -19,6 +19,30 @@
   ],
   "probes": [
     {
+      "path": "/to-product/product-id.html",
+      "status": 200,
+      "mustContain": "<html"
+    },
+    {
+      "path": "/to-product/product-id.html",
+      "status": 200,
+      "mustNotContain": "<html",
+      "mustContain": ":",
+      "headers": {
+        "RSC": 1
+      }
+    },
+    {
+      "path": "/to-product/product-id.html",
+      "status": 200,
+      "mustNotContain": ".prefetch",
+      "mustContain": ":",
+      "headers": {
+        "RSC": 1,
+        "Next-Router-Prefetch": 1
+      }
+    },
+    {
       "path": "/nested/blog-fallback-false/first",
       "status": 200,
       "mustContain": "hello from /nested/blog-fallback-false"

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -53,7 +53,7 @@
       "mustContain": "{}",
       "mustNotContain": ":",
       "responseHeaders": {
-        "x-matched-path": "/nested/blog-fallback-false/first.prefetch.rsc"
+        "x-matched-path": "/nested/blog-fallback-false/first.rsc"
       },
       "headers": {
         "RSC": 1,


### PR DESCRIPTION
Removes .prefetch.rsc rewrites rules for non-PPR, as Next.js doesn't emit any static prefetches otherwise