### PR TITLE
[tests] remove project settings mechanism for dev tests

### DIFF
--- a/.changeset/smart-ladybugs-trade.md
+++ b/.changeset/smart-ladybugs-trade.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] remove project settings mechanism for dev tests

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -377,6 +377,8 @@ test(
   })
 );
 
+// n.b. this test requires the project 00-list-directory to have directory listing
+// enabled at 00-list-directory/settings/advanced
 test(
   '[vercel dev] 00-list-directory',
   testFixtureStdio('00-list-directory', async (testPath: any) => {

--- a/packages/cli/test/dev/integration-5.test.ts
+++ b/packages/cli/test/dev/integration-5.test.ts
@@ -379,16 +379,12 @@ test(
 
 test(
   '[vercel dev] 00-list-directory',
-  testFixtureStdio(
-    '00-list-directory',
-    async (testPath: any) => {
-      await testPath(200, '/', /Files within/m);
-      await testPath(200, '/', /test[0-3]\.txt/m);
-      await testPath(200, '/', /\.well-known/m);
-      await testPath(200, '/.well-known/keybase.txt', 'proof goes here');
-    },
-    { projectSettings: { directoryListing: true } }
-  )
+  testFixtureStdio('00-list-directory', async (testPath: any) => {
+    await testPath(200, '/', /Files within/m);
+    await testPath(200, '/', /test[0-3]\.txt/m);
+    await testPath(200, '/', /\.well-known/m);
+    await testPath(200, '/.well-known/keybase.txt', 'proof goes here');
+  })
 );
 
 test(

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -359,7 +359,7 @@ export async function testFixture(
 export function testFixtureStdio(
   directory: string,
   fn: Function,
-  { skipDeploy = false, projectSettings = {}, readyTimeout = 0 } = {}
+  { skipDeploy = false, readyTimeout = 0 } = {}
 ) {
   return async () => {
     const cwd = fixtureAbsolute(directory);
@@ -395,28 +395,6 @@ export function testFixtureStdio(
           stdout: linkResult.stdout,
         });
         expect(linkResult.exitCode).toBe(0);
-
-        // Patch the project with any non-default properties
-        if (projectSettings) {
-          const { projectId } = await fs.readJson(projectJsonPath);
-          const res = await fetchWithRetry(
-            `https://api.vercel.com/v2/projects/${projectId}${
-              process.env.VERCEL_TEAM_ID
-                ? `?teamId=${process.env.VERCEL_TEAM_ID}`
-                : ''
-            }`,
-            {
-              method: 'PATCH',
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify(projectSettings),
-              retries: isCI ? 3 : 0,
-              status: 200,
-            }
-          );
-          expect(res.status).toBe(200);
-        }
 
         // Run `vc deploy`
         const deployResult = await execa(


### PR DESCRIPTION
The `projectSettings` option for `testFixtureStdio` is used only once. This was likely more useful at some earlier point or was required because we didn't previously have stable projects we tested against (each test run created accounts/projects on its own).

We never do _cleanup_ for this either, so the entire project already has this value set and has for 168 days.

I'd be amenable to leaving in place since it does colocate the specific setting under test with the test itself which I like. But practically this isn't doing anything other than adding a noop HTTP call to a single test.