### PR TITLE
[cli] use subcommandOriginal for help telemetry

### DIFF
--- a/.changeset/weak-rings-occur.md
+++ b/.changeset/weak-rings-occur.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] use subcommandOriginal for help telemetry

--- a/packages/cli/src/commands/alias/index.ts
+++ b/packages/cli/src/commands/alias/index.ts
@@ -65,7 +65,7 @@ export default async function alias(client: Client) {
   switch (subcommand) {
     case 'ls':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('alias', 'list');
+        telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }
@@ -73,7 +73,7 @@ export default async function alias(client: Client) {
       return ls(client, args);
     case 'rm':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('alias', 'remove');
+        telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }
@@ -81,7 +81,7 @@ export default async function alias(client: Client) {
       return rm(client, args);
     default:
       if (needHelp) {
-        telemetry.trackCliFlagHelp('alias', 'set');
+        telemetry.trackCliFlagHelp('alias', subcommandOriginal);
         printHelp(setSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/certs/index.ts
+++ b/packages/cli/src/commands/certs/index.ts
@@ -70,7 +70,7 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'issue':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('certs', 'issue');
+        telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(issueSubcommand);
         return 2;
       }
@@ -78,7 +78,7 @@ export default async function main(client: Client) {
       return issue(client, args);
     case 'ls':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('certs', 'list');
+        telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }
@@ -86,7 +86,7 @@ export default async function main(client: Client) {
       return ls(client, args);
     case 'rm':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('certs', 'remove');
+        telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }
@@ -94,7 +94,7 @@ export default async function main(client: Client) {
       return rm(client, args);
     case 'add':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('certs', 'add');
+        telemetry.trackCliFlagHelp('certs', subcommandOriginal);
         printHelp(addSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/dns/index.ts
+++ b/packages/cli/src/commands/dns/index.ts
@@ -68,7 +68,7 @@ export default async function dns(client: Client) {
   switch (subcommand) {
     case 'add':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('dns', 'add');
+        telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(addSubcommand);
         return 2;
       }
@@ -76,7 +76,7 @@ export default async function dns(client: Client) {
       return add(client, args);
     case 'import':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('dns', 'import');
+        telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(importSubcommand);
         return 2;
       }
@@ -84,7 +84,7 @@ export default async function dns(client: Client) {
       return importZone(client, args);
     case 'rm':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('dns', 'remove');
+        telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }
@@ -92,7 +92,7 @@ export default async function dns(client: Client) {
       return rm(client, args);
     default:
       if (needHelp) {
-        telemetry.trackCliFlagHelp('dns', 'list');
+        telemetry.trackCliFlagHelp('dns', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -46,7 +46,10 @@ export default async function main(client: Client) {
   }
 
   const subArgs = parsedArgs.args.slice(1);
-  const { subcommand, args } = getSubcommand(subArgs, COMMAND_CONFIG);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
 
   const needHelp = parsedArgs.flags['--help'];
 
@@ -65,35 +68,35 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'ls':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('env', 'list');
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandList(subcommand);
+      telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
     case 'add':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('env', 'add');
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(addSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandAdd(subcommand);
+      telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
     case 'rm':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('env', 'remove');
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandRemove(subcommand);
+      telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
     case 'pull':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('env', 'pull');
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
         printHelp(pullSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandPull(subcommand);
+      telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/integration-resource/index.ts
+++ b/packages/cli/src/commands/integration-resource/index.ts
@@ -57,6 +57,7 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'remove': {
       if (needHelp) {
+        telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }
@@ -65,6 +66,7 @@ export default async function main(client: Client) {
     }
     case 'disconnect': {
       if (needHelp) {
+        telemetry.trackCliFlagHelp('integration-resource', subcommandOriginal);
         printHelp(disconnectSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -67,7 +67,7 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'add': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration', 'add');
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(addSubcommand);
         return 2;
       }
@@ -76,7 +76,7 @@ export default async function main(client: Client) {
     }
     case 'list': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration', 'list');
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }
@@ -85,7 +85,7 @@ export default async function main(client: Client) {
     }
     case 'open': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration', 'open');
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(openSubcommand);
         return 2;
       }
@@ -94,7 +94,7 @@ export default async function main(client: Client) {
     }
     case 'remove': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('integration', 'remove');
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
         printHelp(removeSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -69,21 +69,21 @@ export default async function main(client: Client) {
   switch (subcommand) {
     case 'list':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('project', 'list');
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(listSubcommand);
       }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return list(client, args);
     case 'add':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('project', 'add');
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(addSubcommand);
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
     case 'remove':
       if (needHelp) {
-        telemetry.trackCliFlagHelp('project', 'remove');
+        telemetry.trackCliFlagHelp('project', subcommandOriginal);
         return printHelp(removeSubcommand);
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -69,7 +69,7 @@ export default async function teams(client: Client) {
   switch (subcommand) {
     case 'list': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('teams', 'list');
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(listSubcommand);
         return 2;
       }
@@ -78,7 +78,7 @@ export default async function teams(client: Client) {
     }
     case 'switch': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('teams', 'switch');
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(switchSubcommand);
         return 2;
       }
@@ -87,7 +87,7 @@ export default async function teams(client: Client) {
     }
     case 'add': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('teams', 'add');
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(addSubcommand);
         return 2;
       }
@@ -96,7 +96,7 @@ export default async function teams(client: Client) {
     }
     case 'invite': {
       if (needHelp) {
-        telemetry.trackCliFlagHelp('teams', 'invite');
+        telemetry.trackCliFlagHelp('teams', subcommandOriginal);
         printHelp(inviteSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -41,7 +41,7 @@ export default async function telemetry(client: Client) {
     return 1;
   }
 
-  const { subcommand } = getSubcommand(
+  const { subcommand, subcommandOriginal } = getSubcommand(
     parsedArguments.args.slice(1),
     COMMAND_CONFIG
   );
@@ -66,7 +66,7 @@ export default async function telemetry(client: Client) {
   switch (subcommand) {
     case 'status':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', 'status');
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(statusSubcommand);
         return 2;
       }
@@ -74,7 +74,7 @@ export default async function telemetry(client: Client) {
       return status(client);
     case 'enable':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', 'enable');
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(enableSubcommand);
         return 2;
       }
@@ -82,7 +82,7 @@ export default async function telemetry(client: Client) {
       return enable(client);
     case 'disable':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', 'disable');
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
         printHelp(disableSubcommand);
         return 2;
       }

--- a/packages/cli/test/unit/commands/alias/ls.test.ts
+++ b/packages/cli/test/unit/commands/alias/ls.test.ts
@@ -31,7 +31,7 @@ describe('alias ls', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:list`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/alias/rm.test.ts
+++ b/packages/cli/test/unit/commands/alias/rm.test.ts
@@ -16,7 +16,7 @@ describe('alias rm', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:remove`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/certs/ls.test.ts
+++ b/packages/cli/test/unit/commands/certs/ls.test.ts
@@ -28,7 +28,7 @@ describe('certs ls', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:list`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/certs/rm.test.ts
+++ b/packages/cli/test/unit/commands/certs/rm.test.ts
@@ -17,7 +17,7 @@ describe('certs rm', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:remove`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/dns/ls.test.ts
+++ b/packages/cli/test/unit/commands/dns/ls.test.ts
@@ -22,7 +22,7 @@ describe('dns ls', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:list`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/dns/rm.test.ts
+++ b/packages/cli/test/unit/commands/dns/rm.test.ts
@@ -22,7 +22,7 @@ describe('dns rm', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:remove`,
+          value: `${command}:rm`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -56,7 +56,7 @@ describe('env ls', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:list`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -46,7 +46,7 @@ describe('env rm', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:remove`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/project/rm.test.ts
+++ b/packages/cli/test/unit/commands/project/rm.test.ts
@@ -17,7 +17,7 @@ describe('rm', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:remove`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });

--- a/packages/cli/test/unit/commands/teams/ls.test.ts
+++ b/packages/cli/test/unit/commands/teams/ls.test.ts
@@ -17,7 +17,7 @@ describe('teams ls', () => {
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
           key: 'flag:help',
-          value: `${command}:list`,
+          value: `${command}:${subcommand}`,
         },
       ]);
     });


### PR DESCRIPTION
Because the subcommand track events aren't triggered on help invocations, in order to know what alias was used, `subcommandOriginal` is necessary.