### PR TITLE
fix: bump path-to-regexp -- fix test

### DIFF
--- a/.changeset/many-hornets-tan.md
+++ b/.changeset/many-hornets-tan.md
@@ -1,0 +1,5 @@
+---
+"@vercel/routing-utils": patch
+---
+
+fix: bump path-to-regexp -- fix test

--- a/packages/routing-utils/test/superstatic.spec.ts
+++ b/packages/routing-utils/test/superstatic.spec.ts
@@ -938,7 +938,7 @@ test('convertRewrites', () => {
 test('convertHeaders', () => {
   const actual = convertHeaders([
     {
-      source: '(.*)+/(.*)\\.(eot|otf|ttf|ttc|woff|font\\.css)',
+      source: '(.*)/(.*)\\.(eot|otf|ttf|ttc|woff|font\\.css)',
       headers: [
         {
           key: 'Access-Control-Allow-Origin',
@@ -1155,7 +1155,7 @@ test('convertHeaders', () => {
 
   const expected = [
     {
-      src: '^(.*)+(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)$',
+      src: '^(.*)(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)$',
       headers: { 'Access-Control-Allow-Origin': '*' },
       continue: true,
     },


### PR DESCRIPTION
Are we certain that this failing test is using a realistic regex? I think the `+` here after `(.*)` is redundant, though not really invalid to the point that it should error..

---

Related: https://github.com/vercel/vercel/pull/12239