### PR TITLE
[cli] Bug fix proposal: Correct envTargetChoices filtering when existing targets include arrays

### DIFF
--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -68,22 +68,10 @@ export default async function add(
     getCustomEnvironments(client, project.id),
   ]);
   const matchingEnvs = envs.filter(r => r.key === envName);
-  const existingTargets = new Set<string>();
-  const existingCustomEnvs = new Set<string>();
-  for (const env of matchingEnvs) {
-    if (typeof env.target === 'string') {
-      existingTargets.add(env.target);
-    } else if (Array.isArray(env.target)) {
-      for (const target of env.target) {
-        existingTargets.add(target);
-      }
-    }
-    if (env.customEnvironmentIds) {
-      for (const customEnvId of env.customEnvironmentIds) {
-        existingCustomEnvs.add(customEnvId);
-      }
-    }
-  }
+  const existingTargets = new Set(matchingEnvs.map(env => env.target));
+  const existingCustomEnvs = new Set(
+    matchingEnvs.flatMap(env => env.customEnvironmentIds || [])
+  );
   const choices = [
     ...envTargetChoices.filter(c => !existingTargets.has(c.value)),
     ...customEnvironments


### PR DESCRIPTION
### Background
I am preparing a PR to fix a bug in the `envTargetChoices` filtering logic. Currently, when `existingTargets` includes arrays, the resulting `choices` array becomes empty.

In the `src/commands/env/add.ts` file, there is a bug in the `envTargetChoices` filtering logic. When the `existingTargets` variable includes arrays (e.g., `['preview']` or `['production', 'preview', 'development']`), the `choices` array ends up empty because the logic flattens the `existingTargets` values into individual elements, causing all available choices to be filtered out. 

This issue was caused by changes made in [this commit](https://github.com/vercel/vercel/commit/ddcb7a1891b3b9dcaf5ffb1e15c31f0115f30db2). 


The issue is not with the getEnvRecords function itself, but with the logic below where existingTargets and existingCustomEnvs are being processed. Specifically, when iterating over matchingEnvs, if env.target is an array, each value in the array is being added individually to the Set. This causes the CLI to incorrectly filter out valid choices when adding environment variables.

The core problem arises because the values inside `existingTargets` are flattened into individual elements, rather than handling arrays as whole units. This results in the incorrect filtering of choices, leaving no valid options available.

### Proposed Change
- Modify the logic so that arrays are added to `existingTargets` as whole elements rather than flattening them into individual values.
- Update the filtering logic to correctly handle and compare values within arrays inside `existingTargets`.

```diff
- const existingTargets = new Set<string>();
- const existingCustomEnvs = new Set<string>();
- for (const env of matchingEnvs) {
-   if (typeof env.target === 'string') {
-     existingTargets.add(env.target);
-   } else if (Array.isArray(env.target)) {
-     for (const target of env.target) {
-       existingTargets.add(target);
-     }
-   }
-   if (env.customEnvironmentIds) {
-     for (const customEnvId of env.customEnvironmentIds) {
-       existingCustomEnvs.add(customEnvId);
-     }
-   }
- }

+ const existingTargets = new Set(matchingEnvs.map(env => env.target));
+ const existingCustomEnvs = new Set(
+   matchingEnvs.flatMap(env => env.customEnvironmentIds || [])
+ );
```

I believe this change resolves the issue and would appreciate your feedback on the proposed solution.

Thank you!