### PR TITLE
[cli] Skip test that cannot pass

### DIFF
--- a/.changeset/brown-fans-boil.md
+++ b/.changeset/brown-fans-boil.md
@@ -1,0 +1,4 @@
+---
+---
+
+[cli] Skip test that cannot pass

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -112,7 +112,9 @@ afterAll(async () => {
   }
 });
 
-test('assign a domain to a project', async () => {
+// https://linear.app/vercel/issue/ZERO-2555/fix-or-skip-assign-a-domain-to-a-project-test
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('assign a domain to a project', async () => {
   const team = await teamPromise;
   const domain = `project-domain.${team.slug}.vercel.app`;
   const directory = await setupE2EFixture('static-deployment');

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -204,7 +204,9 @@ test('list the scopes', async () => {
   expect(stderr).toMatch(include);
 });
 
-test('domains inspect', async () => {
+// https://linear.app/vercel/issue/ZERO-2555/fix-assign-a-domain-to-a-project-test
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('domains inspect', async () => {
   const team = await teamPromise;
   const domainName = `inspect-${team.slug}-${Math.random()
     .toString()


### PR DESCRIPTION
We're not properly doing cleanup on a test so this has been slowly accumulating domains attached to a project. We hit the system enforced limit so until we add cleanup code this test can never pass. `skip`ing it temporarily.