### PR TITLE
Fix basePath root matching for error pages

### DIFF
--- a/.changeset/hot-jeans-clap.md
+++ b/.changeset/hot-jeans-clap.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix basePath root matching for error pages

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2367,7 +2367,11 @@ export async function serverBuild({
           ]
         : [
             {
-              src: path.posix.join('/', entryDirectory, '.*'),
+              src: path.posix.join(
+                '/',
+                entryDirectory,
+                `${entryDirectory !== '.' ? '?' : ''}.*`
+              ),
               dest: path.posix.join(
                 '/',
                 entryDirectory,
@@ -2412,7 +2416,11 @@ export async function serverBuild({
           ]
         : [
             {
-              src: path.posix.join('/', entryDirectory, '.*'),
+              src: path.posix.join(
+                '/',
+                entryDirectory,
+                `${entryDirectory !== '.' ? '?' : ''}.*`
+              ),
               dest: path.posix.join(
                 '/',
                 entryDirectory,

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2370,6 +2370,9 @@ export async function serverBuild({
               src: path.posix.join(
                 '/',
                 entryDirectory,
+                // if entryDirectory is populated we need to
+                // add optional handling for trailing slash so
+                // that the entryDirectory (basePath) itself matches
                 `${entryDirectory !== '.' ? '?' : ''}.*`
               ),
               dest: path.posix.join(
@@ -2419,6 +2422,9 @@ export async function serverBuild({
               src: path.posix.join(
                 '/',
                 entryDirectory,
+                // if entryDirectory is populated we need to
+                // add optional handling for trailing slash so
+                // that the entryDirectory (basePath) itself matches
                 `${entryDirectory !== '.' ? '?' : ''}.*`
               ),
               dest: path.posix.join(


### PR DESCRIPTION
This ensures we can match the root itself when a `basePath` value is configured on a project and the error page is being matched. 

Verified on https://next-500-vercel-issue-65i0edfn4-vtest314-ijjk-testing.vercel.app/library?q=any

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1731090171198859?thread_ts=1730905462.387389&cid=C0676QZBWKS)
x-ref: NEXT-3850