### PR TITLE
[custom-environments] write custom envs to project.json

### DIFF
--- a/internals/constants/src/index.ts
+++ b/internals/constants/src/index.ts
@@ -1,4 +1,4 @@
-export const PROJECT_ENV_TARGET = [
+export const VERCEL_SYSTEM_ENVIRONMENTS = [
   'production',
   'preview',
   'development',

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -2,9 +2,9 @@ import type { BuilderFunctions } from '@vercel/build-utils';
 import type { Readable, Writable } from 'stream';
 import type * as tty from 'tty';
 import type { Route } from '@vercel/routing-utils';
-import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
+import { VERCEL_SYSTEM_ENVIRONMENTS } from '@vercel-internals/constants';
 
-export type ProjectEnvTarget = (typeof PROJECT_ENV_TARGET)[number];
+export type ProjectEnvTarget = (typeof VERCEL_SYSTEM_ENVIRONMENTS)[number];
 export type ProjectEnvType = 'plain' | 'encrypted' | 'system' | 'sensitive';
 
 export type ProjectSettings = import('@vercel/build-utils').ProjectSettings;

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -1,21 +1,13 @@
 import chalk from 'chalk';
 import { join } from 'path';
 import Client from '../../util/client';
-import type {
-  Project,
-  ProjectEnvTarget,
-  ProjectLinked,
-} from '@vercel-internals/types';
+import type { Project, ProjectLinked } from '@vercel-internals/types';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { parseArguments } from '../../util/get-args';
 import stamp from '../../util/output/stamp';
 import { VERCEL_DIR, VERCEL_DIR_PROJECT } from '../../util/projects/link';
 import { writeProjectSettings } from '../../util/projects/project-settings';
 import envPull from '../env/pull';
-import {
-  isValidEnvTarget,
-  getEnvTargetPlaceholder,
-} from '../../util/env/env-target';
 import { ensureLink } from '../../util/link/ensure-link';
 import humanizePath from '../../util/humanize-path';
 
@@ -45,17 +37,6 @@ async function pullAllEnvFiles(
   );
 }
 
-export function parseEnvironment(
-  environment = 'development'
-): ProjectEnvTarget {
-  if (!isValidEnvTarget(environment)) {
-    throw new Error(
-      `environment "${environment}" not supported; must be one of ${getEnvTargetPlaceholder()}`
-    );
-  }
-  return environment;
-}
-
 export default async function main(client: Client) {
   let parsedArgs = null;
 
@@ -78,12 +59,6 @@ export default async function main(client: Client) {
 
   let cwd = parsedArgs.args[1] || client.cwd;
   const autoConfirm = Boolean(parsedArgs.flags['--yes']);
-  const environment =
-    parseTarget({
-      output: client.output,
-      flagName: 'environment',
-      flags: parsedArgs.flags,
-    }) || 'development';
 
   const link = await ensureLink('pull', client, cwd, { autoConfirm });
   if (typeof link === 'number') {
@@ -97,6 +72,13 @@ export default async function main(client: Client) {
   }
 
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+
+  const environment =
+    parseTarget({
+      output: client.output,
+      flagName: 'environment',
+      flags: parsedArgs.flags,
+    }) || 'development';
 
   const pullResultCode = await pullAllEnvFiles(
     environment,

--- a/packages/cli/src/util/env/env-target.ts
+++ b/packages/cli/src/util/env/env-target.ts
@@ -1,8 +1,8 @@
 import type { ProjectEnvTarget } from '@vercel-internals/types';
-import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
+import { VERCEL_SYSTEM_ENVIRONMENTS } from '@vercel-internals/constants';
 import title from 'title';
 
-export const envTargetChoices = PROJECT_ENV_TARGET.map(t => ({
+export const envTargetChoices = VERCEL_SYSTEM_ENVIRONMENTS.map(t => ({
   name: title(t),
   value: t,
 }));

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -61,9 +61,7 @@ export default async function setupAndLink(
   }
   const isTTY = client.stdin.isTTY;
   const quiet = !isTTY;
-  let rootDirectory: string | null = null;
   let sourceFilesOutsideRootDirectory = true;
-  let newProjectName: string;
   let org;
 
   if (!forceDelete && link.status === 'linked') {
@@ -124,6 +122,8 @@ export default async function setupAndLink(
     autoConfirm
   );
 
+  let newProjectName: string;
+  let rootDirectory: string | null = null;
   if (typeof projectOrNewProjectName === 'string') {
     newProjectName = projectOrNewProjectName;
     rootDirectory = await inputRootDirectory(client, path, autoConfirm);

--- a/packages/cli/src/util/projects/project-settings.ts
+++ b/packages/cli/src/util/projects/project-settings.ts
@@ -18,12 +18,24 @@ export type ProjectLinkAndSettings = Partial<ProjectLink> & {
     framework: Project['framework'];
     nodeVersion: Project['nodeVersion'];
     analyticsId?: string;
+    // TODO: We should use the Project['customEnvironments'] here when it becomes more available / concrete
+    customEnvironments?: {
+      id: string;
+      name: string;
+    }[];
   };
 };
 
-// writeProjectSettings writes the project configuration to `vercel/project.json`
-// Write the project configuration to `.vercel/project.json`
-// that is needed for `vercel build` and `vercel dev` commands
+/**
+ * Write the project configuration to `.vercel/project.json`
+ * that is needed for `vercel build` and `vercel dev` commands
+ *
+ * @param cwd - The current working directory
+ * @param project - The project to write the settings for
+ * @param org - The organization the project belongs to
+ * @param isRepoLinked - Whether the project is linked to a repository
+ * @returns
+ */
 export async function writeProjectSettings(
   cwd: string,
   project: Project,
@@ -54,6 +66,11 @@ export async function writeProjectSettings(
       directoryListing: project.directoryListing,
       nodeVersion: project.nodeVersion,
       analyticsId,
+      customEnvironments:
+        project.customEnvironments?.map(env => ({
+          id: env.id,
+          name: env.name,
+        })) || [],
     },
   };
   const path = join(cwd, VERCEL_DIR, VERCEL_DIR_PROJECT);


### PR DESCRIPTION
To help validate if a target is correct we want to write the custom envs to the project settings so we can validate before reaching out to any services