### PR TITLE
[cli] add subcommand tracking for `domains` group

### DIFF
--- a/.changeset/nine-moles-fetch.md
+++ b/.changeset/nine-moles-fetch.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add subcommand tracking for `domains` group

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -56,14 +56,19 @@ export default async function main(client: Client) {
   );
   switch (subcommand) {
     case 'add':
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, parsedArgs.flags, args);
     case 'inspect':
+      telemetry.trackCliSubcommandInspect(subcommandOriginal);
       return inspect(client, parsedArgs.flags, args);
     case 'move':
+      telemetry.trackCliSubcommandMove(subcommandOriginal);
       return move(client, parsedArgs.flags, args);
     case 'buy':
+      telemetry.trackCliSubcommandBuy(subcommandOriginal);
       return buy(client, parsedArgs.flags, args);
     case 'rm':
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, parsedArgs.flags, args);
     case 'transferIn':
       telemetry.trackCliSubcommandTransferIn(subcommandOriginal);

--- a/packages/cli/src/util/telemetry/commands/domains/index.ts
+++ b/packages/cli/src/util/telemetry/commands/domains/index.ts
@@ -1,6 +1,41 @@
 import { TelemetryClient } from '../..';
 
 export class DomainsTelemetryClient extends TelemetryClient {
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandInspect(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'inspect',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandMove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'move',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandBuy(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'buy',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandTransferIn(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'transfer-in',


### PR DESCRIPTION
No additional tests. The invocation requires a subcommand and the telemetry store updates are reflected in those tests as the first entry.