### PR TITLE
[build-utils] Improve no lockfile detection logic

### DIFF
--- a/.changeset/quiet-comics-tell.md
+++ b/.changeset/quiet-comics-tell.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Improve error message and refactor

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -372,7 +372,7 @@ function detectPackageManagerNameWithoutLockfile(packageJson: PackageJson) {
   const packageJsonPackageManager = packageJson.packageManager;
   if (usingCorepack(process.env, packageJsonPackageManager)) {
     const corepackPackageManager = validateVersionSpecifier(
-      packageJsonPackageManager as string
+      packageJsonPackageManager
     );
     switch (corepackPackageManager?.packageName) {
       case 'npm':
@@ -785,7 +785,7 @@ export function getPathOverrideForPackageManager({
   }
 }
 
-function validateVersionSpecifier(version: string) {
+function validateVersionSpecifier(version?: string) {
   if (!version) {
     return undefined;
   }

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -384,7 +384,7 @@ function detectPackageManagerNameWithoutLockfile(packageJson: PackageJson) {
         return 'npm';
       default:
         throw new Error(
-          `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager.`
+          `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager: npm, pnpm, yarn, bun.`
         );
     }
   }


### PR DESCRIPTION
Two minor improvements missed from the review of https://github.com/vercel/vercel/pull/11697:

- [Include supported package manager names in error message](https://github.com/vercel/vercel/pull/11697#discussion_r1628382867)
- [Avoid `as` to improve type safety](https://github.com/vercel/vercel/pull/11697#discussion_r1628384789)