### PR TITLE
[next] rename middleware manifest env

### DIFF
--- a/.changeset/odd-dogs-brush.md
+++ b/.changeset/odd-dogs-brush.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] rename middleware manifest env

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2784,7 +2784,7 @@ interface EdgeFunctionInfoV2 extends BaseEdgeFunctionInfo {
 
 interface EdgeFunctionInfoV3 extends BaseEdgeFunctionInfo {
   matchers: EdgeFunctionMatcher[];
-  environments: Record<string, string>;
+  env: Record<string, string>;
 }
 
 interface EdgeFunctionMatcher {
@@ -3019,7 +3019,7 @@ export async function getMiddlewareBundle({
                   slug: 'nextjs',
                   version: nextVersion,
                 },
-                environment: edgeFunction.environments,
+                environment: edgeFunction.env,
               });
             })(),
             routeMatchers: getRouteMatchers(edgeFunction, routesManifest),
@@ -3199,7 +3199,7 @@ export function upgradeMiddlewareManifestV1(
     return {
       ...rest,
       matchers: [{ regexp }],
-      environments: {},
+      env: {},
     };
   }
 
@@ -3227,7 +3227,7 @@ export function upgradeMiddlewareManifestV2(
     const { ...rest } = v2Info;
     return {
       ...rest,
-      environments: {},
+      env: {},
     };
   }
 


### PR DESCRIPTION
Rename `environment` property to `env` from middleware manifest added in #11390.
Align with https://github.com/vercel/next.js/pull/64521

The `environments` property wasn't working properly before due to unfinished next.js changes, it should work now after testing with next build from https://github.com/vercel/next.js/pull/64521. We change it to a better naming word `env`.