### PR TITLE
[tests] tweak CI requirements 

### DIFF
--- a/.changeset/fresh-cooks-sparkle.md
+++ b/.changeset/fresh-cooks-sparkle.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+tweak CI requirements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             const script = require('./utils/update-latest-release.js')
             await script({ github, context })
   summary:
-    name: Summary
+    name: Summary (release)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:

--- a/.github/workflows/test-18.yml
+++ b/.github/workflows/test-18.yml
@@ -105,7 +105,7 @@ jobs:
           DD_ENV: ci
 
   summary:
-    name: Summary
+    name: Summary (Node 18)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -52,3 +52,13 @@ jobs:
       - run: pnpm run prettier-check
       - run: pnpm run build
       - run: pnpm run type-check
+
+  summary:
+    name: Summary (lint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - test
+    steps:
+      - name: Check All
+        run: echo OK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
           DD_ENV: ci
 
   summary:
-    name: Summary
+    name: Summary (Node 16)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()


### PR DESCRIPTION
When we split out the node 16/18 tests, both had the same workflow step name of "Summary", which is the only required step for merging. The Lint workflow also has a step with the same name. So, it seems that if any of these succeeded, the PR was mergeable.

I updated the requirements to require Lint, Node 16, and Node 18 versions of this step in the repo settings. This PR updates the names to match.