### PR TITLE
[next] Stabilize Chained Prerenders

### DIFF
--- a/.changeset/large-pants-run.md
+++ b/.changeset/large-pants-run.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': patch
+'vercel': patch
+---
+
+Stabilize Chained Prerenders

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1260,50 +1260,54 @@ export async function serverBuild({
           // perform the initial static shell render.
           lambdas[outputName] = lambda;
 
-          // If this isn't an omitted page, then we should add the link from the
-          // page to the postpone resume lambda.
-          if (!omittedPrerenderRoutes.has(pagePathname)) {
-            const output = getPostponeResumeOutput(entryDirectory, pageName);
-            lambdas[output] = lambda;
+          // If we're using the new chain feature, then we don't need to create
+          // any resume paths as the pathname is the same as the output name.
+          if (typeof routesManifest?.ppr?.chain?.headers === 'undefined') {
+            // If this isn't an omitted page, then we should add the link from the
+            // page to the postpone resume lambda.
+            if (!omittedPrerenderRoutes.has(pagePathname)) {
+              const output = getPostponeResumeOutput(entryDirectory, pageName);
+              lambdas[output] = lambda;
 
-            // We want to add the `experimentalStreamingLambdaPath` to this
-            // output.
-            experimentalStreamingLambdaPaths.set(outputName, {
-              pathname: getPostponeResumePathname(pageName),
-              output,
-            });
+              // We want to add the `experimentalStreamingLambdaPath` to this
+              // output.
+              experimentalStreamingLambdaPaths.set(outputName, {
+                pathname: getPostponeResumePathname(pageName),
+                output,
+              });
+            }
+
+            // For each static route that was generated, we should generate a
+            // specific partial prerendering resume route. This is because any
+            // static route that is matched will not hit the rewrite rules.
+            for (const [
+              routePathname,
+              { srcRoute, renderingMode },
+            ] of Object.entries(prerenderManifest.staticRoutes)) {
+              // If the srcRoute doesn't match or this doesn't support
+              // experimental partial prerendering, then we can skip this route.
+              if (
+                srcRoute !== pagePathname ||
+                renderingMode !== RenderingMode.PARTIALLY_STATIC
+              )
+                continue;
+
+              // If this route is the same as the page route, then we can skip
+              // it, because we've already added the lambda to the output.
+              if (routePathname === pagePathname) continue;
+
+              const output = getPostponeResumePathname(routePathname);
+              lambdas[output] = lambda;
+
+              outputName = path.posix.join(entryDirectory, routePathname);
+              experimentalStreamingLambdaPaths.set(outputName, {
+                pathname: getPostponeResumePathname(routePathname),
+                output,
+              });
+            }
+
+            continue;
           }
-
-          // For each static route that was generated, we should generate a
-          // specific partial prerendering resume route. This is because any
-          // static route that is matched will not hit the rewrite rules.
-          for (const [
-            routePathname,
-            { srcRoute, renderingMode },
-          ] of Object.entries(prerenderManifest.staticRoutes)) {
-            // If the srcRoute doesn't match or this doesn't support
-            // experimental partial prerendering, then we can skip this route.
-            if (
-              srcRoute !== pagePathname ||
-              renderingMode !== RenderingMode.PARTIALLY_STATIC
-            )
-              continue;
-
-            // If this route is the same as the page route, then we can skip
-            // it, because we've already added the lambda to the output.
-            if (routePathname === pagePathname) continue;
-
-            const output = getPostponeResumePathname(routePathname);
-            lambdas[output] = lambda;
-
-            outputName = path.posix.join(entryDirectory, routePathname);
-            experimentalStreamingLambdaPaths.set(outputName, {
-              pathname: getPostponeResumePathname(routePathname),
-              output,
-            });
-          }
-
-          continue;
         }
 
         if (!group.isAppRouter && !group.isAppRouteHandler) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2531,6 +2531,17 @@ export const onPrerenderRoute =
       let experimentalStreamingLambdaPath: string | undefined;
       if (
         renderingMode === RenderingMode.PARTIALLY_STATIC &&
+        routesManifest?.ppr?.chain?.headers
+      ) {
+        // When the chain is present in the routes manifest, we use the
+        // output path as the target for the chain and assign all the provided
+        // headers to the chain.
+        chain = {
+          outputPath: pathnameToOutputName(entryDirectory, routeKey),
+          headers: routesManifest.ppr.chain.headers,
+        };
+      } else if (
+        renderingMode === RenderingMode.PARTIALLY_STATIC &&
         experimentalStreamingLambdaPaths
       ) {
         // Try to get the experimental streaming lambda path for the specific
@@ -2558,25 +2569,15 @@ export const onPrerenderRoute =
         // and this should be the pathname that will work for those cases.
         experimentalStreamingLambdaPath = paths.output;
 
-        if (routesManifest?.ppr?.chain?.headers) {
-          // When the chain is present in the routes manifest, we use the
-          // output path as the target for the chain and assign all the provided
-          // headers to the chain.
-          chain = {
-            outputPath: pathnameToOutputName(entryDirectory, routeKey),
-            headers: routesManifest.ppr.chain.headers,
-          };
-        } else {
-          // When the chain is not present in the routes manifest, we use the
-          // experimental streaming lambda path as the target for the chain and
-          // assign the pathname as the matched path to the headers. This allows
-          // for deployments to upgrade to working when Vercel supports reading
-          // the chain parameter.
-          chain = {
-            outputPath: paths.output,
-            headers: { 'x-matched-path': paths.pathname },
-          };
-        }
+        // When the chain is not present in the routes manifest, we use the
+        // experimental streaming lambda path as the target for the chain and
+        // assign the pathname as the matched path to the headers. This allows
+        // for deployments to upgrade to working when Vercel supports reading
+        // the chain parameter.
+        chain = {
+          outputPath: paths.output,
+          headers: { 'x-matched-path': paths.pathname },
+        };
       }
 
       // If this is a fallback page with PPR enabled, we should not have the

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -525,7 +525,7 @@ describe('PPR', () => {
     });
   });
 
