### PR TITLE
[python] use `ThreadingHTTPServer` to handle concurrent requests

### DIFF
--- a/.changeset/spotty-bats-yawn.md
+++ b/.changeset/spotty-bats-yawn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Use a ThreadingHTTPServer to handle concurrent requests

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -28,7 +28,7 @@ def format_headers(headers, decode=False):
     return keyToList
 
 if 'VERCEL_IPC_FD' in os.environ:
-    from http.server import HTTPServer
+    from http.server import ThreadingHTTPServer
     import http
     import time
     import contextvars
@@ -312,7 +312,7 @@ if 'VERCEL_IPC_FD' in os.environ:
                     asyncio.run(app(scope, receive, send))
 
     if 'Handler' in locals():
-        server = HTTPServer(('127.0.0.1', 0), Handler)
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
         send_message({
             "type": "server-started",
             "payload": {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/12557

Python's `HTTPServer` handles requests sequentially, even if we send multiple requests at the same time. Switch to `ThreadingHTTPServer` to handle requests concurrently when using streaming.