### PR TITLE
[build-utils] log pnpm lockfile selection

### DIFF
--- a/.changeset/smooth-zoos-drop.md
+++ b/.changeset/smooth-zoos-drop.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] pnpm lockfile testing and fixing

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "turbo": "1.13.3",
     "typescript": "4.9.5"
   },
+  "resolutions": {
+    "@vercel/error-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz",
+    "@vercel/build-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz",
+    "@vercel/routing-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz",
+    "vercel": "https://vercel-fn651ovm5.vercel.sh/tarballs/vercel.tgz",
+    "@vercel/fs-detectors": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz",
+    "@vercel/frameworks": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz"
+  },
   "scripts": {
     "build": "node utils/gen.js && turbo --no-update-notifier run build",
     "vercel-build": "pnpm build && pnpm run pack && cd api && node -r ts-eager/register ./_lib/script/build.ts",

--- a/package.json
+++ b/package.json
@@ -36,14 +36,6 @@
     "turbo": "1.13.3",
     "typescript": "4.9.5"
   },
-  "resolutions": {
-    "@vercel/error-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz",
-    "@vercel/build-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz",
-    "@vercel/routing-utils": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz",
-    "vercel": "https://vercel-fn651ovm5.vercel.sh/tarballs/vercel.tgz",
-    "@vercel/fs-detectors": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz",
-    "@vercel/frameworks": "https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz"
-  },
   "scripts": {
     "build": "node utils/gen.js && turbo --no-update-notifier run build",
     "vercel-build": "pnpm build && pnpm run pack && cd api && node -r ts-eager/register ./_lib/script/build.ts",

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -768,10 +768,12 @@ export function getPathForPackageManager({
     env,
   });
 
-  console.log(
-    `[vc] found based on lockfileVersion ${lockfileVersion} (${typeof lockfileVersion}): ${JSON.stringify(
-      overrides
-    )}`
+  debug(
+    `Detected ${
+      overrides.detectedPackageManager
+    } with lockfileVersion ${lockfileVersion} (${typeof lockfileVersion}): ${
+      overrides.path
+    }`
   );
 
   const alreadyInPath = (newPath: string) => {

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -594,6 +594,7 @@ export function getEnvForPackageManager({
 
 type DetectedPnpmVersion =
   | 'not found'
+  | 'pnpm 6'
   | 'pnpm 7'
   | 'pnpm 8'
   | 'pnpm 9'
@@ -608,7 +609,9 @@ function detectPnpmVersion(
       return 'corepack_enabled';
     case lockfileVersion === undefined:
       return 'not found';
-    case lockfileVersion === 5.3 || lockfileVersion === 5.4:
+    case lockfileVersion === 5.3:
+      return 'pnpm 6';
+    case lockfileVersion === 5.4:
       return 'pnpm 7';
     case lockfileVersion === 6.0 || lockfileVersion === 6.1:
       return 'pnpm 8';
@@ -703,6 +706,7 @@ export function getPathOverrideForPackageManager({
             detectedLockfile: 'pnpm-lock.yaml',
             detectedPackageManager: 'pnpm 9',
           };
+        case 'pnpm 6':
         default:
           return no_override;
       }
@@ -763,6 +767,12 @@ export function getPathForPackageManager({
     nodeVersion,
     env,
   });
+
+  console.log(
+    `[vc] found based on lockfileVersion ${lockfileVersion} (${typeof lockfileVersion}): ${JSON.stringify(
+      overrides
+    )}`
+  );
 
   const alreadyInPath = (newPath: string) => {
     const oldPath = env.PATH ?? '';

--- a/packages/build-utils/test/unit.get-env-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-env-for-package-manager.test.ts
@@ -366,6 +366,23 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
       },
     },
     {
+      name: 'should not set path if pnpm 6 is detected',
+      args: {
+        cliType: 'pnpm',
+        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        lockfileVersion: 5.3, // detects as pnpm@6, which is the default
+        env: {
+          FOO: 'bar',
+          PATH: 'foo',
+        },
+      },
+      want: {
+        detectedLockfile: undefined,
+        detectedPackageManager: undefined,
+        path: undefined,
+      },
+    },
+    {
       name: 'should set path if pnpm 7+ is detected',
       args: {
         cliType: 'pnpm',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,17 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  '@vercel/error-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+  '@vercel/build-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+  '@vercel/routing-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+  vercel: https://vercel-fn651ovm5.vercel.sh/tarballs/vercel.tgz
+  '@vercel/fs-detectors': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
+  '@vercel/frameworks': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
+
 importers:
 
   .:
@@ -20,8 +32,8 @@ importers:
         specifier: 5.21.0
         version: 5.21.0(eslint@8.24.0)(typescript@4.9.5)
       '@vercel/build-utils':
-        specifier: '*'
-        version: link:packages/build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/style-guide':
         specifier: 4.0.2
         version: 4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@2.7.0)(typescript@4.9.5)
@@ -132,11 +144,11 @@ importers:
         specifier: 27.4.1
         version: 27.4.1
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../packages/build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/frameworks':
-        specifier: 3.0.2
-        version: link:../packages/frameworks
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
 
   internals/constants:
     devDependencies:
@@ -189,11 +201,11 @@ importers:
         specifier: 1.0.4
         version: link:../constants
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../../packages/build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../../packages/routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
     devDependencies:
       '@vercel-internals/tsconfig':
         specifier: 1.0.0
@@ -253,8 +265,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       aggregate-error:
         specifier: 3.0.1
         version: 3.0.1
@@ -313,8 +325,8 @@ importers:
   packages/cli:
     dependencies:
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/fun':
         specifier: 1.1.0
         version: 1.1.0
@@ -494,17 +506,17 @@ importers:
         specifier: 13.2.3
         version: link:../client
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/frameworks':
-        specifier: 3.0.2
-        version: link:../frameworks
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
       '@vercel/fs-detectors':
-        specifier: 5.2.3
-        version: link:../fs-detectors
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       '@vitest/expect':
         specifier: 1.4.0
         version: 1.4.0
@@ -737,14 +749,14 @@ importers:
   packages/client:
     dependencies:
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       '@zeit/fetch':
         specifier: 5.2.0
         version: 5.2.0(@types/node-fetch@2.5.4)(node-fetch@2.6.7)
@@ -864,8 +876,8 @@ importers:
         specifier: 2.2.3
         version: 2.2.3
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       js-yaml:
         specifier: 3.13.1
         version: 3.13.1
@@ -883,8 +895,8 @@ importers:
         specifier: 2.5.8
         version: 2.5.8
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       ajv:
         specifier: 6.12.2
         version: 6.12.2
@@ -898,14 +910,14 @@ importers:
   packages/fs-detectors:
     dependencies:
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/frameworks':
-        specifier: 3.0.2
-        version: link:../frameworks
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       glob:
         specifier: 8.0.3
         version: 8.0.3
@@ -941,8 +953,8 @@ importers:
         specifier: 7.3.10
         version: 7.3.10
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -972,11 +984,11 @@ importers:
         specifier: 0.25.24
         version: 0.25.24
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       esbuild:
         specifier: 0.14.47
         version: 0.14.47
@@ -1039,8 +1051,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       async-retry:
         specifier: 1.3.3
         version: 1.3.3
@@ -1088,8 +1100,8 @@ importers:
         specifier: 14.18.33
         version: 14.18.33
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1149,11 +1161,11 @@ importers:
         specifier: 3.2.0
         version: 3.2.0
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       async-sema:
         specifier: 3.0.1
         version: 3.0.1
@@ -1236,11 +1248,11 @@ importers:
         specifier: 16.18.11
         version: 16.18.11
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/nft':
         specifier: 0.27.0
         version: 0.27.0
@@ -1276,7 +1288,7 @@ importers:
         version: 12.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.2.218)(@types/node@14.18.33)(typescript@4.9.5)
+        version: 10.9.1(@types/node@16.18.11)(typescript@4.9.5)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -1354,8 +1366,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       execa:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1375,8 +1387,8 @@ importers:
         specifier: 0.27.0
         version: 0.27.0
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       semver:
         specifier: 6.3.1
         version: 6.3.1
@@ -1391,8 +1403,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1406,8 +1418,8 @@ importers:
   packages/remix:
     dependencies:
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/nft':
         specifier: 0.27.0
         version: 0.27.0
@@ -1431,8 +1443,8 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1478,8 +1490,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       execa:
         specifier: 2.0.4
         version: 2.0.4
@@ -1539,20 +1551,20 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vercel/build-utils':
-        specifier: 8.1.0
-        version: link:../build-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
       '@vercel/error-utils':
-        specifier: 2.0.2
-        version: link:../error-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
       '@vercel/frameworks':
-        specifier: 3.0.2
-        version: link:../frameworks
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
       '@vercel/fs-detectors':
-        specifier: 5.2.3
-        version: link:../fs-detectors
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz'
       '@vercel/routing-utils':
-        specifier: 3.1.0
-        version: link:../routing-utils
+        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
+        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -4001,6 +4013,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-android-arm64@1.2.182:
@@ -4018,6 +4031,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-darwin-arm64@1.2.182:
@@ -4035,6 +4049,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-darwin-x64@1.2.182:
@@ -4052,6 +4067,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-freebsd-x64@1.2.182:
@@ -4069,6 +4085,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.2.182:
@@ -4086,6 +4103,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.2.182:
@@ -4103,6 +4121,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.2.182:
@@ -4120,6 +4139,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.2.182:
@@ -4137,6 +4157,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.2.182:
@@ -4154,6 +4175,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.2.182:
@@ -4171,6 +4193,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.2.182:
@@ -4188,6 +4211,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.2.182:
@@ -4205,6 +4229,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core@1.2.182:
@@ -4244,6 +4269,7 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.218
       '@swc/core-win32-ia32-msvc': 1.2.218
       '@swc/core-win32-x64-msvc': 1.2.218
+    dev: true
 
   /@szmarczak/http-timer@4.0.6:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -4777,6 +4803,7 @@ packages:
 
   /@types/node@14.18.33:
     resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
+    dev: true
 
   /@types/node@16.18.11:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
@@ -5653,7 +5680,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.27.5)
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.54.1)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.2.1)(eslint@8.24.0)
@@ -5699,7 +5726,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.27.5)
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.24.0)
       eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.54.1)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.2.1)(eslint@8.24.0)
