### PR TITLE
Remove `.changeset/khaki-mangos-pull.md`

### DIFF
--- a/.changeset/khaki-mangos-pull.md
+++ b/.changeset/khaki-mangos-pull.md
@@ -1,5 +1,0 @@
----
-"@vercel/static-build": patch
----
-
-[framework-fixture-dependencies]: Bump astro from 4.11.5 to 4.12.2 in /packages/static-build/test/fixtures/astro-v4 in the core group across 1 directory


### PR DESCRIPTION
This change (from #11886) does not need to trigger a release of `@vercel/static-build`.