### PR TITLE
[cli] add telemetry for `vercel dns remove`

### DIFF
--- a/.changeset/smooth-pens-cross.md
+++ b/.changeset/smooth-pens-cross.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add telemetry for `vercel dns remove`

--- a/packages/cli/src/util/telemetry/commands/dns/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/rm.ts
@@ -1,0 +1,12 @@
+import { TelemetryClient } from '../..';
+
+export class DnsRmTelemetryClient extends TelemetryClient {
+  trackCliArgumentRecordId(recordId?: string) {
+    if (recordId) {
+      this.trackCliArgument({
+        arg: 'recordId',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/dns/rm.test.ts
+++ b/packages/cli/test/unit/commands/dns/rm.test.ts
@@ -1,5 +1,57 @@
-import { describe } from 'vitest';
+import { describe, beforeEach, expect, it } from 'vitest';
+import { client } from '../../../mocks/client';
+import dns from '../../../../src/commands/dns';
+import { useUser } from '../../../mocks/user';
+import { useDns } from '../../../mocks/dns';
 
-describe.todo('dns rm', () => {
-  describe.todo('[id]', () => {});
+describe('dns rm', () => {
+  beforeEach(() => {
+    useUser();
+    useDns();
+  });
+
+  describe('[id]', () => {
+    it('tracks the use of the argument', async () => {
+      const recordId = '1';
+      client.scenario.get(`/v5/domains/records/${recordId}`, (req, res) => {
+        res.json({
+          id: '1',
+          type: 'A',
+          value: '',
+          mxPriority: '1',
+          domain: {
+            domainName: 'example.com',
+          },
+          createdAt: '1729878610745',
+          name: 'Example',
+        });
+      });
+      client.scenario.delete(
+        `/v3/domains/:domain?/records/${recordId}`,
+        (req, res) => {
+          res.json({});
+        }
+      );
+      client.setArgv('dns', 'rm', recordId);
+      const exitCodePromise = dns(client);
+
+      await expect(client.stderr).toOutput(
+        `The following record will be removed permanently`
+      );
+
+      client.stdin.write('y\n');
+      await expect(exitCodePromise).resolves.toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:remove',
+          value: 'rm',
+        },
+        {
+          key: 'argument:recordId',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
This one required a few existing behavior refactors. Explanation within.