### PR TITLE
[next]: ensure locale prefixed dynamic routes come before non-prefixed

### DIFF
--- a/.changeset/fluffy-doors-knock.md
+++ b/.changeset/fluffy-doors-knock.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+ensure non-locale prefixed route variants come after more specific ones

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -585,13 +585,6 @@ export function localizeDynamicRoutes(
       const isLocalePrefixed =
         isFallback || isBlocking || isAutoExport || isServerMode;
 
-      route.src = route.src.replace(
-        '^',
-        `^${dynamicPrefix ? `${dynamicPrefix}[/]?` : '[/]?'}(?${
-          isLocalePrefixed ? '<nextLocale>' : ':'
-        }${i18n.locales.map(locale => escapeStringRegexp(locale)).join('|')})?`
-      );
-
       // when locale detection is disabled we don't add the default locale
       // to the path while resolving routes so we need to be able to match
       // without it being present
@@ -607,6 +600,13 @@ export function localizeDynamicRoutes(
         );
         nonLocalePrefixedRoutes.push(nonLocalePrefixedRoute);
       }
+
+      route.src = route.src.replace(
+        '^',
+        `^${dynamicPrefix ? `${dynamicPrefix}[/]?` : '[/]?'}(?${
+          isLocalePrefixed ? '<nextLocale>' : ':'
+        }${i18n.locales.map(locale => escapeStringRegexp(locale)).join('|')})?`
+      );
 
       if (
         isLocalePrefixed &&

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -605,7 +605,11 @@ export function localizeDynamicRoutes(
         '^',
         `^${dynamicPrefix ? `${dynamicPrefix}[/]?` : '[/]?'}(?${
           isLocalePrefixed ? '<nextLocale>' : ':'
-        }${i18n.locales.map(locale => escapeStringRegexp(locale)).join('|')})?`
+        }${i18n.locales.map(locale => escapeStringRegexp(locale)).join('|')})${
+          // the locale is not optional on this path with the skip default
+          // locale rewrite flag otherwise can cause double slash in dest
+          skipDefaultLocaleRewrite ? '' : '?'
+        }`
       );
 
       if (


### PR DESCRIPTION
With the experimental flag added in #12916 we added handling to add non-localized redirects for dynamic routes, because we moved the defaultLocale handling to the `handle: miss` case. However, we need to add these redirects after the less-specific localized routes so that those ones are matched first before the fallback case. 