### PR TITLE
[ppr] Fix static case

### DIFF
--- a/.changeset/curvy-actors-warn.md
+++ b/.changeset/curvy-actors-warn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix static case for detecting when a page supports PPR

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2168,6 +2168,7 @@ export const build: BuildV2 = async ({
       appPathRoutesManifest,
       isSharedLambdas,
       canUsePreviewMode,
+      isAppPPREnabled: false,
     });
 
     await Promise.all(

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1345,6 +1345,7 @@ export async function serverBuild({
     hasPages404: routesManifest.pages404,
     isCorrectNotFoundRoutes,
     isEmptyAllowQueryForPrendered,
+    isAppPPREnabled,
   });
 
   await Promise.all(

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1954,6 +1954,7 @@ type OnPrerenderRouteArgs = {
   routesManifest?: RoutesManifest;
   isCorrectNotFoundRoutes?: boolean;
   isEmptyAllowQueryForPrendered?: boolean;
+  isAppPPREnabled: boolean;
 };
 let prerenderGroup = 1;
 
@@ -1990,6 +1991,7 @@ export const onPrerenderRoute =
       routesManifest,
       isCorrectNotFoundRoutes,
       isEmptyAllowQueryForPrendered,
+      isAppPPREnabled,
     } = prerenderRouteArgs;
 
     if (isBlocking && isFallback) {
@@ -2261,14 +2263,14 @@ export const onPrerenderRoute =
 
     let outputPathPrefetchData: null | string = null;
     if (prefetchDataRoute) {
-      if (!experimentalPPR) {
+      if (!isAppPPREnabled) {
         throw new Error(
           "Invariant: prefetchDataRoute can't be set without PPR"
         );
       }
 
       outputPathPrefetchData = normalizeDataRoute(prefetchDataRoute);
-    } else if (experimentalPPR) {
+    } else if (isAppPPREnabled) {
       throw new Error('Invariant: expected to find prefetch data route PPR');
     }
 

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/static/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/app/static/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="sentinel:static">Static</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
@@ -57,6 +57,11 @@
       "mustContain": "sentinel:dynamic"
     },
     {
+      "path": "/static",
+      "status": 200,
+      "mustContain": "sentinel:static"
+    },
+    {
       "path": "/disabled",
       "headers": {
         "RSC": "1",


### PR DESCRIPTION
When PPR is enabled in incremental mode, the previous code used the page information to determine if there was a failure for generating the flight data. This has been moved to the app PPR setting instead.