### PR TITLE
[python] support `VERCEL_IPC_PATH` along `VERCEL_IPC_FD`

### DIFF
--- a/.changeset/thin-flowers-own.md
+++ b/.changeset/thin-flowers-own.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Support VERCEL_IPC_PATH along with VERCEL_IPC_FD

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -27,7 +27,7 @@ def format_headers(headers, decode=False):
         keyToList[key].append(value)
     return keyToList
 
-if 'VERCEL_IPC_FD' in os.environ:
+if 'VERCEL_IPC_FD' in os.environ or 'VERCEL_IPC_PATH' in os.environ:
     from http.server import ThreadingHTTPServer
     import http
     import time
@@ -36,9 +36,14 @@ if 'VERCEL_IPC_FD' in os.environ:
     import builtins
     import logging
 
-    ipc_fd = int(os.getenv("VERCEL_IPC_FD", ""))
-    sock = socket.socket(fileno=ipc_fd)
     start_time = time.time()
+
+    if 'VERCEL_IPC_FD' in os.environ:
+        ipc_fd = int(os.getenv("VERCEL_IPC_FD", ""))
+        sock = socket.socket(fileno=ipc_fd)
+    else:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(os.getenv("VERCEL_IPC_PATH", ""))
 
     send_message = lambda message: sock.sendall((json.dumps(message) + '\0').encode())
     storage = contextvars.ContextVar('storage', default=None)


### PR DESCRIPTION
To communicate between our runtime and language runtimes, we use a Unix Domain Socket for ICP. We currently open a Unix Domain Socket via a file descriptor `VERCEL_IPC_FD`, but not all runtimes that we want to support (e.g. Bun & Deno) support that.

To easily support any language runtime, we're moving to `VERCEL_IPC_PATH` to let the runtime directly connect to the given IPC socket, instead of opening it via a FD.

We need to support both ways right now:
- merge this PR that still supports the old way
- enable the new `VERCEL_IPC_PATH` behavior in our runtime
- delete the old `VERCEL_IPC_FD` in the Python runtime