### PR TITLE
[tests] bump datadog installed version

### DIFF
--- a/.changeset/tricky-dragons-repair.md
+++ b/.changeset/tricky-dragons-repair.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] bump datadog installed version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
           echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
       - name: 'Upload Test Report to Datadog'
         if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
-        run: 'npx @datadog/datadog-ci@2.18.1 junit upload --service vercel-cli .junit-reports'
+        run: 'npx @datadog/datadog-ci@2.36.0 junit upload --service vercel-cli .junit-reports'
         env:
           DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
           DD_ENV: ci


### PR DESCRIPTION
Unsure if this is related to `vitest` migration or something else but a dependency of the `datadog-ci` version we use is gone and [now errors](https://github.com/vercel/vercel/actions/runs/9213580743/job/25348743824?pr=11650). Bumping it to latest.