### PR TITLE
[cli] update warning in ls --update-required for clarity

### DIFF
--- a/.changeset/gold-months-live.md
+++ b/.changeset/gold-months-live.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] update warning in ls --update-required for clarity

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -80,10 +80,15 @@ export default async function list(
     const upcomingDeprecationVersionsList = [];
 
     for (const nodeVersion of NODE_VERSIONS) {
-      if (
+      // This logic presumes that adding a discontinue date for a node version
+      // implies that the version is deprecated.
+      // If there are scenarios where we will be deprecating a version
+      // without knowing the discontinue date
+      // Then we'll want to consider adding a `deprecationDate` field to the nodeVersion type
+      const upcomingDiscontinueDate =
         nodeVersion.discontinueDate &&
-        nodeVersion.discontinueDate.valueOf() > Date.now()
-      ) {
+        nodeVersion.discontinueDate.valueOf() > Date.now();
+      if (upcomingDiscontinueDate) {
         upcomingDeprecationVersionsList.push(nodeVersion.range);
       }
     }

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -89,9 +89,9 @@ export default async function list(
     }
 
     output.warn(
-      `The following Node.js versions will be deprecated soon: ${upcomingDeprecationVersionsList.join(
+      `The following Node.js versions are deprecated: ${upcomingDeprecationVersionsList.join(
         ', '
-      )}. Please upgrade your projects immediately.`
+      )} and will be discontinued soon. Please upgrade your projects immediately.`
     );
     output.log(
       'For more information visit: https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#node.js-version'


### PR DESCRIPTION
Closes #12856.

The existing logic assumes that if a `discontinueDate` has been set for a given version of node, that version of node must be deprecated. It was also easy to mistake the previous code as displaying the warning only _after_ the discontinue date, which it never did.

This PR:

- Clarifies the language communicating the deprecation to users. It's not that the node version _will be_ deprecated. The node version is _already_ deprecated and is at risk of being discontinued.
- Adds an identifier to the logic checking for a deprecated node version, making it clear that the date check is looking into the future.
- Adds a comment clarifying the logic further, and documents the assumption that a `discontinueDate` means that a node version is deprecated.
- Adds a further comment noting that if this assumption is invalid, additional logic may be required. Specifically, in the case where we have deprecated a node version, but don't yet know its discontinue date.