### PR TITLE
ECO-585: Handle non-boolean readonly & mark expressions as unsupported

### DIFF
--- a/.changeset/sour-waves-smash.md
+++ b/.changeset/sour-waves-smash.md
@@ -1,0 +1,6 @@
+---
+"vercel": patch
+---
+
+* Appropriately handle hidden properties in `vercel install` flows
+* Treat complex expressions during `vercel install` flows as unsupported

--- a/packages/cli/src/commands/integration/types.ts
+++ b/packages/cli/src/commands/integration/types.ts
@@ -5,8 +5,8 @@ export interface MetadataSchemaProperty {
   minimum?: number;
   maximum?: number;
   'ui:control': 'input' | 'select' | 'vercel-region' | string;
-  'ui:disabled'?: boolean;
-  'ui:hidden'?: 'create' | boolean | string;
+  'ui:disabled'?: 'create' | Expression | boolean | string;
+  'ui:hidden'?: 'create' | Expression | boolean | string;
   'ui:label'?: string;
   'ui:placeholder'?: string;
   'ui:options'?:
@@ -16,7 +16,11 @@ export interface MetadataSchemaProperty {
         value: string;
         hidden?: boolean;
       }[];
-  'ui:read-only'?: boolean;
+  'ui:read-only'?: 'create' | Expression | boolean | string;
+}
+
+export interface Expression {
+  expr: string;
 }
 
 export type Metadata = Record<string, string | number | undefined>;

