### PR TITLE
`@vercel/functions` expose `oidc` object

### DIFF
--- a/.changeset/eleven-drinks-live.md
+++ b/.changeset/eleven-drinks-live.md
@@ -1,0 +1,5 @@
+---
+"@vercel/functions": major
+---
+
+`@vercel/functions` expose `oidc` object

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -2,6 +2,10 @@
 
 ## Table of contents
 
+### References
+
+- [oidc](index.md#oidc)
+
 ### Interfaces
 
 - [Geo](../interfaces/index.Geo.md)
@@ -13,6 +17,12 @@
 - [getEnv](index.md#getenv)
 - [ipAddress](index.md#ipaddress)
 - [waitUntil](index.md#waituntil)
+
+## References
+
+### oidc
+
+Re-exports [oidc](oidc.md)
 
 ## Functions
 

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -2,16 +2,7 @@
   "name": "@vercel/functions",
   "description": "Runtime functions to be used with your Vercel Functions",
   "homepage": "https://vercel.com",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./oidc": {
-      "types": "./dist/oidc/index.d.ts",
-      "default": "./dist/oidc/index.js"
-    }
-  },
+  "main": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -2,3 +2,4 @@ export type { Request, Geo } from './headers';
 export { geolocation, ipAddress } from './headers';
 export { getEnv } from './get-env';
 export { waitUntil } from './wait-until';
+export * as oidc from './oidc';


### PR DESCRIPTION
Previously, the way to use oidc was importing from `@vercel/functions/oidc` namespace:

```js
import { awsCredentialsProvider } from '@vercel/functions/oidc';
```

This type of import takes advantage of [subpath exports](https://nodejs.org/api/packages.html#subpath-exports).

We have had some users report that this does not work well with their CommonJS bundlers or TypeScript configuration, being just possible to import the library from `dist` folder, like `@vercel/functions/dist/oidc`.

In order to reduce the user friction there as much as possible, the library can just expose a old plain javascript object called `oidc` rather than import from the specific namespace.

So the previous code should be imported in this way:

```js
import { oidc } from '@vercel/functions/oidc';
const { awsCredentialsProvider } = oidc
```

Related https://github.com/vercel/vercel/issues/11918