### PR TITLE
[cli] Explicitly route to `vercel set` subcommand

### DIFF
--- a/.changeset/gold-turkeys-reflect.md
+++ b/.changeset/gold-turkeys-reflect.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Explicitly route to `vercel set` subcommand

--- a/packages/cli/src/commands/alias/index.ts
+++ b/packages/cli/src/commands/alias/index.ts
@@ -85,7 +85,7 @@ export default async function alias(client: Client) {
         printHelp(setSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandList(subcommandOriginal);
+      telemetry.trackCliSubcommandSet(subcommandOriginal);
       return set(client, args);
     default:
       if (needHelp) {

--- a/packages/cli/src/commands/alias/index.ts
+++ b/packages/cli/src/commands/alias/index.ts
@@ -79,6 +79,14 @@ export default async function alias(client: Client) {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
+    case 'set':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('alias', subcommandOriginal);
+        printHelp(setSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandList(subcommandOriginal);
+      return set(client, args);
     default:
       if (needHelp) {
         telemetry.trackCliFlagHelp('alias', subcommandOriginal);


### PR DESCRIPTION
We currently rely on the `default` behavior to route to `set` because it's not being handled explicitly. No behavioral change here, just matching our more defined pattern used in other commands.