### PR TITLE
[cli] redact dns records outside allowed types

### DIFF
--- a/.changeset/gold-onions-jump.md
+++ b/.changeset/gold-onions-jump.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] redact dns records outside allowed types

--- a/packages/cli/src/util/telemetry/commands/dns/add.ts
+++ b/packages/cli/src/util/telemetry/commands/dns/add.ts
@@ -2,6 +2,16 @@ import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { addSubcommand } from '../../../../commands/dns/command';
 
+const ALLOWED_RECORD_TYPES = [
+  'A',
+  'AAAA',
+  'ALIAS',
+  'CNAME',
+  'TXT',
+  'MX',
+  'SRV',
+];
+
 export class DnsAddTelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof addSubcommand>
@@ -30,9 +40,12 @@ export class DnsAddTelemetryClient
 
   trackCliArgumentType(type: string | undefined) {
     if (type) {
+      const allowedType = ALLOWED_RECORD_TYPES.includes(type)
+        ? type
+        : this.redactedValue;
       this.trackCliArgument({
         arg: 'type',
-        value: type,
+        value: allowedType,
       });
     }
   }


### PR DESCRIPTION
Previously, any value could be sent, this change makes it so that only an allowed list can be sent.