### PR TITLE
[next] Ensure only pages enable streaming

### DIFF
--- a/.changeset/selfish-yaks-sparkle.md
+++ b/.changeset/selfish-yaks-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Don't create streaming lambdas for pages router routes

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -947,6 +947,10 @@ export async function serverBuild({
     const appRouterStreamingActionLambdaGroups: LambdaGroup[] = [];
 
     for (const group of appRouterLambdaGroups) {
+      if (!group.isPrerenders || group.isExperimentalPPR) {
+        group.isStreaming = true;
+      }
+
       group.isAppRouter = true;
 
       // We create a streaming variant of the Prerender lambda group
@@ -961,6 +965,9 @@ export async function serverBuild({
     }
 
     for (const group of appRouteHandlersLambdaGroups) {
+      if (!group.isPrerenders) {
+        group.isStreaming = true;
+      }
       group.isAppRouter = true;
       group.isAppRouteHandler = true;
     }

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1508,7 +1508,7 @@ export type LambdaGroup = {
   maxDuration?: number;
   isAppRouter?: boolean;
   isAppRouteHandler?: boolean;
-  readonly isStreaming: boolean;
+  isStreaming?: boolean;
   readonly isPrerenders: boolean;
   readonly isExperimentalPPR: boolean;
   isActionLambda?: boolean;
@@ -1565,7 +1565,6 @@ export async function getPageLambdaGroups({
     const routeName = normalizePage(page.replace(/\.js$/, ''));
     const isPrerenderRoute = prerenderRoutes.has(routeName);
     const isExperimentalPPR = experimentalPPRRoutes?.has(routeName) ?? false;
-    const isStreaming = !isPrerenderRoute || isExperimentalPPR;
 
     let opts: { memory?: number; maxDuration?: number } = {};
 
@@ -1637,7 +1636,6 @@ export async function getPageLambdaGroups({
         ...opts,
         isPrerenders: isPrerenderRoute,
         isExperimentalPPR,
-        isStreaming,
         isApiLambda: !!isApiPage(page),
         pseudoLayerBytes: initialPseudoLayer.pseudoLayerBytes,
         pseudoLayerUncompressedBytes: initialPseudoLayerUncompressed,


### PR DESCRIPTION
This fixes a regression introduced by #11625 that enabled streaming for routes on the pages router (these routes do not support streaming).