### PR TITLE
Add open command

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -27,6 +27,7 @@ export default new Map([
   ['logout', 'logout'],
   ['logs', 'logs'],
   ['ls', 'list'],
+  ['open', 'open'],
   ['project', 'project'],
   ['projects', 'project'],
   ['promote', 'promote'],

--- a/packages/cli/src/commands/open/command.ts
+++ b/packages/cli/src/commands/open/command.ts
@@ -1,0 +1,14 @@
+import { packageName } from '../../util/pkg-name';
+
+export const openCommand = {
+  name: 'open',
+  description: 'Opens the dashboard in the current project you are in.',
+  arguments: [],
+  options: [],
+  examples: [
+    {
+      name: 'Opens a tab in your browser in the overview page for the project you are in',
+      value: `${packageName} open`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/open/index.ts
+++ b/packages/cli/src/commands/open/index.ts
@@ -1,0 +1,49 @@
+import openBrowser from 'open';
+
+import { help } from '../help';
+import { openCommand } from './command';
+
+import { ensureLink } from '../../util/link/ensure-link';
+import { parseArguments } from '../../util/get-args';
+import Client from '../../util/client';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import handleError from '../../util/handle-error';
+
+export default async function open(client: Client): Promise<number> {
+  const { output } = client;
+
+  let parsedArgs = null;
+
+  const flagsSpecification = getFlagsSpecification(openCommand.options);
+
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (error) {
+    handleError(error);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(help(openCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+  const linkedProject = await ensureLink('open', client, client.cwd, {
+    autoConfirm: Boolean(parsedArgs.flags['--yes']),
+  });
+
+  if (typeof linkedProject === 'number') {
+    const err: NodeJS.ErrnoException = new Error('Link project error');
+    err.code = 'ERR_LINK_PROJECT';
+    throw err;
+  }
+
+  const {
+    org: { slug },
+    project: { name },
+  } = linkedProject;
+
+  output.log(`Navigating to https://vercel.com/${slug}/${name}...`);
+  openBrowser(`https://vercel.com/${slug}/${name}`);
+
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -642,6 +642,10 @@ const main = async () => {
           telemetry.trackCliCommandLogout(userSuppliedSubCommand);
           func = require('./commands/logout').default;
           break;
+        case 'open':
+          telemetry.trackCliCommandOpen(userSuppliedSubCommand);
+          func = require('./commands/open').default;
+          break;
         case 'project':
           telemetry.trackCliCommandProject(userSuppliedSubCommand);
           func = require('./commands/project').default;

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -146,6 +146,12 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandOpen(actual: string) {
+    this.trackCliCommand({
+      command: 'open',
+      value: actual,
+    });
+  }
   trackCliCommandProject(actual: string) {
     this.trackCliCommand({
       command: 'project',


### PR DESCRIPTION
This PR introduces a new command `open` that opens the project linked in the current working directory. 

The command uses the default system browser to navigate to the project URL, making it easier to quickly open the dashboard in the current project overview.