### PR TITLE
[tests] always run summary tasks, but control status

### DIFF
--- a/.changeset/eighty-moose-learn.md
+++ b/.changeset/eighty-moose-learn.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+[tests] always run summary tasks, but control status

--- a/.github/workflows/test-18.yml
+++ b/.github/workflows/test-18.yml
@@ -111,6 +111,7 @@ jobs:
     name: Summary (Node 18)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: always()
     needs:
       - test
     steps:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -59,6 +59,7 @@ jobs:
     name: Summary (lint)
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: always()
     needs:
       - enforce-changeset
       - lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,7 @@ jobs:
     name: Summary (Node 16)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: always()
     needs:
       - test
     steps:


### PR DESCRIPTION
Mark the Summary steps as `always()` so that they can control their own exit status. This should make a given Summary step fail if a dependency of that step also failed, where it would normally be "skipped", which passes merge requirements.