### PR TITLE
[cli] Don't print empty "Options" section in --help output (after filtering)

### DIFF
--- a/.changeset/chilly-comics-play.md
+++ b/.changeset/chilly-comics-play.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Don't print empty "Options" section in `--help` output (after filtering)

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -140,14 +140,14 @@ export function buildCommandOptionLines(
   options: BuildHelpOutputOptions,
   sectionTitle: String
 ) {
-  if (commandOptions.length === 0) {
-    return null;
-  }
-
   // Filter out deprecated and intentionally undocumented options
   const filteredCommandOptions = commandOptions.filter(
     option => !option.deprecated && option.description !== undefined
   );
+
+  if (filteredCommandOptions.length === 0) {
+    return null;
+  }
 
   // Sort command options alphabetically
   filteredCommandOptions.sort((a, b) =>

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2004,11 +2004,6 @@ exports[`help command > git help output snapshots > git help column width 40 1`]
                          project   
 
 
-  Options:
-
-
-
-
   Global Options:
 
        --cwd <DIR>            Sets the  
@@ -2078,11 +2073,6 @@ exports[`help command > git help output snapshots > git help column width 80 1`]
                          project                                           
 
 
-  Options:
-
-
-
-
   Global Options:
 
        --cwd <DIR>            Sets the current working directory for a single   
@@ -2125,11 +2115,6 @@ exports[`help command > git help output snapshots > git help column width 120 1`
   connect     [git url]  Connect your Vercel Project to your Git repository or provide the remote URL to your Git  
                          repository                                                                                
   disconnect             Disconnect the Git provider repository from your project                                  
-
-
-  Options:
-
-
 
 
   Global Options:


### PR DESCRIPTION
Similar to #12475, but for the "Options" section. There was already logic to bail when the options array is empty, but that was happening before filtering deprecated / undocumented commands. Move the check to after filtering.