### PR TITLE
Move `@vercel/edge` to `vitest`

### DIFF
--- a/.changeset/gentle-items-rule.md
+++ b/.changeset/gentle-items-rule.md
@@ -1,0 +1,5 @@
+---
+'@vercel/edge': patch
+---
+
+Move `@vercel/edge` to `vitest`

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -31,6 +31,7 @@
     "typedoc-plugin-markdown": "3.15.2",
     "typedoc-plugin-mdn-links": "3.0.3",
     "typescript": "4.9.5",
-    "vitest": "2.1.4"
+    "vitest": "2.1.4",
+    "@edge-runtime/vm": "4.0.4"
   }
 }

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -18,11 +18,11 @@
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "build:docs": "typedoc && node scripts/fix-links.js && prettier --write docs/**/*.md docs/*.md",
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --runInBand --bail",
-    "test-unit": "pnpm test",
+    "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-unit": "glob --absolute 'test/unit.*.test.ts'",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@edge-runtime/jest-environment": "2.3.7",
     "@types/jest": "27.4.1",
     "jest-junit": "16.0.0",
     "ts-node": "8.9.1",
@@ -30,6 +30,7 @@
     "typedoc": "0.24.6",
     "typedoc-plugin-markdown": "3.15.2",
     "typedoc-plugin-mdn-links": "3.0.3",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "vitest": "2.1.4"
   }
 }

--- a/packages/edge/test/docs.test.ts
+++ b/packages/edge/test/docs.test.ts
@@ -3,6 +3,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { expect, it } from 'vitest';
 
 const execAsync = promisify(exec);
 const test = process.platform === 'win32' ? it.skip : it;

--- a/packages/edge/test/edge-headers.test.ts
+++ b/packages/edge/test/edge-headers.test.ts
@@ -1,7 +1,8 @@
 /**
- * @jest-environment @edge-runtime/jest-environment
+ * @vitest-environment edge-runtime
  */
 
