### PR TITLE
Remove "examples" changesets

### DIFF
--- a/.changeset/fair-falcons-own.md
+++ b/.changeset/fair-falcons-own.md
@@ -1,5 +1,0 @@
----
-"examples": major
----
-
-[examples] Remove scully

--- a/.changeset/gorgeous-countries-brush.md
+++ b/.changeset/gorgeous-countries-brush.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Remove "examples" changesets

--- a/.changeset/popular-flies-clap.md
+++ b/.changeset/popular-flies-clap.md
@@ -1,5 +1,0 @@
----
-"examples": major
----
-
-[examples] Remove Saber

--- a/.changeset/quiet-points-invite.md
+++ b/.changeset/quiet-points-invite.md
@@ -1,5 +1,0 @@
----
-"examples": patch
----
-
-[examples] Update Blitz to 2.0

--- a/.changeset/selfish-books-do.md
+++ b/.changeset/selfish-books-do.md
@@ -1,5 +1,0 @@
----
-"examples": major
----
-
-[examples] removed version-specific pinning for examples


### PR DESCRIPTION
The "examples" package is marked as `private: true` in package.json, and including a changeset for it causes publish to fail.