### PR TITLE
readme: add how to respond to 401 in integration test

### DIFF
--- a/.changeset/hip-rules-arrive.md
+++ b/.changeset/hip-rules-arrive.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+readme: add how to respond to 401 in integration test

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Run the test:
 pnpm test test/fixtures/00-server-build/index.test.js
 ```
 
+> **NOTE:** When you receive a `401` status code while fetching the deployment, disable the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) of the deployment.
+
 #### @vercel/nft
 
 Some of the Builders use `@vercel/nft` to tree-shake files before deployment. If you suspect an error with this tree-shaking mechanism, you can create the following script in your project:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Run the test:
 pnpm test test/fixtures/00-server-build/index.test.js
 ```
 
-> **NOTE:** When you receive a `401` status code while fetching the deployment, disable the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) of the deployment.
+> **NOTE:** If you receive a `401` status code while fetching the deployment, you need to disable [Deployment Protection](https://vercel.com/docs/security/deployment-protection) on the project.
 
 #### @vercel/nft
 


### PR DESCRIPTION
### Why?

Received `401` during the probes test on the integration test. The solution was to disable the Deployment Protection, but was not documented.

![CleanShot 2025-01-23 at 19 05 57@2x](https://github.com/user-attachments/assets/e87535a7-d301-48bb-b88e-575d4c0fbc3b)
