### PR TITLE
[Logs] use level to determine build log highlight

### DIFF
--- a/.changeset/thick-bugs-argue.md
+++ b/.changeset/thick-bugs-argue.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+introduce using level to highlight build logs

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -10,6 +10,7 @@ import Client from './client';
 import getDeployment from './get-deployment';
 import getScope from './get-scope';
 
+import { BuildLog } from './logs';
 export interface FindOpts {
   direction: 'forward' | 'backward';
   limit?: number;
@@ -20,16 +21,9 @@ export interface FindOpts {
 
 export interface PrintEventsOptions {
   mode: 'deploy' | string;
-  onEvent: (event: DeploymentEvent) => void;
+  onEvent: (event: BuildLog) => void;
   quiet?: boolean;
   findOpts: FindOpts;
-}
-
-export interface DeploymentEvent {
-  id: string;
-  created: number;
-  date?: number;
-  serial?: string;
 }
 
 async function printEvents(

--- a/packages/cli/src/util/events.ts
+++ b/packages/cli/src/util/events.ts
@@ -10,7 +10,7 @@ import Client from './client';
 import getDeployment from './get-deployment';
 import getScope from './get-scope';
 
-import { BuildLog } from './logs';
+import type { BuildLog } from './logs';
 export interface FindOpts {
   direction: 'forward' | 'backward';
   limit?: number;

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -161,7 +161,7 @@ function printBuildLog(log: any, print: Printer) {
 
   const date = new Date(log.created).toISOString();
 
-  for (const line of colorize(sanitize(log)).split('\n')) {
+  for (const line of colorize(sanitize(log), log).split('\n')) {
     print(`${chalk.dim(date)}  ${line.replace('[now-builder-debug] ', '')}\n`);
   }
 }
@@ -243,25 +243,9 @@ function sanitize(log: any): string {
   );
 }
 
-function colorize(text: string) {
-  if (isError(text)) {
+function colorize(text: string, log: any) {
+  if (log.level === 'error') {
     return chalk.red(text);
   }
-  return isWarning(text) ? chalk.yellow(text) : text;
-}
-
-function isError(text: string) {
-  return (
-    /^(\s+⨯\s+|\s+at\s+|npm err!)/i.test(text) ||
-    /(^| |\[|eval|internal|range|reference|syntax|type|uri|fetch)err(or)?( |:)/i.test(
-      text
-    ) ||
-    /(command not found|module not found|failed to compile|cannot open shared object file|err_pnpm_|please contact vercel.com\/help|exit code 1|elifecycle|exited)/i.test(
-      text
-    )
-  );
-}
-
-function isWarning(text: string) {
-  return /^warn(ing)?(:|!)/i.test(text) && !text.includes('deprecationwarning');
+  return log.level === 'warning' ? chalk.yellow(text) : text;
 }

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -246,6 +246,9 @@ function sanitize(log: any): string {
 function colorize(text: string, log: any) {
   if (log.level === 'error') {
     return chalk.red(text);
+  } else if (log.level === 'warning') {
+    return chalk.yellow(text);
   }
-  return log.level === 'warning' ? chalk.yellow(text) : text;
+
+  return text;
 }


### PR DESCRIPTION
We have moved the build log highlight to api instead of in `front` and `cli`; as a result, cli and front can both have consistent highlight. We have already deployed and tested the changes to front behind a feature flag and we would like to roll out the cli changes in the next version.