### PR TITLE
[cli] redact output mode in telemetry method

### DIFF
--- a/.changeset/warm-carrots-film.md
+++ b/.changeset/warm-carrots-film.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] redact output mode in telemetry method

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -91,10 +91,7 @@ export default async function logs(client: Client) {
 
   // Note: only send literal values to telemetry for known values
   const outputMode = parsedArguments.flags['--output'];
-  telemetry.trackCliOptionOutput(
-    outputMode,
-    outputMode === 'raw' || outputMode === 'short'
-  );
+  telemetry.trackCliOptionOutput(outputMode);
 
   let contextName: string | null = null;
 

--- a/packages/cli/src/util/telemetry/commands/logs/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logs/index.ts
@@ -54,11 +54,14 @@ export class LogsTelemetryClient
     }
   }
 
-  trackCliOptionOutput(n: string | undefined, known?: boolean) {
-    if (n) {
+  trackCliOptionOutput(outputMode: string | undefined) {
+    if (outputMode) {
+      const allowedOutputMode = ['raw', 'short'].includes(outputMode)
+        ? outputMode
+        : this.redactedValue;
       this.trackCliOption({
         option: 'output',
-        value: known ? n : this.redactedValue,
+        value: allowedOutputMode,
       });
     }
   }


### PR DESCRIPTION
This PR moves the logic for checking whether output mode is redacted into the method, making it harder to forget to redact unknown output modes by mistake.