### PR TITLE
[cli] allow prerender to stream

### DIFF
--- a/.changeset/proud-spoons-drop.md
+++ b/.changeset/proud-spoons-drop.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow app router prerender functions to use streaming.

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -948,10 +948,7 @@ export async function serverBuild({
     const appRouterStreamingActionLambdaGroups: LambdaGroup[] = [];
 
     for (const group of appRouterLambdaGroups) {
-      if (!group.isPrerenders || group.isExperimentalPPR) {
-        group.isStreaming = true;
-      }
-
+      group.isStreaming = true;
       group.isAppRouter = true;
 
       // We create a streaming variant of the Prerender lambda group


### PR DESCRIPTION
Allow all app router lambdas to use streaming, including prerender and experimental PPR.

Practically speaking this is a no-op at the moment; `api-builds` has a feature-flagged check to ensure any prerender function will not stream. It is effectively a duplicate of the check that this PR removes.

This is the check in `api-builds`: https://github.com/vercel/api/blob/987de85d6a38a34f717cd1372826cbaf6113dd7d/services/api-builds/src/endpoints/post-lambda.ts#L273