### PR TITLE
[next] Root Params

### DIFF
--- a/.changeset/curvy-flowers-dance.md
+++ b/.changeset/curvy-flowers-dance.md
@@ -1,0 +1,6 @@
+---
+'@vercel/next': major
+'vercel': major
+---
+
+Added root params support for pages powered by partial prerendering

--- a/.changeset/curvy-flowers-dance.md
+++ b/.changeset/curvy-flowers-dance.md
@@ -1,6 +1,6 @@
 ---
-'@vercel/next': major
-'vercel': major
+'@vercel/next': patch
+'vercel': patch
 ---
 
 Added root params support for pages powered by partial prerendering

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -956,6 +956,7 @@ export type NextPrerenderedRoutes = {
       fallbackHeaders?: Record<string, string>;
       fallbackRevalidate?: number | false;
       fallbackRootParams?: string[];
+      fallbackSourceRoute?: string;
       routeRegex: string;
       dataRoute: string | null;
       dataRouteRegex: string | null;
@@ -1199,6 +1200,7 @@ export async function getPrerenderManifest(
             fallbackHeaders?: Record<string, string>;
             fallbackRevalidate: number | false | undefined;
             fallbackRootParams: string[] | undefined;
+            fallbackSourceRoute?: string;
             dataRoute: string | null;
             dataRouteRegex: string | null;
             prefetchDataRoute: string | null | undefined;
@@ -1347,6 +1349,7 @@ export async function getPrerenderManifest(
         let fallbackRevalidate: number | false | undefined;
         let fallbackRootParams: undefined | string[];
         let allowHeader: undefined | string[];
+        let fallbackSourceRoute: undefined | string;
         if (manifest.version === 4) {
           experimentalBypassFor =
             manifest.dynamicRoutes[lazyRoute].experimentalBypassFor;
@@ -1368,6 +1371,8 @@ export async function getPrerenderManifest(
           fallbackRootParams =
             manifest.dynamicRoutes[lazyRoute].fallbackRootParams;
           allowHeader = manifest.dynamicRoutes[lazyRoute].allowHeader;
+          fallbackSourceRoute =
+            manifest.dynamicRoutes[lazyRoute].fallbackSourceRoute;
         }
 
         if (typeof fallback === 'string') {
@@ -1383,6 +1388,7 @@ export async function getPrerenderManifest(
             prefetchDataRouteRegex,
             fallbackRevalidate,
             fallbackRootParams,
+            fallbackSourceRoute,
             renderingMode,
             allowHeader,
           };
@@ -2194,8 +2200,12 @@ export const onPrerenderRoute =
       // When the route has PPR enabled and has a fallback defined, we should
       // read the value from the manifest and use it as the value for the route.
       if (isFallback) {
-        const { fallbackStatus, fallbackHeaders, fallbackRevalidate } =
-          prerenderManifest.fallbackRoutes[routeKey];
+        const {
+          fallbackStatus,
+          fallbackHeaders,
+          fallbackRevalidate,
+          fallbackSourceRoute,
+        } = prerenderManifest.fallbackRoutes[routeKey];
 
         if (fallbackStatus) {
           initialStatus = fallbackStatus;
@@ -2203,6 +2213,10 @@ export const onPrerenderRoute =
 
         if (fallbackHeaders) {
           initialHeaders = fallbackHeaders;
+        }
+
+        if (fallbackSourceRoute) {
+          srcRoute = fallbackSourceRoute;
         }
 
         // If we're rendering with PPR and as this is a fallback, we should use

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -955,6 +955,7 @@ export type NextPrerenderedRoutes = {
       fallbackStatus?: number;
       fallbackHeaders?: Record<string, string>;
       fallbackRevalidate?: number | false;
+      fallbackRootParams?: string[];
       routeRegex: string;
       dataRoute: string | null;
       dataRouteRegex: string | null;
@@ -1197,6 +1198,7 @@ export async function getPrerenderManifest(
             fallbackStatus?: number;
             fallbackHeaders?: Record<string, string>;
             fallbackRevalidate: number | false | undefined;
+            fallbackRootParams: string[] | undefined;
             dataRoute: string | null;
             dataRouteRegex: string | null;
             prefetchDataRoute: string | null | undefined;
@@ -1343,6 +1345,7 @@ export async function getPrerenderManifest(
         let fallbackHeaders: undefined | Record<string, string>;
         let renderingMode: RenderingMode = RenderingMode.STATIC;
         let fallbackRevalidate: number | false | undefined;
+        let fallbackRootParams: undefined | string[];
         let allowHeader: undefined | string[];
         if (manifest.version === 4) {
           experimentalBypassFor =
@@ -1362,6 +1365,8 @@ export async function getPrerenderManifest(
               : RenderingMode.STATIC);
           fallbackRevalidate =
             manifest.dynamicRoutes[lazyRoute].fallbackRevalidate;
+          fallbackRootParams =
+            manifest.dynamicRoutes[lazyRoute].fallbackRootParams;
           allowHeader = manifest.dynamicRoutes[lazyRoute].allowHeader;
         }
 
@@ -1377,6 +1382,7 @@ export async function getPrerenderManifest(
             prefetchDataRoute,
             prefetchDataRouteRegex,
             fallbackRevalidate,
+            fallbackRootParams,
             renderingMode,
             allowHeader,
           };
@@ -2585,7 +2591,10 @@ export const onPrerenderRoute =
       // have a HIT for the fallback page.
       let htmlAllowQuery = allowQuery;
       if (renderingMode === RenderingMode.PARTIALLY_STATIC && isFallback) {
-        htmlAllowQuery = [];
+        const { fallbackRootParams } =
+          prerenderManifest.fallbackRoutes[routeKey];
+
+        htmlAllowQuery = fallbackRootParams ?? [];
       }
 
       prerenders[outputPathPage] = new Prerender({

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -571,4 +571,25 @@ describe('PPR', () => {
       'next-resume': '1',
     });
   });
+
+  describe('root params', () => {
+    it('should not generate a prerender for the missing root params route', async () => {
+      const {
+        buildResult: { output },
+      } = await runBuildLambda(path.join(__dirname, 'ppr-root-params'));
+
+      expect(output['[lang]']).toBeDefined();
+      expect(output['[lang]'].type).toBe('Prerender');
+
+      // We want this to be a chainable prerender (supports Partial
+      // Prerendering).
+      expect(output['[lang]'].chain).toBeDefined();
+
+      // TODO: once we support revalidating this page, we should remove this
+      // We don't want to generate a fallback for this route. If this case fails
+      // it indicates that the fallback was generated, and we're at risk of
+      // cache posioning.
+      expect(output['[lang]'].fallback).toEqual(null);
+    });
+  });
 });

--- a/packages/next/test/integration/ppr-root-params/app/[lang]/layout.js
+++ b/packages/next/test/integration/ppr-root-params/app/[lang]/layout.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  );
+}
+
+export function generateStaticParams() {
+  return [{ lang: 'en-CA' }, { lang: 'fr-CA' }];
+}

--- a/packages/next/test/integration/ppr-root-params/app/[lang]/page.js
+++ b/packages/next/test/integration/ppr-root-params/app/[lang]/page.js
@@ -1,0 +1,5 @@
+export default async function Page({ params }) {
+  const { lang } = await params;
+
+  return <div>This is the page {lang}</div>;
+}

--- a/packages/next/test/integration/ppr-root-params/next.config.js
+++ b/packages/next/test/integration/ppr-root-params/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    ppr: true,
+    dynamicIO: true,
+  },
+};

--- a/packages/next/test/integration/ppr-root-params/package.json
+++ b/packages/next/test/integration/ppr-root-params/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/integration/ppr-root-params/vercel.json
+++ b/packages/next/test/integration/ppr-root-params/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}


### PR DESCRIPTION
Added support for root params on pages powered by partial prerendering. This enables shell generation for pages with the root params. Now, when partial prerendering is enabled for a route with a root parameter, such as structure like this:

```
/[lang]/layout.tsx
/[lang]/page.tsx
```

The `lang` key will be included in the generated shell that's returned. For parameters that were prerendered (via `generateStaticParams`), they will already have more complete shells generated. This specific blocking route is only used when routes are served that have unknown root params.