### PR TITLE
[cli] Fix `vercel integration-resource` subcommand help

### DIFF
--- a/.changeset/swift-chairs-cover.md
+++ b/.changeset/swift-chairs-cover.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vercel integration-resource` subcommand help

--- a/packages/cli/src/commands/integration-resource/index.ts
+++ b/packages/cli/src/commands/integration-resource/index.ts
@@ -46,7 +46,12 @@ export default async function main(client: Client) {
   }
 
   function printHelp(command: Command) {
-    output.print(help(command, { columns: client.stderr.columns }));
+    output.print(
+      help(command, {
+        columns: client.stderr.columns,
+        parent: integrationResourceCommand,
+      })
+    );
   }
 
   switch (subcommand) {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -45,8 +45,13 @@ export default async function main(client: Client) {
 
   const needHelp = flags['--help'];
 
-  function printHelp(command: Command, parent = integrationCommand) {
-    output.print(help(command, { columns: client.stderr.columns, parent }));
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        columns: client.stderr.columns,
+        parent: integrationCommand,
+      })
+    );
   }
 
   if (!subcommand && needHelp) {
@@ -54,7 +59,6 @@ export default async function main(client: Client) {
     output.print(
       help(integrationCommand, {
         columns: client.stderr.columns,
-        parent: undefined,
       })
     );
     return 2;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2756,131 +2756,6 @@ exports[`help command > integration help output snapshots > integration help col
 "
 `;
 
-exports[`help command > integration help output snapshots > integration list subcommand > integration list subcommand help column width 40 1`] = `
-"
-  ▲ vercel integration list [project] [options]
-
-  Lists all resources from marketplace  
-  integrations                          
-
-  Options:
-
-  -a,  --all                 lists all  
-                             resources  
-                             regardless 
-                             of project 
-  -i,  --integration <NAME>  limits the 
-                             resources  
-                             listed to a
-                             designated 
-                             integration
-
-
-  Global Options:
-
-       --cwd <DIR>            Sets the  
-                              current   
-                              working   
-                              directory 
-                              for a     
-                              single run
-                              of a      
-                              command   
-  -d,  --debug                Debug mode
-                              (default  
-                              off)      
-  -Q,  --global-config <DIR>  Path to   
-                              the global
-                              \`.vercel\` 
-                              directory 
-  -h,  --help                 Output    
-                              usage     
-                              informati…
-  -A,  --local-config <FILE>  Path to   
-                              the local 
-                              \`vercel.j…
-                              file      
-       --no-color             No color  
-                              mode      
-                              (default  
-                              off)      
-  -S,  --scope                Set a     
-                              custom    
-                              scope     
-  -t,  --token <TOKEN>        Login     
-                              token     
-  -v,  --version              Output the
-                              version   
-                              number    
-
-
-  Examples:
-
-  - List all resources
-
-    $ vercel integrations list
-
-  - Filter the resources to a single integration
-
-    $ vercel integration list --integration <integration>
-    $ vercel integration list --integration acme
-    $ vercel integration list -i acme
-
-  - List all marketplace resources for the current team
-
-    $ vercel integration list --all
-    $ vercel integration list -a
-
-"
-`;
-
-exports[`help command > integration help output snapshots > integration list subcommand > integration list subcommand help column width 80 1`] = `
-"
-  ▲ vercel integration list [project] [options]
-
-  Lists all resources from marketplace integrations                             
-
-  Options:
-
-  -a,  --all                 lists all resources regardless of project          
-  -i,  --integration <NAME>  limits the resources listed to a designated        
-                             integration                                        
-
-
-  Global Options:
-
-       --cwd <DIR>            Sets the current working directory for a single   
-                              run of a command                                  
-  -d,  --debug                Debug mode (default off)                          
-  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory            
-  -h,  --help                 Output usage information                          
-  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file              
-       --no-color             No color mode (default off)                       
-  -S,  --scope                Set a custom scope                                
-  -t,  --token <TOKEN>        Login token                                       
-  -v,  --version              Output the version number                         
-
-
-  Examples:
-
-  - List all resources
-
-    $ vercel integrations list
-
-  - Filter the resources to a single integration
-
-    $ vercel integration list --integration <integration>
-    $ vercel integration list --integration acme
-    $ vercel integration list -i acme
-
-  - List all marketplace resources for the current team
-
-    $ vercel integration list --all
-    $ vercel integration list -a
-
-"
-`;
-
 exports[`help command > integration help output snapshots > integration list subcommand > integration list subcommand help column width 120 1`] = `
 "
   ▲ vercel integration list [project] [options]
@@ -2922,6 +2797,217 @@ exports[`help command > integration help output snapshots > integration list sub
 
     $ vercel integration list --all
     $ vercel integration list -a
