### PR TITLE
[python] ignore nested `node_modules`, `.next`, `.nuxt`, `.git` & `.vercel`

### DIFF
--- a/.changeset/slow-gorillas-roll.md
+++ b/.changeset/slow-gorillas-roll.md
@@ -1,0 +1,9 @@
+---
+'@vercel/python': minor
+---
+
+Update default ignored folders from the zip output:
+
+- nested `node_modules`
+- nested `.next` & `.nuxt`
+- `.git` & `.vercel`

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -199,7 +199,13 @@ export const build: BuildV3 = async ({
     ignore:
       config && typeof config.excludeFiles === 'string'
         ? config.excludeFiles
-        : '{.next,.nuxt,.git,**/node_modules}/**',
+        : [
+            '.git/**',
+            '.vercel/**',
+            '**/node_modules/**',
+            '**/.next/**',
+            '**/.nuxt/**',
+          ],
   };
 
   const files: Files = await glob('**', globOptions);

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -199,7 +199,7 @@ export const build: BuildV3 = async ({
     ignore:
       config && typeof config.excludeFiles === 'string'
         ? config.excludeFiles
-        : 'node_modules/**',
+        : '{.next,.nuxt,.git,**/node_modules}/**',
   };
 
   const files: Files = await glob('**', globOptions);


### PR DESCRIPTION
By default, the Python builder only ignores the root `node_modules` from the zip output. Many customers have Next.js or Nuxt.js apps along with their Python Vercel Functions, where nested `node_modules` folders and potentially `.next` / `.nuxt` build output folders could also be included in the zip, increasing its size for nothing.

An example of that is our recent [AI SDK Python Streaming template](https://github.com/vercel-labs/ai-sdk-preview-python-streaming), where we had to ignore the `.next` manually because it was blowing up the size of the Python function: https://github.com/vercel-labs/ai-sdk-preview-python-streaming/blob/07a632d6fb60c2c09e725fc3d5be1c2a353855bd/vercel.json#L4

This PR updates the default ignore list to ignore:
- nested `node_modules`
- nested `.next` & `.nuxt` folders
- `.git` & `.vercel`