### PR TITLE
[tests] disable flakey prerender test

### DIFF
--- a/.changeset/odd-crabs-act.md
+++ b/.changeset/odd-crabs-act.md
@@ -1,0 +1,4 @@
+---
+---
+
+[tests] disable flakey prerender test

--- a/packages/next/test/fixtures/00-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-server-build/index.test.js
@@ -28,15 +28,16 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
   });
 
   it.each([
-    {
-      title: 'should update content for prerendered path correctly',
-      pathsToCheck: [
-        { urlPath: '/fallback-blocking/first' },
-        { urlPath: '/fallback-blocking/first', query: '?slug=first' },
-        { urlPath: '/fallback-blocking/first', query: '?slug=random' },
-        { urlPath: '/fallback-blocking/first', query: '?another=value' },
-      ],
-    },
+    // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+    // {
+    //   title: 'should update content for prerendered path correctly',
+    //   pathsToCheck: [
+    //     { urlPath: '/fallback-blocking/first' },
+    //     { urlPath: '/fallback-blocking/first', query: '?slug=first' },
+    //     { urlPath: '/fallback-blocking/first', query: '?slug=random' },
+    //     { urlPath: '/fallback-blocking/first', query: '?another=value' },
+    //   ],
+    // },
     // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
     // {
     //   title: 'should update content for non-prerendered path correctly',

--- a/packages/next/test/fixtures/00-server-build/index.test.js
+++ b/packages/next/test/fixtures/00-server-build/index.test.js
@@ -27,122 +27,121 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
     Object.assign(ctx, info);
   });
 
