### PR TITLE
[build-utils] [tidy] extract getInstallCommandForPackageManager to module scope

### DIFF
--- a/.changeset/friendly-chicken-design.md
+++ b/.changeset/friendly-chicken-design.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] extract getInstallCommandForPackageManager to module scope

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -604,6 +604,41 @@ function isSet<T>(v: any): v is Set<T> {
   return v?.constructor?.name === 'Set';
 }
 
+function getInstallCommandForPackageManager(
+  packageManager: CliType,
+  args: string[]
+) {
+  switch (packageManager) {
+    case 'npm':
+      return {
+        prettyCommand: 'npm install',
+        commandArguments: args
+          .filter(a => a !== '--prefer-offline')
+          .concat(['install', '--no-audit', '--unsafe-perm']),
+      };
+    case 'pnpm':
+      return {
+        prettyCommand: 'pnpm install',
+        // PNPM's install command is similar to NPM's but without the audit nonsense
+        // @see options https://pnpm.io/cli/install
+        commandArguments: args
+          .filter(a => a !== '--prefer-offline')
+          .concat(['install', '--unsafe-perm']),
+      };
+    case 'bun':
+      return {
+        prettyCommand: 'bun install',
+        // @see options https://bun.sh/docs/cli/install
+        commandArguments: ['install', ...args],
+      };
+    case 'yarn':
+      return {
+        prettyCommand: 'yarn install',
+        commandArguments: ['install', ...args],
+      };
+  }
+}
+
 async function runInstallCommand({
   packageManager,
   args,
@@ -613,41 +648,6 @@ async function runInstallCommand({
   args: string[];
   opts: SpawnOptionsExtended;
 }) {
-  const getInstallCommandForPackageManager = (
-    packageManager: CliType,
-    args: string[]
-  ) => {
-    switch (packageManager) {
-      case 'npm':
-        return {
-          prettyCommand: 'npm install',
-          commandArguments: args
-            .filter(a => a !== '--prefer-offline')
-            .concat(['install', '--no-audit', '--unsafe-perm']),
-        };
-      case 'pnpm':
-        return {
-          prettyCommand: 'pnpm install',
-          // PNPM's install command is similar to NPM's but without the audit nonsense
-          // @see options https://pnpm.io/cli/install
-          commandArguments: args
-            .filter(a => a !== '--prefer-offline')
-            .concat(['install', '--unsafe-perm']),
-        };
-      case 'bun':
-        return {
-          prettyCommand: 'bun install',
-          // @see options https://bun.sh/docs/cli/install
-          commandArguments: ['install', ...args],
-        };
-      case 'yarn':
-        return {
-          prettyCommand: 'yarn install',
-          commandArguments: ['install', ...args],
-        };
-    }
-  };
-
   const { commandArguments, prettyCommand } =
     getInstallCommandForPackageManager(packageManager, args);
   opts.prettyCommand = prettyCommand;


### PR DESCRIPTION
Pulls `getInstallCommandForPackageManager` into module scope. 

Addresses: https://github.com/vercel/vercel/pull/13049#discussion_r1953520571