### PR TITLE
[cli] Don't print empty "Examples" section in `--help` output

### DIFF
--- a/.changeset/fast-walls-enjoy.md
+++ b/.changeset/fast-walls-enjoy.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Don't print empty "Examples" section in `--help` output

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -270,6 +270,9 @@ export function buildSubcommandLines(
 }
 
 export function buildCommandExampleLines(command: Command) {
+  if (!command.examples?.length) {
+    return null;
+  }
   const outputArray: string[] = [`${INDENT}${chalk.dim('Examples:')}`, ''];
   for (const example of command.examples) {
     const nameLine: string[] = [INDENT];

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -189,8 +189,6 @@ exports[`help command > alias help output snapshots > alias list subcommand > al
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 
@@ -218,8 +216,6 @@ exports[`help command > alias help output snapshots > alias remove subcommand > 
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 
@@ -241,8 +237,6 @@ exports[`help command > alias help output snapshots > alias set subcommand > ali
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
-
-  Examples:
 
 "
 `;
@@ -1013,8 +1007,6 @@ exports[`help command > dns help output snapshots > dns add help output snapshot
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 
@@ -1275,8 +1267,6 @@ exports[`help command > dns help output snapshots > dns import help output snaps
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 
@@ -1305,8 +1295,6 @@ exports[`help command > dns help output snapshots > dns list help output snapsho
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 
@@ -1328,8 +1316,6 @@ exports[`help command > dns help output snapshots > dns remove help output snaps
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
-
-  Examples:
 
 "
 `;
@@ -2494,8 +2480,6 @@ exports[`help command > integration help output snapshots > integration help col
                               number    
 
 
-  Examples:
-
 "
 `;
 
@@ -2527,8 +2511,6 @@ exports[`help command > integration help output snapshots > integration help col
   -v,  --version              Output the version number                         
 
 
-  Examples:
-
 "
 `;
 
@@ -2558,8 +2540,6 @@ exports[`help command > integration help output snapshots > integration help col
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
-
-  Examples:
 
 "
 `;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -434,8 +434,6 @@ exports[`help command > certs help output snapshots > certs add help output snap
   -v,  --version              Output the version number                                                                 
 
 
-  Examples:
-
 "
 `;
 


### PR DESCRIPTION
There's currently cases where there are no `examples` in the (sub)command spec, and thus an empty "Examples:" section is printed at the bottom of the `--help` output. You could argue that there should always be examples, but let's make the `help()` output generator be defensive about that scenario at least.