### PR TITLE
Use automerge in dependabot PRs

### DIFF
--- a/.changeset/silent-rivers-juggle.md
+++ b/.changeset/silent-rivers-juggle.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Use automerge in dependabot PRs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -33,8 +33,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -58,8 +58,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -93,8 +93,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -123,8 +123,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -153,8 +153,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -193,8 +193,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -218,8 +218,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -243,8 +243,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -268,8 +268,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
@@ -293,8 +293,8 @@ updates:
     reviewers:
       - 'zero-config-support'
     labels:
-      - "pr: automerge"
-      - "dependencies"
+      - 'pr: automerge'
+      - 'dependencies'
     commit-message:
       prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: '@angular*'
@@ -29,8 +32,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'astro*'
@@ -51,8 +57,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: '@remix-run*'
@@ -83,8 +92,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: '@ionic*'
@@ -110,8 +122,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: '@ionic*'
@@ -137,8 +152,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'nuxt'
@@ -174,8 +192,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'parcel'
@@ -196,8 +217,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'preact*'
@@ -218,8 +242,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: '@stencil/core'
@@ -240,8 +267,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'vite'
@@ -262,8 +292,11 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - 'zero-config-support'
+    labels:
+      - "pr: automerge"
+      - "dependencies"
     commit-message:
-      prefix: '[framework-fixtures]'
+      prefix: '[framework-fixture-dependencies]'
     package-ecosystem: 'npm'
     allow:
       - dependency-name: 'vitepress'


### PR DESCRIPTION
Changes:

- PRs will now include the label `pr: automerge`
- PRs will now have the more unique prefix `[framework-fixture-dependencies]` for easier notification filtering