### PR TITLE
[cli] remove name from CustomEnvironment type

### DIFF
--- a/.changeset/fair-chicken-relax.md
+++ b/.changeset/fair-chicken-relax.md
@@ -1,5 +1,5 @@
 ---
-"@vercel-internals/types": patch
+"@vercel-internals/types": major
 ---
 
 [cli] remove name from CustomEnvironment type

--- a/.changeset/fair-chicken-relax.md
+++ b/.changeset/fair-chicken-relax.md
@@ -1,0 +1,5 @@
+---
+"@vercel-internals/types": patch
+---
+
+[cli] remove name from CustomEnvironment type

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -138,7 +138,6 @@ type RouteOrMiddleware =
 
 export interface CustomEnvironment {
   id: string;
-  name: string;
   slug: string;
   type: CustomEnvironmentType;
   description?: string;

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -119,7 +119,7 @@ export default async function add(client: Client, argv: string[]) {
     ...customEnvironments
       .filter(c => !existingCustomEnvs.has(c.id))
       .map(c => ({
-        name: c.name,
+        name: c.slug,
         value: c.id,
       })),
   ];

--- a/packages/cli/src/commands/inspect/index.ts
+++ b/packages/cli/src/commands/inspect/index.ts
@@ -207,8 +207,8 @@ async function printDetails({
   print(chalk.bold('  General\n\n'));
   print(`    ${chalk.cyan('id')}\t\t${id}\n`);
   print(`    ${chalk.cyan('name')}\t${name}\n`);
-  const customEnvironmentName = deployment.customEnvironment?.name;
-  const target = customEnvironmentName ?? deployment.target ?? 'preview';
+  const customEnvironmentSlug = deployment.customEnvironment?.slug;
+  const target = customEnvironmentSlug ?? deployment.target ?? 'preview';
   print(`    ${chalk.cyan('target')}\t`);
   // TODO: once custom environments is shipped for all users,
   // make all deployments link to the environment settings page

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -248,7 +248,7 @@ export default async function list(client: Client) {
             Date.now() - (dep?.undeletedAt ?? dep.createdAt)
           );
           const targetName =
-            dep.customEnvironment?.name ||
+            dep.customEnvironment?.slug ||
             (dep.target === 'production' ? 'Production' : 'Preview');
           const targetSlug =
             dep.customEnvironment?.id || dep.target || 'preview';
@@ -258,7 +258,7 @@ export default async function list(client: Client) {
             stateString(dep.readyState || ''),
             formatEnvironment(contextName, project.name, {
               id: targetSlug,
-              name: targetName,
+              slug: targetName,
             }),
             ...(!showPolicy ? [chalk.gray(getDeploymentDuration(dep))] : []),
             ...(!showPolicy ? [chalk.gray(dep.creator?.username)] : []),

--- a/packages/cli/src/commands/target/list.ts
+++ b/packages/cli/src/commands/target/list.ts
@@ -96,7 +96,6 @@ function withDefaultEnvironmentsIncluded(
       updatedAt: 0,
       type: 'production',
       description: '',
-      name: 'Production',
       domains: [],
     },
     {
@@ -106,7 +105,6 @@ function withDefaultEnvironmentsIncluded(
       updatedAt: 0,
       type: 'preview',
       description: '',
-      name: 'Preview',
       domains: [],
     },
     ...environments,
@@ -117,7 +115,6 @@ function withDefaultEnvironmentsIncluded(
       updatedAt: 0,
       type: 'development',
       description: '',
-      name: 'Development',
       domains: [],
     },
   ];

--- a/packages/cli/src/util/env/format-environments.ts
+++ b/packages/cli/src/util/env/format-environments.ts
@@ -16,7 +16,7 @@ export default function formatEnvironments(
   ).map(t => {
     return formatEnvironment(link.org.slug, link.project.name, {
       id: t,
-      name: title(t),
+      slug: title(t),
     });
   });
   const customTargets = env.customEnvironmentIds

--- a/packages/cli/src/util/target/format-environment.ts
+++ b/packages/cli/src/util/target/format-environment.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import type { CustomEnvironment } from '@vercel-internals/types';
 import output from '../../output-manager';
+import title from 'title';
 
 export function formatEnvironment(
   orgSlug: string,
@@ -8,7 +9,7 @@ export function formatEnvironment(
   environment: Pick<CustomEnvironment, 'slug' | 'id'>
 ) {
   const projectUrl = `https://vercel.com/${orgSlug}/${projectSlug}`;
-  const boldName = chalk.bold(environment.slug);
+  const boldName = chalk.bold(title(environment.slug));
   return output.link(
     boldName,
     `${projectUrl}/settings/environments/${environment.id}`,

--- a/packages/cli/src/util/target/format-environment.ts
+++ b/packages/cli/src/util/target/format-environment.ts
@@ -5,10 +5,10 @@ import output from '../../output-manager';
 export function formatEnvironment(
   orgSlug: string,
   projectSlug: string,
-  environment: Pick<CustomEnvironment, 'name' | 'id'>
+  environment: Pick<CustomEnvironment, 'slug' | 'id'>
 ) {
   const projectUrl = `https://vercel.com/${orgSlug}/${projectSlug}`;
-  const boldName = chalk.bold(environment.name);
+  const boldName = chalk.bold(environment.slug);
   return output.link(
     boldName,
     `${projectUrl}/settings/environments/${environment.id}`,

--- a/packages/cli/test/unit/commands/redeploy/index.test.ts
+++ b/packages/cli/test/unit/commands/redeploy/index.test.ts
@@ -251,7 +251,6 @@ function initRedeployTest({
     name: 'vercel-redeploy',
     customEnvironments: [
       {
-        name: 'Custom',
         slug: 'custom',
         id: 'env_123123',
         type: 'preview',

--- a/packages/cli/test/unit/commands/target/list.test.ts
+++ b/packages/cli/test/unit/commands/target/list.test.ts
@@ -167,7 +167,7 @@ describe('target ls', () => {
 
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
-      'her',
+      'Her',
       'her',
       'env_8DTiPYD33Rcvu2hQwYAdw0rwLquY',
       'Preview',
@@ -176,7 +176,7 @@ describe('target ls', () => {
 
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
-      'ano',
+      'Ano',
       'ano',
       'env_ph1tjPP20xp8VAuiFsYt4rhRYGys',
       'Preview',

--- a/packages/cli/test/unit/commands/target/list.test.ts
+++ b/packages/cli/test/unit/commands/target/list.test.ts
@@ -94,7 +94,6 @@ describe('target ls', () => {
           updatedAt: 1717176548879,
           type: 'preview',
           description: '',
-          name: 'her',
           branchMatcher: {
             type: 'endsWith',
             pattern: 'her',
@@ -107,7 +106,6 @@ describe('target ls', () => {
           updatedAt: 1717176506341,
           type: 'preview',
           description: '',
-          name: 'ano',
           branchMatcher: {
             type: 'startsWith',
             pattern: 'ano',


### PR DESCRIPTION
We'd like to remove `CustomEnvironment`'s `name` property at the API before going GA. Although technically a breaking change, we're just going to communicate to beta/preview customers about this. 

This removes its use in the CLI. We only ever submitted `id` / `slug` to the API and only used `name` for more humane labeling. I've reproduced this with `title(env.name)`, but am open to just never showing this field.