### PR TITLE
[tests] stop pinning gridsome node version in fixture

### DIFF
--- a/.changeset/rotten-pandas-rush.md
+++ b/.changeset/rotten-pandas-rush.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] stop pinning gridsome node version in fixture

--- a/examples/gridsome/package.json
+++ b/examples/gridsome/package.json
@@ -9,8 +9,5 @@
   },
   "dependencies": {
     "gridsome": "0.7.23"
-  },
-  "engines": {
-    "node": "<17"
   }
 }


### PR DESCRIPTION
This made it in because we're missing some required check on CI.