### PR TITLE
[cli] replace 'dev' script references with 'vercel' script in readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,7 +51,7 @@ cd packages/cli
 
 ### `pnpm vercel <cli-commands...>`
 
-From within the `packages/cli` directory, you can use the "dev" script to quickly execute Vercel CLI from its TypeScript source code directly (without having to manually compile first). For example:
+From within the `packages/cli` directory, you can use the "vercel" script to quickly execute Vercel CLI from its TypeScript source code directly (without having to manually compile first). For example:
 
 ```bash
 pnpm vercel deploy


### PR DESCRIPTION
## Summary
This PR updates the CLI documentation to reflect the recent renaming of the “dev” script to “vercel.”
It replaces a single instance of "dev" with "vercel" to ensure the docs match the actual usage.

## Changes
Changed one reference from "dev" to "vercel" in the README.

## Why
Previously, [the “dev” script was renamed to “vercel”](https://github.com/vercel/vercel/commit/f723eb980e0b75bf38e206bf92f132ddc0ea345f) for clarity and consistency, 
but there was one remaining reference in the docs. This single reference could cause confusion for contributors and new users.

Please review and let me know if any additional changes are needed!