### PR TITLE
[cli] redacting regions until we determine method to get list

### DIFF
--- a/.changeset/fluffy-teachers-suffer.md
+++ b/.changeset/fluffy-teachers-suffer.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] redacting regions until we determine method to get list

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -58,7 +58,8 @@ export class DeployTelemetryClient
     if (regions) {
       this.trackCliOption({
         option: 'regions',
-        value: regions,
+        // consider revisiting once we come up with a way to query the list of regions
+        value: this.redactedValue,
       });
     }
   }

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -906,7 +906,7 @@ describe('deploy', () => {
         })
       );
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        { key: 'option:regions', value: 'us-east-1,us-east-2' },
+        { key: 'option:regions', value: '[REDACTED]' },
       ]);
     });
     it('--prebuilt', async () => {


### PR DESCRIPTION
We would like to track regions since it's a Vercel known list, but we don't have a way to easily get that list at the time of the tracking method call here. For now we'll redact this until we have a way to get a list we can scan through.