### PR TITLE
[cli] alias `dev` pnpm command as `vc` and `vercel` as well

### DIFF
--- a/.changeset/shy-ducks-hope.md
+++ b/.changeset/shy-ducks-hope.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] alias `dev` pnpm command as `vc` and `vercel` as well

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,8 @@
     "coverage": "codecov",
     "build": "node scripts/build.mjs",
     "dev": "ts-node ./src/index.ts",
+    "vercel": "pnpm dev",
+    "vc": "pnpm dev",
     "type-check": "tsc --noEmit"
   },
   "bin": {


### PR DESCRIPTION
It always irked me that running `vercel` in development was `pnpm dev`, especially when running the `dev` command with `pnpm dev dev`. 

This adds two aliases to the `dev` pnpm command so it matches global use:

```
vercel env ls
```
and

```
pnpm vercel env ls --cwd="path/to/project
```

I propose should look and act the same.

```
pnpm dev env ls
```

remains if that's still your jam.