### PR TITLE
[build-utils] remove dead node 16 check

### DIFF
--- a/.changeset/silver-foxes-speak.md
+++ b/.changeset/silver-foxes-speak.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] remove dead node 16 check

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -669,30 +669,12 @@ export async function runNpmInstall(
       turboSupportsCorepackHome,
     });
     let commandArgs: string[];
-    const isPotentiallyBrokenNpm =
-      cliType === 'npm' &&
-      (nodeVersion?.major === 16 ||
-        opts.env.PATH?.includes('/node16/bin-npm7')) &&
-      !args.includes('--legacy-peer-deps') &&
-      spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK !== '1';
 
     if (cliType === 'npm') {
       opts.prettyCommand = 'npm install';
       commandArgs = args
         .filter(a => a !== '--prefer-offline')
         .concat(['install', '--no-audit', '--unsafe-perm']);
-      if (
-        isPotentiallyBrokenNpm &&
-        spawnOpts?.env?.VERCEL_NPM_LEGACY_PEER_DEPS === '1'
-      ) {
-        // Starting in npm@8.6.0, if you ran `npm install --legacy-peer-deps`,
-        // and then later ran `npm install`, it would fail. So the only way
-        // to safely upgrade npm from npm@8.5.0 is to set this flag. The docs
-        // say this flag is not recommended so its is behind a feature flag
-        // so we can remove it in node@18, which can introduce breaking changes.
-        // See https://docs.npmjs.com/cli/v8/using-npm/config#legacy-peer-deps
-        commandArgs.push('--legacy-peer-deps');
-      }
     } else if (cliType === 'pnpm') {
       // PNPM's install command is similar to NPM's but without the audit nonsense
       // @see options https://pnpm.io/cli/install
@@ -713,28 +695,8 @@ export async function runNpmInstall(
       commandArgs.push('--production');
     }
 
-    try {
-      await spawnAsync(cliType, commandArgs, opts);
-    } catch (err: unknown) {
-      const potentialErrorPath = path.join(
-        process.env.HOME || '/',
-        '.npm',
-        'eresolve-report.txt'
-      );
-      if (
-        isPotentiallyBrokenNpm &&
-        !commandArgs.includes('--legacy-peer-deps') &&
-        fs.existsSync(potentialErrorPath)
-      ) {
-        console.warn(
-          'Warning: Retrying "Install Command" with `--legacy-peer-deps` which may accept a potentially broken dependency and slow install time.'
-        );
-        commandArgs.push('--legacy-peer-deps');
-        await spawnAsync(cliType, commandArgs, opts);
-      } else {
-        throw err;
-      }
-    }
+    await spawnAsync(cliType, commandArgs, opts);
+
     debug(`Install complete [${Date.now() - installTime}ms]`);
     return true;
   } finally {

--- a/packages/build-utils/test/unit.run-npm-install.test.ts
+++ b/packages/build-utils/test/unit.run-npm-install.test.ts
@@ -52,29 +52,6 @@ it('should not include peer dependencies when missing VERCEL_NPM_LEGACY_PEER_DEP
   });
 });
 
