### PR TITLE
[functions] Convert to CommonJS

### DIFF
--- a/.changeset/sour-cycles-impress.md
+++ b/.changeset/sour-cycles-impress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Convert package to CommonJS

--- a/packages/functions/index.d.ts
+++ b/packages/functions/index.d.ts
@@ -14,4 +14,4 @@
  * }
  * ```
  */
-export const waitUntil: (promise: Promise<unknown>) => void;
+export function waitUntil(promise: Promise<unknown>): void;

--- a/packages/functions/index.js
+++ b/packages/functions/index.js
@@ -1,6 +1,6 @@
 /* global globalThis */
 
-export const waitUntil = promise => {
+exports.waitUntil = promise => {
   if (
     promise === null ||
     typeof promise !== 'object' ||


### PR DESCRIPTION
The package was not working because it is using ESM syntax, but the `package.json` did not have `"type": "module"`.

Anyways, for broader compatibility, let's use CommonJS.