### PR TITLE
[cli] centralize printError import location

### DIFF
--- a/.changeset/healthy-lies-rush.md
+++ b/.changeset/healthy-lies-rush.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] centralize printError import location

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -17,7 +17,7 @@ import getDeployment from '../../util/get-deployment';
 import { help } from '../help';
 import { bisectCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { BisectTelemetryClient } from '../../util/telemetry/commands/bisect';
 

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -6,7 +6,7 @@ import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import type Client from '../../util/client';
 import { NowError } from '../../util/now-error';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import cmd from '../../util/output/cmd';
 import highlight from '../../util/output/highlight';
 import dev from './dev';

--- a/packages/cli/src/commands/dns/add.ts
+++ b/packages/cli/src/commands/dns/add.ts
@@ -17,7 +17,7 @@ import { DnsAddTelemetryClient } from '../../util/telemetry/commands/dns/add';
 import { addSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function add(client: Client, argv: string[]) {
   let parsedArgs;

--- a/packages/cli/src/commands/dns/import.ts
+++ b/packages/cli/src/commands/dns/import.ts
@@ -10,7 +10,7 @@ import { DnsImportTelemetryClient } from '../../util/telemetry/commands/dns/impo
 import { importSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function importZone(client: Client, argv: string[]) {
   let parsedArgs;

--- a/packages/cli/src/commands/dns/index.ts
+++ b/packages/cli/src/commands/dns/index.ts
@@ -1,6 +1,6 @@
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import add from './add';
 import importZone from './import';
 import ls from './ls';

--- a/packages/cli/src/commands/dns/ls.ts
+++ b/packages/cli/src/commands/dns/ls.ts
@@ -18,7 +18,7 @@ import { DnsLsTelemetryClient } from '../../util/telemetry/commands/dns/ls';
 import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function ls(client: Client, argv: string[]) {
   let parsedArgs;

--- a/packages/cli/src/commands/dns/rm.ts
+++ b/packages/cli/src/commands/dns/rm.ts
@@ -13,7 +13,7 @@ import { DnsRmTelemetryClient } from '../../util/telemetry/commands/dns/rm';
 import { removeSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function rm(client: Client, argv: string[]) {
   let parsedArgs;

--- a/packages/cli/src/commands/domains/add.ts
+++ b/packages/cli/src/commands/domains/add.ts
@@ -18,7 +18,7 @@ import { DomainsAddTelemetryClient } from '../../util/telemetry/commands/domains
 import { addSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function add(client: Client, argv: string[]) {
   const telemetry = new DomainsAddTelemetryClient({

--- a/packages/cli/src/commands/domains/buy.ts
+++ b/packages/cli/src/commands/domains/buy.ts
@@ -16,7 +16,7 @@ import type Client from '../../util/client';
 import { buySubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function buy(client: Client, argv: string[]) {
   const telemetry = new DomainsBuyTelemetryClient({

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -1,7 +1,7 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import add from './add';
 import buy from './buy';
 import transferIn from './transfer-in';

--- a/packages/cli/src/commands/domains/inspect.ts
+++ b/packages/cli/src/commands/domains/inspect.ts
@@ -18,7 +18,7 @@ import output from '../../output-manager';
 import { inspectSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function inspect(client: Client, argv: string[]) {
   const telemetry = new DomainsInspectTelemetryClient({

--- a/packages/cli/src/commands/domains/ls.ts
+++ b/packages/cli/src/commands/domains/ls.ts
@@ -19,7 +19,7 @@ import { DomainsLsTelemetryClient } from '../../util/telemetry/commands/domains/
 import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function ls(client: Client, argv: string[]) {
   const telemetry = new DomainsLsTelemetryClient({

--- a/packages/cli/src/commands/domains/move.ts
+++ b/packages/cli/src/commands/domains/move.ts
@@ -15,7 +15,7 @@ import { DomainsMoveTelemetryClient } from '../../util/telemetry/commands/domain
 import { moveSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import type Client from '../../util/client';
 import type { User, Team } from '@vercel-internals/types';
 

--- a/packages/cli/src/commands/domains/rm.ts
+++ b/packages/cli/src/commands/domains/rm.ts
@@ -20,7 +20,7 @@ import { DomainsRmTelemetryClient } from '../../util/telemetry/commands/domains/
 import { removeSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function rm(client: Client, argv: string[]) {
   const telemetry = new DomainsRmTelemetryClient({

--- a/packages/cli/src/commands/domains/transfer-in.ts
+++ b/packages/cli/src/commands/domains/transfer-in.ts
@@ -16,7 +16,7 @@ import output from '../../output-manager';
 import { transferInSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 export default async function transferIn(client: Client, argv: string[]) {
   const telemetry = new DomainsTransferInTelemetryClient({

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -18,7 +18,7 @@ import output from '../../output-manager';
 import { EnvAddTelemetryClient } from '../../util/telemetry/commands/env/add';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { addSubcommand } from './command';
 import { getLinkedProject } from '../../util/projects/link';
 

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -2,7 +2,7 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { type Command, help } from '../help';
 import add from './add';
 import ls from './ls';

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -20,7 +20,7 @@ import { EnvLsTelemetryClient } from '../../util/telemetry/commands/env/ls';
 import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { getLinkedProject } from '../../util/projects/link';
 
 export default async function ls(client: Client, argv: string[]) {

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -26,7 +26,7 @@ import { EnvPullTelemetryClient } from '../../util/telemetry/commands/env/pull';
 import { pullSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
 

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -17,7 +17,7 @@ import output from '../../output-manager';
 import { removeSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { getLinkedProject } from '../../util/projects/link';
 
 export default async function rm(client: Client, argv: string[]) {

--- a/packages/cli/src/commands/git/connect.ts
+++ b/packages/cli/src/commands/git/connect.ts
@@ -20,7 +20,7 @@ import output from '../../output-manager';
 import { GitConnectTelemetryClient } from '../../util/telemetry/commands/git/connect';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { connectSubcommand } from './command';
 import { ensureLink } from '../../util/link/ensure-link';
 

--- a/packages/cli/src/commands/git/disconnect.ts
+++ b/packages/cli/src/commands/git/disconnect.ts
@@ -6,7 +6,7 @@ import output from '../../output-manager';
 import { disconnectSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { GitDisconnectTelemetryClient } from '../../util/telemetry/commands/git/disconnect';
 import type Client from '../../util/client';
 import { ensureLink } from '../../util/link/ensure-link';

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -1,6 +1,6 @@
 import { parseArguments } from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import connect from './connect';
 import disconnect from './disconnect';
 import { help } from '../help';

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,7 +1,7 @@
 import { parseArguments } from '../../util/get-args';
 import getSubcommand from '../../util/get-subcommand';
 import type Client from '../../util/client';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import init from './init';
 import { isError } from '@vercel/error-utils';
 import { help } from '../help';

--- a/packages/cli/src/commands/integration-resource/disconnect.ts
+++ b/packages/cli/src/commands/integration-resource/disconnect.ts
@@ -4,7 +4,7 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getScope from '../../util/get-scope';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import confirm from '../../util/input/confirm';
 import {
   disconnectResourceFromAllProjects,

--- a/packages/cli/src/commands/integration-resource/remove-resource.ts
+++ b/packages/cli/src/commands/integration-resource/remove-resource.ts
@@ -5,7 +5,7 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getScope from '../../util/get-scope';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import confirm from '../../util/input/confirm';
 import { deleteResource as _deleteResource } from '../../util/integration-resource/delete-resource';
 import { getResources } from '../../util/integration-resource/get-resources';

--- a/packages/cli/src/commands/integration/list.ts
+++ b/packages/cli/src/commands/integration/list.ts
@@ -7,7 +7,7 @@ import { getResources } from '../../util/integration-resource/get-resources';
 import { listSubcommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { parseArguments } from '../../util/get-args';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import table from '../../util/output/table';
 import title from 'title';
 import type { Team } from '@vercel-internals/types';

--- a/packages/cli/src/commands/integration/remove-integration.ts
+++ b/packages/cli/src/commands/integration/remove-integration.ts
@@ -5,7 +5,7 @@ import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getScope from '../../util/get-scope';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import confirm from '../../util/input/confirm';
 import { getFirstConfiguration } from '../../util/integration/fetch-marketplace-integrations';
 import { removeIntegration } from '../../util/integration/remove-integration';

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -6,7 +6,7 @@ import { ensureRepoLink } from '../../util/link/repo';
 import { help } from '../help';
 import { linkCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { LinkTelemetryClient } from '../../util/telemetry/commands/link';
 

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -21,7 +21,7 @@ import { help } from '../help';
 import { loginCommand } from './command';
 import { updateCurrentTeamAfterLogin } from '../../util/login/update-current-team-after-login';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { LoginTelemetryClient } from '../../util/telemetry/commands/login';
 

--- a/packages/cli/src/commands/project/add.ts
+++ b/packages/cli/src/commands/project/add.ts
@@ -9,7 +9,7 @@ import { ProjectAddTelemetryClient } from '../../util/telemetry/commands/project
 import { addSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import getScope from '../../util/get-scope';
 
 export default async function add(

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -1,7 +1,7 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getInvalidSubcommand from '../../util/get-invalid-subcommand';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { type Command, help } from '../help';
 import add from './add';
 import list from './list';

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -9,7 +9,7 @@ import output from '../../output-manager';
 import { listSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import getScope from '../../util/get-scope';
 import type Client from '../../util/client';
 import type { Project } from '@vercel-internals/types';

--- a/packages/cli/src/commands/project/rm.ts
+++ b/packages/cli/src/commands/project/rm.ts
@@ -9,7 +9,7 @@ import { ProjectRmTelemetryClient } from '../../util/telemetry/commands/project/
 import output from '../../output-manager';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { removeSubcommand } from './command';
 
 const e = encodeURIComponent;

--- a/packages/cli/src/commands/promote/index.ts
+++ b/packages/cli/src/commands/promote/index.ts
@@ -1,7 +1,7 @@
 import ms from 'ms';
 import { parseArguments } from '../../util/get-args';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { isErrnoException } from '@vercel/error-utils';
 import requestPromote from './request-promote';
 import promoteStatus from './status';

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -19,7 +19,7 @@ import { help } from '../help';
 import { pullCommand, type PullCommandFlags } from './command';
 import parseTarget from '../../util/parse-target';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { PullTelemetryClient } from '../../util/telemetry/commands/pull';
 

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -6,7 +6,7 @@ import { parseArguments } from '../../util/get-args';
 import { getCommandName } from '../../util/pkg-name';
 import { getDeploymentByIdOrURL } from '../../util/deploy/get-deployment-by-id-or-url';
 import getScope from '../../util/get-scope';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { isErrnoException } from '@vercel/error-utils';
 import Now from '../../util';
 import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -14,7 +14,7 @@ import getDeployment from '../../util/get-deployment';
 import getDeploymentsByProjectId from '../../util/deploy/get-deployments-by-project-id';
 import { getCommandName } from '../../util/pkg-name';
 import { parseArguments } from '../../util/get-args';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import type Client from '../../util/client';
 import type { Alias, Deployment, Project } from '@vercel-internals/types';
 import { NowError } from '../../util/now-error';

--- a/packages/cli/src/commands/rollback/index.ts
+++ b/packages/cli/src/commands/rollback/index.ts
@@ -1,7 +1,7 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
 import getProjectByCwdOrLink from '../../util/projects/get-project-by-cwd-or-link';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { isErrnoException } from '@vercel/error-utils';
 import ms from 'ms';
 import requestRollback from './request-rollback';

--- a/packages/cli/src/commands/target/index.ts
+++ b/packages/cli/src/commands/target/index.ts
@@ -5,7 +5,7 @@ import { type Command, help } from '../help';
 import list from './list';
 import { listSubcommand, targetCommand } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { TargetTelemetryClient } from '../../util/telemetry/commands/target';
 import { getCommandAliases } from '..';

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -12,7 +12,7 @@ import {
 } from './command';
 import { type Command, help } from '../help';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { TeamsTelemetryClient } from '../../util/telemetry/commands/teams';
 import output from '../../output-manager';
 import getSubcommand from '../../util/get-subcommand';

--- a/packages/cli/src/commands/teams/invite.ts
+++ b/packages/cli/src/commands/teams/invite.ts
@@ -16,7 +16,7 @@ import { TeamsInviteTelemetryClient } from '../../util/telemetry/commands/teams/
 import output from '../../output-manager';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { inviteSubcommand } from './command';
 
 const validateEmail = (data: string) =>

--- a/packages/cli/src/commands/teams/list.ts
+++ b/packages/cli/src/commands/teams/list.ts
@@ -8,7 +8,7 @@ import getCommandFlags from '../../util/get-command-flags';
 import cmd from '../../util/output/cmd';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { listSubcommand } from './command';
 import output from '../../output-manager';

--- a/packages/cli/src/commands/teams/switch.ts
+++ b/packages/cli/src/commands/teams/switch.ts
@@ -11,7 +11,7 @@ import type Client from '../../util/client';
 import { switchSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 
 const updateCurrentTeam = (config: GlobalConfig, team?: Team) => {
   if (team) {

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -5,7 +5,7 @@ import getScope from '../../util/get-scope';
 import { parseArguments } from '../../util/get-args';
 import type Client from '../../util/client';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
-import { printError } from '../../util/print-error';
+import { printError } from '../../util/error';
 import output from '../../output-manager';
 import { WhoamiTelemetryClient } from '../../util/telemetry/commands/whoami';
 

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -14,7 +14,7 @@ import {
 } from '../projects/link';
 import createProject from '../projects/create-project';
 import type Client from '../client';
-import { printError } from '../print-error';
+import { printError } from '../error';
 import confirm from '../input/confirm';
 import toHumanPath from '../humanize-path';
 import { isDirectory } from '../config/global-path';


### PR DESCRIPTION
While working on https://github.com/vercel/vercel/pull/12821, I found that we had two import paths for `printError`, both `print-error.ts` and `error.ts` were exporting the function. This PR unifies all imports to come from `error.ts`.