### PR TITLE
Support Go up to 1.22.4 and 1.21.11

### DIFF
--- a/.changeset/shiny-pianos-love.md
+++ b/.changeset/shiny-pianos-love.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Support Go up to 1.22.3 and 1.21.10

--- a/.changeset/shiny-pianos-love.md
+++ b/.changeset/shiny-pianos-love.md
@@ -2,4 +2,4 @@
 '@vercel/go': patch
 ---
 
-Support Go up to 1.22.3 and 1.21.10
+Support Go up to 1.22.4 and 1.21.11

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -22,8 +22,8 @@ import type { Env } from '@vercel/build-utils';
 const streamPipeline = promisify(pipeline);
 
 const versionMap = new Map([
-  ['1.22', '1.22.2'],
-  ['1.21', '1.21.8'],
+  ['1.22', '1.22.3'],
+  ['1.21', '1.21.10'],
   ['1.20', '1.20.14'],
   ['1.19', '1.19.13'],
   ['1.18', '1.18.10'],

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -22,8 +22,8 @@ import type { Env } from '@vercel/build-utils';
 const streamPipeline = promisify(pipeline);
 
 const versionMap = new Map([
-  ['1.22', '1.22.3'],
-  ['1.21', '1.21.10'],
+  ['1.22', '1.22.4'],
+  ['1.21', '1.21.11'],
   ['1.20', '1.20.14'],
   ['1.19', '1.19.13'],
   ['1.18', '1.18.10'],


### PR DESCRIPTION
Minor Go release version bumps. 