### PR TITLE
[cli] add `open` command

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -40,6 +40,7 @@ export const help = () => `
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
       logs                 [url]       Displays the logs for a deployment
+      open                 [url]       Opens the browser pointing to the deployment
       projects                         Manages your Projects
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -18,6 +18,7 @@ import { listCommand } from './list/command';
 import { loginCommand } from './login/command';
 import { logoutCommand } from './logout/command';
 import { logsCommand } from './logs/command';
+import { openCommand } from './open/command';
 import { projectCommand } from './project/command';
 import { promoteCommand } from './promote/command';
 import { pullCommand } from './pull/command';
@@ -51,6 +52,7 @@ const commandsStructs = [
   loginCommand,
   logoutCommand,
   logsCommand,
+  openCommand,
   projectCommand,
   promoteCommand,
   pullCommand,

--- a/packages/cli/src/commands/open/command.ts
+++ b/packages/cli/src/commands/open/command.ts
@@ -1,0 +1,21 @@
+import { packageName } from '../../util/pkg-name';
+
+export const openCommand = {
+  name: 'open',
+  aliases: ['o'],
+  description: 'Open a project in vercel.com',
+  arguments: [
+    {
+      name: ':team/:project',
+      required: false,
+      multiple: false,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Open the current project',
+      value: `${packageName} open`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/open/index.ts
+++ b/packages/cli/src/commands/open/index.ts
@@ -1,0 +1,125 @@
+import openBrowser from 'open';
+import { help } from '../help';
+import { openCommand } from './command';
+import { ensureLink } from '../../util/link/ensure-link';
+import { parseArguments } from '../../util/get-args';
+import type Client from '../../util/client';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import handleError from '../../util/handle-error';
+import output from '../../output-manager';
+
+type ParsedArgs = {
+  args: string[];
+  flags: Record<string, any>;
+};
+
+function isFlag(input: string) {
+  return input.startsWith('--');
+}
+
+async function fromCurrent(
+  client: Client,
+  parsedArgs: ParsedArgs
+): Promise<string> {
+  const linkedProject = await ensureLink('open', client, client.cwd, {
+    autoConfirm: Boolean(parsedArgs.flags['--yes']),
+  });
+
+  if (typeof linkedProject === 'number') {
+    const err: NodeJS.ErrnoException = new Error('Link project error');
+    err.code = 'ERR_LINK_PROJECT';
+    throw err;
+  }
+
+  const {
+    org: { slug },
+    project: { name },
+  } = linkedProject;
+
+  return `${slug}/${name}`;
+}
+
+async function getArgs(
+  client: Client,
+  parsedArgs: ParsedArgs
+): Promise<{ orgAndProject: string; section: string }> {
+  const args = parsedArgs.args;
+
+  if (args.length === 0) {
+    return {
+      orgAndProject: await fromCurrent(client, parsedArgs),
+      section: '',
+    };
+  }
+
+  if (args.length === 1) {
+    if (!args[0].includes('/')) {
+      return {
+        orgAndProject: await fromCurrent(client, parsedArgs),
+        section: args[0],
+      };
+    } else {
+      return {
+        orgAndProject: args[0],
+        section: '',
+      };
+    }
+  }
+
+  if (args.length === 2) {
+    return {
+      orgAndProject: args[0],
+      section: args[1],
+    };
+  }
+
+  throw new Error('Invalid arguments');
+}
+
+export default async function open(client: Client): Promise<number> {
+  let parsedArgs: null | ParsedArgs = null;
+
+  const flagsSpecification = getFlagsSpecification(openCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(3), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    handleError(error);
+    return 1;
+  }
+
+  if (parsedArgs.flags['--help']) {
+    output.print(help(openCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  const { args, query } = parsedArgs.args.reduce<{
+    args: string[];
+    query: Record<string, string>;
+  }>(
+    (acc, arg) => {
+      if (isFlag(arg)) {
+        const [key, value] = arg.split('=');
+        acc.query[key.replace('--', '')] = value;
+      } else {
+        acc.args.push(arg);
+      }
+      return acc;
+    },
+    { args: [], query: {} }
+  );
+
+  const { orgAndProject, section } = await getArgs(client, {
+    args,
+    flags: parsedArgs.flags,
+  });
+
+  const url = new URL(`${orgAndProject}/${section}`, 'https://vercel.com/');
+  url.search = new URLSearchParams(query).toString();
+
+  await openBrowser(url.toString());
+  output.dim(`opened ${url} in your browser`);
+
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -711,6 +711,10 @@ const main = async () => {
           telemetry.trackCliCommandWhoami(userSuppliedSubCommand);
           func = require('./commands/whoami').default;
           break;
+        case 'open':
+          telemetry.trackCliCommandWhoami(userSuppliedSubCommand);
+          func = require('./commands/open').default;
+          break;
         default:
           func = null;
           break;

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -159,6 +159,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandOpen(actual: string) {
+    this.trackCliCommand({
+      command: 'open',
+      value: actual,
+    });
+  }
+
   trackCliCommandProject(actual: string) {
     this.trackCliCommand({
       command: 'project',

--- a/packages/cli/test/unit/open/index.test.ts
+++ b/packages/cli/test/unit/open/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+
+import { getArgsAndQuery } from '../../../src/commands/open';
+
+describe('index', () => {
+  it('getArgsAndQuery', () => {
+    const { args, query } = getArgsAndQuery([
+      'settings',
+      '--latest',
+      '--foo',
+      'bar',
+      '--level=warning',
+    ]);
+    expect(args).toEqual(['settings']);
+    expect(query).toEqual({ latest: true, foo: 'bar', level: 'warning' });
+  });
+});


### PR DESCRIPTION
It adds `vc open` command 🎉

**TL;DR**

```
# specifying the project
vc open # open `vercel.com/:team/:project` based in your cwd
vc open [ORG_NAME/PROJECT_NAME] # non inferring open

# specifying the action
vc open settings # open `vercel.com/:team/:project/settings`
vc open logs # open logs of the project
vc open [ORG_NAME/PROJECT_NAME] settings

# any vercel.com query parameter is supported
vc open logs --levels=error
```

**TODO**

- [ ] turn into an extension (?)
- [ ] add tests