### PR TITLE
[build-utils] Handle case of not having lockfile

### DIFF
--- a/.changeset/tender-bags-tell.md
+++ b/.changeset/tender-bags-tell.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"vercel": patch
+---
+
+[built-utils] Handle case of not having lockfile when corepack is enabled

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -353,29 +353,9 @@ export async function scanParentDirs(
     // TODO: read "bun-lockfile-format-v0"
     lockfileVersion = 0;
   } else {
-    const packageJsonPackageManager = packageJson?.packageManager;
-    if (usingCorepack(process.env, packageJsonPackageManager)) {
-      const corepackPackageManager = validateVersionSpecifier(
-        packageJsonPackageManager as string
-      );
-      switch (corepackPackageManager?.packageName) {
-        case 'npm':
-        case 'pnpm':
-        case 'yarn':
-        case 'bun':
-          cliType = corepackPackageManager.packageName;
-          break;
-        case undefined:
-          cliType = 'npm';
-          break;
-        default:
-          throw new Error(
-            `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager.`
-          );
-      }
-    } else {
-      cliType = 'npm';
-    }
+    cliType = packageJson
+      ? detectPackageManagerNameWithoutLockfile(packageJson)
+      : 'npm';
   }
 
   const packageJsonPath = pkgJsonPath || undefined;
@@ -386,6 +366,29 @@ export async function scanParentDirs(
     lockfileVersion,
     packageJsonPath,
   };
+}
+
+function detectPackageManagerNameWithoutLockfile(packageJson: PackageJson) {
+  const packageJsonPackageManager = packageJson.packageManager;
+  if (usingCorepack(process.env, packageJsonPackageManager)) {
+    const corepackPackageManager = validateVersionSpecifier(
+      packageJsonPackageManager as string
+    );
+    switch (corepackPackageManager?.packageName) {
+      case 'npm':
+      case 'pnpm':
+      case 'yarn':
+      case 'bun':
+        return corepackPackageManager.packageName;
+      case undefined:
+        return 'npm';
+      default:
+        throw new Error(
+          `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager.`
+        );
+    }
+  }
+  return 'npm';
 }
 
 function usingCorepack(

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -354,12 +354,9 @@ export async function scanParentDirs(
     lockfileVersion = 0;
   } else {
     const packageJsonPackageManager = packageJson?.packageManager;
-    if (
-      packageJsonPackageManager &&
-      usingCorepack(process.env, packageJsonPackageManager)
-    ) {
+    if (usingCorepack(process.env, packageJsonPackageManager)) {
       const corepackPackageManager = validateVersionSpecifier(
-        packageJsonPackageManager
+        packageJsonPackageManager as string
       );
       switch (corepackPackageManager?.packageName) {
         case 'npm':
@@ -368,9 +365,13 @@ export async function scanParentDirs(
         case 'bun':
           cliType = corepackPackageManager.packageName;
           break;
-        default:
+        case undefined:
           cliType = 'npm';
           break;
+        default:
+          throw new Error(
+            `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager.`
+          );
       }
     } else {
       cliType = 'npm';

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -366,7 +366,7 @@ export async function scanParentDirs(
         case 'pnpm':
         case 'yarn':
         case 'bun':
-          cliType = corepackPackageManager?.packageName;
+          cliType = corepackPackageManager.packageName;
           break;
         default:
           cliType = 'npm';

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -263,6 +263,7 @@ test('[vc build] should build project with corepack and select pnpm@7.1.0', asyn
       path.join(directory, '.vercel/cache/corepack')
     );
     expect(contents).toEqual(['home', 'shim']);
+    expect(output.stdout).toMatch(/Running "pnpm run build"/gm);
   } finally {
     delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
   }
@@ -291,6 +292,7 @@ test('[vc build] should build project with corepack and select yarn@2.4.3', asyn
       path.join(directory, '.vercel/cache/corepack')
     );
     expect(contents).toEqual(['home', 'shim']);
+    expect(output.stdout).toMatch(/Running "yarn run build"/gm);
   } finally {
     delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
   }


### PR DESCRIPTION
In the scenario where we don't have a lockfile, cliType was detected by build utils as npm regardless of what's set in corepack. This fixes that.