### PR TITLE
[cli] Add default team id for logged out users

### DIFF
--- a/.changeset/big-dolphins-check.md
+++ b/.changeset/big-dolphins-check.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] Add default team id for logged out users

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -16,6 +16,7 @@ interface Options {
 }
 
 interface Event {
+  teamId: string;
   sessionId?: string;
   id: string;
   key: string;
@@ -167,6 +168,7 @@ export class TelemetryEventStore {
   private output: Output;
   private isDebug: boolean;
   private sessionId: string;
+  private teamId: string = 'NO_TEAM_ID';
   private config: GlobalConfig['telemetry'];
 
   constructor(opts: {
@@ -183,6 +185,7 @@ export class TelemetryEventStore {
 
   add(event: Event) {
     event.sessionId = this.sessionId;
+    event.teamId = this.teamId;
     this.events.push(event);
   }
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -16,7 +16,7 @@ interface Options {
 }
 
 interface Event {
-  teamId: string;
+  teamId?: string;
   sessionId?: string;
   id: string;
   key: string;

--- a/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
+++ b/packages/cli/test/mocks/matchers/to-have-telemetry-events.ts
@@ -24,6 +24,7 @@ export function toHaveTelemetryEvents(
       const expectCommonSessionEventObject = (event?: EventData) =>
         expect.objectContaining({
           id: expect.any(String),
+          teamId: expect.any(String),
           sessionId: firstEvent?.sessionId,
           key: event?.key,
           value: event?.value,


### PR DESCRIPTION
Our CLI users will not always be logged into a team, in those cases we'll record 'NO_TEAM_ID' as the id for their events.