### PR TITLE
[cli] pass `projecRoot` -> `cwd` to `getWorkspaces` to avoid searching from `/`

### DIFF
--- a/.changeset/nervous-baboons-film.md
+++ b/.changeset/nervous-baboons-film.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] pass `projecRoot` -> `cwd` to `getWorkspaces` to avoid searching from `/`

--- a/packages/cli/src/util/projects/detect-projects.ts
+++ b/packages/cli/src/util/projects/detect-projects.ts
@@ -9,7 +9,7 @@ import {
 
 export async function detectProjects(cwd: string) {
   const fs = new LocalFileSystemDetector(cwd);
-  const workspaces = await getWorkspaces({ fs });
+  const workspaces = await getWorkspaces({ fs, cwd });
   const detectedProjects = new Map<string, Framework[]>();
   const packagePaths = (
     await Promise.all(


### PR DESCRIPTION
Closes https://github.com/vercel/vercel/issues/12281

We unintentionally were not passing this along causing `getWorkspaces` to search from its default value `/`, which was very slow!