### PR TITLE
[build-utils] [tidy] Move `runNpmInstallSema` closer to where it's used

### DIFF
--- a/.changeset/empty-wombats-look.md
+++ b/.changeset/empty-wombats-look.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] Move `runNpmInstallSema` closer to where it's used

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -27,9 +27,6 @@ import { readConfigFile } from './read-config-file';
 import { cloneEnv } from '../clone-env';
 import json5 from 'json5';
 
-// Only allow one `runNpmInstall()` invocation to run concurrently
-const runNpmInstallSema = new Sema(1);
-
 const NO_OVERRIDE = {
   detectedLockfile: undefined,
   detectedPackageManager: undefined,
@@ -658,6 +655,9 @@ async function runInstallCommand({
 
   await spawnAsync(packageManager, commandArguments, opts);
 }
+
+// Only allow one `runNpmInstall()` invocation to run concurrently
+const runNpmInstallSema = new Sema(1);
 
 export async function runNpmInstall(
   destPath: string,


### PR DESCRIPTION
Simple tidy that move the Semaphore that prevents multiple simultaneous `runNpmInstall` invocations closer to where it's used.