### PR TITLE
[tests] remove tests verifying dojo and scully are tested

### DIFF
--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -215,7 +215,7 @@ async function getDeployment(host: string) {
 }
 
 describe('frameworks', () => {
-  const skipExamples = ['sanity-v3', 'solidstart'];
+  const skipExamples = ['sanity-v3', 'solidstart', 'dojo', 'scully'];
 
   it('ensure there is an example for every framework', async () => {
     const root = join(__dirname, '..', '..', '..');


### PR DESCRIPTION
These were removed in
* https://github.com/vercel/vercel/pull/12881
* https://github.com/vercel/vercel/pull/12882

But our turbo config means this tests didn't run. It would eventually fail mysteriously. 