### PR TITLE
[ppr] Fix for error case involving prefetch data routes

### DIFF
--- a/.changeset/sixty-lions-check.md
+++ b/.changeset/sixty-lions-check.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Fix related to erroring when a prefetch route is not provided but the route is PPR enabled

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2270,7 +2270,7 @@ export const onPrerenderRoute =
       }
 
       outputPathPrefetchData = normalizeDataRoute(prefetchDataRoute);
-    } else if (isAppPPREnabled) {
+    } else if (experimentalPPR) {
       throw new Error('Invariant: expected to find prefetch data route PPR');
     }
 


### PR DESCRIPTION
Only error when the prefetch data route is present but the route also has PPR enabled.