### PR TITLE
Experiment: Support a global main.py

### DIFF
--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -10,6 +10,7 @@ import type {
   BuilderFunctions,
   ProjectSettings,
 } from '@vercel/build-utils';
+import { debug } from '@vercel/build-utils';
 import { isOfficialRuntime } from './is-official-runtime';
 const slugToFramework = new Map<string | null, Framework>(
   frameworkList.map(f => [f.slug, f])
@@ -145,6 +146,7 @@ export async function detectBuilders(
       b.use = `${b.use}${withTag}`;
       return b;
     });
+  debug('Api matches', apiMatches);
 
   // If either is missing we'll make the frontend static
   const makeFrontendStatic = buildCommand === '' || outputDirectory === '';

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -464,7 +464,7 @@ function getApiMatches(): Builder[] {
     },
     { src: 'api/**/*.+(js|mjs|ts|tsx)', use: `@vercel/node`, config },
     { src: 'api/**/!(*_test).go', use: `@vercel/go`, config },
-    { src: 'api/**/*.py', use: `@vercel/python`, config },
+    { src: '{api/**/*.py,main.py}', use: `@vercel/python`, config },
     { src: 'api/**/*.rb', use: `@vercel/ruby`, config },
   ];
 }
@@ -917,6 +917,10 @@ function createRouteFromPath(
   let isDynamic = false;
 
   const srcParts = parts.map((segment, i): string => {
+    if (parts.length === 1 && segment === 'main.py') {
+      isDynamic = true;
+      return '(.*)';
+    }
     const name = getSegmentName(segment);
     const isLast = i === parts.length - 1;
 

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -10,7 +10,6 @@ import type {
   BuilderFunctions,
   ProjectSettings,
 } from '@vercel/build-utils';
-import { debug } from '@vercel/build-utils';
 import { isOfficialRuntime } from './is-official-runtime';
 const slugToFramework = new Map<string | null, Framework>(
   frameworkList.map(f => [f.slug, f])
@@ -146,7 +145,7 @@ export async function detectBuilders(
       b.use = `${b.use}${withTag}`;
       return b;
     });
-  debug('Api matches', apiMatches);
+  console.warn('Api matches', apiMatches);
 
   // If either is missing we'll make the frontend static
   const makeFrontendStatic = buildCommand === '' || outputDirectory === '';

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -372,16 +372,18 @@ function maybeGetApiBuilder(
   apiMatches: Builder[],
   options: Options
 ) {
-  const middleware =
-    fileName === 'middleware.js' || fileName === 'middleware.ts';
+  const globalBinary =
+    fileName === 'middleware.js' ||
+    fileName === 'middleware.ts' ||
+    fileName === 'main.py';
 
   // Root-level Middleware file is handled by `@vercel/next`, so don't
   // schedule a separate Builder when "nextjs" framework is selected
-  if (middleware && options.projectSettings?.framework === 'nextjs') {
+  if (globalBinary && options.projectSettings?.framework === 'nextjs') {
     return null;
   }
 
-  if (!(fileName.startsWith('api/') || middleware)) {
+  if (!(fileName.startsWith('api/') || globalBinary)) {
     return null;
   }
 
@@ -415,7 +417,7 @@ function maybeGetApiBuilder(
 
   const config: Config = { zeroConfig: true };
 
-  if (middleware) {
+  if (globalBinary) {
     config.middleware = true;
   }
 

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -64,6 +64,7 @@ export const build: BuildV3 = async ({
   meta = {},
   config,
 }) => {
+  debug('Building python', workPath, entrypoint, meta, config);
   let pythonVersion = getLatestPythonVersion(meta);
 
   workPath = await downloadFilesInWorkPath({


### PR DESCRIPTION
Detects a global `main.py` and if present creates a serverless function for it paired with a catch all route invoking it.


Demo deployment https://vercel.com/uncurated-tests/fasthtml-hello-world/GYEmy31CQ6MGKEWRzYjaRi5hjL7y
https://fasthtml-hello-world-git-zero-config-uncurated-tests.vercel.app/