### PR TITLE
[cli] add telemetry tracking to `git connect` and `git disconnect`

### DIFF
--- a/.changeset/giant-hats-cheat.md
+++ b/.changeset/giant-hats-cheat.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add telemetry tracking to `git connect` and `git disconnect`

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -16,6 +16,7 @@ import {
   parseRepoUrl,
   printRemoteUrls,
 } from '../../util/git/connect-git-provider';
+import { GitConnectTelemetryClient } from '../../util/telemetry/commands/git/connect';
 
 interface GitRepoCheckParams {
   client: Client;
@@ -56,6 +57,16 @@ export default async function connect(
   org: Org | undefined
 ) {
   const { cwd, output } = client;
+  const telemetry = new GitConnectTelemetryClient({
+    opts: {
+      output,
+      store: client.telemetryEventStore,
+    },
+  });
+
+  telemetry.trackCliFlagYes(argv['--yes']);
+  telemetry.trackCliFlagConfirm(argv['--confirm']);
+
   const confirm = Boolean(argv['--yes']);
   const repoArg = args[0];
 
@@ -92,6 +103,7 @@ export default async function connect(
       );
       return 1;
     }
+    telemetry.trackCliArgumentGitUrl(repoArg);
     if (gitConfig) {
       return await connectArgWithLocalGit({
         client,

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -8,6 +8,7 @@ import disconnect from './disconnect';
 import { help } from '../help';
 import { gitCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { GitTelemetryClient } from '../../util/telemetry/commands/git';
 
 const COMMAND_CONFIG = {
   connect: ['connect'],
@@ -29,6 +30,13 @@ export default async function main(client: Client) {
     return 1;
   }
   const { output } = client;
+  const telemetry = new GitTelemetryClient({
+    opts: {
+      output,
+      store: client.telemetryEventStore,
+    },
+  });
+
   if (parsedArgs.flags['--help']) {
     output.print(help(gitCommand, { columns: client.stderr.columns }));
     return 2;
@@ -55,8 +63,10 @@ export default async function main(client: Client) {
 
   switch (subcommand) {
     case 'connect':
+      telemetry.trackCliSubcommandConnect('connect');
       return await connect(client, parsedArgs.flags, args, project, org);
     case 'disconnect':
+      telemetry.trackCliSubcommandDisconnect('disconnect');
       return await disconnect(client, args, project, org);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/util/telemetry/commands/git/connect.ts
+++ b/packages/cli/src/util/telemetry/commands/git/connect.ts
@@ -1,0 +1,24 @@
+import { TelemetryClient } from '../..';
+
+export class GitConnectTelemetryClient extends TelemetryClient {
+  trackCliArgumentGitUrl(name?: string) {
+    if (name) {
+      this.trackCliArgument({
+        arg: 'gitUrl',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagYes(yes?: boolean) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliFlagConfirm(confirm?: boolean) {
+    if (confirm) {
+      this.trackCliFlag('confirm');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/git/index.ts
+++ b/packages/cli/src/util/telemetry/commands/git/index.ts
@@ -1,0 +1,17 @@
+import { TelemetryClient } from '../..';
+
+export class GitTelemetryClient extends TelemetryClient {
+  trackCliSubcommandConnect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'connect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDisconnect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'disconnect',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
 import { join } from 'path';
 import fs from 'fs-extra';
 import { useUser } from '../../../mocks/user';
@@ -9,18 +9,12 @@ import git from '../../../../src/commands/git';
 import type { Project } from '@vercel-internals/types';
 
 describe('git connect', () => {
-  describe.todo('[git url]');
-  describe.todo('--yes');
-  describe.todo('--confirm');
-
   const fixture = (name: string) =>
     join(__dirname, '../../../fixtures/unit/commands/git/connect', name);
 
-  it('connects an unlinked project', async () => {
+  describe('connecting an unlinked project', () => {
     const cwd = fixture('unlinked');
-    client.cwd = cwd;
-    try {
-      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+    beforeEach(async () => {
       useUser();
       useTeams('team_dummy');
       useProject({
@@ -28,6 +22,121 @@ describe('git connect', () => {
         id: 'unlinked',
         name: 'unlinked',
       });
+
+      client.cwd = cwd;
+      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+    });
+
+    afterEach(async () => {
+      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+    });
+
+    describe('passing [git url]', () => {
+      it('tracks telemetry', async () => {
+        const remoteUrl = 'https://github.com/user2/repo2';
+        client.setArgv('git', 'connect', remoteUrl);
+        const gitPromise = git(client);
+
+        await expect(client.stderr).toOutput('Set up');
+        client.stdin.write('y\n');
+
+        await expect(client.stderr).toOutput(
+          'Which scope should contain your project?'
+        );
+        client.stdin.write('\r');
+
+        await expect(client.stderr).toOutput('Found project');
+        client.stdin.write('y\n');
+
+        await expect(client.stderr).toOutput(
+          `Do you still want to connect https://github.com/user2/repo2?`
+        );
+        client.stdin.write('y\n');
+
+        await expect(client.stderr).toOutput(
+          `Connecting Git remote: https://github.com/user2/repo2`
+        );
+
+        const exitCode = await gitPromise;
+        await expect(client.stderr).toOutput(
+          'Connected GitHub repository user2/repo2!'
+        );
+
+        expect(exitCode).toEqual(0);
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:connect',
+            value: 'connect',
+          },
+          {
+            key: 'argument:gitUrl',
+            value: '[REDACTED]',
+          },
+        ]);
+      });
+    });
+
+    describe('--yes', () => {
+      it('tracks telemetry', async () => {
+        client.setArgv('git', 'connect', '--yes');
+        const gitPromise = git(client);
+
+        await expect(client.stderr).toOutput(
+          `Connecting Git remote: https://github.com/user/repo`
+        );
+        await expect(client.stderr).toOutput(
+          `> Connected GitHub repository user/repo!\n`
+        );
+
+        const exitCode = await gitPromise;
+        expect(exitCode).toEqual(0);
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:connect',
+            value: 'connect',
+          },
+          {
+            key: 'flag:yes',
+            value: 'TRUE',
+          },
+        ]);
+      });
+    });
+
+    describe('--confirm', () => {
+      it('tracks telemetry', async () => {
+        client.setArgv('git', 'connect', '--confirm');
+        const gitPromise = git(client);
+
+        await expect(client.stderr).toOutput(
+          `Connecting Git remote: https://github.com/user/repo`
+        );
+        await expect(client.stderr).toOutput(
+          `> Connected GitHub repository user/repo!\n`
+        );
+
+        const exitCode = await gitPromise;
+        expect(exitCode).toEqual(0);
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:connect',
+            value: 'connect',
+          },
+          {
+            key: 'flag:yes',
+            value: 'TRUE',
+          },
+          {
+            key: 'flag:confirm',
+            value: 'TRUE',
+          },
+        ]);
+      });
+    });
+
+    it('connects an unlinked project', async () => {
+      const cwd = fixture('unlinked');
+      client.cwd = cwd;
       client.setArgv('git', 'connect');
       const gitPromise = git(client);
 
@@ -63,9 +172,7 @@ describe('git connect', () => {
         createdAt: 1656109539791,
         updatedAt: 1656109539791,
       });
-    } finally {
-      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-    }
+    });
   });
 
   it('connects an unlinked project with a remote url', async () => {


### PR DESCRIPTION
These were small enough to tackle as a group. `git disconnect` has no args, options, or flags, so no client needed there.