@@ -8210,7 +8237,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.24.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.7:
@@ -8233,7 +8260,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.24.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.24.0)
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -8243,7 +8270,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint@8.24.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8268,7 +8295,6 @@ packages:
       debug: 3.2.7
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.24.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8284,7 +8310,7 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.24.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8302,7 +8328,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint@8.24.0)
       has: 1.0.3
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11150,7 +11176,6 @@ packages:
   /json5@2.2.2:
     resolution: {integrity: sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -12966,7 +12991,6 @@ packages:
 
   /path-to-regexp@6.1.0:
     resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
-    dev: false
 
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
@@ -15031,6 +15055,38 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@16.18.11)(typescript@4.9.5):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 16.18.11
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
 
   /ts-node@8.9.1(typescript@4.9.5):
     resolution: {integrity: sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==}
@@ -16135,6 +16191,45 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz':
+    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz}
+    name: '@vercel/build-utils'
+    version: 8.1.0-ff9b406
+
+  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz':
+    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz}
+    name: '@vercel/error-utils'
+    version: 2.0.2-ff9b406
+
+  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz':
+    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz}
+    name: '@vercel/frameworks'
+    version: 3.0.2-ff9b406
+    dependencies:
+      '@iarna/toml': 2.2.3
+      '@vercel/error-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+      js-yaml: 3.13.1
+
+  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz':
+    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz}
+    name: '@vercel/fs-detectors'
+    version: 5.2.3-ff9b406
+    dependencies:
+      '@vercel/error-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+      '@vercel/frameworks': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
+      '@vercel/routing-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+      glob: 8.0.3
+      js-yaml: 4.1.0
+      json5: 2.2.2
+      minimatch: 3.1.2
+      semver: 6.3.1
+    dev: true
+
+  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz':
+    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz}
+    name: '@vercel/routing-utils'
+    version: 3.1.0-ff9b406
+    dependencies:
+      path-to-regexp: 6.1.0
+    optionalDependencies:
+      ajv: 6.12.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,14 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@vercel/error-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-  '@vercel/build-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-  '@vercel/routing-utils': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-  vercel: https://vercel-fn651ovm5.vercel.sh/tarballs/vercel.tgz
-  '@vercel/fs-detectors': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
-  '@vercel/frameworks': https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
-
 importers:
 
   .:
@@ -32,8 +24,8 @@ importers:
         specifier: 5.21.0
         version: 5.21.0(eslint@8.24.0)(typescript@4.9.5)
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: '*'
+        version: link:packages/build-utils
       '@vercel/style-guide':
         specifier: 4.0.2
         version: 4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@2.7.0)(typescript@4.9.5)
@@ -144,11 +136,11 @@ importers:
         specifier: 27.4.1
         version: 27.4.1
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../packages/build-utils
       '@vercel/frameworks':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
+        specifier: 3.0.2
+        version: link:../packages/frameworks
 
   internals/constants:
     devDependencies:
@@ -201,11 +193,11 @@ importers:
         specifier: 1.0.4
         version: link:../constants
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../../packages/build-utils
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../../packages/routing-utils
     devDependencies:
       '@vercel-internals/tsconfig':
         specifier: 1.0.0
@@ -265,8 +257,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       aggregate-error:
         specifier: 3.0.1
         version: 3.0.1
@@ -325,8 +317,8 @@ importers:
   packages/cli:
     dependencies:
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/fun':
         specifier: 1.1.0
         version: 1.1.0
@@ -506,17 +498,17 @@ importers:
         specifier: 13.2.3
         version: link:../client
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/frameworks':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
+        specifier: 3.0.2
+        version: link:../frameworks
       '@vercel/fs-detectors':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz'
