### PR TITLE
[cli] remove trackCommandError method - unused

### DIFF
--- a/.changeset/good-comics-admire.md
+++ b/.changeset/good-comics-admire.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] remove trackCommandError method - unused

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -152,11 +152,6 @@ export class TelemetryClient {
     });
   }
 
-  trackCommandError(error: string): Event | undefined {
-    output.error(error);
-    return;
-  }
-
   trackCliFlagHelp(command: string, subcommands?: string | string[]) {
     let subcommand: string | undefined;
     if (subcommands) {


### PR DESCRIPTION
The method `trackCommandError` was unused