### PR TITLE
Fix missing Go version in generated go.work files

### DIFF
--- a/.changeset/dirty-dingos-wave.md
+++ b/.changeset/dirty-dingos-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+fix missing go directive of go.work


### PR DESCRIPTION
## Problem
The generated `go.work` files defaulted to Go 1.18, causing compatibility issues with modules requiring newer Go versions (particularly Go 1.21+). This led to errors when modules required higher Go versions than what was declared in the workspace file.

> Starting in Go 1.21, the Go distribution consists of a go command and a bundled Go toolchain, which is the standard library as well as the compiler, assembler, and other tools. The go command can use its bundled Go toolchain as well as other versions that it finds in the local PATH or downloads as needed.

## Solution
Updated the `writeGoWork` function to properly handle Go version declarations by:
1. Reading the Go version from the module's `go.mod` file
2. Using this version when generating the `go.work` file
3. Defaulting to Go 1.18 only when no version information is available

This change is particularly important for Go 1.21+ projects, which introduce new toolchain management features requiring proper version declarations.