### PR TITLE
Remove runners and commands for node 16 specific tests

### DIFF
--- a/.changeset/unlucky-elephants-rescue.md
+++ b/.changeset/unlucky-elephants-rescue.md
@@ -1,0 +1,4 @@
+---
+---
+
+Remove runners and commands for node 16 specific tests

--- a/turbo.json
+++ b/turbo.json
@@ -48,10 +48,6 @@
       "dependsOn": ["build"],
       "outputMode": "new-only"
     },
-    "test-next-local-legacy": {
-      "dependsOn": ["build"],
-      "outputMode": "new-only"
-    },
     "test": {
       "dependsOn": ["build"],
       "outputMode": "new-only"

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -56,17 +56,6 @@ const runnersMap = new Map([
     },
   ],
   [
-    'test-next-local-legacy',
-    {
-      min: 1,
-      max: 5,
-      runners: ['ubuntu-latest'],
-
-      testScript: 'test',
-      nodeVersions: ['16'],
-    },
-  ],
-  [
     'test-dev',
     {
       min: 1,


### PR DESCRIPTION
Just updating monorepo related tasks around node 16. Removing the CI entry for `test-next-local-legacy` and the matching turbo entry. This is unused elsewhere.

I've left the command in the next builders's [package.json](https://github.com/vercel/vercel/blob/d144571a901a759984eaf6591f8af73cc609f6f0/packages/next/package.json#L12), the [directory it invokes](https://github.com/vercel/vercel/tree/d144571a901a759984eaf6591f8af73cc609f6f0/packages/next/test/integration/legacy), and any fixtures it references. Some fixtures are referenced by tests we have kept.

I'll let the Next team know if they'd like to come tidy those up.