### PR TITLE
[cli] set telemetry enabled to false with `$VERCEL_TELEMETRY_DISABLED`

### DIFF
--- a/.changeset/rude-waves-check.md
+++ b/.changeset/rude-waves-check.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] set telemetry enabled to false with VERCEL_TELEMETRY_DISABLED

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -173,6 +173,10 @@ export class TelemetryEventStore {
   }
 
   enabled() {
+    if (process.env.VERCEL_TELEMETRY_DISABLED) {
+      return false;
+    }
+
     return this.config?.enabled === false ? false : true;
   }
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -172,7 +172,7 @@ export class TelemetryEventStore {
     this.events = [];
   }
 
-  enabled() {
+  get enabled() {
     if (process.env.VERCEL_TELEMETRY_DISABLED) {
       return false;
     }
@@ -189,7 +189,7 @@ export class TelemetryEventStore {
         this.output.log(JSON.stringify(event));
       });
     }
-    if (this.enabled()) {
+    if (this.enabled) {
       // send events to the server
     }
   }

--- a/packages/cli/test/unit/index.test.ts
+++ b/packages/cli/test/unit/index.test.ts
@@ -45,6 +45,7 @@ describe('main', () => {
         { key: 'cpu_count', value: '1' },
       ]);
     });
+
     it('tracks platform', () => {
       vi.spyOn(os, 'platform').mockImplementation(() => 'linux');
       const output = new Output(process.stderr, {
@@ -68,6 +69,7 @@ describe('main', () => {
         { key: 'platform', value: 'linux' },
       ]);
     });
+
     it('tracks arch', () => {
       vi.spyOn(os, 'arch').mockImplementation(() => 'x86');
       const output = new Output(process.stderr, {
@@ -137,6 +139,28 @@ describe('main', () => {
         expect(telemetryEventStore).toHaveTelemetryEvents([
           { key: 'version', value: '1.0.0' },
         ]);
+      });
+    });
+
+    describe('tracking enabled', () => {
+      it('is false when VERCEL_TELEMETRY_DISABLED set', () => {
+        const configThatWillBeIgnoredAnyway = {
+          enabled: true,
+        };
+
+        vi.stubEnv('VERCEL_TELEMETRY_DISABLED', '1');
+        const output = new Output(process.stderr, {
+          debug: true,
+          noColor: false,
+        });
+
+        const telemetryEventStore = new TelemetryEventStore({
+          isDebug: true,
+          output,
+          config: configThatWillBeIgnoredAnyway,
+        });
+
+        expect(telemetryEventStore.enabled).toBe(false);
       });
     });
 


### PR DESCRIPTION
When `$VERCEL_TELEMETRY_DISABLED` the store is disabled even if configuration is `true`