### PR TITLE
[cli] fix minor issues vercel init

### DIFF
--- a/.changeset/serious-apricots-search.md
+++ b/.changeset/serious-apricots-search.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] fix minor issues vercel init

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -15,7 +15,7 @@ const COMMAND_CONFIG = {
 };
 
 export default async function main(client: Client) {
-  let parsedArgs = null;
+  let parsedArgs;
 
   const flagsSpecification = getFlagsSpecification(initCommand.options);
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -15,8 +15,6 @@ const COMMAND_CONFIG = {
 };
 
 export default async function main(client: Client) {
-  let args;
-
   let parsedArgs = null;
 
   const flagsSpecification = getFlagsSpecification(initCommand.options);
@@ -41,7 +39,7 @@ export default async function main(client: Client) {
     return 2;
   }
 
-  args = getSubcommand(parsedArgs.args.slice(1), COMMAND_CONFIG).args;
+  const args = getSubcommand(parsedArgs.args.slice(1), COMMAND_CONFIG).args;
 
   if (parsedArgs.args.length > 3) {
     output.error('Too many arguments.');

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -128,7 +128,7 @@ async function extractExample(
   name: string,
   dir: string,
   force?: boolean,
-  ver: string = 'v2'
+  ver = 'v2'
 ) {
   const folder = prepareFolder(client.cwd, dir || name, force);
   output.spinner(`Fetching ${name}`);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -41,14 +41,14 @@ export default async function init(
   const examples = await fetchExampleList(client);
 
   if (!examples) {
-    throw new Error(`Could not fetch example list.`);
+    throw new Error('Could not fetch example list.');
   }
 
   const exampleList = examples.filter(x => x.visible).map(x => x.name);
 
   if (!name) {
     if (client.stdin.isTTY !== true) {
-      output.print(`No framework provided`);
+      output.print('No framework provided');
       return 0;
     }
     const chosen = await chooseFromDropdown(
@@ -213,7 +213,7 @@ function prepareFolder(cwd: string, folder: string, force?: boolean) {
 async function guess(client: Client, exampleList: string[], name: string) {
   const GuessError = new Error(
     `No example found for ${chalk.bold(name)}, run ${getCommandName(
-      `init`
+      'init'
     )} to see the list of available examples.`
   );
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import tar from 'tar-fs';
 import chalk from 'chalk';
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -8,12 +8,12 @@ import listInput from '../../util/input/list';
 import listItem from '../../util/output/list-item';
 import confirm from '../../util/input/confirm';
 import toHumanPath from '../../util/humanize-path';
-import Client from '../../util/client';
+import type Client from '../../util/client';
 import cmd from '../../util/output/cmd';
 import didYouMean from '../../util/init/did-you-mean';
 import { getCommandName } from '../../util/pkg-name';
 import output from '../../output-manager';
-import { InitTelemetryClient } from '../../util/telemetry/commands/init';
+import type { InitTelemetryClient } from '../../util/telemetry/commands/init';
 
 type Options = {
   '--debug': boolean;


### PR DESCRIPTION
- **[cli] prefer `node:` prefix for node modules**
- **[cli] type only imports**
- **[cli] prefer string literal**
- **[cli] remove redundant type for literal**
- **[cli] remove unnecessary let**
- **[cli] fix type diagnostics**
