### PR TITLE
[sdk] ignore @vercel/sdk on changeset release

### DIFF
--- a/.changeset/nice-bobcats-train.md
+++ b/.changeset/nice-bobcats-train.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+ignore @vercel/sdk on changeset release

--- a/utils/update-canary-tags.mjs
+++ b/utils/update-canary-tags.mjs
@@ -2,8 +2,13 @@ import fs from 'fs';
 import { spawnSync } from 'child_process';
 
 const packagesDir = new URL('../packages/', import.meta.url);
+const ignoredPackages = ['sdk'];
 
 for (const name of fs.readdirSync(packagesDir)) {
+  if (ignoredPackages.includes(name)) {
+    continue;
+  }
+
   const pkg = JSON.parse(
     fs.readFileSync(new URL(`${name}/package.json`, packagesDir), 'utf8')
   );


### PR DESCRIPTION
This was left out of https://github.com/vercel/vercel/pull/12047/files

Causing a failure to release: https://vercel.slack.com/archives/C048KLPEEH1/p1725389884355449