### PR TITLE
bump cookie and sentry/node

### DIFF
--- a/.changeset/thick-wasps-fly.md
+++ b/.changeset/thick-wasps-fly.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+"@vercel/node": patch
+"api": patch
+---
+
+bump cookie and sentry/node

--- a/.changeset/thick-wasps-fly.md
+++ b/.changeset/thick-wasps-fly.md
@@ -1,7 +1,5 @@
 ---
 "vercel": patch
-"@vercel/node": patch
-"api": patch
 ---
 
 bump cookie and sentry/node

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {},
   "dependencies": {
-    "@sentry/node": "5.11.1",
+    "@sentry/node": "7.120.1",
     "got": "11.8.5",
     "node-fetch": "2.6.7",
     "parse-github-url": "1.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@inquirer/input": "2.1.2",
     "@inquirer/select": "2.2.2",
     "@next/env": "11.1.2",
-    "@sentry/node": "5.5.0",
+    "@sentry/node": "7.120.1",
     "@sindresorhus/slugify": "0.11.0",
     "@swc/core": "1.2.218",
     "@tootallnate/once": "1.1.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -54,7 +54,7 @@
     "@vercel/functions": "workspace:*",
     "@vitest/expect": "1.4.0",
     "content-type": "1.0.5",
-    "cookie": "0.4.0",
+    "cookie": "0.7.0",
     "cross-env": "7.0.3",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
   api:
     dependencies:
       '@sentry/node':
-        specifier: 5.11.1
-        version: 5.11.1
+        specifier: 7.120.1
+        version: 7.120.1
       got:
         specifier: 11.8.5
         version: 11.8.5
@@ -395,8 +395,8 @@ importers:
         specifier: 11.1.2
         version: 11.1.2
       '@sentry/node':
-        specifier: 5.5.0
-        version: 5.5.0
+        specifier: 7.120.1
+        version: 7.120.1
       '@sindresorhus/slugify':
         specifier: 0.11.0
         version: 0.11.0
@@ -1396,8 +1396,8 @@ importers:
         specifier: 1.0.5
         version: 1.0.5
       cookie:
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.7.0
+        version: 0.7.0
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -4821,144 +4821,49 @@ packages:
       - zenObservable
     dev: true
 
-  /@sentry/apm@5.11.1:
-    resolution: {integrity: sha512-4iZH11p/7w9IMLT9hqNY1+EqLESltiIoF6/YsbpK93sXWGEs8VQ83IuvGuKWxajvHgDmj4ND0TxIliTsYqTqFw==}
-    engines: {node: '>=6'}
+  /@sentry-internal/tracing@7.120.1:
+    resolution: {integrity: sha512-MwZlhQY27oM4V05m2Q46WB2F7jqFu8fewg14yRcjCuK3tdxvQoLsXOEPMZxLxpoXPTqPCm3Ig7mA4GwdlCL41w==}
+    engines: {node: '>=8'}
     dependencies:
-      '@sentry/browser': 5.11.1
-      '@sentry/hub': 5.11.1
-      '@sentry/minimal': 5.11.1
-      '@sentry/types': 5.11.0
-      '@sentry/utils': 5.11.1
-      tslib: 1.14.1
-    dev: false
+      '@sentry/core': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
 
-  /@sentry/browser@5.11.1:
-    resolution: {integrity: sha512-oqOX/otmuP92DEGRyZeBuQokXdeT9HQRxH73oqIURXXNLMP3PWJALSb4HtT4AftEt/2ROGobZLuA4TaID6My/Q==}
-    engines: {node: '>=6'}
+  /@sentry/core@7.120.1:
+    resolution: {integrity: sha512-tXpJlf/8ngsSCpcRD+4DDvh4TqUbY0MlvE9Mpc/jO5GgYl/goAH2H1COw6W/UNfkr/l80P2jejS0HLPk0moi0A==}
+    engines: {node: '>=8'}
     dependencies:
-      '@sentry/core': 5.11.1
-      '@sentry/types': 5.11.0
-      '@sentry/utils': 5.11.1
-      tslib: 1.14.1
-    dev: false
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
 
-  /@sentry/core@5.11.1:
-    resolution: {integrity: sha512-BpvPosVNT20Xso4gAV54Lu3KqDmD20vO63HYwbNdST5LUi8oYV4JhvOkoBraPEM2cbBwQvwVcFdeEYKk4tin9A==}
-    engines: {node: '>=6'}
+  /@sentry/integrations@7.120.1:
+    resolution: {integrity: sha512-dshhLZUN+pYpyZiS5QRYKaYSqvWYtmsbwmBlH4SCGOnN9sbY4nZn0h8njr+xKT8UFnPxoTlbZmkcrVY3qPVMfg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@sentry/hub': 5.11.1
-      '@sentry/minimal': 5.11.1
-      '@sentry/types': 5.11.0
-      '@sentry/utils': 5.11.1
-      tslib: 1.14.1
-    dev: false
+      '@sentry/core': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
+      localforage: 1.10.0
 
-  /@sentry/core@5.5.0:
-    resolution: {integrity: sha512-xOcBud0t5mfhFdyd2tQQti4uuWSrLiJihpXzxeRpdCfk2ic+xmpeQs3G4UqnluvQDc48ug/Igt7LXfSBRBx4eg==}
-    engines: {node: '>=6'}
+  /@sentry/node@7.120.1:
+    resolution: {integrity: sha512-YF/TDUCtUOQeUMwL4vcUWGNv/8Qz9624xBnaL8nXW888xNBoSRr2vH/zMrmTup5zfmWAh9lVbp98BZFF6F0WJg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@sentry/hub': 5.5.0
-      '@sentry/minimal': 5.5.0
-      '@sentry/types': 5.5.0
-      '@sentry/utils': 5.5.0
-      tslib: 1.14.1
-    dev: true
+      '@sentry-internal/tracing': 7.120.1
+      '@sentry/core': 7.120.1
+      '@sentry/integrations': 7.120.1
+      '@sentry/types': 7.120.1
+      '@sentry/utils': 7.120.1
 
-  /@sentry/hub@5.11.1:
-    resolution: {integrity: sha512-ucKprYCbGGLLjVz4hWUqHN9KH0WKUkGf5ZYfD8LUhksuobRkYVyig0ZGbshECZxW5jcDTzip4Q9Qimq/PkkXBg==}
-    engines: {node: '>=6'}
+  /@sentry/types@7.120.1:
+    resolution: {integrity: sha512-f/WT7YUH8SA2Jhez/hYz/dA351AJqr1Eht/URUdYsqMFecXr/blAcNKRVFccSsvQeTqWVV9HVQ9BXUSjPJOvFA==}
+    engines: {node: '>=8'}
+
+  /@sentry/utils@7.120.1:
+    resolution: {integrity: sha512-4boeo5Y3zw3gFrWZmPHsYOIlTh//eBaGBgWL25FqLbLObO23gFE86G6O6knP1Gamm1DGX2IWH7w4MChYuBm6tA==}
+    engines: {node: '>=8'}
     dependencies:
-      '@sentry/types': 5.11.0
-      '@sentry/utils': 5.11.1
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/hub@5.5.0:
-    resolution: {integrity: sha512-+jKh5U1nv8ufoquGciWoZPOmKuEjFPH5m0VifCs6t3NcEbAq2qnfF26KUGqhUNznlUN/PkbWB4qMfKn14uNE2Q==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/types': 5.5.0
-      '@sentry/utils': 5.5.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/minimal@5.11.1:
-    resolution: {integrity: sha512-HK8zs7Pgdq7DsbZQTThrhQPrJsVWzz7MaluAbQA0rTIAJ3TvHKQpsVRu17xDpjZXypqWcKCRsthDrC4LxDM1Bg==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/hub': 5.11.1
-      '@sentry/types': 5.11.0
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/minimal@5.5.0:
-    resolution: {integrity: sha512-o6O30+/pNrO7fTgwKxgZynHB7cMScJlw9HXgnNXgLXS6LBiqjYCQfVnWAgV//SyyG0uUlcjH3P6PnV6TsJOmVQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/hub': 5.5.0
-      '@sentry/types': 5.5.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/node@5.11.1:
-    resolution: {integrity: sha512-FbJs0blJ36gEzE0rc2yBfA/KE+kXOLl8MUfFTcyJCBdCGF8XMETDCmgINnJ4TyBUJviwKoPw2TCk9TL2pa/A1w==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/apm': 5.11.1
-      '@sentry/core': 5.11.1
-      '@sentry/hub': 5.11.1
-      '@sentry/types': 5.11.0
-      '@sentry/utils': 5.11.1
-      cookie: 0.3.1
-      https-proxy-agent: 4.0.0
-      lru_map: 0.3.3
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@sentry/node@5.5.0:
-    resolution: {integrity: sha512-Qn60k7NqJhzpI7PnW/dOz2Y1ofD6kMKGEgLWAO5vcbNShyQj7m2JYFk0c7nFU9HDgertqkxQnvhvIGvT+QokaQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/core': 5.5.0
-      '@sentry/hub': 5.5.0
-      '@sentry/types': 5.5.0
-      '@sentry/utils': 5.5.0
-      cookie: 0.3.1
-      https-proxy-agent: 2.2.1
-      lru_map: 0.3.3
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@sentry/types@5.11.0:
-    resolution: {integrity: sha512-1Uhycpmeo1ZK2GLvrtwZhTwIodJHcyIS6bn+t4IMkN9MFoo6ktbAfhvexBDW/IDtdLlCGJbfm8nIZerxy0QUpg==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /@sentry/types@5.5.0:
-    resolution: {integrity: sha512-3otF/miVDth91o+iign00x0o31McUPeyIFbMjLbgeTRRW9rXpu2jGrcRrvHfofECtoqCf5Y734hwvvlBvFZeIw==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /@sentry/utils@5.11.1:
-    resolution: {integrity: sha512-O0Zl4R2JJh8cTkQ8ZL2cDqGCmQdpA5VeXpuBbEl1v78LQPkBDISi35wH4mKmLwMsLBtTVpx2UeUHBj0KO5aLlA==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/types': 5.11.0
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/utils@5.5.0:
-    resolution: {integrity: sha512-gO8Bs/QcKDn7ncc2f2fIOTPx2AiZKrGj4us1Yxu6mBU8JZqMQRl9XjDMFAUECJQvquBAta+TFJyYj71ZedeQUQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/types': 5.5.0
-      tslib: 1.14.1
-    dev: true
+      '@sentry/types': 7.120.1
 
   /@sinclair/typebox@0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -7490,18 +7395,6 @@ packages:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
 
-  /agent-base@4.3.0:
-    resolution: {integrity: sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==}
-    engines: {node: '>= 4.0.0'}
-    dependencies:
-      es6-promisify: 5.0.0
-    dev: true
-
-  /agent-base@5.1.1:
-    resolution: {integrity: sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==}
-    engines: {node: '>= 6.0.0'}
-    dev: false
-
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -8726,17 +8619,13 @@ packages:
     engines: {node: '>=6.6.0'}
     dev: true
 
-  /cookie@0.3.1:
-    resolution: {integrity: sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==}
-    engines: {node: '>= 0.6'}
-
-  /cookie@0.4.0:
-    resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
+  /cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
     dev: true
 
-  /cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  /cookie@0.7.0:
+    resolution: {integrity: sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==}
     engines: {node: '>= 0.6'}
     dev: true
 
@@ -9527,16 +9416,6 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-    dev: true
-
-  /es6-promise@4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
-    dev: true
-
-  /es6-promisify@5.0.0:
-    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
-    dependencies:
-      es6-promise: 4.2.8
     dev: true
 
   /esbuild-android-64@0.14.47:
@@ -11515,26 +11394,6 @@ packages:
       resolve-alpn: 1.2.1
     dev: false
 
-  /https-proxy-agent@2.2.1:
-    resolution: {integrity: sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==}
-    engines: {node: '>= 4.5.0'}
-    dependencies:
-      agent-base: 4.3.0
-      debug: 3.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /https-proxy-agent@4.0.0:
-    resolution: {integrity: sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==}
-    engines: {node: '>= 6.0.0'}
-    dependencies:
-      agent-base: 5.1.1
-      debug: 4.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -11619,6 +11478,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
     dev: true
+
+  /immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   /import-fresh@2.0.0:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
@@ -12982,6 +12844,11 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+    dependencies:
+      immediate: 3.0.6
+
   /lilconfig@3.1.1:
     resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
@@ -13095,6 +12962,11 @@ packages:
       mlly: 1.6.1
       pkg-types: 1.0.3
     dev: true
+
+  /localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+    dependencies:
+      lie: 3.1.1
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -13245,9 +13117,6 @@ packages:
     resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
     engines: {node: 14 || >=16.14}
     dev: true
-
-  /lru_map@0.3.3:
-    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
 
   /lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -16917,6 +16786,7 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}


### PR DESCRIPTION
Bumps the version of `@sentry/node` to transitively bump `cookie`, as well as a bump to `cookie` directly.