### PR TITLE
Upgrade to @vercel/nft 0.27.2 with browser remapping support

### DIFF
--- a/.changeset/small-candles-grow.md
+++ b/.changeset/small-candles-grow.md
@@ -1,0 +1,8 @@
+---
+'@vercel/redwood': patch
+'@vercel/remix-builder': patch
+'@vercel/next': patch
+'@vercel/node': patch
+---
+
+Upgrade to @vercel/nft 0.27.2 with browser remapping support

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@vercel/nft": "0.27.0"
+    "@vercel/nft": "0.27.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.19",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
     "@types/node": "16.18.11",
     "@vercel/build-utils": "8.2.1",
     "@vercel/error-utils": "2.0.2",
-    "@vercel/nft": "0.27.0",
+    "@vercel/nft": "0.27.2",
     "@vercel/static-config": "3.0.0",
     "async-listen": "3.0.0",
     "cjs-module-lexer": "1.2.3",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@vercel/nft": "0.27.0",
+    "@vercel/nft": "0.27.2",
     "@vercel/routing-utils": "3.1.0",
     "semver": "6.3.1"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@vercel/error-utils": "2.0.2",
-    "@vercel/nft": "0.27.0",
+    "@vercel/nft": "0.27.2",
     "@vercel/static-config": "3.0.0",
     "ts-morph": "12.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1103,8 +1103,8 @@ importers:
   packages/next:
     dependencies:
       '@vercel/nft':
-        specifier: 0.27.0
-        version: 0.27.0
+        specifier: 0.27.2
+        version: 0.27.2
     devDependencies:
       '@types/aws-lambda':
         specifier: 8.10.19
@@ -1242,8 +1242,8 @@ importers:
         specifier: 2.0.2
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 0.27.0
-        version: 0.27.0
+        specifier: 0.27.2
+        version: 0.27.2
       '@vercel/static-config':
         specifier: 3.0.0
         version: link:../static-config
@@ -1384,8 +1384,8 @@ importers:
   packages/redwood:
     dependencies:
       '@vercel/nft':
-        specifier: 0.27.0
-        version: 0.27.0
+        specifier: 0.27.2
+        version: 0.27.2
       '@vercel/routing-utils':
         specifier: 3.1.0
         version: link:../routing-utils
@@ -1421,8 +1421,8 @@ importers:
         specifier: 2.0.2
         version: link:../error-utils
       '@vercel/nft':
-        specifier: 0.27.0
-        version: 0.27.0
+        specifier: 0.27.2
+        version: 0.27.2
       '@vercel/static-config':
         specifier: 3.0.0
         version: link:../static-config
@@ -5529,8 +5529,8 @@ packages:
       - supports-color
     dev: false
 
-  /@vercel/nft@0.27.0:
-    resolution: {integrity: sha512-W5pValyhToK9hbgEUAM6sLRUIl1I++RsFnXKHXtND50P1+vZ+OYPCzq1OOz0Ok6ghK6aOwae8G/rEAXkLedC+w==}
+  /@vercel/nft@0.27.2:
+    resolution: {integrity: sha512-7LeioS1yE5hwPpQfD3DdH04tuugKjo5KrJk3yK5kAI3Lh76iSsK/ezoFQfzuT08X3ZASQOd1y9ePjLNI9+TxTQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -6098,6 +6098,7 @@ packages:
   /are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
@@ -9252,6 +9253,7 @@ packages:
   /gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
     dependencies:
       aproba: 2.0.0
       color-support: 1.1.3
@@ -9437,6 +9439,7 @@ packages:
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -12540,6 +12543,7 @@ packages:
 
   /npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
     dependencies:
       are-we-there-yet: 2.0.0
       console-control-strings: 1.1.0


### PR DESCRIPTION
See https://github.com/vercel/nft/pull/424 for more details.