+import { describe, expect, test } from 'vitest';
 import {
   CITY_HEADER_NAME,
   COUNTRY_HEADER_NAME,
@@ -14,6 +15,11 @@ import {
   REGION_HEADER_NAME,
   REQUEST_ID_HEADER_NAME,
 } from '../src';
+
+test('vitest environment is correctly added', () => {
+  // @ts-ignore
+  expect(globalThis.EdgeRuntime).toBeDefined();
+});
 
 test('`ipAddress` returns the value from the header', () => {
   const req = new Request('https://example.vercel.sh', {

--- a/packages/edge/test/middleware-helpers.test.ts
+++ b/packages/edge/test/middleware-helpers.test.ts
@@ -1,7 +1,8 @@
 /**
- * @jest-environment @edge-runtime/jest-environment
+ * @vitest-environment edge-runtime
  */
 
+import { describe, expect, test } from 'vitest';
 import { next, rewrite } from '../src/middleware-helpers';
 
 describe('rewrite', () => {

--- a/packages/edge/test/response.test.ts
+++ b/packages/edge/test/response.test.ts
@@ -1,7 +1,8 @@
 /**
- * @jest-environment @edge-runtime/jest-environment
+ * @vitest-environment edge-runtime
  */
 
+import { describe, expect, it } from 'vitest';
 import { json } from '../src/response';
 
 describe('json', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,9 +824,6 @@ importers:
 
   packages/edge:
     devDependencies:
-      '@edge-runtime/jest-environment':
-        specifier: 2.3.7
-        version: 2.3.7
       '@types/jest':
         specifier: 27.4.1
         version: 27.4.1
@@ -851,6 +848,9 @@ importers:
       typescript:
         specifier: 4.9.5
         version: 4.9.5
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@14.18.33)
 
   packages/error-utils:
     devDependencies:
@@ -3041,17 +3041,6 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@edge-runtime/jest-environment@2.3.7:
-    resolution: {integrity: sha512-gfr8yAlvqt3WkyHOzuxf84Y6naPawGjn4CHlaMnH0MYBVYKvF6J/WORuw85z88fwzK5dmJwiBSQoVdyP2ndIzQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@edge-runtime/vm': 3.1.7
-      '@jest/environment': 29.5.0
-      '@jest/fake-timers': 29.5.0
-      jest-mock: 29.5.0
-      jest-util: 29.5.0
-    dev: true
-
   /@edge-runtime/node-utils@2.3.0:
     resolution: {integrity: sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==}
     engines: {node: '>=16'}
@@ -3061,21 +3050,9 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@edge-runtime/primitives@4.0.5:
-    resolution: {integrity: sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==}
-    engines: {node: '>=16'}
-    dev: true
-
   /@edge-runtime/primitives@4.1.0:
     resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
     engines: {node: '>=16'}
-
-  /@edge-runtime/vm@3.1.7:
-    resolution: {integrity: sha512-hUMFbDQ/nZN+1TLMi6iMO1QFz9RSV8yGG8S42WFPFma1d7VSNE0eMdJUmwjmtav22/iQkzHMmu6oTSfAvRGS8g==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@edge-runtime/primitives': 4.0.5
-    dev: true
 
   /@edge-runtime/vm@3.2.0:
     resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
@@ -7419,7 +7396,7 @@ packages:
     dependencies:
       '@vitest/spy': 2.0.1
       '@vitest/utils': 2.0.1
-      chai: 5.1.1
+      chai: 5.1.2
     dev: true
 
   /@vitest/expect@2.0.3:
@@ -7427,7 +7404,7 @@ packages:
     dependencies:
       '@vitest/spy': 2.0.3
       '@vitest/utils': 2.0.3
-      chai: 5.1.1
+      chai: 5.1.2
       tinyrainbow: 1.2.0
     dev: true
 
@@ -7436,7 +7413,16 @@ packages:
     dependencies:
       '@vitest/spy': 2.1.3
       '@vitest/utils': 2.1.3
-      chai: 5.1.1
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
+    dev: true
+
+  /@vitest/expect@2.1.4:
+    resolution: {integrity: sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==}
+    dependencies:
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.1.2
       tinyrainbow: 1.2.0
     dev: true
 
@@ -7453,6 +7439,23 @@ packages:
         optional: true
     dependencies:
       '@vitest/spy': 2.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.12
+      vite: 5.1.6(@types/node@14.18.33)
+    dev: true
+
+  /@vitest/mocker@2.1.4(vite@5.1.6):
+    resolution: {integrity: sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
       vite: 5.1.6(@types/node@14.18.33)
@@ -7476,6 +7479,12 @@ packages:
       tinyrainbow: 1.2.0
     dev: true
 
+  /@vitest/pretty-format@2.1.4:
+    resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
+    dependencies:
+      tinyrainbow: 1.2.0
+    dev: true
+
   /@vitest/runner@2.0.1:
     resolution: {integrity: sha512-XfcSXOGGxgR2dQ466ZYqf0ZtDLLDx9mZeQcKjQDLQ9y6Cmk2Wl7wxMuhiYK4Fo1VxCtLcFEGW2XpcfMuiD1Maw==}
     dependencies:
@@ -7494,6 +7503,13 @@ packages:
     resolution: {integrity: sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==}
     dependencies:
       '@vitest/utils': 2.1.3
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/runner@2.1.4:
+    resolution: {integrity: sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==}
+    dependencies:
+      '@vitest/utils': 2.1.4
       pathe: 1.1.2
     dev: true
 
@@ -7521,6 +7537,14 @@ packages:
       pathe: 1.1.2
     dev: true
 
+  /@vitest/snapshot@2.1.4:
+    resolution: {integrity: sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      magic-string: 0.30.12
+      pathe: 1.1.2
+    dev: true
+
   /@vitest/spy@1.4.0:
     resolution: {integrity: sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==}
     dependencies:
@@ -7536,13 +7560,19 @@ packages:
   /@vitest/spy@2.0.3:
     resolution: {integrity: sha512-sfqyAw/ypOXlaj4S+w8689qKM1OyPOqnonqOc9T91DsoHbfN5mU7FdifWWv3MtQFf0lEUstEwR9L/q/M390C+A==}
     dependencies:
-      tinyspy: 3.0.0
+      tinyspy: 3.0.2
     dev: true
 
   /@vitest/spy@2.1.3:
     resolution: {integrity: sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==}
     dependencies:
       tinyspy: 3.0.0
+    dev: true
+
+  /@vitest/spy@2.1.4:
+    resolution: {integrity: sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==}
+    dependencies:
+      tinyspy: 3.0.2
     dev: true
 
   /@vitest/utils@1.4.0:
@@ -7559,7 +7589,7 @@ packages:
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
-      loupe: 3.1.1
+      loupe: 3.1.2
       pretty-format: 29.7.0
     dev: true
 
@@ -7568,7 +7598,7 @@ packages:
     dependencies:
       '@vitest/pretty-format': 2.0.3
       estree-walker: 3.0.3
-      loupe: 3.1.1
+      loupe: 3.1.2
       tinyrainbow: 1.2.0
     dev: true
 
@@ -7576,7 +7606,15 @@ packages:
     resolution: {integrity: sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==}
     dependencies:
       '@vitest/pretty-format': 2.1.3
-      loupe: 3.1.1
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+    dev: true
+
+  /@vitest/utils@2.1.4:
+    resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      loupe: 3.1.2
       tinyrainbow: 1.2.0
     dev: true
 
@@ -8509,6 +8547,17 @@ packages:
 
   /chai@5.1.1:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.2
+      pathval: 2.0.0
+    dev: true
+
+  /chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
     dependencies:
       assertion-error: 2.0.1
@@ -10280,7 +10329,7 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.57.0
-      ignore: 5.2.4
+      ignore: 5.3.2
     dev: true
 
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.24.0):
@@ -11078,6 +11127,11 @@ packages:
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /expect@29.5.0:
@@ -13809,6 +13863,10 @@ packages:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
     dependencies:
       get-func-name: 2.0.2
+    dev: true
+
+  /loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
     dev: true
 
   /lowercase-keys@2.0.0:
@@ -17375,6 +17433,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     dev: true
 
+  /tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    dev: true
+
   /tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
@@ -17392,6 +17455,11 @@ packages:
 
   /tinyspy@3.0.0:
     resolution: {integrity: sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -18338,6 +18406,26 @@ packages:
       - terser
     dev: true
 
+  /vite-node@2.1.4(@types/node@14.18.33):
+    resolution: {integrity: sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      pathe: 1.1.2
+      vite: 5.1.6(@types/node@14.18.33)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite@5.1.6(@types/node@14.18.33):
     resolution: {integrity: sha512-yYIAZs9nVfRJ/AiOLCA91zzhjsHUgMjB+EigzFb6W2XTLO8JixBCKCjvhKZaye+NKYHCrkv3Oh50dH9EdLU2RA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -18564,6 +18652,63 @@ packages:
       tinyrainbow: 1.2.0
       vite: 5.1.6(@types/node@14.18.33)
       vite-node: 2.1.3(@types/node@14.18.33)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@2.1.4(@types/node@14.18.33):
+    resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.4
+      '@vitest/ui': 2.1.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 14.18.33
+      '@vitest/expect': 2.1.4
+      '@vitest/mocker': 2.1.4(vite@5.1.6)
+      '@vitest/pretty-format': 2.1.4
+      '@vitest/runner': 2.1.4
+      '@vitest/snapshot': 2.1.4
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.1.2
+      debug: 4.3.7
+      expect-type: 1.1.0
+      magic-string: 0.30.12
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.1.6(@types/node@14.18.33)
+      vite-node: 2.1.4(@types/node@14.18.33)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
 
   packages/edge:
     devDependencies:
+      '@edge-runtime/vm':
+        specifier: 4.0.4
+        version: 4.0.4
       '@types/jest':
         specifier: 27.4.1
         version: 27.4.1
@@ -850,7 +853,7 @@ importers:
         version: 4.9.5
       vitest:
         specifier: 2.1.4
-        version: 2.1.4(@types/node@14.18.33)
+        version: 2.1.4(@edge-runtime/vm@4.0.4)(@types/node@14.18.33)
 
   packages/error-utils:
     devDependencies:
@@ -3054,11 +3057,23 @@ packages:
     resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
     engines: {node: '>=16'}
 
+  /@edge-runtime/primitives@5.1.1:
+    resolution: {integrity: sha512-osrHE4ObQ3XFkvd1sGBLkheV2mcHUqJI/Bum2AWA0R3U78h9lif3xZAdl6eLD/XnW4xhsdwjPUejLusXbjvI4Q==}
+    engines: {node: '>=16'}
+    dev: true
+
   /@edge-runtime/vm@3.2.0:
     resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
     engines: {node: '>=16'}
     dependencies:
       '@edge-runtime/primitives': 4.1.0
+
+  /@edge-runtime/vm@4.0.4:
+    resolution: {integrity: sha512-LqPw+yaSPpCNnVZl5XoHQAySEzlnZiC9gReUuQHMh9GI03KKqwpVqWkIK1UfK116Yww7f2WZuAgnY/nhHwTsJA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@edge-runtime/primitives': 5.1.1
+    dev: true
 
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
@@ -18664,7 +18679,7 @@ packages:
       - terser
     dev: true
 
-  /vitest@2.1.4(@types/node@14.18.33):
+  /vitest@2.1.4(@edge-runtime/vm@4.0.4)(@types/node@14.18.33):
     resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -18689,6 +18704,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@edge-runtime/vm': 4.0.4
       '@types/node': 14.18.33
       '@vitest/expect': 2.1.4
       '@vitest/mocker': 2.1.4(vite@5.1.6)


### PR DESCRIPTION
`vitest` supports `edge-runtime` as an environment, using `@edge-runtime/vm` if provided

https://github.com/vitest-dev/vitest/pull/1574