+        specifier: 5.2.3
+        version: link:../fs-detectors
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       '@vitest/expect':
         specifier: 1.4.0
         version: 1.4.0
@@ -749,14 +741,14 @@ importers:
   packages/client:
     dependencies:
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       '@zeit/fetch':
         specifier: 5.2.0
         version: 5.2.0(@types/node-fetch@2.5.4)(node-fetch@2.6.7)
@@ -876,8 +868,8 @@ importers:
         specifier: 2.2.3
         version: 2.2.3
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       js-yaml:
         specifier: 3.13.1
         version: 3.13.1
@@ -895,8 +887,8 @@ importers:
         specifier: 2.5.8
         version: 2.5.8
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       ajv:
         specifier: 6.12.2
         version: 6.12.2
@@ -910,14 +902,14 @@ importers:
   packages/fs-detectors:
     dependencies:
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/frameworks':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
+        specifier: 3.0.2
+        version: link:../frameworks
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       glob:
         specifier: 8.0.3
         version: 8.0.3
@@ -953,8 +945,8 @@ importers:
         specifier: 7.3.10
         version: 7.3.10
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -984,11 +976,11 @@ importers:
         specifier: 0.25.24
         version: 0.25.24
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       esbuild:
         specifier: 0.14.47
         version: 0.14.47
@@ -1051,8 +1043,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       async-retry:
         specifier: 1.3.3
         version: 1.3.3
