### PR TITLE
[cli] add telemetry for `vc env add`

### DIFF
--- a/.changeset/eleven-tools-argue.md
+++ b/.changeset/eleven-tools-argue.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+add telemetry tracking to `env add`

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -15,6 +15,7 @@ import { getCommandName } from '../../util/pkg-name';
 import { isAPIError } from '../../util/errors-ts';
 import { getCustomEnvironments } from '../../util/target/get-custom-environments';
 import type { ProjectLinked } from '@vercel-internals/types';
+import { EnvAddTelemetryClient } from '../../util/telemetry/commands/env/add';
 
 type Options = {
   '--debug': boolean;
@@ -32,6 +33,19 @@ export default async function add(
   const { project } = link;
   const stdInput = await readStandardInput(client.stdin);
   let [envName, envTargetArg, envGitBranch] = args;
+
+  const telemetryClient = new EnvAddTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
+  telemetryClient.trackCliArgumentName(envName);
+  telemetryClient.trackCliArgumentEnvironment(envTargetArg);
+  telemetryClient.trackCliArgumentGitBranch(envGitBranch);
+  telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
+  telemetryClient.trackCliFlagForce(opts['--force']);
+  telemetryClient.trackCliFlagDebug(opts['--debug']);
 
   if (args.length > 3) {
     output.error(

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -45,7 +45,6 @@ export default async function add(
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
-  telemetryClient.trackCliFlagDebug(opts['--debug']);
 
   if (args.length > 3) {
     output.error(

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -14,6 +14,7 @@ import rm from './rm';
 import { envCommand } from './command';
 import parseTarget from '../../util/parse-target';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { EnvTelemetryClient } from '../../util/telemetry/commands/env';
 
 const COMMAND_CONFIG = {
   ls: ['ls', 'list'],
@@ -23,6 +24,13 @@ const COMMAND_CONFIG = {
 };
 
 export default async function main(client: Client) {
+  const telemetryClient = new EnvTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
+
   let parsedArgs = null;
 
   const flagsSpecification = getFlagsSpecification(envCommand.options);
@@ -67,12 +75,16 @@ export default async function main(client: Client) {
     config.currentTeam = link.org.type === 'team' ? link.org.id : undefined;
     switch (subcommand) {
       case 'ls':
+        telemetryClient.trackCliSubcommandLs(subcommand);
         return ls(client, link, parsedArgs.flags, args);
       case 'add':
+        telemetryClient.trackCliSubcommandAdd(subcommand);
         return add(client, link, parsedArgs.flags, args);
       case 'rm':
+        telemetryClient.trackCliSubcommandRm(subcommand);
         return rm(client, link, parsedArgs.flags, args);
       case 'pull':
+        telemetryClient.trackCliSubcommandPull(subcommand);
         return pull(
           client,
           link,

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -1,0 +1,48 @@
+import { TelemetryClient } from '../..';
+
+export class EnvAddTelemetryClient extends TelemetryClient {
+  trackCliArgumentName(name?: string) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'name',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentEnvironment(environment?: string) {
+    if (environment) {
+      this.trackCliArgument({
+        arg: 'environment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentGitBranch(gitBranch?: string) {
+    if (gitBranch) {
+      this.trackCliArgument({
+        arg: 'git-branch',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagSensitive(sensitive?: boolean) {
+    if (sensitive) {
+      this.trackCliFlag('sensitive');
+    }
+  }
+
+  trackCliFlagForce(force?: boolean) {
+    if (force) {
+      this.trackCliFlag('force');
+    }
+  }
+
+  trackCliFlagDebug(debug?: boolean) {
+    if (debug) {
+      this.trackCliFlag('debug');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -39,10 +39,4 @@ export class EnvAddTelemetryClient extends TelemetryClient {
       this.trackCliFlag('force');
     }
   }
-
-  trackCliFlagDebug(debug?: boolean) {
-    if (debug) {
-      this.trackCliFlag('debug');
-    }
-  }
 }

--- a/packages/cli/src/util/telemetry/commands/env/index.ts
+++ b/packages/cli/src/util/telemetry/commands/env/index.ts
@@ -1,0 +1,30 @@
+import { TelemetryClient } from '../..';
+
+export class EnvTelemetryClient extends TelemetryClient {
+  trackCliSubcommandLs(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'ls',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRm(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'rm',
+      value: actual,
+    });
+  }
+  trackCliSubcommandPull(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'pull',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import env from '../../../../src/commands/env';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 import { client } from '../../../mocks/client';
@@ -7,38 +7,119 @@ import { useTeams } from '../../../mocks/team';
 import { useUser } from '../../../mocks/user';
 
 describe('env add', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject(
+      {
+        ...defaultProject,
+        id: 'vercel-env-pull',
+        name: 'vercel-env-pull',
+      },
+      [
+        ...envs,
+        {
+          type: 'encrypted',
+          id: '781dt89g8r2h789g',
+          key: 'REDIS_CONNECTION_STRING',
+          value: 'redis://abc123@redis.example.dev:6379',
+          target: ['development'],
+          gitBranch: undefined,
+          configurationId: null,
+          updatedAt: 1557241361455,
+          createdAt: 1557241361455,
+        },
+      ]
+    );
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+  });
+
   describe('[name]', () => {
-    describe.todo('--sensitive');
-    describe.todo('--force');
+    describe('--sensitive', () => {
+      it('tracks flag', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'SENSITIVE_FLAG',
+          'preview',
+          'branchName',
+          '--sensitive'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          "What's the value of SENSITIVE_FLAG?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: `subcommand:add`,
+            value: 'add',
+          },
+          {
+            key: `argument:name`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:environment`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:git-branch`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `flag:sensitive`,
+            value: 'TRUE',
+          },
+        ]);
+      });
+    });
+    describe('--force', () => {
+      it('tracks flag', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'FORCE_FLAG',
+          'preview',
+          'branchName',
+          '--force'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: `subcommand:add`,
+            value: 'add',
+          },
+          {
+            key: `argument:name`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:environment`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:git-branch`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `flag:force`,
+            value: 'TRUE',
+          },
+        ]);
+      });
+    });
 
     describe('[environment]', () => {
       describe('[gitBranch]', () => {
         it('should allow `gitBranch` to be passed', async () => {
-          useUser();
-          useTeams('team_dummy');
-          useProject(
-            {
-              ...defaultProject,
-              id: 'vercel-env-pull',
-              name: 'vercel-env-pull',
-            },
-            [
-              ...envs,
-              {
-                type: 'encrypted',
-                id: '781dt89g8r2h789g',
-                key: 'REDIS_CONNECTION_STRING',
-                value: 'redis://abc123@redis.example.dev:6379',
-                target: ['development'],
-                gitBranch: undefined,
-                configurationId: null,
-                updatedAt: 1557241361455,
-                createdAt: 1557241361455,
-              },
-            ]
-          );
-          const cwd = setupUnitFixture('vercel-env-pull');
-          client.cwd = cwd;
           client.setArgv(
             'env',
             'add',
@@ -55,6 +136,41 @@ describe('env add', () => {
             'Added Environment Variable REDIS_CONNECTION_STRING to Project vercel-env-pull'
           );
           await expect(exitCodePromise).resolves.toEqual(0);
+        });
+
+        it('tracks telemetry events', async () => {
+          client.setArgv(
+            'env',
+            'add',
+            'TELEMETRY_EVENTS',
+            'preview',
+            'branchName'
+          );
+          const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput(
+            "What's the value of TELEMETRY_EVENTS?"
+          );
+          client.stdin.write('testvalue\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+
+          expect(client.telemetryEventStore).toHaveTelemetryEvents([
+            {
+              key: `subcommand:add`,
+              value: 'add',
+            },
+            {
+              key: `argument:name`,
+              value: '[REDACTED]',
+            },
+            {
+              key: `argument:environment`,
+              value: '[REDACTED]',
+            },
+            {
+              key: `argument:git-branch`,
+              value: '[REDACTED]',
+            },
+          ]);
         });
       });
     });


### PR DESCRIPTION
Telemetry for `vc env add`:

3 arguments (name, env, git branch)
2 flags (sensitive, force)
0 options