### PR TITLE
[cli] create standard method for redacted targets

### DIFF
--- a/.changeset/five-lemons-promise.md
+++ b/.changeset/five-lemons-promise.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] create standard method for redacted targets

--- a/packages/cli/src/util/telemetry/commands/build/index.ts
+++ b/packages/cli/src/util/telemetry/commands/build/index.ts
@@ -19,7 +19,7 @@ export class BuildTelemetryClient
     if (option) {
       this.trackCliOption({
         option: 'target',
-        value: option,
+        value: this.redactedTargetName(option),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -64,12 +64,9 @@ export class DeployTelemetryClient
   }
   trackCliOptionTarget(target: string | undefined) {
     if (target) {
-      const value = ['production', 'preview'].includes(target)
-        ? target
-        : 'CUSTOM_ID_OR_SLUG';
       this.trackCliOption({
         option: 'target',
-        value,
+        value: this.redactedTargetName(target),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/list/index.ts
+++ b/packages/cli/src/util/telemetry/commands/list/index.ts
@@ -26,15 +26,9 @@ export class ListTelemetryClient
 
   trackCliOptionEnvironment(environment: string | undefined) {
     if (environment) {
-      const redactUnknownEnvironment = (environment: string) => {
-        if (environment !== 'production' && environment !== 'preview') {
-          return this.redactedValue;
-        }
-        return environment;
-      };
       this.trackCliOption({
         option: 'environment',
-        value: redactUnknownEnvironment(environment),
+        value: this.redactedTargetName(environment),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/pull/index.ts
+++ b/packages/cli/src/util/telemetry/commands/pull/index.ts
@@ -17,12 +17,9 @@ export class PullTelemetryClient
 
   trackCliOptionEnvironment(environment: string | undefined) {
     if (environment) {
-      const standardEnvironments = ['production', 'preview', 'development'];
       this.trackCliOption({
         option: 'environment',
-        value: standardEnvironments.includes(environment)
-          ? environment
-          : this.redactedValue,
+        value: this.redactedTargetName(environment),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/redeploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/redeploy/index.ts
@@ -23,10 +23,9 @@ export class RedeployTelemetryClient
 
   trackCliOptionTarget(target: string | undefined) {
     if (target) {
-      const trackedValues = ['production', 'staging', 'preview'];
       this.trackCliArgument({
         arg: 'target',
-        value: trackedValues.includes(target) ? target : this.redactedValue,
+        value: this.redactedTargetName(target),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -37,6 +37,12 @@ export class TelemetryClient {
     }
     return 'NONE';
   };
+  protected redactedTargetName = (target: string) => {
+    if (['production', 'preview', 'development'].includes(target)) {
+      return target;
+    }
+    return this.redactedValue;
+  };
 
   constructor({ opts }: Args) {
     this.isDebug = opts.isDebug || false;

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import type { GlobalConfig } from '@vercel-internals/types';
 import output from '../../output-manager';
+import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
 
 const LogLabel = `['telemetry']:`;
 
@@ -38,7 +39,7 @@ export class TelemetryClient {
     return 'NONE';
   };
   protected redactedTargetName = (target: string) => {
-    if (['production', 'preview', 'development'].includes(target)) {
+    if ((PROJECT_ENV_TARGET as ReadonlyArray<string>).includes(target)) {
       return target;
     }
     return this.redactedValue;

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1098,7 +1098,7 @@ describe('deploy', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'option:target',
-          value: 'CUSTOM_ID_OR_SLUG',
+          value: '[REDACTED]',
         },
       ]);
     });


### PR DESCRIPTION
This PR creates a standard method so that all targets get redacted in the same way.