### PR TITLE
[next] Expose allowHeader

### DIFF
--- a/.changeset/two-mangos-thank.md
+++ b/.changeset/two-mangos-thank.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': patch
+'@vercel/next': patch
+'vercel': patch
+---
+
+Support allowHeader from Next.js for filtering request headers during revalidation

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -8,6 +8,7 @@ interface PrerenderOptions {
   group?: number;
   bypassToken?: string | null /* optional to be non-breaking change */;
   allowQuery?: string[];
+  allowHeader?: string[];
   initialHeaders?: Record<string, string>;
   initialStatus?: number;
   passQuery?: boolean;
@@ -25,6 +26,7 @@ export class Prerender {
   public group?: number;
   public bypassToken: string | null;
   public allowQuery?: string[];
+  public allowHeader?: string[];
   public initialHeaders?: Record<string, string>;
   public initialStatus?: number;
   public passQuery?: boolean;
@@ -40,6 +42,7 @@ export class Prerender {
     group,
     bypassToken,
     allowQuery,
+    allowHeader,
     initialHeaders,
     initialStatus,
     passQuery,
@@ -158,6 +161,20 @@ export class Prerender {
         );
       }
       this.allowQuery = allowQuery;
+    }
+
+    if (allowHeader !== undefined) {
+      if (!Array.isArray(allowHeader)) {
+        throw new Error(
+          'The `allowHeader` argument for `Prerender` must be Array.'
+        );
+      }
+      if (!allowHeader.every(q => typeof q === 'string')) {
+        throw new Error(
+          'The `allowHeader` argument for `Prerender` must be Array of strings.'
+        );
+      }
+      this.allowHeader = allowHeader;
     }
 
     if (experimentalStreamingLambdaPath !== undefined) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -932,6 +932,7 @@ export type NextPrerenderedRoutes = {
       initialHeaders?: Record<string, string>;
       experimentalBypassFor?: HasField;
       renderingMode: RenderingMode;
+      allowHeader: string[] | undefined;
     };
   };
 
@@ -944,6 +945,7 @@ export type NextPrerenderedRoutes = {
       prefetchDataRouteRegex?: string | null;
       experimentalBypassFor?: HasField;
       renderingMode: RenderingMode;
+      allowHeader: string[] | undefined;
     };
   };
 
@@ -960,6 +962,7 @@ export type NextPrerenderedRoutes = {
       prefetchDataRouteRegex?: string | null;
       experimentalBypassFor?: HasField;
       renderingMode: RenderingMode;
+      allowHeader: string[] | undefined;
     };
   };
 
@@ -976,6 +979,7 @@ export type NextPrerenderedRoutes = {
       prefetchDataRouteRegex: string | null | undefined;
       experimentalBypassFor?: HasField;
       renderingMode: RenderingMode;
+      allowHeader: string[] | undefined;
     };
   };
 
@@ -1183,6 +1187,7 @@ export async function getPrerenderManifest(
             experimentalBypassFor?: HasField;
             experimentalPPR?: boolean;
             renderingMode?: RenderingMode;
+            allowHeader?: string[];
           };
         };
         dynamicRoutes: {
@@ -1199,6 +1204,7 @@ export async function getPrerenderManifest(
             experimentalBypassFor?: HasField;
             experimentalPPR?: boolean;
             renderingMode?: RenderingMode;
+            allowHeader?: string[];
           };
         };
         preview: {
@@ -1234,6 +1240,7 @@ export async function getPrerenderManifest(
           dataRoute,
           srcRoute,
           renderingMode: RenderingMode.STATIC,
+          allowHeader: undefined,
         };
       });
 
@@ -1248,6 +1255,7 @@ export async function getPrerenderManifest(
             dataRoute,
             dataRouteRegex,
             renderingMode: RenderingMode.STATIC,
+            allowHeader: undefined,
           };
         } else {
           ret.blockingFallbackRoutes[lazyRoute] = {
@@ -1255,6 +1263,7 @@ export async function getPrerenderManifest(
             dataRoute,
             dataRouteRegex,
             renderingMode: RenderingMode.STATIC,
+            allowHeader: undefined,
           };
         }
       });
