### PR TITLE
[next] Fix route handlers operation type

### DIFF
--- a/.changeset/real-snails-sneeze.md
+++ b/.changeset/real-snails-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix route handlers operation type

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -943,6 +943,7 @@ export async function serverBuild({
       internalPages,
       pageExtensions,
       inversedAppPathManifest,
+      isRouteHandlers: true,
     });
 
     const appRouterStreamingActionLambdaGroups: LambdaGroup[] = [];

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1535,7 +1535,9 @@ export async function getPageLambdaGroups({
   pageExtensions,
   inversedAppPathManifest,
   experimentalAllowBundling,
+  isRouteHandlers,
 }: {
+  isRouteHandlers?: boolean;
   entryPath: string;
   config: Config;
   functionsConfigManifest?: FunctionsConfigManifestV1;
@@ -1636,7 +1638,7 @@ export async function getPageLambdaGroups({
         ...opts,
         isPrerenders: isPrerenderRoute,
         isExperimentalPPR,
-        isApiLambda: !!isApiPage(page),
+        isApiLambda: !!isApiPage(page) || !!isRouteHandlers,
         pseudoLayerBytes: initialPseudoLayer.pseudoLayerBytes,
         pseudoLayerUncompressedBytes: initialPseudoLayerUncompressed,
         pseudoLayer: Object.assign({}, initialPseudoLayer.pseudoLayer),


### PR DESCRIPTION
Noticed route handlers were incorrectly showing as "page" in our deployment summary due to the incorrect operation type being assigned. 