### PR TITLE
TS issue, remove endpoints, fix usage examples

### DIFF
--- a/packages/sdk/.speakeasy/gen.yaml
+++ b/packages/sdk/.speakeasy/gen.yaml
@@ -43,7 +43,7 @@ typescript:
   inputModelSuffix: input
   maxMethodParams: 0
   methodArguments: require-security-and-request
-  moduleFormat: dual
+  moduleFormat: esm
   outputModelSuffix: output
   packageName: '@vercel/sdk'
   responseFormat: flat

--- a/packages/sdk/.speakeasy/workflow.yaml
+++ b/packages/sdk/.speakeasy/workflow.yaml
@@ -6,6 +6,7 @@ sources:
             - location: https://openapi.vercel.sh/
         overlays:
             - location: overlay.yaml
+        output: vercel-spec.yaml
         ruleset: vercelRestAPIRuleset
         registry:
             location: registry.speakeasyapi.dev/vercel/vercel-docs/vercel-oas

--- a/packages/sdk/overlay.yaml
+++ b/packages/sdk/overlay.yaml
@@ -18,15 +18,15 @@ actions:
     remove: true
   # End of remove paths
   # Marking endpoints to show up in Example Usage section of readme
-  - target: $["paths"]["/v6/deployments"]["get"]
+  - target: $["paths"]["/v6/deployments"].get
     update:
-      - x-speakeasy-usage-example:
+      x-speakeasy-usage-example:
         title: List deployments
         description: List deployments under the authenticated user or team.
         position: 1
-  - target: $["paths"]["/v9/projects/{idOrName}"]["patch"]
+  - target: $["paths"]["/v9/projects/{idOrName}"].patch
     update:
-      - x-speakeasy-usage-example:
+      x-speakeasy-usage-example:
         title: Update an existing project
         description: Update the fields of a project using either its name or id.
         position: 2

--- a/packages/sdk/overlay.yaml
+++ b/packages/sdk/overlay.yaml
@@ -2,17 +2,35 @@ overlay: 1.0.0
 info:
   title: Fix https://openapi.vercel.sh/ with lint issues
   version: 0.0.0
-# The fixes below from the errors found with speakeasy openapi lint
+# The fixes below from the errors found with speakeasy openapi lint and testing the usage of the SDK and endpoints
 actions:
-  - target: $["paths"]["/data-cache/purge-all"]["delete"]
+  # Removing these paths as they return errors at the source (by calling the endpoint directly)
+  - target: $["paths"]["/data-cache/purge-all"]
+    remove: true
+  - target: $["paths"]["/data-cache/billing-settings"]
+    remove: true
+  - target: $["paths"]["/certs"]
+    remove: true
+  # Removing these paths as they are deprecated but kept for legacy
+  - target: $["paths"]["/v2/secrets"]
+    remove: true
+  - target: $["paths"]["/v3/secrets"]
+    remove: true
+  # End of remove paths
+  # Marking endpoints to show up in Example Usage section of readme
+  - target: $["paths"]["/v6/deployments"]["get"]
     update:
-      operationId: datacachePurgeall
-  - target: $["paths"]["/data-cache/billing-settings"]["patch"]
+      - x-speakeasy-usage-example:
+        title: List deployments
+        description: List deployments under the authenticated user or team.
+        position: 1
+  - target: $["paths"]["/v9/projects/{idOrName}"]["patch"]
     update:
-      operationId: dataCacheBillingSettings
-  - target: $["paths"]["/certs"]["get"]
-    update:
-      operationId: getCerts
+      - x-speakeasy-usage-example:
+        title: Update an existing project
+        description: Update the fields of a project using either its name or id.
+        position: 2
+  # Fixing lint and TS issues from source
   - target: $["paths"]["/v13/deployments"]["post"]["parameters"][0]
     remove: true
   - target: $["paths"]["/v13/deployments"]["post"]["parameters"][2]
@@ -111,16 +129,6 @@ actions:
           type: string
           description: The Team identifier to perform the request on behalf of.
           example: team_LLHUOMOoDlqOp8wPE4kFo9pE
-  - target: $["paths"]["/v2/secrets/{name}"]["post"]["parameters"]
-    update:
-      - name: name
-        description: The name of the secret.
-        in: path
-        required: true
-        schema:
-          description: The name of the secret.
-          type: string
-          example: my-api-key
   - target: $.paths['/v1/data-cache/projects/{projectId}'].patch.responses['200'].content['application/json'].schema.properties['env'].items.properties['target'].oneOf[1].enum
     remove: true
   - target: $.paths['/v1/data-cache/projects/{projectId}'].patch.responses['200'].content['application/json'].schema.properties['env'].items.properties['target'].oneOf[1]
@@ -614,6 +622,7 @@ actions:
           type: number
           description: The date when the alias was created in milliseconds since the UNIX epoch
           example: 1540095775941
+          nullable: true
         creator:
           properties:
             uid:
@@ -638,6 +647,7 @@ actions:
           type: number
           description: The date when the alias was deleted in milliseconds since the UNIX epoch
           example: 1540095775941
+          nullable: true
         deployment:
           properties:
             id:
@@ -687,6 +697,7 @@ actions:
           type: number
           description: The date when the alias was updated in milliseconds since the UNIX epoch
           example: 1540095775941
+          nullable: true
         protectionBypass:
           additionalProperties:
             oneOf:


### PR DESCRIPTION
From our most recent testing:
https://www.notion.so/vercel/Vercel-SDK-Edits-104e06b059c48085ad11f9288118b604?pvs=4#137e06b059c4809c81b6ce2940292d17
- Also adding output to the workflow so that the overlaid spec is saved in the PR (we can use this to generate the docs)
- Moving to `esm` instead of `dual` in `gen.yaml` to move away from `tshy`