--- a/packages/cli/src/commands/integration/wizard.ts
+++ b/packages/cli/src/commands/integration/wizard.ts
@@ -246,12 +246,12 @@ function isDisabled(schema: MetadataSchemaProperty) {
   );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-function instanceOfExpression(obj: any): obj is Expression {
-  if (obj !== Object(obj)) {
+function instanceOfExpression(obj: unknown): obj is Expression {
+  const checkedAsObject = Object(obj);
+  if (obj !== checkedAsObject) {
     return false;
   }
-  return 'expr' in obj;
+  return 'expr' in checkedAsObject;
 }
 
 class ExpressionError extends Error {}

--- a/packages/cli/src/commands/integration/wizard.ts
+++ b/packages/cli/src/commands/integration/wizard.ts
@@ -1,6 +1,7 @@
 import type Client from '../../util/client';
 import list, { type ListChoice } from '../../util/input/list';
 import type {
+  Expression,
   Metadata,
   MetadataEntry,
   MetadataSchema,
@@ -134,17 +135,29 @@ export function createMetadataWizard(
   const steps: Step[] = [];
 
   for (const [key, schema] of Object.entries(properties)) {
-    if (isHidden(schema)) {
-      continue;
-    }
+    try {
+      if (isHidden(schema)) {
+        continue;
+      }
 
-    if (!supportedUIControls.has(schema['ui:control'])) {
-      isSupported = false;
-      break;
-    }
+      if (isDisabled(schema)) {
+        continue;
+      }
 
-    if (!isReadOnly(schema)) {
-      allFieldsAreReadonly = false;
+      if (!supportedUIControls.has(schema['ui:control'])) {
+        isSupported = false;
+        break;
+      }
+
+      if (!isReadOnly(schema)) {
+        allFieldsAreReadonly = false;
+      }
+    } catch (error) {
+      if (error instanceof ExpressionError) {
+        isSupported = false;
+        break;
+      }
+      throw error;
     }
 
     switch (schema['ui:control']) {
@@ -207,11 +220,38 @@ async function getMetadataFromSteps(
 }
 
 function isHidden(schema: MetadataSchemaProperty) {
+  if (instanceOfExpression(schema['ui:hidden'])) {
+    throw new ExpressionError('Expression found in schema');
+  }
   return Boolean(
     schema['ui:hidden'] === true || schema['ui:hidden'] === 'create'
   );
 }
 
 function isReadOnly(schema: MetadataSchemaProperty) {
-  return Boolean(schema['ui:read-only']);
+  if (instanceOfExpression(schema['ui:read-only'])) {
+    throw new ExpressionError('Expression found in schema');
+  }
+  return Boolean(
+    schema['ui:read-only'] === true || schema['ui:read-only'] === 'create'
+  );
 }
+
+function isDisabled(schema: MetadataSchemaProperty) {
+  if (instanceOfExpression(schema['ui:disabled'])) {
+    throw new ExpressionError('Expression found in schema');
+  }
+  return Boolean(
+    schema['ui:disabled'] === true || schema['ui:disabled'] === 'create'
+  );
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+function instanceOfExpression(obj: any): obj is Expression {
+  if (obj !== Object(obj)) {
+    return false;
+  }
+  return 'expr' in obj;
+}
+
+class ExpressionError extends Error {}

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -145,7 +145,9 @@ test('output the version', async () => {
   expect(version).toBe(pkg.version);
 });
 
-test('login with unregistered user', async () => {
+// https://linear.app/vercel/issue/ZERO-2736/turn-login-with-unregistered-user-test-in-a-unit-test
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('login with unregistered user', async () => {
   const { stdout, stderr, exitCode } = await execCli(
     binaryPath,
     ['login', `${session}@${session}.com`],

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -144,6 +144,40 @@ const metadataSchema3: MetadataSchema = {
   required: ['Region'],
 };
 
+const metadataUnsupported: MetadataSchema = {
+  type: 'object',
+  properties: {
+    region: {
+      'ui:control': 'select',
+      'ui:label': 'Primary Region',
+      default: 'us-east-1',
+      description: 'Primary region where your database will be hosted',
+      'ui:placeholder': 'Choose your region',
+      type: 'string',
+      'ui:options': [
+        {
+          value: 'us-west-1',
+          label: 'West US (North California)',
+        },
+        {
+          value: 'us-east-1',
+          label: 'East US (North Virginia)',
+        },
+      ],
+    },
+    storage: {
+      type: 'number',
+      'ui:control': 'input',
+      'ui:hidden': { expr: "Region == 'us-east-1" },
+      'ui:label': 'Storage',
+      description: 'Disk space in GiB',
+      minimum: 1,
+      maximum: 256,
+    },
+  },
+  required: ['region'],
+};
+
 const integrations: Record<string, Integration> = {
   acme: {
     id: 'acme',
@@ -193,6 +227,21 @@ const integrations: Record<string, Integration> = {
     name: 'Acme Integration No Products',
     slug: 'acme-no-products',
     products: [],
+  },
+  'acme-unsupported': {
+    id: 'acme',
+    name: 'Acme Integration',
+    slug: 'acme',
+    products: [
+      {
+        id: 'acme-product',
+        name: 'Acme Product',
+        slug: 'acme',
+        type: 'storage',
+        shortDescription: 'The Acme product',
+        metadataSchema: metadataUnsupported,
+      },
+    ],
   },
 };
 

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -238,6 +238,31 @@ describe('integration', () => {
           await expect(exitCodePromise).resolves.toEqual(0);
           expect(openMock).not.toHaveBeenCalled();
         });
+
+        it('should require the vercel dashboard for expressions in UI wizard', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-add',
+            name: 'vercel-integration-add',
+          });
+          const cwd = setupUnitFixture('vercel-integration-add');
+          client.cwd = cwd;
+          client.setArgv('integration', 'add', 'acme-unsupported');
+          const exitCodePromise = integrationCommand(client);
+          await expect(client.stderr).toOutput(
+            `Installing Acme Product by Acme Integration under ${team.slug}`
+          );
+          await expect(client.stderr).toOutput(
+            'Do you want to link this resource to the current project? (Y/n)'
+          );
+          client.stdin.write('n\n');
+          await expect(client.stderr).toOutput(
+            'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
+          );
+          client.stdin.write('n\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+          expect(openMock).not.toHaveBeenCalled();
+        });
       });
 
       describe('errors', () => {

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -259,6 +259,33 @@ describe('integration', () => {
           await expect(client.stderr).toOutput(
             'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
           );
+          client.stdin.write('Y\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+          expect(openMock).toHaveBeenCalledWith(
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+          );
+        });
+
+        it('should gracefully exit when the user does not want to continue the setup wizard in the Vercel dashboard for an install flow using expressions in UI display rules', async () => {
+          useProject({
+            ...defaultProject,
+            id: 'vercel-integration-add',
+            name: 'vercel-integration-add',
+          });
+          const cwd = setupUnitFixture('vercel-integration-add');
+          client.cwd = cwd;
+          client.setArgv('integration', 'add', 'acme-unsupported');
+          const exitCodePromise = integrationCommand(client);
+          await expect(client.stderr).toOutput(
+            `Installing Acme Product by Acme Integration under ${team.slug}`
+          );
+          await expect(client.stderr).toOutput(
+            'Do you want to link this resource to the current project? (Y/n)'
+          );
+          client.stdin.write('n\n');
+          await expect(client.stderr).toOutput(
+            'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
+          );
           client.stdin.write('n\n');
           await expect(exitCodePromise).resolves.toEqual(0);
           expect(openMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `vc install <integration>` flow. Now `ui:disabled` is recognized (and skipped), and `ui:hidden` won't break when set to `create` or `update`. Additionally, complex expressions are explicitly unsupported.

## Details

Integrations sometimes have complex UI cases (situational hidden, read-only, disabled) that are allowed in Vercel but weren't properly detected and handled in the CLI integration installation wizard. The `ui:disabled` property was being ignored outright in the wizard, while the `ui:hidden` property was being too aggressive, considering any value to mean it should be skipped. The `ui:hidden` property can be set to `update` to mean the field is _not_ readonly during creation, which the wizard manages. For Upstash Vector, this meant all the necessary fields were being skipped by the wizard, since they're readonly in update flows, but not the creation flow.

Additionally, Upstash Vector uses an expression for one of its fields to determine if it should be visible & populated or not. Our CLI tool does not have the same full parser for complex expressions that our UI has, so for cases where we see expressions we should direct the user to the web UI to complete the process.

## How to test

Build and run locally (or use `pnpm dev` instead of `vc` when in the `packages/cli` folder).

```
vc install upstash vector
-> select Upstash Vector as the product
```