### PR TITLE
[cli] add Node Version to project list output table

### DIFF
--- a/.changeset/odd-shirts-think.md
+++ b/.changeset/odd-shirts-think.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] add Node Version to project list output table

--- a/.changeset/odd-shirts-think.md
+++ b/.changeset/odd-shirts-think.md
@@ -1,5 +1,5 @@
 ---
-"vercel": patch
+"vercel": minor
 ---
 
 [cli] add Node Version to project list output table

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -114,14 +114,18 @@ export default async function list(
   if (projectList.length > 0) {
     const tablePrint = table(
       [
-        ['Project Name', 'Latest Production URL', 'Updated'].map(header =>
-          chalk.bold(chalk.cyan(header))
-        ),
+        [
+          'Project Name',
+          'Latest Production URL',
+          'Updated',
+          'Node Version',
+        ].map(header => chalk.bold(chalk.cyan(header))),
         ...projectList.flatMap(project => [
           [
             chalk.bold(project.name),
             getLatestProdUrl(project),
             chalk.gray(ms(Date.now() - project.updatedAt)),
+            project.nodeVersion ?? '',
           ],
         ]),
       ],

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -115,6 +115,7 @@ describe('list', () => {
       'Project Name',
       'Latest Production URL',
       'Updated',
+      'Node Version',
     ]);
 
     line = await lines.next();
@@ -158,6 +159,7 @@ describe('list', () => {
       'Project Name',
       'Latest Production URL',
       'Updated',
+      'Node Version',
     ]);
 
     line = await lines.next();


### PR DESCRIPTION
This PR adds `Node Version` to the table of outputs for `vercel project list`. This addition allows users to see what node version is set for a given project, which is especially important for deprecated projects in `--update-required`.

Before:
![image](https://github.com/user-attachments/assets/4f3ac3c6-1ae1-41cb-8c43-57c22b75871b)


After:
![image](https://github.com/user-attachments/assets/ba3a5933-3bd9-4a3f-8fd3-8f42bb089ab5)
