### PR TITLE
[next] Fix missing initial RSC headers

### DIFF
--- a/.changeset/lemon-pants-pretend.md
+++ b/.changeset/lemon-pants-pretend.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix missing initial RSC headers

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2465,6 +2465,7 @@ export const onPrerenderRoute =
           ...(rscEnabled
             ? {
                 initialHeaders: {
+                  ...initialHeaders,
                   'content-type': rscContentTypeHeader,
                   vary: rscVaryHeader,
                   // If it contains a pre-render, then it was postponed.


### PR DESCRIPTION
While investigating https://github.com/vercel/next.js/issues/59883 we noticed the RSC Prerender did not have all the expected headers like the HTML Prerender which caused unexpected revalidation behavior specifically on client-transition as some of these headers are used to detect if a revalidated tag is associated with specific outputs. 

x-ref: https://github.com/vercel/next.js/issues/59883
