### PR TITLE
[cli] integration resource was always redacted simplify method

### DIFF
--- a/.changeset/clean-boats-live.md
+++ b/.changeset/clean-boats-live.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] integration resource was always redacted simplify method

--- a/packages/cli/src/util/telemetry/commands/integration-resource/remove.ts
+++ b/packages/cli/src/util/telemetry/commands/integration-resource/remove.ts
@@ -6,11 +6,11 @@ export class IntegrationResourceRemoveTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof removeSubcommand>
 {
-  trackCliArgumentResource(v: string | undefined, known?: boolean) {
+  trackCliArgumentResource(v: string | undefined) {
     if (v) {
       this.trackCliArgument({
         arg: 'resource',
-        value: known ? v : this.redactedValue,
+        value: this.redactedValue,
       });
     }
   }


### PR DESCRIPTION
The only call site for `trackCliArgumentResource` did not pass a second argument, meaning it was always redacted. This change makes it clear in the method that this is the case.