### PR TITLE
[cli] Add telemetry for `vercel init`

### DIFF
--- a/.changeset/pretty-news-pull.md
+++ b/.changeset/pretty-news-pull.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add telemetry for `vercel init`

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -12,6 +12,7 @@ import Client from '../../util/client';
 import cmd from '../../util/output/cmd';
 import didYouMean from '../../util/init/did-you-mean';
 import { getCommandName } from '../../util/pkg-name';
+import { InitTelemetryClient } from '../../util/telemetry/commands/init';
 
 type Options = {
   '--debug': boolean;
@@ -30,7 +31,8 @@ const EXAMPLE_API = 'https://now-example-files.zeit.sh';
 export default async function init(
   client: Client,
   opts: Partial<Options>,
-  args: string[]
+  args: string[],
+  telemetry: InitTelemetryClient
 ) {
   const { output } = client;
   const [name, dir] = args;
@@ -64,13 +66,17 @@ export default async function init(
   }
 
   if (exampleList.includes(name)) {
+    telemetry.trackCliArgumentExample(name, true);
     return extractExample(client, name, dir, force);
   }
 
   const oldExample = examples.find(x => !x.visible && x.name === name);
   if (oldExample) {
+    telemetry.trackCliArgumentExample(name, true);
     return extractExample(client, name, dir, force, 'v1');
   }
+
+  telemetry.trackCliArgumentExample(name, false);
 
   const found = await guess(client, exampleList, name);
 

--- a/packages/cli/src/util/telemetry/commands/init/index.ts
+++ b/packages/cli/src/util/telemetry/commands/init/index.ts
@@ -1,0 +1,27 @@
+import { TelemetryClient } from '../..';
+
+export class InitTelemetryClient extends TelemetryClient {
+  trackCliArgumentExample(v: string, knownValue: boolean) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'example',
+        value: knownValue ? v : this.redactedValue,
+      });
+    }
+  }
+
+  trackCliArgumentDir(v?: string) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'dir',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagForce(v?: boolean) {
+    if (v) {
+      this.trackCliFlag('force');
+    }
+  }
+}


### PR DESCRIPTION
This one is a slightly odd duck because the "example" positional argument will track the literal value, but only for valid template names. If the user typos or supplies an otherwise unknown value, we will redact the data from the telemetry. Since the list of known template names requires an API call, this tracking happens further into the command's logic than the others.