### PR TITLE
[remix-builder][node][routing-utils] revert path-to-regexp updates

### DIFF
--- a/.changeset/three-icons-hear.md
+++ b/.changeset/three-icons-hear.md
@@ -1,0 +1,7 @@
+---
+"@vercel/node": major
+"@vercel/remix-builder": major
+"@vercel/routing-utils": major
+---
+
+[remix-builder][node][routing-utils] revert path-to-regexp updates

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,7 +36,7 @@
     "esbuild": "0.14.47",
     "etag": "1.8.1",
     "node-fetch": "2.6.9",
-    "path-to-regexp": "6.3.0",
+    "path-to-regexp": "6.2.1",
     "ts-morph": "12.0.0",
     "ts-node": "10.9.1",
     "typescript": "4.9.5",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -36,7 +36,7 @@
     "@vercel/build-utils": "8.8.0",
     "glob": "10.3.16",
     "jest-junit": "16.0.0",
-    "path-to-regexp": "6.3.0",
+    "path-to-regexp": "6.2.1",
     "semver": "7.5.2",
     "vitest": "2.0.1"
   }

--- a/packages/routing-utils/package.json
+++ b/packages/routing-utils/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "path-to-regexp": "6.3.0"
+    "path-to-regexp": "6.1.0"
   },
   "devDependencies": {
     "@types/jest": "27.4.1",

--- a/packages/routing-utils/test/superstatic.spec.ts
+++ b/packages/routing-utils/test/superstatic.spec.ts
@@ -938,7 +938,7 @@ test('convertRewrites', () => {
 test('convertHeaders', () => {
   const actual = convertHeaders([
     {
-      source: '(.*)/(.*)\\.(eot|otf|ttf|ttc|woff|font\\.css)',
+      source: '(.*)+/(.*)\\.(eot|otf|ttf|ttc|woff|font\\.css)',
       headers: [
         {
           key: 'Access-Control-Allow-Origin',
@@ -1155,7 +1155,7 @@ test('convertHeaders', () => {
 
   const expected = [
     {
-      src: '^(.*)(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)$',
+      src: '^(.*)+(?:\\/(.*))\\.(eot|otf|ttf|ttc|woff|font\\.css)$',
       headers: { 'Access-Control-Allow-Origin': '*' },
       continue: true,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1539,8 +1539,8 @@ importers:
         specifier: 16.0.0
         version: 16.0.0
       path-to-regexp:
-        specifier: 6.3.0
-        version: 6.3.0
+        specifier: 6.2.1
+        version: 6.2.1
       semver:
         specifier: 7.5.2
         version: 7.5.2
@@ -14599,8 +14599,13 @@ packages:
     resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
     dev: true
 
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+    dev: true
+
   /path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1347,8 +1347,8 @@ importers:
         specifier: 2.6.9
         version: 2.6.9
       path-to-regexp:
-        specifier: 6.3.0
-        version: 6.3.0
+        specifier: 6.2.1
+        version: 6.2.1
       ts-morph:
         specifier: 12.0.0
         version: 12.0.0
@@ -1551,8 +1551,8 @@ importers:
   packages/routing-utils:
     dependencies:
       path-to-regexp:
-        specifier: 6.3.0
-        version: 6.3.0
+        specifier: 6.1.0
+        version: 6.1.0
     optionalDependencies:
       ajv:
         specifier: ^6.0.0
@@ -14599,13 +14599,12 @@ packages:
     resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
     dev: true
 
+  /path-to-regexp@6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+    dev: false
+
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
-    dev: true
-
-  /path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}


### PR DESCRIPTION
We decided to roll out some monitoring for this case first.


