### PR TITLE
[cli] add remaining root command tracking

### DIFF
--- a/.changeset/smooth-fireants-buy.md
+++ b/.changeset/smooth-fireants-buy.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add remaining root command tracking

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -560,6 +560,7 @@ const main = async () => {
           func = require('./commands/alias').default;
           break;
         case 'bisect':
+          telemetry.trackCliCommandBisect(userSuppliedSubCommand);
           func = require('./commands/bisect').default;
           break;
         case 'build':
@@ -567,6 +568,7 @@ const main = async () => {
           func = require('./commands/build').default;
           break;
         case 'certs':
+          telemetry.trackCliCommandCerts(userSuppliedSubCommand);
           func = require('./commands/certs').default;
           break;
         case 'deploy':
@@ -575,9 +577,11 @@ const main = async () => {
           func = require('./commands/deploy').default;
           break;
         case 'dev':
+          telemetry.trackCliCommandDev(userSuppliedSubCommand);
           func = require('./commands/dev').default;
           break;
         case 'dns':
+          telemetry.trackCliCommandDns(userSuppliedSubCommand);
           func = require('./commands/dns').default;
           break;
         case 'domains':
@@ -585,33 +589,43 @@ const main = async () => {
           func = require('./commands/domains').default;
           break;
         case 'env':
+          telemetry.trackCliCommandEnv(userSuppliedSubCommand);
           func = require('./commands/env').default;
           break;
         case 'git':
+          telemetry.trackCliCommandGit(userSuppliedSubCommand);
           func = require('./commands/git').default;
           break;
         case 'init':
+          telemetry.trackCliCommandInit(userSuppliedSubCommand);
           func = require('./commands/init').default;
           break;
         case 'inspect':
+          telemetry.trackCliCommandInspect(userSuppliedSubCommand);
           func = require('./commands/inspect').default;
           break;
         case 'install':
+          telemetry.trackCliCommandInstall(userSuppliedSubCommand);
           func = require('./commands/install').default;
           break;
         case 'integration':
+          telemetry.trackCliCommandIntegration(userSuppliedSubCommand);
           func = require('./commands/integration').default;
           break;
         case 'link':
+          telemetry.trackCliCommandLink(userSuppliedSubCommand);
           func = require('./commands/link').default;
           break;
         case 'list':
+          telemetry.trackCliCommandList(userSuppliedSubCommand);
           func = require('./commands/list').default;
           break;
         case 'logs':
+          telemetry.trackCliCommandLogs(userSuppliedSubCommand);
           func = require('./commands/logs').default;
           break;
         case 'login':
+          telemetry.trackCliCommandLogin(userSuppliedSubCommand);
           func = require('./commands/login').default;
           break;
         case 'logout':
@@ -619,18 +633,23 @@ const main = async () => {
           func = require('./commands/logout').default;
           break;
         case 'project':
+          telemetry.trackCliCommandProject(userSuppliedSubCommand);
           func = require('./commands/project').default;
           break;
         case 'promote':
+          telemetry.trackCliCommandPromote(userSuppliedSubCommand);
           func = require('./commands/promote').default;
           break;
         case 'pull':
+          telemetry.trackCliCommandPull(userSuppliedSubCommand);
           func = require('./commands/pull').default;
           break;
         case 'redeploy':
+          telemetry.trackCliCommandRedeploy(userSuppliedSubCommand);
           func = require('./commands/redeploy').default;
           break;
         case 'remove':
+          telemetry.trackCliCommandRemove(userSuppliedSubCommand);
           func = require('./commands/remove').default;
           break;
         case 'rollback':
@@ -638,6 +657,7 @@ const main = async () => {
           func = require('./commands/rollback').default;
           break;
         case 'target':
+          telemetry.trackCliCommandTarget(userSuppliedSubCommand);
           func = require('./commands/target').default;
           break;
         case 'teams':

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -1,22 +1,16 @@
 import { TelemetryClient } from '.';
 
 export class RootTelemetryClient extends TelemetryClient {
-  trackCliDefaultDeploy(defaultDeploy: boolean) {
-    if (defaultDeploy) {
-      this.trackDefaultDeploy();
-    }
-  }
-
-  trackCliCommandDomains(actual: string) {
+  trackCliCommandAlias(actual: string) {
     this.trackCliCommand({
-      command: 'domains',
+      command: 'alias',
       value: actual,
     });
   }
 
-  trackCliCommandAlias(actual: string) {
+  trackCliCommandBisect(actual: string) {
     this.trackCliCommand({
-      command: 'alias',
+      command: 'bisect',
       value: actual,
     });
   }
@@ -28,6 +22,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandCerts(actual: string) {
+    this.trackCliCommand({
+      command: 'certs',
+      value: actual,
+    });
+  }
+
   trackCliCommandDeploy(actual: string) {
     this.trackCliCommand({
       command: 'deploy',
@@ -35,9 +36,127 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
-  trackCliCommandWhoami(actual: string) {
+  trackCliDefaultDeploy(defaultDeploy: boolean) {
+    if (defaultDeploy) {
+      this.trackDefaultDeploy();
+    }
+  }
+
+  trackCliCommandDev(actual: string) {
     this.trackCliCommand({
-      command: 'whoami',
+      command: 'dev',
+      value: actual,
+    });
+  }
+
+  trackCliCommandDomains(actual: string) {
+    this.trackCliCommand({
+      command: 'domains',
+      value: actual,
+    });
+  }
+
+  trackCliCommandDns(actual: string) {
+    this.trackCliCommand({
+      command: 'dns',
+      value: actual,
+    });
+  }
+
+  trackCliCommandEnv(actual: string) {
+    this.trackCliCommand({
+      command: 'env',
+      value: actual,
+    });
+  }
+
+  trackCliCommandGit(actual: string) {
+    this.trackCliCommand({
+      command: 'git',
+      value: actual,
+    });
+  }
+
+  trackCliCommandInit(actual: string) {
+    this.trackCliCommand({
+      command: 'init',
+      value: actual,
+    });
+  }
+
+  trackCliCommandInspect(actual: string) {
+    this.trackCliCommand({
+      command: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliCommandInstall(actual: string) {
+    this.trackCliCommand({
+      command: 'install',
+      value: actual,
+    });
+  }
+
+  trackCliCommandIntegration(actual: string) {
+    this.trackCliCommand({
+      command: 'integration',
+      value: actual,
+    });
+  }
+
+  trackCliCommandLink(actual: string) {
+    this.trackCliCommand({
+      command: 'link',
+      value: actual,
+    });
+  }
+
+  trackCliCommandList(actual: string) {
+    this.trackCliCommand({
+      command: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliCommandLogin(actual: string) {
+    this.trackCliCommand({
+      command: 'login',
+      value: actual,
+    });
+  }
+
+  trackCliCommandLogout(actual: string) {
+    this.trackCliCommand({
+      command: 'logout',
+      value: actual,
+    });
+  }
+
+  trackCliCommandLogs(actual: string) {
+    this.trackCliCommand({
+      command: 'logs',
+      value: actual,
+    });
+  }
+
+  trackCliCommandProject(actual: string) {
+    this.trackCliCommand({
+      command: 'project',
+      value: actual,
+    });
+  }
+
+  trackCliCommandPromote(actual: string) {
+    this.trackCliCommand({
+      command: 'promote',
+      value: actual,
+    });
+  }
+
+  trackCliCommandPull(actual: string) {
+    this.trackCliCommand({
+      command: 'pull',
       value: actual,
     });
   }
@@ -45,6 +164,27 @@ export class RootTelemetryClient extends TelemetryClient {
   trackCliCommandRollback(actual: string) {
     this.trackCliCommand({
       command: 'rollback',
+      value: actual,
+    });
+  }
+
+  trackCliCommandRedeploy(actual: string) {
+    this.trackCliCommand({
+      command: 'redeploy',
+      value: actual,
+    });
+  }
+
+  trackCliCommandRemove(actual: string) {
+    this.trackCliCommand({
+      command: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliCommandTarget(actual: string) {
+    this.trackCliCommand({
+      command: 'target',
       value: actual,
     });
   }
@@ -63,9 +203,9 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
-  trackCliCommandLogout(actual: string) {
+  trackCliCommandWhoami(actual: string) {
     this.trackCliCommand({
-      command: 'logout',
+      command: 'whoami',
       value: actual,
     });
   }


### PR DESCRIPTION
Add the remaining tracking for root command invocation. We kept merge conflicting each other so it seemed prudent do this in well swell foop.

Please double check:
* the correct method name is called in the case statement ( 'bisect' / `telemetry.trackCliCommandBisect`)
* the correct argument is passed to `this.trackCliCommand` within the implementation (`telemetry.trackCliCommandBisect`/ 'bisect')

and my spelling. Human isn't my first language. These are, as of now, untestable until `main` is extracted.