### PR TITLE
[cli] add subcommand tracking for `dns` group

### DIFF
--- a/.changeset/clean-months-design.md
+++ b/.changeset/clean-months-design.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add subcommand tracking for `dns` group

--- a/packages/cli/src/util/telemetry/commands/dns/index.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/index.ts
@@ -1,0 +1,31 @@
+import { TelemetryClient } from '../..';
+
+export class DnsTelemetryClient extends TelemetryClient {
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandImport(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'import',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/dns/index.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/index.ts
@@ -1,0 +1,31 @@
+import { TelemetryClient } from '../..';
+
+export class DnsTelemetryClient extends TelemetryClient {
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRemove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'remove',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandImportZone(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'import',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+}


### PR DESCRIPTION
No additional tests. The invocation requires a subcommand and the telemetry store updates are reflected in those tests as the first entry.