### PR TITLE
[build-utils] feat: allowed CloudFront and S3 URLs to be overridden through environment variables

### DIFF
--- a/.changeset/itchy-carpets-report.md
+++ b/.changeset/itchy-carpets-report.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": minor
+---
+
+[build-utils] feat: allowed CloudFront and S3 URLs to be overridden through environment variables

--- a/.changeset/itchy-carpets-report.md
+++ b/.changeset/itchy-carpets-report.md
@@ -1,5 +1,0 @@
----
-"@vercel/build-utils": minor
----
-
-[build-utils] feat: allowed CloudFront and S3 URLs to be overridden through environment variables

--- a/.changeset/six-socks-design.md
+++ b/.changeset/six-socks-design.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": minor
+---
+
+Add support for `NOW_EPHEMERAL_FILES_S3_URL`, `NOW_FILES_CLOUDFRONT_URL` and `NOW_FILES_S3_URL` environment variables

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -45,13 +45,24 @@ export default class FileRef implements FileBase {
     this.mutable = mutable;
   }
 
-  private getMutableFilesCloudfrontUrl(): string {
+  /**
+   * Retrieves the URL of the CloudFront distribution for the S3
+   * bucket represented by {@link getNowFilesS3Url}.
+   *
+   * @returns The URL of the CloudFront distribution
+   */
+  private getNowFilesCloudfrontUrl(): string {
     return (
-      process.env.MUTABLE_FILES_CLOUDFRONT_URL ||
+      process.env.NOW_FILES_CLOUDFRONT_URL ||
       'https://dmmcy0pwk6bqi.cloudfront.net'
     );
   }
 
+  /**
+   * Retrieves the URL of the S3 bucket for storing ephemeral files.
+   *
+   * @returns The URL of the S3 bucket
+   */
   private getNowEphemeralFilesS3Url(): string {
     return (
       process.env.NOW_EPHEMERAL_FILES_S3_URL ||
@@ -59,6 +70,11 @@ export default class FileRef implements FileBase {
     );
   }
 
+  /**
+   * Retrieves the URL of the S3 bucket for storing files.
+   *
+   * @returns The URL of the S3 bucket
+   */
   private getNowFilesS3Url(): string {
     return process.env.NOW_FILES_S3_URL || 'https://now-files.s3.amazonaws.com';
   }
@@ -70,10 +86,9 @@ export default class FileRef implements FileBase {
     if (digestType === 'sha') {
       // This CloudFront URL edge caches the `now-files` S3 bucket to prevent
       // overloading it. Mutable files cannot be cached.
-      // `https://now-files.s3.amazonaws.com/${digestHash}`
       url = this.mutable
         ? `${this.getNowFilesS3Url()}/${digestHash}`
-        : `${this.getMutableFilesCloudfrontUrl()}/${digestHash}`;
+        : `${this.getNowFilesCloudfrontUrl()}/${digestHash}`;
     } else if (digestType === 'sha+ephemeral') {
       // This URL is currently only used for cache files that constantly
       // change. We shouldn't cache it on CloudFront because it'd always be a

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -144,17 +144,17 @@ export default class FileRef implements FileBase {
 }
 
 /**
- * Get the value of the environment variable `key` as a valid URL string or `null` if unset.
+ * Get the value of the environment variable `key` as a valid URL string or `undefined` if unset.
  *
  * @param key The `process.env` member which holds the value to validate
- * @returns The valid URL string or `null` if `key` is not set on `process.env`
+ * @returns The valid URL string or `undefined` if `key` is not set on `process.env`
  */
 function getEnvAsUrlOrThrow(
   key: keyof (typeof process)['env']
-): ReturnType<URL['toString']> | null {
+): ReturnType<URL['toString']> | undefined {
   const value = process.env[key];
 
-  if (value === undefined) return null;
+  if (value === undefined) return undefined;
 
   try {
     new URL(value);

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -53,7 +53,7 @@ export default class FileRef implements FileBase {
    */
   private getNowFilesCloudfrontUrl(): string {
     return (
-      process.env.NOW_FILES_CLOUDFRONT_URL ||
+      getEnvAsUrlOrThrow('NOW_FILES_CLOUDFRONT_URL') ||
       'https://dmmcy0pwk6bqi.cloudfront.net'
     );
   }
@@ -65,7 +65,7 @@ export default class FileRef implements FileBase {
    */
   private getNowEphemeralFilesS3Url(): string {
     return (
-      process.env.NOW_EPHEMERAL_FILES_S3_URL ||
+      getEnvAsUrlOrThrow('NOW_EPHEMERAL_FILES_S3_URL') ||
       'https://now-ephemeral-files.s3.amazonaws.com'
     );
   }
@@ -76,7 +76,10 @@ export default class FileRef implements FileBase {
    * @returns The URL of the S3 bucket
    */
   private getNowFilesS3Url(): string {
-    return process.env.NOW_FILES_S3_URL || 'https://now-files.s3.amazonaws.com';
+    return (
+      getEnvAsUrlOrThrow('NOW_FILES_S3_URL') ||
+      'https://now-files.s3.amazonaws.com'
+    );
   }
 
   async toStreamAsync(): Promise<NodeJS.ReadableStream> {
@@ -137,5 +140,32 @@ export default class FileRef implements FileBase {
           cb(error, null);
         });
     });
+  }
+}
+
+/**
+ * Get the value of the environment variable `key` as a valid URL string or `null` if unset.
+ *
+ * @param key The `process.env` member which holds the value to validate
+ * @returns The valid URL string or `null` if `key` is not set on `process.env`
+ */
+function getEnvAsUrlOrThrow(
+  key: keyof (typeof process)['env']
+): ReturnType<URL['toString']> | null {
+  const value = process.env[key];
+
+  if (value === undefined) return null;
+
+  try {
+    new URL(value);
+    return value;
+  } catch (e) {
+    if (e instanceof TypeError && 'code' in e && e.code === 'ERR_INVALID_URL') {
+      throw new Error(
+        `A non-URL value was supplied to the ${key} environment variable`
+      );
+    } else {
+      throw e;
+    }
   }
 }

--- a/packages/build-utils/src/file-ref.ts
+++ b/packages/build-utils/src/file-ref.ts
@@ -45,6 +45,24 @@ export default class FileRef implements FileBase {
     this.mutable = mutable;
   }
 
+  private getMutableFilesCloudfrontUrl(): string {
+    return (
+      process.env.MUTABLE_FILES_CLOUDFRONT_URL ||
+      'https://dmmcy0pwk6bqi.cloudfront.net'
+    );
+  }
+
+  private getNowEphemeralFilesS3Url(): string {
+    return (
+      process.env.NOW_EPHEMERAL_FILES_S3_URL ||
+      'https://now-ephemeral-files.s3.amazonaws.com'
+    );
+  }
+
+  private getNowFilesS3Url(): string {
+    return process.env.NOW_FILES_S3_URL || 'https://now-files.s3.amazonaws.com';
+  }
+
   async toStreamAsync(): Promise<NodeJS.ReadableStream> {
     let url = '';
     // sha:24be087eef9fac01d61b30a725c1a10d7b45a256
@@ -54,13 +72,13 @@ export default class FileRef implements FileBase {
       // overloading it. Mutable files cannot be cached.
       // `https://now-files.s3.amazonaws.com/${digestHash}`
       url = this.mutable
-        ? `https://now-files.s3.amazonaws.com/${digestHash}`
-        : `https://dmmcy0pwk6bqi.cloudfront.net/${digestHash}`;
+        ? `${this.getNowFilesS3Url()}/${digestHash}`
+        : `${this.getMutableFilesCloudfrontUrl()}/${digestHash}`;
     } else if (digestType === 'sha+ephemeral') {
       // This URL is currently only used for cache files that constantly
       // change. We shouldn't cache it on CloudFront because it'd always be a
       // MISS.
-      url = `https://now-ephemeral-files.s3.amazonaws.com/${digestHash}`;
+      url = `${this.getNowEphemeralFilesS3Url()}/${digestHash}`;
     } else {
       throw new Error('Expected digest to be sha');
     }


### PR DESCRIPTION
### Summary

This PR aims to grant more control to consumers of the `vercel` CLI over where the `FileRef` contents are downloaded from for a given `digest`. This is done by adding 3 new environment variables, which take precedence over the current hardcoded URLs.