### PR TITLE
[tests] rely on local project detection for Hugo

### DIFF
--- a/.changeset/quick-guests-drum.md
+++ b/.changeset/quick-guests-drum.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] rely on local project detection for Hugo

--- a/packages/cli/test/dev/fixtures/08-hugo/vercel.json
+++ b/packages/cli/test/dev/fixtures/08-hugo/vercel.json
@@ -1,0 +1,3 @@
+{
+  "framework": "hugo"
+}

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -80,25 +80,6 @@ test(
 
 test('[vercel dev] 08-hugo', async () => {
   if (process.platform === 'darwin') {
-    // 1. run the test without Hugo in the PATH
-    let tester = await testFixtureStdio(
-      '08-hugo',
-      async () => {
-        throw new Error('Expected dev server to fail to be ready');
-      },
-      {
-        readyTimeout: 2000,
-
-        // Important: for the first test, we MUST deploy this app so that the
-        // framework (e.g. Hugo) will be detected by the server and associated
-        // with the project since `vc dev` doesn't do framework detection
-        skipDeploy: false,
-      }
-    );
-    await expect(tester()).rejects.toThrow(
-      new Error('Dev server timed out while waiting to be ready')
-    );
-
     // 2. Download `hugo` and update PATH
     const hugoFixture = resolve(fixture('08-hugo'));
     await spawnAsync(

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -91,7 +91,7 @@ test('[vercel dev] 08-hugo', async () => {
     );
     process.env.PATH = `${hugoFixture}${delimiter}${process.env.PATH}`;
 
-    // 3. Rerun the test now that Hugo is in the PATH
+    // 2. Rerun the test now that Hugo is in the PATH
     const tester = testFixtureStdio(
       '08-hugo',
       async (testPath: any) => {

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -80,7 +80,7 @@ test(
 
 test('[vercel dev] 08-hugo', async () => {
   if (process.platform === 'darwin') {
-    // 2. Download `hugo` and update PATH
+    // 1. Download `hugo` and update PATH
     const hugoFixture = resolve(fixture('08-hugo'));
     await spawnAsync(
       `curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.56.0/hugo_0.56.0_macOS-64bit.tar.gz | tar -xz -C "${hugoFixture}"`,
@@ -92,7 +92,7 @@ test('[vercel dev] 08-hugo', async () => {
     process.env.PATH = `${hugoFixture}${delimiter}${process.env.PATH}`;
 
     // 3. Rerun the test now that Hugo is in the PATH
-    tester = testFixtureStdio(
+    const tester = testFixtureStdio(
       '08-hugo',
       async (testPath: any) => {
         await testPath(200, '/', /Hugo/m);

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -496,7 +496,6 @@ export function testFixtureStdio(
         stderr += data;
 
         if (stripAnsi(data).includes('Ready! Available at')) {
-          clearTimeout(readyTimer);
           readyResolver.resolve(null);
         }
 

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -359,7 +359,7 @@ export async function testFixture(
 export function testFixtureStdio(
   directory: string,
   fn: Function,
-  { skipDeploy = false, readyTimeout = 0 } = {}
+  { skipDeploy = false } = {}
 ) {
   return async () => {
     const cwd = fixtureAbsolute(directory);
@@ -443,18 +443,6 @@ export function testFixtureStdio(
     let stderr = '';
     const readyResolver = createResolver();
     const exitResolver = createResolver();
-
-    // By default, tests will wait 6 minutes for the dev server to be ready and
-    // perform the tests, however a `readyTimeout` can be used to reduce the
-    // wait time if the dev server is expected to fail to start or hang
-    let readyTimer: NodeJS.Timeout;
-    if (readyTimeout > 0) {
-      readyTimer = setTimeout(() => {
-        readyResolver.reject(
-          new Error('Dev server timed out while waiting to be ready')
-        );
-      }, readyTimeout);
-    }
 
     try {
       let printedOutput = false;


### PR DESCRIPTION
Hardcode framework detection for Hugo `dev` test. An initial deploy was being used _only_ to detect framework and comes from a time before local detection and fixed test projects. This is also the last use of `readyTimeout` on the `testFixtureStdio` helper.