### PR TITLE
[functions] decode city name

### DIFF
--- a/.changeset/thick-bottles-lick.md
+++ b/.changeset/thick-bottles-lick.md
@@ -1,0 +1,5 @@
+---
+"@vercel/functions": patch
+---
+
+[functions] decode city name

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -59,7 +59,7 @@ The location information of the request, in this way:
 
 #### Defined in
 
-[packages/functions/src/headers.ts:158](https://github.com/vercel/vercel/blob/main/packages/functions/src/headers.ts#L158)
+[packages/functions/src/headers.ts:166](https://github.com/vercel/vercel/blob/main/packages/functions/src/headers.ts#L166)
 
 ---
 
@@ -144,7 +144,7 @@ The IP address of the request.
 
 #### Defined in
 
-[packages/functions/src/headers.ts:111](https://github.com/vercel/vercel/blob/main/packages/functions/src/headers.ts#L111)
+[packages/functions/src/headers.ts:119](https://github.com/vercel/vercel/blob/main/packages/functions/src/headers.ts#L119)
 
 ---
 

--- a/packages/functions/src/headers.ts
+++ b/packages/functions/src/headers.ts
@@ -74,6 +74,14 @@ function getHeader(request: Request, key: string): string | undefined {
   return request.headers.get(key) ?? undefined;
 }
 
+function getHeaderWithDecode(
+  request: Request,
+  key: string
+): string | undefined {
+  const header = getHeader(request, key);
+  return header ? decodeURIComponent(header) : undefined;
+}
+
 /**
  * Converts the 2 digit countryCode into a flag emoji by adding the current character value to the emoji flag unicode starting position. See [Country Code to Flag Emoji](https://dev.to/jorik/country-code-to-flag-emoji-a21) by Jorik Tangelder.
  *
@@ -157,7 +165,8 @@ function getRegionFromRequestId(requestId?: string): string | undefined {
  */
 export function geolocation(request: Request): Geo {
   return {
-    city: getHeader(request, CITY_HEADER_NAME),
+    // city name may be encoded to support multi-byte characters
+    city: getHeaderWithDecode(request, CITY_HEADER_NAME),
     country: getHeader(request, COUNTRY_HEADER_NAME),
     flag: getFlag(getHeader(request, COUNTRY_HEADER_NAME)),
     countryRegion: getHeader(request, REGION_HEADER_NAME),

--- a/packages/functions/test/unit/headers.test.ts
+++ b/packages/functions/test/unit/headers.test.ts
@@ -121,4 +121,27 @@ describe('`geolocation`', () => {
       countryRegion: '13',
     });
   });
+
+  test('reads values from headers (city with multi-byte chars)', () => {
+    const req = new Request('https://example.vercel.sh', {
+      headers: {
+        // São Paulo
+        [CITY_HEADER_NAME]: 'S%C3%A3o%20Paulo',
+        [COUNTRY_HEADER_NAME]: 'BR',
+        [LATITUDE_HEADER_NAME]: '-23.6283',
+        [LONGITUDE_HEADER_NAME]: '-46.6409',
+        [REGION_HEADER_NAME]: 'SP',
+        [REQUEST_ID_HEADER_NAME]: 'gru1::kpwjx-123455678-c0ffee',
+      },
+    });
+    expect(geolocation(req)).toEqual<Geo>({
+      city: 'São Paulo',
+      flag: '🇧🇷',
+      country: 'BR',
+      latitude: '-23.6283',
+      longitude: '-46.6409',
+      region: 'gru1',
+      countryRegion: 'SP',
+    });
+  });
 });


### PR DESCRIPTION
`x-vercel-ip-city` value from downstream may be encoded to support multi-byte characters. Adding a helper function to decode such value transparently to users.