### PR TITLE
[ppr] Add missng `.rsc` route for non-ppr enabled pages

### DIFF
--- a/.changeset/real-moose-hope.md
+++ b/.changeset/real-moose-hope.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Adds a route for the `.rsc` pathname as well when app has ppr enabled but not all routes.

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/index.test.js
@@ -4,8 +4,7 @@ const { deployAndTest } = require('../../utils');
 
 const ctx = {};
 
-// TODO: investigate invariant 
-describe.skip(`${__dirname.split(path.sep).pop()}`, () => {
+describe(`${__dirname.split(path.sep).pop()}`, () => {
   it('should deploy and pass probe checks', async () => {
     const info = await deployAndTest(__dirname);
     Object.assign(ctx, info);

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "15.0.0-canary.7",
+    "next": "canary",
     "react": "19.0.0-rc-f994737d14-20240522",
     "react-dom": "19.0.0-rc-f994737d14-20240522"
   },

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "canary",
+    "next": "15.0.0-canary.7",
     "react": "19.0.0-rc-f994737d14-20240522",
     "react-dom": "19.0.0-rc-f994737d14-20240522"
   },

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
@@ -62,6 +62,23 @@
       "mustContain": "sentinel:static"
     },
     {
+      "path": "/static",
+      "status": 200,
+      "mustContain": "sentinel:static",
+      "headers": {
+        "RSC": "1"
+      }
+    },
+    {
+      "path": "/static",
+      "status": 200,
+      "mustContain": "sentinel:static",
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      }
+    },
+    {
       "path": "/disabled",
       "headers": {
         "RSC": "1",

--- a/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-incremental-ppr/vercel.json
@@ -85,7 +85,7 @@
         "Next-Router-Prefetch": "1"
       },
       "status": 200,
-      "mustContain": "sentinel:dynamic"
+      "mustNotContain": "sentinel:dynamic"
     },
     {
       "path": "/disabled",

--- a/packages/next/test/fixtures/00-app-dir-ppr/app/static/page.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr/app/static/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static page</p>;
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -349,6 +349,30 @@
       "path": "/api/pages-headers",
       "status": 200,
       "mustContain": "{\"port\":\"443\"}"
+    },
+    {
+      "path": "/static",
+      "status": 200,
+      "mustContain": "static page"
+    },
+    {
+      "path": "/static",
+      "status": 200,
+      "headers": {
+        "RSC": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/static",
+      "status": 200,
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
     }
   ]
 }


### PR DESCRIPTION
When deploying partial prerendering (PPR), there may some pages that are not enabled for PPR but still appear in the `prerender-manifest.json`. Due to the branching of the client router, these routes also have to have a `.rsc` as well as a `.prefetch.rsc` variants in order to prevent 404's. This change adds support for adding the extra route to the prerender for pages that have PPR disabled.