### PR TITLE
[cli] Normalize POSIX paths in `filePathMap` for `vc build`

### DIFF
--- a/.changeset/early-lobsters-pump.md
+++ b/.changeset/early-lobsters-pump.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Normalize POSIX paths in `filePathMap` for `vc build`

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -591,7 +591,7 @@ export async function* findDirs(
  * and returns them in a JSON serializable map of repo root
  * relative paths to Lambda destination paths.
  */
-function filesWithoutFsRefs(
+export function filesWithoutFsRefs(
   files: Files,
   repoRootPath: string
 ): { files: Files; filePathMap?: Record<string, string> } {
@@ -600,6 +600,7 @@ function filesWithoutFsRefs(
   for (const [path, file] of Object.entries(files)) {
     if (file.type === 'FileFsRef') {
       if (!filePathMap) filePathMap = {};
+      //filePathMap[normalizePath(path)] = normalizePath(relative(repoRootPath, file.fsPath));
       filePathMap[path] = relative(repoRootPath, file.fsPath);
     } else {
       out[path] = file;

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -600,8 +600,9 @@ export function filesWithoutFsRefs(
   for (const [path, file] of Object.entries(files)) {
     if (file.type === 'FileFsRef') {
       if (!filePathMap) filePathMap = {};
-      //filePathMap[normalizePath(path)] = normalizePath(relative(repoRootPath, file.fsPath));
-      filePathMap[path] = relative(repoRootPath, file.fsPath);
+      filePathMap[normalizePath(path)] = normalizePath(
+        relative(repoRootPath, file.fsPath)
+      );
     } else {
       out[path] = file;
     }

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -9,22 +9,31 @@ describe('filesWithoutFsRefs()', () => {
       __dirname,
       '../../../fixtures/unit/commands/build/monorepo'
     );
-    const files = {
+    const input = {
       ...(await glob('**', repoRootPath)),
       'blob-file.txt': new FileBlob({ data: 'blob file' }),
     };
-    const result = filesWithoutFsRefs(files, repoRootPath);
-    expect(Object.keys(result.filePathMap!)).not.contain('blob-file.txt');
-    expect(result.filePathMap).toMatchInlineSnapshot(`
-          {
-            ".vercel/project.json": ".vercel/project.json",
-            "apps/nextjs/.gitignore": "apps/nextjs/.gitignore",
-            "apps/nextjs/next.config.js": "apps/nextjs/next.config.js",
-            "apps/nextjs/package.json": "apps/nextjs/package.json",
-            "apps/nextjs/pages/index.jsx": "apps/nextjs/pages/index.jsx",
-            "package-lock.json": "package-lock.json",
-            "package.json": "package.json",
-          }
-        `);
+    const { files, filePathMap = {} } = filesWithoutFsRefs(input, repoRootPath);
+
+    // Only the "blob-file.txt" file should be in the `files` object
+    expect(Object.keys(files)).toHaveLength(1);
+    expect(files['blob-file.txt']).toEqual(input['blob-file.txt']);
+
+    // The `filePathMap` should have normalized POSIX paths, even on Windows
+    expect(Object.keys(filePathMap)).not.contain('blob-file.txt');
+    expect(filePathMap['apps/nextjs/.gitignore']).toEqual(
+      'apps/nextjs/.gitignore'
+    );
+    expect(filePathMap['apps/nextjs/next.config.js']).toEqual(
+      'apps/nextjs/next.config.js'
+    );
+    expect(filePathMap['apps/nextjs/package.json']).toEqual(
+      'apps/nextjs/package.json'
+    );
+    expect(filePathMap['apps/nextjs/pages/index.jsx']).toEqual(
+      'apps/nextjs/pages/index.jsx'
+    );
+    expect(filePathMap['package-lock.json']).toEqual('package-lock.json');
+    expect(filePathMap['package.json']).toEqual('package.json');
   });
 });

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -1,0 +1,30 @@
+import { join } from 'path';
+import { glob, FileBlob } from '@vercel/build-utils';
+import { describe, expect, it } from 'vitest';
+import { filesWithoutFsRefs } from '../../../../src/util/build/write-build-result';
+
+describe('filesWithoutFsRefs()', () => {
+  it('should create `filePathMap` with normalized POSIX paths', async () => {
+    const repoRootPath = join(
+      __dirname,
+      '../../../fixtures/unit/commands/build/monorepo'
+    );
+    const files = {
+      ...(await glob('**', repoRootPath)),
+      'blob-file.txt': new FileBlob({ data: 'blob file' }),
+    };
+    const result = filesWithoutFsRefs(files, repoRootPath);
+    expect(Object.keys(result.filePathMap!)).not.contain('blob-file.txt');
+    expect(result.filePathMap).toMatchInlineSnapshot(`
+          {
+            ".vercel/project.json": ".vercel/project.json",
+            "apps/nextjs/.gitignore": "apps/nextjs/.gitignore",
+            "apps/nextjs/next.config.js": "apps/nextjs/next.config.js",
+            "apps/nextjs/package.json": "apps/nextjs/package.json",
+            "apps/nextjs/pages/index.jsx": "apps/nextjs/pages/index.jsx",
+            "package-lock.json": "package-lock.json",
+            "package.json": "package.json",
+          }
+        `);
+  });
+});


### PR DESCRIPTION
Fixes an issue when using `vc build` on Windows where the `filePathMap` object would be written with Windows-style slashes. This caused issues when trying to create a prebuilt deployment. Using the expected POSIX style slashes makes the deployment succeed as expected.

Added unit tests to ensure this behavior does not break in the future.