### PR TITLE
[tests] allow errors to define retry delay

### DIFF
--- a/.changeset/hip-oranges-worry.md
+++ b/.changeset/hip-oranges-worry.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+allow errors to define retry delay

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -108,6 +108,7 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
           found = true;
           break;
         } else {
+          ctx.deploymentLogs = null;
           throw new Error(
             `Expected deployment logs of ${deploymentId} not to contain ${toCheck}, but found ${log.text}`
           );
@@ -122,6 +123,7 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
         deploymentLogs,
         logLength: deploymentLogs?.length,
       });
+      ctx.deploymentLogs = null;
       const error = new Error(
         `Expected deployment logs of ${deploymentId} to contain ${toCheck}, it was not found`
       );

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -126,7 +126,7 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
         `Expected deployment logs of ${deploymentId} to contain ${toCheck}, it was not found`
       );
       error.retries = 20;
-      error.retryDelay = 2000; // ms
+      error.retryDelay = 5000; // ms
       throw error;
     } else {
       logWithinTest('finished testing', JSON.stringify(probe));

--- a/test/lib/deployment/test-deployment.js
+++ b/test/lib/deployment/test-deployment.js
@@ -126,6 +126,7 @@ async function runProbe(probe, deploymentId, deploymentUrl, ctx) {
         `Expected deployment logs of ${deploymentId} to contain ${toCheck}, it was not found`
       );
       error.retries = 20;
+      error.retryDelay = 2000; // ms
       throw error;
     } else {
       logWithinTest('finished testing', JSON.stringify(probe));
@@ -449,6 +450,8 @@ async function testDeployment(fixturePath, opts = {}) {
         throw err;
       }
 
+      const retryDelay = Math.max(probe.retryDelay || 0, err.retryDelay || 0);
+
       for (let i = 0; i < retries; i++) {
         logWithinTest(`re-trying ${i + 1}/${retries}:`, stringifiedProbe);
 
@@ -460,9 +463,9 @@ async function testDeployment(fixturePath, opts = {}) {
             throw err;
           }
 
-          if (probe.retryDelay) {
-            logWithinTest(`Waiting ${probe.retryDelay}ms before retrying`);
-            await new Promise(resolve => setTimeout(resolve, probe.retryDelay));
+          if (retryDelay) {
+            logWithinTest(`Waiting ${retryDelay}ms before retrying`);
+            await new Promise(resolve => setTimeout(resolve, retryDelay));
           }
         }
       }


### PR DESCRIPTION
Errors can now define their own retry delay. This is necessary for some kinds of errors where all retries will run within the same second.