### PR TITLE
Enable tracing within the cli and builder framework

### DIFF
--- a/.changeset/odd-dogs-shake.md
+++ b/.changeset/odd-dogs-shake.md
@@ -1,0 +1,7 @@
+---
+'@vercel/build-utils': minor
+'@vercel/next': minor
+'vercel': minor
+---
+
+Support process tracing

--- a/packages/build-utils/src/trace/trace.ts
+++ b/packages/build-utils/src/trace/trace.ts
@@ -71,7 +71,8 @@ export class Span {
 
     this.status = 'stopped';
 
-    const duration = Date.now() - this._start;
+    // durations are reported in microseconds
+    const duration = (Date.now() - this._start) * 1000;
 
     const traceEvent: TraceEvent = {
       name: this.name,

--- a/packages/build-utils/src/trace/trace.ts
+++ b/packages/build-utils/src/trace/trace.ts
@@ -13,7 +13,6 @@ export type TraceEvent = {
 };
 
 export type Reporter = {
-  flushAll: (opts?: { end: boolean }) => Promise<void> | void;
   report: (event: TraceEvent) => void;
 };
 

--- a/packages/build-utils/src/trace/trace.ts
+++ b/packages/build-utils/src/trace/trace.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
+const NUM_OF_MICROSEC_IN_NANOSEC = BigInt('1000');
+
 export type SpanId = string;
 
 export type TraceEvent = {
@@ -38,7 +40,8 @@ export class Span {
   private status: 'started' | 'stopped';
 
   // Number of nanoseconds since epoch.
-  private _start: number;
+  private _start: bigint;
+  private now: number;
 
   private _reporter: Reporter | undefined;
 
@@ -59,8 +62,15 @@ export class Span {
     this.status = 'started';
 
     this.id = randomUUID();
-    this._start = Date.now();
     this._reporter = reporter;
+
+    // hrtime cannot be used to reconstruct tracing span's actual start time
+    // since it does not have relation to clock time:
+    // `These times are relative to an arbitrary time in the past, and not related to the time of day and therefore not subject to clock drift`
+    // https://nodejs.org/api/process.html#processhrtimetime
+    // Capturing current datetime as additional metadata for external reconstruction.
+    this.now = Date.now();
+    this._start = process.hrtime.bigint();
   }
 
   stop() {
@@ -70,17 +80,19 @@ export class Span {
 
     this.status = 'stopped';
 
-    // durations are reported in microseconds
-    const duration = (Date.now() - this._start) * 1000;
+    const end = process.hrtime.bigint();
+    const duration = Number((end - this._start) / NUM_OF_MICROSEC_IN_NANOSEC);
+
+    const timestamp = Number(this._start / NUM_OF_MICROSEC_IN_NANOSEC);
 
     const traceEvent: TraceEvent = {
       name: this.name,
-      duration: Number(duration),
-      timestamp: this._start,
+      duration,
+      timestamp,
       id: this.id,
       parentId: this.parentId,
       tags: this.attrs,
-      startTime: this._start,
+      startTime: this.now,
     };
 
     if (this._reporter) {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -345,7 +345,8 @@ export default async function main(client: Client): Promise<number> {
         JSON.stringify(reporter.events)
       );
     } catch (err) {
-      // Ignore errors when writing diagnostics
+      output.error('Failed to write diagnostics trace file');
+      output.prettyError(err);
     }
 
     // Unset environment variables that were added by dotenv

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -125,8 +125,6 @@ export interface BuildsManifest {
 class InMemoryReporter implements Reporter {
   public events: TraceEvent[] = [];
 
-  async flushAll() {}
-
   report(event: TraceEvent) {
     this.events.push(event);
   }

--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -22,7 +22,7 @@ export interface BuilderWithPkg {
   path: string;
   pkgPath: string;
   builder: BuilderV2 | BuilderV3;
-  pkg: PackageJson;
+  pkg: PackageJson & { name: string };
 }
 
 type ResolveBuildersResult =
@@ -162,7 +162,10 @@ export async function resolveBuilders(
 
       builders.set(spec, {
         builder,
-        pkg: builderPkg,
+        pkg: {
+          name,
+          ...builderPkg,
+        },
         path,
         pkgPath,
       });

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1226,7 +1226,12 @@ describe.skipIf(flakey)('build', () => {
 
       const files = await fs.readdir(output);
       // we should NOT see `functions` because that means `middleware.ts` was processed
-      expect(files.sort()).toEqual(['builds.json', 'config.json', 'static']);
+      expect(files.sort()).toEqual([
+        'builds.json',
+        'config.json',
+        'static',
+        'trace',
+      ]);
     } finally {
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;
     }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1229,8 +1229,8 @@ describe.skipIf(flakey)('build', () => {
       expect(files.sort()).toEqual([
         'builds.json',
         'config.json',
-        'static',
         'diagnostics',
+        'static',
       ]);
     } finally {
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1232,6 +1232,9 @@ describe.skipIf(flakey)('build', () => {
         'diagnostics',
         'static',
       ]);
+
+      const diagnostics = await fs.readdir(join(output, 'diagnostics'));
+      expect(diagnostics.sort()).toEqual(['cli_traces.json']);
     } finally {
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;
     }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1230,7 +1230,7 @@ describe.skipIf(flakey)('build', () => {
         'builds.json',
         'config.json',
         'static',
-        'trace',
+        'diagnostics',
       ]);
     } finally {
       delete process.env.STORYBOOK_DISABLE_TELEMETRY;


### PR DESCRIPTION
To enable open telemetry and metric aggregation on our builder layers, I've added a port of the [next.js](https://github.com/vercel/next.js/blob/5d7713f833d6fea6e599d49ea7d7c14307e64570/packages/next/src/trace/trace.ts) tracing implementation which is compatible with our open telemetry ingestion.

This allows us to construct build spans across the CLI & zero-config builder framework and we'll eventually be able to reconstruct these into telemetry spans on the backend.