### PR TITLE
[cli] Fix incorrect type for challenge-only

### DIFF
--- a/.changeset/nasty-seahorses-punch.md
+++ b/.changeset/nasty-seahorses-punch.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix incorrect type for certs challenge-only flag

--- a/packages/cli/src/commands/certs/command.ts
+++ b/packages/cli/src/commands/certs/command.ts
@@ -51,7 +51,7 @@ export const certsCommand = {
       name: 'challenge-only',
       description: 'Only show challenges needed to issue a cert',
       shorthand: null,
-      type: String,
+      type: Boolean,
       deprecated: false,
     },
     {


### PR DESCRIPTION
`--challenge-only` is supposed to be a `Boolean`, but when we switched to using `command.ts` for flags, it was incorrectly set to be a `String`. This PR fixes that.