### PR TITLE
change fs-detectors.getApiMatches pattren,to keep my project structure like this vercel/api

### DIFF
--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -480,8 +480,11 @@ function getApiMatches(): Builder[] {
     },
     { src: 'api/**/*.+(js|mjs|ts|tsx)', use: `@vercel/node`, config },
     { src: 'api/**/!(*_test).go', use: `@vercel/go`, config },
+    { src: 'vercel/api/**/!(*_test).go', use: `@vercel/go`, config },
     { src: 'api/**/*.py', use: `@vercel/python`, config },
+    { src: 'vercel/api/**/*.py', use: `@vercel/python`, config },
     { src: 'api/**/*.rb', use: `@vercel/ruby`, config },
+    { src: 'vercel/api/**/*.rb', use: `@vercel/ruby`, config },
   ];
 }
 


### PR DESCRIPTION
I want to keep my project structure like this vercel/api
I added vercel support to my golang gin project, instead of creating serverless functions for each interface, so I want to keep the api directory