### PR TITLE
[cli] Fix framework detection for `vc deploy` when using `--archive` and/or `--prebuilt`

### DIFF
--- a/.changeset/slimy-owls-fail.md
+++ b/.changeset/slimy-owls-fail.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+---
+
+Fix framework detection for `vc deploy` when using `--archive` and/or
+`--prebuilt`

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -9,7 +9,7 @@ import {
   VALID_ARCHIVE_FORMATS,
   VercelConfig,
 } from '@vercel/client';
-import { errorToString, isErrnoException, isError } from '@vercel/error-utils';
+import { errorToString, isError } from '@vercel/error-utils';
 import bytes from 'bytes';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -50,13 +50,7 @@ import {
 import { parseArguments } from '../../util/get-args';
 import getDeployment from '../../util/get-deployment';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import getProjectName from '../../util/get-project-name';
-import toHumanPath from '../../util/humanize-path';
-import confirm from '../../util/input/confirm';
 import editProjectSettings from '../../util/input/edit-project-settings';
-import inputProject from '../../util/input/input-project';
-import { inputRootDirectory } from '../../util/input/input-root-directory';
-import selectOrg from '../../util/input/select-org';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
 import param from '../../util/output/param';
@@ -64,10 +58,6 @@ import stamp from '../../util/output/stamp';
 import { parseEnv } from '../../util/parse-env';
 import parseMeta from '../../util/parse-meta';
 import { getCommandName } from '../../util/pkg-name';
-import {
-  getLinkedProject,
-  linkFolderToProject,
-} from '../../util/projects/link';
 import { pickOverrides } from '../../util/projects/project-settings';
 import validatePaths, {
   validateRootDirectory,
@@ -77,6 +67,7 @@ import { deployCommand } from './command';
 import parseTarget from '../../util/parse-target';
 import { DeployTelemetryClient } from '../../util/telemetry/commands/deploy';
 import output from '../../output-manager';
+import { ensureLink } from '../../util/link/ensure-link';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -228,100 +219,23 @@ export default async (client: Client): Promise<number> => {
     return 1;
   }
 
-  // retrieve `project` and `org` from .vercel
-  const link = await getLinkedProject(client, cwd);
-
-  if (link.status === 'error') {
-    return link.exitCode;
+  // Retrieve `project` and `org` from linked Project.
+  // If not linked, prompt user to set up a new Project.
+  const link = await ensureLink('deploy', client, cwd, {
+    setupMsg: 'Set up and deploy',
+  });
+  if (typeof link === 'number') {
+    return link;
   }
 
-  let { org, project, status } = link;
-
-  let newProjectName = null;
-  let rootDirectory = project ? project.rootDirectory : null;
-  let sourceFilesOutsideRootDirectory: boolean | undefined = true;
-
-  if (status === 'not_linked') {
-    const shouldStartSetup =
-      autoConfirm ||
-      (await confirm(
-        client,
-        `Set up and deploy ${chalk.cyan(`“${toHumanPath(cwd)}”`)}?`,
-        true
-      ));
-
-    if (!shouldStartSetup) {
-      output.print(`Canceled. Project not set up.\n`);
-      return 0;
-    }
-
-    try {
-      org = await selectOrg(
-        client,
-        'Which scope do you want to deploy to?',
-        autoConfirm
-      );
-    } catch (err: unknown) {
-      if (
-        isErrnoException(err) &&
-        (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')
-      ) {
-        output.error(err.message);
-        return 1;
-      }
-
-      throw err;
-    }
-
-    // We use `localConfig` here to read the name
-    // even though the `vercel.json` file can change
-    // afterwards, this is fine since the property
-    // will be deprecated and can be replaced with
-    // user input.
-    const detectedProjectName = getProjectName({
-      nameParam: parsedArguments.flags['--name'],
-      nowConfig: localConfig,
-      paths,
-    });
-
-    const projectOrNewProjectName = await inputProject(
-      client,
-      org,
-      detectedProjectName,
-      autoConfirm
-    );
-
-    if (typeof projectOrNewProjectName === 'string') {
-      newProjectName = projectOrNewProjectName;
-      rootDirectory = await inputRootDirectory(client, cwd, autoConfirm);
-    } else {
-      project = projectOrNewProjectName;
-      rootDirectory = project.rootDirectory;
-      sourceFilesOutsideRootDirectory = project.sourceFilesOutsideRootDirectory;
-
-      // we can already link the project
-      await linkFolderToProject(
-        client,
-        cwd,
-        {
-          projectId: project.id,
-          orgId: org.id,
-        },
-        project.name,
-        org.slug
-      );
-      status = 'linked';
-    }
-  }
+  const { org, project } = link;
+  const rootDirectory = project.rootDirectory;
+  const sourceFilesOutsideRootDirectory =
+    project.sourceFilesOutsideRootDirectory;
 
   // For repo-style linking, reset the path to the root of the repository
-  if (link.status === 'linked' && link.repoRoot) {
+  if (link.repoRoot) {
     cwd = link.repoRoot;
-  }
-
-  // At this point `org` should be populated
-  if (!org) {
-    throw new Error(`"org" is not defined`);
   }
 
   // #region Build `--prebuilt`
@@ -331,11 +245,7 @@ export default async (client: Client): Promise<number> => {
 
     // For repo-style linking, update `cwd` to be the Project
     // subdirectory when `rootDirectory` setting is defined
-    if (
-      link.status === 'linked' &&
-      link.repoRoot &&
-      link.project.rootDirectory
-    ) {
+    if (link.repoRoot && link.project.rootDirectory) {
       vercelOutputDir = join(cwd, link.project.rootDirectory, '.vercel/output');
     }
 
@@ -528,7 +438,7 @@ export default async (client: Client): Promise<number> => {
   const regions = regionFlag.length > 0 ? regionFlag : localConfig.regions;
   // #endregion
 
-  const currentTeam = org?.type === 'team' ? org.id : undefined;
+  const currentTeam = org.type === 'team' ? org.id : undefined;
   const now = new Now({
     client,
     currentTeam,
@@ -539,7 +449,7 @@ export default async (client: Client): Promise<number> => {
 
   const localConfigurationOverrides = pickOverrides(localConfig);
 
-  const name = project ? project.name : newProjectName;
+  const name = project.name;
   if (!name) {
     throw new Error(
       '`name` not found on project or provided by existing project'
@@ -587,14 +497,8 @@ export default async (client: Client): Promise<number> => {
       createArgs.projectSettings = {
         sourceFilesOutsideRootDirectory,
         rootDirectory,
+        ...localConfigurationOverrides,
       };
-
-      if (status === 'linked') {
-        createArgs.projectSettings = {
-          ...createArgs.projectSettings,
-          ...localConfigurationOverrides,
-        };
-      }
     }
 
     // Read the `engines.node` field from `package.json` and send as a

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -150,6 +150,7 @@ export default async (client: Client): Promise<number> => {
   let localConfig = client.localConfig || readLocalConfig(paths[0]);
 
   if (localConfig) {
+    client.localConfig = localConfig;
     const { version } = localConfig;
     const file = highlight(localConfig[fileNameSymbol]!);
     const prop = code('version');

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -50,7 +50,7 @@ import {
 import { parseArguments } from '../../util/get-args';
 import getDeployment from '../../util/get-deployment';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import editProjectSettings from '../../util/input/edit-project-settings';
+import getProjectName from '../../util/get-project-name';
 import code from '../../util/output/code';
 import highlight from '../../util/output/highlight';
 import param from '../../util/output/param';
@@ -222,7 +222,13 @@ export default async (client: Client): Promise<number> => {
   // Retrieve `project` and `org` from linked Project.
   // If not linked, prompt user to set up a new Project.
   const link = await ensureLink('deploy', client, cwd, {
+    autoConfirm,
     setupMsg: 'Set up and deploy',
+    projectName: getProjectName({
+      nameParam: parsedArguments.flags['--name'],
+      nowConfig: localConfig,
+      paths,
+    }),
   });
   if (typeof link === 'number') {
     return link;
@@ -231,7 +237,7 @@ export default async (client: Client): Promise<number> => {
   const { org, project } = link;
   const rootDirectory = project.rootDirectory;
   const sourceFilesOutsideRootDirectory =
-    project.sourceFilesOutsideRootDirectory;
+    project.sourceFilesOutsideRootDirectory ?? true;
 
   // For repo-style linking, reset the path to the root of the repository
   if (link.repoRoot) {
@@ -537,41 +543,41 @@ export default async (client: Client): Promise<number> => {
       archive
     );
 
-    if (deployment.code === 'missing_project_settings') {
-      let { projectSettings, framework } = deployment;
-      if (rootDirectory) {
-        projectSettings.rootDirectory = rootDirectory;
-      }
+    //if (deployment.code === 'missing_project_settings') {
+    //  let { projectSettings, framework } = deployment;
+    //  if (rootDirectory) {
+    //    projectSettings.rootDirectory = rootDirectory;
+    //  }
 
-      if (typeof sourceFilesOutsideRootDirectory !== 'undefined') {
-        projectSettings.sourceFilesOutsideRootDirectory =
-          sourceFilesOutsideRootDirectory;
-      }
+    //  if (typeof sourceFilesOutsideRootDirectory !== 'undefined') {
+    //    projectSettings.sourceFilesOutsideRootDirectory =
+    //      sourceFilesOutsideRootDirectory;
+    //  }
 
-      const settings = await editProjectSettings(
-        client,
-        projectSettings,
-        framework,
-        false,
-        localConfigurationOverrides
-      );
+    //  const settings = await editProjectSettings(
+    //    client,
+    //    projectSettings,
+    //    framework,
+    //    false,
+    //    localConfigurationOverrides
+    //  );
 
-      // deploy again, but send projectSettings this time
-      createArgs.projectSettings = settings;
+    //  // deploy again, but send projectSettings this time
+    //  createArgs.projectSettings = settings;
 
-      deployStamp = stamp();
-      createArgs.deployStamp = deployStamp;
-      deployment = await createDeploy(
-        client,
-        now,
-        contextName,
-        sourcePath,
-        createArgs,
-        org,
-        false,
-        cwd
-      );
-    }
+    //  deployStamp = stamp();
+    //  createArgs.deployStamp = deployStamp;
+    //  deployment = await createDeploy(
+    //    client,
+    //    now,
+    //    contextName,
+    //    sourcePath,
+    //    createArgs,
+    //    org,
+    //    false,
+    //    cwd
+    //  );
+    //}
 
     if (deployment instanceof NotDomainOwner) {
       output.error(deployment.message);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -543,42 +543,6 @@ export default async (client: Client): Promise<number> => {
       archive
     );
 
-    //if (deployment.code === 'missing_project_settings') {
-    //  let { projectSettings, framework } = deployment;
-    //  if (rootDirectory) {
-    //    projectSettings.rootDirectory = rootDirectory;
-    //  }
-
-    //  if (typeof sourceFilesOutsideRootDirectory !== 'undefined') {
-    //    projectSettings.sourceFilesOutsideRootDirectory =
-    //      sourceFilesOutsideRootDirectory;
-    //  }
-
-    //  const settings = await editProjectSettings(
-    //    client,
-    //    projectSettings,
-    //    framework,
-    //    false,
-    //    localConfigurationOverrides
-    //  );
-
-    //  // deploy again, but send projectSettings this time
-    //  createArgs.projectSettings = settings;
-
-    //  deployStamp = stamp();
-    //  createArgs.deployStamp = deployStamp;
-    //  deployment = await createDeploy(
-    //    client,
-    //    now,
-    //    contextName,
-    //    sourcePath,
-    //    createArgs,
-    //    org,
-    //    false,
-    //    cwd
-    //  );
-    //}
-
     if (deployment instanceof NotDomainOwner) {
       output.error(deployment.message);
       return 1;

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -12,7 +12,6 @@ import Now from '../../util';
 import { emoji, prependEmoji } from '../emoji';
 import { displayBuildLogs } from '../logs';
 import { progress } from '../output/progress';
-import { linkFolderToProject } from '../projects/link';
 import ua from '../ua';
 import output from '../../output-manager';
 
@@ -34,7 +33,6 @@ function printInspectUrl(
 
 export default async function processDeployment({
   org,
-  cwd,
   projectName,
   isSettingUpProject,
   archive,
@@ -59,7 +57,6 @@ export default async function processDeployment({
   isSettingUpProject: boolean;
   archive?: ArchiveFormat;
   skipAutoDetectionConfirmation?: boolean;
-  cwd: string;
   rootDirectory?: string | null;
   noWait?: boolean;
   withLogs?: boolean;
@@ -179,17 +176,6 @@ export default async function processDeployment({
 
       if (event.type === 'created') {
         const deployment: Deployment = event.payload;
-
-        await linkFolderToProject(
-          client,
-          cwd,
-          {
-            orgId: org.id,
-            projectId: deployment.projectId!,
-          },
-          projectName,
-          org.slug
-        );
 
         now.url = deployment.url;
 

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -195,7 +195,7 @@ export default async function processDeployment({
           ) + `\n`
         );
 
-        if (quiet) {
+        if (quiet || process.env.FORCE_TTY === '1') {
           process.stdout.write(`https://${event.payload.url}`);
         }
 

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -171,7 +171,6 @@ export default class Now {
       isSettingUpProject,
       archive,
       skipAutoDetectionConfirmation,
-      cwd,
       prebuilt,
       vercelOutputDir,
       rootDirectory,

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -21,7 +21,7 @@ const settingKeys = Object.keys(settingMap).sort() as unknown as readonly [
 
 export type PartialProjectSettings = Pick<ProjectSettings, ConfigKeys>;
 
-export default async function editProjectSettings(
+export async function editProjectSettings(
   client: Client,
   projectSettings: PartialProjectSettings | null,
   framework: Framework | null,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -31,6 +31,7 @@ import { isAPIError } from '../errors-ts';
 import output from '../../output-manager';
 import { getPrettyError } from '@vercel/build-utils';
 import { SchemaValidationFailed } from '../errors';
+import { fileNameSymbol } from '@vercel/client';
 
 export interface SetupAndLinkOptions {
   autoConfirm?: boolean;
@@ -266,8 +267,7 @@ export default async function setupAndLink(
   } catch (err) {
     if (err instanceof SchemaValidationFailed) {
       const niceError = getPrettyError(err.meta);
-      //const fileName = localConfig[fileNameSymbol] || 'vercel.json';
-      const fileName = 'vercel.json';
+      const fileName = localConfig?.[fileNameSymbol] || 'vercel.json';
       niceError.message = `Invalid ${fileName} - ${niceError.message}`;
       output.prettyError(niceError);
       return { status: 'error', exitCode: 1 };

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -19,8 +19,9 @@ import selectOrg from '../input/select-org';
 import inputProject from '../input/input-project';
 import { validateRootDirectory } from '../validate-paths';
 import { inputRootDirectory } from '../input/input-root-directory';
-import editProjectSettings, {
-  PartialProjectSettings,
+import {
+  editProjectSettings,
+  type PartialProjectSettings,
 } from '../input/edit-project-settings';
 import stamp from '../output/stamp';
 import { EmojiLabel } from '../emoji';

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -483,6 +483,44 @@ test('deploy from a nested directory', async () => {
   vc.kill();
 });
 
+test('deploy from a nested directory with `--archive=tgz` option', async () => {
+  const root = await setupE2EFixture('zero-config-next-js-nested');
+  const projectName = `project-link-dev-${
+    Math.random().toString(36).split('.')[1]
+  }`;
+
+  const vc = execCli(
+    binaryPath,
+    ['deploy', '--archive=tgz', `--name=${projectName}`],
+    {
+      cwd: root,
+      env: {
+        FORCE_TTY: '1',
+      },
+    }
+  );
+
+  await waitForPrompt(vc, /Set up and deploy[^?]+\?/);
+  vc.stdin?.write('yes\n');
+
+  await waitForPrompt(vc, 'Which scope should contain your project?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'Link to existing project?');
+  vc.stdin?.write('no\n');
+
+  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
+  vc.stdin?.write(`\n`);
+
+  await waitForPrompt(vc, 'In which directory is your code located?');
+  vc.stdin?.write('app\n');
+
+  // This means the framework detection worked!
+  await waitForPrompt(vc, 'Auto-detected Project Settings (Next.js)');
+
+  vc.kill();
+});
+
 test('deploy using --local-config flag above target', async () => {
   const root = await setupE2EFixture('local-config-above-target');
   const target = path.join(root, 'dir');

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -457,12 +457,15 @@ test('deploy from a nested directory', async () => {
 
   const vc = execCli(binaryPath, ['deploy', `--name=${projectName}`], {
     cwd: root,
+    env: {
+      FORCE_TTY: '1',
+    },
   });
 
   await waitForPrompt(vc, /Set up and deploy[^?]+\?/);
   vc.stdin?.write('yes\n');
 
-  await waitForPrompt(vc, 'Which scope do you want to deploy to?');
+  await waitForPrompt(vc, 'Which scope should contain your project?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Link to existing project?');

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -258,7 +258,7 @@ test('should prefill "project name" prompt with now.json `name`', async () => {
   await waitForPrompt(now, /Set up and deploy[^?]+\?/);
   now.stdin?.write('yes\n');
 
-  await waitForPrompt(now, 'Which scope do you want to deploy to?');
+  await waitForPrompt(now, 'Which scope should contain your project?');
   now.stdin?.write('\n');
 
   await waitForPrompt(now, 'Link to existing project?');

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -159,7 +159,11 @@ test('should show prompts to set up project during first deploy', async () => {
   // remove previously linked project if it exists
   await remove(path.join(dir, '.vercel'));
 
-  const now = execCli(binaryPath, [dir]);
+  const now = execCli(binaryPath, [dir], {
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
 
   await setupProject(now, projectName, {
     buildCommand: `mkdir -p o && echo '<h1>custom hello</h1>' > o/index.html`,

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -360,7 +360,11 @@ test('deploy shows notice when project in `.vercel` does not exists', async () =
     })
   );
 
-  const now = execCli(binaryPath, [directory]);
+  const now = execCli(binaryPath, [directory], {
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
 
   let detectedNotice = false;
 
@@ -1185,13 +1189,17 @@ test('vercel.json configuration overrides in a new project prompt user and merge
   }`;
   const parent = path.join(directory, '..');
   const newDirectory = path.join(parent, randomDirectoryName);
-  await fs.renameSync(directory, newDirectory);
+  fs.renameSync(directory, newDirectory);
   directory = newDirectory;
 
   // remove previously linked project if it exists
   await remove(path.join(directory, '.vercel'));
 
-  const vc = execCli(binaryPath, [directory]);
+  const vc = execCli(binaryPath, [directory], {
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
 
   await waitForPrompt(vc, 'Set up and deploy');
   vc.stdin?.write('y\n');

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -716,9 +716,10 @@ describe('deploy', () => {
     await Promise.all<void>([runCommand(), slowlyDeploy()]);
 
     // remove first 4 lines which contains randomized data
-    expect(client.getFullOutput().split('\n').slice(4).join('\n'))
+    expect(client.getFullOutput().split('\n').slice(3).join('\n'))
       .toMatchInlineSnapshot(`
-        "2024-06-03T15:01:10.339Z  Hello, world!
+        "Building
+        2024-06-03T15:01:10.339Z  Hello, world!
         2024-06-03T15:01:10.439Z  slow...
         2024-06-03T15:01:10.540Z  Bye...
         "

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -718,8 +718,7 @@ describe('deploy', () => {
     // remove first 4 lines which contains randomized data
     expect(client.getFullOutput().split('\n').slice(4).join('\n'))
       .toMatchInlineSnapshot(`
-        "Building
-        2024-06-03T15:01:10.339Z  Hello, world!
+        "2024-06-03T15:01:10.339Z  Hello, world!
         2024-06-03T15:01:10.439Z  slow...
         2024-06-03T15:01:10.540Z  Bye...
         "
@@ -1148,14 +1147,33 @@ describe('deploy', () => {
   describe('first deploy', () => {
     describe('project setup', () => {
       const directoryName = 'unlinked';
+      let missingProjectSettings = false;
+
       beforeEach(() => {
+        missingProjectSettings = true;
+
         const user = useUser();
         client.scenario.get(`/v9/projects/:id`, (_req, res) => {
           return res.status(404).json({});
         });
 
+        client.scenario.post(`/v1/projects`, (req, res) => {
+          return res.status(200).json(req.body);
+        });
+
         const createdDeploymentId = 'dpl_1';
         client.scenario.post(`/v13/deployments`, (req, res) => {
+          if (missingProjectSettings) {
+            res.status(400).json({
+              error: {
+                code: 'missing_project_settings',
+                framework: null,
+                projectSettings: {},
+              },
+            });
+            missingProjectSettings = false;
+            return;
+          }
           res.json({
             creator: {
               uid: user.id,
@@ -1201,7 +1219,7 @@ describe('deploy', () => {
         client.stdin.write('y\n');
 
         await expect(client.stderr).toOutput(
-          '? Which scope do you want to deploy to?'
+          '? Which scope should contain your project?'
         );
         client.stdin.write('\n');
 
@@ -1233,7 +1251,7 @@ describe('deploy', () => {
         client.stdin.write('y\n');
 
         await expect(client.stderr).toOutput(
-          '? Which scope do you want to deploy to?'
+          '? Which scope should contain your project?'
         );
         client.stdin.write('\n');
 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -715,7 +715,7 @@ describe('deploy', () => {
 
     await Promise.all<void>([runCommand(), slowlyDeploy()]);
 
-    // remove first 4 lines which contains randomized data
+    // remove first 3 lines which contains randomized data
     expect(client.getFullOutput().split('\n').slice(3).join('\n'))
       .toMatchInlineSnapshot(`
         "Building

--- a/packages/cli/test/unit/util/input/edit-project-settings.test.ts
+++ b/packages/cli/test/unit/util/input/edit-project-settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { Framework, frameworks } from '@vercel/frameworks';
-import editProjectSettings from '../../../../src/util/input/edit-project-settings';
+import { editProjectSettings } from '../../../../src/util/input/edit-project-settings';
 import { client } from '../../../mocks/client';
 
 const otherFramework = frameworks.find(


### PR DESCRIPTION
Leverage the `ensureLink()` function in `vc deploy`. This ends up being a multi-win:

* Since `ensureLink` doesn't know/care about `--archive`/`--prebuilt`, the source code is uploaded for server-side framework detection (the _fix_ aspect of this PR).
* Quite a bit of duplicated code gets removed, and the logic is cleaner (previously, the linking logic was intertwined with the deployment logic itself, making it hard to follow).
* This is a prefactor for enabling local framework detection, which I plan to do as a follow-up PR.