### PR TITLE
[cli] Add tracking for most global flags and options

### DIFF
--- a/.changeset/sour-cougars-type.md
+++ b/.changeset/sour-cougars-type.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Add tracking for most global flags and options

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -262,6 +262,15 @@ const main = async () => {
   telemetry.trackArch();
   telemetry.trackCIVendorName();
   telemetry.trackVersion(pkg.version);
+  telemetry.trackCliOptionCwd(parsedArgs.flags['--cwd']);
+  telemetry.trackCliOptionLocalConfig(parsedArgs.flags['--local-config']);
+  telemetry.trackCliOptionGlobalConfig(parsedArgs.flags['--global-config']);
+  telemetry.trackCliFlagDebug(parsedArgs.flags['--debug']);
+  telemetry.trackCliFlagNoColor(parsedArgs.flags('--no-color'));
+  telemetry.trackCliOptionScope(parsedArgs.flags('--scope'));
+  telemetry.trackCliOptionToken(parsedArgs.flags('--token'));
+  telemetry.trackCliOptionTeam(parsedArgs.flags('--team'));
+  telemetry.trackCliOptionApi(parsedArgs.flags('--api'));
 
   if (typeof parsedArgs.flags['--api'] === 'string') {
     apiUrl = parsedArgs.flags['--api'];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -266,11 +266,11 @@ const main = async () => {
   telemetry.trackCliOptionLocalConfig(parsedArgs.flags['--local-config']);
   telemetry.trackCliOptionGlobalConfig(parsedArgs.flags['--global-config']);
   telemetry.trackCliFlagDebug(parsedArgs.flags['--debug']);
-  telemetry.trackCliFlagNoColor(parsedArgs.flags('--no-color'));
-  telemetry.trackCliOptionScope(parsedArgs.flags('--scope'));
-  telemetry.trackCliOptionToken(parsedArgs.flags('--token'));
-  telemetry.trackCliOptionTeam(parsedArgs.flags('--team'));
-  telemetry.trackCliOptionApi(parsedArgs.flags('--api'));
+  telemetry.trackCliFlagNoColor(parsedArgs.flags['--no-color']);
+  telemetry.trackCliOptionScope(parsedArgs.flags['--scope']);
+  telemetry.trackCliOptionToken(parsedArgs.flags['--token']);
+  telemetry.trackCliOptionTeam(parsedArgs.flags['--team']);
+  telemetry.trackCliOptionApi(parsedArgs.flags['--api']);
 
   if (typeof parsedArgs.flags['--api'] === 'string') {
     apiUrl = parsedArgs.flags['--api'];

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -83,6 +83,78 @@ export class RootTelemetryClient extends TelemetryClient {
   trackVersion(version?: string) {
     super.trackVersion(version);
   }
+
+  trackCliOptionCwd(cwd?: string) {
+    if (cwd) {
+      this.trackCliOption({ option: 'cwd', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionLocalConfig(localConfig?: string) {
+    if (localConfig) {
+      this.trackCliOption({
+        option: 'local-config',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionGlobalConfig(globalConfig?: string) {
+    if (globalConfig) {
+      this.trackCliOption({
+        option: 'global-config',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionScope(scope?: string) {
+    if (scope) {
+      this.trackCliOption({
+        option: 'scope',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionToken(token?: string) {
+    if (token) {
+      this.trackCliOption({
+        option: 'token',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionTeam(team?: string) {
+    if (team) {
+      this.trackCliOption({
+        option: 'team',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionApi(api?: string) {
+    if (api) {
+      this.trackCliOption({
+        option: 'api',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagDebug(debug?: boolean) {
+    if (debug) {
+      this.trackCliFlag('debug');
+    }
+  }
+
+  trackCliFlagNoColor(noColor?: boolean) {
+    if (noColor) {
+      this.trackCliFlag('no-color');
+    }
+  }
 }
 
 interface Vendor {


### PR DESCRIPTION
Add tracking for all global flags and options except --help and --version. Which themselves need additional thought into their implementation.