### PR TITLE
[next] Patch for missing Prefetch RSC configurations

### DIFF
--- a/.changeset/yellow-kings-march.md
+++ b/.changeset/yellow-kings-march.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Backport Partial Prerendering fix for older Next.js versions (see https://github.com/vercel/next.js/pull/66102)

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2152,6 +2152,19 @@ export const onPrerenderRoute =
       } = pr);
     }
 
+    // Prior to v14.3.0-canary.78, prefetchDataRoute was not set for all the app
+    // path routes, and was only set for routes with PPR enabled. This affects
+    // all apps that use incremental PPR with an older version of Next.js. This
+    // patches the prefetchDataRoute for those apps.
+    if (
+      isAppPPREnabled &&
+      !prefetchDataRoute &&
+      dataRoute &&
+      dataRoute.endsWith('.rsc')
+    ) {
+      prefetchDataRoute = dataRoute.replace(/\.rsc$/, RSC_PREFETCH_SUFFIX);
+    }
+
     let isAppPathRoute = false;
 
     // `renderingMode === RenderingMode.PARTIALLY_STATIC` signals app path route
@@ -2273,6 +2286,7 @@ export const onPrerenderRoute =
               ),
             });
     }
+
     const jsonFsRef =
       // JSON data does not exist for fallback or blocking pages
       isFallback || isBlocking || (isNotFound && !static404Page) || !dataRoute
@@ -2293,7 +2307,7 @@ export const onPrerenderRoute =
                       // be from the prefetch data route. If this isn't enabled
                       // for ppr, the only way to get the data is from the data
                       // route.
-                      renderingMode === RenderingMode.PARTIALLY_STATIC
+                      isAppPPREnabled
                       ? prefetchDataRoute
                       : dataRoute
                     : routeFileNoExt + '.json'

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/app/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/app/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/index.test.js
@@ -1,0 +1,9 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    ppr: true,
+  },
+};

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/package.json
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "14.3.0-canary.58",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/fixtures/00-app-dir-legacy-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-legacy-ppr/vercel.json
@@ -1,0 +1,25 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next",
+      "config": {
+        "functions": {
+          "app/**/*": {
+            "maxDuration": 5,
+            "memory": 512
+          }
+        }
+      }
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "responseHeaders": {
+        "Content-Type": "text/html; charset=utf-8"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For older Next.js versions (before v14.3.0-canary.78) the `prefetchRSC` field was not correctly emitted, this patches this when it should be required (see https://github.com/vercel/next.js/pull/66102).
