### PR TITLE
[cli] Unskip tests

### DIFF
--- a/.changeset/clean-cows-perform.md
+++ b/.changeset/clean-cows-perform.md
@@ -1,0 +1,4 @@
+---
+---
+
+[cli] Unskip tests

--- a/packages/cli/test/unit/commands/promote/index.test.ts
+++ b/packages/cli/test/unit/commands/promote/index.test.ts
@@ -15,7 +15,7 @@ import { vi } from 'vitest';
 vi.setConfig({ testTimeout: 60000 });
 
 describe('promote', () => {
-  describe.todo('[deployment id/url]', () => {
+  describe('[deployment id/url]', () => {
     describe.todo('--status');
     describe.todo('--timeout');
 


### PR DESCRIPTION
We had a `describe.todo` block and then moved some existing tests inside of it. This unintentionally skips those tests.