### PR TITLE
Cleanup vitest test matchers

### DIFF
--- a/.changeset/dirty-eels-vanish.md
+++ b/.changeset/dirty-eels-vanish.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clean up test matcher types

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -1,13 +1,18 @@
 import { expect } from 'vitest';
-import { toOutput, toHaveTelemetryEvents } from './matchers';
-
-interface ToOutputMatchers<R = unknown> {
-  toOutput: (test: string, timeout?: number) => Promise<R>;
-}
+import {
+  toOutput,
+  ToOutputMatchers,
+  toHaveTelemetryEvents,
+  ToHaveTelemetryEventsMatchers,
+} from './matchers';
 
 declare module 'vitest' {
+  // https://vitest.dev/guide/extending-matchers#extending-matchers
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface Assertion<T = any> extends ToOutputMatchers<T> {}
+  // https://vitest.dev/guide/extending-matchers#extending-matchers
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Assertion<T = any> extends ToHaveTelemetryEventsMatchers<T> {}
 }
 
 expect.extend({ toOutput, toHaveTelemetryEvents });

--- a/packages/cli/test/mocks/matchers/index.ts
+++ b/packages/cli/test/mocks/matchers/index.ts
@@ -1,18 +1,14 @@
 import { expect } from 'vitest';
 import {
-  toOutput,
-  ToOutputMatchers,
   toHaveTelemetryEvents,
   ToHaveTelemetryEventsMatchers,
-} from './matchers';
+} from './to-have-telemetry-events';
+import { toOutput, ToOutputMatchers } from './to-output';
 
 declare module 'vitest' {
-  // https://vitest.dev/guide/extending-matchers#extending-matchers
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface Assertion<T = any> extends ToOutputMatchers<T> {}
-  // https://vitest.dev/guide/extending-matchers#extending-matchers
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface Assertion<T = any> extends ToHaveTelemetryEventsMatchers<T> {}
+  interface Assertion<T = any>
+    extends ToOutputMatchers<T>,
+      ToHaveTelemetryEventsMatchers<T> {}
 }
 
 expect.extend({ toOutput, toHaveTelemetryEvents });

--- a/packages/cli/test/mocks/matchers/matchers.ts
+++ b/packages/cli/test/mocks/matchers/matchers.ts
@@ -1,2 +1,0 @@
-export * from './to-output';
-export * from './to-have-telemetry-events';

--- a/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
+++ b/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
@@ -5,8 +5,10 @@ import type { TelemetryEventStore } from '../../../src/util/telemetry';
 interface EventData {
   key: string;
   value: string;
-  sessionId: string;
-  id: string;
+}
+
+export interface ToHaveTelemetryEventsMatchers<R = unknown> {
+  toHaveTelemetryEvents: (test: EventData[], timeout?: number) => Promise<R>;
 }
 
 export function toHaveTelemetryEvents(

--- a/packages/cli/test/mocks/matchers/to-output.ts
+++ b/packages/cli/test/mocks/matchers/to-output.ts
@@ -9,6 +9,10 @@ import type { MatcherState } from '@vitest/expect';
 import type { MatcherHintOptions } from 'jest-matcher-utils';
 import stripAnsi from 'strip-ansi';
 
+export interface ToOutputMatchers<R = unknown> {
+  toOutput: (test: string, timeout?: number) => Promise<R>;
+}
+
 export async function toOutput(
   this: MatcherState,
   stream: Readable,


### PR DESCRIPTION
Add `ToHaveTelemetryEventsMatchers` to vitest types, reorganize matcher type exports