### PR TITLE
Fix broken link to Code of Conduct in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can use the `dev` script to run local changes as if you were invoking Vercel
 
 When contributing to this repository, please first discuss the change you wish to make via [GitHub Discussions](https://github.com/vercel/vercel/discussions/new) with the owners of this repository before submitting a Pull Request.
 
-Please read our [Code of Conduct](CODE_OF_CONDUCT.md) and follow it in all your interactions with the project.
+Please read our [Code of Conduct](./.github/CODE_OF_CONDUCT.md) and follow it in all your interactions with the project.
 
 ### Local development
 


### PR DESCRIPTION
### Purpose of the Pull Request

This PR addresses a broken link in the README.md file that is supposed to direct readers to the Code of Conduct. Previously, the link pointed to `CODE_OF_CONDUCT.md`, which does not exist in the repository's main directory. The corrected link points to the actual location of the file in the `.github` directory.

### Changes Made

- Updated the link to the Code of Conduct from `[Code of Conduct](CODE_OF_CONDUCT.md)` to `[Code of Conduct](./.github/CODE_OF_CONDUCT.md)` to reflect the correct path.

### Additional Information

I previously opened discussion #11498 regarding this issue with the goal of following the [Contribuing Guidelines](https://github.com/vercel/vercel?tab=readme-ov-file#contributing), but did not receive any feedback over the past week. Given the nature of the change (a simple documentation fix), I proceeded with this pull request to ensure the documentation remains useful and accurate for all users.

### Impact

This change will help ensure that new contributors and users can easily access the Code of Conduct, fostering better community interactions and adherence to project standards.

Thank you for considering this pull request. I am open to any further suggestions or requirements needed to merge this change.
