### PR TITLE
Make waitUntil consistent for Node.js & Edge

### DIFF
--- a/.changeset/hot-stingrays-remain.md
+++ b/.changeset/hot-stingrays-remain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': major
+---
+
+Initial release

--- a/.changeset/wild-ladybugs-leave.md
+++ b/.changeset/wild-ladybugs-leave.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": minor
+---
+
+Make waitUntil consistent for Node.js & Edge

--- a/packages/functions/index.d.ts
+++ b/packages/functions/index.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Extends the lifetime of the request handler for the lifetime of the given {@link Promise}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil
+ *
+ * @param promise The promise to wait for.
+ * @example
+ *
+ * ```
+ * import { waitUntil } from '@vercel/functions';
+ *
+ * export function GET(request) {
+ *   waitUntil(fetch('https://vercel.com'));
+ *   return new Response('OK');
+ * }
+ * ```
+ */
+export const waitUntil: (promise: Promise<unknown>) => void;

--- a/packages/functions/index.js
+++ b/packages/functions/index.js
@@ -1,0 +1,24 @@
+/* global globalThis */
+
+export const waitUntil = promise => {
+  if (
+    promise instanceof Promise === false ||
+    promise === null ||
+    typeof promise !== 'object' ||
+    typeof promise.then !== 'function'
+  ) {
+    throw new TypeError(
+      `waitUntil can only be called with a Promise, got ${typeof promise}`
+    );
+  }
+
+  const ctx = globalThis[Symbol.for('@vercel/request-context')]?.get?.() ?? {};
+
+  if (!ctx.waitUntil) {
+    throw new Error(
+      'failed to get waitUntil function for this request context'
+    );
+  }
+
+  ctx.waitUntil(promise);
+};