@@ -1100,8 +1092,8 @@ importers:
         specifier: 14.18.33
         version: 14.18.33
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1161,11 +1153,11 @@ importers:
         specifier: 3.2.0
         version: 3.2.0
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       async-sema:
         specifier: 3.0.1
         version: 3.0.1
@@ -1248,11 +1240,11 @@ importers:
         specifier: 16.18.11
         version: 16.18.11
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/nft':
         specifier: 0.27.0
         version: 0.27.0
@@ -1366,8 +1358,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       execa:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1387,8 +1379,8 @@ importers:
         specifier: 0.27.0
         version: 0.27.0
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       semver:
         specifier: 6.3.1
         version: 6.3.1
@@ -1403,8 +1395,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -1418,8 +1410,8 @@ importers:
   packages/remix:
     dependencies:
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/nft':
         specifier: 0.27.0
         version: 0.27.0
@@ -1443,8 +1435,8 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1490,8 +1482,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       execa:
         specifier: 2.0.4
         version: 2.0.4
@@ -1551,20 +1543,20 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
       '@vercel/build-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz'
+        specifier: 8.1.0
+        version: link:../build-utils
       '@vercel/error-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
+        specifier: 2.0.2
+        version: link:../error-utils
       '@vercel/frameworks':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
+        specifier: 3.0.2
+        version: link:../frameworks
       '@vercel/fs-detectors':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz'
+        specifier: 5.2.3
+        version: link:../fs-detectors
       '@vercel/routing-utils':
-        specifier: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz
-        version: '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
+        specifier: 3.1.0
+        version: link:../routing-utils
       execa:
         specifier: 3.2.0
         version: 3.2.0
@@ -11176,6 +11168,7 @@ packages:
   /json5@2.2.2:
     resolution: {integrity: sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -12991,6 +12984,7 @@ packages:
 
   /path-to-regexp@6.1.0:
     resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+    dev: false
 
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
@@ -16190,46 +16184,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/build-utils.tgz':
-    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/build-utils.tgz}
-    name: '@vercel/build-utils'
-    version: 8.1.0-ff9b406
-
-  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz':
-    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/error-utils.tgz}
-    name: '@vercel/error-utils'
-    version: 2.0.2-ff9b406
-
-  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz':
-    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/frameworks.tgz}
-    name: '@vercel/frameworks'
-    version: 3.0.2-ff9b406
-    dependencies:
-      '@iarna/toml': 2.2.3
-      '@vercel/error-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
-      js-yaml: 3.13.1
-
-  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/fs-detectors.tgz':
-    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/fs-detectors.tgz}
-    name: '@vercel/fs-detectors'
-    version: 5.2.3-ff9b406
-    dependencies:
-      '@vercel/error-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/error-utils.tgz'
-      '@vercel/frameworks': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/frameworks.tgz'
-      '@vercel/routing-utils': '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz'
-      glob: 8.0.3
-      js-yaml: 4.1.0
-      json5: 2.2.2
-      minimatch: 3.1.2
-      semver: 6.3.1
-    dev: true
-
-  '@vercel-fn651ovm5.vercel.sh/tarballs/%2540vercel/routing-utils.tgz':
-    resolution: {tarball: https://vercel-fn651ovm5.vercel.sh/tarballs/%40vercel/routing-utils.tgz}
-    name: '@vercel/routing-utils'
-    version: 3.1.0-ff9b406
-    dependencies:
-      path-to-regexp: 6.1.0
-    optionalDependencies:
-      ajv: 6.12.2


### PR DESCRIPTION
Both `pnpm@6` and `pnpm@7` can parse lockfile versions `5.3` and `5.4`, but if there's a mismatch, `pnpm` will output a warning saying so. In order to prevent confusing warnings from being displayed to the user, this PR aligns the pnpm version with the exact lockfile verison.

It also adds a debug log to show which package manager version was determined based on the lockfile version.