### PR TITLE
[cli] track invocation of `vercel alias *`

### DIFF
--- a/.changeset/heavy-pens-report.md
+++ b/.changeset/heavy-pens-report.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] track invocation of `vercel alias *`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -554,6 +554,7 @@ const main = async () => {
       let func: any;
       switch (targetCommand) {
         case 'alias':
+          telemetry.trackCliCommandAlias(userSuppliedSubCommand);
           func = require('./commands/alias').default;
           break;
         case 'bisect':

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -8,6 +8,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandAlias(actual: string) {
+    this.trackCliCommand({
+      command: 'alias',
+      value: actual,
+    });
+  }
+
   trackCPUs() {
     super.trackCPUs();
   }


### PR DESCRIPTION
I missed this as part of https://github.com/vercel/vercel/pull/12194. Tests didn't catch this because we can't test `main()` in the current setup 🙃 