### PR TITLE
[remix] extract sourceSearchValue into FrameworkSettings

### DIFF
--- a/.changeset/dull-rules-cross.md
+++ b/.changeset/dull-rules-cross.md
@@ -1,0 +1,5 @@
+---
+"@vercel/remix-builder": patch
+---
+
+[remix] extract sourceSearchValue into FrameworkSettings

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -98,6 +98,7 @@ interface FrameworkSettings {
   buildCommand: string;
   buildResultFilePath: string;
   slug: string;
+  sourceSearchValue: string;
 
   createRenderFunction: (
     options: RenderFunctionOptions
@@ -109,6 +110,7 @@ const REMIX_FRAMEWORK_SETTINGS: FrameworkSettings = {
   buildCommand: 'remix build',
   buildResultFilePath: '.vercel/remix-build-result.json',
   slug: 'remix',
+  sourceSearchValue: '@remix-run/dev/server-build',
 
   createRenderFunction({
     nodeVersion,
@@ -147,6 +149,7 @@ const REACT_ROUTER_FRAMEWORK_SETTINGS: FrameworkSettings = {
   buildCommand: 'react-router build',
   buildResultFilePath: '.vercel/react-router-build-result.json',
   slug: 'react-router',
+  sourceSearchValue: 'ENTRYPOINT_PLACEHOLDER',
 
   createRenderFunction({
     nodeVersion,
@@ -488,7 +491,7 @@ async function createRenderReactRouterFunction(
     await fs.writeFile(
       handlerPath,
       reactRouterServerSrc.replace(
-        'ENTRYPOINT_PLACEHOLDER',
+        REACT_ROUTER_FRAMEWORK_SETTINGS.sourceSearchValue,
         `./${baseServerBuildPath}.js`
       )
     );
@@ -569,7 +572,7 @@ async function createRenderNodeFunction(
     await fs.writeFile(
       handlerPath,
       nodeServerSrc.replace(
-        '@remix-run/dev/server-build',
+        REMIX_FRAMEWORK_SETTINGS.sourceSearchValue,
         `./${baseServerBuildPath}.js`
       )
     );
@@ -626,7 +629,7 @@ async function createRenderEdgeFunction(
     await fs.writeFile(
       handlerPath,
       edgeServerSrc.replace(
-        '@remix-run/dev/server-build',
+        REMIX_FRAMEWORK_SETTINGS.sourceSearchValue,
         `./${baseServerBuildPath}.js`
       )
     );


### PR DESCRIPTION
The `searchValue` used for the source seems to be the same across both edge and node functions, so this PR extracts into the FrameworkSettings.