### PR TITLE
[cli] standardize uses of confirm on confirm.ts

### DIFF
--- a/.changeset/lovely-bobcats-mix.md
+++ b/.changeset/lovely-bobcats-mix.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] standardizes uses of confirm on confirm.ts

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -23,6 +23,7 @@ import { fetchInstallations } from '../../util/integration/fetch-installations';
 import { fetchIntegration } from '../../util/integration/fetch-integration';
 import output from '../../output-manager';
 import { IntegrationAddTelemetryClient } from '../../util/telemetry/commands/integration/add';
+import confirm from '../../util/input/confirm';
 
 export async function add(client: Client, args: string[]) {
   const telemetry = new IntegrationAddTelemetryClient({
@@ -138,11 +139,12 @@ export async function add(client: Client, args: string[]) {
       return projectLink.exitCode;
     }
 
-    const openInWeb = await client.input.confirm({
-      message: !installation
+    const openInWeb = await confirm(
+      client,
+      !installation
         ? 'Terms have not been accepted. Open Vercel Dashboard?'
-        : 'This resource must be provisioned through the Web UI. Open Vercel Dashboard?',
-    });
+        : 'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
+    );
 
     if (openInWeb) {
       privisionResourceViaWebUI(
@@ -172,9 +174,10 @@ async function getOptionalLinkedProject(client: Client) {
     return;
   }
 
-  const shouldLinkToProject = await client.input.confirm({
-    message: 'Do you want to link this resource to the current project?',
-  });
+  const shouldLinkToProject = await confirm(
+    client,
+    'Do you want to link this resource to the current project?'
+  );
 
   if (!shouldLinkToProject) {
     return;
@@ -370,9 +373,7 @@ async function confirmProductSelection(
     `${chalk.dim(`- ${chalk.bold('Plan:')} ${billingPlan.name}`)}\n`
   );
 
-  return client.input.confirm({
-    message: 'Confirm selection?',
-  });
+  return confirm(client, 'Confirm selection?');
 }
 
 async function provisionStorageProduct(

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -143,7 +143,8 @@ export async function add(client: Client, args: string[]) {
       client,
       !installation
         ? 'Terms have not been accepted. Open Vercel Dashboard?'
-        : 'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
+        : 'This resource must be provisioned through the Web UI. Open Vercel Dashboard?',
+      true
     );
 
     if (openInWeb) {
@@ -176,7 +177,8 @@ async function getOptionalLinkedProject(client: Client) {
 
   const shouldLinkToProject = await confirm(
     client,
-    'Do you want to link this resource to the current project?'
+    'Do you want to link this resource to the current project?',
+    true
   );
 
   if (!shouldLinkToProject) {
@@ -373,7 +375,7 @@ async function confirmProductSelection(
     `${chalk.dim(`- ${chalk.bold('Plan:')} ${billingPlan.name}`)}\n`
   );
 
-  return confirm(client, 'Confirm selection?');
+  return confirm(client, 'Confirm selection?', true);
 }
 
 async function provisionStorageProduct(

--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -3,7 +3,7 @@ import type Client from '../client';
 export default async function confirm(
   client: Client,
   message: string,
-  preferred: boolean
+  preferred: boolean = true
 ): Promise<boolean> {
   return client.input.confirm({
     message,

--- a/packages/cli/src/util/input/confirm.ts
+++ b/packages/cli/src/util/input/confirm.ts
@@ -3,7 +3,7 @@ import type Client from '../client';
 export default async function confirm(
   client: Client,
   message: string,
-  preferred: boolean = true
+  preferred: boolean
 ): Promise<boolean> {
   return client.input.confirm({
     message,


### PR DESCRIPTION
Prior to this PR, we had a mixed usage of the `confirm` interactive input component. Some came through `client.input.confirm` and some came through the function `confirm` that wraps it. This PR standardizes on the function `confirm` since that was in use in more places and restricts the options that a call site can use.

This PR doesn't prevent `client.input.confirm` from being called directly in the future. It may be worth considering an `input-manager` similar to the previous `output-manager` refactor.