### PR TITLE
[sdk] build only during speakeasy publish

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,8 +18,8 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 src",
-    "build": "tshy",
-    "prepublishOnly": "npm run build"
+    "build-package": "tshy",
+    "prepublishOnly": "npm run build-package"
   },
   "peerDependencies": {
     "zod": ">= 3"
@@ -35,6 +35,6 @@
     "zod": "^3.23.4"
   },
   "dependencies": {
-    
+
   }
 }


### PR DESCRIPTION
Problem: Running `pnpm build` at the root of this repo will trigger `packages/sdk`'s build script. This takes extra time and generates a diff in `packages/sdk/package.json`.

Solution: Change the `package.json` script from `build` to `build-package` so that the `turbo` invocation at the root for all `build` scripts doesn't pick up the one for `packages/sdk`.