### PR TITLE
[next] Make app route prerender filter dynamic route specific

### DIFF
--- a/.changeset/warm-carrots-scream.md
+++ b/.changeset/warm-carrots-scream.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Make app route prerender filter dynamic route specific

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1403,12 +1403,18 @@ export async function serverBuild({
 
   prerenderRoutes.forEach(route => {
     if (experimentalPPRRoutes.has(route)) return;
-    // we can't delete app route lambdas just because
-    // they are in the prerender manifest since a dynamic
-    // route can have some prerendered paths and the rest SSR
-    if (inversedAppPathManifest?.[route]) return;
     if (routesManifest?.i18n) {
       route = normalizeLocalePath(route, routesManifest.i18n.locales).pathname;
+    }
+
+    if (
+      // we can't delete dynamic app route lambdas just because
+      // they are in the prerender manifest since a dynamic
+      // route can have some prerendered paths and the rest SSR
+      inversedAppPathManifest[route] &&
+      isDynamicRoute(route)
+    ) {
+      return;
     }
 
     delete lambdas[

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -88,7 +88,7 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
       )
     ).toBeFalsy();
 
-    expect(lambdas.size).toBe(7);
+    expect(lambdas.size).toBe(5);
 
     // RSC, root-level page.js
     expect(buildResult.output['index']).toBeDefined();

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -88,7 +88,7 @@ if (parseInt(process.versions.node.split('.')[0], 10) >= 16) {
       )
     ).toBeFalsy();
 
-    expect(lambdas.size).toBe(5);
+    expect(lambdas.size).toBe(6);
 
     // RSC, root-level page.js
     expect(buildResult.output['index']).toBeDefined();


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/11862 ensuring we only filter for dynamic app routes as those are the only ones we were concerned about specifically and the related test change shouldn't have been necessary. 