### PR TITLE
Collect telemetry for `whoami` command

### DIFF
--- a/.changeset/dry-suns-enjoy.md
+++ b/.changeset/dry-suns-enjoy.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Collect telemetry for `vc whoami`. Telemetry collection is not currently enabled and when it is, will be a major version bump for the CLI.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -640,6 +640,7 @@ const main = async () => {
           func = require('./commands/telemetry').default;
           break;
         case 'whoami':
+          telemetry.trackCliCommandWhoami(userSuppliedSubCommand);
           func = require('./commands/whoami').default;
           break;
         default:

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -15,6 +15,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandWhoami(actual: string) {
+    this.trackCliCommand({
+      command: 'whoami',
+      value: actual,
+    });
+  }
+
   trackCPUs() {
     super.trackCPUs();
   }


### PR DESCRIPTION
`vc whoami` takes no arguments, flags, or options.