### PR TITLE
Fix corepack packageManager detection on monorepos

### DIFF
--- a/.changeset/loud-hounds-travel.md
+++ b/.changeset/loud-hounds-travel.md
@@ -1,0 +1,10 @@
+---
+'@vercel/static-build': patch
+'@vercel/build-utils': patch
+'@vercel/hydrogen': patch
+'@vercel/redwood': patch
+'@vercel/remix-builder': patch
+'@vercel/next': patch
+---
+
+Fix corepack `packageManager` detection on monorepos

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -62,6 +62,12 @@ export interface ScanParentDirsResult {
    */
   lockfileVersion?: number;
   /**
+   * The contents of the `packageManager` field from `package.json` if found.
+   * The value may come from a different `package.json` file than the one
+   * specified by `packageJsonPath`, in the case of a monorepo.
+   */
+  packageJsonPackageManager?: string;
+  /**
    * Whether Turborepo supports the `COREPACK_HOME` environment variable.
    * `undefined` if not a Turborepo project.
    */
@@ -348,17 +354,19 @@ export async function scanParentDirs(
     readPackageJson && pkgJsonPath
       ? JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'))
       : undefined;
-  const [yarnLockPath, npmLockPath, pnpmLockPath, bunLockPath] =
-    await walkParentDirsMulti({
-      base,
-      start: destPath,
-      filenames: [
-        'yarn.lock',
-        'package-lock.json',
-        'pnpm-lock.yaml',
-        'bun.lockb',
-      ],
-    });
+  const {
+    paths: [yarnLockPath, npmLockPath, pnpmLockPath, bunLockPath],
+    packageJsonPackageManager,
+  } = await walkParentDirsMulti({
+    base,
+    start: destPath,
+    filenames: [
+      'yarn.lock',
+      'package-lock.json',
+      'pnpm-lock.yaml',
+      'bun.lockb',
+    ],
+  });
   let lockfilePath: string | undefined;
   let lockfileVersion: number | undefined;
   let cliType: CliType;
@@ -413,19 +421,17 @@ export async function scanParentDirs(
     // TODO: read "bun-lockfile-format-v0"
     lockfileVersion = 0;
   } else {
-    cliType =
-      packageJson && rootProjectInfo
-        ? detectPackageManagerNameWithoutLockfile(
-            packageJson,
-            turboSupportsCorepackHome
-          )
-        : 'npm';
+    cliType = detectPackageManagerNameWithoutLockfile(
+      packageJsonPackageManager,
+      turboSupportsCorepackHome
+    );
   }
 
   const packageJsonPath = pkgJsonPath || undefined;
   return {
     cliType,
     packageJson,
+    packageJsonPackageManager,
     lockfilePath,
     lockfileVersion,
     packageJsonPath,
@@ -471,10 +477,9 @@ export function turboVersionSpecifierSupportsCorepack(
 }
 
 function detectPackageManagerNameWithoutLockfile(
-  packageJson: PackageJson,
+  packageJsonPackageManager: string | undefined,
   turboSupportsCorepackHome: boolean | undefined
 ) {
-  const packageJsonPackageManager = packageJson.packageManager;
   if (
     usingCorepack(
       process.env,
@@ -546,20 +551,35 @@ async function walkParentDirsMulti({
   base,
   start,
   filenames,
-}: WalkParentDirsMultiProps): Promise<(string | undefined)[]> {
+}: WalkParentDirsMultiProps): Promise<{
+  paths: (string | undefined)[];
+  packageJsonPackageManager?: string;
+}> {
+  let packageManager: string | undefined;
+
   for (const dir of traverseUpDirectories({ start, base })) {
     const fullPaths = filenames.map(f => path.join(dir, f));
     const existResults = await Promise.all(
       fullPaths.map(f => fs.pathExists(f))
     );
     const foundOneOrMore = existResults.some(b => b);
+    const packageJsonPath = path.join(dir, 'package.json');
+    const packageJson: PackageJson | null = await fs
+      .readJSON(packageJsonPath)
+      .catch(() => null);
+    if (packageJson?.packageManager) {
+      packageManager = packageJson.packageManager;
+    }
 
     if (foundOneOrMore) {
-      return fullPaths.map((f, i) => (existResults[i] ? f : undefined));
+      return {
+        paths: fullPaths.map((f, i) => (existResults[i] ? f : undefined)),
+        packageJsonPackageManager: packageManager,
+      };
     }
   }
 
-  return [];
+  return { paths: [], packageJsonPackageManager: packageManager };
 }
 
 function isSet<T>(v: any): v is Set<T> {
@@ -587,6 +607,7 @@ export async function runNpmInstall(
       packageJsonPath,
       packageJson,
       lockfileVersion,
+      packageJsonPackageManager,
       turboSupportsCorepackHome,
     } = await scanParentDirs(destPath, true);
 
@@ -623,7 +644,7 @@ export async function runNpmInstall(
     opts.env = getEnvForPackageManager({
       cliType,
       lockfileVersion,
-      packageJsonPackageManager: packageJson?.packageManager,
+      packageJsonPackageManager,
       nodeVersion,
       env,
       packageJsonEngines: packageJson?.engines,
@@ -1163,12 +1184,17 @@ export async function runCustomInstallCommand({
   spawnOpts?: SpawnOptions;
 }) {
   console.log(`Running "install" command: \`${installCommand}\`...`);
-  const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-    await scanParentDirs(destPath, true);
+  const {
+    cliType,
+    lockfileVersion,
+    packageJson,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(destPath, true);
   const env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts?.env || {},
     packageJsonEngines: packageJson?.engines,
@@ -1189,8 +1215,13 @@ export async function runPackageJsonScript(
 ) {
   assert(path.isAbsolute(destPath));
 
-  const { packageJson, cliType, lockfileVersion, turboSupportsCorepackHome } =
-    await scanParentDirs(destPath, true);
+  const {
+    packageJson,
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(destPath, true);
   const scriptName = getScriptName(
     packageJson,
     typeof scriptNames === 'string' ? [scriptNames] : scriptNames
@@ -1206,7 +1237,7 @@ export async function runPackageJsonScript(
     env: getEnvForPackageManager({
       cliType,
       lockfileVersion,
-      packageJsonPackageManager: packageJson?.packageManager,
+      packageJsonPackageManager,
       nodeVersion: undefined,
       env: cloneEnv(process.env, spawnOpts?.env),
       packageJsonEngines: packageJson?.engines,

--- a/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/a/package.json
+++ b/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/a/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "a21",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "^4.3.2"
+  }
+}

--- a/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/b/package.json
+++ b/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "b21",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cowsay": "^1.5.0"
+  }
+}

--- a/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/package.json
+++ b/packages/build-utils/test/fixtures/41-npm-workspaces-corepack/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "41-npm-workspaces-corepack",
+  "version": "1.0.0",
+  "packageManager": "npm@10.7.0",
+  "workspaces": [
+    "a",
+    "b"
+  ]
+}

--- a/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/c/package.json
+++ b/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/c/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "build-c23",
+  "license": "MIT",
+  "version": "0.1.0"
+}

--- a/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/d/package.json
+++ b/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/d/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "build-d23",
+  "license": "MIT",
+  "version": "0.1.0",
+  "devDependencies": {
+    "once": "1.4.0"
+  }
+}

--- a/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/package.json
+++ b/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "42-pnpm-workspaces-corepack",
+  "packageManager": "pnpm@8.3.1",
+  "license": "MIT",
+  "version": "1.0.0"
+}

--- a/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/pnpm-workspace.yaml
+++ b/packages/build-utils/test/fixtures/42-pnpm-workspaces-corepack/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'c'
+  - 'd'

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -836,6 +836,41 @@ it('should detect non-turborepo monorepo', async () => {
   expect(result.turboSupportsCorepackHome).toEqual(undefined);
 });
 
+it('should detect `packageManager` in npm monorepo', async () => {
+  try {
+    process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
+
+    const base = path.join(__dirname, 'fixtures', '41-npm-workspaces-corepack');
+    const fixture = path.join(base, 'a');
+    const result = await scanParentDirs(fixture, false, base);
+    expect(result.cliType).toEqual('npm');
+    expect(result.packageJsonPackageManager).toEqual('npm@10.7.0');
+    expect(result.lockfileVersion).toEqual(undefined);
+    expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
+  } finally {
+    delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
+  }
+});
+
+it('should detect `packageManager` in pnpm monorepo', async () => {
+  try {
+    process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
+    const base = path.join(
+      __dirname,
+      'fixtures',
+      '42-pnpm-workspaces-corepack'
+    );
+    const fixture = path.join(base, 'c');
+    const result = await scanParentDirs(fixture, false, base);
+    expect(result.cliType).toEqual('pnpm');
+    expect(result.packageJsonPackageManager).toEqual('pnpm@8.3.1');
+    expect(result.lockfileVersion).toEqual(undefined);
+    expect(result.packageJsonPath).toEqual(path.join(fixture, 'package.json'));
+  } finally {
+    delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
+  }
+});
+
 it('should retry npm install when peer deps invalid and npm@8 on node@16', async () => {
   const nodeMajor = Number(process.versions.node.split('.')[0]);
   if (nodeMajor !== 16) {

--- a/packages/hydrogen/src/build.ts
+++ b/packages/hydrogen/src/build.ts
@@ -51,13 +51,17 @@ export const build: BuildV2 = async ({
   );
 
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
-  const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-    await scanParentDirs(entrypointDir, true);
+  const {
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(entrypointDir, true);
 
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts.env || {},
     turboSupportsCorepackHome,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -261,13 +261,17 @@ export const build: BuildV2 = async buildOptions => {
   const nextVersionRange = await getNextVersionRange(entryPath);
   const nodeVersion = await getNodeVersion(entryPath, undefined, config, meta);
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
-  const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-    await scanParentDirs(entryPath, true);
+  const {
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(entryPath, true);
 
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts.env || {},
     turboSupportsCorepackHome,

--- a/packages/redwood/src/index.ts
+++ b/packages/redwood/src/index.ts
@@ -79,13 +79,17 @@ export const build: BuildV2 = async ({
   if (!spawnOpts.env) {
     spawnOpts.env = {};
   }
-  const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-    await scanParentDirs(entrypointFsDirname, true);
+  const {
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(entrypointFsDirname, true);
 
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts.env || {},
     turboSupportsCorepackHome,

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -107,9 +107,9 @@ export const build: BuildV2 = async ({
   const {
     cliType,
     packageJsonPath,
-    packageJson,
     lockfileVersion,
     lockfilePath,
+    packageJsonPackageManager,
     turboSupportsCorepackHome,
   } = await scanParentDirs(entrypointFsDirname, true);
 
@@ -131,7 +131,7 @@ export const build: BuildV2 = async ({
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts.env,
     turboSupportsCorepackHome,

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -86,8 +86,13 @@ export const build: BuildV2 = async ({
     meta
   );
 
-  const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-    await scanParentDirs(entrypointFsDirname, true);
+  const {
+    cliType,
+    lockfileVersion,
+    packageJson,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(entrypointFsDirname, true);
 
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
   if (!spawnOpts.env) {
@@ -97,7 +102,7 @@ export const build: BuildV2 = async ({
   spawnOpts.env = getEnvForPackageManager({
     cliType,
     lockfileVersion,
-    packageJsonPackageManager: packageJson?.packageManager,
+    packageJsonPackageManager,
     nodeVersion,
     env: spawnOpts.env,
     turboSupportsCorepackHome,

--- a/packages/static-build/src/index.ts
+++ b/packages/static-build/src/index.ts
@@ -482,13 +482,17 @@ export const build: BuildV2 = async ({
       spawnOpts.env.CI = 'false';
     }
 
-    const { cliType, lockfileVersion, packageJson, turboSupportsCorepackHome } =
-      await scanParentDirs(entrypointDir, true);
+    const {
+      cliType,
+      lockfileVersion,
+      packageJsonPackageManager,
+      turboSupportsCorepackHome,
+    } = await scanParentDirs(entrypointDir, true);
 
     spawnOpts.env = getEnvForPackageManager({
       cliType,
       lockfileVersion,
-      packageJsonPackageManager: packageJson?.packageManager,
+      packageJsonPackageManager,
       nodeVersion,
       env: spawnOpts.env || {},
       turboSupportsCorepackHome,


### PR DESCRIPTION
This was reverted in https://github.com/vercel/vercel/pull/12242 to attempt fixing a semver parsing error, but the problem was actually https://github.com/vercel/vercel/pull/12249.

https://vercel.slack.com/archives/C07R9QVM5L1/p1728490597868659