### PR TITLE
[tests] remove failing deno test

### DIFF
--- a/.changeset/lazy-news-help.md
+++ b/.changeset/lazy-news-help.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] remove failing deno test

--- a/packages/cli/test/dev/fixtures/custom-runtime/.gitignore
+++ b/packages/cli/test/dev/fixtures/custom-runtime/.gitignore
@@ -1,2 +1,0 @@
-.now
-.vercel

--- a/packages/cli/test/dev/fixtures/custom-runtime/api/user.ts
+++ b/packages/cli/test/dev/fixtures/custom-runtime/api/user.ts
@@ -1,3 +1,0 @@
-export default (req: Request) => {
-  return new Response('Hello, from Deno!');
-}

--- a/packages/cli/test/dev/fixtures/custom-runtime/vercel.json
+++ b/packages/cli/test/dev/fixtures/custom-runtime/vercel.json
@@ -1,7 +1,0 @@
-{
-  "functions": {
-    "api/user.ts": {
-      "runtime": "vercel-deno@3.1.0"
-    }
-  }
-}

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -1,4 +1,3 @@
-import execa from 'execa';
 import { isIP } from 'net';
 import { exec, fixture, testFixture, testFixtureStdio } from './utils';
 
@@ -125,25 +124,6 @@ test(
     });
   })
 );
-
-test('[vercel dev] Use custom runtime from the "functions" property', async () => {
-  const origPATH = process.env.PATH;
-  try {
-    // "deno" needs to be installed for this test
-    await execa('curl -fsSL https://deno.land/install.sh | sh', {
-      stdio: 'inherit',
-      shell: true,
-    });
-    process.env.PATH = `${process.env.HOME}/.deno/bin:${origPATH}`;
-    const tester = testFixtureStdio('custom-runtime', async (testPath: any) => {
-      await testPath(200, `/api/user`, /Hello, from Deno!/m);
-      await testPath(200, `/api/user.ts`, /Hello, from Deno!/m);
-    });
-    await tester();
-  } finally {
-    process.env.PATH = origPATH;
-  }
-});
 
 test(
   '[vercel dev] Should work with nested `tsconfig.json` files',


### PR DESCRIPTION
Removing this deno test for `vc dev`. It's broken on `main`.

Note that the real error was:

```
│ error: TypeScript files are not supported in npm packages:
  file:///Users/smassa/source/vercel/vercel-2/packages/cli/test/dev/fixtures/custom-runtime/.vercel/builders/node_modules/vercel-deno/dist/dev-server.ts
│ Error: Failed to start dev server for "api/user.ts" (code=1, signal=null)
```

