### PR TITLE
[cli] add subcommand tracking for `integration` group

### DIFF
--- a/.changeset/lemon-actors-give.md
+++ b/.changeset/lemon-actors-give.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add subcommand tracking for `integration` group

--- a/.changeset/purple-lemons-sip.md
+++ b/.changeset/purple-lemons-sip.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add subcommand tracking for `integration` group

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -8,6 +8,7 @@ import { add } from './add';
 import { integrationCommand } from './command';
 import { list } from './list';
 import { openIntegration } from './open-integration';
+import { IntegrationTelemetryClient } from '../../util/telemetry/commands/integration';
 
 const COMMAND_CONFIG = {
   add: ['add'],
@@ -16,15 +17,22 @@ const COMMAND_CONFIG = {
 };
 
 export default async function main(client: Client) {
+  const telemetry = new IntegrationTelemetryClient({
+    opts: {
+      output: client.output,
+      store: client.telemetryEventStore,
+    },
+  });
   const { args, flags } = parseArguments(
     client.argv.slice(2),
     getFlagsSpecification(integrationCommand.options),
     { permissive: true }
   );
-  const { subcommand, args: subArgs } = getSubcommand(
-    args.slice(1),
-    COMMAND_CONFIG
-  );
+  const {
+    subcommand,
+    subcommandOriginal,
+    args: subArgs,
+  } = getSubcommand(args.slice(1), COMMAND_CONFIG);
 
   if (flags['--help']) {
     client.output.print(
@@ -35,12 +43,15 @@ export default async function main(client: Client) {
 
   switch (subcommand) {
     case 'add': {
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, subArgs);
     }
     case 'list': {
+      telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client);
     }
     case 'open': {
+      telemetry.trackCliSubcommandOpen(subcommandOriginal);
       return openIntegration(client, subArgs);
     }
     default: {

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -1,0 +1,31 @@
+import { TelemetryClient } from '../..';
+
+export class IntegrationTelemetryClient extends TelemetryClient {
+  trackCliSubcommandAdd(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'add',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandMove(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'move',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandOpen(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'open',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -15,13 +15,6 @@ export class IntegrationTelemetryClient extends TelemetryClient {
     });
   }
 
-  trackCliSubcommandMove(actual: string) {
-    this.trackCliSubcommand({
-      subcommand: 'move',
-      value: actual,
-    });
-  }
-
   trackCliSubcommandOpen(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'open',


### PR DESCRIPTION
No additional tests. The invocation requires a subcommand and the telemetry store updates are reflected in those tests as the first entry.