### PR TITLE
[cli] Prevent confirmation prompt for `vercel disconnect --yes`

### DIFF
--- a/.changeset/eleven-grapes-return.md
+++ b/.changeset/eleven-grapes-return.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prevent confirmation prompt for `vercel disconnect --yes`

--- a/packages/cli/src/commands/git/disconnect.ts
+++ b/packages/cli/src/commands/git/disconnect.ts
@@ -62,13 +62,15 @@ export default async function disconnect(client: Client, argv: string[]) {
     output.print(
       `Your Vercel project will no longer create deployments when you push to this repository.\n`
     );
-    const confirmDisconnect = await confirm(
-      client,
-      `Are you sure you want to disconnect ${chalk.cyan(
-        `${linkOrg}/${repo}`
-      )} from your project?`,
-      false
-    );
+    const confirmDisconnect =
+      autoConfirm ||
+      (await confirm(
+        client,
+        `Are you sure you want to disconnect ${chalk.cyan(
+          `${linkOrg}/${repo}`
+        )} from your project?`,
+        false
+      ));
 
     if (confirmDisconnect) {
       await disconnectGitProvider(client, org, project.id);

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -525,4 +525,187 @@ describe('git connect', () => {
       await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
     }
   });
+
+  it('should connect a given repository', async () => {
+    const cwd = fixture('no-remote-url');
+    client.cwd = cwd;
+    try {
+      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'no-remote-url',
+        name: 'no-remote-url',
+      });
+
+      client.setArgv('git', 'connect', 'https://github.com/user2/repo2');
+      const gitPromise = git(client);
+
+      await expect(client.stderr).toOutput(
+        `Connecting Git remote: https://github.com/user2/repo2`
+      );
+      await expect(client.stderr).toOutput(
+        `Connected GitHub repository user2/repo2!`
+      );
+
+      const newProjectData: Project = await client.fetch(
+        `/v8/projects/no-remote-url`
+      );
+      expect(newProjectData.link).toMatchObject({
+        type: 'github',
+        repo: 'user2/repo2',
+        repoId: 1010,
+        gitCredentialId: '',
+        sourceless: true,
+        createdAt: 1656109539791,
+        updatedAt: 1656109539791,
+      });
+
+      await expect(gitPromise).resolves.toEqual(0);
+    } finally {
+      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+    }
+  });
+
+  it('should prompt when it finds a repository', async () => {
+    const cwd = fixture('new-connection');
+    client.cwd = cwd;
+    try {
+      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'new-connection',
+        name: 'new-connection',
+      });
+
+      client.setArgv('git', 'connect', 'https://github.com/user2/repo2');
+      const gitPromise = git(client);
+
+      await expect(client.stderr).toOutput(
+        `Found a repository in your local Git Config: https://github.com/user/repo`
+      );
+      await expect(client.stderr).toOutput(
+        `Do you still want to connect https://github.com/user2/repo2? (y/N)`
+      );
+      client.stdin.write('y\n');
+      await expect(client.stderr).toOutput(
+        `Connecting Git remote: https://github.com/user2/repo2`
+      );
+      await expect(client.stderr).toOutput(
+        `Connected GitHub repository user2/repo2!`
+      );
+
+      const newProjectData: Project = await client.fetch(
+        `/v8/projects/new-connection`
+      );
+      expect(newProjectData.link).toMatchObject({
+        type: 'github',
+        repo: 'user2/repo2',
+        repoId: 1010,
+        gitCredentialId: '',
+        sourceless: true,
+        createdAt: 1656109539791,
+        updatedAt: 1656109539791,
+      });
+
+      await expect(gitPromise).resolves.toEqual(0);
+    } finally {
+      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+    }
+  });
+
+  it('should prompt when it finds multiple remotes', async () => {
+    const cwd = fixture('multiple-remotes');
+    client.cwd = cwd;
+    try {
+      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'multiple-remotes',
+        name: 'multiple-remotes',
+      });
+
+      client.setArgv('git', 'connect', 'https://github.com/user3/repo3');
+      const gitPromise = git(client);
+
+      await expect(client.stderr).toOutput(
+        `Found multiple Git repositories in your local Git config:\n  • origin: https://github.com/user/repo.git\n  • secondary: https://github.com/user/repo2.git`
+      );
+      await expect(client.stderr).toOutput(
+        `Do you still want to connect https://github.com/user3/repo3? (y/N)`
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Connecting Git remote: https://github.com/user3/repo3`
+      );
+      await expect(client.stderr).toOutput(
+        `Connected GitHub repository user3/repo3!`
+      );
+
+      const newProjectData: Project = await client.fetch(
+        `/v8/projects/multiple-remotes`
+      );
+      expect(newProjectData.link).toMatchObject({
+        type: 'github',
+        repo: 'user3/repo3',
+        repoId: 1010,
+        gitCredentialId: '',
+        sourceless: true,
+        createdAt: 1656109539791,
+        updatedAt: 1656109539791,
+      });
+
+      await expect(gitPromise).resolves.toEqual(0);
+    } finally {
+      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+    }
+  });
+
+  it('should continue as normal when input matches single git remote', async () => {
+    const cwd = fixture('new-connection');
+    client.cwd = cwd;
+    try {
+      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'new-connection',
+        name: 'new-connection',
+      });
+
+      client.setArgv('git', 'connect', 'https://github.com/user/repo');
+      const gitPromise = git(client);
+
+      await expect(client.stderr).toOutput(
+        `Connecting Git remote: https://github.com/user/repo`
+      );
+      await expect(client.stderr).toOutput(
+        `Connected GitHub repository user/repo!`
+      );
+
+      const newProjectData: Project = await client.fetch(
+        `/v8/projects/new-connection`
+      );
+      expect(newProjectData.link).toMatchObject({
+        type: 'github',
+        repo: 'user/repo',
+        repoId: 1010,
+        gitCredentialId: '',
+        sourceless: true,
+        createdAt: 1656109539791,
+        updatedAt: 1656109539791,
+      });
+
+      await expect(gitPromise).resolves.toEqual(0);
+    } finally {
+      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+    }
+  });
 });

