### PR TITLE
Enable new storage integrations via wizard

### DIFF
--- a/.changeset/plenty-phones-happen.md
+++ b/.changeset/plenty-phones-happen.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Bug fix: new integrations using protocols for storage category can be created via the CLI wizard

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -117,7 +117,10 @@ export async function add(client: Client, args: string[]) {
   // At the time of writing, we don't support native integrations besides storage products.
   // However, when we introduce new categories, we avoid breaking this version of the CLI by linking all
   // non-storage categories to the dashboard.
-  const isStorageProduct = product.type === 'storage';
+  // product.type is the old way of defining categories, while the protocols are the new way.
+  const isStorageProduct =
+    product.type === 'storage' ||
+    product.protocols?.storage?.status === 'enabled';
 
   // The provisioning via cli is possible when
   // 1. The integration was installed once (terms have been accepted)

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -118,9 +118,11 @@ export async function add(client: Client, args: string[]) {
   // However, when we introduce new categories, we avoid breaking this version of the CLI by linking all
   // non-storage categories to the dashboard.
   // product.type is the old way of defining categories, while the protocols are the new way.
-  const isStorageProduct =
-    product.type === 'storage' ||
+  const isPreProtocolStorageProduct = product.type === 'storage';
+  const isPostProtocolStorageProduct =
     product.protocols?.storage?.status === 'enabled';
+  const isStorageProduct =
+    isPreProtocolStorageProduct || isPostProtocolStorageProduct;
 
   // The provisioning via cli is possible when
   // 1. The integration was installed once (terms have been accepted)

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -32,12 +32,27 @@ export interface MetadataSchema {
   required?: string[];
 }
 
+export type IntegrationProductProtocolBase = {
+  status: 'enabled' | 'disabled';
+};
+
+export type StorageIntegrationProtocol = IntegrationProductProtocolBase & {
+  repl?: {
+    enabled: boolean;
+    supportsReadOnlyMode: boolean;
+    welcomeMessage?: string;
+  };
+};
+
 export interface IntegrationProduct {
   id: string;
   slug: string;
   name: string;
   shortDescription: string;
-  type: 'storage' | string;
+  type?: 'storage' | string;
+  protocols?: {
+    storage?: StorageIntegrationProtocol;
+  };
   metadataSchema: MetadataSchema;
 }
 


### PR DESCRIPTION
We moved from using a `type` field to a `protocols` object with some additional information for determining the category of an integration. New storage products don't have the old `type` field, instead using the new protocols, but are otherwise still storage products with the same wizard setup needs. New integrations that would otherwise be fine to use the wizard for setup were directing users to the dashboard to complete the installation process (undesired behaviour).

This PR adds in the typing for the protocols currently in use (as of this PR, just storage), so that our newest integration products can be added purely via the CLI.