### PR TITLE
[remix] Use native fetch polyfills for Node 20+

### DIFF
--- a/.changeset/tall-foxes-attack.md
+++ b/.changeset/tall-foxes-attack.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Add opt-in env var to use native Fetch polyfills

--- a/packages/remix/defaults/server-node.mjs
+++ b/packages/remix/defaults/server-node.mjs
@@ -17,11 +17,11 @@ const handleRequest = createRemixRequestHandler(
   process.env.NODE_ENV
 );
 
-function createRemixHeaders(requestHeaders) {
+function toWebHeaders(nodeHeaders) {
   const headers = new Headers();
 
-  for (const key in requestHeaders) {
-    const header = requestHeaders[key];
+  for (const key in nodeHeaders) {
+    const header = nodeHeaders[key];
     // set-cookie is an array (maybe others)
     if (Array.isArray(header)) {
       for (const value of header) {
@@ -35,8 +35,12 @@ function createRemixHeaders(requestHeaders) {
   return headers;
 }
 
+function toNodeHeaders(webHeaders) {
+  return webHeaders.raw?.() || [...webHeaders].flat();
+}
+
 function createRemixRequest(req, res) {
-  const host = req.headers['x-forwarded-host'] || req.headers['host'];
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
   const protocol = req.headers['x-forwarded-proto'] || 'https';
   const url = new URL(req.url, `${protocol}://${host}`);
 
@@ -46,7 +50,7 @@ function createRemixRequest(req, res) {
 
   const init = {
     method: req.method,
-    headers: createRemixHeaders(req.headers),
+    headers: toWebHeaders(req.headers),
     signal: controller.signal,
   };
 
@@ -59,11 +63,10 @@ function createRemixRequest(req, res) {
 
 async function sendRemixResponse(res, nodeResponse) {
   res.statusMessage = nodeResponse.statusText;
-  let multiValueHeaders = nodeResponse.headers.raw();
   res.writeHead(
     nodeResponse.status,
     nodeResponse.statusText,
-    multiValueHeaders
+    toNodeHeaders(nodeResponse.headers),
   );
 
   if (nodeResponse.body) {

--- a/packages/remix/defaults/server-node.mjs
+++ b/packages/remix/defaults/server-node.mjs
@@ -5,7 +5,9 @@ import {
 } from '@remix-run/node';
 
 installGlobals({
-  nativeFetch: parseInt(process.versions.node, 10) >= 20 && process.env.VERCEL_REMIX_NATIVE_FETCH === '1',
+  nativeFetch:
+    parseInt(process.versions.node, 10) >= 20 &&
+    process.env.VERCEL_REMIX_NATIVE_FETCH === '1',
 });
 
 import * as build from '@remix-run/dev/server-build';

--- a/packages/remix/defaults/server-node.mjs
+++ b/packages/remix/defaults/server-node.mjs
@@ -66,7 +66,7 @@ async function sendRemixResponse(res, nodeResponse) {
   res.writeHead(
     nodeResponse.status,
     nodeResponse.statusText,
-    toNodeHeaders(nodeResponse.headers),
+    toNodeHeaders(nodeResponse.headers)
   );
 
   if (nodeResponse.body) {

--- a/packages/remix/defaults/server-node.mjs
+++ b/packages/remix/defaults/server-node.mjs
@@ -4,7 +4,9 @@ import {
   installGlobals,
 } from '@remix-run/node';
 
-installGlobals();
+installGlobals({
+  nativeFetch: parseInt(process.versions.node, 10) >= 20 && process.env.VERCEL_REMIX_NATIVE_FETCH === '1',
+});
 
 import * as build from '@remix-run/dev/server-build';
 


### PR DESCRIPTION
Allows for the native `fetch` in Node.js to be used instead of the `node-fetch` that Remix uses by default. Currently opt-in via an env var.