### PR TITLE
[cli] fix integration not found

### DIFF
--- a/.changeset/popular-bottles-appear.md
+++ b/.changeset/popular-bottles-appear.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fixes integration not found error when using `vercel install`

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -80,7 +80,7 @@ export async function add(client: Client, args: string[]) {
 async function fetchIntegration(client: Client, team: Team, slug: string) {
   try {
     return await client.fetch<Integration>(
-      `/v1/integrations/integration/${slug}?teamSlug=${team.slug}&source=marketplace`,
+      `/v1/integrations/integration/${slug}?teamSlug=${team.slug}&source=marketplace&public=1`,
       {
         json: true,
       }


### PR DESCRIPTION
Without the `public` this endpoint returns 404 unless you are the owner of the integration.