### PR TITLE
[next] provide @next/request-context to Next.js handlers

### DIFF
--- a/.changeset/strong-snails-punch.md
+++ b/.changeset/strong-snails-punch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': minor
+---
+
+Provide `waitUntil` via `@next/request-context`

--- a/packages/next/build.mjs
+++ b/packages/next/build.mjs
@@ -18,10 +18,17 @@ await Promise.all([
   esbuild({
     entryPoints: [
       'src/legacy-launcher.ts',
-      'src/server-launcher.ts',
       'src/templated-launcher-shared.ts',
       'src/templated-launcher.ts',
     ],
+  }),
+  // server-launcher imports some modules, so we need to bundle it
+  esbuild({
+    entryPoints: ['src/server-launcher.ts'],
+    bundle: true,
+    external: ['__NEXT_SERVER_PATH__'],
+    // make sure the `// @preserve ...` comments we use for code injection stay in the same place
+    legalComments: 'inline',
   }),
   buildEdgeFunctionTemplate(),
 ]);

--- a/packages/next/scripts/build-edge-function-template.js
+++ b/packages/next/scripts/build-edge-function-template.js
@@ -37,10 +37,3 @@ async function buildNextjsWrapper() {
 }
 
 module.exports = buildNextjsWrapper;
-
-if (!module.parent) {
-  buildNextjsWrapper().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
-}

--- a/packages/next/scripts/build-edge-function-template.js
+++ b/packages/next/scripts/build-edge-function-template.js
@@ -19,6 +19,7 @@ async function buildTemplate(options) {
     // To see the latest stable chrome version: https://www.chromestatus.com/features/schedule
     target: 'esnext',
     write: options.write,
+    external: ['async_hooks'], // available in edge runtime
   });
 }
 

--- a/packages/next/src/edge-function-source/get-edge-function.ts
+++ b/packages/next/src/edge-function-source/get-edge-function.ts
@@ -1,5 +1,6 @@
 /// <reference lib="DOM" />
 
