### PR TITLE
[cli] add compile cache to improve startup performance

### DIFF
--- a/.changeset/stupid-seals-exercise.md
+++ b/.changeset/stupid-seals-exercise.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add compile cache to improve startup performance

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,8 @@
     "type-check": "tsc --noEmit"
   },
   "bin": {
-    "vc": "./dist/index.js",
-    "vercel": "./dist/index.js"
+    "vc": "./dist/vc.js",
+    "vercel": "./dist/vc.js"
   },
   "files": [
     "dist"

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -50,7 +50,8 @@ copyFileSync(
   new URL('get-latest-worker.js', distRoot)
 );
 
-writeFileSync(new URL('vc.js', distRoot),
+writeFileSync(
+  new URL('vc.js', distRoot),
   `#!/usr/bin/env node
 
 "use strict";

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -49,7 +49,4 @@ copyFileSync(
   new URL('src/util/get-latest-version/get-latest-worker.js', repoRoot),
   new URL('get-latest-worker.js', distRoot)
 );
-copyFileSync(
-  new URL('src/vc.js', repoRoot),
-  new URL('vc.js', distRoot)
-);
+copyFileSync(new URL('src/vc.js', repoRoot), new URL('vc.js', distRoot));

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -49,21 +49,7 @@ copyFileSync(
   new URL('src/util/get-latest-version/get-latest-worker.js', repoRoot),
   new URL('get-latest-worker.js', distRoot)
 );
-
-writeFileSync(
-  new URL('vc.js', distRoot),
-  `#!/usr/bin/env node
-
-"use strict";
-// This shim defers loading the real module until the compile cache is enabled.
-// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
-try {
-  const { enableCompileCache } = require('node:module');
-  if (enableCompileCache) {
-    enableCompileCache();
-  }
-} catch {}
-require('./index.js');
-`,
-  'utf8'
+copyFileSync(
+  new URL('src/vc.js', repoRoot),
+  new URL('vc.js', distRoot)
 );

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -49,3 +49,20 @@ copyFileSync(
   new URL('src/util/get-latest-version/get-latest-worker.js', repoRoot),
   new URL('get-latest-worker.js', distRoot)
 );
+
+writeFileSync(new URL('vc.js', distRoot),
+  `#!/usr/bin/env node
+
+"use strict";
+// This shim defers loading the real module until the compile cache is enabled.
+// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+try {
+  const { enableCompileCache } = require('node:module');
+  if (enableCompileCache) {
+    enableCompileCache();
+  }
+} catch {}
+require('./index.js');
+`,
+  'utf8'
+);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { isErrnoException, isError, errorToString } from '@vercel/error-utils';
 
 try {

--- a/packages/cli/src/vc.js
+++ b/packages/cli/src/vc.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict';
+// This shim defers loading the real module until the compile cache is enabled.
+// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+try {
+  const { enableCompileCache } = require('node:module');
+  if (enableCompileCache) {
+    enableCompileCache();
+  }
+} catch {}
+require('./index.js');


### PR DESCRIPTION
This improves the startup of Vercel CLI by about 200ms on my MacBook Pro M3 running Node.js 22.

References

- https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#support-for-v8-compile-caching-in-node.js