### PR TITLE
Add video integration category to the CLI

### DIFF
--- a/.changeset/chilly-coats-divide.md
+++ b/.changeset/chilly-coats-divide.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add video integration category to the integration install CLI

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -114,22 +114,24 @@ export async function add(client: Client, args: string[]) {
   const metadataSchema = product.metadataSchema;
   const metadataWizard = createMetadataWizard(metadataSchema);
 
-  // At the time of writing, we don't support native integrations besides storage products.
+  // At the time of writing, we don't support native integrations besides storage & video products.
   // However, when we introduce new categories, we avoid breaking this version of the CLI by linking all
   // non-storage categories to the dashboard.
   // product.type is the old way of defining categories, while the protocols are the new way.
   const isPreProtocolStorageProduct = product.type === 'storage';
   const isPostProtocolStorageProduct =
     product.protocols?.storage?.status === 'enabled';
+  const isVideoProduct = product.protocols?.video?.status;
   const isStorageProduct =
     isPreProtocolStorageProduct || isPostProtocolStorageProduct;
+  const isSupportedProductType = isStorageProduct || isVideoProduct;
 
   // The provisioning via cli is possible when
   // 1. The integration was installed once (terms have been accepted)
   // 2. The provider-defined metadata is supported (does not use metadata expressions etc.)
   // 3. The product type is supported
   const provisionResourceViaCLIIsSupported =
-    installation && metadataWizard.isSupported && isStorageProduct;
+    installation && metadataWizard.isSupported && isSupportedProductType;
 
   if (!provisionResourceViaCLIIsSupported) {
     const projectLink = await getOptionalLinkedProject(client);

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -44,6 +44,8 @@ export type StorageIntegrationProtocol = IntegrationProductProtocolBase & {
   };
 };
 
+export type VideoIntegrationProtocol = IntegrationProductProtocolBase;
+
 export interface IntegrationProduct {
   id: string;
   slug: string;
@@ -52,6 +54,7 @@ export interface IntegrationProduct {
   type?: 'storage' | string;
   protocols?: {
     storage?: StorageIntegrationProtocol;
+    video?: VideoIntegrationProtocol;
   };
   metadataSchema: MetadataSchema;
 }


### PR DESCRIPTION
Relates to [this ticket](https://linear.app/vercel/issue/ECO-1144/investigate-mux-prompt-issue-in-cli).

We originally wrote the CLI integration install wizard to enable the creation of storage products, and weren't yet certain if future product groups would use the same structure and systems, so to be safe our CLI redirects non-storage products to the dashboard to finish setup. The video product from Mux uses the same underlying structures as storage, just a different protocol.

In the future, if different integration categories continue to all share the same underlying structure, we should be able to remove the guardrail check around if the integration is of a product type supported by the CLI.