### PR TITLE
Update CODEOWNERS for firewall

### DIFF
--- a/.changeset/metal-turkeys-doubt.md
+++ b/.changeset/metal-turkeys-doubt.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Update CODEOWNERS for firewall

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /packages/static-build                   @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads
 /packages/edge                           @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @vercel/compute
 /packages/functions                      @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @vercel/compute
+/packages/firewall                       @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @cramforce @sueplex
 /examples                                @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @leerob
 /examples/create-react-app               @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @Timer
 /examples/nextjs                         @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @timneutkens @ijjk @ztanner @huozhi


### PR DESCRIPTION
Updates codeowners for the new `@vercel/firewall` package.

Leaving Zero Config folks on it in case we need to approve a PR in a hurry.