--- a/packages/cli/test/unit/commands/git/disconnect.test.ts
+++ b/packages/cli/test/unit/commands/git/disconnect.test.ts
@@ -75,6 +75,58 @@ describe('git disconnect', () => {
     }
   });
 
+  describe('--yes', () => {
+    it('tracks telemetry', async () => {
+      const cwd = fixture('new-connection');
+      client.cwd = cwd;
+      try {
+        await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
+        useUser();
+        useTeams('team_dummy');
+        const project = useProject({
+          ...defaultProject,
+          id: 'new-connection',
+          name: 'new-connection',
+        });
+        project.project.link = {
+          type: 'github',
+          repo: 'repo',
+          org: 'user',
+          repoId: 1010,
+          gitCredentialId: '',
+          sourceless: true,
+          createdAt: 1656109539791,
+          updatedAt: 1656109539791,
+        };
+        client.setArgv('git', 'disconnect', '--yes');
+        const gitPromise = git(client);
+
+        await expect(client.stderr).toOutput('Disconnected user/repo.');
+
+        const newProjectData: Project = await client.fetch(
+          `/v8/projects/new-connection`
+        );
+        expect(newProjectData.link).toBeUndefined();
+
+        const exitCode = await gitPromise;
+        expect(exitCode).toEqual(0);
+      } finally {
+        await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
+      }
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:disconnect',
+          value: 'disconnect',
+        },
+        {
+          key: 'flag:yes',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
+
   it('should disconnect a repository', async () => {
     const cwd = fixture('new-connection');
     client.cwd = cwd;
@@ -140,189 +192,6 @@ describe('git disconnect', () => {
 
       const exitCode = await gitPromise;
       expect(exitCode).toEqual(1);
-    } finally {
-      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-    }
-  });
-
-  it('should connect a given repository', async () => {
-    const cwd = fixture('no-remote-url');
-    client.cwd = cwd;
-    try {
-      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
-      useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'no-remote-url',
-        name: 'no-remote-url',
-      });
-
-      client.setArgv('git', 'connect', 'https://github.com/user2/repo2');
-      const gitPromise = git(client);
-
-      await expect(client.stderr).toOutput(
-        `Connecting Git remote: https://github.com/user2/repo2`
-      );
-      await expect(client.stderr).toOutput(
-        `Connected GitHub repository user2/repo2!`
-      );
-
-      const newProjectData: Project = await client.fetch(
-        `/v8/projects/no-remote-url`
-      );
-      expect(newProjectData.link).toMatchObject({
-        type: 'github',
-        repo: 'user2/repo2',
-        repoId: 1010,
-        gitCredentialId: '',
-        sourceless: true,
-        createdAt: 1656109539791,
-        updatedAt: 1656109539791,
-      });
-
-      await expect(gitPromise).resolves.toEqual(0);
-    } finally {
-      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-    }
-  });
-
-  it('should prompt when it finds a repository', async () => {
-    const cwd = fixture('new-connection');
-    client.cwd = cwd;
-    try {
-      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
-      useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'new-connection',
-        name: 'new-connection',
-      });
-
-      client.setArgv('git', 'connect', 'https://github.com/user2/repo2');
-      const gitPromise = git(client);
-
-      await expect(client.stderr).toOutput(
-        `Found a repository in your local Git Config: https://github.com/user/repo`
-      );
-      await expect(client.stderr).toOutput(
-        `Do you still want to connect https://github.com/user2/repo2? (y/N)`
-      );
-      client.stdin.write('y\n');
-      await expect(client.stderr).toOutput(
-        `Connecting Git remote: https://github.com/user2/repo2`
-      );
-      await expect(client.stderr).toOutput(
-        `Connected GitHub repository user2/repo2!`
-      );
-
-      const newProjectData: Project = await client.fetch(
-        `/v8/projects/new-connection`
-      );
-      expect(newProjectData.link).toMatchObject({
-        type: 'github',
-        repo: 'user2/repo2',
-        repoId: 1010,
-        gitCredentialId: '',
-        sourceless: true,
-        createdAt: 1656109539791,
-        updatedAt: 1656109539791,
-      });
-
-      await expect(gitPromise).resolves.toEqual(0);
-    } finally {
-      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-    }
-  });
-
-  it('should prompt when it finds multiple remotes', async () => {
-    const cwd = fixture('multiple-remotes');
-    client.cwd = cwd;
-    try {
-      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
-      useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'multiple-remotes',
-        name: 'multiple-remotes',
-      });
-
-      client.setArgv('git', 'connect', 'https://github.com/user3/repo3');
-      const gitPromise = git(client);
-
-      await expect(client.stderr).toOutput(
-        `Found multiple Git repositories in your local Git config:\n  • origin: https://github.com/user/repo.git\n  • secondary: https://github.com/user/repo2.git`
-      );
-      await expect(client.stderr).toOutput(
-        `Do you still want to connect https://github.com/user3/repo3? (y/N)`
-      );
-      client.stdin.write('y\n');
-
-      await expect(client.stderr).toOutput(
-        `Connecting Git remote: https://github.com/user3/repo3`
-      );
-      await expect(client.stderr).toOutput(
-        `Connected GitHub repository user3/repo3!`
-      );
-
-      const newProjectData: Project = await client.fetch(
-        `/v8/projects/multiple-remotes`
-      );
-      expect(newProjectData.link).toMatchObject({
-        type: 'github',
-        repo: 'user3/repo3',
-        repoId: 1010,
-        gitCredentialId: '',
-        sourceless: true,
-        createdAt: 1656109539791,
-        updatedAt: 1656109539791,
-      });
-
-      await expect(gitPromise).resolves.toEqual(0);
-    } finally {
-      await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
-    }
-  });
-
-  it('should continue as normal when input matches single git remote', async () => {
-    const cwd = fixture('new-connection');
-    client.cwd = cwd;
-    try {
-      await fs.rename(join(cwd, 'git'), join(cwd, '.git'));
-      useUser();
-      useTeams('team_dummy');
-      useProject({
-        ...defaultProject,
-        id: 'new-connection',
-        name: 'new-connection',
-      });
-
-      client.setArgv('git', 'connect', 'https://github.com/user/repo');
-      const gitPromise = git(client);
-
-      await expect(client.stderr).toOutput(
-        `Connecting Git remote: https://github.com/user/repo`
-      );
-      await expect(client.stderr).toOutput(
-        `Connected GitHub repository user/repo!`
-      );
-
-      const newProjectData: Project = await client.fetch(
-        `/v8/projects/new-connection`
-      );
-      expect(newProjectData.link).toMatchObject({
-        type: 'github',
-        repo: 'user/repo',
-        repoId: 1010,
-        gitCredentialId: '',
-        sourceless: true,
-        createdAt: 1656109539791,
-        updatedAt: 1656109539791,
-      });
-
-      await expect(gitPromise).resolves.toEqual(0);
     } finally {
       await fs.rename(join(cwd, '.git'), join(cwd, 'git'));
     }


### PR DESCRIPTION
* Fixes the `--yes` flag being respected for the disconnect confirmation prompt in `vc disconnect`.
* Adds a unit test for telemetry tracking for `--yes`.
* Moves a few `vc connect` tests to the correct file.