### PR TITLE
[react-router] Ensure proper files are published

### DIFF
--- a/.changeset/lemon-bottles-jump.md
+++ b/.changeset/lemon-bottles-jump.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': patch
+---
+
+Ensure proper files are published

--- a/packages/react-router/turbo.json
+++ b/packages/react-router/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": ["*.js", "*.d.ts", "edge/*.js", "edge/*.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
A Turbo cache hit during publish caused the build command to be skipped during publish, and thus the compiled `*.js` and `*.d.ts` files are missing in the `@vercel/react-router@1.0.0` release.