### PR TITLE
[next] Fix next data route replacing

### DIFF
--- a/.changeset/fresh-flowers-exercise.md
+++ b/.changeset/fresh-flowers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix next data route replacing

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1327,7 +1327,7 @@ export const build: BuildV2 = async buildOptions => {
 
                 // ensure root-most index data route doesn't end in index.json
                 if (dataRoute.page === '/') {
-                  route.src = route.src.replace(/\/index\.json/, '.json');
+                  route.src = route.src.replace(/\/index(\\)?\.json/, '.json');
                 }
 
                 // make sure to route to the correct prerender output

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2182,7 +2182,7 @@ export async function serverBuild({
             // filter to only static data routes as dynamic routes will be handled
             // below
             const { pathname } = new URL(route.dest || '/', 'http://n');
-            return !isDynamicRoute(pathname.replace(/\.json$/, ''));
+            return !isDynamicRoute(pathname.replace(/(\\)?\.json$/, ''));
           })
         : []),
 

--- a/packages/next/test/fixtures/00-i18n-gssp/index.test.js
+++ b/packages/next/test/fixtures/00-i18n-gssp/index.test.js
@@ -2,8 +2,6 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  // https://linear.app/vercel/issue/ZERO-3045/unskip-failing-nextjs-test
-  // eslint-disable-next-line jest/no-disabled-tests
   it('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });

--- a/packages/next/test/fixtures/00-i18n-gssp/index.test.js
+++ b/packages/next/test/fixtures/00-i18n-gssp/index.test.js
@@ -4,7 +4,7 @@ const { deployAndTest } = require('../../utils');
 describe(`${__dirname.split(path.sep).pop()}`, () => {
   // https://linear.app/vercel/issue/ZERO-3045/unskip-failing-nextjs-test
   // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should deploy and pass probe checks', async () => {
+  it('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });


### PR DESCRIPTION
This fixes our route generation from replacing assuming the dot isn't escaped which changed in https://github.com/vercel/next.js/pull/73850

Re-enables test disabled in https://linear.app/vercel/issue/ZERO-3045/unskip-failing-nextjs-test