### PR TITLE
[cli] expand `getLatestVersion` cache boundary

### DIFF
--- a/.changeset/short-mice-allow.md
+++ b/.changeset/short-mice-allow.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] expand cache boundary

--- a/packages/cli/src/util/get-latest-version/index.ts
+++ b/packages/cli/src/util/get-latest-version/index.ts
@@ -67,7 +67,7 @@ export default function getLatestVersion({
     }
   }
 
-  if (!cache || !cache.expireAt || cache.expireAt < Date.now()) {
+  if (!cache || !cache.expireAt || cache.expireAt <= Date.now()) {
     spawnWorker({
       cacheFile,
       distTag,
@@ -77,7 +77,7 @@ export default function getLatestVersion({
   }
 
   if (cache) {
-    const shouldNotify = !cache.notifyAt || cache.notifyAt < Date.now();
+    const shouldNotify = !cache.notifyAt || cache.notifyAt <= Date.now();
 
     let updateAvailable = false;
     if (cache.version && pkg.version) {


### PR DESCRIPTION
The tests around this flake in CI and I suspect it's because  setting`expireAt` and `Date.now` are occurring too closely together in a test scenario.

ref: https://github.com/vercel/vercel/actions/runs/12263787875/job/34216318924?pr=12723#step:8:1102