### PR TITLE
[build-utils] extract install command specific logic into helper

### DIFF
--- a/.changeset/fuzzy-radios-walk.md
+++ b/.changeset/fuzzy-radios-walk.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] extract package manager specific install command logic into helper

--- a/.changeset/fuzzy-radios-walk.md
+++ b/.changeset/fuzzy-radios-walk.md
@@ -2,4 +2,4 @@
 "@vercel/build-utils": patch
 ---
 
-[build-utils] extract package manager specific install command logic into helper
+[build-utils] extract install command specific logic into helper

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -622,6 +622,8 @@ function getInstallCommandForPackageManager({
     case 'pnpm':
       return {
         prettyCommand: 'pnpm install',
+        // PNPM's install command is similar to NPM's but without the audit nonsense
+        // @see options https://pnpm.io/cli/install
         commandArguments: args
           .filter(a => a !== '--prefer-offline')
           .concat(['install', '--unsafe-perm']),
@@ -629,6 +631,7 @@ function getInstallCommandForPackageManager({
     case 'bun':
       return {
         prettyCommand: 'bun install',
+        // @see options https://bun.sh/docs/cli/install
         commandArguments: ['install', ...args],
       };
     case 'yarn':


### PR DESCRIPTION
This PR does some tidying on the `runNpmInstall` function, extracting some logic into a named helper function for ease of reading.