### PR TITLE
feat(turbo): add support for turbo 2 configuration

### DIFF
--- a/.changeset/lovely-trains-jog.md
+++ b/.changeset/lovely-trains-jog.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Add support for detecting Turborepo 2

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "turbo": "latest"
+  }
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/packages/app-1/package.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/packages/app-1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-14",
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/turbo.json
+++ b/packages/fs-detectors/test/fixtures/get-monorepo-default-settings/turbo-2/turbo.json
@@ -1,0 +1,2 @@
+// TEST COMMENT TO VERIFY JSON5 SUPPORT
+{ "tasks": { "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] } } }

--- a/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
+++ b/packages/fs-detectors/test/unit.get-monorepo-default-settings.test.ts
@@ -17,10 +17,16 @@ describe('getMonorepoDefaultSettings', () => {
     );
   });
   test('MissingBuildPipeline is an error', () => {
-    const missingBuildPipeline = new MissingBuildPipeline();
+    const missingBuildPipeline = new MissingBuildPipeline(false);
     expect(missingBuildPipeline).toBeInstanceOf(Error);
     expect(missingBuildPipeline.message).toBe(
       'Missing required `build` pipeline in turbo.json or package.json Turbo configuration.'
+    );
+
+    const missingBuildTask = new MissingBuildPipeline(true);
+    expect(missingBuildTask).toBeInstanceOf(Error);
+    expect(missingBuildTask.message).toBe(
+      'Missing required `build` task in turbo.json.'
     );
   });
 
@@ -31,6 +37,7 @@ describe('getMonorepoDefaultSettings', () => {
     ['turbo-npm', 'turbo', true, 'app-15', false, false],
     ['turbo-npm-root-proj', 'turbo', true, 'app-root-proj', true, false],
     ['turbo-latest', 'turbo', false, 'app-14', false, false],
+    ['turbo-2', 'turbo', false, 'app-14', false, false],
     ['nx', 'nx', false, 'app-12', false, false],
     ['nx-package-config', 'nx', false, 'app-11', false, false],
     ['nx-project-and-package-config-1', 'nx', false, 'app-10', false, false],


### PR DESCRIPTION
With the release of Turborepo 2 we're renaming `pipeline` to `tasks`. 

This PR updates the default settings logic to look in `tasks` for a `build` task definition in addition to looking at `pipeline`. It also updates the message to no longer mention Turbo configuration in `package.json` as this is fully ignored in Turborepo 2.

Added a quick unit test to verify `build` task definitions are found in the `tasks` section of `turbo.json`.

Please let me know if there are other tests/places I should update.