### PR TITLE
[remix] Leverage project settings to determine framework

### DIFF
--- a/.changeset/slimy-needles-sip.md
+++ b/.changeset/slimy-needles-sip.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Leverage project settings to determine framework

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -23,7 +23,6 @@ import {
   getPackageVersion,
   hasScript,
   logNftWarnings,
-  findConfig,
 } from './utils';
 import type { BuildV2, Files, NodeVersion } from '@vercel/build-utils';
 
@@ -248,20 +247,6 @@ const REACT_ROUTER_FRAMEWORK_SETTINGS: FrameworkSettings = {
   },
 };
 
-function determineFrameworkSettings(workPath: string) {
-  const isReactRouter = findConfig(workPath, 'react-router.config', [
-    '.js',
-    '.ts',
-    '.mjs',
-    '.mts',
-  ]);
-
-  if (isReactRouter) {
-    return REACT_ROUTER_FRAMEWORK_SETTINGS;
-  }
-  return REMIX_FRAMEWORK_SETTINGS;
-}
-
 interface HandlerOptions {
   rootDir: string;
   serverBuildPath: string;
@@ -304,7 +289,10 @@ export const build: BuildV2 = async ({
   const mountpoint = dirname(entrypoint);
   const entrypointFsDirname = join(workPath, mountpoint);
 
-  const frameworkSettings = determineFrameworkSettings(workPath);
+  const frameworkSettings =
+    config.framework === 'react-router'
+      ? REACT_ROUTER_FRAMEWORK_SETTINGS
+      : REMIX_FRAMEWORK_SETTINGS;
 
   // Run "Install Command"
   const nodeVersion = await getNodeVersion(


### PR DESCRIPTION
Turns out that the `react-router.config.*` file is optional, so it's not a complete test to determine if React Router is being used.

The Framework detection logic already considers if the React Router Vite plugin is being used in `vite.config.*`, so we'll have the Remix builder rely on the Framework preset being set, which centralizes the detection logic / removes the (incomplete) duplicated logic.