### PR TITLE
fix: Vercel Python function with ASGI for Python version >= 3.10 (specifically 3.12)

### DIFF
--- a/packages/python/LICENSE
+++ b/packages/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jordan Eremieff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Resolves: #11545

**Problem**:

ASGI application running with Vercel Python runtime 3.12 would crash with `500: INTERNAL_SERVER_ERROR
`and `Code: FUNCTION_INVOCATION_FAILED` because the `loop` parameter in `asyncio.Queue` was deprecated in 3.8 and then removed in 3.10, which was used in Mangum back in the day.

Vercel log
```
LAMBDA_WARNING: Unhandled exception. [...]
[ERROR] TypeError: Queue.__init__() got an unexpected keyword argument 'loop'
Traceback (most recent call last):
  File "/var/task/vc__handler__python.py", line 305, in vc_handler
    response = asgi_cycle(__vc_module.app, body)
  File "/var/task/vc__handler__python.py", line 202, in __call__
    self.app_queue = asyncio.Queue(loop=loop)
```

Code
https://github.com/vercel/vercel/blob/af29e9be49803be1f40664b57c4ea058bab43bae/packages/python/vc_init.py#L202

Ref
https://docs.python.org/3.8/library/asyncio-queue.html#:~:text=Deprecated%20since%20version%203.8%2C%20will%20be%20removed%20in%20version%203.10%3A%20The%20loop%20parameter.

**Fix**:

Since the oldest deployable Python runtime version on Vercel is 3.9, there's no reason to keep using the obsolete code. Porting the latest Mangum implementation should fix the issue.

Related PR: #11541

**Changes**:

- Using the new `HTTPCycle` ASGI runner from Mangum, replacing `ASGICycle`
- Add Mangum's LICENSE
- Replace logging with print for consistency

---

**Edited**:

Since #11675 has been merged, the maintainers can close this PR if you think this port is unnecessary.