### PR TITLE
[tests] rename env var we use to skip linking step in dev tests

### DIFF
--- a/.changeset/friendly-keys-deny.md
+++ b/.changeset/friendly-keys-deny.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] rename env var we use to skip linking step in dev tests

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -30,7 +30,7 @@ export default async function dev(
   // retrieve dev command
   let link = await getLinkedProject(client, cwd);
 
-  if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_DEV_CMD) {
+  if (link.status === 'not_linked' && !process.env.__VERCEL_SKIP_LINKING) {
     link = await setupAndLink(client, cwd, {
       autoConfirm: opts['--yes'],
       link,

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -161,7 +161,7 @@ export async function exec(directory: string, args: string[] = []) {
   return execa(binaryPath, ['dev', directory, '-t', token, ...scope, ...args], {
     reject: false,
     shell: true,
-    env: { __VERCEL_SKIP_DEV_CMD: '1' },
+    env: { __VERCEL_SKIP_LINKING: '1' },
   });
 }
 
@@ -267,7 +267,7 @@ export async function testFixture(
       shell: true,
       stdio: 'pipe',
       ...opts,
-      env: { ...opts.env, __VERCEL_SKIP_DEV_CMD: '1' },
+      env: { ...opts.env, __VERCEL_SKIP_LINKING: '1' },
     }
   );
 
@@ -488,7 +488,7 @@ export function testFixtureStdio(
         } --debug`
       );
       const env = skipDeploy
-        ? { ...process.env, __VERCEL_SKIP_DEV_CMD: '1' }
+        ? { ...process.env, __VERCEL_SKIP_LINKING: '1' }
         : process.env;
       dev = execa(
         binaryPath,


### PR DESCRIPTION
`__VERCEL_SKIP_DEV_CMD` does not skip the dev command, it skips linking to a project when `vercel dev` is run during tests. Just a rename for clarity.