### PR TITLE
[envs] add `VERCEL_TARGET_ENV` to prefixed env vars

### DIFF
--- a/.changeset/fluffy-dolphins-share.md
+++ b/.changeset/fluffy-dolphins-share.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": minor
+---
+
+[envs] add `VERCEL_TARGET_ENV` to prefixed env vars

--- a/packages/build-utils/src/get-prefixed-env-vars.ts
+++ b/packages/build-utils/src/get-prefixed-env-vars.ts
@@ -17,6 +17,7 @@ export function getPrefixedEnvVars({
   const allowed = [
     'VERCEL_URL',
     'VERCEL_ENV',
+    'VERCEL_TARGET_ENV',
     'VERCEL_REGION',
     'VERCEL_BRANCH_URL',
     'VERCEL_PROJECT_PRODUCTION_URL',

--- a/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-prefixed-env-vars.test.ts
@@ -15,6 +15,7 @@ describe('Test `getPrefixedEnvVars()`', () => {
           VERCEL: '1',
           VERCEL_URL: 'example.vercel.sh',
           VERCEL_ENV: 'production',
+          VERCEL_TARGET_ENV: 'production',
           VERCEL_BRANCH_URL: 'example-git-main-acme.vercel.app',
           VERCEL_PROJECT_PRODUCTION_URL: 'example.com',
           USER_ENV_VAR_NOT_VERCEL: 'example.com',
@@ -25,6 +26,7 @@ describe('Test `getPrefixedEnvVars()`', () => {
       want: {
         NEXT_PUBLIC_VERCEL_URL: 'example.vercel.sh',
         NEXT_PUBLIC_VERCEL_ENV: 'production',
+        NEXT_PUBLIC_VERCEL_TARGET_ENV: 'production',
         NEXT_PUBLIC_VERCEL_BRANCH_URL: 'example-git-main-acme.vercel.app',
         NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: 'example.com',
         TURBO_CI_VENDOR_ENV_KEY: 'NEXT_PUBLIC_VERCEL_',


### PR DESCRIPTION
Looks like we're not `NEXT_PUBLIC` prefixing the `VERCEL_TARGET_ENV`, so let's change that