### PR TITLE
[cli] Allows warnings for `ls --update-required` to show for deprecated versions

### DIFF
--- a/.changeset/beige-swans-pull.md
+++ b/.changeset/beige-swans-pull.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"vercel": minor
+---
+
+[cli] Allows warnings for `ls --update-required` to show for deprecated versions

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -15,6 +15,7 @@ export const NODE_VERSIONS: NodeVersion[] = [
     range: '16.x',
     runtime: 'nodejs16.x',
     discontinueDate: new Date('2025-01-31'),
+    deprecationDate: new Date('2025-01-14'),
   },
   {
     major: 14,

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -15,7 +15,7 @@ export const NODE_VERSIONS: NodeVersion[] = [
     range: '16.x',
     runtime: 'nodejs16.x',
     discontinueDate: new Date('2025-01-31'),
-    deprecationDate: new Date('2025-01-14'),
+    deprecationDate: new Date('2023-05-19'),
   },
   {
     major: 14,

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -333,6 +333,8 @@ export interface NodeVersion {
   runtime: string;
   /** date beyond which this version is discontinued: 2023-08-17T19:05:45.951Z */
   discontinueDate?: Date;
+  /** date beyond which this version will alert about future removal: 2023-08-17T19:05:45.951Z */
+  deprecationDate?: Date;
 }
 
 export interface Builder {

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -81,8 +81,8 @@ export default async function list(
 
     for (const nodeVersion of NODE_VERSIONS) {
       if (
-        nodeVersion.discontinueDate &&
-        nodeVersion.discontinueDate.valueOf() > Date.now()
+        nodeVersion.deprecationDate &&
+        nodeVersion.deprecationDate.valueOf() > Date.now()
       ) {
         upcomingDeprecationVersionsList.push(nodeVersion.range);
       }


### PR DESCRIPTION
Currently we only show a warning if a runtime version's `discontinueDate` has passed, but customers should be able to run this before that date to see what they need to change. Setting the date for the soon-to-be removed node@16 to the date from the [changelog](https://vercel.com/changelog/node-js-16-deprecation-2gFqvRhzEw1gA6wvTCrKy0)