### PR TITLE
[tests] Remove local tests of corepack behavior

### DIFF
--- a/.changeset/breezy-starfishes-laugh.md
+++ b/.changeset/breezy-starfishes-laugh.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] unskip tests that were failing due to platform issues

--- a/.changeset/purple-donuts-drum.md
+++ b/.changeset/purple-donuts-drum.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] unskip tests that were failing due to platform issues

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { exec, execCli } from './helpers/exec';
+import { execCli } from './helpers/exec';
 import fetch from 'node-fetch';
 import { apiFetch } from './helpers/api-fetch';
 import fs from 'fs-extra';
@@ -80,93 +80,6 @@ afterAll(async () => {
     // eslint-disable-next-line no-console
     console.log('Removing temp dir: ', tmpDir.name);
     tmpDir.removeCallback();
-  }
-});
-
-test('[vc build] should build project with corepack and select npm@8.1.0', async () => {
-  try {
-    process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
-    const directory = await setupE2EFixture('vc-build-corepack-npm');
-    const before = await exec(directory, 'npm', ['--version']);
-    const output = await execCli(binaryPath, ['build'], { cwd: directory });
-
-    expect(output.exitCode, formatOutput(output)).toBe(0);
-    expect(output.stderr).toMatch(/Build Completed/gm);
-    const after = await exec(directory, 'npm', ['--version']);
-    // Ensure global npm didn't change
-    expect(before.stdout).toBe(after.stdout);
-    // Ensure version is correct
-    expect(
-      await fs.readFile(
-        path.join(directory, '.vercel/output/static/index.txt'),
-        'utf8'
-      )
-    ).toBe('8.1.0\n');
-    // Ensure corepack will be cached
-    const contents = fs.readdirSync(
-      path.join(directory, '.vercel/cache/corepack')
-    );
-    expect(contents).toEqual(['home', 'shim']);
-  } finally {
-    delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
-  }
-});
-
-test('[vc build] should build project with corepack and select pnpm@7.1.0', async () => {
-  try {
-    process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
-    const directory = await setupE2EFixture('vc-build-corepack-pnpm');
-    const before = await exec(directory, 'pnpm', ['--version']);
-    const output = await execCli(binaryPath, ['build'], { cwd: directory });
-    expect(output.exitCode, formatOutput(output)).toBe(0);
-    expect(output.stderr).toMatch(/Build Completed/gm);
-    const after = await exec(directory, 'pnpm', ['--version']);
-    // Ensure global pnpm didn't change
-    expect(before.stdout).toBe(after.stdout);
-    // Ensure version is correct
-    expect(
-      await fs.readFile(
-        path.join(directory, '.vercel/output/static/index.txt'),
-        'utf8'
-      )
-    ).toBe('7.1.0\n');
-    // Ensure corepack will be cached
-    const contents = fs.readdirSync(
-      path.join(directory, '.vercel/cache/corepack')
-    );
-    expect(contents).toEqual(['home', 'shim']);
-    expect(output.stdout).toMatch(/Running "pnpm run build"/gm);
-  } finally {
-    delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
-  }
-});
-
-test('[vc build] should build project with corepack and select yarn@2.4.3', async () => {
-  try {
-    process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
-    const directory = await setupE2EFixture('vc-build-corepack-yarn');
-    const before = await exec(directory, 'yarn', ['--version']);
-    const output = await execCli(binaryPath, ['build'], { cwd: directory });
-    expect(output.exitCode, formatOutput(output)).toBe(0);
-    expect(output.stderr).toMatch(/Build Completed/gm);
-    const after = await exec(directory, 'yarn', ['--version']);
-    // Ensure global yarn didn't change
-    expect(before.stdout).toBe(after.stdout);
-    // Ensure version is correct
-    expect(
-      await fs.readFile(
-        path.join(directory, '.vercel/output/static/index.txt'),
-        'utf8'
-      )
-    ).toBe('2.4.3\n');
-    // Ensure corepack will be cached
-    const contents = fs.readdirSync(
-      path.join(directory, '.vercel/cache/corepack')
-    );
-    expect(contents).toEqual(['home', 'shim']);
-    expect(output.stdout).toMatch(/Running "yarn run build"/gm);
-  } finally {
-    delete process.env.ENABLE_EXPERIMENTAL_COREPACK;
   }
 });
 

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -83,9 +83,7 @@ afterAll(async () => {
   }
 });
 
-// https://linear.app/vercel/issue/ZERO-3239/unskip-tests-failing-due-to-corepack-issues
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip('[vc build] should build project with corepack and select npm@8.1.0', async () => {
+test('[vc build] should build project with corepack and select npm@8.1.0', async () => {
   try {
     process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
     const directory = await setupE2EFixture('vc-build-corepack-npm');
@@ -114,9 +112,7 @@ test.skip('[vc build] should build project with corepack and select npm@8.1.0', 
   }
 });
 
-// https://linear.app/vercel/issue/ZERO-3239/unskip-tests-failing-due-to-corepack-issues
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip('[vc build] should build project with corepack and select pnpm@7.1.0', async () => {
+test('[vc build] should build project with corepack and select pnpm@7.1.0', async () => {
   try {
     process.env.ENABLE_EXPERIMENTAL_COREPACK = '1';
     const directory = await setupE2EFixture('vc-build-corepack-pnpm');


### PR DESCRIPTION
NPM changed its singing keys, which corepack uses to verify that the downloaded package manager is legit. This means that corepack has be updated _on our platform_ to install newer packages that were signed with the newer key.

In effect: You could not install `pnpm@10.1.0` or `pnpm@9.15.4` with `corepack@0.30.0` or below briefly on platform before we fixed.

This is _still_ true for tests running in CI and customers using this locally. 

These unit tests covered the general corepack selection behavior when we assumed the corepack that shipped with node would exactly match what we used on platform, which is no longer true.

This behavior now needs to be tested with actual deploys as part of the platform build process, not the CLI itself.