### PR TITLE
[next] Output different Prerenders for Fallback HTML/RSC

### DIFF
--- a/.changeset/many-laws-cheer.md
+++ b/.changeset/many-laws-cheer.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Fix caching issue with prerenders while Partial Prerendering is enabled

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2444,14 +2444,13 @@ export const onPrerenderRoute =
         (r): r is RoutesManifestRoute =>
           r.page === pageKey && !('isMiddleware' in r)
       ) as RoutesManifestRoute | undefined;
+      const isDynamic = isDynamicRoute(routeKey);
       const routeKeys = route?.routeKeys;
       // by default allowQuery should be undefined and only set when
       // we have sufficient information to set it
       let allowQuery: string[] | undefined;
 
       if (isEmptyAllowQueryForPrendered) {
-        const isDynamic = isDynamicRoute(routeKey);
-
         if (!isDynamic) {
           // for non-dynamic routes we use an empty array since
           // no query values bust the cache for non-dynamic prerenders
@@ -2543,10 +2542,18 @@ export const onPrerenderRoute =
         }
       }
 
+      // If this is a fallback page with PPR enabled, we should not have the
+      // cache key vary based on the route parameters to ensure that we always
+      // have a HIT for the fallback page.
+      let htmlAllowQuery = allowQuery;
+      if (renderingMode === RenderingMode.PARTIALLY_STATIC && isFallback) {
+        htmlAllowQuery = [];
+      }
+
       prerenders[outputPathPage] = new Prerender({
         expiration: initialRevalidate,
         lambda,
-        allowQuery,
+        allowQuery: htmlAllowQuery,
         fallback: htmlFsRef,
         group: prerenderGroup,
         bypassToken: prerenderManifest.bypassToken,
@@ -2586,6 +2593,14 @@ export const onPrerenderRoute =
       };
 
       if (outputPathData || outputPathPrefetchData) {
+        // If the allowQuery is different than the original allowQuery, then we
+        // shouldn't use the same prerender group as the HTML prerender because
+        // they should not be revalidated together (one needs to be revalidated
+        // when the allowQuery changes, one does not).
+        if (htmlAllowQuery !== allowQuery) {
+          prerenderGroup++;
+        }
+
         const prerender = new Prerender({
           expiration: initialRevalidate,
           lambda,

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/dynamic/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/dynamic/page.jsx
@@ -5,7 +5,9 @@ function Agent() {
   return <div data-agent>{headers().get('user-agent')}</div>;
 }
 
-export default function Page({ params: { slug } }) {
+export default async function Page(props) {
+  const { slug } = await props.params;
+
   return (
     <>
       <div data-page>This is the validation page: {slug}</div>

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/layout.jsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return children
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'static-01' }, { slug: 'static-02' }]
+}

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/app/fallback/[slug]/page.jsx
@@ -1,3 +1,5 @@
-export default function Page({ params }) {
-  return <div data-page>This is the validation page: {params.slug}</div>;
+export default async function Page(props) {
+  const { slug } = await props.params;
+
+  return <div data-page>This is the validation page: {slug}</div>;
 }

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -265,6 +265,20 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
           // here means that the cache was poisoned.
           expect($('[data-slug]').data('slug')).toEqual(slug);
 
+          res = await fetch(`${ctx.deploymentUrl}${pathname}`, {
+            headers: {
+              "RSC": "1",
+              "Next-Router-Prefetch": "1",
+            }
+          });
+          expect(res.status).toEqual(200);
+
+          let rsc = await res.text();
+
+          // Expect that the page contains the correct slug in the RSC payload.
+          // A failure here means that the cache was poisoned.
+          expect(rsc).toContain(slug);
+
           // Send the revalidation request.
           res = await fetch(`${ctx.deploymentUrl}/api/revalidate${pathname}`, {
             method: 'DELETE',
@@ -281,6 +295,20 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
           // Expect that the poisoned page contains the correct slug. If it's
           // poisoned, the slug will be incorrect.
           expect($('[data-slug]').data('slug')).toEqual(slug);
+
+          res = await fetch(`${ctx.deploymentUrl}${pathname}`, {
+            headers: {
+              "RSC": "1",
+              "Next-Router-Prefetch": "1",
+            }
+          });
+          expect(res.status).toEqual(200);
+
+          rsc = await res.text();
+
+          // Expect that the page contains the correct slug in the RSC payload.
+          // A failure here means that the cache was poisoned.
+          expect(rsc).toContain(slug);
         }
       });
     });


### PR DESCRIPTION
Previously when the `allowQuery` was set to `[]` it also incorrectly applied it to the Prefetch RSC, causing a cache error when a prefetch revalidated a page.