### PR TITLE
[build-utils] extract some PackageManager details into typed objects

### DIFF
--- a/.changeset/breezy-cobras-pump.md
+++ b/.changeset/breezy-cobras-pump.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+[build-utils] extract some PackageManager details into typed objects

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -38,6 +38,44 @@ const NO_OVERRIDE = {
 
 export type CliType = 'yarn' | 'npm' | 'pnpm' | 'bun';
 
+interface PackageManager {
+  cliType: CliType;
+  prettyInstallCommand: string;
+  prettyRunCommand: (scriptName: string) => string;
+}
+
+const NPM: PackageManager = {
+  cliType: 'npm',
+  prettyInstallCommand: 'npm install',
+  prettyRunCommand: (scriptName: string) => {
+    return `npm run ${scriptName}`;
+  },
+};
+
+const YARN: PackageManager = {
+  cliType: 'yarn',
+  prettyInstallCommand: 'yarn install',
+  prettyRunCommand: (scriptName: string) => {
+    return `yarn run ${scriptName}`;
+  },
+};
+
+const PNPM: PackageManager = {
+  cliType: 'pnpm',
+  prettyInstallCommand: 'pnpm install',
+  prettyRunCommand: (scriptName: string) => {
+    return `pnpm run ${scriptName}`;
+  },
+};
+
+const BUN: PackageManager = {
+  cliType: 'bun',
+  prettyInstallCommand: 'bun install',
+  prettyRunCommand: (scriptName: string) => {
+    return `bun run ${scriptName}`;
+  },
+};
+
 export interface ScanParentDirsResult {
   /**
    * "yarn", "npm", or "pnpm" depending on the presence of lockfiles.
@@ -611,14 +649,14 @@ function getInstallCommandForPackageManager(
   switch (packageManager) {
     case 'npm':
       return {
-        prettyCommand: 'npm install',
+        prettyCommand: NPM.prettyInstallCommand,
         commandArguments: args
           .filter(a => a !== '--prefer-offline')
           .concat(['install', '--no-audit', '--unsafe-perm']),
       };
     case 'pnpm':
       return {
-        prettyCommand: 'pnpm install',
+        prettyCommand: PNPM.prettyInstallCommand,
         // PNPM's install command is similar to NPM's but without the audit nonsense
         // @see options https://pnpm.io/cli/install
         commandArguments: args
@@ -627,13 +665,13 @@ function getInstallCommandForPackageManager(
       };
     case 'bun':
       return {
-        prettyCommand: 'bun install',
+        prettyCommand: BUN.prettyInstallCommand,
         // @see options https://bun.sh/docs/cli/install
         commandArguments: ['install', ...args],
       };
     case 'yarn':
       return {
-        prettyCommand: 'yarn install',
+        prettyCommand: YARN.prettyInstallCommand,
         commandArguments: ['install', ...args],
       };
   }
@@ -1271,13 +1309,13 @@ export async function runPackageJsonScript(
   };
 
   if (cliType === 'npm') {
-    opts.prettyCommand = `npm run ${scriptName}`;
+    opts.prettyCommand = NPM.prettyRunCommand(scriptName);
   } else if (cliType === 'pnpm') {
-    opts.prettyCommand = `pnpm run ${scriptName}`;
+    opts.prettyCommand = PNPM.prettyRunCommand(scriptName);
   } else if (cliType === 'bun') {
-    opts.prettyCommand = `bun run ${scriptName}`;
+    opts.prettyCommand = BUN.prettyRunCommand(scriptName);
   } else {
-    opts.prettyCommand = `yarn run ${scriptName}`;
+    opts.prettyCommand = YARN.prettyRunCommand(scriptName);
   }
 
   console.log(`Running "${opts.prettyCommand}"`);


### PR DESCRIPTION
There are a lot of instances in `run-user-scripts.ts` that switch on `cliType`. Rather than having a diversity of switch statements, it makes sense to colocate concerns that are specific to a given package manager.

This PR takes a first step towards centralizing some of those concerns, but doesn't yet remove switch statements. 

One concern I have with modeling `PackageManager` is that we export the type `CliType`, so we can't simply change call signatures and return types to use the `PackageManager` type instead of `CliType`.

However, I still think it's worth modeling PackageManager internally to `run-user-scripts` with aspirations to refactor all callers to use this type instead of `CliType`. 

For review, I'm particularly interested in:

- what we think of this approach?
- should the names of the constants be changed (perhaps `NPM_SETTINGS`?)
- anything else that comes to mind