### PR TITLE
[functions] Publish release after #12758

### DIFF
--- a/.changeset/plenty-brooms-do.md
+++ b/.changeset/plenty-brooms-do.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Add middleware-related helper functions


### PR DESCRIPTION
The changes in #12758 moved code from `@vercel/edge` to `@vercel/functions`, however the changeset did not reference the functions package so the moved code was not published in a release.

This PR adds a changeset to trigger a publish of that moved code.