### PR TITLE
[next]: ensure route handlers aren't skipped when creating .rsc variants

### DIFF
--- a/.changeset/blue-colts-grow.md
+++ b/.changeset/blue-colts-grow.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+don't skip creation of `.rsc` outputs for route handlers

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1594,16 +1594,10 @@ export async function serverBuild({
   if (appPathRoutesManifest) {
     // create .rsc variant for app lambdas and edge functions
     // to match prerenders so we can route the same when the
-    // __rsc__ header is present
+    // RSC header is present
     const edgeFunctions = middleware.edgeFunctions;
 
     for (const route of Object.values(appPathRoutesManifest)) {
-      const ogRoute = inversedAppPathManifest[route];
-
-      if (ogRoute.endsWith('/route')) {
-        continue;
-      }
-
       const pathname = path.posix.join(
         './',
         entryDirectory,

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/[category]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/[category]/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+    return <div>Hello World</div>
+}

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/[category]/page.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/[category]/page.js
@@ -1,3 +1,3 @@
 export default function Page() {
-    return <div>Hello World</div>
+  return <div>Hello World</div>;
 }

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/route-handler/route.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/route-handler/route.js
@@ -1,0 +1,5 @@
+export const GET = req => {
+    console.log(req.url);
+    return new Response('hello world');
+  };
+  

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/route-handler/route.js
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/app/dynamic/route-handler/route.js
@@ -1,5 +1,4 @@
 export const GET = req => {
-    console.log(req.url);
-    return new Response('hello world');
-  };
-  
+  console.log(req.url);
+  return new Response('hello world');
+};

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -454,6 +454,23 @@
         "RSC": "1",
         "Next-Router-Prefetch": "1"
       }
+    },
+    {
+      "path": "/dynamic/route-handler",
+      "status": 200,
+      "mustContain": "hello world",
+      "headers": {
+        "RSC": "1"
+      }
+    },
+    {
+      "path": "/dynamic/route-handler",
+      "status": 200,
+      "mustContain": "hello world",
+      "headers": {
+        "RSC": "1",
+        "Next-Router-Prefetch": "1"
+      }
     }
   ]
 }

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -128,7 +128,6 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
 
     expect(buildResult.output['edge-route-handler']).toBeDefined();
     expect(buildResult.output['edge-route-handler'].type).toBe('EdgeFunction');
-    expect(buildResult.output['edge-route-handler.rsc']).not.toBeDefined();
 
     // prefixed static generation output with `/app` under dist server files
     expect(buildResult.output['dashboard'].type).toBe('Prerender');


### PR DESCRIPTION
The Next.js builder attempts to route RSC requests to their `.rsc` output if it detects the request contains the `RSC` header. We currently skip creating a `.rsc` variant for route handlers because we assumed that there isn't a reason to make an RSC request to a route handler.

However, this means that something as trivial as having a `<Link />` component pointing to a page that is served by the route handler to throw a 500, since the `Link` component would  automatically attempt a prefetch. 

This removes the handling that skipped creating `.rsc` outputs for route handlers.