### PR TITLE
[build-utils] Add `useWebApi` property to `NodejsLambda` class

### DIFF
--- a/.changeset/chilled-worms-hunt.md
+++ b/.changeset/chilled-worms-hunt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add `shouldUseWebApi` property to `NodejsLambda` class

--- a/.changeset/chilled-worms-hunt.md
+++ b/.changeset/chilled-worms-hunt.md
@@ -2,4 +2,4 @@
 '@vercel/build-utils': minor
 ---
 
-Add `shouldUseWebApi` property to `NodejsLambda` class
+Add `useWebApi` property to `NodejsLambda` class

--- a/packages/build-utils/src/nodejs-lambda.ts
+++ b/packages/build-utils/src/nodejs-lambda.ts
@@ -3,29 +3,29 @@ import { Lambda, LambdaOptionsWithFiles } from './lambda';
 interface NodejsLambdaOptions extends LambdaOptionsWithFiles {
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
-  shouldUseWebApi?: boolean;
   awsLambdaHandler?: string;
+  useWebApi?: boolean;
 }
 
 export class NodejsLambda extends Lambda {
   launcherType: 'Nodejs';
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
-  shouldUseWebApi?: boolean;
   awsLambdaHandler?: string;
+  useWebApi?: boolean;
 
   constructor({
     shouldAddHelpers,
     shouldAddSourcemapSupport,
-    shouldUseWebApi,
     awsLambdaHandler,
+    useWebApi,
     ...opts
   }: NodejsLambdaOptions) {
     super(opts);
     this.launcherType = 'Nodejs';
     this.shouldAddHelpers = shouldAddHelpers;
     this.shouldAddSourcemapSupport = shouldAddSourcemapSupport;
-    this.shouldUseWebApi = shouldUseWebApi;
     this.awsLambdaHandler = awsLambdaHandler;
+    this.useWebApi = useWebApi;
   }
 }

--- a/packages/build-utils/src/nodejs-lambda.ts
+++ b/packages/build-utils/src/nodejs-lambda.ts
@@ -3,6 +3,7 @@ import { Lambda, LambdaOptionsWithFiles } from './lambda';
 interface NodejsLambdaOptions extends LambdaOptionsWithFiles {
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
+  shouldUseWebApi?: boolean;
   awsLambdaHandler?: string;
 }
 
@@ -10,11 +11,13 @@ export class NodejsLambda extends Lambda {
   launcherType: 'Nodejs';
   shouldAddHelpers: boolean;
   shouldAddSourcemapSupport: boolean;
+  shouldUseWebApi?: boolean;
   awsLambdaHandler?: string;
 
   constructor({
     shouldAddHelpers,
     shouldAddSourcemapSupport,
+    shouldUseWebApi,
     awsLambdaHandler,
     ...opts
   }: NodejsLambdaOptions) {
@@ -22,6 +25,7 @@ export class NodejsLambda extends Lambda {
     this.launcherType = 'Nodejs';
     this.shouldAddHelpers = shouldAddHelpers;
     this.shouldAddSourcemapSupport = shouldAddSourcemapSupport;
+    this.shouldUseWebApi = shouldUseWebApi;
     this.awsLambdaHandler = awsLambdaHandler;
   }
 }


### PR DESCRIPTION
Currently Node.js functions can opt-in to the Web API syntax by exporting named HTTP methods as request handlers (`export const GET = () => new Response()`), but there is no way to export a default catch-all handler.

For backwards compat reasons, we can not change the default `export default` as a Node.js HTTP handler syntax, so this new opt-in property `useWebApi` will enable Web API syntax for the default export.

This is a prerequisite to making React Router v7+ work on Vercel in a sane way.