### PR TITLE
[cli] Don't send telemetry if debugging

### DIFF
--- a/.changeset/new-poets-divide.md
+++ b/.changeset/new-poets-divide.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Don't send telemetry if debugging

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -184,7 +184,10 @@ export class TelemetryEventStore {
       this.events.forEach(event => {
         this.output.log(JSON.stringify(event));
       });
+
+      return;
     }
+
     if (this.enabled()) {
       // send events to the server
     }


### PR DESCRIPTION
I can't think of a straightforward way to test this because the unit tests use mocks and the mock store has its own `save` implementation.