### PR TITLE
[build-utils] [tidy] remove redundant sema release

### DIFF
--- a/.changeset/long-bees-invent.md
+++ b/.changeset/long-bees-invent.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+[build-utils] remove redundant sema release

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -688,7 +688,6 @@ export async function runNpmInstall(
       debug(
         `Skipping dependency installation because no package.json was found for ${destPath}`
       );
-      runNpmInstallSema.release();
       return false;
     }
 


### PR DESCRIPTION
`runNpmInstallSema.release()` is already called in the `finally` block, so this call inside the `try` is redundant: 

```ts
} finally {
    runNpmInstallSema.release();
}
```

I spent some time puzzling over why this return had a release and the others didn't and realized it was redundant.