### PR TITLE
[cli] Run framework detection locally when setting up a new Project

### DIFF
--- a/.changeset/early-bikes-remember.md
+++ b/.changeset/early-bikes-remember.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Run framework detection locally when setting up a new Project

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -446,7 +446,6 @@ export type ProjectLinkedError = {
     | 'TEAM_DELETED'
     | 'PATH_IS_FILE'
     | 'INVALID_ROOT_DIRECTORY'
-    | 'MISSING_PROJECT_SETTINGS'
     | 'TOO_MANY_PROJECTS';
 };
 

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -89,7 +89,7 @@ export default async function main(client: Client) {
   const [passedDir] = args;
   telemetry.trackCliArgumentDir(passedDir);
 
-  const dir = passedDir || '.';
+  const dir = passedDir || process.cwd();
 
   const vercelConfig = await readConfig(dir);
 

--- a/packages/cli/src/util/config/read-config.ts
+++ b/packages/cli/src/util/config/read-config.ts
@@ -1,11 +1,10 @@
-import { join } from 'path';
 import { CantParseJSONFile } from '../errors-ts';
 import readJSONFile from '../read-json-file';
 import { VercelConfig } from '../dev/types';
 import getLocalConfigPath from './local-path';
 
 export default async function readConfig(dir: string) {
-  const pkgFilePath = getLocalConfigPath(join(process.cwd(), dir));
+  const pkgFilePath = getLocalConfigPath(dir);
   const result = await readJSONFile<VercelConfig>(pkgFilePath);
 
   if (result instanceof CantParseJSONFile) {

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -31,7 +31,7 @@ import { getPrettyError } from '@vercel/build-utils';
 import { SchemaValidationFailed } from '../errors';
 import { fileNameSymbol } from '@vercel/client';
 import readConfig from '../config/read-config';
-import frameworkList from '@vercel/frameworks';
+import { frameworkList } from '@vercel/frameworks';
 
 export interface SetupAndLinkOptions {
   autoConfirm?: boolean;

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -1,6 +1,6 @@
-import { join, basename } from 'path';
 import chalk from 'chalk';
 import { remove } from 'fs-extra';
+import { join, basename } from 'path';
 import { ProjectLinkResult, ProjectSettings } from '@vercel-internals/types';
 import {
   getLinkedProject,
@@ -27,9 +27,6 @@ import { EmojiLabel } from '../emoji';
 import { CantParseJSONFile, isAPIError } from '../errors-ts';
 import output from '../../output-manager';
 import { detectProjects } from '../projects/detect-projects';
-import { getPrettyError } from '@vercel/build-utils';
-import { SchemaValidationFailed } from '../errors';
-import { fileNameSymbol } from '@vercel/client';
 import readConfig from '../config/read-config';
 import { frameworkList } from '@vercel/frameworks';
 
@@ -220,15 +217,6 @@ export default async function setupAndLink(
 
     return { status: 'linked', org, project };
   } catch (err) {
-    if (err instanceof SchemaValidationFailed) {
-      // TODO: I think this is dead code now? The validation should only happen in `vc deploy`
-      const niceError = getPrettyError(err.meta);
-      const fileName = localConfig?.[fileNameSymbol] || 'vercel.json';
-      niceError.message = `Invalid ${fileName} - ${niceError.message}`;
-      output.prettyError(niceError);
-      return { status: 'error', exitCode: 1 };
-    }
-
     if (isAPIError(err) && err.code === 'too_many_projects') {
       output.prettyError(err);
       return { status: 'error', exitCode: 1, reason: 'TOO_MANY_PROJECTS' };

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -180,7 +180,8 @@ export default async function setupAndLink(
         pathWithRootDirectory
       );
 
-      // Select the first framework detected the "Other" preset if none was detected.
+      // Select the first framework detected, or use
+      // the "Other" preset if none was detected.
       const detectedProjects = detectedProjectsForWorkspace.get('') || [];
       const framework =
         detectedProjects[0] ?? frameworkList.find(f => f.slug === null);

--- a/packages/cli/src/util/validate-paths.ts
+++ b/packages/cli/src/util/validate-paths.ts
@@ -12,7 +12,7 @@ import output from '../output-manager';
 export async function validateRootDirectory(
   cwd: string,
   path: string,
-  errorSuffix: string
+  errorSuffix = ''
 ) {
   const pathStat = await lstat(path).catch(() => null);
   const suffix = errorSuffix ? ` ${errorSuffix}` : '';

--- a/packages/cli/test/mocks/deployment.ts
+++ b/packages/cli/test/mocks/deployment.ts
@@ -78,43 +78,6 @@ export function useDeployment({
   return deployment;
 }
 
-export function useDeploymentMissingProjectSettings() {
-  client.scenario.post('/:version/deployments', (_req, res) => {
-    res.status(400).json({
-      error: {
-        code: 'missing_project_settings',
-        message:
-          'The `projectSettings` object is required for new projects, but is missing in the deployment payload',
-        framework: {
-          name: 'Other',
-          slug: null,
-          logo: 'https://api-frameworks.vercel.sh/framework-logos/other.svg',
-          description: 'No framework or an unoptimized framework.',
-          settings: {
-            installCommand: {
-              placeholder: '`yarn install`, `pnpm install`, or `npm install`',
-            },
-            buildCommand: {
-              placeholder: '`npm run vercel-build` or `npm run build`',
-              value: null,
-            },
-            devCommand: { placeholder: 'None', value: null },
-            outputDirectory: { placeholder: '`public` if it exists, or `.`' },
-          },
-        },
-        projectSettings: {
-          devCommand: null,
-          installCommand: null,
-          buildCommand: null,
-          outputDirectory: null,
-          rootDirectory: null,
-          framework: null,
-        },
-      },
-    });
-  });
-}
-
 export function useBuildLogs({
   deployment,
   logProducer,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1147,11 +1147,8 @@ describe('deploy', () => {
   describe('first deploy', () => {
     describe('project setup', () => {
       const directoryName = 'unlinked';
-      let missingProjectSettings = false;
 
       beforeEach(() => {
-        missingProjectSettings = true;
-
         const user = useUser();
         client.scenario.get(`/v9/projects/:id`, (_req, res) => {
           return res.status(404).json({});
@@ -1163,17 +1160,6 @@ describe('deploy', () => {
 
         const createdDeploymentId = 'dpl_1';
         client.scenario.post(`/v13/deployments`, (req, res) => {
-          if (missingProjectSettings) {
-            res.status(400).json({
-              error: {
-                code: 'missing_project_settings',
-                framework: null,
-                projectSettings: {},
-              },
-            });
-            missingProjectSettings = false;
-            return;
-          }
           res.json({
             creator: {
               uid: user.id,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1223,6 +1223,9 @@ describe('deploy', () => {
         );
         client.stdin.write('\n');
 
+        await expect(client.stderr).toOutput('Want to modify these settings?');
+        client.stdin.write('\n');
+
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
       });
@@ -1253,6 +1256,9 @@ describe('deploy', () => {
         await expect(client.stderr).toOutput(
           '? In which directory is your code located?'
         );
+        client.stdin.write('\n');
+
+        await expect(client.stderr).toOutput('Want to modify these settings?');
         client.stdin.write('\n');
 
         const exitCode = await exitCodePromise;


### PR DESCRIPTION
Refactors the `setupAndLink()` function to invoke the framework detection locally, rather than uploading the source files and then making an API request to the create deployment endpoint. This is faster, simpler, easier to debug. A net 100 LOC reduction.