### PR TITLE
[tests] skip tests failing at platform

### DIFF
--- a/.changeset/fast-pots-build.md
+++ b/.changeset/fast-pots-build.md
@@ -1,0 +1,4 @@
+---
+---
+
+Random change to invalidate cache and prove failure

--- a/packages/cli/src/commands/alias/command.ts
+++ b/packages/cli/src/commands/alias/command.ts
@@ -1,5 +1,5 @@
-import { packageName } from '../../util/pkg-name';
 import { limitOption, nextOption, yesOption } from '../../util/arg-common';
+import { packageName } from '../../util/pkg-name';
 
 export const setSubcommand = {
   name: 'set',

--- a/packages/cli/src/commands/alias/command.ts
+++ b/packages/cli/src/commands/alias/command.ts
@@ -1,5 +1,5 @@
-import { limitOption, nextOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
+import { limitOption, nextOption, yesOption } from '../../util/arg-common';
 
 export const setSubcommand = {
   name: 'set',

--- a/packages/cli/test/dev/integration-4.test.ts
+++ b/packages/cli/test/dev/integration-4.test.ts
@@ -248,14 +248,18 @@ test(
   })
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] Middleware with error in function handler',
   testFixtureStdio('middleware-error-in-handler', async (testPath: any) => {
     await testPath(500, '/', /EDGE_FUNCTION_INVOCATION_FAILED/);
   })
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] Middleware with error at init',
   testFixtureStdio('middleware-error-at-init', async (testPath: any) => {
     await testPath(500, '/', /EDGE_FUNCTION_INVOCATION_FAILED/);

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -38,7 +38,8 @@ module.exports = function setupTests(groupIndex) {
     console.log('testing group', groupIndex, fixtures);
   }
 
-  const fixturesToSkip = [];
+  // https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
+  const fixturesToSkip = ['ember-v3'];
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fixtures) {


### PR DESCRIPTION
We have some tests failing due to platform issues. This unblocks other work while we investigate.