### PR TITLE
[tests] skip ember-v5 tests. It's started failing unrelated to our tests

### DIFF
--- a/.changeset/spotty-apricots-know.md
+++ b/.changeset/spotty-apricots-know.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] skip ember-v5 tests. It's started failing unrelated to our tests

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -39,7 +39,7 @@ module.exports = function setupTests(groupIndex) {
   }
 
   // https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
-  const fixturesToSkip = ['ember-v3'];
+  const fixturesToSkip = ['ember-v3', 'ember-v5'];
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fixtures) {


### PR DESCRIPTION
Failing for platform reasons. Will dig in.