### PR TITLE
[@vercel/functions]: don't throw error if context is missing

### DIFF
--- a/.changeset/calm-shoes-cough.md
+++ b/.changeset/calm-shoes-cough.md
@@ -1,0 +1,5 @@
+---
+"@vercel/functions": patch
+---
+
+Don't throw error if context is missing

--- a/packages/functions/index.js
+++ b/packages/functions/index.js
@@ -13,12 +13,5 @@ export const waitUntil = promise => {
   }
 
   const ctx = globalThis[Symbol.for('@vercel/request-context')]?.get?.() ?? {};
-
-  if (!ctx.waitUntil) {
-    throw new Error(
-      'failed to get waitUntil function for this request context'
-    );
-  }
-
-  ctx.waitUntil(promise);
+  ctx.waitUntil?.(promise);
 };

--- a/packages/functions/index.js
+++ b/packages/functions/index.js
@@ -2,7 +2,6 @@
 
 export const waitUntil = promise => {
   if (
-    promise instanceof Promise === false ||
     promise === null ||
     typeof promise !== 'object' ||
     typeof promise.then !== 'function'

--- a/packages/functions/index.test.js
+++ b/packages/functions/index.test.js
@@ -23,14 +23,11 @@ test.each([
 });
 
 test.each([null, undefined, {}])(
-  'waitUntil throws when context is %s',
+  'waitUntil does not throw an error when context is %s',
   input => {
     const promise = Promise.resolve();
     globalThis[Symbol.for('@vercel/request-context')] = input;
-    expect(() => waitUntil(promise)).toThrow(Error);
-    expect(() => waitUntil(promise)).toThrow(
-      'failed to get waitUntil function for this request context'
-    );
+    expect(() => waitUntil(promise)).not.toThrow();
   }
 );
 


### PR DESCRIPTION
making `waituntil` a noop