+
+"
+`;
+
+exports[`help command > integration-resource help output snapshots > integration-resource disconnect subcommand > integration-resource disconnect subcommand help column width 120 1`] = `
+"
+  ▲ vercel integration-resource disconnect resource [project] [options]
+
+  Disconnect a resource from a project, or the current project                                                          
+
+  Options:
+
+  -a,  --all  disconnects all projects from the specified resource                                                      
+  -y,  --yes  Skip the confirmation prompt when disconnecting a resource                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Disconnect a resource from the current projecct
+
+    $ vercel integration-resource disconnect <resource>
+    $ vercel integration-resource disconnect my-acme-resource
+
+  - Disconnect all projects from a resource
+
+    $ vercel integration-resource disconnect <resource> --unlink-all
+    $ vercel integration-resource disconnect my-acme-resource --all
+    $ vercel integration-resource disconnect my-acme-resource -a
+
+  - Disconnect a resource from a specified project
+
+    $ vercel integration-resource disconnect <resource> <project>
+    $ vercel integration-resource disconnect my-acme-resource my-project
+
+"
+`;
+
+exports[`help command > integration-resource help output snapshots > integration-resource help column width 40 1`] = `
+"
+  ▲ vercel integration-resource command
+
+  Manage marketplace integration        
+  resources                             
+
+  Commands:
+
+  disconnect  resource [project]  …
+                                  a
+                                  …
+                                  …
+                                  a
+                                  …
+                                  …
+                                  …
+                                  …
+                                  …
+  remove      resource            …
+                                  …
+                                  …
+                                  …
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the  
+                              current   
+                              working   
+                              directory 
+                              for a     
+                              single run
+                              of a      
+                              command   
+  -d,  --debug                Debug mode
+                              (default  
+                              off)      
+  -Q,  --global-config <DIR>  Path to   
+                              the global
+                              \`.vercel\` 
+                              directory 
+  -h,  --help                 Output    
+                              usage     
+                              informati…
+  -A,  --local-config <FILE>  Path to   
+                              the local 
+                              \`vercel.j…
+                              file      
+       --no-color             No color  
+                              mode      
+                              (default  
+                              off)      
+  -S,  --scope                Set a     
+                              custom    
+                              scope     
+  -t,  --token <TOKEN>        Login     
+                              token     
+  -v,  --version              Output the
+                              version   
+                              number    
+
+
+"
+`;
+
+exports[`help command > integration-resource help output snapshots > integration-resource help column width 80 1`] = `
+"
+  ▲ vercel integration-resource command
+
+  Manage marketplace integration resources                                      
+
+  Commands:
+
+  disconnect  resource [project]  Disconnect a resource from a project, 
+                                  or the current project                
+  remove      resource            Delete an integration resource        
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single   
+                              run of a command                                  
+  -d,  --debug                Debug mode (default off)                          
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory            
+  -h,  --help                 Output usage information                          
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file              
+       --no-color             No color mode (default off)                       
+  -S,  --scope                Set a custom scope                                
+  -t,  --token <TOKEN>        Login token                                       
+  -v,  --version              Output the version number                         
+
+
+"
+`;
+
+exports[`help command > integration-resource help output snapshots > integration-resource help column width 120 1`] = `
+"
+  ▲ vercel integration-resource command
+
+  Manage marketplace integration resources                                                                              
+
+  Commands:
+
+  disconnect  resource [project]  Disconnect a resource from a project, or the current project                  
+  remove      resource            Delete an integration resource                                                
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+"
+`;
+
+exports[`help command > integration-resource help output snapshots > integration-resource remove subcommand > integration-resource remove subcommand help column width 120 1`] = `
+"
+  ▲ vercel integration-resource remove resource [options]
+
+  Delete an integration resource                                                                                        
+
+  Options:
+
+  -a,  --disconnect-all  disconnects all projects from the specified resource before deletion                           
+  -y,  --yes             Skip the confirmation prompt when deleting a resource                                          
+
+
+  Global Options:
+
+       --cwd <DIR>            Sets the current working directory for a single run of a command                          
+  -d,  --debug                Debug mode (default off)                                                                  
+  -Q,  --global-config <DIR>  Path to the global \`.vercel\` directory                                                    
+  -h,  --help                 Output usage information                                                                  
+  -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
+       --no-color             No color mode (default off)                                                               
+  -S,  --scope                Set a custom scope                                                                        
+  -t,  --token <TOKEN>        Login token                                                                               
+  -v,  --version              Output the version number                                                                 
+
+
+  Examples:
+
+  - Delete a resource
+
+    $ vercel integration-resource remove <resource>
+    $ vercel integration-resource remove my-acme-resource
+
+  - Disconnect all projects from a resource, then delete it
+
+    $ vercel integration-resource remove <resource> --disconnect-all
+    $ vercel integration-resource remove my-acme-resource --disconnect-all
+    $ vercel integration-resource remove my-acme-resource -a
 
 "
 `;

