### PR TITLE
Change node 16.x EOL for Vercel

### DIFF
--- a/.changeset/funny-foxes-cough.md
+++ b/.changeset/funny-foxes-cough.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Change node 16.x EOL for Vercel

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -13,7 +13,7 @@ export const NODE_VERSIONS: NodeVersion[] = [
     major: 16,
     range: '16.x',
     runtime: 'nodejs16.x',
-    discontinueDate: new Date('2025-02-28'),
+    discontinueDate: new Date('2025-01-31'),
   },
   {
     major: 14,

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -356,8 +356,8 @@ it('should warn for deprecated versions, soon to be discontinued', async () => {
       'Error: Node.js version 12.x has reached End-of-Life. Deployments created on or after 2022-10-03 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
       'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
       'Error: Node.js version 14.x has reached End-of-Life. Deployments created on or after 2023-08-15 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
-      'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2025-02-28 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
-      'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2025-02-28 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
+      'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2025-01-31 will fail to build. Please set "engines": { "node": "20.x" } in your `package.json` file to use Node.js 20.',
+      'Error: Node.js version 16.x has reached End-of-Life. Deployments created on or after 2025-01-31 will fail to build. Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.',
     ]);
   } finally {
     global.Date.now = realDateNow;


### PR DESCRIPTION
https://github.com/vercel/vercel/pull/11671 changed the EOL date for node 16.x to be AWS's final date. We want ours to be ~ a month earlier.