### PR TITLE
[next]: skip vary header for Next.js >= 13.4.6

### DIFF
--- a/.changeset/late-lizards-brake.md
+++ b/.changeset/late-lizards-brake.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+bug: do not emit vary header in next.js >=13.4.6

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2272,6 +2272,9 @@ export const build: BuildV2 = async buildOptions => {
       canUsePreviewMode,
       isAppPPREnabled: false,
       isAppClientSegmentCacheEnabled: false,
+      // Relevant Next.js versions will be handled by server-build.ts, which
+      // does correctly configure this variable.
+      shouldSkipVaryHeader: false,
     });
 
     await Promise.all(

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -104,6 +104,14 @@ const BUNDLED_SERVER_NEXT_VERSION = 'v13.5.4';
 const BUNDLED_SERVER_NEXT_PATH =
   'next/dist/compiled/next-server/server.runtime.prod.js';
 
+// Next.js 13.4.6 removed the need for the vary header because it generates a
+// hash of the request headers and adds that to the request URL.
+//
+// See:
+// https://github.com/vercel/next.js/pull/49140
+// https://github.com/vercel/next.js/pull/50970
+const NEXT_VARY_INERT_VERSION = 'v13.4.6';
+
 export async function serverBuild({
   dynamicPages,
   pagesDir,
@@ -216,6 +224,7 @@ export async function serverBuild({
     nextVersion,
     EMPTY_ALLOW_QUERY_FOR_PRERENDERED_VERSION
   );
+  const shouldSkipVaryHeader = semver.gte(nextVersion, NEXT_VARY_INERT_VERSION);
   const projectDir = requiredServerFilesManifest.relativeAppDir
     ? path.join(baseDir, requiredServerFilesManifest.relativeAppDir)
     : requiredServerFilesManifest.appDir || entryPath;
@@ -1526,6 +1535,7 @@ export async function serverBuild({
     isEmptyAllowQueryForPrendered,
     isAppPPREnabled,
     isAppClientSegmentCacheEnabled,
+    shouldSkipVaryHeader,
   });
 
   await Promise.all(
@@ -2226,7 +2236,9 @@ export async function serverBuild({
                       entryDirectory,
                       `/__index${RSC_PREFETCH_SUFFIX}`
                     ),
-                    headers: { vary: rscVaryHeader },
+                    headers: shouldSkipVaryHeader
+                      ? {}
+                      : { vary: rscVaryHeader },
                     continue: true,
                     override: true,
                   },
@@ -2247,7 +2259,9 @@ export async function serverBuild({
                       entryDirectory,
                       `/$1${RSC_PREFETCH_SUFFIX}`
                     ),
-                    headers: { vary: rscVaryHeader },
+                    headers: shouldSkipVaryHeader
+                      ? {}
+                      : { vary: rscVaryHeader },
                     continue: true,
                     override: true,
                   },
@@ -2262,7 +2276,9 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
-              headers: { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader
+                ? {}
+                : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },
@@ -2279,7 +2295,9 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
-              headers: { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader
+                ? {}
+                : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2276,9 +2276,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
-              headers: shouldSkipVaryHeader
-                ? {}
-                : { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader ? {} : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },
@@ -2295,9 +2293,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
-              headers: shouldSkipVaryHeader
-                ? {}
-                : { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader ? {} : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2237,7 +2237,7 @@ export async function serverBuild({
                       `/__index${RSC_PREFETCH_SUFFIX}`
                     ),
                     headers: shouldSkipVaryHeader
-                      ? {}
+                      ? undefined
                       : { vary: rscVaryHeader },
                     continue: true,
                     override: true,
@@ -2260,7 +2260,7 @@ export async function serverBuild({
                       `/$1${RSC_PREFETCH_SUFFIX}`
                     ),
                     headers: shouldSkipVaryHeader
-                      ? {}
+                      ? undefined
                       : { vary: rscVaryHeader },
                     continue: true,
                     override: true,
@@ -2276,7 +2276,9 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
-              headers: shouldSkipVaryHeader ? {} : { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader
+                ? undefined
+                : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },
@@ -2293,7 +2295,9 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
-              headers: shouldSkipVaryHeader ? {} : { vary: rscVaryHeader },
+              headers: shouldSkipVaryHeader
+                ? undefined
+                : { vary: rscVaryHeader },
               continue: true,
               override: true,
             },

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2158,6 +2158,7 @@ type OnPrerenderRouteArgs = {
   isEmptyAllowQueryForPrendered?: boolean;
   isAppPPREnabled: boolean;
   isAppClientSegmentCacheEnabled: boolean;
+  shouldSkipVaryHeader: boolean;
 };
 let prerenderGroup = 1;
 
@@ -2196,6 +2197,7 @@ export const onPrerenderRoute =
       isEmptyAllowQueryForPrendered,
       isAppPPREnabled,
       isAppClientSegmentCacheEnabled,
+      shouldSkipVaryHeader,
     } = prerenderRouteArgs;
 
     if (isBlocking && isFallback) {
@@ -2767,7 +2769,9 @@ export const onPrerenderRoute =
           ? {
               initialHeaders: {
                 ...initialHeaders,
-                vary: rscVaryHeader,
+                ...(shouldSkipVaryHeader
+                  ? {}
+                  : { vary: rscVaryHeader }),
               },
             }
           : {}),
@@ -2815,7 +2819,9 @@ export const onPrerenderRoute =
             ? {
                 initialHeaders: {
                   ...initialHeaders,
-                  vary: rscVaryHeader,
+                  ...(shouldSkipVaryHeader
+                    ? {}
+                    : { vary: rscVaryHeader }),
                   ...((outputPathData || outputPathPrefetchData)?.endsWith(
                     '.json'
                   )

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2769,9 +2769,7 @@ export const onPrerenderRoute =
           ? {
               initialHeaders: {
                 ...initialHeaders,
-                ...(shouldSkipVaryHeader
-                  ? {}
-                  : { vary: rscVaryHeader }),
+                ...(shouldSkipVaryHeader ? {} : { vary: rscVaryHeader }),
               },
             }
           : {}),
@@ -2819,9 +2817,7 @@ export const onPrerenderRoute =
             ? {
                 initialHeaders: {
                   ...initialHeaders,
-                  ...(shouldSkipVaryHeader
-                    ? {}
-                    : { vary: rscVaryHeader }),
+                  ...(shouldSkipVaryHeader ? {} : { vary: rscVaryHeader }),
                   ...((outputPathData || outputPathPrefetchData)?.endsWith(
                     '.json'
                   )

--- a/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
@@ -145,8 +145,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        "content-type": "text/x-component"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
@@ -42,7 +42,7 @@
         "Next-Router-Prefetch": 1
       }
     },
-    
+
     {
       "path": "/hello/world/dashboard/hello",
       "status": 200,
@@ -65,17 +65,11 @@
     {
       "path": "/hello/world/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from /ssg"
     },
     {
       "path": "/hello/world/ssg",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -105,17 +99,11 @@
     {
       "path": "/hello/world/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
     },
     {
       "path": "/hello/world/dashboard/deployments/123/settings",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -125,17 +113,11 @@
     {
       "path": "/hello/world/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "catchall"
     },
     {
       "path": "/hello/world/dashboard/deployments/catchall/something",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -145,10 +127,7 @@
     {
       "path": "/hello/world/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard"
     },
     {
       "path": "/hello/world/dashboard",

--- a/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
@@ -21,9 +21,6 @@
       "fetchOptions": {
         "redirect": "manual"
       },
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -45,9 +42,6 @@
       "fetchOptions": {
         "redirect": "manual"
       },
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -68,9 +62,6 @@
       "status": 200,
       "fetchOptions": {
         "redirect": "manual"
-      },
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       },
       "headers": {
         "RSC": "1"

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -267,10 +267,7 @@
     {
       "path": "/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from /ssg"
     },
     {
       "path": "/client-nested",
@@ -297,9 +294,6 @@
     {
       "path": "/ssg",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -343,17 +337,11 @@
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
     },
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -363,17 +351,11 @@
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "catchall"
     },
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -383,10 +365,7 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard"
     },
     {
       "path": "/dashboard",

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -304,7 +304,6 @@
       "path": "/ssg",
       "status": 200,
       "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch",
         "content-type": "text/x-component"
       },
       "headers": {
@@ -383,8 +382,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        "content-type": "text/x-component"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -169,7 +169,6 @@
       "path": "/ssg",
       "status": 200,
       "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch",
         "content-type": "text/x-component"
       },
       "headers": {
@@ -248,8 +247,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        "content-type": "text/x-component"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -145,10 +145,7 @@
     {
       "path": "/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from /ssg"
     },
     {
       "path": "/client-nested",
@@ -162,9 +159,6 @@
     {
       "path": "/ssg",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -208,17 +202,11 @@
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
     },
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -228,17 +216,11 @@
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "catchall"
     },
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -248,10 +230,7 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard"
     },
     {
       "path": "/dashboard",

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -9,10 +9,7 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard"
     },
     {
       "path": "/dashboard",

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -27,8 +27,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        "content-type": "text/x-component"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -45,17 +45,11 @@
     {
       "path": "/ssg/",
       "status": 200,
-      "mustContain": "hello from /ssg",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from /ssg"
     },
     {
       "path": "/ssg/",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -85,17 +79,11 @@
     {
       "path": "/dashboard/deployments/123/settings/",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
     },
     {
       "path": "/dashboard/deployments/123/settings/",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -105,17 +93,11 @@
     {
       "path": "/dashboard/deployments/catchall/something/",
       "status": 200,
-      "mustContain": "catchall",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "catchall"
     },
     {
       "path": "/dashboard/deployments/catchall/something/",
       "status": 200,
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      },
       "headers": {
         "RSC": "1"
       },
@@ -125,10 +107,7 @@
     {
       "path": "/dashboard/",
       "status": 200,
-      "mustContain": "hello from app/dashboard",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "hello from app/dashboard"
     },
     {
       "path": "/dashboard/",

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -125,8 +125,7 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component",
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+        "content-type": "text/x-component"
       }
     },
     {

--- a/packages/next/test/fixtures/01-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/01-app-dir-static/vercel.json
@@ -9,10 +9,7 @@
     {
       "path": "/blog/about",
       "status": 200,
-      "mustContain": "about",
-      "responseHeaders": {
-        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
-      }
+      "mustContain": "about"
     },
     {
       "path": "/404",


### PR DESCRIPTION
### TL;DR
Skip adding the `vary` header for Next.js versions 13.4.6 and above, as it's no longer needed due to request header hashing.

### What changed?
- Added a new version check against Next.js 13.4.6 to determine if the `vary` header should be included
- Introduced `shouldSkipVaryHeader` flag to control header inclusion
- Modified RSC route configurations to conditionally include the `vary` header based on the Next.js version

### How to test?
1. Deploy an application using Next.js version 13.4.6 or higher
2. Verify that RSC routes do not include the `vary` header
3. Deploy an application using Next.js version below 13.4.6
4. Confirm that RSC routes include the appropriate `vary` header

### Why make this change?
Starting from Next.js 13.4.6, the framework generates a hash of request headers and adds it to the request URL, making the `vary` header redundant. This change optimizes the response headers by removing unnecessary information while maintaining compatibility with older Next.js versions.

References:
- https://github.com/vercel/next.js/pull/49140
- https://github.com/vercel/next.js/pull/50970