--- a/packages/cli/test/unit/commands/help.test.ts
+++ b/packages/cli/test/unit/commands/help.test.ts
@@ -14,6 +14,8 @@ import * as env from '../../../src/commands/env/command';
 import * as git from '../../../src/commands/git/command';
 import { initCommand } from '../../../src/commands/init/command';
 import { inspectCommand } from '../../../src/commands/inspect/command';
+import * as integration from '../../../src/commands/integration/command';
+import * as integrationResource from '../../../src/commands/integration-resource/command';
 import { linkCommand } from '../../../src/commands/link/command';
 import { listCommand } from '../../../src/commands/list/command';
 import { loginCommand } from '../../../src/commands/login/command';
@@ -27,10 +29,6 @@ import * as target from '../../../src/commands/target/command';
 import * as teams from '../../../src/commands/teams/command';
 import * as telemetry from '../../../src/commands/telemetry/command';
 import { whoamiCommand } from '../../../src/commands/whoami/command';
-import {
-  integrationCommand,
-  listSubcommand as integrationListSubcommand,
-} from '../../../src/commands/integration/command';
 import dev from '../../../src/commands/dev';
 import { client } from '../../mocks/client';
 
@@ -419,37 +417,64 @@ describe('help command', () => {
 
   describe('integration help output snapshots', () => {
     it('integration help column width 40', () => {
-      expect(help(integrationCommand, { columns: 40 })).toMatchSnapshot();
+      expect(
+        help(integration.integrationCommand, { columns: 40 })
+      ).toMatchSnapshot();
     });
     it('integration help column width 80', () => {
-      expect(help(integrationCommand, { columns: 80 })).toMatchSnapshot();
+      expect(
+        help(integration.integrationCommand, { columns: 80 })
+      ).toMatchSnapshot();
     });
     it('integration help column width 120', () => {
-      expect(help(integrationCommand, { columns: 120 })).toMatchSnapshot();
+      expect(
+        help(integration.integrationCommand, { columns: 120 })
+      ).toMatchSnapshot();
     });
-
     describe('integration list subcommand', () => {
-      it('integration list subcommand help column width 40', () => {
-        expect(
-          help(integrationListSubcommand, {
-            columns: 40,
-            parent: integrationCommand,
-          })
-        ).toMatchSnapshot();
-      });
-      it('integration list subcommand help column width 80', () => {
-        expect(
-          help(integrationListSubcommand, {
-            columns: 80,
-            parent: integrationCommand,
-          })
-        ).toMatchSnapshot();
-      });
       it('integration list subcommand help column width 120', () => {
         expect(
-          help(integrationListSubcommand, {
+          help(integration.listSubcommand, {
             columns: 120,
-            parent: integrationCommand,
+            parent: integration.integrationCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('integration-resource help output snapshots', () => {
+    it('integration-resource help column width 40', () => {
+      expect(
+        help(integrationResource.integrationResourceCommand, { columns: 40 })
+      ).toMatchSnapshot();
+    });
+    it('integration-resource help column width 80', () => {
+      expect(
+        help(integrationResource.integrationResourceCommand, { columns: 80 })
+      ).toMatchSnapshot();
+    });
+    it('integration-resource help column width 120', () => {
+      expect(
+        help(integrationResource.integrationResourceCommand, { columns: 120 })
+      ).toMatchSnapshot();
+    });
+    describe('integration-resource disconnect subcommand', () => {
+      it('integration-resource disconnect subcommand help column width 120', () => {
+        expect(
+          help(integrationResource.disconnectSubcommand, {
+            columns: 120,
+            parent: integrationResource.integrationResourceCommand,
+          })
+        ).toMatchSnapshot();
+      });
+    });
+    describe('integration-resource remove subcommand', () => {
+      it('integration-resource remove subcommand help column width 120', () => {
+        expect(
+          help(integrationResource.removeSubcommand, {
+            columns: 120,
+            parent: integrationResource.integrationResourceCommand,
           })
         ).toMatchSnapshot();
       });


### PR DESCRIPTION
Pass in the `integrationResourceCommand` as the "parent" command when generating the help output.