### PR TITLE
[tests] run workflows on force push, too

### DIFF
--- a/.changeset/angry-kangaroos-add.md
+++ b/.changeset/angry-kangaroos-add.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Version Packages

--- a/.github/workflows/test-18.yml
+++ b/.github/workflows/test-18.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - '!*'
   pull_request:
+  pull_request_target:
 
 env:
   NODE_VERSION: '18'

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - '!*'
   pull_request:
+  pull_request_target:
 
 env:
   TURBO_REMOTE_ONLY: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - '!*'
   pull_request:
+  pull_request_target:
 
 env:
   NODE_VERSION: '16'


### PR DESCRIPTION
Make sure workflows are triggered on force push, which is how changesets-bot works. I can't find a way to prevent that.

I tested this in this PR and it seemed to run the workflows just fine before and after force push.