### PR TITLE
Avoid retries by default when using the MockClient

### DIFF
--- a/.changeset/giant-moles-fry.md
+++ b/.changeset/giant-moles-fry.md
@@ -1,0 +1,4 @@
+---
+---
+
+Avoid retries by default when using the MockClient

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -9,7 +9,7 @@ import { PassThrough } from 'stream';
 import { createServer, Server } from 'http';
 import express, { Express, Router } from 'express';
 import { listen } from 'async-listen';
-import Client from '../../src/util/client';
+import Client, { FetchOptions } from '../../src/util/client';
 import { Output } from '../../src/util/output';
 import stripAnsi from 'strip-ansi';
 import ansiEscapes from 'ansi-escapes';
@@ -243,6 +243,19 @@ export class MockClient extends Client {
 
   useScenario(scenario: Scenario) {
     this.scenario = scenario;
+  }
+
+  /**
+   * Client's fetch automatically retries, but for mocked
+   * requests we don't want to retry by default.
+   */
+  fetch(url: string, opts: FetchOptions = {}): Promise<any> {
+    if (!opts.retry) {
+      opts.retry = {
+        retries: 0,
+      };
+    }
+    return super.fetch(url, opts);
   }
 }
 

--- a/packages/cli/test/unit/commands/promote/index.test.ts
+++ b/packages/cli/test/unit/commands/promote/index.test.ts
@@ -479,7 +479,6 @@ function initPromoteTest({
     '/:version/projects/:project/promote/:id',
     (req: Request, res: Response) => {
       if (promoteStatusCode === 500) {
-        client.output.log(`scenario ${new Date().toISOString()}`);
         res.statusCode = 500;
         res.end('Server error');
         return;
@@ -532,10 +531,6 @@ function initPromoteTest({
       });
     }
   );
-
-  client.scenario.get('/:version/deployments/:id', (req, res) => {
-    res.json(currentDeployment);
-  });
 
   return {
     cwd,

--- a/packages/cli/test/unit/commands/promote/index.test.ts
+++ b/packages/cli/test/unit/commands/promote/index.test.ts
@@ -301,8 +301,7 @@ describe('promote', () => {
         `Fetching deployment "${previousDeployment.id}" in ${previousDeployment.creator?.username}`
       );
 
-      // we need to wait a super long time because fetch will return on 500
-      await expect(client.stderr).toOutput('Response Error (500)', 20000);
+      await expect(client.stderr).toOutput('Response Error (500)');
 
       await expect(exitCodePromise).resolves.toEqual(1);
     });
@@ -480,6 +479,7 @@ function initPromoteTest({
     '/:version/projects/:project/promote/:id',
     (req: Request, res: Response) => {
       if (promoteStatusCode === 500) {
+        client.output.log(`scenario ${new Date().toISOString()}`);
         res.statusCode = 500;
         res.end('Server error');
         return;
@@ -532,6 +532,10 @@ function initPromoteTest({
       });
     }
   );
+
+  client.scenario.get('/:version/deployments/:id', (req, res) => {
+    res.json(currentDeployment);
+  });
 
   return {
     cwd,

--- a/packages/cli/test/unit/commands/rollback/index.test.ts
+++ b/packages/cli/test/unit/commands/rollback/index.test.ts
@@ -182,7 +182,6 @@ describe('rollback', () => {
     await expect(client.stderr).toOutput(
       `Fetching deployment "${previousDeployment.id}" in ${previousDeployment.creator?.username}`
     );
-    // we need to wait a super long time because fetch will return on 500
     await expect(client.stderr).toOutput('Response Error (500)');
 
     await expect(exitCodePromise).resolves.toEqual(1);

--- a/packages/cli/test/unit/commands/rollback/index.test.ts
+++ b/packages/cli/test/unit/commands/rollback/index.test.ts
@@ -183,7 +183,7 @@ describe('rollback', () => {
       `Fetching deployment "${previousDeployment.id}" in ${previousDeployment.creator?.username}`
     );
     // we need to wait a super long time because fetch will return on 500
-    await expect(client.stderr).toOutput('Response Error (500)', 20000);
+    await expect(client.stderr).toOutput('Response Error (500)');
 
     await expect(exitCodePromise).resolves.toEqual(1);
   });


### PR DESCRIPTION
When some of our test mocks intentionally respond with a 500, that response takes several seconds because the [client's `fetch` function](https://github.com/vercel/vercel/blob/7e8fbd20e01135513ad28936155b078650732d37/packages/cli/src/util/client.ts#L173-L174) automatically retries the request. 

But since we're mocking these requests we should just automatically fail.