### PR TITLE
Replace minimatch with Node.js LTS (20.17.0) Native Glob Matching

### DIFF
--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import Sema from 'async-sema';
 import { ZipFile } from 'yazl';
-import minimatch from 'minimatch';
+import path from 'path';
 import { readlink } from 'fs-extra';
 import { isSymbolicLink, isDirectory } from './fs/download';
 import streamToBuffer from './fs/stream-to-buffer';
@@ -283,7 +283,7 @@ export async function getLambdaOptionsFromFunction({
 > {
   if (config?.functions) {
     for (const [pattern, fn] of Object.entries(config.functions)) {
-      if (sourceFile === pattern || minimatch(sourceFile, pattern)) {
+      if (sourceFile === pattern || path.matchesGlob(sourceFile, pattern)) {
         return {
           memory: fn.memory,
           maxDuration: fn.maxDuration,

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -17,7 +17,7 @@ import {
 } from '@vercel/build-utils';
 import { isStaticRuntime } from '@vercel/fs-detectors';
 import plural from 'pluralize';
-import minimatch from 'minimatch';
+import path from 'path';
 
 import { Output } from '../output';
 import highlight from '../output/highlight';
@@ -231,7 +231,7 @@ export async function executeBuild(
     }
 
     for (const [src, func] of Object.entries(config.functions || {})) {
-      if (src === entrypoint || minimatch(entrypoint, src)) {
+      if (src === entrypoint || path.matchesGlob(entrypoint, src)) {
         if (func.maxDuration) {
           output.maxDuration = func.maxDuration;
         }
@@ -436,7 +436,9 @@ export async function getBuildMatches(
     }
 
     const files = fileList
-      .filter(name => name === src || minimatch(name, src, { dot: true }))
+      .filter(
+        name => name === src || path.matchesGlob(name, src, { dot: true })
+      )
       .map(name => join(cwd, name));
 
     if (files.length === 0) {

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -6,7 +6,6 @@ import fetch from 'node-fetch';
 import plural from 'pluralize';
 import rawBody from 'raw-body';
 import { listen } from 'async-listen';
-import minimatch from 'minimatch';
 import httpProxy from 'http-proxy';
 import { randomBytes } from 'crypto';
 import serveHandler from 'serve-handler';
@@ -2569,7 +2568,7 @@ function isIndex(path: string): boolean {
 
 function minimatches(files: string[], pattern: string): boolean {
   return files.some(
-    file => file === pattern || minimatch(file, pattern, { dot: true })
+    file => file === pattern || path.matchesGlob(file, pattern, { dot: true })
   );
 }
 

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -1,4 +1,4 @@
-import minimatch from 'minimatch';
+import path from 'path';
 import { valid as validSemver } from 'semver';
 import { parse as parsePath, extname } from 'path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
@@ -417,7 +417,7 @@ function maybeGetApiBuilder(
   }
 
   const match = apiMatches.find(({ src = '**' }) => {
-    return src === fileName || minimatch(fileName, src);
+    return src === fileName || path.matchesGlob(fileName, src);
   });
 
   const { fnPattern, func } = getFunction(fileName, options);
@@ -462,7 +462,9 @@ function getFunction(fileName: string, { functions = {} }: Options) {
     return { fnPattern: null, func: null };
   }
 
-  const func = keys.find(key => key === fileName || minimatch(fileName, key));
+  const func = keys.find(
+    key => key === fileName || path.matchesGlob(fileName, key)
+  );
 
   return func
     ? { fnPattern: func, func: functions[func] }


### PR DESCRIPTION
> This PR **replaces the existing usage of glob matching** libraries if used (such as minimatch,micromatch, picomatch) with the newly introduced native glob matching support in Node.js LTS (20.17.0).

>  This change aims to streamline the codebase by leveraging the built-in capabilities of Node.js, reducing the dependency footprint and potentially improving performance and maintainability. 