+import { withNextRequestContext } from '../next-request-context';
 import { toPlainHeaders } from './to-plain-headers';
 
 export interface NextjsParams {
@@ -108,26 +109,30 @@ export default function getNextjsEdgeFunction(
     }
 
     // Invoke the function injecting missing parameters
-    const result = await _ENTRIES[`middleware_${params.name}`].default.call(
-      {},
-      {
-        request: {
-          url: request.url,
-          method: request.method,
-          headers: toPlainHeaders(request.headers),
-          ip: header(request.headers, IncomingHeaders.Ip),
-          geo: {
-            city: header(request.headers, IncomingHeaders.City, true),
-            country: header(request.headers, IncomingHeaders.Country, true),
-            latitude: header(request.headers, IncomingHeaders.Latitude),
-            longitude: header(request.headers, IncomingHeaders.Longitude),
-            region: header(request.headers, IncomingHeaders.Region, true),
-          },
-          nextConfig: params.nextConfig,
-          page: pageMatch,
-          body: request.body,
-        },
-      }
+    const result = await withNextRequestContext(
+      { waitUntil: context.waitUntil },
+      () =>
+        _ENTRIES[`middleware_${params.name}`].default.call(
+          {},
+          {
+            request: {
+              url: request.url,
+              method: request.method,
+              headers: toPlainHeaders(request.headers),
+              ip: header(request.headers, IncomingHeaders.Ip),
+              geo: {
+                city: header(request.headers, IncomingHeaders.City, true),
+                country: header(request.headers, IncomingHeaders.Country, true),
+                latitude: header(request.headers, IncomingHeaders.Latitude),
+                longitude: header(request.headers, IncomingHeaders.Longitude),
+                region: header(request.headers, IncomingHeaders.Region, true),
+              },
+              nextConfig: params.nextConfig,
+              page: pageMatch,
+              body: request.body,
+            },
+          }
+        )
     );
 
     if (result.waitUntil) {

--- a/packages/next/src/edge-function-source/get-edge-function.ts
+++ b/packages/next/src/edge-function-source/get-edge-function.ts
@@ -130,7 +130,9 @@ export default function getNextjsEdgeFunction(
       }
     );
 
-    context.waitUntil(result.waitUntil);
+    if (result.waitUntil) {
+      context.waitUntil(result.waitUntil);
+    }
 
     return result.response;
   };

--- a/packages/next/src/next-request-context.ts
+++ b/packages/next/src/next-request-context.ts
@@ -1,0 +1,60 @@
+/*
+WARNING: WATCH OUT IF YOU'RE MODIFYING THIS FILE!
+The types here must be kept in sync (or at least backwards-compatible)
+with "@next/request-context" in the Next.js codebase.
+
+This module defines `globalThis[Symbol.for("@next/request-context")]`
+which Next.js uses to access `waitUntil`.
+It is expected that the platform provides this.
+*/
+
+import { AsyncLocalStorage } from 'async_hooks';
+
+const name = '@next/request-context';
+export const NEXT_REQUEST_CONTEXT_SYMBOL = Symbol.for(name);
+
+const INTERNAL_STORAGE_FIELD_SYMBOL = Symbol.for('internal.storage');
+
+export type NextRequestContextValue = {
+  waitUntil?: WaitUntil;
+};
+
+export type NextRequestContext = {
+  get(): NextRequestContextValue | undefined;
+  /** @ignore */
+  [INTERNAL_STORAGE_FIELD_SYMBOL]: AsyncLocalStorage<NextRequestContextValue>;
+};
+
+export type WaitUntil = (promise: Promise<any>) => void;
+
+/** Next.js will read this context off of `globalThis[Symbol.for("@next-request-context")]`,
+ * So it's important that it's only ever created (and installed) once, regardless of any
+ * bundling shenanigans
+ */
+function getOrCreateContextSingleton(): NextRequestContext {
+  const _globalThis = globalThis as typeof globalThis & {
+    [NEXT_REQUEST_CONTEXT_SYMBOL]?: NextRequestContext;
+  };
+
+  // make sure we only define the context once.
+  if (!_globalThis[NEXT_REQUEST_CONTEXT_SYMBOL]) {
+    const storage = new AsyncLocalStorage<NextRequestContextValue>();
+    const Context: NextRequestContext = {
+      get: () => storage.getStore(),
+      [INTERNAL_STORAGE_FIELD_SYMBOL]: storage,
+    };
+    _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL] = Context;
+  }
+
+  return _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL];
+}
+
+export const NextRequestContext = getOrCreateContextSingleton();
+
+export function withNextRequestContext<T>(
+  value: NextRequestContextValue,
+  callback: () => T
+): T {
+  const storage = NextRequestContext[INTERNAL_STORAGE_FIELD_SYMBOL];
+  return storage.run(value, callback);
+}

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -691,7 +691,7 @@ export async function serverBuild({
     );
     let launcher = launcherData
       .replace(
-        'const conf = __NEXT_CONFIG__',
+        /(?:var|const) conf = __NEXT_CONFIG__/,
         `const conf = ${JSON.stringify({
           ...requiredServerFilesManifest.config,
           distDir: path.relative(

--- a/packages/next/src/vercel-request-context.ts
+++ b/packages/next/src/vercel-request-context.ts
@@ -1,0 +1,15 @@
+// duplicated from @vercel/functions. can we re-use it?
+
+type Context = {
+  waitUntil?: (promise: Promise<unknown>) => void;
+  headers?: Record<string, string>;
+};
+
+export const SYMBOL_FOR_REQ_CONTEXT = Symbol.for('@vercel/request-context');
+
+export function getContext(): Context {
+  const fromSymbol: typeof globalThis & {
+    [SYMBOL_FOR_REQ_CONTEXT]?: { get?: () => Context };
+  } = globalThis;
+  return fromSymbol[SYMBOL_FOR_REQ_CONTEXT]?.get?.() ?? {};
+}

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -28,7 +28,10 @@ function parseTsConfig(tsconfigPath) {
   return result;
 }
 
-export async function esbuild(opts = {}, cwd = process.cwd()) {
+export async function esbuild(
+  /** @type {import('esbuild').BuildOptions} */ opts = {},
+  cwd = process.cwd()
+) {
   const configPath = path.join(cwd, 'tsconfig.json');
   const tsconfig = parseTsConfig(configPath);
 


### PR DESCRIPTION
Some time ago, Next.js introduced `@next/request-context` which is meant as a platform-agnostic way of providing `waitUntil` to Next.js: https://github.com/vercel/next.js/blob/086f715c27391d0559af1b993668b4effc202eaf/packages/next/src/server/after/builtin-request-context.ts#L3-L14

This PR changes the next.js builder to provide this context to handlers.

`@next/request-context` is very close to our existing `globalThis[Symbol.for("@vercel/request-context")]` (and mirrors a subset of its interface) but isn't tied to the vercel platform.

---

x-ref: removing usage of `@vercel/request-context` from Next.js (needs this change)
https://github.com/vercel/next.js/pull/71383