### PR TITLE
[build-utils] Allow Node.js v22 behind env var

### DIFF
--- a/.changeset/rotten-donkeys-invent.md
+++ b/.changeset/rotten-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Allow Node.js v22 behind env var feature flag

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -42,6 +42,12 @@ export const NODE_VERSIONS: NodeVersion[] = [
 ];
 
 function getOptions() {
+  if (process.env.VERCEL_ALLOW_NODEJS22 === '1') {
+    return [
+      { major: 22, range: '22.x', runtime: 'nodejs22.x' },
+      ...NODE_VERSIONS,
+    ];
+  }
   return NODE_VERSIONS;
 }
 

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -311,6 +311,23 @@ it('should throw for discontinued versions', async () => {
   }
 });
 
+it('should only allow nodejs22.x when env var is set', async () => {
+  try {
+    expect(getLatestNodeVersion()).toHaveProperty('major', 20);
+    expect(getSupportedNodeVersion('22.x')).rejects.toThrow();
+
+    process.env.VERCEL_ALLOW_NODEJS22 = '1';
+
+    expect(getLatestNodeVersion()).toHaveProperty('major', 22);
+    expect(await getSupportedNodeVersion('22.x')).toHaveProperty('major', 22);
+    expect(await getSupportedNodeVersion('22')).toHaveProperty('major', 22);
+    expect(await getSupportedNodeVersion('22.1.0')).toHaveProperty('major', 22);
+    expect(await getSupportedNodeVersion('>=20')).toHaveProperty('major', 22);
+  } finally {
+    delete process.env.VERCEL_ALLOW_NODEJS22;
+  }
+});
+
 it('should warn for deprecated versions, soon to be discontinued', async () => {
   // Mock a future date so that Node 16 warns
   const realDateNow = Date.now;


### PR DESCRIPTION
Allows for Node.js v22 to be selected at build-time, but behind a feature flag for now for internal testing.