### PR TITLE
[next] ensure action outputs are created for edge functions

### DIFF
--- a/.changeset/nine-cooks-serve.md
+++ b/.changeset/nine-cooks-serve.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+ensure `.action` outputs are created for edge functions

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1601,6 +1601,10 @@ export async function serverBuild({
           edgeFunctions[`${pathname}${RSC_PREFETCH_SUFFIX}`] =
             edgeFunctions[pathname];
         }
+
+        if (hasActionOutputSupport) {
+          edgeFunctions[`${pathname}.action`] = edgeFunctions[pathname];
+        }
       }
     }
   }

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/dynamic/[id]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/dynamic/[id]/page.js
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import { increment } from '../../../../actions';
+
+export default function Page() {
+  const [count, setCount] = useState(0);
+  async function updateCount() {
+    const newCount = await increment(count);
+    setCount(newCount);
+  }
+
+  return (
+    <form action={updateCount}>
+      <div id="count">{count}</div>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/dynamic/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/dynamic/layout.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic';
+
+export default function Layout({ children }) {
+  return children;
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/[dynamic-static]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/[dynamic-static]/page.js
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import { increment } from '../../../../actions';
+
+export default function Page() {
+  const [count, setCount] = useState(0);
+  async function updateCount() {
+    const newCount = await increment(count);
+    setCount(newCount);
+  }
+
+  return (
+    <form action={updateCount}>
+      <div id="count">{count}</div>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/layout.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static';
+
+export default function Layout({ children }) {
+  return children;
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/client/static/page.js
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+import { increment } from '../../../actions';
+
+export default function Page() {
+  const [count, setCount] = useState(0);
+  async function updateCount() {
+    const newCount = await increment(count);
+    setCount(newCount);
+  }
+
+  return (
+    <form action={updateCount}>
+      <div id="count">{count}</div>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/layout.js
@@ -1,0 +1,5 @@
+export const runtime = 'edge';
+
+export default function Layout({ children }) {
+  return <div>{children}</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/other/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/other/page.js
@@ -1,0 +1,45 @@
+'use client';
+
+// @ts-ignore
+import { useCallback, useState } from 'react';
+
+function request(method) {
+  return fetch('/api/test', {
+    method,
+    headers: {
+      'content-type': 'multipart/form-data;.*',
+    },
+  });
+}
+
+export default function Home() {
+  const [result, setResult] = useState('Press submit');
+  const onClick = useCallback(async method => {
+    const res = await request(method);
+    const text = await res.text();
+
+    setResult(res.ok ? `${method} ${text}` : 'Error: ' + res.status);
+  }, []);
+
+  return (
+    <>
+      <div className="flex flex-col items-center justify-center h-screen">
+        <div className="flex flex-row space-x-2 items-center justify-center">
+          <button
+            className="border border-white rounded-sm p-4 mb-4"
+            onClick={() => onClick('GET')}
+          >
+            Submit GET
+          </button>
+          <button
+            className="border border-white rounded-sm p-4 mb-4"
+            onClick={() => onClick('POST')}
+          >
+            Submit POST
+          </button>
+        </div>
+        <div className="text-white">{result}</div>
+      </div>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/dynamic/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/dynamic/layout.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic';
+
+export default function Layout({ children }) {
+  return children;
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/dynamic/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/dynamic/page.js
@@ -1,0 +1,15 @@
+import { revalidatePath } from 'next/cache';
+
+export default async function Page() {
+  async function serverAction() {
+    'use server';
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    revalidatePath('/dynamic');
+  }
+
+  return (
+    <form action={serverAction}>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/[dynamic-static]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/[dynamic-static]/page.js
@@ -1,0 +1,15 @@
+import { revalidatePath } from 'next/cache';
+
+export default async function Page() {
+  async function serverAction() {
+    'use server';
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    revalidatePath('/dynamic');
+  }
+
+  return (
+    <form action={serverAction}>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/generate-static-params/[slug]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/generate-static-params/[slug]/page.js
@@ -1,0 +1,19 @@
+import { revalidatePath } from 'next/cache';
+
+export default async function Page() {
+  async function serverAction() {
+    'use server';
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    revalidatePath('/dynamic');
+  }
+
+  return (
+    <form action={serverAction}>
+      <button>Submit</button>
+    </form>
+  );
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'pre-generated' }];
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/layout.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static';
+
+export default function Layout({ children }) {
+  return children;
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/page.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/app/edge/rsc/static/page.js
@@ -1,0 +1,15 @@
+import { revalidatePath } from 'next/cache'
+
+export default async function Page() {
+  async function serverAction() {
+    'use server';
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    revalidatePath('/dynamic');
+  }
+
+  return (
+    <form action={serverAction}>
+      <button>Submit</button>
+    </form>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-actions-experimental-streaming/index.test.js
@@ -5,10 +5,12 @@ const fetch = require('../../../../../test/lib/deployment/fetch-retry');
 
 const ctx = {};
 
-function findActionId(page) {
+function findActionId(page, runtime) {
   page = `app${page}/page`; // add /app prefix and /page suffix
 
-  for (const [actionId, details] of Object.entries(ctx.actionManifest.node)) {
+  for (const [actionId, details] of Object.entries(
+    ctx.actionManifest[runtime]
+  )) {
     if (details.workers[page]) {
       return actionId;
     }
@@ -41,141 +43,115 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     Object.assign(ctx, info);
   });
 
-  describe('client component', () => {
-    it('should bypass the static cache for a server action', async () => {
-      const path = '/client/static';
-      const actionId = findActionId(path);
+  describe.each(['node', 'edge'])('runtime: %s', runtime => {
+    const basePath = runtime === 'edge' ? '/edge' : '';
+    describe('client component', () => {
+      it('should bypass the static cache for a server action', async () => {
+        const path = `${basePath}/client/static`;
+        const actionId = findActionId(path, runtime);
 
-      const res = await fetch(`${ctx.deploymentUrl}${path}`, {
-        method: 'POST',
-        body: JSON.stringify([1337]),
-        headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
-          'Next-Action': actionId,
-        },
+        const res = await fetch(`${ctx.deploymentUrl}${path}`, {
+          method: 'POST',
+          body: JSON.stringify([1337]),
+          headers: {
+            'Content-Type': 'text/plain;charset=UTF-8',
+            'Next-Action': actionId,
+          },
+        });
+
+        expect(res.status).toEqual(200);
+        const body = await res.text();
+        expect(body).toContain('1338');
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          // in edge runtime, x-vercel-cache is not returned on MISSes for some reason.
+          // this checks to ensure it was routed to the edge function instead.
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
       });
 
-      expect(res.status).toEqual(200);
-      const body = await res.text();
-      expect(body).toContain('1338');
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
+      it('should bypass the static cache for a server action on a page with dynamic params', async () => {
+        const path = `${basePath}/client/static/[dynamic-static]`;
+        const actionId = findActionId(path, runtime);
 
-    it('should bypass the static cache for a server action on a page with dynamic params', async () => {
-      const path = '/client/static/[dynamic-static]';
-      const actionId = findActionId(path);
+        const res = await fetch(`${ctx.deploymentUrl}${path}`, {
+          method: 'POST',
+          body: JSON.stringify([1337]),
+          headers: {
+            'Content-Type': 'text/plain;charset=UTF-8',
+            'Next-Action': actionId,
+          },
+        });
 
-      const res = await fetch(`${ctx.deploymentUrl}${path}`, {
-        method: 'POST',
-        body: JSON.stringify([1337]),
-        headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
-          'Next-Action': actionId,
-        },
+        expect(res.status).toEqual(200);
+        const body = await res.text();
+        expect(body).toContain('1338');
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
       });
 
-      expect(res.status).toEqual(200);
-      const body = await res.text();
-      expect(body).toContain('1338');
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
+      it('should bypass the static cache for a multipart request (no action header)', async () => {
+        const path = `${basePath}/client/static`;
+        const actionId = findActionId(path, runtime);
 
-    it('should bypass the static cache for a multipart request (no action header)', async () => {
-      const path = '/client/static';
-      const actionId = findActionId(path);
+        const res = await fetch(`${ctx.deploymentUrl}${path}`, {
+          method: 'POST',
+          body: `------WebKitFormBoundaryHcVuFa30AN0QV3uZ\r\nContent-Disposition: form-data; name=\"1_$ACTION_ID_${actionId}\"\r\n\r\n\r\n------WebKitFormBoundaryHcVuFa30AN0QV3uZ\r\nContent-Disposition: form-data; name=\"0\"\r\n\r\n[\"$K1\"]\r\n------WebKitFormBoundaryHcVuFa30AN0QV3uZ--\r\n`,
+          headers: {
+            'Content-Type':
+              'multipart/form-data; boundary=----WebKitFormBoundaryHcVuFa30AN0QV3uZ',
+          },
+        });
 
-      const res = await fetch(`${ctx.deploymentUrl}${path}`, {
-        method: 'POST',
-        body: `------WebKitFormBoundaryHcVuFa30AN0QV3uZ\r\nContent-Disposition: form-data; name=\"1_$ACTION_ID_${actionId}\"\r\n\r\n\r\n------WebKitFormBoundaryHcVuFa30AN0QV3uZ\r\nContent-Disposition: form-data; name=\"0\"\r\n\r\n[\"$K1\"]\r\n------WebKitFormBoundaryHcVuFa30AN0QV3uZ--\r\n`,
-        headers: {
-          'Content-Type':
-            'multipart/form-data; boundary=----WebKitFormBoundaryHcVuFa30AN0QV3uZ',
-        },
-      });
-
-      expect(res.status).toEqual(200);
-      expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
-      // This is a "BYPASS" because no action ID was provided, so it'll fall back to
-      // `experimentalBypassFor` handling.
-      expect(res.headers.get('x-vercel-cache')).toBe('BYPASS');
-      expect(res.headers.get('x-matched-path')).toBe(path);
-    });
-
-    it('should properly invoke the action on a dynamic page', async () => {
-      const path = '/client/dynamic/[id]';
-      const actionId = findActionId(path);
-
-      const res = await fetch(`${ctx.deploymentUrl}${path}`, {
-        method: 'POST',
-        body: JSON.stringify([1337]),
-        headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
-          'Next-Action': actionId,
-        },
-      });
-
-      expect(res.status).toEqual(200);
-      const body = await res.text();
-      expect(body).toContain('1338');
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
-  });
-
-  describe('server component', () => {
-    it('should bypass the static cache for a server action', async () => {
-      const path = '/rsc/static';
-      const actionId = findActionId(path);
-
-      const res = await fetch(
-        `${ctx.deploymentUrl}${path}`,
-        generateFormDataPayload(actionId)
-      );
-
-      expect(res.status).toEqual(200);
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('content-type')).toBe('text/x-component');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
-
-    it('should bypass the static cache for a server action on a page with dynamic params', async () => {
-      const path = '/rsc/static/[dynamic-static]';
-      const actionId = findActionId(path);
-
-      const res = await fetch(
-        `${ctx.deploymentUrl}${path}`,
-        generateFormDataPayload(actionId)
-      );
-
-      expect(res.status).toEqual(200);
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('content-type')).toBe('text/x-component');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
-
-    it('should properly invoke the action on a dynamic page', async () => {
-      const path = '/rsc/dynamic';
-      const actionId = findActionId(path);
-
-      const res = await fetch(
-        `${ctx.deploymentUrl}${path}`,
-        generateFormDataPayload(actionId)
-      );
-
-      expect(res.status).toEqual(200);
-      expect(res.headers.get('x-matched-path')).toBe(path + '.action');
-      expect(res.headers.get('content-type')).toBe('text/x-component');
-      expect(res.headers.get('x-vercel-cache')).toBe('MISS');
-    });
-
-    describe('generateStaticParams', () => {
-      it('should bypass the static cache for a server action when pre-generated', async () => {
-        const path = '/rsc/static/generate-static-params/pre-generated';
-        const actionId = findActionId(
-          '/rsc/static/generate-static-params/[slug]'
+        expect(res.status).toEqual(200);
+        expect(res.headers.get('content-type')).toBe(
+          'text/html; charset=utf-8'
         );
+        if (runtime === 'node') {
+          // This is a "BYPASS" because no action ID was provided, so it'll fall back to
+          // `experimentalBypassFor` handling.
+          expect(res.headers.get('x-vercel-cache')).toBe('BYPASS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
+        expect(res.headers.get('x-matched-path')).toBe(path);
+      });
+
+      it('should properly invoke the action on a dynamic page', async () => {
+        const path = `${basePath}/client/dynamic/[id]`;
+        const actionId = findActionId(path, runtime);
+
+        const res = await fetch(`${ctx.deploymentUrl}${path}`, {
+          method: 'POST',
+          body: JSON.stringify([1337]),
+          headers: {
+            'Content-Type': 'text/plain;charset=UTF-8',
+            'Next-Action': actionId,
+          },
+        });
+
+        expect(res.status).toEqual(200);
+        const body = await res.text();
+        expect(body).toContain('1338');
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
+      });
+    });
+
+    describe('server component', () => {
+      it('should bypass the static cache for a server action', async () => {
+        const path = `${basePath}/rsc/static`;
+        const actionId = findActionId(path, runtime);
 
         const res = await fetch(
           `${ctx.deploymentUrl}${path}`,
@@ -183,26 +159,94 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         );
 
         expect(res.status).toEqual(200);
-        expect(res.headers.get('x-matched-path')).toBe(
-          '/rsc/static/generate-static-params/[slug].action'
-        );
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
         expect(res.headers.get('content-type')).toBe('text/x-component');
-        expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
       });
 
-      it('should bypass the static cache for a server action when not pre-generated', async () => {
-        const page = '/rsc/static/generate-static-params/[slug]';
-        const actionId = findActionId(page);
+      it('should bypass the static cache for a server action on a page with dynamic params', async () => {
+        const path = `${basePath}/rsc/static/[dynamic-static]`;
+        const actionId = findActionId(path, runtime);
 
         const res = await fetch(
-          `${ctx.deploymentUrl}/rsc/static/generate-static-params/not-pre-generated`,
+          `${ctx.deploymentUrl}${path}`,
           generateFormDataPayload(actionId)
         );
 
         expect(res.status).toEqual(200);
-        expect(res.headers.get('x-matched-path')).toBe(page + '.action');
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
         expect(res.headers.get('content-type')).toBe('text/x-component');
-        expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
+      });
+
+      it('should properly invoke the action on a dynamic page', async () => {
+        const path = `${basePath}/rsc/dynamic`;
+        const actionId = findActionId(path, runtime);
+
+        const res = await fetch(
+          `${ctx.deploymentUrl}${path}`,
+          generateFormDataPayload(actionId)
+        );
+
+        expect(res.status).toEqual(200);
+        expect(res.headers.get('x-matched-path')).toBe(path + '.action');
+        expect(res.headers.get('content-type')).toBe('text/x-component');
+        if (runtime === 'node') {
+          expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+        } else {
+          expect(res.headers.get('x-edge-runtime')).toBe('1');
+        }
+      });
+
+      describe('generateStaticParams', () => {
+        it('should bypass the static cache for a server action when pre-generated', async () => {
+          const path = `${basePath}/rsc/static/generate-static-params/pre-generated`;
+          const dynamicPath = `${basePath}/rsc/static/generate-static-params/[slug]`;
+          const actionId = findActionId(dynamicPath, runtime);
+
+          const res = await fetch(
+            `${ctx.deploymentUrl}${path}`,
+            generateFormDataPayload(actionId)
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.headers.get('x-matched-path')).toBe(
+            dynamicPath + '.action'
+          );
+          expect(res.headers.get('content-type')).toBe('text/x-component');
+          if (runtime === 'node') {
+            expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+          } else {
+            expect(res.headers.get('x-edge-runtime')).toBe('1');
+          }
+        });
+
+        it('should bypass the static cache for a server action when not pre-generated', async () => {
+          const page = `${basePath}/rsc/static/generate-static-params/[slug]`;
+          const actionId = findActionId(page, runtime);
+
+          const res = await fetch(
+            `${ctx.deploymentUrl}/${basePath}/rsc/static/generate-static-params/not-pre-generated`,
+            generateFormDataPayload(actionId)
+          );
+
+          expect(res.status).toEqual(200);
+          expect(res.headers.get('x-matched-path')).toBe(page + '.action');
+          expect(res.headers.get('content-type')).toBe('text/x-component');
+          if (runtime === 'node') {
+            expect(res.headers.get('x-vercel-cache')).toBe('MISS');
+          } else {
+            expect(res.headers.get('x-edge-runtime')).toBe('1');
+          }
+        });
       });
     });
   });

--- a/packages/next/test/fixtures/00-app-dir-actions/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-actions/vercel.json
@@ -5,10 +5,5 @@
       "use": "@vercel/next"
     }
   ],
-  "build": {
-    "env": {
-      "NEXT_EXPERIMENTAL_STREAMING_ACTIONS": false
-    }
-  },
   "probes": []
 }

--- a/packages/next/test/fixtures/00-app-dir-actions/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-actions/vercel.json
@@ -5,5 +5,10 @@
       "use": "@vercel/next"
     }
   ],
+  "build": {
+    "env": {
+      "NEXT_EXPERIMENTAL_STREAMING_ACTIONS": false
+    }
+  },
   "probes": []
 }


### PR DESCRIPTION
Since we're rewriting `next-action` requests to `.action` outputs, we need to ensure that we also duplicate the edge function handler for it. 

This runs all of the existing Node runtime tests in the Edge runtime as well. However, there's a discrepancy in how `x-vercel-cache` is returned, so for now we instead validate that its responding with `x-edge-runtime`. 