### PR TITLE
[next] Fix changeset from #11745

### DIFF
--- a/.changeset/proud-spoons-drop.md
+++ b/.changeset/proud-spoons-drop.md
@@ -1,5 +1,5 @@
 ---
-'vercel': patch
+'@vercel/next': patch
 ---
 
-Allow app router prerender functions to use streaming.
+Allow app router prerender functions to use streaming


### PR DESCRIPTION
The changeset file from #11745 incorrectly references the `vercel` package, but the code change is in `@vercel/next`. The changeset file needs to reference that package otherwise a new version of `@vercel/next` will not be published to include the change from the PR.