### PR TITLE
Add a hidden `telemetry flush` to use for the telemetry send process

### DIFF
--- a/.changeset/orange-pants-talk.md
+++ b/.changeset/orange-pants-talk.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add tests for send telemetry

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -34,6 +34,7 @@ export interface Command {
   readonly aliases: ReadonlyArray<string>;
   readonly description: string;
   readonly default?: true;
+  readonly hidden?: true;
   readonly arguments: ReadonlyArray<CommandArgument>;
   readonly subcommands?: ReadonlyArray<Command>;
   readonly options: ReadonlyArray<CommandOption>;
@@ -225,6 +226,9 @@ export function buildSubcommandLines(
   let maxWidthOfUnwrappedColumns = 0;
   const rows: (string | undefined | _CellOptions)[][] = [];
   for (const command of subcommands) {
+    if (command.hidden) {
+      continue;
+    }
     const nameCell = `${INDENT}${command.name}`;
     let argsCell = INDENT;
 

--- a/packages/cli/src/commands/telemetry/command.ts
+++ b/packages/cli/src/commands/telemetry/command.ts
@@ -16,6 +16,16 @@ export const enableSubcommand = {
   examples: [],
 } as const;
 
+export const flushSubcommand = {
+  name: 'flush',
+  aliases: [],
+  description: 'Interal command to flush telemetry events',
+  hidden: true,
+  arguments: [],
+  options: [],
+  examples: [],
+} as const;
+
 export const disableSubcommand = {
   name: 'disable',
   aliases: [],
@@ -30,7 +40,12 @@ export const telemetryCommand = {
   aliases: [],
   description: 'Allows you to enable or disable telemetry collection',
   arguments: [],
-  subcommands: [enableSubcommand, disableSubcommand, statusSubcommand],
+  subcommands: [
+    enableSubcommand,
+    disableSubcommand,
+    statusSubcommand,
+    flushSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/telemetry/flush.ts
+++ b/packages/cli/src/commands/telemetry/flush.ts
@@ -1,0 +1,38 @@
+import type Client from '../../util/client';
+
+export default async function flush(client: Client, args: string[]) {
+  const url =
+    process.env.VERCEL_TELEMETRY_BRIDGE_URL ||
+    'https://telemetry.vercel.com/api/vercel-cli/v1/events';
+  const { headers, body } = JSON.parse(args[0]);
+  try {
+    const res = await client.fetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      json: false,
+    });
+    const status = res.status;
+    const cliTracked = res.headers.get('x-vercel-cli-tracked') || '';
+    const wasRecorded = cliTracked === '1';
+
+    if (status === 204) {
+      if (wasRecorded) {
+        // Intentionally not using `output.debug` as this command is called via a subprocess
+        process.stderr.write('Telemetry event tracked');
+      } else {
+        process.stderr.write('Telemetry event ignored');
+      }
+    } else {
+      process.stderr.write(
+        `Failed to send telemetry events. Unexpected response from telemetry server: ${status}`
+      );
+    }
+    return 0;
+  } catch (error) {
+    if (error instanceof Error) {
+      process.stderr.write(`Failed to send telemetry events. ${error.message}`);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -5,11 +5,13 @@ import { type Command, help } from '../help';
 import status from './status';
 import enable from './enable';
 import disable from './disable';
+import flush from './flush';
 import {
   disableSubcommand,
   enableSubcommand,
   statusSubcommand,
   telemetryCommand,
+  flushSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { TelemetryTelemetryClient } from '../../util/telemetry/commands/telemetry';
@@ -22,6 +24,7 @@ const COMMAND_CONFIG = {
   status: getCommandAliases(statusSubcommand),
   enable: getCommandAliases(enableSubcommand),
   disable: getCommandAliases(disableSubcommand),
+  flush: getCommandAliases(flushSubcommand),
 };
 
 export default async function telemetry(client: Client) {
@@ -41,7 +44,7 @@ export default async function telemetry(client: Client) {
     return 1;
   }
 
-  const { subcommand } = getSubcommand(
+  const { subcommand, args } = getSubcommand(
     parsedArguments.args.slice(1),
     COMMAND_CONFIG
   );
@@ -72,6 +75,8 @@ export default async function telemetry(client: Client) {
       }
       telemetryClient.trackCliSubcommandStatus(subcommand);
       return status(client);
+    case 'flush':
+      return flush(client, args);
     case 'enable':
       if (needHelp) {
         telemetryClient.trackCliFlagHelp('telemetry', 'enable');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -368,7 +368,14 @@ const main = async () => {
     client.argv.push('-h');
   }
 
-  const subcommandsWithoutToken = ['login', 'logout', 'help', 'init', 'build'];
+  const subcommandsWithoutToken = [
+    'login',
+    'logout',
+    'help',
+    'init',
+    'build',
+    'telemetry',
+  ];
 
   // Prompt for login if there is no current token
   if (

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -791,7 +791,7 @@ const main = async () => {
     return 1;
   }
 
-  // FIXME: the telemetry flush event is called by `telemetryEventStore.save`, and it reinvokes the `main` function
+  // The telemetry flush event is called by `telemetryEventStore.save`, and it reinvokes the `main` function
   if (subSubCommand !== 'flush') {
     await telemetryEventStore.save();
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -791,8 +791,10 @@ const main = async () => {
     return 1;
   }
 
-  // specifically don't await this, we want to fire and forget
-  await telemetryEventStore.save();
+  // FIXME: the telemetry flush event is called by `telemetryEventStore.save`, and it reinvokes the `main` function
+  if (parsedArgs.args[3] !== 'flush') {
+    await telemetryEventStore.save();
+  }
   return exitCode;
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -792,7 +792,7 @@ const main = async () => {
   }
 
   // FIXME: the telemetry flush event is called by `telemetryEventStore.save`, and it reinvokes the `main` function
-  if (parsedArgs.args[3] !== 'flush') {
+  if (subSubCommand !== 'flush') {
     await telemetryEventStore.save();
   }
   return exitCode;

--- a/packages/cli/src/util/telemetry/commands/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/commands/telemetry/index.ts
@@ -25,4 +25,10 @@ export class TelemetryTelemetryClient
     // NOTE: this function is intentionally not implemented
     // because the user has explicitly opted out of telemetry
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  trackCliSubcommandFlush(_: string) {
+    // NOTE: this function is intentionally not implemented
+    // because the user has explicitly opted out of telemetry
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/commands/telemetry/index.ts
@@ -27,8 +27,5 @@ export class TelemetryTelemetryClient
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  trackCliSubcommandFlush(_: string) {
-    // NOTE: this function is intentionally not implemented
-    // because the user has explicitly opted out of telemetry
-  }
+  trackCliSubcommandFlush(_: string) {}
 }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -282,6 +282,10 @@ export class TelemetryEventStore {
           output.debug(d);
         });
 
+        setTimeout(() => {
+          childProcess.kill();
+        }, 2000);
+
         childProcess.on('exit', () => {
           output.debug('Telemetry subprocess exited');
           childProcess.unref();

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -270,12 +270,6 @@ export class TelemetryEventStore {
           stdio: ['ignore', 'pipe', 'pipe'],
         });
 
-        // If the child process doesn't exit within 2 seconds, kill it
-        setTimeout(() => {
-          childProcess.kill();
-          output.debug('Telemetry event subprocess timed out');
-        }, 2000);
-
         childProcess.stderr.on('data', data => output.debug(data.toString()));
         childProcess.stdout.on('data', data => output.debug(data.toString()));
         childProcess.on('error', d => {
@@ -283,7 +277,9 @@ export class TelemetryEventStore {
         });
 
         childProcess.on('exit', () => {
+          output.debug('Telemetry subprocess exited');
           childProcess.unref();
+          process.exit(0);
           // An error in the subprocess should not trigger a bad exit code, so don't reject under any circumstances
           resolve();
         });

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -250,7 +250,13 @@ export class TelemetryEventStore {
     }
   }
 
-  // This is separated so that we can easily mock it for testing purposes
+  /**
+   * Send the telemetry events to a subprocess, this invokes the `telemetry flush` command
+   * and passes a stringified payload to the subprocess, there's a risk that if the event payload
+   * increases in size, it may exceed the maximum buffer size for the subprocess, in which case the
+   * child process will error and not send anything.
+   * FIXME: handle max buffer size
+   */
   async sendToSubprocess(payload: object, outputDebugEnabled: boolean) {
     const args = [process.execPath, process.argv[0], process.argv[1]];
     if (args[0] === args[1]) {

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -279,7 +279,6 @@ export class TelemetryEventStore {
         childProcess.on('exit', () => {
           output.debug('Telemetry subprocess exited');
           childProcess.unref();
-          process.exit(0);
           // An error in the subprocess should not trigger a bad exit code, so don't reject under any circumstances
           resolve();
         });

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -584,7 +584,7 @@ test('whoami with local .vercel scope', async () => {
   await remove(path.join(directory, '.vercel'));
 });
 
-describe('telemtry submits data', () => {
+describe('telemetry submits data', () => {
   const prepareBridge = async () => {
     const mockTelemetryBridgeApp = express();
     const mockTelemetryBridgeServer = createServer(mockTelemetryBridgeApp);
@@ -616,9 +616,9 @@ describe('telemtry submits data', () => {
   };
   describe('when --debug is not enabled', () => {
     test('does not wait for the send process before exiting', async () => {
-      let resolveThing: () => void;
-      let promiseSomething = new Promise<void>(resolve => {
-        resolveThing = resolve;
+      let resolveBridgeEvent: () => void;
+      let bridgeEventPromise = new Promise<void>(resolve => {
+        resolveBridgeEvent = resolve;
       });
       const { mockTelemetryBridgeApp, directory, cleanup } =
         await prepareBridge();
@@ -627,7 +627,7 @@ describe('telemtry submits data', () => {
         mockTelemetryBridgeWasCalled = true;
         res.header('x-vercel-cli-tracked', '1');
         res.status(204).send();
-        resolveThing();
+        resolveBridgeEvent();
       });
       const output = await execCli(binaryPath, ['whoami'], {
         cwd: directory,
@@ -635,7 +635,7 @@ describe('telemtry submits data', () => {
       expect(mockTelemetryBridgeWasCalled).toEqual(false);
       expect(output.exitCode, formatOutput(output)).toBe(0);
 
-      await promiseSomething;
+      await bridgeEventPromise;
       expect(mockTelemetryBridgeWasCalled).toEqual(true);
 
       await cleanup();

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -652,7 +652,7 @@ describe('telemetry submits data', () => {
       const output = await execCli(binaryPath, ['whoami', '-d'], {
         cwd: directory,
       });
-      expect(output.stderr).toContain('Telemetry event subprocess timed out');
+      expect(output.stderr).toContain('Telemetry subprocess exited');
       expect(output.exitCode, formatOutput(output)).toBe(0);
       expect(mockTelemetryBridgeWasCalled).toEqual(true);
       // clean up


### PR DESCRIPTION
The way we were previously sending the telemetry event wasn't compatible with our ability to invoke the CLI from `ts-node` because finding the `send-telemetry` module wasn't in the expected path. Instead, the `sendToSubprocess` function invokes the CLI with the `telemetry flush` command, providing the events as a stringified JSON argument.