### PR TITLE
Suggest `--archive=tgz` when upload limits are reached

### DIFF
--- a/.changeset/swift-berries-travel.md
+++ b/.changeset/swift-berries-travel.md
@@ -1,0 +1,6 @@
+---
+'@vercel/client': patch
+'vercel': patch
+---
+
+Suggest archive flag during specific failed deployment errors

--- a/.changeset/tame-fishes-begin.md
+++ b/.changeset/tame-fishes-begin.md
@@ -1,5 +1,0 @@
----
-'vercel': patch
----
-
-Suggest archive flag when it solves the error

--- a/.changeset/tame-fishes-begin.md
+++ b/.changeset/tame-fishes-begin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Suggest archive flag when it solves the error

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -68,7 +68,7 @@ import parseTarget from '../../util/parse-target';
 import { DeployTelemetryClient } from '../../util/telemetry/commands/deploy';
 import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
-import { UploadMissingArchiveError } from '../../util/deploy/process-deployment';
+import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -586,7 +586,7 @@ export default async (client: Client): Promise<number> => {
       debug(`Error: ${err}\n${err.stack}`);
     }
 
-    if (err instanceof UploadMissingArchiveError) {
+    if (err instanceof UploadErrorMissingArchive) {
       output.prettyError(err);
       return 1;
     }

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -68,6 +68,7 @@ import parseTarget from '../../util/parse-target';
 import { DeployTelemetryClient } from '../../util/telemetry/commands/deploy';
 import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
+import { UploadMissingArchiveError } from '../../util/deploy/process-deployment';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -583,6 +584,11 @@ export default async (client: Client): Promise<number> => {
   } catch (err: unknown) {
     if (isError(err)) {
       debug(`Error: ${err}\n${err.stack}`);
+    }
+
+    if (err instanceof UploadMissingArchiveError) {
+      output.prettyError(err);
+      return 1;
     }
 
     if (err instanceof NotDomainOwner) {

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -289,7 +289,7 @@ export default async function processDeployment({
 export const archiveSuggestionText =
   'Try using `--archive=tgz` to limit the amount of files you upload.';
 
-export class UploadMissingArchiveError extends Error {
+export class UploadErrorMissingArchive extends Error {
   link = 'https://vercel.com/docs/cli/deploy#archive';
 }
 

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -287,7 +287,11 @@ export default async function processDeployment({
 }
 
 export const archiveSuggestionText =
-  'Try using `--archive=tgz` to limit the amount of files you upload.\nLearn more: https://vercel.com/docs/cli/deploy#archive';
+  'Try using `--archive=tgz` to limit the amount of files you upload.';
+
+export class UploadMissingArchiveError extends Error {
+  link = 'https://vercel.com/docs/cli/deploy#archive';
+}
 
 export function handleErrorSolvableWithArchive(error: unknown) {
   const errorIsObject = typeof error === 'object' && error !== null;
@@ -301,7 +305,9 @@ export function handleErrorSolvableWithArchive(error: unknown) {
       'code' in error && error.code === 'too_many_files';
 
     if (isUploadRateLimit || isTooManyFilesLimit) {
-      throw new Error(`${error.message}\n${archiveSuggestionText}`);
+      throw new UploadMissingArchiveError(
+        `${error.message}\n${archiveSuggestionText}`
+      );
     }
   }
 }

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -300,9 +300,9 @@ export class UploadErrorMissingArchive extends Error {
 export function handleErrorSolvableWithArchive(error: unknown) {
   if (isErrorLike(error)) {
     const isUploadRateLimit =
-      'rateLimitName' in error &&
-      typeof error.rateLimitName === 'string' &&
-      error.rateLimitName.startsWith('api-upload-');
+      'errorName' in error &&
+      typeof error.errorName === 'string' &&
+      error.errorName.startsWith('api-upload-');
     const isTooManyFilesLimit =
       'code' in error && error.code === 'too_many_files';
 

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -297,15 +297,16 @@ export function handleErrorSolvableWithArchive(error: unknown) {
   const errorIsObject = typeof error === 'object' && error !== null;
   if (errorIsObject && 'message' in error) {
     const isUploadRateLimit =
-      'code' in error &&
-      error.code === 'rate_limited' &&
-      typeof error.message === 'string' &&
-      error.message.includes('api-upload');
+      'rateLimitName' in error &&
+      typeof error.rateLimitName === 'string' &&
+      ['api-upload-free', 'api-upload-paid', 'api-upload-extended'].includes(
+        error.rateLimitName
+      );
     const isTooManyFilesLimit =
       'code' in error && error.code === 'too_many_files';
 
     if (isUploadRateLimit || isTooManyFilesLimit) {
-      throw new UploadMissingArchiveError(
+      throw new UploadErrorMissingArchive(
         `${error.message}\n${archiveSuggestionText}`
       );
     }

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('processDeployment()', () => {
   describe('handleErrorSolvableWithArchive()', () => {
-    it('should throw on too many files error', () => {
+    it('should return a too many files error', () => {
       const originalMessage = `Invalid request: 'files' should NOT have more than 15000 items, received 15001.`;
       const result = handleErrorSolvableWithArchive({
         code: 'too_many_files',
@@ -19,14 +19,14 @@ describe('processDeployment()', () => {
       );
     });
 
-    it('should throw on upload rate limit error', () => {
+    it('should return an upload rate limit error', () => {
       const originalMessage =
         'Too many requests - try again in 22 hours (more than 5000, code: "api-upload-paid").';
 
       const result = handleErrorSolvableWithArchive({
         code: 'rate_limited',
         message: originalMessage,
-        rateLimitName: 'api-upload-paid',
+        errorName: 'api-upload-paid',
       });
       expect(result).toBeInstanceOf(UploadErrorMissingArchive);
       expect(result?.message).toEqual(

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  handleErrorSolvableWithArchive,
+  archiveSuggestionText,
+} from '../../../../src/util/deploy/process-deployment';
+
+describe('processDeployment()', () => {
+  describe('handleErrorSolvableWithArchive()', () => {
+    it('should throw on too many files error', () => {
+      const originalMessage = `Invalid request: 'files' should NOT have more than 15000 items, received 15001.`;
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'too_many_files',
+          message: originalMessage,
+        })
+      ).toThrow(`${originalMessage}\n${archiveSuggestionText}`);
+    });
+
+    it('should throw on upload rate limit error', () => {
+      const originalMessage =
+        'Too many requests - try again in 22 hours (more than 5000, code: "api-upload-paid").';
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'rate_limited',
+          message: originalMessage,
+        })
+      ).toThrow(`${originalMessage}\n${archiveSuggestionText}`);
+    });
+
+    it('should not throw for wrong code', () => {
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'other',
+          message: 'string containing api-upload',
+        })
+      ).not.toThrow();
+    });
+
+    it('should not throw if rate_limited message missing `api-upload`', () => {
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'rate_limited',
+          message: 'other message',
+        })
+      ).not.toThrow();
+    });
+
+    it('should not throw if no message', () => {
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'too_many_files',
+        })
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -9,68 +9,65 @@ describe('processDeployment()', () => {
   describe('handleErrorSolvableWithArchive()', () => {
     it('should throw on too many files error', () => {
       const originalMessage = `Invalid request: 'files' should NOT have more than 15000 items, received 15001.`;
-      expect(() =>
-        handleErrorSolvableWithArchive({
-          code: 'too_many_files',
-          message: originalMessage,
-        })
-      ).toThrow(
-        new UploadErrorMissingArchive(
-          `${originalMessage}\n${archiveSuggestionText}`
-        )
+      const result = handleErrorSolvableWithArchive({
+        code: 'too_many_files',
+        message: originalMessage,
+      });
+      expect(result).toBeInstanceOf(UploadErrorMissingArchive);
+      expect(result?.message).toEqual(
+        `${originalMessage}\n${archiveSuggestionText}`
       );
     });
 
     it('should throw on upload rate limit error', () => {
       const originalMessage =
         'Too many requests - try again in 22 hours (more than 5000, code: "api-upload-paid").';
-      expect(() =>
-        handleErrorSolvableWithArchive({
-          code: 'rate_limited',
-          message: originalMessage,
-          rateLimitName: 'api-upload-paid',
-        })
-      ).toThrow(
-        new UploadErrorMissingArchive(
-          `${originalMessage}\n${archiveSuggestionText}`
-        )
+
+      const result = handleErrorSolvableWithArchive({
+        code: 'rate_limited',
+        message: originalMessage,
+        rateLimitName: 'api-upload-paid',
+      });
+      expect(result).toBeInstanceOf(UploadErrorMissingArchive);
+      expect(result?.message).toEqual(
+        `${originalMessage}\n${archiveSuggestionText}`
       );
     });
 
     it('should not throw if missing `rateLimitName`', () => {
-      expect(() =>
+      expect(
         handleErrorSolvableWithArchive({
           code: 'rate_limited',
           message: 'string containing api-upload',
         })
-      ).not.toThrow();
+      ).not.toBeInstanceOf(UploadErrorMissingArchive);
     });
 
     it('should not throw for other rate limits', () => {
-      expect(() =>
+      expect(
         handleErrorSolvableWithArchive({
           code: 'rate_limited',
           message: 'string containing api-upload',
           rateLimitName: 'api-size-limit',
         })
-      ).not.toThrow();
+      ).not.toBeInstanceOf(UploadErrorMissingArchive);
     });
 
     it('should not throw if rate_limited message missing `api-upload`', () => {
-      expect(() =>
+      expect(
         handleErrorSolvableWithArchive({
           code: 'rate_limited',
           message: 'other message',
         })
-      ).not.toThrow();
+      ).not.toBeInstanceOf(UploadErrorMissingArchive);
     });
 
     it('should not throw if no message', () => {
-      expect(() =>
+      expect(
         handleErrorSolvableWithArchive({
           code: 'too_many_files',
         })
-      ).not.toThrow();
+      ).not.toBeInstanceOf(UploadErrorMissingArchive);
     });
   });
 });

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   handleErrorSolvableWithArchive,
   archiveSuggestionText,
+  UploadMissingArchiveError,
 } from '../../../../src/util/deploy/process-deployment';
 
 describe('processDeployment()', () => {
@@ -13,7 +14,11 @@ describe('processDeployment()', () => {
           code: 'too_many_files',
           message: originalMessage,
         })
-      ).toThrow(`${originalMessage}\n${archiveSuggestionText}`);
+      ).toThrow(
+        new UploadMissingArchiveError(
+          `${originalMessage}\n${archiveSuggestionText}`
+        )
+      );
     });
 
     it('should throw on upload rate limit error', () => {
@@ -24,7 +29,11 @@ describe('processDeployment()', () => {
           code: 'rate_limited',
           message: originalMessage,
         })
-      ).toThrow(`${originalMessage}\n${archiveSuggestionText}`);
+      ).toThrow(
+        new UploadMissingArchiveError(
+          `${originalMessage}\n${archiveSuggestionText}`
+        )
+      );
     });
 
     it('should not throw for wrong code', () => {

--- a/packages/cli/test/unit/util/deploy/process-deployment.test.ts
+++ b/packages/cli/test/unit/util/deploy/process-deployment.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   handleErrorSolvableWithArchive,
   archiveSuggestionText,
-  UploadMissingArchiveError,
+  UploadErrorMissingArchive,
 } from '../../../../src/util/deploy/process-deployment';
 
 describe('processDeployment()', () => {
@@ -15,7 +15,7 @@ describe('processDeployment()', () => {
           message: originalMessage,
         })
       ).toThrow(
-        new UploadMissingArchiveError(
+        new UploadErrorMissingArchive(
           `${originalMessage}\n${archiveSuggestionText}`
         )
       );
@@ -28,19 +28,30 @@ describe('processDeployment()', () => {
         handleErrorSolvableWithArchive({
           code: 'rate_limited',
           message: originalMessage,
+          rateLimitName: 'api-upload-paid',
         })
       ).toThrow(
-        new UploadMissingArchiveError(
+        new UploadErrorMissingArchive(
           `${originalMessage}\n${archiveSuggestionText}`
         )
       );
     });
 
-    it('should not throw for wrong code', () => {
+    it('should not throw if missing `rateLimitName`', () => {
       expect(() =>
         handleErrorSolvableWithArchive({
-          code: 'other',
+          code: 'rate_limited',
           message: 'string containing api-upload',
+        })
+      ).not.toThrow();
+    });
+
+    it('should not throw for other rate limits', () => {
+      expect(() =>
+        handleErrorSolvableWithArchive({
+          code: 'rate_limited',
+          message: 'string containing api-upload',
+          rateLimitName: 'api-size-limit',
         })
       ).not.toThrow();
     });

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -2,10 +2,10 @@ export class DeploymentError extends Error {
   constructor(err: { code: string; message: string; name?: string }) {
     super(err.message);
     this.code = err.code;
-    this.rateLimitName = err.name;
+    this.errorName = err.name;
     this.name = 'DeploymentError';
   }
 
   code: string;
-  rateLimitName: string | undefined;
+  errorName: string | undefined;
 }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,9 +1,11 @@
 export class DeploymentError extends Error {
-  constructor(err: { code: string; message: string }) {
+  constructor(err: { code: string; message: string; name?: string }) {
     super(err.message);
     this.code = err.code;
+    this.rateLimitName = err.name;
     this.name = 'DeploymentError';
   }
 
   code: string;
+  rateLimitName: string | undefined;
 }


### PR DESCRIPTION
The `api-upload` rate limit and file amount limits can be avoided with `--archive=tgz`. Previously, this wasn't clear from the errors.

New errors:
<img width="736" alt="Screenshot 2024-11-21 at 12 57 04 PM" src="https://github.com/user-attachments/assets/8759f080-af8b-4dc0-8e35-92d5a39af37a">
<img width="779" alt="Screenshot 2024-11-21 at 12 58 36 PM" src="https://github.com/user-attachments/assets/b4491611-e161-43ee-91e7-69ad7d29f73e">

It was tricky deciding where exactly to put this error handling. There are multiple levels of try/catch which mutate errors as they bubble up, and lots of the existing error handling code uses `any` types in ways that make it scary to touch. The error handling code surrounding deployments can use some refactoring in the future, but for now I think this is a good, low-friction solution.