### PR TITLE
Warn on `vc env pull [filename]` when `[filename]` is not in `.gitignore`

### DIFF
--- a/.changeset/red-mugs-compare.md
+++ b/.changeset/red-mugs-compare.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+Warn on vc env pull [filename] when filename is not in .gitignore

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
+    "test:debug": "node --inspect-brk ../../node_modules/jest/bin/jest.js --runInBand --reporters=default --reporters=jest-junit --env node --verbose --bail",
     "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-run:debug": "vitest --inspect-brk --no-file-parallelism -c ../../vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
     "test-e2e": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
     "test-dev": "pnpm test test/dev/",


### PR DESCRIPTION
## Warn on vc env pull [filename] when [filename] is not in .gitignore

This PR enhances the `vercel env pull` command to improve security and user experience:

1. Adds warning when pulling environment variables to non-gitignored files
2. Prompts user to add the file to .gitignore if not already present
3. Maintains backward compatibility with --yes flag
4. Introduces new utility functions for .gitignore operations
5. Adds unit tests for new functionality

The changes aim to prevent accidental exposure of sensitive data while maintaining existing workflow

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/042434c0-7595-4f12-bc4a-0d994b374e3d">



