### PR TITLE
[sdk] add sdk exports

### DIFF
--- a/.changeset/cold-gorillas-glow.md
+++ b/.changeset/cold-gorillas-glow.md
@@ -1,0 +1,5 @@
+---
+"@vercel/sdk": patch
+---
+
+add sdk exports

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,7 +35,47 @@
     "typescript": "^5.4.5",
     "zod": "^3.23.4"
   },
-  "dependencies": {
-    
-  }
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "import": {
+        "source": "./src/index.ts",
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "source": "./src/index.ts",
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./*.js": {
+      "import": {
+        "source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "source": "./src/*.ts",
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "source": "./src/*.ts",
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "type": "module"
 }


### PR DESCRIPTION
In `packages/sdk`, [tshy](https://www.npmjs.com/package/tshy) is updating the `package.json#exports` field on build. This was causing a dirty git status, [blocking release](https://github.com/vercel/vercel/actions/runs/10928286634/job/30336343279).

This PR commits that output.