### PR TITLE
Cleanup vitest matchers

### DIFF
--- a/.changeset/plenty-penguins-begin.md
+++ b/.changeset/plenty-penguins-begin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Cleanup vitest matchers

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -1,13 +1,18 @@
 import { expect } from 'vitest';
-import { toOutput, toHaveTelemetryEvents } from './matchers';
-
-interface ToOutputMatchers<R = unknown> {
-  toOutput: (test: string, timeout?: number) => Promise<R>;
-}
+import {
+  toOutput,
+  ToOutputMatchers,
+  toHaveTelemetryEvents,
+  ToHaveTelemetryEventsMatchers,
+} from './matchers';
 
 declare module 'vitest' {
+  // https://vitest.dev/guide/extending-matchers#extending-matchers
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface Assertion<T = any> extends ToOutputMatchers<T> {}
+  // https://vitest.dev/guide/extending-matchers#extending-matchers
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Assertion<T = any> extends ToHaveTelemetryEventsMatchers<T> {}
 }
 
 expect.extend({ toOutput, toHaveTelemetryEvents });

--- a/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
+++ b/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
@@ -5,8 +5,10 @@ import type { TelemetryEventStore } from '../../../src/util/telemetry';
 interface EventData {
   key: string;
   value: string;
-  sessionId: string;
-  id: string;
+}
+
+export interface ToHaveTelemetryEventsMatchers<R = unknown> {
+  toHaveTelemetryEvents: (test: EventData[], timeout?: number) => Promise<R>;
 }
 
 export function toHaveTelemetryEvents(

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -9,6 +9,10 @@ import type { MatcherState } from '@vitest/expect';
 import type { MatcherHintOptions } from 'jest-matcher-utils';
 import stripAnsi from 'strip-ansi';
 
+export interface ToOutputMatchers<R = unknown> {
+  toOutput: (test: string, timeout?: number) => Promise<R>;
+}
+
 export async function toOutput(
   this: MatcherState,
   stream: Readable,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,47 @@
     "typescript": "^5.4.5",
     "zod": "^3.23.4"
   },
-  "dependencies": {
-    
-  }
+  "dependencies": {},
+  "exports": {
+    ".": {
+      "import": {
+        "source": "./src/index.ts",
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "source": "./src/index.ts",
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./*.js": {
+      "import": {
+        "source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "source": "./src/*.ts",
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "source": "./src/*.ts",
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "type": "module"
 }


### PR DESCRIPTION
Add `ToHaveTelemetryEventsMatchers` to vitest types, reorganize matcher type exports