### PR TITLE
[cli] Readd diagnostics download operation

### DIFF
--- a/.changeset/old-kids-perform.md
+++ b/.changeset/old-kids-perform.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+fix glob path for next.js diagnostics

--- a/.changeset/witty-readers-tie.md
+++ b/.changeset/witty-readers-tie.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add download of diagnostics

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -6,6 +6,7 @@ import minimatch from 'minimatch';
 import { join, normalize, relative, resolve, sep } from 'path';
 import { frameworkList } from '@vercel/frameworks';
 import {
+  download,
   getDiscontinuedNodeVersions,
   getInstalledPackageVersion,
   normalizePath,
@@ -587,6 +588,13 @@ async function doBuild(
         buildJsonBuild.error = toEnumerableError(err);
       }
       throw err;
+    } finally {
+      ops.push(
+        download(diagnostics, join(outputDir, 'diagnostics')).then(
+          () => undefined,
+          err => err
+        )
+      );
     }
   }
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2751,7 +2751,7 @@ export const diagnostics: Diagnostics = async ({
   return {
     // Collect output in `.next/diagnostics`
     ...(await glob(
-      'diagnostics/*',
+      '*',
       path.join(basePath, diagnosticsEntrypoint, outputDirectory, 'diagnostics')
     )),
     // Collect `.next/trace` file


### PR DESCRIPTION
Follow up from #11653 where we moved out the actual `download` operation accidentally ([this commit](https://github.com/vercel/vercel/pull/11653/commits/c24f95ba0a3f180e538bb5de23bd0eec11cb511c#diff-452a115a951a23488dd3257a83934cc9439918fbd41143a0ded219164dd13c6fL609-L614))

Closes BD-1269.