### PR TITLE
Ensure firewall tests run

### DIFF
--- a/.changeset/chilled-ladybugs-visit.md
+++ b/.changeset/chilled-ladybugs-visit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+Ensure firewall tests run

--- a/packages/firewall/package.json
+++ b/packages/firewall/package.json
@@ -45,7 +45,8 @@
   },
   "scripts": {
     "pretest": "pnpm run build:code",
-    "test": "vitest",
+    "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-e2e": "glob --absolute 'test/e2e/*.test.ts'",
     "build": "pnpm run build:code && pnpm run build:docs",
     "build:code": "node ../../utils/build.mjs",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"

--- a/packages/firewall/package.json
+++ b/packages/firewall/package.json
@@ -41,12 +41,12 @@
     }
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 20"
   },
   "scripts": {
     "pretest": "pnpm run build:code",
     "vitest-run": "vitest -c ../../vitest.config.mts",
-    "vitest-e2e": "glob --absolute 'test/e2e/*.test.ts'",
+    "vitest-e2e-node-20": "glob --absolute 'test/e2e/*.test.ts'",
     "build": "pnpm run build:code && pnpm run build:docs",
     "build:code": "node ../../utils/build.mjs",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,10 @@
       "dependsOn": ["build"],
       "outputMode": "new-only"
     },
+    "vitest-e2e-node-20": {
+      "dependsOn": ["build"],
+      "outputMode": "new-only"
+    },
     "test-unit": {
       "dependsOn": ["build"],
       "outputMode": "new-only"

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -23,6 +23,16 @@ const runnersMap = new Map([
     },
   ],
   [
+    'vitest-e2e-node-20',
+    {
+      min: 1,
+      max: 7,
+      testScript: 'vitest-run',
+      runners: ['ubuntu-latest'],
+      nodeVersions: ['20'],
+    },
+  ],
+  [
     'test-unit',
     {
       min: 1,


### PR DESCRIPTION
Since we run these tests in chunks, we need to use the `vitest-` scripts so we know to include them in the "Find changes" action. From what I can see we haven't actually been testing this package until now.

Also this package isn't designed to run on Node <20 so updated `engines` and created a new entry in the `chunk-tests` workflow.

https://github.com/vercel/vercel/actions/runs/11730172571/job/32677564246?pr=12551