### PR TITLE
Fix overlay version

### DIFF
--- a/packages/sdk/overlay.yaml
+++ b/packages/sdk/overlay.yaml
@@ -1,4 +1,4 @@
-overlay: 1.0.2
+overlay: 1.0.0
 info:
   title: Fix https://openapi.vercel.sh/ from lint and testing
   version: 0.0.2


### PR DESCRIPTION
Fixing this GH action error
https://github.com/vercel/vercel/actions/runs/11843237910/job/33003717526#step:5:253

This version needs to be fixed to the speakeasy version - Not my file's version!