### PR TITLE
[tests] log mock endpoint failures

### DIFF
--- a/.changeset/little-ravens-agree.md
+++ b/.changeset/little-ravens-agree.md
@@ -1,0 +1,4 @@
+---
+---
+
+log mock endpoint failures

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -79,13 +79,13 @@ class MockTelemetryEventStore extends TelemetryEventStore {
   }
 }
 
-function setupMockServer(scenario: express.Router): Express {
+function setupMockServer(mockClient: MockClient): Express {
   const app = express();
   app.use(express.json());
 
   // play scenario
   app.use((req, res, next) => {
-    scenario(req, res, next);
+    mockClient.scenario(req, res, next);
   });
 
   // catch requests that were not intercepted
@@ -144,7 +144,7 @@ export class MockClient extends Client {
     });
 
     this.scenario = Router();
-    this.app = setupMockServer(this.scenario);
+    this.app = setupMockServer(this);
 
     this.reset();
   }

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -79,6 +79,42 @@ class MockTelemetryEventStore extends TelemetryEventStore {
   }
 }
 
+function setupMockServer(scenario: express.Router): Express {
+  const app = express();
+  app.use(express.json());
+
+  // play scenario
+  app.use((req, res, next) => {
+    scenario(req, res, next);
+  });
+
+  // catch requests that were not intercepted
+  app.use((req, res) => {
+    const message = `[Vercel API Mock] \`${req.method} ${req.path}\` was not handled.`;
+    // eslint-disable-next-line no-console
+    console.warn(message);
+    res.status(500).json({
+      error: {
+        code: 'not_found',
+        message,
+      },
+    });
+  });
+
+  // global error handling must be last
+  // @ts-ignore - this signature is actually valid
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((error, _req, res, _next) => {
+    res.status(500).json({
+      error: {
+        message: error.message,
+      },
+    });
+  });
+
+  return app;
+}
+
 export class MockClient extends Client {
   stdin!: MockStream;
   stdout!: MockStream;
@@ -104,30 +140,11 @@ export class MockClient extends Client {
 
     this.telemetryEventStore = new MockTelemetryEventStore({
       output: this.output,
-    });
-
-    this.app = express();
-    this.app.use(express.json());
-
-    // play scenario
-    this.app.use((req, res, next) => {
-      this.scenario(req, res, next);
-    });
-
-    // catch requests that were not intercepted
-    this.app.use((req, res) => {
-      const message = `[Vercel API Mock] \`${req.method} ${req.path}\` was not handled.`;
-      // eslint-disable-next-line no-console
-      console.warn(message);
-      res.status(500).json({
-        error: {
-          code: 'not_found',
-          message,
-        },
-      });
+      config: undefined,
     });
 
     this.scenario = Router();
+    this.app = setupMockServer(this.scenario);
 
     this.reset();
   }

--- a/packages/cli/test/unit/commands/domains/ls.test.ts
+++ b/packages/cli/test/unit/commands/domains/ls.test.ts
@@ -11,8 +11,8 @@ describe('domains ls', () => {
     useDomains();
     client.setArgv('domains', 'ls');
     let exitCodePromise = domains(client);
-    await expect(client.stderr).toOutput('example-19.com');
     await expect(exitCodePromise).resolves.toEqual(0);
+    await expect(client.stderr).toOutput('example-19.com');
   });
 
   describe('--limit', () => {
@@ -21,8 +21,8 @@ describe('domains ls', () => {
       useDomains();
       client.setArgv('domains', 'ls', '--limit', '2');
       const exitCodePromise = domains(client);
-      await expect(client.stderr).toOutput('example-1.com');
       await expect(exitCodePromise).resolves.toEqual(0);
+      await expect(client.stderr).toOutput('example-1.com');
     });
   });
   describe.todo('--next');


### PR DESCRIPTION
When a mock server endpoint handler fails, by default it was sending back an HTML error. Because this didn't parse as JSON, the fallback error was being sent to the code under test:

> Resposne Error (500)

After this PR's changes, you'll see the actual error:

> Some actual error from the failed mock endpoint handler.
