### PR TITLE
[cli] use subcommandOriginal in telemetry

### DIFF
--- a/.changeset/lemon-feet-walk.md
+++ b/.changeset/lemon-feet-walk.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] use subcommandOriginal in telemetry

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -46,7 +46,10 @@ export default async function main(client: Client) {
   }
 
   const subArgs = parsedArgs.args.slice(1);
-  const { subcommand, args } = getSubcommand(subArgs, COMMAND_CONFIG);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
 
   const needHelp = parsedArgs.flags['--help'];
 
@@ -69,7 +72,7 @@ export default async function main(client: Client) {
         printHelp(listSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandList(subcommand);
+      telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
     case 'add':
       if (needHelp) {
@@ -77,7 +80,7 @@ export default async function main(client: Client) {
         printHelp(addSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandAdd(subcommand);
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
     case 'rm':
       if (needHelp) {
@@ -85,7 +88,7 @@ export default async function main(client: Client) {
         printHelp(removeSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandRemove(subcommand);
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
     case 'pull':
       if (needHelp) {
@@ -93,7 +96,7 @@ export default async function main(client: Client) {
         printHelp(pullSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandPull(subcommand);
+      telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -41,7 +41,7 @@ export default async function telemetry(client: Client) {
     return 1;
   }
 
-  const { subcommand } = getSubcommand(
+  const { subcommand, subcommandOriginal } = getSubcommand(
     parsedArguments.args.slice(1),
     COMMAND_CONFIG
   );
@@ -70,7 +70,7 @@ export default async function telemetry(client: Client) {
         printHelp(statusSubcommand);
         return 2;
       }
-      telemetryClient.trackCliSubcommandStatus(subcommand);
+      telemetryClient.trackCliSubcommandStatus(subcommandOriginal);
       return status(client);
     case 'enable':
       if (needHelp) {
@@ -78,7 +78,7 @@ export default async function telemetry(client: Client) {
         printHelp(enableSubcommand);
         return 2;
       }
-      telemetryClient.trackCliSubcommandEnable(subcommand);
+      telemetryClient.trackCliSubcommandEnable(subcommandOriginal);
       return enable(client);
     case 'disable':
       if (needHelp) {


### PR DESCRIPTION
for subcommands, we want to know exactly what the user typed to successfully invoke that subcommand, not just the name of the subcommand.