### PR TITLE
Add hint to `vercel deploy` error

### DIFF
--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -81,7 +81,7 @@ function validateDistDir(distDir: string) {
   if (!exists()) {
     throw new NowBuildError({
       code: 'STATIC_BUILD_NO_OUT_DIR',
-      message: `No Output Directory named "${distDirName}" found after the Build completed. You can configure the Output Directory in your Project Settings.`,
+      message: `No Output Directory named "${distDirName}" found after the Build completed. You can configure the Output Directory in your Project Settings. Hint: have you already run `vercel build`?`,
       link,
     });
   }


### PR DESCRIPTION
I hit this error after trying to build my project manually using `pnpm build`. I did not realize that I had to specifically use Vercel CLI's build tool. 

Fix: this hint indicates the command that I had failed to run before hitting this error.