### PR TITLE
[build-utils] log more around package manager detection

### DIFF
--- a/.changeset/calm-peaches-occur.md
+++ b/.changeset/calm-peaches-occur.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] log more around package manager detection

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -553,8 +553,9 @@ export function getEnvForPackageManager({
     env,
   });
 
+  const corepackEnabled = env.ENABLE_EXPERIMENTAL_COREPACK === '1';
   debug(
-    `Detected ${detectedPackageManager} with lockfileVersion ${lockfileVersion} (${typeof lockfileVersion}): ${newPath}`
+    `Detected ${detectedPackageManager} given lockfileVersion "${lockfileVersion}", package manager cli "${cliType}", and corepack enabled? ${corepackEnabled}: ${newPath}`
   );
 
   const newEnv: { [x: string]: string | undefined } = {
@@ -771,14 +772,6 @@ export function getPathForPackageManager({
     nodeVersion,
     env,
   });
-
-  debug(
-    `Detected ${
-      overrides.detectedPackageManager
-    } with lockfileVersion ${lockfileVersion} (${typeof lockfileVersion}): ${
-      overrides.path
-    }`
-  );
 
   const alreadyInPath = (newPath: string) => {
     const oldPath = env.PATH ?? '';


### PR DESCRIPTION
Add more loggign around package manager detection to see why we're not properly detecting `pnpm` given a pnpm lockfile.