### PR TITLE
[python] add `supportsResponseStreaming` to build output

### DIFF
--- a/.changeset/sweet-boats-admire.md
+++ b/.changeset/sweet-boats-admire.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Add `supportsResponseStreaming` to build output

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -229,6 +229,7 @@ export const build: BuildV3 = async ({
     handler: `${handlerPyFilename}.vc_handler`,
     runtime: pythonVersion.runtime,
     environment: {},
+    supportsResponseStreaming: true,
   });
 
   return { output };


### PR DESCRIPTION
In https://github.com/vercel/vercel/pull/12557, we added support for response streaming to the Python runtime. However, if a user uses an old Vercel CLI version (either pinned `@vercel/python` version in `vercel.json`, using an old build cache, using `--prebuilt`...), we need to make sure we won't apply streaming capabilities to the function.

This PR adds `supportsResponseStreaming: true` to the build output of `@vercel/python`, which we'll check before applying streaming capabilities when deploying a project.