### PR TITLE
chore: set pnpm version for SDK generation action

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -25,6 +25,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       working_directory: packages/sdk
+      pnpm_version: "8.3.1"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
This change sets an explicit version of pnpm to install for the SDK generation action. 