### PR TITLE
[tests] better test-dev errors

### DIFF
--- a/.changeset/violet-pillows-destroy.md
+++ b/.changeset/violet-pillows-destroy.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] better test-dev errors

--- a/packages/cli/test/dev/utils.ts
+++ b/packages/cli/test/dev/utils.ts
@@ -204,19 +204,21 @@ export async function testPath(
 
   // eslint-disable-next-line no-console
   console.log(msg);
-  expect(res.status).toBe(status);
+  expect(res.status, getEnvironmentMessage(isDev)).toBe(status);
   validateResponseHeaders(res);
 
   if (typeof expectedText === 'string') {
     const actualText = await res.text();
-    expect(actualText.trim()).toBe(expectedText.trim());
+    expect(actualText.trim(), getEnvironmentMessage(isDev)).toBe(
+      expectedText.trim()
+    );
   } else if (typeof expectedText === 'function') {
     const actualText = await res.text();
     await expectedText(actualText, res, isDev);
   } else if (expectedText instanceof RegExp) {
     const actualText = await res.text();
     expectedText.lastIndex = 0; // reset since we test twice
-    expect(actualText).toMatch(expectedText);
+    expect(actualText, getEnvironmentMessage(isDev)).toMatch(expectedText);
   }
 
   if (expectedHeaders) {
@@ -228,9 +230,16 @@ export async function testPath(
         // See https://github.com/node-fetch/node-fetch/issues/417#issuecomment-587233352
         actualValue = '/';
       }
-      expect(actualValue).toBe(expectedValue);
+      expect(actualValue, getEnvironmentMessage(isDev)).toBe(expectedValue);
     });
   }
+}
+
+function getEnvironmentMessage(isDev: boolean): string {
+  if (isDev) {
+    return 'FROM DEV SERVER';
+  }
+  return `FROM DEPLOYMENT`;
 }
 
 export async function testFixture(


### PR DESCRIPTION
When running `test-dev`, the assertions are run against a deployment and the local dev server. The error messages do not tell you which one failed.

This PR adds a custom assertion message that makes it clearer which one failed. The options are "FROM DEPLOYMENT" and "FROM DEV SERVER".

Now, errors will have this up top:

```
    Custom message:
      FROM DEPLOYMENT
```

---

Full error example:

```

  ● [vercel dev] Middleware with error at init

    Custom message:
      FROM DEPLOYMENT

    expect(received).toMatch(expected)

    Expected pattern: /EDGE_FUNCTION_INVOCATION_FAILED/
    Received string:  "A server error has occurred·
    INTERNAL_SERVER_ERROR
    "

      217 |     const actualText = await res.text();
      218 |     expectedText.lastIndex = 0; // reset since we test twice
    > 219 |     expect(actualText, getEnvironmentMessage(isDev)).toMatch(expectedText);
          |                                                      ^
      220 |   }
      221 |
      222 |   if (expectedHeaders) {

      at testPath (test/dev/utils.ts:219:54)
      at helperTestPath (test/dev/utils.ts:578:11)
      at test/dev/integration-4.test.ts:262:5
      at Object.<anonymous> (test/dev/utils.ts:583:7)
```