### PR TITLE
[client] Refactor upload abort controllers to avoid setting global max listeners

### DIFF
--- a/.changeset/old-actors-clean.md
+++ b/.changeset/old-actors-clean.md
@@ -1,0 +1,5 @@
+---
+'@vercel/client': patch
+---
+
+Refactor to avoid setting max listeners globally

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import https from 'https';
 import { Readable } from 'stream';
-import events, { EventEmitter } from 'node:events';
+import { EventEmitter } from 'node:events';
 import retry from 'async-retry';
 import { Sema } from 'async-sema';
 
@@ -82,9 +82,8 @@ export async function* upload(
   const defaultAgent = apiUrl?.startsWith('https://')
     ? new https.Agent({ keepAlive: true })
     : new http.Agent({ keepAlive: true });
-  const abortController = new AbortController();
-  // default max is 10, but abort controller may have 50 connections at once
-  events.setMaxListeners(50);
+  const abortControllers = new Set<AbortController>();
+  let aborted = false;
 
   shas.forEach((sha, index) => {
     const uploadProgress = uploads[index];
@@ -129,6 +128,11 @@ export async function* upload(
 
         let err;
         let result;
+        const abortController = new AbortController();
+        abortControllers.add(abortController);
+        if (aborted) {
+          abortController.abort();
+        }
 
         try {
           const res = await fetch(
@@ -193,11 +197,15 @@ export async function* upload(
           } else {
             debug('Other error, bailing: ' + err.message);
             // Otherwise we bail
-            abortController.abort();
+            if (!aborted) {
+              aborted = true;
+              abortControllers.forEach(controller => controller.abort());
+            }
             return bail(err);
           }
         }
 
+        abortControllers.delete(abortController);
         return result;
       },
       {

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -220,9 +220,7 @@ export async function* upload(
 
   while (Object.keys(uploadList).length > 0) {
     try {
-      const event = await Promise.race(
-        Object.keys(uploadList).map((key): Promise<any> => uploadList[key])
-      );
+      const event = await Promise.race(Object.values(uploadList));
 
       delete uploadList[event.payload.sha];
       yield event;

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -99,6 +99,10 @@ export async function* upload(
 
         await semaphore.acquire();
 
+        if (aborted) {
+          return bail(new Error('Upload aborted'));
+        }
+
         const { data } = file;
         if (typeof data === 'undefined') {
           // Directories don't need to be uploaded
@@ -130,9 +134,6 @@ export async function* upload(
         let result;
         const abortController = new AbortController();
         abortControllers.add(abortController);
-        if (aborted) {
-          abortController.abort();
-        }
 
         try {
           const res = await fetch(


### PR DESCRIPTION
@EndangeredMassa brought up a good point in https://github.com/vercel/vercel/pull/12635#discussion_r1854520641. However, it also feels unfortunate moving the max listener 50 setting so far from the semaphore of size 50.

Instead of moving the global setting, I removed it entirely! Now each request gets its own abort controller so we never go past 1 listener per signal.

Tested with a rate limit error manually and it works as expected.