### PR TITLE
[cli] correctly call to create new deployment when promoting preview deployment

### DIFF
--- a/.changeset/violet-moles-float.md
+++ b/.changeset/violet-moles-float.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] correctly call to create new deployment when promoting preview deployment


### PR DESCRIPTION
We previously removed the behavior at the API of directly promoting a preview deployment to production. This corrects the CLI behavior to create a _new_ production deployment with user permission.

Also verified manually.