### PR TITLE
chore: temporarily disable sdk codegen schedule

### DIFF
--- a/.changeset/loud-humans-grow.md
+++ b/.changeset/loud-humans-grow.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+chore: temporarily disable sdk codegen schedule

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -14,8 +14,8 @@ permissions:
       set_version:
         description: optionally set a specific SDK version
         type: string
-  schedule:
-    - cron: 0 0 * * *
+  # schedule:
+  #   - cron: 0 0 * * *
 jobs:
   generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15


### PR DESCRIPTION
This change comments out the cron schedule on the SDK generation workflow while we work through the onboarding phase into the monorepo. We can reinstate this schedule after #12053 is merged.