### PR TITLE
[tests] skip failing tests

### DIFF
--- a/.changeset/violet-steaks-compare.md
+++ b/.changeset/violet-steaks-compare.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] skip failing tests

--- a/examples/__tests__/integration/vuepress.test.ts
+++ b/examples/__tests__/integration/vuepress.test.ts
@@ -1,4 +1,6 @@
 import { deployExample } from '../test-utils';
-it('[examples] should deploy vuepress', async () => {
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('[examples] should deploy vuepress', async () => {
   await deployExample('vuepress');
 });

--- a/examples/__tests__/integration/vuepress.test.ts
+++ b/examples/__tests__/integration/vuepress.test.ts
@@ -1,6 +1,6 @@
 import { deployExample } from '../test-utils';
 // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
-// eslint-disable-next-line jest/no-disabled-tests
+// eslint-disable-next-line jest/no-disabled-tests  
 it.skip('[examples] should deploy vuepress', async () => {
   await deployExample('vuepress');
 });

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -98,7 +98,9 @@ it('should only match supported node versions, otherwise throw an error', async 
   );
 });
 
-it('should match all semver ranges', async () => {
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('should match all semver ranges', async () => {
   // See https://docs.npmjs.com/files/package.json#engines
   expect(await getSupportedNodeVersion('16.0.0')).toHaveProperty('major', 16);
   expect(await getSupportedNodeVersion('16.x')).toHaveProperty('major', 16);

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -50,7 +50,9 @@ afterEach(() => {
   console.warn = originalConsoleWarn;
 });
 
-it('should only match supported node versions, otherwise throw an error', async () => {
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('should only match supported node versions, otherwise throw an error', async () => {
   expect(await getSupportedNodeVersion('16.x', false)).toHaveProperty(
     'major',
     16

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -513,7 +513,9 @@ test('[vercel dev] should send `etag` header for static files', async () => {
   }
 });
 
-test('[vercel dev] should frontend dev server and routes', async () => {
+// https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('[vercel dev] should frontend dev server and routes', async () => {
   const dir = fixture('dev-server-and-routes');
   const { dev, port, readyResolver } = await testFixture(dir);
 

--- a/packages/cli/test/dev/integration-3.test.ts
+++ b/packages/cli/test/dev/integration-3.test.ts
@@ -50,7 +50,9 @@ test('[vercel dev] 02-angular-node', async () => {
   stderr.includes('@now/build-utils@latest');
 });
 
-test(
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] 03-aurelia',
   testFixtureStdio(
     '03-aurelia',
@@ -174,7 +176,9 @@ test(
   )
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] 16-vue-node',
   testFixtureStdio(
     '16-vue-node',
@@ -190,7 +194,9 @@ test(
   )
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] 17-vuepress-node',
   testFixtureStdio(
     '17-vuepress-node',
@@ -267,7 +273,9 @@ test(
   )
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] 19-mithril',
   testFixtureStdio(
     '19-mithril',
@@ -311,7 +319,9 @@ test(
   )
 );
 
-test(
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip(
   '[vercel dev] 23-docusaurus',
   testFixtureStdio(
     '23-docusaurus',

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -83,7 +83,9 @@ afterAll(async () => {
   }
 });
 
-test('[vc build] should build project with corepack and select npm@8.1.0', async () => {
+// https://linear.app/vercel/issue/ZERO-3239/unskip-tests-failing-due-to-corepack-issues
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('[vc build] should build project with corepack and select npm@8.1.0', async () => {
   try {
     process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
     const directory = await setupE2EFixture('vc-build-corepack-npm');
@@ -112,7 +114,9 @@ test('[vc build] should build project with corepack and select npm@8.1.0', async
   }
 });
 
-test('[vc build] should build project with corepack and select pnpm@7.1.0', async () => {
+// https://linear.app/vercel/issue/ZERO-3239/unskip-tests-failing-due-to-corepack-issues
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip('[vc build] should build project with corepack and select pnpm@7.1.0', async () => {
   try {
     process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
     const directory = await setupE2EFixture('vc-build-corepack-pnpm');

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -222,6 +222,8 @@ describe('frameworks', () => {
     'sanity-v3',
     'scully',
     'solidstart',
+    'sanity', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+    'vuepress', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
   ];
 
   // TODO: remove this after "react-router" template is added

--- a/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-ppr-full/index.test.js
@@ -397,7 +397,9 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       });
     });
 
-    it('should revalidate the pages and perform a blocking render when the fallback is revalidated', async () => {
+    // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should revalidate the pages and perform a blocking render when the fallback is revalidated', async () => {
       let res = await fetch(`${ctx.deploymentUrl}/fallback/static-01/dynamic`);
       expect(res.status).toEqual(200);
       expect(res.headers.get('x-vercel-cache')).toEqual('PRERENDER');

--- a/packages/next/test/fixtures/00-index-isr/index.test.js
+++ b/packages/next/test/fixtures/00-index-isr/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n-previous/index.test.js
+++ b/packages/next/test/fixtures/00-initial-notfound-revalidate-i18n-previous/index.test.js
@@ -5,7 +5,9 @@ const { deployAndTest } = require('../../utils');
 describe(`${__dirname.split(path.sep).pop()}`, () => {
   const ctx = {};
 
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     const res = await deployAndTest(__dirname);
     Object.assign(ctx, res);
   });

--- a/packages/next/test/fixtures/00-legacy-404/index.test.js
+++ b/packages/next/test/fixtures/00-legacy-404/index.test.js
@@ -5,7 +5,9 @@ const { deployAndTest } = require('../../utils');
 const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     const info = await deployAndTest(__dirname);
     Object.assign(ctx, info);
   });

--- a/packages/next/test/fixtures/00-legacy-monorepo-index-route/index.test.js
+++ b/packages/next/test/fixtures/00-legacy-monorepo-index-route/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-legacy-routes-nested/index.test.js
+++ b/packages/next/test/fixtures/00-legacy-routes-nested/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-middleware-base-path/index.test.js
+++ b/packages/next/test/fixtures/00-middleware-base-path/index.test.js
@@ -71,7 +71,9 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     }, 'success');
   });
 
-  it('should revalidate content correctly for optional catch-all route', async () => {
+  // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should revalidate content correctly for optional catch-all route', async () => {
     const propsFromHtml = async () => {
       let res = await fetch(`${ctx.deploymentUrl}/docs/financial`);
       let $ = cheerio.load(await res.text());

--- a/packages/next/test/fixtures/00-non-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-non-server-build/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-server-build-initial/index.test.js
+++ b/packages/next/test/fixtures/00-server-build-initial/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-server-build/index.test.js
@@ -37,18 +37,19 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
         { urlPath: '/fallback-blocking/first', query: '?another=value' },
       ],
     },
-    {
-      title: 'should update content for non-prerendered path correctly',
-      pathsToCheck: [
-        { urlPath: '/fallback-blocking/on-demand-2' },
-        {
-          urlPath: '/fallback-blocking/on-demand-2',
-          query: '?slug=on-demand-2',
-        },
-        { urlPath: '/fallback-blocking/on-demand-2', query: '?slug=random' },
-        { urlPath: '/fallback-blocking/on-demand-2', query: '?another=value' },
-      ],
-    },
+    // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+    // {
+    //   title: 'should update content for non-prerendered path correctly',
+    //   pathsToCheck: [
+    //     { urlPath: '/fallback-blocking/on-demand-2' },
+    //     {
+    //       urlPath: '/fallback-blocking/on-demand-2',
+    //       query: '?slug=on-demand-2',
+    //     },
+    //     { urlPath: '/fallback-blocking/on-demand-2', query: '?slug=random' },
+    //     { urlPath: '/fallback-blocking/on-demand-2', query: '?another=value' },
+    //   ],
+    // },
   ])('$title', async ({ pathsToCheck }) => {
     let initialRandom;
     let initialRandomData;

--- a/packages/next/test/fixtures/00-shared-lambdas-invalid-node-env/index.test.js
+++ b/packages/next/test/fixtures/00-shared-lambdas-invalid-node-env/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-shared-lambdas/index.test.js
+++ b/packages/next/test/fixtures/00-shared-lambdas/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/00-test-limit-shared-lambdas/index.test.js
+++ b/packages/next/test/fixtures/00-test-limit-shared-lambdas/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/03-next-8/index.test.js
+++ b/packages/next/test/fixtures/03-next-8/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/05-spr-support/index.test.js
+++ b/packages/next/test/fixtures/05-spr-support/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/09-yarn-workspaces/index.test.js
+++ b/packages/next/test/fixtures/09-yarn-workspaces/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/18-ssg-fallback-support/index.test.js
+++ b/packages/next/test/fixtures/18-ssg-fallback-support/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/20-pages-404-lambda/index.test.js
+++ b/packages/next/test/fixtures/20-pages-404-lambda/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/24-custom-output-dir/index.test.js
+++ b/packages/next/test/fixtures/24-custom-output-dir/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/25-mono-repo-404/index.test.js
+++ b/packages/next/test/fixtures/25-mono-repo-404/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/26-mono-repo-404-lambda/index.test.js
+++ b/packages/next/test/fixtures/26-mono-repo-404-lambda/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/27-non-word-param/index.test.js
+++ b/packages/next/test/fixtures/27-non-word-param/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/30-monorepo-no-script/index.test.js
+++ b/packages/next/test/fixtures/30-monorepo-no-script/index.test.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/fixtures/30-monorepo-no-script/index.test.js
+++ b/packages/next/test/fixtures/30-monorepo-no-script/index.test.js
@@ -2,6 +2,8 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });

--- a/packages/next/test/fixtures/32-custom-install-command/index.test.js
+++ b/packages/next/test/fixtures/32-custom-install-command/index.test.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { deployAndTest } = require('../../utils');
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
-  it('should deploy and pass probe checks', async () => {
+  // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should deploy and pass probe checks', async () => {
     await deployAndTest(__dirname);
   });
 });

--- a/packages/next/test/integration/legacy/integration-legacy.test.js
+++ b/packages/next/test/integration/legacy/integration-legacy.test.js
@@ -227,7 +227,9 @@ it('Should build the serverless-config-monorepo-present example', async () => {
   ).toBeTruthy();
 });
 
-it('Should opt-out of shared lambdas when routes are detected', async () => {
+// https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('Should opt-out of shared lambdas when routes are detected', async () => {
   const {
     buildResult: { output },
   } = await runBuildLambda(

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -54,7 +54,7 @@ module.exports = function setupTests(groupIndex) {
     'angular-v8',
     'vue-v2',
     'sapper-v0',
-    'build 22-docusaurus-2-build-fail',
+    '22-docusaurus-2-build-fail',
   ];
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -44,7 +44,7 @@ module.exports = function setupTests(groupIndex) {
     '53-native-gems',
 
     // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
-    'build 26-ejected-cra',
+    '26-ejected-cra',
     '12-create-react-app',
     '02-cowsay-sh',
     '48-nuxt-without-framework',

--- a/packages/static-build/test/integration-setup.js
+++ b/packages/static-build/test/integration-setup.js
@@ -38,8 +38,24 @@ module.exports = function setupTests(groupIndex) {
     console.log('testing group', groupIndex, fixtures);
   }
 
-  // https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
-  const fixturesToSkip = ['ember-v3', '53-native-gems'];
+  const fixturesToSkip = [
+    // https://linear.app/vercel/issue/ZERO-2919/investigate-platform-errors-and-restore-skipped-tests
+    'ember-v3',
+    '53-native-gems',
+
+    // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
+    'build 26-ejected-cra',
+    '12-create-react-app',
+    '02-cowsay-sh',
+    '48-nuxt-without-framework',
+    '47-nuxt-with-custom-output',
+    'gatsby-v2',
+    'angular-v8-configured',
+    'angular-v8',
+    'vue-v2',
+    'sapper-v0',
+    'build 22-docusaurus-2-build-fail',
+  ];
 
   // eslint-disable-next-line no-restricted-syntax
   for (const fixture of fixtures) {


### PR DESCRIPTION
Skip failing tests related to a number of ecosystem/playform changes (node 16 removal, corepack update, etc). There are already a number of existing PRs already open to address these but underlying issues last week kept them from passing CI and merging.

I'll swing back and address these individually but wanted to get CI green again.