### PR TITLE
[cli] refactor `getSubcommand` to return original user input

### DIFF
--- a/.changeset/proud-poets-learn.md
+++ b/.changeset/proud-poets-learn.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] refactor getSubcommand to return original user input

--- a/packages/cli/src/util/get-subcommand.ts
+++ b/packages/cli/src/util/get-subcommand.ts
@@ -2,14 +2,24 @@ type CommandConfig = {
   [command: string]: string[];
 };
 
+interface SubcommandParsed {
+  subcommand: string | string[];
+  args: string[];
+  subcommandActual?: string;
+}
+
 export default function getSubcommand(
   cliArgs: string[],
   config: CommandConfig
-) {
+): SubcommandParsed {
   const [subcommand, ...rest] = cliArgs;
   for (const k of Object.keys(config)) {
     if (k !== 'default' && config[k].indexOf(subcommand) !== -1) {
-      return { subcommand: k, args: rest };
+      return {
+        subcommand: k,
+        subcommandActual: subcommand,
+        args: rest,
+      };
     }
   }
   return {


### PR DESCRIPTION
`getSubcommand` currently returns the canonical subcommand name and rest args. But we'd like to also know if anyone is using the non-canonical formats at all.