### PR TITLE
[cli] Remove unused error handling code

### DIFF
--- a/.changeset/flat-kangaroos-mix.md
+++ b/.changeset/flat-kangaroos-mix.md
@@ -1,4 +1,0 @@
----
----
-
-Remove unused error handling

--- a/.changeset/flat-kangaroos-mix.md
+++ b/.changeset/flat-kangaroos-mix.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove unused error handling

--- a/.changeset/plenty-bees-play.md
+++ b/.changeset/plenty-bees-play.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove unused error handling code

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -7,7 +7,6 @@ import bytes from 'bytes';
 import chalk from 'chalk';
 import ua from './ua';
 import processDeployment from './deploy/process-deployment';
-import highlight from './output/highlight';
 import { responseError } from './error';
 import stamp from './output/stamp';
 import { APIError, BuildError } from './errors-ts';
@@ -254,24 +253,13 @@ export default class Now {
     if (error.status >= 400 && error.status < 500) {
       const err = new Error();
 
-      const { code, unreferencedBuildSpecs } = error;
+      const { code } = error;
 
       if (code === 'env_value_invalid_type') {
         const { key } = error;
         err.message =
           `The env key ${key} has an invalid type: ${typeof env[key]}. ` +
           'Please supply a String or a Number (https://err.sh/vercel/env-value-invalid-type)';
-      } else if (code === 'unreferenced_build_specifications') {
-        const count = unreferencedBuildSpecs.length;
-        const prefix = count === 1 ? 'build' : 'builds';
-
-        err.message =
-          `You defined ${count} ${prefix} that did not match any source files (please ensure they are NOT defined in ${highlight(
-            '.vercelignore'
-          )}):` +
-          `\n- ${unreferencedBuildSpecs
-            .map((item: any) => JSON.stringify(item))
-            .join('\n- ')}`;
       } else {
         Object.assign(err, error);
       }


### PR DESCRIPTION
Errors with code `unreferenced_build_specifications` were removed from `api` in https://github.com/vercel/api/pull/5142/.