### PR TITLE
[next] Partial Prerendering Fallback Shells

### DIFF
--- a/.changeset/metal-flies-check.md
+++ b/.changeset/metal-flies-check.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Partial Prerendering Fallback Shells now respect the revalidate config and now do not produce route shells on-demand.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -952,6 +952,7 @@ export type NextPrerenderedRoutes = {
       fallback: string;
       fallbackStatus?: number;
       fallbackHeaders?: Record<string, string>;
+      fallbackRevalidate?: number | false;
       routeRegex: string;
       dataRoute: string | null;
       dataRouteRegex: string | null;
@@ -1190,6 +1191,7 @@ export async function getPrerenderManifest(
             fallback: string | false;
             fallbackStatus?: number;
             fallbackHeaders?: Record<string, string>;
+            fallbackRevalidate: number | false | undefined;
             dataRoute: string | null;
             dataRouteRegex: string | null;
             prefetchDataRoute: string | null | undefined;
@@ -1327,6 +1329,7 @@ export async function getPrerenderManifest(
         let fallbackStatus: undefined | number;
         let fallbackHeaders: undefined | Record<string, string>;
         let renderingMode: RenderingMode = RenderingMode.STATIC;
+        let fallbackRevalidate: number | false | undefined;
 
         if (manifest.version === 4) {
           experimentalBypassFor =
@@ -1344,6 +1347,8 @@ export async function getPrerenderManifest(
             (manifest.dynamicRoutes[lazyRoute].experimentalPPR
               ? RenderingMode.PARTIALLY_STATIC
               : RenderingMode.STATIC);
+          fallbackRevalidate =
+            manifest.dynamicRoutes[lazyRoute].fallbackRevalidate;
         }
 
         if (typeof fallback === 'string') {
@@ -1357,6 +1362,7 @@ export async function getPrerenderManifest(
             dataRouteRegex,
             prefetchDataRoute,
             prefetchDataRouteRegex,
+            fallbackRevalidate,
             renderingMode,
           };
         } else if (fallback === null) {
@@ -2161,7 +2167,7 @@ export const onPrerenderRoute =
       // When the route has PPR enabled and has a fallback defined, we should
       // read the value from the manifest and use it as the value for the route.
       if (isFallback) {
-        const { fallbackStatus, fallbackHeaders } =
+        const { fallbackStatus, fallbackHeaders, fallbackRevalidate } =
           prerenderManifest.fallbackRoutes[routeKey];
 
         if (fallbackStatus) {
@@ -2170,6 +2176,15 @@ export const onPrerenderRoute =
 
         if (fallbackHeaders) {
           initialHeaders = fallbackHeaders;
+        }
+
+        // If we're rendering with PPR and as this is a fallback, we should use
+        // the revalidation time to also apply to the fallback shell.
+        if (
+          renderingMode === RenderingMode.PARTIALLY_STATIC &&
+          typeof fallbackRevalidate !== 'undefined'
+        ) {
+          initialRevalidate = fallbackRevalidate;
         }
       }
     }
@@ -2452,7 +2467,13 @@ export const onPrerenderRoute =
       if (isEmptyAllowQueryForPrendered) {
         const isDynamic = isDynamicRoute(routeKey);
 
-        if (!isDynamic) {
+        // If this is a page being rendered with PPR and it's the fallback, then
+        // we shouldn't allow any dynamic parameters to poison the cache during
+        // revalidation and should instead just use the fallback until it needs
+        // to get revalidated in the background.
+        if (renderingMode === RenderingMode.PARTIALLY_STATIC && isFallback) {
+          allowQuery = [];
+        } else if (!isDynamic) {
           // for non-dynamic routes we use an empty array since
           // no query values bust the cache for non-dynamic prerenders
           // prerendered paths also do not pass allowQuery as they match

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/dynamic/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/dynamic/page.jsx
@@ -5,7 +5,9 @@ function Agent() {
   return <div data-agent>{headers().get('user-agent')}</div>;
 }
 
-export default function Page({ params: { slug } }) {
+export default async function Page(props) {
+  const { slug } = await props.params;
+
   return (
     <>
       <div data-page>This is the validation page: {slug}</div>

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/layout.jsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return children
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'static-01' }, { slug: 'static-02' }]
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/page.jsx
@@ -1,3 +1,5 @@
-export default function Page({ params }) {
-  return <div data-page>This is the validation page: {params.slug}</div>;
+export default async function Page(props) {
+  const { slug } = await props.params;
+
+  return <div data-page>This is the validation page: {slug}</div>;
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/dynamic/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/dynamic/page.jsx
@@ -1,0 +1,21 @@
+import { headers } from 'next/headers';
+import { Suspense } from 'react';
+
+function Agent() {
+  return <div data-agent>{headers().get('user-agent')}</div>;
+}
+
+export default async function Page(props) {
+  const { slug } = await props.params;
+
+  return (
+    <>
+      <div data-page data-slug={slug}>
+        This is the validation page: {slug}
+      </div>
+      <Suspense>
+        <Agent />
+      </Suspense>
+    </>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/layout.jsx
@@ -1,0 +1,7 @@
+export async function generateStaticParams() {
+  return [{ slug: 'static-01' }, { slug: 'static-02' }];
+}
+
+export default function Layout({ children }) {
+  return children;
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/loading.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-loading>Loading...</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/poison/[slug]/page.jsx
@@ -1,0 +1,9 @@
+export default async function Page(props) {
+  const { slug } = await props.params;
+
+  return (
+    <div data-page data-slug={slug}>
+      This is the validation page: {slug}
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -208,7 +208,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     );
   });
 
-  describe('fallback should be used correctly', () => {
+  describe.only('fallback should be used correctly', () => {
     const assertRouteShell = $ => {
       expect($('[data-page]').closest('[hidden]')).toHaveLength(0);
     };
@@ -284,7 +284,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     it('should serve the fallback shell for new pages', async () => {
       let res = await fetch(`${ctx.deploymentUrl}/fallback/second/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
+      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
       let html = await res.text();
       let $ = cheerio.load(html);
@@ -304,7 +304,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
       res = await fetch(`${ctx.deploymentUrl}/fallback/third/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
+      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
       html = await res.text();
       $ = cheerio.load(html);
@@ -326,7 +326,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     it('should revalidate the pages and perform a blocking render when the fallback is revalidated', async () => {
       let res = await fetch(`${ctx.deploymentUrl}/fallback/fourth/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
+      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
       let html = await res.text();
       let $ = cheerio.load(html);
@@ -363,7 +363,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
       res = await fetch(`${ctx.deploymentUrl}/fallback/fifth/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
+      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
       html = await res.text();
       $ = cheerio.load(html);

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -266,7 +266,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
         html = await res.text();
         $ = cheerio.load(html);
-        assertRouteShell($);
+        assertFallbackShell($);
       });
     });
 
@@ -326,7 +326,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     it('should revalidate the pages and perform a blocking render when the fallback is revalidated', async () => {
       let res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
+      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
 
       let html = await res.text();
       let $ = cheerio.load(html);
@@ -364,7 +364,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       // The remaining requests should be cached.
       res = await fetch(`${ctx.deploymentUrl}/fallback/static-02/dynamic`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
+      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
 
       html = await res.text();
       $ = cheerio.load(html);

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -208,7 +208,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     );
   });
 
-  describe.only('fallback should be used correctly', () => {
+  describe('fallback should be used correctly', () => {
     const assertRouteShell = $ => {
       expect($('[data-page]').closest('[hidden]')).toHaveLength(0);
     };

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -253,7 +253,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     it('should use the route shell on the second request', async () => {
       let res = await fetch(`${ctx.deploymentUrl}/fallback/second`);
       expect(res.status).toEqual(200);
-      expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');
+      expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
       let html = await res.text();
       let $ = cheerio.load(html);
@@ -298,7 +298,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
         html = await res.text();
         $ = cheerio.load(html);
-        assertRouteShell($);
+        assertFallbackShell($);
         assertDynamicPostponed($);
       });
 
@@ -318,13 +318,13 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
         html = await res.text();
         $ = cheerio.load(html);
-        assertRouteShell($);
+        assertFallbackShell($);
         assertDynamicPostponed($);
       });
     });
 
     it('should revalidate the pages and perform a blocking render when the fallback is revalidated', async () => {
-      let res = await fetch(`${ctx.deploymentUrl}/fallback/fourth/dynamic`);
+      let res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
       expect(res.status).toEqual(200);
       expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
@@ -333,7 +333,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       assertFallbackShell($);
 
       await retry(async () => {
-        res = await fetch(`${ctx.deploymentUrl}/fallback/fourth/dynamic`);
+        res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
         expect(res.status).toEqual(200);
         expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
@@ -344,7 +344,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
       // Send the revalidation request.
       res = await fetch(
-        `${ctx.deploymentUrl}/api/revalidate/fallback/fourth/dynamic`,
+        `${ctx.deploymentUrl}/api/revalidate/fallback/static-01/dynamic`,
         {
           method: 'DELETE',
         }
@@ -352,7 +352,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       expect(res.status).toEqual(200);
 
       await retry(async () => {
-        res = await fetch(`${ctx.deploymentUrl}/fallback/fourth/dynamic`);
+        res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
         expect(res.status).toEqual(200);
         expect(res.headers.get('x-vercel-cache')).toMatch(/REVALIDATED|STALE/);
 
@@ -361,7 +361,8 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         assertRouteShell($);
       });
 
-      res = await fetch(`${ctx.deploymentUrl}/fallback/fifth/dynamic`);
+      // The remaining requests should be cached.
+      res = await fetch(`${ctx.deploymentUrl}/fallback/static-02/dynamic`);
       expect(res.status).toEqual(200);
       expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 
@@ -371,7 +372,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       assertDynamicPostponed($);
 
       await retry(async () => {
-        res = await fetch(`${ctx.deploymentUrl}/fallback/fifth/dynamic`);
+        res = await fetch(`${ctx.deploymentUrl}/fallback/static-02/dynamic`);
         expect(res.status).toEqual(200);
         expect(res.headers.get('x-vercel-cache')).toEqual('HIT');
 

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -330,7 +330,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
       let html = await res.text();
       let $ = cheerio.load(html);
-      assertFallbackShell($);
+      assertRouteShell($);
 
       await retry(async () => {
         res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
@@ -368,7 +368,6 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
 
       html = await res.text();
       $ = cheerio.load(html);
-      assertFallbackShell($);
       assertDynamicPostponed($);
 
       await retry(async () => {


### PR DESCRIPTION
When Partial Prerendering Fallbacks are enabled via the `experimental.pprFallbacks: true` flag, this will cause any route that's a fallback route to not generate a route shell. We plan to introduce a new API soon to re-implement this feature for Dynamic I/O.