-it('should include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node16', async () => {
-  const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
-  const meta: Meta = {};
-  const spawnOpts = getTestSpawnOpts({ VERCEL_NPM_LEGACY_PEER_DEPS: '1' });
-  const nodeVersion = getNodeVersion(16);
-  await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
-  expect(spawnMock.mock.calls.length).toBe(1);
-  const args = spawnMock.mock.calls[0];
-  expect(args[0]).toEqual('npm');
-  expect(args[1]).toEqual([
-    'install',
-    '--no-audit',
-    '--unsafe-perm',
-    '--legacy-peer-deps',
-  ]);
-  expect(args[2]).toEqual({
-    cwd: fixture,
-    prettyCommand: 'npm install',
-    stdio: 'inherit',
-    env: expect.any(Object),
-  });
-});
-
 it('should not include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node14 and npm6', async () => {
   const fixture = path.join(__dirname, 'fixtures', '14-npm-6-legacy-peer-deps');
   const meta: Meta = {};

--- a/packages/build-utils/test/unit.run-npm-install.test.ts
+++ b/packages/build-utils/test/unit.run-npm-install.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { runNpmInstall, cloneEnv } from '../src';
+import { runNpmInstall } from '../src';
 import type { Meta } from '../src/types';
 import { afterEach, expect, it, vi } from 'vitest';
 
@@ -24,72 +24,6 @@ vi.mock('cross-spawn', () => {
 afterEach(() => {
   spawnExitCode = 0;
   spawnMock.mockClear();
-});
-
-function getTestSpawnOpts(env: Record<string, string>) {
-  return { env: cloneEnv(process.env, env) };
-}
-
-function getNodeVersion(major: number) {
-  return { major, range: `${major}.x`, runtime: `nodejs${major}.x` };
-}
-
-it('should not include peer dependencies when missing VERCEL_NPM_LEGACY_PEER_DEPS on node16', async () => {
-  const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
-  const meta: Meta = {};
-  const spawnOpts = getTestSpawnOpts({});
-  const nodeVersion = getNodeVersion(16);
-  await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
-  expect(spawnMock.mock.calls.length).toBe(1);
-  const args = spawnMock.mock.calls[0];
-  expect(args[0]).toEqual('npm');
-  expect(args[1]).toEqual(['install', '--no-audit', '--unsafe-perm']);
-  expect(args[2]).toEqual({
-    cwd: fixture,
-    prettyCommand: 'npm install',
-    stdio: 'inherit',
-    env: expect.any(Object),
-  });
-});
-
-it('should not include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node14 and npm6', async () => {
-  const fixture = path.join(__dirname, 'fixtures', '14-npm-6-legacy-peer-deps');
-  const meta: Meta = {};
-  const spawnOpts = getTestSpawnOpts({ VERCEL_NPM_LEGACY_PEER_DEPS: '1' });
-
-  const nodeVersion = getNodeVersion(14);
-  await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
-  expect(spawnMock.mock.calls.length).toBe(1);
-  const args = spawnMock.mock.calls[0];
-  expect(args[0]).toEqual('npm');
-  expect(args[1]).toEqual(['install', '--no-audit', '--unsafe-perm']);
-  expect(args[2]).toEqual({
-    cwd: fixture,
-    prettyCommand: 'npm install',
-    stdio: 'inherit',
-    env: expect.any(Object),
-  });
-});
-
-it('should not include peer dependencies when VERCEL_NPM_LEGACY_PEER_DEPS=1 on node16 with corepack enabled', async () => {
-  const fixture = path.join(__dirname, 'fixtures', '20-npm-7');
-  const meta: Meta = {};
-  const spawnOpts = getTestSpawnOpts({
-    VERCEL_NPM_LEGACY_PEER_DEPS: '1',
-    ENABLE_EXPERIMENTAL_COREPACK: '1',
-  });
-  const nodeVersion = getNodeVersion(16);
-  await runNpmInstall(fixture, [], spawnOpts, meta, nodeVersion);
-  expect(spawnMock.mock.calls.length).toBe(1);
-  const args = spawnMock.mock.calls[0];
-  expect(args[0]).toEqual('npm');
-  expect(args[1]).toEqual(['install', '--no-audit', '--unsafe-perm']);
-  expect(args[2]).toEqual({
-    cwd: fixture,
-    prettyCommand: 'npm install',
-    stdio: 'inherit',
-    env: expect.any(Object),
-  });
 });
 
 it('should only invoke `runNpmInstall()` once per `package.json` file (serial)', async () => {


### PR DESCRIPTION
With Node 16 discontinued, the `isPotentiallyBrokenNpm` check will always fail: 

```ts
const isPotentiallyBrokenNpm =
      cliType === 'npm' &&
      (nodeVersion?.major === 16 ||
        opts.env.PATH?.includes('/node16/bin-npm7')) &&
      !args.includes('--legacy-peer-deps') &&
      spawnOpts?.env?.ENABLE_EXPERIMENTAL_COREPACK !== '1';
```

This PR removes the now dead check, and simplifies code that was previously using that boolean.