### PR TITLE
Pass `VERCEL_TELEMETRY_DISABLED` to flush command

### DIFF
--- a/.changeset/thin-monkeys-occur.md
+++ b/.changeset/thin-monkeys-occur.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Invoke the telemetry flush command with telemetry disabled

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -798,10 +798,8 @@ const main = async () => {
     return 1;
   }
 
-  // The telemetry flush event is called by `telemetryEventStore.save`, and it reinvokes the `main` function
-  if (subSubCommand !== 'flush') {
-    await telemetryEventStore.save();
-  }
+  await telemetryEventStore.save();
+
   return exitCode;
 };
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -4,7 +4,7 @@ import type { GlobalConfig } from '@vercel-internals/types';
 import output from '../../output-manager';
 import { spawn } from 'node:child_process';
 import { PROJECT_ENV_TARGET } from '@vercel-internals/constants';
-import { cloneEnv } from '@vercel/build-utils/dist';
+import { cloneEnv } from '@vercel/build-utils';
 
 const LogLabel = `['telemetry']:`;
 

--- a/packages/cli/test/unit/util/telemetry-check-status.test.ts
+++ b/packages/cli/test/unit/util/telemetry-check-status.test.ts
@@ -54,18 +54,7 @@ describe('checkTelemetryStatus', () => {
     });
 
     it('does not inform the user', async () => {
-      await expect(client.stderr).not.toOutput(
-        'The Vercel CLI now collects telemetry regarding usage.'
-      );
-      await expect(client.stderr).not.toOutput(
-        'This information is used to shape the CLI roadmap and prioritize features.'
-      );
-      await expect(client.stderr).not.toOutput(
-        "You can learn more, including how to opt-out if you'd not like to participate in this program, by visiting the following URL:"
-      );
-      await expect(client.stderr).not.toOutput(
-        'https://vercel.com/docs/cli/about-telemetry'
-      );
+      expect(client.getFullOutput()).toEqual('');
     });
 
     it('does not change opt out status the customer in', async () => {
@@ -85,18 +74,7 @@ describe('checkTelemetryStatus', () => {
     });
 
     it('does not inform the user', async () => {
-      await expect(client.stderr).not.toOutput(
-        'The Vercel CLI now collects telemetry regarding usage.'
-      );
-      await expect(client.stderr).not.toOutput(
-        'This information is used to shape the CLI roadmap and prioritize features.'
-      );
-      await expect(client.stderr).not.toOutput(
-        "You can learn more, including how to opt-out if you'd not like to participate in this program, by visiting the following URL:"
-      );
-      await expect(client.stderr).not.toOutput(
-        'https://vercel.com/docs/cli/about-telemetry'
-      );
+      expect(client.getFullOutput()).toEqual('');
     });
 
     it('does not change opt out status the customer in', async () => {


### PR DESCRIPTION
Now calls `telemetry flush` with `VERCEL_TELEMETRY_DISABLED=1` to avoid an infinite loop on `telemetryEventStore.save()`

[See comment](https://github.com/vercel/vercel/pull/12555#pullrequestreview-2434378618)
