### PR TITLE
[tests] hide spammy token message in CI

### DIFF
--- a/.changeset/small-rings-joke.md
+++ b/.changeset/small-rings-joke.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+hide spammy token message in CI

--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -8,6 +8,7 @@ const fileModeSymbol = Symbol('fileMode');
 const { logWithinTest } = require('./log');
 const ms = require('ms');
 
+const IS_CI = !!process.env.CI;
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
@@ -218,7 +219,7 @@ async function fetchTokenWithRetry(retries = 5) {
     VERCEL_TEST_REGISTRATION_URL,
   } = process.env;
   if (VERCEL_TOKEN || NOW_TOKEN || TEMP_TOKEN) {
-    if (!TEMP_TOKEN) {
+    if (!TEMP_TOKEN && !IS_CI) {
       logWithinTest(
         'Your personal token will be used to make test deployments.'
       );
@@ -227,7 +228,7 @@ async function fetchTokenWithRetry(retries = 5) {
   }
   if (!VERCEL_TEST_TOKEN || !VERCEL_TEST_REGISTRATION_URL) {
     throw new Error(
-      process.env.CI
+      IS_CI
         ? 'Failed to create test deployment. This is expected for 3rd-party Pull Requests. Please run tests locally.'
         : 'Failed to create test deployment. Please set `VERCEL_TOKEN` environment variable and run again.'
     );


### PR DESCRIPTION
Hides this token message when running in CI, avoiding a lot of spam.

> Your personal token will be used to make test deployments.

Spam example:
![CleanShot 2024-07-10 at 14 53 36@2x](https://github.com/vercel/vercel/assets/41545/7ee8389d-2d49-4b6b-88c6-52a5886b1c08)
