### PR TITLE
extract vc pull logic from entrypoint

### DIFF
--- a/.changeset/witty-spies-help.md
+++ b/.changeset/witty-spies-help.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+extract vc pull logic from entrypoint

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -41,7 +41,7 @@ import {
 import { fileNameSymbol } from '@vercel/client';
 import type { VercelConfig } from '@vercel/client';
 
-import pull from '../pull';
+import { pullCommandLogic } from '../pull';
 import { staticFiles as getFiles } from '../../util/get-files';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
@@ -226,7 +226,13 @@ export default async function main(client: Client): Promise<number> {
       `--environment`,
       target,
     ];
-    const result = await pull(client);
+    const result = await pullCommandLogic(
+      client,
+      client.cwd,
+      Boolean(parsedArgs.flags['--yes']),
+      target,
+      parsedArgs.flags
+    );
     if (result !== 0) {
       return result;
     }

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -1,6 +1,8 @@
 import { packageName } from '../../util/pkg-name';
 import { getEnvTargetPlaceholder } from '../../util/env/env-target';
 import { forceOption, yesOption } from '../../util/arg-common';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
 
 const targetPlaceholder = getEnvTargetPlaceholder();
 
@@ -178,3 +180,11 @@ export const envCommand = {
     },
   ],
 } as const;
+
+export type EnvCommandSpec = ReturnType<
+  typeof getFlagsSpecification<(typeof envCommand)['options']>
+>;
+
+export type EnvCommandFlags = ReturnType<
+  typeof parseArguments<EnvCommandSpec>
+>['flags'];

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -82,7 +82,7 @@ export default async function pull(
   const skipConfirmation = opts['--yes'];
   const gitBranch = opts['--git-branch'];
 
-  await pullCommandLogic(
+  await envPullCommandLogic(
     client,
     output,
     filename,
@@ -97,7 +97,7 @@ export default async function pull(
   return 0;
 }
 
-export async function pullCommandLogic(
+export async function envPullCommandLogic(
   client: Client,
   output: Output,
   filename: string,

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -96,7 +96,7 @@ export default async function main(client: Client) {
   return returnCode;
 }
 
-async function pullCommandLogic(
+export async function pullCommandLogic(
   client: Client,
   cwd: string,
   autoConfirm: boolean,

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -7,7 +7,7 @@ import { parseArguments } from '../../util/get-args';
 import stamp from '../../util/output/stamp';
 import { VERCEL_DIR, VERCEL_DIR_PROJECT } from '../../util/projects/link';
 import { writeProjectSettings } from '../../util/projects/project-settings';
-import { pullCommandLogic } from '../env/pull';
+import { envPullCommandLogic } from '../env/pull';
 import {
   isValidEnvTarget,
   getEnvTargetPlaceholder,
@@ -16,7 +16,8 @@ import { ensureLink } from '../../util/link/ensure-link';
 import humanizePath from '../../util/humanize-path';
 
 import { help } from '../help';
-import { pullCommand, type PullCommandFlags } from './command';
+import { pullCommand } from './command';
+import { type EnvCommandFlags } from '../env/command';
 import parseTarget from '../../util/parse-target';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import handleError from '../../util/handle-error';
@@ -25,12 +26,12 @@ async function pullAllEnvFiles(
   environment: string,
   client: Client,
   link: ProjectLinked,
-  flags: PullCommandFlags,
+  flags: EnvCommandFlags,
   cwd: string
 ): Promise<number> {
   const environmentFile = `.env.${environment}.local`;
 
-  await pullCommandLogic(
+  await envPullCommandLogic(
     client,
     client.output,
     join('.vercel', environmentFile),
@@ -85,6 +86,23 @@ export default async function main(client: Client) {
       flags: parsedArgs.flags,
     }) || 'development';
 
+  const returnCode = await pullCommandLogic(
+    client,
+    cwd,
+    autoConfirm,
+    environment,
+    parsedArgs.flags
+  );
+  return returnCode;
+}
+
+async function pullCommandLogic(
+  client: Client,
+  cwd: string,
+  autoConfirm: boolean,
+  environment: string,
+  flags: EnvCommandFlags
+): Promise<number> {
   const link = await ensureLink('pull', client, cwd, { autoConfirm });
   if (typeof link === 'number') {
     return link;
@@ -102,7 +120,7 @@ export default async function main(client: Client) {
     environment,
     client,
     link,
-    parsedArgs.flags,
+    flags,
     cwd
   );
   if (pullResultCode !== 0) {


### PR DESCRIPTION
This is a very basic extraction of the core `vc pull` logic out of the command invocation for use in the build command invocation. This gives us a place to add telemetry later in only the `vc pull` invocation logic so that invoking `vc build` does not trigger `vc pull` telemetry metrics.

I manually tested this to make sure I didn't break it.