### PR TITLE
[cli] Fix deploy hanging on error

### DIFF
--- a/.changeset/thick-geckos-heal.md
+++ b/.changeset/thick-geckos-heal.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix deploy hanging on error

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -14,6 +14,7 @@ import { displayBuildLogs } from '../logs';
 import { progress } from '../output/progress';
 import ua from '../ua';
 import output from '../../output-manager';
+import type EventEmitter from 'node:events';
 
 function printInspectUrl(
   inspectorUrl: string | null | undefined,
@@ -110,10 +111,12 @@ export default async function processDeployment({
   const indications = [];
 
   let abortController: AbortController | undefined;
+  let uploadEmitters: EventEmitter[] | undefined;
 
   function stopSpinner(): void {
     abortController?.abort();
     output.stopSpinner();
+    uploadEmitters?.forEach(emitter => emitter.removeAllListeners());
   }
 
   try {
@@ -162,7 +165,8 @@ export default async function processDeployment({
           }
         };
 
-        uploads.forEach((e: any) => e.on('progress', updateProgress));
+        uploads.forEach((e: EventEmitter) => e.on('progress', updateProgress));
+        uploadEmitters = uploads;
         updateProgress();
       }
 


### PR DESCRIPTION
Errors during uploading would cause the CLI to hang:

https://github.com/user-attachments/assets/da51a65a-9eda-4371-bdf2-2b583f2e1c54

The problem was upload progress event connections not being disconnected. After fixing:

https://github.com/user-attachments/assets/2dacc808-a3e5-4e9b-a5fb-8555413b1983

The CLI still hangs for ~5 seconds after the error, but at least it closes on its own and doesn't show incorrect progress. There may still be more things to cancel to get rid of the remaining delay? Another solution entirely is to just do `process.exit(1)` after printing upload errors.