### PR TITLE
[next] Bump fs-extra

### DIFF
--- a/.changeset/afraid-gifts-grab.md
+++ b/.changeset/afraid-gifts-grab.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Bump fs-extra

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -51,7 +51,7 @@
     "escape-string-regexp": "2.0.0",
     "execa": "2.0.4",
     "find-up": "4.1.0",
-    "fs-extra": "7.0.0",
+    "fs-extra": "11.2.0",
     "get-port": "5.0.0",
     "jest-junit": "16.0.0",
     "nanoid": "3.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,8 +1197,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       fs-extra:
-        specifier: 7.0.0
-        version: 7.0.0
+        specifier: 11.2.0
+        version: 11.2.0
       get-port:
         specifier: 5.0.0
         version: 5.0.0
@@ -8327,7 +8327,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.54.1(eslint@8.24.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.7
@@ -8357,7 +8357,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.54.1(eslint@8.24.0)(typescript@4.9.5)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -8481,7 +8481,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.24.0
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.54.1)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.4)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.54.1)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.24.0):
@@ -9259,13 +9259,13 @@ packages:
       universalify: 2.0.0
     dev: true
 
-  /fs-extra@7.0.0:
-    resolution: {integrity: sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==}
-    engines: {node: '>=6 <7 || >=8'}
+  /fs-extra@11.2.0:
+    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
     dependencies:
-      graceful-fs: 4.2.10
-      jsonfile: 4.0.0
-      universalify: 0.1.2
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
     dev: true
 
   /fs-extra@7.0.1:


### PR DESCRIPTION
Just upgrades to latest version of fs-extra as it's had improvements to stat and dropped legacy Node.js support. 