### PR TITLE
Use support team for dependabot PR reviews

### DIFF
--- a/.changeset/fluffy-cats-sit.md
+++ b/.changeset/fluffy-cats-sit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use support team for dependabot PR reviews

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -30,9 +28,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -54,9 +50,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -88,9 +82,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -117,9 +109,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -146,9 +136,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -185,12 +173,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
-      - 'erikareads'
-      - 'jeffsee55'
-      - 'onsclom'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -212,9 +195,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -236,9 +217,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -260,9 +239,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'
@@ -284,12 +261,7 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 1
     reviewers:
-      - 'trek'
-      - 'TooTallNate'
-      - 'EndangeredMassa'
-      - 'jefsee55'
-      - 'onsclom'
-      - 'erikareads'
+      - 'zero-config-support'
     commit-message:
       prefix: '[framework-fixtures]'
     package-ecosystem: 'npm'


### PR DESCRIPTION
This should minimize PR review request spam. Now only whomever is on support will get these.