### PR TITLE
[cli]: better error message when calling logs command without a deployment url

### DIFF
--- a/.changeset/fluffy-taxis-divide.md
+++ b/.changeset/fluffy-taxis-divide.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Better error message when calling logs command without a deployment url

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -14,6 +14,7 @@ import getScope from '../../util/get-scope';
 import { displayRuntimeLogs } from '../../util/logs';
 import type { Output } from '../../util/output';
 import param from '../../util/output/param';
+import { getCommandName } from '../../util/pkg-name';
 import { help } from '../help';
 import { stateString } from '../list';
 import { logsCommand } from './command';
@@ -64,6 +65,13 @@ export default async function logs(client: Client) {
 
   // extract the first parameter
   let [deploymentIdOrHost] = parsedArguments.args;
+  if (!deploymentIdOrHost) {
+    error(
+      `${getCommandName('logs <deployment>')} expects exactly one argument`
+    );
+    print(help(logsCommand, { columns: client.stderr.columns }));
+    return 1;
+  }
 
   let contextName: string | null = null;
 

--- a/packages/cli/test/unit/commands/inspect.test.ts
+++ b/packages/cli/test/unit/commands/inspect.test.ts
@@ -6,6 +6,16 @@ import inspect from '../../../src/commands/inspect';
 import sleep from '../../../src/util/sleep';
 
 describe('inspect', () => {
+  it('prints error when not providing deployement id or url', async () => {
+    client.setArgv('inspect');
+    const exitCode = await inspect(client);
+    const output = client.getFullOutput();
+    expect(exitCode).toEqual(1);
+    expect(output).toContain(
+      '`vercel inspect <url>` expects exactly one argument'
+    );
+  });
+
   it('should print out deployment information', async () => {
     const user = useUser();
     const deployment = useDeployment({ creator: user });

--- a/packages/cli/test/unit/commands/logs.test.ts
+++ b/packages/cli/test/unit/commands/logs.test.ts
@@ -109,6 +109,16 @@ describe('logs', () => {
     `);
   });
 
+  it('prints error when not providing deployement id or url', async () => {
+    client.setArgv('logs');
+    const exitCode = await logs(client);
+    const output = client.getFullOutput();
+    expect(exitCode).toEqual(1);
+    expect(output).toContain(
+      '`vercel logs <deployment>` expects exactly one argument'
+    );
+  });
+
   it('prints error when deployment not found', async () => {
     client.setArgv('logs', 'bad.com');
     await expect(logs(client)).rejects.toThrow(


### PR DESCRIPTION
### 🧐 What's in there?

`vc logs` command requires a deployment id or url (could we considering to default to the current prod deployment in the future?)
Right now users are getting an infamous error message:

```shell
▲  vc logs
Vercel CLI 35.0.3
Error: An unexpected error occurred in logs: TypeError: Cannot read properties of undefined (reading 'includes')
```

This PR handles that case better and show the appropriate disclaimer in addition to the command help.

### 🧪 How to test?

It's covered by unit tests.
To try it live:
- `pnpm build`
- `pnpm -F vercel dev logs`
   > yields: Error: `vercel logs <deployment>` expects exactly one argument