### PR TITLE
[python] report Request Metrics when using `urllib3`

### DIFF
--- a/.changeset/quiet-lions-remain.md
+++ b/.changeset/quiet-lions-remain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Report Request Metrics when using urllib3/requests


### PR DESCRIPTION
Report Request Metrics when using the `urllib3` library or `requests` (since it's based on `urllib3`). Similarly to how logs are sent via IPC, we wrap a specific method (`urllib3.connectionpool.HTTPConnectionPool.urlopen`) to report the host, method, path, search params, response status and duration of HTTP requests.

The patching is nested under a `try: ... except: pass` since we import the `urllib3` package while the user code might not have it installed.