-  it('should have the chain mirrored to the experimentalStreamingLambdaPath', async () => {
+  it('should have the chain added', async () => {
     const {
       buildResult: { output },
     } = await runBuildLambda(path.join(__dirname, 'ppr'));
@@ -543,12 +543,6 @@ describe('PPR', () => {
     expect(output['index']).toBeDefined();
     expect(output['index'].type).toBe('Prerender');
     expect(output['index'].chain?.outputPath).toBe('index');
-
-    // TODO: remove the following once we have stabilized the chained responses
-    expect(output['index'].experimentalStreamingLambdaPath).toBe(
-      '_next/postponed/resume/index'
-    );
-    expect(output['_next/postponed/resume/index']).toBeDefined();
   });
 
   it('should support basePath', async () => {
@@ -571,18 +565,6 @@ describe('PPR', () => {
     expect(output['chat/index'].type).toBe('Prerender');
     expect(output['chat/index'].lambda).toBeDefined();
     expect(output['chat/index'].lambda.type).toBe('Lambda');
-
-    expect(output['chat/index'].chain?.outputPath).toBe('chat/index');
-
-    // TODO: remove the following once we have stabilized the chained responses
-    expect(output['chat/index'].experimentalStreamingLambdaPath).toBe(
-      'chat/_next/postponed/resume/index'
-    );
-    expect(output['chat/_next/postponed/resume/index']).toBeDefined();
-    expect(output['chat/_next/postponed/resume/index'].type).toBe('Lambda');
-    expect(output['chat/_next/postponed/resume/index']).toBe(
-      output['chat/index'].lambda
-    );
 
     expect(output['chat/index'].chain?.outputPath).toBe('chat/index');
     expect(output['chat/index'].chain?.headers).toEqual({


### PR DESCRIPTION
This removes the duplication made for the experimental streaming lambda path and instead only relies on the new chained data in the prerender.