### PR TITLE
[cli] redact unknown archive formats

### DIFF
--- a/.changeset/tidy-geckos-leave.md
+++ b/.changeset/tidy-geckos-leave.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] redact unknown archive formats

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -16,9 +16,12 @@ export class DeployTelemetryClient
   }
   trackCliOptionArchive(format: string | undefined) {
     if (format) {
+      const allowedFormat = ['tgz'].includes(format)
+        ? format
+        : this.redactedValue;
       this.trackCliOption({
         option: 'archive',
-        value: format,
+        value: allowedFormat,
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -1,6 +1,7 @@
 import { TelemetryClient } from '../..';
 import type { TelemetryMethods } from '../../types';
 import type { deployCommand } from '../../../../commands/deploy/command';
+import { VALID_ARCHIVE_FORMATS } from '@vercel/client';
 
 export class DeployTelemetryClient
   extends TelemetryClient
@@ -16,7 +17,9 @@ export class DeployTelemetryClient
   }
   trackCliOptionArchive(format: string | undefined) {
     if (format) {
-      const allowedFormat = ['tgz'].includes(format)
+      const allowedFormat = (
+        VALID_ARCHIVE_FORMATS as ReadonlyArray<string>
+      ).includes(format)
         ? format
         : this.redactedValue;
       this.trackCliOption({


### PR DESCRIPTION
previously, it was possible to send any incorrect format a user typed, this restricts it to a known list.