### PR TITLE
[routing-utils] Update routes schema for new routes limit

### DIFF
--- a/.changeset/tiny-radios-tie.md
+++ b/.changeset/tiny-radios-tie.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+Update routes schema for new limit of 2048

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -227,7 +227,7 @@ describe('validateConfig', () => {
       ],
     });
     expect(error!.message).toEqual(
-      'Invalid vercel.json - `headers[1].headers` should NOT have more than 2048 items.'
+      'Invalid vercel.json - `headers[1].headers` should NOT have more than 1024 items.'
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#headers'

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -203,7 +203,7 @@ describe('validateConfig', () => {
       })),
     });
     expect(error!.message).toEqual(
-      'Invalid vercel.json - `redirects` should NOT have more than 1024 items.'
+      'Invalid vercel.json - `redirects` should NOT have more than 2048 items.'
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#redirects'
@@ -227,7 +227,7 @@ describe('validateConfig', () => {
       ],
     });
     expect(error!.message).toEqual(
-      'Invalid vercel.json - `headers[1].headers` should NOT have more than 1024 items.'
+      'Invalid vercel.json - `headers[1].headers` should NOT have more than 2048 items.'
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#headers'

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -55,7 +55,7 @@ export const hasSchema = {
  */
 export const routesSchema = {
   type: 'array',
-  maxItems: 1024,
+  maxItems: 2048,
   deprecated: true,
   description:
     'A list of routes objects used to rewrite paths to point towards other internal or external paths',
@@ -186,7 +186,7 @@ export const routesSchema = {
 
 export const rewritesSchema = {
   type: 'array',
-  maxItems: 1024,
+  maxItems: 2048,
   description: 'A list of rewrite definitions.',
   items: {
     type: 'object',
@@ -221,7 +221,7 @@ export const rewritesSchema = {
 export const redirectsSchema = {
   title: 'Redirects',
   type: 'array',
-  maxItems: 1024,
+  maxItems: 2048,
   description: 'A list of redirect definitions.',
   items: {
     type: 'object',
@@ -261,7 +261,7 @@ export const redirectsSchema = {
 
 export const headersSchema = {
   type: 'array',
-  maxItems: 1024,
+  maxItems: 2048,
   description: 'A list of header definitions.',
   items: {
     type: 'object',

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -225,7 +225,7 @@ describe('normalizeRoutes', () => {
     );
   });
 
-  test('fails if over 1024 routes', () => {
+  test('fails if over 2048 routes', () => {
     assertError('string', [
       {
         dataPath: '',
@@ -238,16 +238,16 @@ describe('normalizeRoutes', () => {
       },
     ]);
 
-    const arr = new Array(1026);
+    const arr = new Array(2049);
     arr.fill(true);
 
     assertError(arr, [
       {
         dataPath: '',
         keyword: 'maxItems',
-        message: 'should NOT have more than 1024 items',
+        message: 'should NOT have more than 2048 items',
         params: {
-          limit: '1024',
+          limit: '2048',
         },
         schemaPath: '#/maxItems',
       },


### PR DESCRIPTION
We updated our default limit to 2048 and have updated documentation so this schema should be updated as well to match. 