### PR TITLE
[cli] separately track if deploy is done by default

### DIFF
--- a/.changeset/shiny-pets-play.md
+++ b/.changeset/shiny-pets-play.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] separately track if deploy is done by default

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -298,6 +298,7 @@ const main = async () => {
   }
   const { cwd } = client;
 
+  let defaultDeploy = false;
   // Gets populated to the subcommand name when a built-in is
   // provided, otherwise it remains undefined for an extension
   let subcommand: string | undefined = undefined;
@@ -332,6 +333,7 @@ const main = async () => {
   } else {
     debug('user supplied no target, defaulting to deploy');
     subcommand = 'deploy';
+    defaultDeploy = true;
   }
 
   if (subcommand === 'help') {
@@ -568,6 +570,7 @@ const main = async () => {
           break;
         case 'deploy':
           telemetry.trackCliCommandDeploy(userSuppliedSubCommand);
+          telemetry.trackCliDefaultDeploy(defaultDeploy);
           func = require('./commands/deploy').default;
           break;
         case 'dev':

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -138,6 +138,13 @@ export class TelemetryClient {
     }
   }
 
+  protected trackDefaultDeploy() {
+    this.track({
+      key: 'default-deploy',
+      value: 'TRUE',
+    });
+  }
+
   trackCommandError(error: string): Event | undefined {
     this.output.error(error);
     return;

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -1,6 +1,12 @@
 import { TelemetryClient } from '.';
 
 export class RootTelemetryClient extends TelemetryClient {
+  trackCliDefaultDeploy(defaultDeploy: boolean) {
+    if (defaultDeploy) {
+      this.trackDefaultDeploy();
+    }
+  }
+
   trackCliCommandDomains(actual: string) {
     this.trackCliCommand({
       command: 'domains',


### PR DESCRIPTION
We want to know when the CLI is invoked as only vercel and deploys.