### PR TITLE
[cli] track teamId right before telemetry is sent

### DIFF
--- a/.changeset/tender-bears-warn.md
+++ b/.changeset/tender-bears-warn.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] fix issue that prevented teamId from being sent in some situations

--- a/.changeset/tender-bears-warn.md
+++ b/.changeset/tender-bears-warn.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-[cli] fix issue that prevented teamId from being sent in some situations
+Ensure `teamId` metric is sent when `--token` option is used

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -559,8 +559,6 @@ const main = async () => {
     }
   }
 
-  client.telemetryEventStore.updateTeamId(client.config.currentTeam);
-
   let exitCode;
 
   try {
@@ -798,6 +796,7 @@ const main = async () => {
     return 1;
   }
 
+  telemetryEventStore.updateTeamId(client.config.currentTeam);
   await telemetryEventStore.save();
 
   return exitCode;

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -218,12 +218,27 @@ export class TelemetryEventStore {
     return this.config?.enabled ?? true;
   }
 
+  private normalizeEvents(events: Event[]) {
+    return events.map(event => {
+      delete event.sessionId;
+      delete event.teamId;
+      const { eventTime, ...rest } = event;
+      return { event_time: eventTime, team_id: this.teamId, ...rest };
+    });
+  }
+
   async save() {
+    const sessionId = this.events[0].sessionId;
+    if (!sessionId) {
+      output.debug('Unable to send metrics: no session ID');
+      return;
+    }
     if (this.isDebug) {
       // Intentionally not using `output.debug` as it will
       // not write to stderr unless it is run with `--debug`
       output.log(`${LogLabel} Flushing Events`);
-      for (const event of this.events) {
+      output.log(`${LogLabel} Session ID - ${sessionId}`);
+      for (const event of this.normalizeEvents(this.events)) {
         output.log(JSON.stringify(event));
       }
 
@@ -231,16 +246,7 @@ export class TelemetryEventStore {
     }
 
     if (this.enabled) {
-      const sessionId = this.events[0].sessionId;
-      if (!sessionId) {
-        output.debug('Unable to send metrics: no session ID');
-        return;
-      }
-      const events = this.events.map(event => {
-        delete event.sessionId;
-        const { eventTime, teamId, ...rest } = event;
-        return { event_time: eventTime, team_id: teamId, ...rest };
-      });
+      const events = this.normalizeEvents(this.events);
       const payload = {
         headers: {
           'Client-id': 'vercel-cli',


### PR DESCRIPTION
`teamId` wasn't appropriately sending in situations where the user had set `--token`. Now, if that token is used for an API endpoint where `teamId` is set, that is appropriately passed along in the telemetry events.