### PR TITLE
[edge] deprecate `ipAddress` & `geolocation`

### DIFF
--- a/.changeset/soft-ways-relax.md
+++ b/.changeset/soft-ways-relax.md
@@ -1,0 +1,5 @@
+---
+"@vercel/edge": patch
+---
+
+[edge] deprecate `ipAddress` & `geolocation`.

--- a/packages/edge/docs/README.md
+++ b/packages/edge/docs/README.md
@@ -154,7 +154,7 @@ Returns the location information for the incoming request.
 
 #### Defined in
 
-[packages/edge/src/edge-headers.ts:128](https://github.com/vercel/vercel/blob/main/packages/edge/src/edge-headers.ts#L128)
+[packages/edge/src/edge-headers.ts:131](https://github.com/vercel/vercel/blob/main/packages/edge/src/edge-headers.ts#L131)
 
 ---
 

--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -98,7 +98,7 @@ function getFlag(countryCode: string | undefined): string | undefined {
  */
 export function ipAddress(request: Request): string | undefined {
   console.warn(
-    'This method will be removed in the next major version. Use `{ ipAddress } from @vercel/functions` instead.'
+    'This method will be removed in the next major version. Use `import { ipAddress } from @vercel/functions` instead.'
   );
   return getHeader(request, IP_HEADER_NAME);
 }
@@ -130,7 +130,7 @@ function getRegionFromRequestId(requestId?: string): string | undefined {
  */
 export function geolocation(request: Request): Geo {
   console.warn(
-    'This method will be removed in the next major version. Use `{ geolocation } from @vercel/functions` instead.'
+    'This method will be removed in the next major version. Use `import { geolocation } from @vercel/functions` instead.'
   );
 
   return {

--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -97,6 +97,9 @@ function getFlag(countryCode: string | undefined): string | undefined {
  * @param request The incoming request object which provides the IP
  */
 export function ipAddress(request: Request): string | undefined {
+  console.warn(
+    'This method will removed in the next major version. Use `{ ipAddress } from @vercel/functions` instead.'
+  );
   return getHeader(request, IP_HEADER_NAME);
 }
 
@@ -126,6 +129,10 @@ function getRegionFromRequestId(requestId?: string): string | undefined {
  * @param request The incoming request object which provides the geolocation data
  */
 export function geolocation(request: Request): Geo {
+  console.warn(
+    'This method will removed in the next major version. Use `{ geolocation } from @vercel/functions` instead.'
+  );
+
   return {
     city: getHeader(request, CITY_HEADER_NAME),
     country: getHeader(request, COUNTRY_HEADER_NAME),

--- a/packages/edge/src/edge-headers.ts
+++ b/packages/edge/src/edge-headers.ts
@@ -98,7 +98,7 @@ function getFlag(countryCode: string | undefined): string | undefined {
  */
 export function ipAddress(request: Request): string | undefined {
   console.warn(
-    'This method will removed in the next major version. Use `{ ipAddress } from @vercel/functions` instead.'
+    'This method will be removed in the next major version. Use `{ ipAddress } from @vercel/functions` instead.'
   );
   return getHeader(request, IP_HEADER_NAME);
 }
@@ -130,7 +130,7 @@ function getRegionFromRequestId(requestId?: string): string | undefined {
  */
 export function geolocation(request: Request): Geo {
   console.warn(
-    'This method will removed in the next major version. Use `{ geolocation } from @vercel/functions` instead.'
+    'This method will be removed in the next major version. Use `{ geolocation } from @vercel/functions` instead.'
   );
 
   return {


### PR DESCRIPTION
We want to encourage users to use the same method that is now hosted in the @vercel/functions package.