### PR TITLE
[tests] remove pr target workflow

### DIFF
--- a/.github/workflows/test-18.yml
+++ b/.github/workflows/test-18.yml
@@ -7,7 +7,6 @@ on:
     tags:
       - '!*'
   pull_request:
-  pull_request_target:
 
 env:
   NODE_VERSION: '18'

--- a/.github/workflows/test-18.yml
+++ b/.github/workflows/test-18.yml
@@ -111,7 +111,6 @@ jobs:
     name: Summary (Node 18)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always()
     needs:
       - test
     steps:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -7,7 +7,6 @@ on:
     tags:
       - '!*'
   pull_request:
-  pull_request_target:
 
 env:
   TURBO_REMOTE_ONLY: 'true'

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -58,11 +58,18 @@ jobs:
   summary:
     name: Summary (lint)
     runs-on: ubuntu-latest
-    if: always()
     timeout-minutes: 1
     needs:
       - enforce-changeset
       - lint
     steps:
       - name: Check All
-        run: echo OK
+        run: |-
+          for status in ${{ join(needs.*.result, ' ') }}
+          do
+            if [ "$status" != "success" ] && [ "$status" != "skipped" ]
+            then
+              echo "Some checks failed"
+              exit 1
+            fi
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
     tags:
       - '!*'
   pull_request:
-  pull_request_target:
 
 env:
   NODE_VERSION: '16'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,6 @@ jobs:
     name: Summary (Node 16)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always()
     needs:
       - test
     steps:


### PR DESCRIPTION
More tweaks to the CI workflow:

- remove `pull_request_target`: I added this because it covered force pushes, but it also complicates the step reporting in a PR summary. I don't think we need this anymore with the github token fix. It also breaks the merge requirements because a `pull_request_target` version of the summary step completes when the `pull_request` version is still running the actual tests.
- do not `always()` run summary steps: I think this is confusing the state to always be successful; testing removing it