### PR TITLE
[react-router] Publish as "public" on npm

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -62,5 +62,8 @@
     "isbot": "5",
     "react": ">=18",
     "react-dom": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
To fix error from https://github.com/vercel/vercel/actions/runs/13023023388/job/36327301788:

> npm ERR! code EUSAGE
> npm ERR! Can't generate provenance for new or private package, you must set `access` to public.

__Note:__ Intentionally not adding a changeset here so that changesets publishes upon merge.