### PR TITLE
[next] Fix re-tracing app router entries

### DIFF
--- a/.changeset/empty-seals-tease.md
+++ b/.changeset/empty-seals-tease.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+Fix re-tracing app router entries

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -769,7 +769,8 @@ export async function serverBuild({
 
     const pathsToTrace: string[] = mergedPageKeys
       .map(page => {
-        if (!getBuildTraceFile(page)) {
+        const originalPagePath = getOriginalPagePath(page);
+        if (!getBuildTraceFile(originalPagePath)) {
           return lambdaPages[page].fsPath;
         }
       })


### PR DESCRIPTION
Pulls in one of the fixes from https://github.com/vercel/vercel/pull/10631 which corrects the trace file lookup which currently is incorrect causing us to re-trace some app route entries un-necessarily. 

On a larger Next.js app with route groups this removes `30s` of additional tracing. 