### PR TITLE
[react-router] Fix "entry.server" Edge runtime condition

### DIFF
--- a/.changeset/seven-owls-perform.md
+++ b/.changeset/seven-owls-perform.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': patch
+---
+
+Fix "entry.server" Edge runtime condition

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -12,7 +12,7 @@
     },
     "./entry.server": {
       "types": "./entry.server.d.ts",
-      "edge": "./edge/entry.server.js",
+      "edge-light": "./edge/entry.server.js",
       "default": "./entry.server.js"
     },
     "./vite": {


### PR DESCRIPTION
The proper name is "edge-light", not "edge".