### PR TITLE
[cli] Fix file uploading in `vc deploy` when `sourceFilesOutsideRootDirectory` setting is `false`

### DIFF
--- a/.changeset/dirty-news-sin.md
+++ b/.changeset/dirty-news-sin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix file uploading in `vc deploy` when `sourceFilesOutsideRootDirectory` setting is `false`

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -310,18 +310,11 @@ export default async (client: Client): Promise<number> => {
   const contextName = org.slug;
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
 
-  // if we have `sourceFilesOutsideRootDirectory` set to `true`, we use the current path
-  // and upload the entire directory.
-  const sourcePath =
-    rootDirectory && !sourceFilesOutsideRootDirectory
-      ? join(cwd, rootDirectory)
-      : cwd;
-
   if (
     rootDirectory &&
     (await validateRootDirectory(
       cwd,
-      sourcePath,
+      join(cwd, rootDirectory),
       project
         ? `To change your Project Settings, go to https://vercel.com/${org?.slug}/${project.name}/settings`
         : ''
@@ -536,11 +529,10 @@ export default async (client: Client): Promise<number> => {
       client,
       now,
       contextName,
-      sourcePath,
+      cwd,
       createArgs,
       org,
       !project,
-      cwd,
       archive
     );
 

--- a/packages/cli/src/util/deploy/create-deploy.ts
+++ b/packages/cli/src/util/deploy/create-deploy.ts
@@ -16,18 +16,10 @@ export default async function createDeploy(
   createArgs: CreateOptions,
   org: Org,
   isSettingUpProject: boolean,
-  cwd: string,
   archive?: ArchiveFormat
 ): Promise<any | DeploymentError> {
   try {
-    return await now.create(
-      path,
-      createArgs,
-      org,
-      isSettingUpProject,
-      cwd,
-      archive
-    );
+    return await now.create(path, createArgs, org, isSettingUpProject, archive);
   } catch (err: unknown) {
     if (ERRORS_TS.isAPIError(err)) {
       if (err.code === 'rate_limited') {
@@ -112,8 +104,7 @@ export default async function createDeploy(
           path,
           createArgs,
           org,
-          isSettingUpProject,
-          cwd
+          isSettingUpProject
         );
       }
 

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -130,7 +130,6 @@ export default class Now {
     }: CreateOptions,
     org: Org,
     isSettingUpProject: boolean,
-    cwd: string,
     archive?: ArchiveFormat
   ) {
     let hashes: any = {};

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -211,8 +211,7 @@ export default async function setupAndLink(
         sourcePath,
         createArgs,
         org,
-        true,
-        path
+        true
       );
 
       if (

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -779,7 +779,6 @@ describe('deploy', () => {
       createArgs: expect.any(Object),
       org: expect.any(Object),
       isSettingUpProject: expect.any(Boolean),
-      cwd: expect.any(String),
       archive: undefined,
     };
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/vercel/vercel/pull/12598, where the incorrect set of file paths was being used for a deployment when the `sourceFilesOutsideRootDirectory` project setting is disabled.