--- a/packages/functions/index.test.js
+++ b/packages/functions/index.test.js
@@ -1,0 +1,45 @@
+/* global globalThis */
+
+import { vi, expect, test } from 'vitest';
+
+import { waitUntil } from '.';
+
+test.each([
+  {},
+  () => {},
+  function () {},
+  NaN,
+  1,
+  false,
+  undefined,
+  null,
+  [],
+  '▲',
+])('waitUntil throws when called with %s', input => {
+  expect(() => waitUntil(input)).toThrow(TypeError);
+  expect(() => waitUntil(input)).toThrow(
+    `waitUntil can only be called with a Promise, got ${typeof input}`
+  );
+});
+
+test.each([null, undefined, {}])(
+  'waitUntil throws when context is %s',
+  input => {
+    const promise = Promise.resolve();
+    globalThis[Symbol.for('@vercel/request-context')] = input;
+    expect(() => waitUntil(promise)).toThrow(Error);
+    expect(() => waitUntil(promise)).toThrow(
+      'failed to get waitUntil function for this request context'
+    );
+  }
+);
+
+test('waitUntil calls ctx.waitUntil when available', async () => {
+  const promise = Promise.resolve();
+  const waitUntilMock = vi.fn().mockReturnValue(promise);
+  globalThis[Symbol.for('@vercel/request-context')] = {
+    get: () => ({ waitUntil: waitUntilMock }),
+  };
+  waitUntil(promise);
+  expect(waitUntilMock).toHaveBeenCalledWith(promise);
+});

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@vercel/functions",
+  "description": "Runtime functions to be used with your Vercel Functions",
+  "homepage": "https://vercel.com",
+  "version": "0.0.0",
+  "types": "index.d.ts",
+  "main": "index.js",
+  "repository": {
+    "directory": "packages/functions",
+    "type": "git",
+    "url": "git+https://github.com/vercel/vercel.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/vercel/issues"
+  },
+  "devDependencies": {
+    "vitest": "1.3.1"
+  },
+  "engines": {
+    "node": ">= 16"
+  },
+  "files": [
+    "index.d.ts",
+    "index.js"
+  ],
+  "scripts": {
+    "test": "vitest"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,7 +23,7 @@
     "@edge-runtime/node-utils": "2.3.0",
     "@edge-runtime/primitives": "4.1.0",
     "@edge-runtime/vm": "3.2.0",
-    "@types/node": "14.18.33",
+    "@types/node": "16.18.11",
     "@vercel/build-utils": "8.0.0",
     "@vercel/error-utils": "2.0.2",
     "@vercel/nft": "0.26.4",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -50,6 +50,7 @@
     "@types/cookie": "0.3.3",
     "@types/etag": "1.8.0",
     "@types/jest": "29.5.0",
+    "@vercel/functions": "workspace:*",
     "content-type": "1.0.5",
     "cookie": "0.4.0",
     "cross-env": "7.0.3",

--- a/packages/node/src/awaiter.ts
+++ b/packages/node/src/awaiter.ts
@@ -1,0 +1,40 @@
+export class Awaiter {
+  private waitFunctions: Set<() => Promise<unknown>> = new Set();
+  private onError: ((error: Error) => void) | undefined;
+
+  constructor({ onError }: { onError?: (error: Error) => void } = {}) {
+    this.onError = onError;
+  }
+
+  public awaiting = async () => {
+    return this.waitForBatch().then(() => {
+      return this.waitFunctions.size > 0
+        ? this.waitForBatch()
+        : Promise.resolve();
+    });
+  };
+
+  public waitUntil = (
+    promiseOrFunc: Promise<unknown> | (() => Promise<unknown>)
+  ) => {
+    this.waitFunctions.add(
+      typeof promiseOrFunc === 'function' ? promiseOrFunc : () => promiseOrFunc
+    );
+  };
+
+  private waitForBatch = async () => {
+    const promiseOrFuncs = Array.from(this.waitFunctions);
+    this.waitFunctions.clear();
+    await Promise.all(
+      promiseOrFuncs.map(func => {
+        return Promise.resolve(func()).then(
+          () => undefined,
+          error => {
+            const onError = this.onError ?? console.error;
+            onError(error);
+          }
+        );
+      })
+    );
+  };
+}

--- a/packages/node/src/awaiter.ts
+++ b/packages/node/src/awaiter.ts
@@ -2,42 +2,29 @@
  * The Awaiter class is used to manage and await multiple promises.
  */
 export class Awaiter {
-  private waitFunctions: Set<() => Promise<unknown>> = new Set();
+  private promises: Set<Promise<unknown>> = new Set();
   private onError: ((error: Error) => void) | undefined;
 
   constructor({ onError }: { onError?: (error: Error) => void } = {}) {
-    this.onError = onError;
+    this.onError = onError ?? console.error;
   }
 
-  public awaiting = async () => {
-    return this.waitForBatch().then(() => {
-      return this.waitFunctions.size > 0
-        ? this.waitForBatch()
-        : Promise.resolve();
-    });
-  };
-
-  public waitUntil = (
-    promiseOrFunc: Promise<unknown> | (() => Promise<unknown>)
-  ) => {
-    this.waitFunctions.add(
-      typeof promiseOrFunc === 'function' ? promiseOrFunc : () => promiseOrFunc
+  public awaiting = () =>
+    this.waitForBatch().then(() =>
+      this.promises.size > 0 ? this.waitForBatch() : Promise.resolve()
     );
+
+  public waitUntil = (promise: Promise<unknown>) => {
+    this.promises.add(promise);
   };
 
   private waitForBatch = async () => {
-    const promiseOrFuncs = Array.from(this.waitFunctions);
-    this.waitFunctions.clear();
+    const promises = Array.from(this.promises);
+    this.promises.clear();
     await Promise.all(
-      promiseOrFuncs.map(func => {
-        return Promise.resolve(func()).then(
-          () => undefined,
-          error => {
-            const onError = this.onError ?? console.error;
-            onError(error);
-          }
-        );
-      })
+      promises.map(promise =>
+        Promise.resolve(promise).then(() => undefined, this.onError)
+      )
     );
   };
 }

--- a/packages/node/src/awaiter.ts
+++ b/packages/node/src/awaiter.ts
@@ -1,3 +1,6 @@
+/**
+ * The Awaiter class is used to manage and await multiple promises.
+ */
 export class Awaiter {
   private waitFunctions: Set<() => Promise<unknown>> = new Set();
   private onError: ((error: Error) => void) | undefined;

--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -167,7 +167,6 @@ process.on('message', async m => {
       if (onExit) {
         await onExit();
       }
-
       process.exit(0);
     default:
       console.error(`unknown IPC message from parent:`, m);

--- a/packages/node/src/edge-functions/edge-handler-template.js
+++ b/packages/node/src/edge-functions/edge-handler-template.js
@@ -88,7 +88,12 @@ function registerFetchListener(module, options, dependencies) {
           `No default or HTTP-named export was found at ${url}. Add one to handle requests. Learn more: https://vercel.link/creating-edge-middleware`
         );
       }
-      const response = await respond(handler, event, options, dependencies);
+      const response = await respond(
+        (req, ctx) => handler(req, { waitUntil: ctx.waitUntil.bind(ctx) }),
+        event,
+        options,
+        dependencies
+      );
       event.respondWith(response);
     } catch (error) {
       event.respondWith(toResponseError(error, dependencies.Response));

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -172,7 +172,7 @@ async function createEdgeRuntimeServer(params?: {
           ...wasmBindings,
 
           FetchEvent: class extends context.FetchEvent {
-            waitUntil = (promise: any) => {
+            waitUntil = (promise: Promise<unknown>) => {
               params!.awaiter.waitUntil(promise);
             };
           },

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -168,22 +168,18 @@ async function createEdgeRuntimeServer(params?: {
 
     const server = await runServer({ runtime });
 
-    const onExit = async () => {
-      const waitUntil = server.close();
-      return new Promise<void>((resolve, reject) => {
+    const onExit = async () =>
+      new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           console.warn(waitUntilWarning(params.entrypointPath));
           resolve();
         }, WAIT_UNTIL_TIMEOUT_MS);
 
-        waitUntil
+        Promise.all([params.awaiter.awaiting(), server.close()])
           .then(() => resolve())
           .catch(reject)
-          .finally(() => {
-            clearTimeout(timeout);
-          });
+          .finally(() => clearTimeout(timeout));
       });
-    };
 
     return { server, onExit };
   } catch (error: any) {

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -15,6 +15,7 @@ export function forkDevServer(options: {
   require_: NodeRequire;
   entrypoint: string;
   meta: Meta;
+  printLogs?: boolean;
 
   /**
    * A path to the dev-server path. This is used in tests.
@@ -59,8 +60,18 @@ export function forkDevServer(options: {
         : undefined,
       NODE_OPTIONS: nodeOptions,
     }),
+    stdio: options.printLogs ? 'pipe' : undefined,
   };
   const child = fork(devServerPath, [], forkOptions);
+
+  if (options.printLogs) {
+    child.stdout?.on('data', data => {
+      console.log(`stdout: ${data}`);
+    });
+    child.stderr?.on('data', data => {
+      console.error(`stderr: ${data}`);
+    });
+  }
 
   checkForPid(devServerPath, child);
 

--- a/packages/node/src/serverless-functions/helpers-web.ts
+++ b/packages/node/src/serverless-functions/helpers-web.ts
@@ -1,44 +1,51 @@
 import type { ServerResponse, IncomingMessage } from 'http';
 import type { NodeHandler } from '@edge-runtime/node-utils';
+import type { Awaiter } from '../awaiter';
 import { buildToNodeHandler } from '@edge-runtime/node-utils';
-import Edge from '@edge-runtime/primitives';
 
-const webHandlerToNodeHandler = buildToNodeHandler(
-  {
-    Headers,
-    ReadableStream,
-    // @ts-expect-error Property 'duplex' is missing in type 'Request'
-    Request: class extends Request {
-      constructor(input: RequestInfo | URL, init?: RequestInit | undefined) {
-        super(input, addDuplexToInit(init));
-      }
+export const createWebExportsHandler = (awaiter: Awaiter) => {
+  const webHandlerToNodeHandler = buildToNodeHandler(
+    {
+      Headers,
+      ReadableStream,
+      // @ts-expect-error Property 'duplex' is missing in type 'Request'
+      Request: class extends Request {
+        constructor(input: RequestInfo | URL, init?: RequestInit | undefined) {
+          super(input, addDuplexToInit(init));
+        }
+      },
+      Uint8Array,
+      // @ts-expect-error Property 'waitUntil' is missing in type 'FetchEvent'
+      FetchEvent: class {
+        waitUntil = (promise: Promise<any>) => awaiter.waitUntil(promise);
+      },
     },
-    Uint8Array,
-    FetchEvent: Edge.FetchEvent,
-  },
-  { defaultOrigin: 'https://vercel.com' }
-);
+    { defaultOrigin: 'https://vercel.com' }
+  );
 
-/**
- * When users export at least one HTTP handler, we will generate
- * a generic handler routing to the right method. If there is no
- * handler function exported returns null.
- */
-export function getWebExportsHandler(listener: any, methods: string[]) {
-  const handlerByMethod: { [key: string]: NodeHandler } = {};
+  /**
+   * When users export at least one HTTP handler, we will generate
+   * a generic handler routing to the right method. If there is no
+   * handler function exported returns null.
+   */
+  function getWebExportsHandler(listener: any, methods: string[]) {
+    const handlerByMethod: { [key: string]: NodeHandler } = {};
 
-  for (const key of methods) {
-    handlerByMethod[key] =
-      typeof listener[key] !== 'undefined'
-        ? webHandlerToNodeHandler(listener[key])
-        : defaultHttpHandler;
+    for (const key of methods) {
+      handlerByMethod[key] =
+        typeof listener[key] !== 'undefined'
+          ? webHandlerToNodeHandler(listener[key])
+          : defaultHttpHandler;
+    }
+
+    return (req: IncomingMessage, res: ServerResponse) => {
+      const method = req.method ?? 'GET';
+      handlerByMethod[method](req, res);
+    };
   }
 
-  return (req: IncomingMessage, res: ServerResponse) => {
-    const method = req.method ?? 'GET';
-    handlerByMethod[method](req, res);
-  };
-}
+  return getWebExportsHandler;
+};
 
 /**
  * Add `duplex: 'half'` by default to all requests

--- a/packages/node/src/serverless-functions/helpers-web.ts
+++ b/packages/node/src/serverless-functions/helpers-web.ts
@@ -17,7 +17,7 @@ export const createWebExportsHandler = (awaiter: Awaiter) => {
       Uint8Array,
       // @ts-expect-error Property 'waitUntil' is missing in type 'FetchEvent'
       FetchEvent: class {
-        waitUntil = (promise: Promise<any>) => awaiter.waitUntil(promise);
+        waitUntil = (promise: Promise<unknown>) => awaiter.waitUntil(promise);
       },
     },
     { defaultOrigin: 'https://vercel.com' }

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -95,6 +95,17 @@ export async function createServerlessEventHandler(
   onExit: () => Promise<void>;
 }> {
   const awaiter = new Awaiter();
+
+  Object.defineProperty(globalThis, Symbol.for('@vercel/request-context'), {
+    enumerable: false,
+    configurable: true,
+    value: {
+      get: () => ({
+        waitUntil: awaiter.waitUntil.bind(awaiter),
+      }),
+    },
+  });
+
   const userCode = await compileUserCode(entrypointPath, awaiter, options);
   const server = await createServerlessServer(userCode);
   const isStreaming = options.mode === 'streaming';

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -3,6 +3,22 @@ import { pathToRegexp } from 'path-to-regexp';
 import type { IncomingMessage } from 'http';
 import { extname } from 'path';
 
+// When exiting this process, wait for Vercel Function server to finish
+// all its work, especially waitUntil promises before exiting this process.
+//
+// Here we use a short timeout (10 seconds) to let the user know that
+// it has a long-running waitUntil promise.
+const WAIT_UNTIL_TIMEOUT = 10;
+export const WAIT_UNTIL_TIMEOUT_MS = 10 * 1000;
+
+export const waitUntilWarning = (entrypointPath: string) =>
+  `
+The function \`${entrypointPath
+    .split('/')
+    .pop()}\` is still running after ${WAIT_UNTIL_TIMEOUT}s.
+(hint: do you have a long-running waitUntil() promise?)
+`.trim();
+
 export function getRegExpFromMatchers(matcherOrMatchers: unknown): string {
   if (!matcherOrMatchers) {
     return '^/.*$';

--- a/packages/node/test/dev-fixtures/wait-until-ctx-edge.js
+++ b/packages/node/test/dev-fixtures/wait-until-ctx-edge.js
@@ -1,0 +1,12 @@
+const baseUrl = ({ headers }) =>
+  `${headers.get('x-forwarded-proto')}://${headers.get('x-forwarded-host')}`;
+
+export function GET(request, ctx) {
+  const { searchParams } = new URL(request.url, baseUrl(request));
+  const url = searchParams.get('url');
+
+  ctx.waitUntil(fetch(url));
+  return Response.json({ keys: Object.keys(ctx) });
+}
+
+export const config = { runtime: 'edge' };

--- a/packages/node/test/dev-fixtures/wait-until-ctx-node-rejected.js
+++ b/packages/node/test/dev-fixtures/wait-until-ctx-node-rejected.js
@@ -1,0 +1,12 @@
+function lazyError() {
+  return new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error('oh no'));
+    }, 100);
+  });
+}
+
+export function GET(_, ctx) {
+  ctx.waitUntil(lazyError());
+  return Response.json({ keys: Object.keys(ctx) });
+}

--- a/packages/node/test/dev-fixtures/wait-until-ctx-node.js
+++ b/packages/node/test/dev-fixtures/wait-until-ctx-node.js
@@ -1,0 +1,10 @@
+const baseUrl = ({ headers }) =>
+  `${headers.get('x-forwarded-proto')}://${headers.get('x-forwarded-host')}`;
+
+export function GET(request, ctx) {
+  const { searchParams } = new URL(request.url, baseUrl(request));
+  const url = searchParams.get('url');
+
+  ctx.waitUntil(fetch(url));
+  return Response.json({ keys: Object.keys(ctx) });
+}

--- a/packages/node/test/dev-fixtures/wait-until-edge.js
+++ b/packages/node/test/dev-fixtures/wait-until-edge.js
@@ -1,0 +1,13 @@
+import { waitUntil } from '@vercel/functions';
+
+const baseUrl = ({ headers }) =>
+  `${headers.get('x-forwarded-proto')}://${headers.get('x-forwarded-host')}`;
+
+export function GET(request) {
+  const { searchParams } = new URL(request.url, baseUrl(request));
+  const url = searchParams.get('url');
+  waitUntil(fetch(url));
+  return new Response('OK');
+}
+
+export const config = { runtime: 'edge' };

--- a/packages/node/test/dev-fixtures/wait-until-node.js
+++ b/packages/node/test/dev-fixtures/wait-until-node.js
@@ -1,0 +1,11 @@
+import { waitUntil } from '@vercel/functions';
+
+const baseUrl = ({ headers }) =>
+  `${headers.get('x-forwarded-proto')}://${headers.get('x-forwarded-host')}`;
+
+export function GET(request) {
+  const { searchParams } = new URL(request.url, baseUrl(request));
+  const url = searchParams.get('url');
+  waitUntil(fetch(url));
+  return new Response('OK');
+}

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -9,7 +9,10 @@ jest.setTimeout(20 * 1000);
 
 const [NODE_MAJOR] = process.versions.node.split('.').map(v => Number(v));
 
-function testForkDevServer(entrypoint: string) {
+function testForkDevServer(
+  entrypoint: string,
+  options: { printLogs?: boolean } = {}
+) {
   const ext = extname(entrypoint);
   const isTypeScript = ext === '.ts';
   const isEsm = ext === '.mjs';
@@ -26,6 +29,7 @@ function testForkDevServer(entrypoint: string) {
     workPath: resolve(__dirname, '../dev-fixtures'),
     entrypoint,
     devServerPath: resolve(__dirname, '../../dist/dev-server.mjs'),
+    printLogs: options.printLogs,
   });
 }
 

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -1,18 +1,17 @@
 import { forkDevServer, readMessage } from '../../src/fork-dev-server';
 import { resolve, extname } from 'path';
-import { fetch } from 'undici';
 import { createServer } from 'http';
 import { listen } from 'async-listen';
-import zlib from 'zlib';
+import { once } from 'node:events';
+import { fetch } from 'undici';
+import { promisify } from 'util';
+import { setTimeout } from 'timers/promises';
 
 jest.setTimeout(20 * 1000);
 
 const [NODE_MAJOR] = process.versions.node.split('.').map(v => Number(v));
 
-function testForkDevServer(
-  entrypoint: string,
-  options: { printLogs?: boolean } = {}
-) {
+function testForkDevServer(entrypoint: string) {
   const ext = extname(entrypoint);
   const isTypeScript = ext === '.ts';
   const isEsm = ext === '.mjs';
@@ -29,27 +28,87 @@ function testForkDevServer(
     workPath: resolve(__dirname, '../dev-fixtures'),
     entrypoint,
     devServerPath: resolve(__dirname, '../../dist/dev-server.mjs'),
-    printLogs: options.printLogs,
   });
 }
 
-(NODE_MAJOR < 18 ? test.skip : test)(
-  'web handlers for node runtime',
-  async () => {
-    const child = testForkDevServer('./web-handlers-node.js');
-    try {
-      const result = await readMessage(child);
-      if (result.state !== 'message') {
-        throw new Error('Exited. error: ' + JSON.stringify(result.value));
-      }
+const teardown: any = [];
+afterAll(() => Promise.all(teardown.map((fn: any) => fn())));
 
-      const { address, port } = result.value;
+async function withHttpServer(hander: (req: any, res: any) => void) {
+  const server = createServer(hander);
+  teardown.push(promisify(server.close.bind(server)));
+  const address = await listen(server, { port: 0, host: '127.0.0.1' });
+  return address.toString();
+}
 
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'GET' }
-        );
+async function withDevServer(
+  entrypoint: string,
+  fn: (url: string) => Promise<void>,
+  { runningTimeout }: { runningTimeout?: number } = {}
+) {
+  const child = testForkDevServer(entrypoint);
+
+  const result = await readMessage(child);
+  if (result.state !== 'message') {
+    throw new Error('Exited. error: ' + JSON.stringify(result.value));
+  }
+  const { address, port } = result.value;
+  const url = `http://${address}:${port}`;
+
+  const start = Date.now();
+
+  return fn(url).finally(async () => {
+    const elapsed = Date.now() - start;
+    if (runningTimeout) await setTimeout(runningTimeout - elapsed);
+    child.send('shutdown', err => {
+      if (err) child.kill(9);
+    });
+    await once(child, 'exit');
+  });
+}
+
+(NODE_MAJOR < 18 ? describe.skip : describe)('web handlers', () => {
+  describe('for node runtime', () => {
+    test('with `waitUntil` from import', () =>
+      withDevServer(
+        './wait-until-node.js',
+        async (url: string) => {
+          let isWaitUntilCalled = false;
+          const serverUrl = await withHttpServer((_, res) => {
+            isWaitUntilCalled = true;
+            res.end();
+          });
+          await fetch(`${url}/api/wait-until-node?url=${serverUrl}`);
+          await setTimeout(50); // wait a bit for waitUntil resolution
+          expect(isWaitUntilCalled).toBe(true);
+        },
+        { runningTimeout: 300 }
+      ));
+
+    test('with `waitUntil` from context', () =>
+      withDevServer(
+        './wait-until-ctx-node.js',
+        async (url: string) => {
+          let isWaitUntilCalled = false;
+          const serverUrl = await withHttpServer((_, res) => {
+            isWaitUntilCalled = true;
+            res.end();
+          });
+          const response = await fetch(
+            `${url}/api/wait-until-ctx-node?url=${serverUrl}`
+          );
+          expect(await response.json()).toEqual({ keys: ['waitUntil'] });
+          await setTimeout(50); // wait a bit for waitUntil resolution
+          expect(isWaitUntilCalled).toBe(true);
+        },
+        { runningTimeout: 300 }
+      ));
+
+    test('exporting GET', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'GET',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -61,12 +120,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using GET',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'POST' }
-        );
+      }));
+
+    test('exporting POST', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'POST',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -78,12 +138,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using POST',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'DELETE' }
-        );
+      }));
+
+    test('exporting DELETE', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'DELETE',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -95,12 +156,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using DELETE',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'PUT' }
-        );
+      }));
+
+    test('exporting PUT', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'PUT',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -112,12 +174,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using PUT',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'PATCH' }
-        );
+      }));
+
+    test('exporting PATCH', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'PATCH',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -129,25 +192,31 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using PATCH',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'HEAD' }
-        );
+      }));
+
+    test('exporting HEAD', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'HEAD',
+        });
         expect({
           status: response.status,
+          body: await response.text(),
+          transferEncoding: response.headers.get('transfer-encoding'),
           'x-web-handler': response.headers.get('x-web-handler'),
         }).toEqual({
           status: 200,
+          body: '',
+          transferEncoding: null,
           'x-web-handler': 'Web handler using HEAD',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-node`,
-          { method: 'OPTIONS' }
-        );
+      }));
+
+    test('exporting OPTIONS', () =>
+      withDevServer('./web-handlers-node.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'OPTIONS',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -159,30 +228,140 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using OPTIONS',
         });
-      }
-    } finally {
-      child.kill(9);
-    }
-  }
-);
+      }));
+  });
 
-(NODE_MAJOR < 18 ? test.skip : test)(
-  'web handlers for edge runtime',
-  async () => {
-    const child = testForkDevServer('./web-handlers-edge.js');
-    try {
-      const result = await readMessage(child);
-      if (result.state !== 'message') {
-        throw new Error('Exited. error: ' + JSON.stringify(result.value));
-      }
+  describe('for edge runtime', () => {
+    test('with `waitUntil` from import', () =>
+      withDevServer(
+        './wait-until-edge.js',
+        async (url: string) => {
+          let isWaitUntilCalled = false;
+          const serverUrl = await withHttpServer((_, res) => {
+            isWaitUntilCalled = true;
+            res.end();
+          });
+          await fetch(`${url}/api/wait-until-edge?url=${serverUrl}`);
+          await setTimeout(50); // wait a bit for waitUntil resolution
+          expect(isWaitUntilCalled).toBe(true);
+        },
+        { runningTimeout: 300 }
+      ));
 
-      const { address, port } = result.value;
+    test('with `waitUntil` from context', () =>
+      withDevServer(
+        './wait-until-ctx-edge.js',
+        async (url: string) => {
+          let isWaitUntilCalled = false;
+          const serverUrl = await withHttpServer((_, res) => {
+            isWaitUntilCalled = true;
+            res.end();
+          });
+          const response = await fetch(
+            `${url}/api/wait-until-ctx-edge?url=${serverUrl}`
+          );
+          expect(await response.json()).toEqual({ keys: ['waitUntil'] });
+          await setTimeout(50); // wait a bit for waitUntil resolution
+          expect(isWaitUntilCalled).toBe(true);
+        },
+        { runningTimeout: 300 }
+      ));
 
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'GET' }
-        );
+    test("user code doesn't interfere with runtime", () =>
+      withDevServer('./edge-self.js', async (url: string) => {
+        const response = await fetch(`${url}/api/edge-self`);
+        expect({
+          status: response.status,
+        }).toEqual({
+          status: 200,
+        });
+      }));
+
+    test('with `WebSocket`', () =>
+      withDevServer('./edge-websocket.js', async (url: string) => {
+        const response = await fetch(`${url}/api/edge-websocket`);
+        expect({
+          status: response.status,
+          body: await response.text(),
+        }).toEqual({
+          status: 200,
+          body: '3210',
+        });
+      }));
+
+    test('with `Buffer`', () =>
+      withDevServer('./edge-buffer.js', async (url: string) => {
+        const response = await fetch(`${url}/api/edge-buffer`);
+        expect({
+          status: response.status,
+          json: await response.json(),
+        }).toEqual({
+          status: 200,
+          json: {
+            encoded: Buffer.from('Hello, world!').toString('base64'),
+            'Buffer === B.Buffer': true,
+          },
+        });
+      }));
+
+    test('runs a mjs endpoint', () =>
+      withDevServer('./esm-module.mjs', async (url: string) => {
+        const response = await fetch(`${url}/api/hello`);
+        expect({
+          status: response.status,
+          headers: Object.fromEntries(response.headers),
+          text: await response.text(),
+        }).toEqual({
+          status: 200,
+          headers: expect.objectContaining({
+            'x-hello': 'world',
+          }),
+          text: 'Hello, world!',
+        });
+      }));
+    (process.platform === 'win32' ? test.skip : test)(
+      'runs a esm typescript endpoint',
+      () =>
+        withDevServer('./esm-module.ts', async (url: string) => {
+          const response = await fetch(`${url}/api/hello`);
+          expect({
+            status: response.status,
+            headers: Object.fromEntries(response.headers),
+            text: await response.text(),
+          }).toEqual({
+            status: 200,
+            headers: expect.objectContaining({
+              'x-hello': 'world',
+            }),
+            text: 'Hello, world!',
+          });
+        })
+    );
+    (process.platform === 'win32' ? test.skip : test)(
+      'allow setting multiple cookies with same name',
+      () =>
+        withDevServer('./multiple-cookies.ts', async (url: string) => {
+          const response = await fetch(`${url}/api/hello`, { method: 'GET' });
+          expect({
+            status: response.status,
+            text: await response.text(),
+          }).toEqual({
+            status: 200,
+            text: 'Hello, world!',
+          });
+          expect(response.headers.getSetCookie()).toEqual([
+            'a=x',
+            'b=y',
+            'c=z',
+          ]);
+        })
+    );
+
+    test('exporting GET', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'GET',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -194,12 +373,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using GET',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'POST' }
-        );
+      }));
+
+    test('exporting POST', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'POST',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -211,29 +391,31 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using POST',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'DELETE' }
-        );
+      }));
 
-        console.log(response);
+    test('exporting DELETE', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'DELETE',
+        });
         expect({
           status: response.status,
+          body: await response.text(),
           transferEncoding: response.headers.get('transfer-encoding'),
           'x-web-handler': response.headers.get('x-web-handler'),
         }).toEqual({
           status: 200,
+          body: 'Web handler using DELETE',
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using DELETE',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'PUT' }
-        );
+      }));
+
+    test('exporting PUT', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'PUT',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -245,12 +427,13 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using PUT',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'PATCH' }
-        );
+      }));
+
+    test('exporting PATCH', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'PATCH',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -262,25 +445,31 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using PATCH',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'HEAD' }
-        );
+      }));
+
+    test('exporting HEAD', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'HEAD',
+        });
         expect({
           status: response.status,
+          body: await response.text(),
+          transferEncoding: response.headers.get('transfer-encoding'),
           'x-web-handler': response.headers.get('x-web-handler'),
         }).toEqual({
           status: 200,
+          body: '',
+          transferEncoding: null,
           'x-web-handler': 'Web handler using HEAD',
         });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/web-handlers-edge`,
-          { method: 'OPTIONS' }
-        );
+      }));
+
+    test('exporting OPTIONS', () =>
+      withDevServer('./web-handlers-edge.js', async (url: string) => {
+        const response = await fetch(`${url}/api/web-handlers-node`, {
+          method: 'OPTIONS',
+        });
         expect({
           status: response.status,
           body: await response.text(),
@@ -292,338 +481,6 @@ function testForkDevServer(
           transferEncoding: 'chunked',
           'x-web-handler': 'Web handler using OPTIONS',
         });
-      }
-    } finally {
-      child.kill(9);
-    }
-  }
-);
-
-(NODE_MAJOR < 18 ? test.skip : test)(
-  'buffer fetch response correctly',
-  async () => {
-    const child = testForkDevServer('./serverless-fetch.js');
-
-    const server = createServer((req, res) => {
-      res.setHeader('Content-Encoding', 'br');
-      const searchParams = new URLSearchParams(req.url!.substring(1));
-      const encoding = searchParams.get('encoding') ?? 'identity';
-      res.writeHead(200, {
-        'content-type': 'text/plain',
-        'content-encoding': encoding,
-      });
-      let payload = Buffer.from('Greetings, Vercel');
-
-      if (encoding === 'br') {
-        payload = zlib.brotliCompressSync(payload, {
-          params: {
-            [zlib.constants.BROTLI_PARAM_QUALITY]: 0,
-          },
-        });
-      } else if (encoding === 'gzip') {
-        payload = zlib.gzipSync(payload, {
-          level: zlib.constants.Z_BEST_SPEED,
-        });
-      } else if (encoding === 'deflate') {
-        payload = zlib.deflateSync(payload, {
-          level: zlib.constants.Z_BEST_SPEED,
-        });
-      }
-
-      res.end(payload);
-    });
-
-    const serverUrl = (await listen(server)).toString();
-
-    try {
-      const result = await readMessage(child);
-      if (result.state !== 'message') {
-        throw new Error('Exited. error: ' + JSON.stringify(result.value));
-      }
-
-      const { address, port } = result.value;
-
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=br`
-        );
-        expect(response.headers.get('content-encoding')).toBe('br');
-        expect(response.headers.get('content-length')).toBe('21');
-        expect({
-          status: response.status,
-          body: await response.text(),
-        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=gzip`
-        );
-        expect(response.headers.get('content-encoding')).toBe('gzip');
-        expect(response.headers.get('content-length')).toBe('37');
-        expect({
-          status: response.status,
-          body: await response.text(),
-        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
-      }
-      {
-        const response = await fetch(
-          `http://${address}:${port}/api/serverless-fetch?url=${serverUrl}&encoding=deflate`
-        );
-        expect(response.headers.get('content-encoding')).toBe('deflate');
-        expect(response.headers.get('content-length')).toBe('25');
-        expect({
-          status: response.status,
-          body: await response.text(),
-        }).toEqual({ status: 200, body: 'Greetings, Vercel' });
-      }
-    } finally {
-      server.close();
-      child.kill(9);
-    }
-  }
-);
-
-test("user code doesn't interfere with runtime", async () => {
-  const child = testForkDevServer('./edge-self.js');
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(`http://${address}:${port}/api/edge-self`);
-
-    expect({
-      status: response.status,
-    }).toEqual({
-      status: 200,
-    });
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('runs an edge function that uses `WebSocket`', async () => {
-  const child = testForkDevServer('./edge-websocket.js');
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(
-      `http://${address}:${port}/api/edge-websocket`
-    );
-
-    expect({
-      status: response.status,
-      body: await response.text(),
-    }).toEqual({
-      status: 200,
-      body: '3210',
-    });
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('runs an edge function that uses `buffer`', async () => {
-  const child = testForkDevServer('./edge-buffer.js');
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(`http://${address}:${port}/api/edge-buffer`);
-    expect({
-      status: response.status,
-      json: await response.json(),
-    }).toEqual({
-      status: 200,
-      json: {
-        encoded: Buffer.from('Hello, world!').toString('base64'),
-        'Buffer === B.Buffer': true,
-      },
-    });
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('runs a mjs endpoint', async () => {
-  const child = testForkDevServer('./esm-module.mjs');
-
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(`http://${address}:${port}/api/hello`);
-    expect({
-      status: response.status,
-      headers: Object.fromEntries(response.headers),
-      text: await response.text(),
-    }).toEqual({
-      status: 200,
-      headers: expect.objectContaining({
-        'x-hello': 'world',
-      }),
-      text: 'Hello, world!',
-    });
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('runs a esm typescript endpoint', async () => {
-  if (process.platform === 'win32') {
-    console.log('Skipping test on Windows');
-    return;
-  }
-
-  const child = testForkDevServer('./esm-module.ts');
-
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(`http://${address}:${port}/api/hello`);
-    expect({
-      status: response.status,
-      headers: Object.fromEntries(response.headers),
-      text: await response.text(),
-    }).toEqual({
-      status: 200,
-      headers: expect.objectContaining({
-        'x-hello': 'world',
-      }),
-      text: 'Hello, world!',
-    });
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('allow setting multiple cookies with same name', async () => {
-  if (process.platform === 'win32') {
-    console.log('Skipping test on Windows');
-    return;
-  }
-
-  const child = testForkDevServer('./multiple-cookies.ts');
-
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error(`Exited. error: ${JSON.stringify(result.value)}`);
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(`http://${address}:${port}/api/hello`);
-    expect({
-      status: response.status,
-      text: await response.text(),
-    }).toEqual({
-      status: 200,
-      text: 'Hello, world!',
-    });
-
-    expect(response.headers.getSetCookie()).toEqual(['a=x', 'b=y', 'c=z']);
-  } finally {
-    child.kill(9);
-  }
-});
-
-test('dev server waits for waitUntil promises to resolve', async () => {
-  async function startPingServer() {
-    let resolve: (value: any) => void;
-    const promise = new Promise<void>(resolve_ => {
-      resolve = resolve_;
-    });
-
-    const pingServer = createServer((req, res) => {
-      res.end('pong');
-      resolve('got a fetch from waitUntil');
-    });
-
-    const pingUrl = (await listen(pingServer)).toString();
-    return {
-      pingUrl,
-      pingServer,
-      promise,
-    };
-  }
-
-  async function withTimeout(
-    promise: Promise<unknown>,
-    name: string,
-    ms: number
-  ) {
-    return await Promise.race([
-      promise,
-      new Promise(resolve =>
-        setTimeout(
-          () => resolve(`${name} promise was not resolved in ${ms} ms`),
-          ms
-        )
-      ),
-    ]);
-  }
-
-  const { promise: pingPromise, pingServer, pingUrl } = await startPingServer();
-  const child = testForkDevServer('./edge-waituntil.js');
-  const exitPromise = new Promise(resolve => {
-    child.on('exit', code => {
-      resolve(`child has exited with ${code}`);
-    });
+      }));
   });
-
-  try {
-    const result = await readMessage(child);
-    if (result.state !== 'message') {
-      throw new Error('Exited. error: ' + JSON.stringify(result.value));
-    }
-
-    const { address, port } = result.value;
-    const response = await fetch(
-      `http://${address}:${port}/api/edge-waituntil`,
-      {
-        headers: {
-          'x-ping-url': pingUrl,
-        },
-      }
-    );
-
-    expect({
-      status: response.status,
-      body: await response.text(),
-    }).toEqual({
-      status: 200,
-      body: 'running waitUntil promises asynchronously...',
-    });
-
-    // Dev server should keep running until waitUntil promise resolves...
-    child.send('shutdown');
-
-    // Wait for waitUntil promise to resolve...
-    expect(await withTimeout(pingPromise, 'ping server', 3000)).toBe(
-      'got a fetch from waitUntil'
-    );
-    // Make sure child process has exited.
-    expect(await withTimeout(exitPromise, 'child exit', 5000)).toBe(
-      'child has exited with 0'
-    );
-  } finally {
-    child.kill(9);
-    pingServer.close();
-  }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1308,6 +1308,9 @@ importers:
       '@types/jest':
         specifier: 29.5.0
         version: 29.5.0
+      '@vercel/functions':
+        specifier: workspace:*
+        version: link:../functions
       content-type:
         specifier: 1.0.5
         version: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,12 @@ importers:
         specifier: 4.9.5
         version: 4.9.5
 
+  packages/functions:
+    devDependencies:
+      vitest:
+        specifier: 1.3.1
+        version: 1.3.1(@types/node@14.18.33)
+
   packages/gatsby-plugin-vercel-analytics:
     dependencies:
       web-vitals:
@@ -1227,8 +1233,8 @@ importers:
         specifier: 3.2.0
         version: 3.2.0
       '@types/node':
-        specifier: 14.18.33
-        version: 14.18.33
+        specifier: 16.18.11
+        version: 16.18.11
       '@vercel/build-utils':
         specifier: 8.0.0
         version: link:../build-utils
@@ -10417,7 +10423,7 @@ packages:
       jest-snapshot: 29.5.0
       jest-util: 29.5.0
       p-limit: 3.1.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       pure-rand: 6.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -10513,7 +10519,7 @@ packages:
       jest-validate: 29.5.0
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -10552,7 +10558,7 @@ packages:
       jest-validate: 29.5.0
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -10591,7 +10597,7 @@ packages:
       jest-validate: 29.5.0
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -10633,9 +10639,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.0
-      diff-sequences: 29.4.3
+      diff-sequences: 29.6.3
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-docblock@29.4.3:
@@ -10653,7 +10659,7 @@ packages:
       chalk: 4.1.0
       jest-get-type: 29.4.3
       jest-util: 29.5.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-environment-node@29.5.0:
@@ -10722,7 +10728,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-matcher-utils@27.5.1:
@@ -10915,7 +10921,7 @@ packages:
       jest-message-util: 29.5.0
       jest-util: 29.5.0
       natural-compare: 1.4.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
@@ -10954,7 +10960,7 @@ packages:
       chalk: 4.1.0
       jest-get-type: 29.4.3
       leven: 3.1.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-watcher@29.5.0:


### PR DESCRIPTION
This PR makes `waitUntil` consistent when interacting with it via `vc dev`. That includes:

**be possible to call `waitUntil` from the context second argument in web handlers functions (Node.js & Edge)**:

```js
export function GET(request, { waitUntil }) {
  waitUntil(fetch('https://vercel.com'));
  return new Response('OK');
}
```

**be possible to call `waitUntil` imported from `@vercel/functions`** (Node.js & Edge):

```js
import { waitUntil } from '@vercel/functions';

export function GET(request) {
  waitUntil(fetch('https://vercel.com'));
  return new Response('OK');
}
```

Additionally, `@vercel/functions` can be adopted for other framework to take advantage of this pattern at Vercel.