### PR TITLE
[cli] add telemetry for `vercel target ls`

### DIFF
--- a/.changeset/famous-laws-do.md
+++ b/.changeset/famous-laws-do.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add telemetry for `vercel target ls`

--- a/packages/cli/src/commands/target/index.ts
+++ b/packages/cli/src/commands/target/index.ts
@@ -7,6 +7,7 @@ import { targetCommand } from './command';
 import { ensureLink } from '../../util/link/ensure-link';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import handleError from '../../util/handle-error';
+import { TargetTelemetryClient } from '../../util/telemetry/commands/target';
 
 const COMMAND_CONFIG = {
   ls: ['ls', 'list'],
@@ -27,7 +28,13 @@ export default async function main(client: Client) {
     return 1;
   }
 
-  const { output } = client;
+  const { output, telemetryEventStore } = client;
+  const telemetry = new TargetTelemetryClient({
+    opts: {
+      output: output,
+      store: telemetryEventStore,
+    },
+  });
 
   if (parsedArgs.flags['--help']) {
     output.print(help(targetCommand, { columns: client.stderr.columns }));
@@ -47,6 +54,7 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'ls':
     case 'list':
+      telemetry.trackCliSubcommandList(subcommand);
       return await list(client, parsedArgs.flags, args, linkedProject);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/util/telemetry/commands/target/index.ts
+++ b/packages/cli/src/util/telemetry/commands/target/index.ts
@@ -1,0 +1,10 @@
+import { TelemetryClient } from '../..';
+
+export class TargetTelemetryClient extends TelemetryClient {
+  trackCliSubcommandList(subcommandActual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: subcommandActual,
+    });
+  }
+}

--- a/packages/cli/test/unit/commands/target/list.test.ts
+++ b/packages/cli/test/unit/commands/target/list.test.ts
@@ -1,5 +1,5 @@
 import ms from 'ms';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, beforeEach, it } from 'vitest';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import target from '../../../../src/commands/target';
@@ -10,7 +10,45 @@ import createLineIterator from 'line-async-iterator';
 import { parseSpacedTableRow } from '../../../helpers/parse-table';
 
 describe('target ls', () => {
-  describe.todo('--next');
+  describe('telemetry', () => {
+    beforeEach(() => {
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'static',
+        id: 'static',
+      });
+
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.stderr.isTTY = false;
+    });
+
+    it('tracks invocation', async () => {
+      const subcommandActual = 'list';
+      client.setArgv('target', subcommandActual);
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:list',
+          value: subcommandActual,
+        },
+      ]);
+    });
+
+    it('tracks invocation of alias command name', async () => {
+      const subcommandActual = 'ls';
+      client.setArgv('target', subcommandActual);
+      const exitCode = await target(client);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:list',
+          value: subcommandActual,
+        },
+      ]);
+    });
+  });
 
   it('should show custom environments with `vc target ls`', async () => {
     useUser();


### PR DESCRIPTION
A pretty easy one! `vercel target` only has one subcommand (tracked now) and `vercel target ls` has nothing unique to track.