### PR TITLE
[next] Support Incremental Partial Prerendering

### DIFF
--- a/.changeset/grumpy-socks-hope.md
+++ b/.changeset/grumpy-socks-hope.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Support incremental partial prerendering

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -218,7 +218,9 @@ export async function serverBuild({
   }
 
   const experimental = {
-    ppr: requiredServerFilesManifest.config.experimental?.ppr === true,
+    ppr:
+      requiredServerFilesManifest.config.experimental?.ppr === true ||
+      requiredServerFilesManifest.config.experimental?.ppr === 'incremental',
   };
 
   let appRscPrefetches: UnwrapPromise<ReturnType<typeof glob>> = {};
@@ -228,8 +230,6 @@ export async function serverBuild({
   if (appPathRoutesManifest) {
     appDir = path.join(pagesDir, '../app');
     appBuildTraces = await glob('**/*.js.nft.json', appDir);
-
-    // TODO: maybe?
     appRscPrefetches = experimental.ppr
       ? {}
       : await glob(`**/*${RSC_PREFETCH_SUFFIX}`, appDir);

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/disabled/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/disabled/page.jsx
@@ -1,0 +1,3 @@
+export { default } from '../page';
+
+export const experimental_ppr = false;

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/page.jsx
@@ -1,0 +1,17 @@
+import { unstable_noStore } from 'next/cache';
+import { Suspense } from 'react';
+
+export const experimental_ppr = true;
+
+function Dynamic() {
+  unstable_noStore();
+  return <div id="sentinel:dynamic">Dynamic</div>;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div id="sentinel:loading">Loading...</div>}>
+      <Dynamic />
+    </Suspense>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    ppr: 'incremental',
+  },
+};

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "experimental",
+    "react-dom": "experimental"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
@@ -1,0 +1,77 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next",
+      "config": {
+        "functions": {
+          "app/**/*": {
+            "maxDuration": 5,
+            "memory": 512
+          },
+          "pages/api/**/*": {
+            "maxDuration": 5,
+            "memory": 512
+          }
+        }
+      }
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "sentinel:loading"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "sentinel:dynamic"
+    },
+    {
+      "path": "/",
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      },
+      "status": 200,
+      "mustContain": "sentinel:loading",
+      "mustNotContain": "sentinel:dynamic"
+    },
+    {
+      "path": "/",
+      "headers": {
+        "RSC": "1"
+      },
+      "status": 200,
+      "mustContain": "sentinel:dynamic"
+    },
+    {
+      "path": "/disabled",
+      "status": 200,
+      "mustContain": "sentinel:loading"
+    },
+    {
+      "path": "/disabled",
+      "status": 200,
+      "mustContain": "sentinel:dynamic"
+    },
+    {
+      "path": "/disabled",
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      },
+      "status": 200,
+      "mustContain": "sentinel:dynamic"
+    },
+    {
+      "path": "/disabled",
+      "headers": {
+        "RSC": "1"
+      },
+      "status": 200,
+      "mustContain": "sentinel:dynamic"
+    }
+  ]
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/package.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "next": "canary",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "experimental",
+    "react-dom": "experimental"
   },
   "ignoreNextjsUpdates": true
 }


### PR DESCRIPTION
This fixes the logic that detects if partial prerendering (PPR) has been enabled for a project. The new incremental adoption pathway allows setting the `experimental.ppr = 'incremental'` which the previous code did not support.