-  it.each([
-    // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
-    // {
-    //   title: 'should update content for prerendered path correctly',
-    //   pathsToCheck: [
-    //     { urlPath: '/fallback-blocking/first' },
-    //     { urlPath: '/fallback-blocking/first', query: '?slug=first' },
-    //     { urlPath: '/fallback-blocking/first', query: '?slug=random' },
-    //     { urlPath: '/fallback-blocking/first', query: '?another=value' },
-    //   ],
-    // },
-    // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
-    // {
-    //   title: 'should update content for non-prerendered path correctly',
-    //   pathsToCheck: [
-    //     { urlPath: '/fallback-blocking/on-demand-2' },
-    //     {
-    //       urlPath: '/fallback-blocking/on-demand-2',
-    //       query: '?slug=on-demand-2',
-    //     },
-    //     { urlPath: '/fallback-blocking/on-demand-2', query: '?slug=random' },
-    //     { urlPath: '/fallback-blocking/on-demand-2', query: '?another=value' },
-    //   ],
-    // },
-  ])('$title', async ({ pathsToCheck }) => {
-    let initialRandom;
-    let initialRandomData;
-    let preRevalidateRandom;
-    let preRevalidateRandomData;
+  // https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures
+  // it.each([
+  //   {
+  //     title: 'should update content for prerendered path correctly',
+  //     pathsToCheck: [
+  //       { urlPath: '/fallback-blocking/first' },
+  //       { urlPath: '/fallback-blocking/first', query: '?slug=first' },
+  //       { urlPath: '/fallback-blocking/first', query: '?slug=random' },
+  //       { urlPath: '/fallback-blocking/first', query: '?another=value' },
+  //     ],
+  //   },
+  //   {
+  //     title: 'should update content for non-prerendered path correctly',
+  //     pathsToCheck: [
+  //       { urlPath: '/fallback-blocking/on-demand-2' },
+  //       {
+  //         urlPath: '/fallback-blocking/on-demand-2',
+  //         query: '?slug=on-demand-2',
+  //       },
+  //       { urlPath: '/fallback-blocking/on-demand-2', query: '?slug=random' },
+  //       { urlPath: '/fallback-blocking/on-demand-2', query: '?another=value' },
+  //     ],
+  //   },
+  // ])('$title', async ({ pathsToCheck }) => {
+  //   let initialRandom;
+  //   let initialRandomData;
+  //   let preRevalidateRandom;
+  //   let preRevalidateRandomData;
 
-    const checkPaths = async pathsToCheck => {
-      for (const { urlPath, query } of pathsToCheck) {
-        console.log('checking', {
-          urlPath,
-          query,
-          initialRandom,
-          preRevalidateRandom,
-        });
+  //   const checkPaths = async pathsToCheck => {
+  //     for (const { urlPath, query } of pathsToCheck) {
+  //       console.log('checking', {
+  //         urlPath,
+  //         query,
+  //         initialRandom,
+  //         preRevalidateRandom,
+  //       });
 
-        if (preRevalidateRandom) {
-          // wait for change as cache may take a little to propagate
-          const initialUrl = `${ctx.deploymentUrl}${urlPath}${query || ''}`;
-          await checkForChange(initialUrl, preRevalidateRandom, async () => {
-            const res = await fetch(initialUrl);
-            const $ = cheerio.load(await res.text());
-            return JSON.parse($('#props').text()).random;
-          });
-        }
+  //       if (preRevalidateRandom) {
+  //         // wait for change as cache may take a little to propagate
+  //         const initialUrl = `${ctx.deploymentUrl}${urlPath}${query || ''}`;
+  //         await checkForChange(initialUrl, preRevalidateRandom, async () => {
+  //           const res = await fetch(initialUrl);
+  //           const $ = cheerio.load(await res.text());
+  //           return JSON.parse($('#props').text()).random;
+  //         });
+  //       }
 
-        const res = await fetch(`${ctx.deploymentUrl}${urlPath}${query || ''}`);
-        expect(res.status).toBe(200);
+  //       const res = await fetch(`${ctx.deploymentUrl}${urlPath}${query || ''}`);
+  //       expect(res.status).toBe(200);
 
-        const $ = await cheerio.load(await res.text());
-        const props = JSON.parse($('#props').text());
+  //       const $ = await cheerio.load(await res.text());
+  //       const props = JSON.parse($('#props').text());
 
-        if (initialRandom) {
-          // for fallback paths the initial value is generated
-          // in the foreground and then a revalidation is kicked off
-          // in the background so the initial value will be replaced
-          if (initialRandom !== props.random && urlPath.includes('on-demand')) {
-            initialRandom = props.random;
-          } else {
-            expect(initialRandom).toBe(props.random);
-          }
-        } else {
-          initialRandom = props.random;
-        }
-        expect(isNaN(initialRandom)).toBe(false);
+  //       if (initialRandom) {
+  //         // for fallback paths the initial value is generated
+  //         // in the foreground and then a revalidation is kicked off
+  //         // in the background so the initial value will be replaced
+  //         if (initialRandom !== props.random && urlPath.includes('on-demand')) {
+  //           initialRandom = props.random;
+  //         } else {
+  //           expect(initialRandom).toBe(props.random);
+  //         }
+  //       } else {
+  //         initialRandom = props.random;
+  //       }
+  //       expect(isNaN(initialRandom)).toBe(false);
 
-        const dataRes = await fetch(
-          `${ctx.deploymentUrl}/_next/data/testing-build-id${urlPath}.json${
-            query || ''
-          }`
-        );
-        expect(dataRes.status).toBe(200);
+  //       const dataRes = await fetch(
+  //         `${ctx.deploymentUrl}/_next/data/testing-build-id${urlPath}.json${
+  //           query || ''
+  //         }`
+  //       );
+  //       expect(dataRes.status).toBe(200);
 
-        const { pageProps: dataProps } = await dataRes.json();
+  //       const { pageProps: dataProps } = await dataRes.json();
 
-        if (initialRandomData) {
-          // for fallback paths the initial value is generated
-          // in the foreground and then a revalidation is kicked off
-          // in the background so the initial value will be replaced
-          if (
-            initialRandomData !== dataProps.random &&
-            urlPath.includes('on-demand-2')
-          ) {
-            initialRandomData = dataProps.random;
-          } else {
-            expect(initialRandomData).toBe(dataProps.random);
-          }
-        } else {
-          initialRandomData = dataProps.random;
-        }
-        expect(isNaN(initialRandomData)).toBe(false);
-      }
-    };
+  //       if (initialRandomData) {
+  //         // for fallback paths the initial value is generated
+  //         // in the foreground and then a revalidation is kicked off
+  //         // in the background so the initial value will be replaced
+  //         if (
+  //           initialRandomData !== dataProps.random &&
+  //           urlPath.includes('on-demand-2')
+  //         ) {
+  //           initialRandomData = dataProps.random;
+  //         } else {
+  //           expect(initialRandomData).toBe(dataProps.random);
+  //         }
+  //       } else {
+  //         initialRandomData = dataProps.random;
+  //       }
+  //       expect(isNaN(initialRandomData)).toBe(false);
+  //     }
+  //   };
 
-    await checkPaths(pathsToCheck);
+  //   await checkPaths(pathsToCheck);
 
-    preRevalidateRandom = initialRandom;
-    preRevalidateRandomData = initialRandomData;
+  //   preRevalidateRandom = initialRandom;
+  //   preRevalidateRandomData = initialRandomData;
 
-    initialRandom = undefined;
-    initialRandomData = undefined;
+  //   initialRandom = undefined;
+  //   initialRandomData = undefined;
 
-    const revalidateRes = await fetch(
-      `${ctx.deploymentUrl}/api/revalidate?urlPath=${pathsToCheck[0].urlPath}`
-    );
-    expect(revalidateRes.status).toBe(200);
-    expect((await revalidateRes.json()).revalidated).toBe(true);
+  //   const revalidateRes = await fetch(
+  //     `${ctx.deploymentUrl}/api/revalidate?urlPath=${pathsToCheck[0].urlPath}`
+  //   );
+  //   expect(revalidateRes.status).toBe(200);
+  //   expect((await revalidateRes.json()).revalidated).toBe(true);
 
-    await checkPaths(pathsToCheck);
+  //   await checkPaths(pathsToCheck);
 
-    expect(preRevalidateRandom).toBeDefined();
-    expect(preRevalidateRandomData).toBeDefined();
-  });
+  //   expect(preRevalidateRandom).toBeDefined();
+  //   expect(preRevalidateRandomData).toBeDefined();
+  // });
 
   it('should revalidate 404 page itself correctly', async () => {
     const initial404 = await fetch(`${ctx.deploymentUrl}/404`);


### PR DESCRIPTION
This prerender test occasionally fails.

Disabling it along with other similar flakey tests. https://linear.app/vercel/issue/ZERO-3240/unskip-random-test-failures

Recent failure example: https://github.com/vercel/vercel/actions/runs/13187072443/job/36811748262?pr=13026#step:8:501