### PR TITLE
[frameworks] Enable "demo" property for "react-router" framework

### DIFF
--- a/.changeset/moody-panthers-hope.md
+++ b/.changeset/moody-panthers-hope.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Enable "demo" property for "react-router" framework

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -241,14 +241,13 @@ export const frameworks = [
   {
     name: 'React Router',
     slug: 'react-router',
-    // TODO: uncomment this after "react-router" template is added
-    //demo: 'https://react-router-v7-template.vercel.app',
+    demo: 'https://react-router-v7-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/react-router.svg',
     darkModeLogo:
       'https://api-frameworks.vercel.sh/framework-logos/react-router-dark.svg',
     tagline: 'Declarative routing for React',
     description:
-      'A user‑obsessed, standards‑focused, multi‑strategy router you can deploy anywhere.',
+      'A user-obsessed, standards-focused, multi-strategy router you can deploy anywhere.',
     website: 'https://reactrouter.com',
     sort: 7,
     supersedes: ['hydrogen', 'vite'],

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -226,9 +226,6 @@ describe('frameworks', () => {
     'vuepress', // https://linear.app/vercel/issue/ZERO-3238/unskip-tests-failing-due-to-node-16-removal
   ];
 
-  // TODO: remove this after "react-router" template is added
-  skipExamples.push('react-router');
-
   it('ensure there is an example for every framework', async () => {
     const root = join(__dirname, '..', '..', '..');
     const getExample = (name: string) => join(root, 'examples', name);


### PR DESCRIPTION
Re-enables a couple tests that were disabled before the ["react-router" template was added](https://github.com/vercel/vercel/pull/12913).