### PR TITLE
[cli] sort imports in build/index.ts

### DIFF
--- a/.changeset/slimy-horses-admire.md
+++ b/.changeset/slimy-horses-admire.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] sort imports in build/index.ts


### PR DESCRIPTION
Breaks the imports in `build/index.ts` into three sorted groups: external dependencies, monorepo dependencies, and other modules in `package/cli`. 

I did this PR as a standalone on one module so that we can discuss whether we:

- Want to sort our imports?
- Want to do an automated sweep across other modules in `package/cli` or the whole repo?
- Want to enforce import sorting with the formatter/linter?

This particular sort was done using a manual invocation of the Zed 'organize imports' code action.