### PR TITLE
[cli] Error instead of warn when `--prod` and `--target`/`--environment` are combined

### DIFF
--- a/.changeset/modern-bees-hammer.md
+++ b/.changeset/modern-bees-hammer.md
@@ -1,0 +1,5 @@
+---
+'vercel': major
+---
+
+Error when --prod and --target/--environment are combined

--- a/packages/cli/src/util/parse-target.ts
+++ b/packages/cli/src/util/parse-target.ts
@@ -15,9 +15,10 @@ export default function parseTarget({
   prodFlagValue?: boolean;
 }): string | undefined {
   if (prodFlagValue && targetFlagValue) {
-    output.warn(
-      `Both \`--prod\` and \`--${targetFlagName}\` detected. Ignoring \`--prod\`.`
+    output.error(
+      `Both \`--prod\` and \`--${targetFlagName}\` detected. Only one should be used at a time.`
     );
+    process.exit(1);
   }
 
   if (targetFlagValue) {

--- a/packages/cli/test/unit/util/parse-target.test.ts
+++ b/packages/cli/test/unit/util/parse-target.test.ts
@@ -10,6 +10,7 @@ describe('parseTarget', () => {
     output = new Output();
     output.warn = vi.fn();
     output.debug = vi.fn();
+    output.error = vi.fn();
   });
 
   it('defaults to `undefined`', () => {
@@ -40,17 +41,18 @@ describe('parseTarget', () => {
     expect(output.debug).toHaveBeenCalledWith('Setting target to staging');
   });
 
-  it('prefers target over production argument', () => {
-    let result = parseTarget({
-      output,
-      targetFlagName: 'target',
-      targetFlagValue: 'staging',
-      prodFlagValue: true,
-    });
-    expect(output.warn).toHaveBeenCalledWith(
-      'Both `--prod` and `--target` detected. Ignoring `--prod`.'
+  it('throws with both `--prod` and `--target` flags', () => {
+    expect(() => {
+      parseTarget({
+        output,
+        targetFlagName: 'target',
+        targetFlagValue: 'staging',
+        prodFlagValue: true,
+      });
+    }).toThrow();
+    expect(output.error).toHaveBeenCalledWith(
+      'Both `--prod` and `--target` detected. Only one should be used at a time.'
     );
-    expect(result).toEqual('staging');
   });
 
   it('parses production argument when `true`', () => {


### PR DESCRIPTION
This affects the commands `build`, `deploy`, and `list` as they all support `--prod` with `--target`/`--environment`.