### PR TITLE
[cli] add telemetry for `vc project remove`

### DIFF
--- a/.changeset/popular-fireants-sin.md
+++ b/.changeset/popular-fireants-sin.md
@@ -2,4 +2,4 @@
 'vercel': minor
 ---
 
-[cli] add telemetry tracking to `alias ls`
+[cli] add telemetry tracking to `project rm`

--- a/.changeset/popular-fireants-sin.md
+++ b/.changeset/popular-fireants-sin.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+[cli] add telemetry tracking to `alias ls`

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -9,6 +9,7 @@ import list from './list';
 import rm from './rm';
 import { projectCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { ProjectTelemetryClient } from '../../util/telemetry/commands/project';
 
 const COMMAND_CONFIG = {
   ls: ['ls', 'list'],
@@ -17,6 +18,13 @@ const COMMAND_CONFIG = {
 };
 
 export default async function main(client: Client) {
+  const telemetryClient = new ProjectTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
+
   let subcommand: string | string[];
 
   let parsedArgs = null;
@@ -47,11 +55,14 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'ls':
     case 'list':
+      telemetryClient.trackCliSubcommandLs(subcommand);
       return await list(client, parsedArgs.flags, args, contextName);
     case 'add':
+      telemetryClient.trackCliSubcommandAdd(subcommand);
       return await add(client, args, contextName);
     case 'rm':
     case 'remove':
+      telemetryClient.trackCliSubcommandRm(subcommand);
       return await rm(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/project/rm.ts
+++ b/packages/cli/src/commands/project/rm.ts
@@ -5,10 +5,18 @@ import { emoji, prependEmoji } from '../../util/emoji';
 import { isAPIError } from '../../util/errors-ts';
 import confirm from '../../util/input/confirm';
 import { getCommandName } from '../../util/pkg-name';
+import { ProjectRmTelemetryClient } from '../../util/telemetry/commands/project/rm';
 
 const e = encodeURIComponent;
 
 export default async function rm(client: Client, args: string[]) {
+  const telemetryClient = new ProjectRmTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
+
   if (args.length !== 1) {
     client.output.error(
       `Invalid number of arguments. Usage: ${chalk.cyan(
@@ -19,6 +27,7 @@ export default async function rm(client: Client, args: string[]) {
   }
 
   const name = args[0];
+  telemetryClient.trackCliArgumentName(name);
 
   const start = Date.now();
 

--- a/packages/cli/src/util/telemetry/commands/project/index.ts
+++ b/packages/cli/src/util/telemetry/commands/project/index.ts
@@ -1,0 +1,24 @@
+import { TelemetryClient } from '../..';
+
+export class ProjectTelemetryClient extends TelemetryClient {
+  trackCliSubcommandLs(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'ls',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRm(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'rm',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/project/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/project/rm.ts
@@ -1,0 +1,12 @@
+import { TelemetryClient } from '../..';
+
+export class ProjectRmTelemetryClient extends TelemetryClient {
+  trackCliArgumentName(name?: string) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/project/rm.test.ts
+++ b/packages/cli/test/unit/commands/project/rm.test.ts
@@ -25,5 +25,36 @@ describe('rm', () => {
       const exitCode = await projectsPromise;
       expect(exitCode).toEqual(0);
     });
+
+    it('tracks argument', async () => {
+      useUser();
+      useProject({
+        ...defaultProject,
+        id: 'test-project',
+        name: 'test-project',
+      });
+
+      client.setArgv('project', 'rm', 'test-project');
+      const projectsPromise = projects(client);
+
+      await expect(client.stderr).toOutput(
+        `The project test-project will be removed permanently.`
+      );
+      client.stdin.write('y\n');
+
+      const exitCode = await projectsPromise;
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: `subcommand:rm`,
+          value: 'rm',
+        },
+        {
+          key: `argument:name`,
+          value: '[REDACTED]',
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Telemetry for `vc project remove`:
- 1 argument (`name`)
- 0 flags
- 0 options

Also, starts the process for `project add` and `project ls`.