### PR TITLE
[cli] separately track integration-resource command

### DIFF
--- a/.changeset/fair-knives-watch.md
+++ b/.changeset/fair-knives-watch.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] separately track integration-resource command

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -638,7 +638,7 @@ const main = async () => {
           func = require('./commands/integration').default;
           break;
         case 'integration-resource':
-          telemetry.trackCliCommandIntegration(userSuppliedSubCommand);
+          telemetry.trackCliCommandIntegrationResource(userSuppliedSubCommand);
           func = require('./commands/integration-resource').default;
           break;
         case 'link':

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -118,6 +118,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandIntegrationResource(actual: string) {
+    this.trackCliCommand({
+      command: 'integration-resource',
+      value: actual,
+    });
+  }
+
   trackCliCommandLink(actual: string) {
     this.trackCliCommand({
       command: 'link',


### PR DESCRIPTION
Previously, we tracked both `vercel integration` and `vercel integration-resource` with the same `integration` event.