### PR TITLE
Add `open-api.yaml` file codeowners

### DIFF
--- a/.changeset/light-toes-collect.md
+++ b/.changeset/light-toes-collect.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `open-api.yaml` file codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /packages/functions                      @vercel/compute
 /packages/firewall                       @cramforce @sueplex
 /packages/sdk                            @leerob @molebox
+/open-api.yaml                           @leerob @molebox
 /examples                                @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @leerob
 /examples/create-react-app               @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @Timer
 /examples/nextjs                         @ijjk @ztanner @huozhi


### PR DESCRIPTION
`open-api.yaml` is required for `packages/sdk` but needs to live at repo root. Giving it matching a CODEOWNERS entry.