### PR TITLE
[cli] Fix `vercel env pull` is adding an extra rule `.env*local` to `.gitignore`

### DIFF
--- a/.changeset/moody-bulldogs-tease.md
+++ b/.changeset/moody-bulldogs-tease.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] fix `vercel env pull` is adding an extra rule `.env*local` to `.gitignore`

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -17,7 +17,7 @@ import {
   createEnvObject,
 } from '../../util/env/diff-env-files';
 import { isErrnoException } from '@vercel/error-utils';
-import { addToGitIgnore } from '../../util/link/add-to-gitignore';
+import { addToGitIgnore } from '../../util/add-to-gitignore';
 import JSONparse from 'json-parse-better-errors';
 import { formatProject } from '../../util/projects/format-project';
 import type { ProjectLinked } from '@vercel-internals/types';

--- a/packages/cli/src/util/add-to-gitignore.ts
+++ b/packages/cli/src/util/add-to-gitignore.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import { join } from 'path';
 import { readFile, writeFile } from 'fs-extra';
-import { VERCEL_DIR } from '../projects/link';
+import { VERCEL_DIR } from './projects/link';
 
 export async function addToGitIgnore(path: string, ignore = VERCEL_DIR) {
   let isGitIgnoreUpdated = false;

--- a/packages/cli/src/util/get-dominant-eol.ts
+++ b/packages/cli/src/util/get-dominant-eol.ts
@@ -1,0 +1,17 @@
+import os from 'os';
+
+export default function getDominantEOL(text: string) {
+  const lines = (text.match(/\r\n|\n/g) ?? []) as Array<'\r\n' | '\n'>;
+
+  const { '\n': LFCount, '\r\n': CRLFCount } = lines.reduce(
+    (counter, lineEnding) => {
+      counter[lineEnding] += 1;
+      return counter;
+    },
+    { '\n': 0, '\r\n': 0 }
+  );
+
+  const dominantEOL = LFCount > CRLFCount ? '\n' : '\r\n';
+
+  return LFCount === CRLFCount ? os.EOL : dominantEOL;
+}

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -13,7 +13,7 @@ import { getRemoteUrls } from '../create-git-meta';
 import link from '../output/link';
 import { emoji, prependEmoji } from '../emoji';
 import selectOrg from '../input/select-org';
-import { addToGitIgnore } from './add-to-gitignore';
+import { addToGitIgnore } from '../add-to-gitignore';
 import type Client from '../client';
 import type { Framework } from '@vercel/frameworks';
 import type { Project } from '@vercel-internals/types';

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -22,7 +22,7 @@ import { NowBuildError, getPlatformEnv } from '@vercel/build-utils';
 import outputCode from '../output/code';
 import { isErrnoException, isError } from '@vercel/error-utils';
 import { findProjectsFromPath, getRepoLink } from '../link/repo';
-import { addToGitIgnore } from '../link/add-to-gitignore';
+import { addToGitIgnore } from '../add-to-gitignore';
 import type { RepoProjectConfig } from '../link/repo';
 
 const readFile = promisify(fs.readFile);

--- a/packages/cli/test/unit/util/add-to-gitignore.test.ts
+++ b/packages/cli/test/unit/util/add-to-gitignore.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs-extra';
+import path from 'path';
+import tmp from 'tmp-promise';
+import { describe, expect, beforeEach, it, afterAll, beforeAll } from 'vitest';
+import { addToGitIgnore } from '../../../src/util/add-to-gitignore';
+
+const tmpDir = tmp.tmpNameSync({
+  prefix: 'test-vercel-cli-add-to-git-ignore',
+});
+
+describe('addToGitIgnore', () => {
+  const gitignoreFilePath = path.join(tmpDir, '.gitignore');
+  const readGitIgnore = () => fs.readFileSync(gitignoreFilePath).toString();
+  const createGitIgnore = (rules: string = '') =>
+    fs.writeFileSync(gitignoreFilePath, rules);
+
+  beforeAll(() => {
+    fs.mkdirs(tmpDir);
+  });
+  afterAll(() => {
+    fs.rmSync(gitignoreFilePath);
+  });
+
+  describe('when .gitignore is empty', () => {
+    beforeEach(() => {
+      createGitIgnore();
+    });
+
+    it('should add only once', async () => {
+      const newRule = '.env*local';
+      const modified = await addToGitIgnore(tmpDir, newRule);
+      const file = readGitIgnore();
+
+      expect(modified).toBe(true);
+      expect(file).contains(newRule);
+    });
+
+    it('should not add twice', async () => {
+      const newRule = '.env*local';
+      const modifiedFirstRun = await addToGitIgnore(tmpDir, newRule);
+      const modifiedSecondRun = await addToGitIgnore(tmpDir, newRule);
+      const file = readGitIgnore();
+
+      expect(file).contains(newRule);
+      expect(modifiedFirstRun).toBe(true);
+      expect(modifiedSecondRun).toEqual(false);
+    });
+  });
+});

--- a/packages/cli/test/unit/util/get-dominant-eol.test.ts
+++ b/packages/cli/test/unit/util/get-dominant-eol.test.ts
@@ -1,0 +1,18 @@
+import os from 'os';
+import { describe, expect, it } from 'vitest';
+import getDominantEOL from '../../../src/util/get-dominant-eol';
+
+describe('getDominantEOL', () => {
+  it('should return the most frequent end-of-line', () => {
+    expect(getDominantEOL('a\nb\nc\nd')).toEqual('\n');
+    expect(getDominantEOL('a\r\nb\r\nc\r\nd')).toEqual('\r\n');
+
+    expect(getDominantEOL('a\nb\nc\r\nd')).toEqual('\n');
+    expect(getDominantEOL('a\r\nb\nc\r\nd')).toEqual('\r\n');
+  });
+
+  it('should return the os end-of-line when the line endings has the same frequency', () => {
+    expect(getDominantEOL('a\nb\r\nc')).toEqual(os.EOL);
+    expect(getDominantEOL('a\r\nb\nc')).toEqual(os.EOL);
+  });
+});


### PR DESCRIPTION
# 📝 Description

This is not a critical bug but is little boring have to remove this extra rule always that I added a new rule to vercel.

## 🔎 Details

* CLI Version: **37.12.1**
* OS: **Microsoft Windows 11 Pro**

## 📷 Evidence

![evidence](https://github.com/user-attachments/assets/6cc3f56c-6a3b-4291-b8eb-355eabc203f3)

##  🐾 Steps to reproduce the issue

1. Using an OS that has end-of-line `crlf` by default like Windows
2. Run `vercel env pull` Into a project that already has a the vercel rules into the `.gitignore` 

#### 🧪 What's the expected result?

Only add the rule `.env*.local` when the `.gitignore` does not have it.

#### ❌ What's the actual result?

Is adding the same rule multiple times.

#### 🫚 Root cause

This is happeing because [this condition](https://github.com/vercel/vercel/blob/main/packages/cli/src/util/link/add-to-gitignore.ts#L13) in this file `packages/cli/src/util/link/add-to-gitignore.ts` this is the code:

```ts
const EOL = gitIgnore.includes('\r\n') ? '\r\n' : os.EOL;
// ..
if (!gitIgnore.split(EOL).includes(ignore)) { /* add the rule */
```

In some cases this condition can be translated to:

```ts
const EOL = gitIgnore.includes('\r\n') ? '\r\n' : '\r\n';
```

For example in my case my file is using `lf` = `\n` but my os use `crlf` = `\r\n` by default that is this condition will never be `true`.

### ✅ Solution

I opened [this Feedback](https://vercel.community/t/always-that-run-the-command-vercel-env-pull-is-adding-an-extra-rule-env-local-to-gitignore/1686) at vercel community to talk about it but I think that is better to open a PR here!

I did a few changes in this code but if I need to do something else I will be happy to do it 😊!

#### Changes

1. Move this file `add-to-gitignore.ts` from `src/util/link` to `src/util` since it is not only used in **link** command but also in **env** command.

2. Change the code to check as an string. It is good for two reasons:
    - The `.gitignore` can have multiples rules at the same line
    - Doesn't matter what is the end-of-line

```ts
if (gitIgnore.includes(ignore)) return isGitIgnoreUpdated;
```

3. The last change that I would like to check if it is ok 🤔 or is too much. I created a function to get the dominant end-of-line and use it when add a new line. This is the code:

```ts
function getDominantEOL(text: string) {
  const lines = (text.match(/\r\n|\n/g) ?? []) as Array<'\r\n' | '\n'>;

  const {
    '\n': LFCount,
    '\r\n': CRLFCount,
  } = lines.reduce(
    (counter, lineEnding) => {
      counter[lineEnding] += 1;
      return counter;
    },
    { '\n': 0, '\r\n': 0 },
  );

  const dominantEOL = LFCount > CRLFCount ? '\n' : '\r\n';

  return LFCount === CRLFCount ? os.EOL : dominantEOL;
}
```

However It can be simpler checking if there is any kind of end-of-line otherwise it uses the os end-of-line:

```ts
function getEOL(text: string) {
  if (text.includes('\r\n')) return '\r\n';
  if (text.includes('\n')) return '\n';
  return os.EOL;
}
```