### PR TITLE
[cli] Migrate `vercel promote` subcommands to their own command specifications

### DIFF
--- a/.changeset/flat-olives-applaud.md
+++ b/.changeset/flat-olives-applaud.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Migrate `vercel promote` subcommands to their own command specifications

--- a/packages/cli/src/commands/promote/command.ts
+++ b/packages/cli/src/commands/promote/command.ts
@@ -1,31 +1,45 @@
 import { packageName } from '../../util/pkg-name';
 import { yesOption } from '../../util/arg-common';
 
+export const statusSubcommand = {
+  name: 'status',
+  aliases: [],
+  description: 'Show the status of any current pending promotions',
+  arguments: [
+    {
+      name: 'project',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when linking a Project',
+    },
+  ],
+  examples: [
+    {
+      name: 'Show the status of any current pending promotions',
+      value: [
+        `${packageName} promote status`,
+        `${packageName} promote status <project>`,
+        `${packageName} promote status --timeout 30s`,
+      ],
+    },
+  ],
+} as const;
+
 export const promoteCommand = {
   name: 'promote',
   aliases: [],
-  description: 'Promote an existing deployment to current.',
+  description: 'Promote an existing Deployment to current',
   arguments: [
     {
       name: 'url|deploymentId',
       required: true,
     },
   ],
-  subcommands: [
-    {
-      name: 'status',
-      aliases: [],
-      description: 'Show the status of any current pending promotions',
-      arguments: [
-        {
-          name: 'project',
-          required: false,
-        },
-      ],
-      options: [],
-      examples: [],
-    },
-  ],
+  subcommands: [statusSubcommand],
   options: [
     {
       name: 'timeout',
@@ -35,21 +49,15 @@ export const promoteCommand = {
       type: String,
       deprecated: false,
     },
-    yesOption,
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when linking a Project',
+    },
   ],
   examples: [
     {
-      name: 'Show the status of any current pending promotions',
-      value: [
-        `${packageName} promote`,
-        `${packageName} promote status`,
-        `${packageName} promote status <project>`,
-        `${packageName} promote status --timeout 30s`,
-      ],
-    },
-    {
-      name: 'Promote a deployment using id or url',
-      value: `${packageName} promote <deployment id/url>`,
+      name: 'Promote a Deployment using ID or URL',
+      value: `${packageName} promote <deployment id|url>`,
     },
   ],
 } as const;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3519,8 +3519,8 @@ exports[`help command > promote help output snapshots > promote help column widt
 "
   ▲ vercel promote url|deploymentId [options]
 
-  Promote an existing deployment to     
-  current.                              
+  Promote an existing Deployment to     
+  current                               
 
   Commands:
 
@@ -3533,9 +3533,13 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   Options:
 
-   --timeout <timeout>  Time to wait for 
-                        promotion        
-                        completion [3m]  
+       --timeout <timeout>  Time to wait for 
+                            promotion        
+                            completion [3m]  
+  -y,  --yes                Skip the         
+                            confirmation     
+                            prompt when      
+                            linking a Project
 
 
   Global Options:
@@ -3578,16 +3582,9 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   Examples:
 
-  - Show the status of any current pending promotions
+  - Promote a Deployment using ID or URL
 
-    $ vercel promote
-    $ vercel promote status
-    $ vercel promote status <project>
-    $ vercel promote status --timeout 30s
-
-  - Promote a deployment using id or url
-
-    $ vercel promote <deployment id/url>
+    $ vercel promote <deployment id|url>
 
 "
 `;
@@ -3596,7 +3593,7 @@ exports[`help command > promote help output snapshots > promote help column widt
 "
   ▲ vercel promote url|deploymentId [options]
 
-  Promote an existing deployment to current.                                    
+  Promote an existing Deployment to current                                     
 
   Commands:
 
@@ -3605,7 +3602,8 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   Options:
 
-   --timeout <timeout>  Time to wait for promotion completion [3m]               
+       --timeout <timeout>  Time to wait for promotion completion [3m]               
+  -y,  --yes                Skip the confirmation prompt when linking a Project      
 
 
   Global Options:
@@ -3624,16 +3622,9 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   Examples:
 
-  - Show the status of any current pending promotions
+  - Promote a Deployment using ID or URL
 
-    $ vercel promote
-    $ vercel promote status
-    $ vercel promote status <project>
-    $ vercel promote status --timeout 30s
-
-  - Promote a deployment using id or url
-
-    $ vercel promote <deployment id/url>
+    $ vercel promote <deployment id|url>
 
 "
 `;
@@ -3642,7 +3633,7 @@ exports[`help command > promote help output snapshots > promote help column widt
 "
   ▲ vercel promote url|deploymentId [options]
 
-  Promote an existing deployment to current.                                                                            
+  Promote an existing Deployment to current                                                                             
 
   Commands:
 
@@ -3651,7 +3642,41 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   Options:
 
-   --timeout <timeout>  Time to wait for promotion completion [3m]                                                       
+       --timeout <timeout>  Time to wait for promotion completion [3m]                                                       
+  -y,  --yes                Skip the confirmation prompt when linking a Project                                              
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Promote a Deployment using ID or URL
+
+    $ vercel promote <deployment id|url>
+
+"
+`;
+
+exports[`help command > promote help output snapshots > promote status help output snapshots > promote status help column width 120 1`] = `
+"
+  ▲ vercel promote status [project] [options]
+
+  Show the status of any current pending promotions                                                                     
+
+  Options:
+
+  -y,  --yes  Skip the confirmation prompt when linking a Project                                                       
 
 
   Global Options:
@@ -3671,14 +3696,9 @@ exports[`help command > promote help output snapshots > promote help column widt
 
   - Show the status of any current pending promotions
 
-    $ vercel promote
     $ vercel promote status
     $ vercel promote status <project>
     $ vercel promote status --timeout 30s
-
-  - Promote a deployment using id or url
-
-    $ vercel promote <deployment id/url>
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -18,7 +18,7 @@ import { linkCommand } from '../../../src/commands/link/command';
 import { listCommand } from '../../../src/commands/list/command';
 import { loginCommand } from '../../../src/commands/login/command';
 import { projectCommand } from '../../../src/commands/project/command';
-import { promoteCommand } from '../../../src/commands/promote/command';
+import * as promote from '../../../src/commands/promote/command';
 import { pullCommand } from '../../../src/commands/pull/command';
 import { redeployCommand } from '../../../src/commands/redeploy/command';
 import { removeCommand } from '../../../src/commands/remove/command';
@@ -389,13 +389,23 @@ describe('help command', () => {
 
   describe('promote help output snapshots', () => {
     it('promote help column width 40', () => {
-      expect(help(promoteCommand, { columns: 40 })).toMatchSnapshot();
+      expect(help(promote.promoteCommand, { columns: 40 })).toMatchSnapshot();
     });
     it('promote help column width 80', () => {
-      expect(help(promoteCommand, { columns: 80 })).toMatchSnapshot();
+      expect(help(promote.promoteCommand, { columns: 80 })).toMatchSnapshot();
     });
     it('promote help column width 120', () => {
-      expect(help(promoteCommand, { columns: 120 })).toMatchSnapshot();
+      expect(help(promote.promoteCommand, { columns: 120 })).toMatchSnapshot();
+    });
+    describe('promote status help output snapshots', () => {
+      it('promote status help column width 120', () => {
+        expect(
+          help(promote.statusSubcommand, {
+            columns: 120,
+            parent: promote.promoteCommand,
+          })
+        ).toMatchSnapshot();
+      });
     });
   });
 

--- a/packages/cli/test/unit/commands/promote/status.test.ts
+++ b/packages/cli/test/unit/commands/promote/status.test.ts
@@ -1,6 +1,0 @@
-import { describe } from 'vitest';
-
-describe('promote status', () => {
-  describe.todo('--status');
-  describe.todo('--timeout');
-});


### PR DESCRIPTION
This one is set up a bit wonky and could use some additional cleanup/consistency refactoring (default command is inlined into the index file), but at least this gets us separate help output for `vc promote --help` vs. `vc promote status --help`.