@@ -1289,6 +1298,7 @@ export async function getPrerenderManifest(
         let initialHeaders: undefined | Record<string, string>;
         let experimentalBypassFor: undefined | HasField;
         let prefetchDataRoute: undefined | string | null;
+        let allowHeader: undefined | string[];
         let renderingMode: RenderingMode;
 
         if (manifest.version === 4) {
@@ -1296,6 +1306,7 @@ export async function getPrerenderManifest(
           initialHeaders = manifest.routes[route].initialHeaders;
           experimentalBypassFor = manifest.routes[route].experimentalBypassFor;
           prefetchDataRoute = manifest.routes[route].prefetchDataRoute;
+          allowHeader = manifest.routes[route].allowHeader;
           renderingMode =
             manifest.routes[route].renderingMode ??
             (manifest.routes[route].experimentalPPR
@@ -1303,6 +1314,7 @@ export async function getPrerenderManifest(
               : RenderingMode.STATIC);
         } else {
           renderingMode = RenderingMode.STATIC;
+          allowHeader = undefined;
         }
 
         ret.staticRoutes[route] = {
@@ -1315,6 +1327,7 @@ export async function getPrerenderManifest(
           srcRoute,
           initialStatus,
           initialHeaders,
+          allowHeader,
           experimentalBypassFor,
           renderingMode,
         };
@@ -1330,7 +1343,7 @@ export async function getPrerenderManifest(
         let fallbackHeaders: undefined | Record<string, string>;
         let renderingMode: RenderingMode = RenderingMode.STATIC;
         let fallbackRevalidate: number | false | undefined;
-
+        let allowHeader: undefined | string[];
         if (manifest.version === 4) {
           experimentalBypassFor =
             manifest.dynamicRoutes[lazyRoute].experimentalBypassFor;
@@ -1349,6 +1362,7 @@ export async function getPrerenderManifest(
               : RenderingMode.STATIC);
           fallbackRevalidate =
             manifest.dynamicRoutes[lazyRoute].fallbackRevalidate;
+          allowHeader = manifest.dynamicRoutes[lazyRoute].allowHeader;
         }
 
         if (typeof fallback === 'string') {
@@ -1364,6 +1378,7 @@ export async function getPrerenderManifest(
             prefetchDataRouteRegex,
             fallbackRevalidate,
             renderingMode,
+            allowHeader,
           };
         } else if (fallback === null) {
           ret.blockingFallbackRoutes[lazyRoute] = {
@@ -1374,6 +1389,7 @@ export async function getPrerenderManifest(
             prefetchDataRoute,
             prefetchDataRouteRegex,
             renderingMode,
+            allowHeader,
           };
         } else {
           ret.omittedRoutes[lazyRoute] = {
@@ -1384,6 +1400,7 @@ export async function getPrerenderManifest(
             prefetchDataRoute,
             prefetchDataRouteRegex,
             renderingMode,
+            allowHeader,
           };
         }
       });
@@ -2116,6 +2133,7 @@ export const onPrerenderRoute =
     let initialHeaders: Record<string, string> | undefined;
     let experimentalBypassFor: HasField | undefined;
     let renderingMode: RenderingMode;
+    let allowHeader: string[] | undefined;
 
     if (isFallback || isBlocking) {
       const pr = isFallback
@@ -2132,6 +2150,7 @@ export const onPrerenderRoute =
       }
       srcRoute = null;
       dataRoute = pr.dataRoute;
+      allowHeader = pr.allowHeader;
       experimentalBypassFor = pr.experimentalBypassFor;
       renderingMode = pr.renderingMode;
       prefetchDataRoute = pr.prefetchDataRoute;
@@ -2139,6 +2158,7 @@ export const onPrerenderRoute =
       initialRevalidate = false;
       srcRoute = routeKey;
       dataRoute = prerenderManifest.omittedRoutes[routeKey].dataRoute;
+      allowHeader = prerenderManifest.omittedRoutes[routeKey].allowHeader;
       experimentalBypassFor =
         prerenderManifest.omittedRoutes[routeKey].experimentalBypassFor;
       renderingMode = prerenderManifest.omittedRoutes[routeKey].renderingMode;
@@ -2152,6 +2172,7 @@ export const onPrerenderRoute =
         dataRoute,
         initialHeaders,
         initialStatus,
+        allowHeader,
         experimentalBypassFor,
         renderingMode,
         prefetchDataRoute,
@@ -2461,6 +2482,7 @@ export const onPrerenderRoute =
       ) as RoutesManifestRoute | undefined;
       const isDynamic = isDynamicRoute(routeKey);
       const routeKeys = route?.routeKeys;
+
       // by default allowQuery should be undefined and only set when
       // we have sufficient information to set it
       let allowQuery: string[] | undefined;
@@ -2578,6 +2600,7 @@ export const onPrerenderRoute =
         sourcePath,
         experimentalStreamingLambdaPath,
         chain,
+        allowHeader,
 
         ...(isNotFound
           ? {
@@ -2624,6 +2647,7 @@ export const onPrerenderRoute =
           group: prerenderGroup,
           bypassToken: prerenderManifest.bypassToken,
           experimentalBypassFor,
+          allowHeader,
 
           ...(isNotFound
             ? {

--- a/packages/next/test/fixtures/00-middleware/index.test.js
+++ b/packages/next/test/fixtures/00-middleware/index.test.js
@@ -109,7 +109,7 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         `${ctx.deploymentUrl}/_next/data/testing-build-id/financial.json?slug=financial`
       ).then(res => res.json());
 
-      console.log({ newData, data });
+      console.log(JSON.stringify({ newData, data }, null, 2));
 
       if (isNaN(newData.now)) {
         throw new Error();


### PR DESCRIPTION
Exposes the `allowHeader` exposed from the `prerender-manifest.json` on the Prerender document.

### Related

https://github.com/vercel/next.js/pull/72033