### PR TITLE
[cli] add telemetry for `vercel redeploy`

### DIFF
--- a/.changeset/tidy-squids-live.md
+++ b/.changeset/tidy-squids-live.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add telemetry for `vercel redeploy`

--- a/packages/cli/src/util/telemetry/commands/redeploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/redeploy/index.ts
@@ -1,0 +1,18 @@
+import { TelemetryClient } from '../..';
+
+export class RedeployTelemetryClient extends TelemetryClient {
+  trackCliArgumentDeploymentIdOrName(idOrName?: string) {
+    if (idOrName) {
+      this.trackCliArgument({
+        arg: 'idOrName',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagNoWait(noWait: boolean | undefined) {
+    if (noWait) {
+      this.trackCliFlag('no-wait');
+    }
+  }
+}


### PR DESCRIPTION
Another basic one. Redeploy has no subcommands and only a single argument and single flag. There were existing tests so that part was mostly copy/paste various bits.