### PR TITLE
[cli] Remove incorrect --output docs for `vercel certs`

### DIFF
--- a/.changeset/twenty-swans-lick.md
+++ b/.changeset/twenty-swans-lick.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Remove incorrect --output docs for `vercel certs`

--- a/packages/cli/src/commands/certs/command.ts
+++ b/packages/cli/src/commands/certs/command.ts
@@ -89,7 +89,6 @@ export const certsCommand = {
       description: 'Show next page of results',
     },
     { name: 'overwrite', shorthand: null, type: Boolean, deprecated: false },
-    { name: 'output', shorthand: null, type: String, deprecated: false },
   ],
   examples: [
     {


### PR DESCRIPTION
This option is not used in `vercel certs`. Probably copy/paste error or we removed the usage ages ago and left this bit in.