### PR TITLE
[cli] add telemetry tracking to `alias ls`

### DIFF
--- a/.changeset/little-parrots-fry.md
+++ b/.changeset/little-parrots-fry.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] add telemetry tracking to `alias ls`

--- a/packages/cli/src/commands/alias/index.ts
+++ b/packages/cli/src/commands/alias/index.ts
@@ -8,6 +8,7 @@ import rm from './rm';
 import set from './set';
 import { aliasCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { AliasTelemetryClient } from '../../util/telemetry/commands/alias';
 
 const COMMAND_CONFIG = {
   default: ['set'],
@@ -17,6 +18,13 @@ const COMMAND_CONFIG = {
 };
 
 export default async function alias(client: Client) {
+  let telemetryClient = new AliasTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
+
   let parsedArguments;
 
   const flagsSpecification = getFlagsSpecification(aliasCommand.options);
@@ -33,13 +41,14 @@ export default async function alias(client: Client) {
     return 2;
   }
 
-  const { subcommand, args } = getSubcommand(
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
     parsedArguments.args.slice(1),
     COMMAND_CONFIG
   );
 
   switch (subcommand) {
     case 'ls':
+      telemetryClient.trackCliSubcommandLs(subcommandOriginal);
       return ls(client, parsedArguments.flags, args);
     case 'rm':
       return rm(client, parsedArguments.flags, args);

--- a/packages/cli/src/commands/alias/ls.ts
+++ b/packages/cli/src/commands/alias/ls.ts
@@ -11,6 +11,8 @@ import {
 import stamp from '../../util/output/stamp';
 import getCommandFlags from '../../util/get-command-flags';
 import { getCommandName } from '../../util/pkg-name';
+import { AliasLsTelemetryClient } from '../../util/telemetry/commands/alias/ls';
+
 import type { Alias } from '@vercel-internals/types';
 
 export default async function ls(
@@ -21,10 +23,20 @@ export default async function ls(
   const { output } = client;
   const { contextName } = await getScope(client);
 
+  const telemetryClient = new AliasLsTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
   let paginationOptions;
 
   try {
     paginationOptions = getPaginationOpts(opts);
+    let [next, limit] = paginationOptions;
+
+    telemetryClient.trackCliOptionNext(next);
+    telemetryClient.trackCliOptionLimit(limit);
   } catch (err: unknown) {
     output.prettyError(err);
     return 1;

--- a/packages/cli/src/util/telemetry/commands/alias/index.ts
+++ b/packages/cli/src/util/telemetry/commands/alias/index.ts
@@ -1,0 +1,10 @@
+import { TelemetryClient } from '../..';
+
+export class AliasTelemetryClient extends TelemetryClient {
+  trackCliSubcommandLs(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'ls',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/alias/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/alias/ls.ts
@@ -14,7 +14,7 @@ export class AliasLsTelemetryClient extends TelemetryClient {
     if (next) {
       this.trackCliOption({
         flag: 'next',
-        value: String(next),
+        value: '[REDACTED]',
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/alias/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/alias/ls.ts
@@ -1,0 +1,21 @@
+import { TelemetryClient } from '../..';
+
+export class AliasLsTelemetryClient extends TelemetryClient {
+  trackCliOptionLimit(limit?: number) {
+    if (limit) {
+      this.trackCliOption({
+        flag: 'limit',
+        value: String(limit),
+      });
+    }
+  }
+
+  trackCliOptionNext(next?: number) {
+    if (next) {
+      this.trackCliOption({
+        flag: 'next',
+        value: String(next),
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/alias/ls.test.ts
+++ b/packages/cli/test/unit/commands/alias/ls.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import { client } from '../../../mocks/client';
 import alias from '../../../../src/commands/alias';
 import { useUser } from '../../../mocks/user';
 import { useAlias } from '../../../mocks/alias';
 
 describe('alias ls', () => {
-  it('should list up to 20 aliases by default', async () => {
+  beforeEach(() => {
     useUser();
+  });
+
+  it('should list up to 20 aliases by default', async () => {
     useAlias();
     client.setArgv('alias', 'ls');
     const exitCodePromise = alias(client);
@@ -14,16 +17,51 @@ describe('alias ls', () => {
     await expect(client.stdout).toOutput('dummy-19.app');
   });
 
-  describe.todo('--next');
+  describe('--next', () => {
+    it('tracks subcommand and option values', async () => {
+      useAlias();
+      client.setArgv('alias', 'ls', '--next', '1727714910573');
+      const exitCodePromise = alias(client);
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: `subcommand:ls`,
+          value: 'ls',
+        },
+        {
+          key: `flag:next`,
+          value: '1727714910573',
+        },
+      ]);
+    });
+  });
 
   describe('--limit', () => {
     it('should list up to 2 aliases', async () => {
-      useUser();
       useAlias();
       client.setArgv('alias', 'ls', '--limit', '2');
       const exitCodePromise = alias(client);
       await expect(exitCodePromise).resolves.toEqual(0);
       await expect(client.stdout).toOutput('dummy-1.app');
+    });
+
+    it('tracks subcommand and option values', async () => {
+      useAlias();
+      client.setArgv('alias', 'ls', '--limit', '2');
+      const exitCodePromise = alias(client);
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: `subcommand:ls`,
+          value: 'ls',
+        },
+        {
+          key: `flag:limit`,
+          value: '2',
+        },
+      ]);
     });
   });
 });

--- a/packages/cli/test/unit/commands/alias/ls.test.ts
+++ b/packages/cli/test/unit/commands/alias/ls.test.ts
@@ -31,7 +31,7 @@ describe('alias ls', () => {
         },
         {
           key: `flag:next`,
-          value: '1727714910573',
+          value: '[REDACTED]',
         },
       ]);
     });


### PR DESCRIPTION
Part of a series of PRs to add telemetry to the Vercel CLI. This tracks the use of `vercel alias ls` and its options