### PR TITLE
[build-utils] [tidy] extract checkIfAlreadyInstalled helper to clarify intent

### DIFF
--- a/.changeset/hungry-meals-itch.md
+++ b/.changeset/hungry-meals-itch.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] extract checkIfAlreadyInstalled helper to clarify intent

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -674,7 +674,7 @@ function checkIfAlreadyInstalled(
   const alreadyInstalled = initializedRunNpmInstallSet.has(packageJsonPath);
 
   initializedRunNpmInstallSet.add(packageJsonPath);
-  return { alreadyInstalled, initializedRunNpmInstallSet };
+  return { alreadyInstalled, runNpmInstallSet: initializedRunNpmInstallSet };
 }
 
 export async function runNpmInstall(

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -671,16 +671,10 @@ function checkIfAlreadyInstalled(
   packageJsonPath: string
 ) {
   const initializedRunNpmInstallSet = initializeSet(runNpmInstallSet);
-
-  if (initializedRunNpmInstallSet.has(packageJsonPath)) {
-    return { alreadyInstalled: true, initializedRunNpmInstallSet };
-  }
+  const alreadyInstalled = initializedRunNpmInstallSet.has(packageJsonPath);
 
   initializedRunNpmInstallSet.add(packageJsonPath);
-  return {
-    alreadyInstalled: false,
-    runNpmInstallSet: initializedRunNpmInstallSet,
-  };
+  return { alreadyInstalled, initializedRunNpmInstallSet };
 }
 
 export async function runNpmInstall(


### PR DESCRIPTION
Prior to this PR, we had logic in `runNpmInstall` that prevented duplicate installs based on the same `packageJsonPath`. The code was a nest of conditionals that made it difficult to follow what it was trying to accomplish. 

This PR extracts the conditional logic into a couple helper functions, and refactors `runNpmInstall` to make it clear what's happening: we're returning early if a default install has already happened for a given packageJsonPath.