### PR TITLE
[python] remove `VERCEL_IPC_FD` usage

### DIFF
--- a/.changeset/green-doors-bake.md
+++ b/.changeset/green-doors-bake.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Remove support for VERCEL_IPC_FD

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -27,7 +27,7 @@ def format_headers(headers, decode=False):
         keyToList[key].append(value)
     return keyToList
 
-if 'VERCEL_IPC_FD' in os.environ or 'VERCEL_IPC_PATH' in os.environ:
+if 'VERCEL_IPC_PATH' in os.environ:
     from http.server import ThreadingHTTPServer
     import http
     import time
@@ -37,13 +37,8 @@ if 'VERCEL_IPC_FD' in os.environ or 'VERCEL_IPC_PATH' in os.environ:
     import logging
 
     start_time = time.time()
-
-    if 'VERCEL_IPC_FD' in os.environ:
-        ipc_fd = int(os.getenv("VERCEL_IPC_FD", ""))
-        sock = socket.socket(fileno=ipc_fd)
-    else:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.connect(os.getenv("VERCEL_IPC_PATH", ""))
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(os.getenv("VERCEL_IPC_PATH", ""))
 
     send_message = lambda message: sock.sendall((json.dumps(message) + '\0').encode())
     storage = contextvars.ContextVar('storage', default=None)


### PR DESCRIPTION
In https://github.com/vercel/vercel/pull/12800, we added support for both `VERCEL_IPC_FD` and `VERCEL_IPC_PATH` while migrating from the former to the latter. The migration has now been completed, so we can remove the old `VERCEL_IPC_FD` logic to always use `VERCEL_IPC_PATH`.