### PR TITLE
[cli] Gracefully report error in `vercel link --repo` when a new Project fails to be created

### DIFF
--- a/.changeset/silent-rivers-listen.md
+++ b/.changeset/silent-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Gracefully report error in `vercel link --repo` when a new Project fails to be created

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -353,7 +353,6 @@ async function checkExistsAndConnect({
   if (!gitProviderLink) {
     const connect = await connectGitProvider(
       client,
-      org,
       project.id,
       provider,
       repoPath
@@ -391,7 +390,6 @@ async function checkExistsAndConnect({
     await disconnectGitProvider(client, org, project.id);
     const connect = await connectGitProvider(
       client,
-      org,
       project.id,
       provider,
       repoPath

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -61,7 +61,12 @@ export default async function link(client: Client) {
 
   if (parsedArgs.flags['--repo']) {
     output.warn(`The ${cmd('--repo')} flag is in alpha, please report issues`);
-    await ensureRepoLink(client, cwd, { yes, overwrite: true });
+    try {
+      await ensureRepoLink(client, cwd, { yes, overwrite: true });
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
   } else {
     const link = await ensureLink('link', client, cwd, {
       autoConfirm: yes,

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -30,7 +30,6 @@ export async function disconnectGitProvider(
 
 export async function connectGitProvider(
   client: Client,
-  org: Org,
   projectId: string,
   type: string,
   repo: string

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -21,7 +21,6 @@ import createProject from '../projects/create-project';
 import { detectProjects } from '../projects/detect-projects';
 import { repoInfoToUrl } from '../git/repo-info-to-url';
 import { connectGitProvider, parseRepoUrl } from '../git/connect-git-provider';
-import { isAPIError } from '../errors-ts';
 import { isGitWorktreeOrSubmodule } from '../git-helpers';
 import output from '../../output-manager';
 
@@ -275,31 +274,23 @@ export async function ensureRepoLink(
       output.spinner(`Creating new Project: ${orgAndName}`);
       delete selection.newProject;
       if (!selection.rootDirectory) delete selection.rootDirectory;
-      try {
-        const project = (selected[i] = await createProject(client, {
-          ...selection,
-          framework: selection.framework.slug,
-        }));
-        await connectGitProvider(
-          client,
-          org,
-          project.id,
-          parsedRepoUrl.provider,
-          `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
-        );
-        output.log(
-          `Created new Project: ${output.link(
-            orgAndName,
-            `https://vercel.com/${orgAndName}`,
-            { fallback: false }
-          )}`
-        );
-      } catch (err) {
-        if (isAPIError(err) && err.code === 'too_many_projects') {
-          output.prettyError(err);
-          return;
-        }
-      }
+      const project = (selected[i] = await createProject(client, {
+        ...selection,
+        framework: selection.framework.slug,
+      }));
+      await connectGitProvider(
+        client,
+        project.id,
+        parsedRepoUrl.provider,
+        `${parsedRepoUrl.org}/${parsedRepoUrl.repo}`
+      );
+      output.log(
+        `Created new Project: ${output.link(
+          orgAndName,
+          `https://vercel.com/${orgAndName}`,
+          { fallback: false }
+        )}`
+      );
     }
 
     repoConfig = {

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -147,15 +147,20 @@ export const defaultProject: Project = {
  */
 export function useUnknownProject() {
   let project: Project;
-  client.scenario.get(`/:version/projects/:projectNameOrId`, (_req, res) => {
+  client.scenario.get(`/:version/projects/:projectNameOrId`, (req, res) => {
+    if (
+      project?.id === req.params.projectNameOrId ||
+      project?.name === req.params.projectNameOrId
+    ) {
+      return res.json(project);
+    }
     res.status(404).send();
   });
   client.scenario.post(`/:version/projects`, (req, res) => {
-    const { name } = req.body;
     project = {
       ...defaultProject,
-      name,
-      id: name,
+      ...req.body,
+      id: req.body.name,
     };
     res.json(project);
   });

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -2,7 +2,14 @@ import { EOL } from 'node:os';
 import { describe, it, expect } from 'vitest';
 import { basename, join } from 'path';
 import { readFile } from 'fs-extra';
-import { readJSON, mkdirp, writeFile, pathExists, remove } from 'fs-extra';
+import {
+  readJSON,
+  mkdirp,
+  writeFile,
+  writeJSON,
+  pathExists,
+  remove,
+} from 'fs-extra';
 import link from '../../../../src/commands/link';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
@@ -16,6 +23,8 @@ import {
   setupTmpDir,
   setupUnitFixture,
 } from '../../../helpers/setup-unit-fixture';
+import getProjectByNameOrId from '../../../../src/util/projects/get-project-by-id-or-name';
+import { ProjectNotFound } from '../../../../src/util/errors-ts';
 
 describe('link', () => {
   describe('--help', () => {
@@ -100,6 +109,144 @@ describe('link', () => {
         ],
         remoteName: 'upstream',
       });
+    });
+
+    it('should create new Project with Git connection linked', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "upstream"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/upstream/*\n`
+      );
+
+      // Set up the root-level `package.json` to simulate a Next.js project
+      await writeJSON(join(cwd, 'package.json'), {
+        dependencies: {
+          next: 'latest',
+        },
+      });
+
+      useTeams('team_dummy');
+      useUnknownProject();
+      client.scenario.get(`/v9/projects`, (_req, res) => {
+        res.json({
+          projects: [],
+          pagination: { count: 0, next: null, prev: null },
+        });
+      });
+
+      client.cwd = cwd;
+      client.setArgv('--repo');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput(
+        'The `--repo` flag is in alpha, please report issues'
+      );
+
+      await expect(client.stderr).toOutput('Link Git repository at ');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your Project(s)?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(`Fetching Projects for ${repoUrl}`);
+      await expect(client.stderr).toOutput(`No Projects are linked`);
+      await expect(client.stderr).toOutput(
+        `Detected 1 new Project that may be created.`
+      );
+      await expect(client.stderr).toOutput(`Which Projects should be created?`);
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to 1 Project under ${user.username} (created .vercel and added it to .gitignore)`
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(cwd, '.vercel/repo.json'));
+      expect(repoJson.orgId).toEqual(user.id);
+      expect(repoJson.remoteName).toEqual('upstream');
+      expect(repoJson.projects).toHaveLength(1);
+      expect(repoJson.projects[0].directory).toEqual('.');
+      const project = await getProjectByNameOrId(
+        client,
+        repoJson.projects[0].id
+      );
+      if (project instanceof ProjectNotFound) {
+        throw project;
+      }
+      expect(project.name).toEqual(repoJson.projects[0].name);
+      expect(project.framework).toEqual('nextjs');
+      expect(project.link?.repo).toEqual('user/repo');
+      expect(project.link?.type).toEqual('github');
+    });
+
+    it('should gracefully report error when creating new Project fails', async () => {
+      useUser();
+      const cwd = setupTmpDir();
+
+      // Set up a `.git/config` file to simulate a repo
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/repo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "upstream"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/upstream/*\n`
+      );
+
+      // Set up the root-level `package.json` to simulate a Next.js project
+      await writeJSON(join(cwd, 'package.json'), {
+        dependencies: {
+          next: 'latest',
+        },
+      });
+
+      useTeams('team_dummy');
+      client.scenario.get(`/v9/projects`, (_req, res) => {
+        res.json({
+          projects: [],
+          pagination: { count: 0, next: null, prev: null },
+        });
+      });
+      client.scenario.post(`/v1/projects`, (_req, res) => {
+        res.status(400).send();
+      });
+
+      client.cwd = cwd;
+      client.setArgv('link', '--repo');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput(
+        'The `--repo` flag is in alpha, please report issues'
+      );
+
+      await expect(client.stderr).toOutput('Link Git repository at ');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your Project(s)?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(`Fetching Projects for ${repoUrl}`);
+      await expect(client.stderr).toOutput(`No Projects are linked`);
+      await expect(client.stderr).toOutput(
+        `Detected 1 new Project that may be created.`
+      );
+      await expect(client.stderr).toOutput(`Which Projects should be created?`);
+      client.stdin.write('y\n');
+
+      // This next step should fail because `POST /v1/projects` returns a 400
+      await expect(client.stderr).toOutput('Error: Response Error (400)');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
     });
 
     it('should track use of `--repo` flag', async () => {


### PR DESCRIPTION
Fixes a bug in the `vc link --repo` command where an API error would be ignored, causing the command to fail further down in the logic. Now the API error is properly propagated and logged, and the command exits with a proper exit code.

Includes a unit test of the of this failure scenario, and an additional bonus unit test for the success case of `--repo` creating a new Project, since that was missing before.