### PR TITLE
[dependencies] Bump `@vercel/build-utils` for new system env

### DIFF
--- a/.changeset/famous-pets-raise.md
+++ b/.changeset/famous-pets-raise.md
@@ -1,0 +1,19 @@
+---
+"vercel": patch
+"@vercel/client": patch
+"@vercel/fs-detectors": patch
+"@vercel/gatsby-plugin-vercel-builder": patch
+"@vercel/go": patch
+"@vercel/hydrogen": patch
+"@vercel/next": patch
+"@vercel/node": patch
+"@vercel/python": patch
+"@vercel/redwood": patch
+"@vercel/remix-builder": patch
+"@vercel/ruby": patch
+"@vercel/static-build": patch
+"examples": patch
+"@vercel-internals/types": patch
+---
+
+[dependencies] Bump `@vercel/build-utils` for new system env

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.1",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/frameworks": "3.6.1"
   },
   "version": null

--- a/internals/types/package.json
+++ b/internals/types/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@types/node": "14.14.31",
     "@vercel-internals/constants": "1.0.4",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/routing-utils": "5.0.4"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "node": ">= 18"
   },
   "dependencies": {
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/fun": "1.1.4",
     "@vercel/go": "3.2.1",
     "@vercel/hydrogen": "1.1.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/error-utils": "2.0.3",
     "@vercel/routing-utils": "5.0.4",
     "async-retry": "1.2.3",

--- a/packages/fs-detectors/package.json
+++ b/packages/fs-detectors/package.json
@@ -37,7 +37,7 @@
     "@types/minimatch": "3.0.5",
     "@types/node": "14.18.33",
     "@types/semver": "7.3.10",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "jest-junit": "16.0.0",
     "typescript": "4.9.5"
   }

--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.25.24",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "esbuild": "0.14.47",
     "etag": "1.8.1",
     "fs-extra": "11.1.0"

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -29,7 +29,7 @@
     "@types/node-fetch": "^2.3.0",
     "@types/tar": "6.1.5",
     "@types/yauzl-promise": "2.1.0",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "async-retry": "1.3.3",
     "execa": "^1.0.0",
     "fs-extra": "^7.0.0",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/jest": "27.5.1",
     "@types/node": "14.18.33",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",
     "jest-junit": "16.0.0"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/next",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "license": "Apache-2.0",
   "main": "./dist/index",
   "homepage": "https://vercel.com/docs/runtimes#official-runtimes/next-js",
@@ -40,7 +40,7 @@
     "@types/semver": "6.0.0",
     "@types/text-table": "0.2.1",
     "@types/webpack-sources": "3.2.0",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/routing-utils": "5.0.4",
     "async-sema": "3.0.1",
     "buffer-crc32": "0.2.13",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -25,7 +25,7 @@
     "@edge-runtime/primitives": "4.1.0",
     "@edge-runtime/vm": "3.2.0",
     "@types/node": "16.18.11",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/error-utils": "2.0.3",
     "@vercel/nft": "0.27.10",
     "@vercel/static-config": "3.0.0",

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "27.4.1",
     "@types/node": "14.18.33",
     "@types/which": "3.0.0",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "cross-env": "7.0.3",
     "execa": "^1.0.0",
     "fs-extra": "11.1.1",

--- a/packages/redwood/package.json
+++ b/packages/redwood/package.json
@@ -26,7 +26,7 @@
     "@types/aws-lambda": "8.10.19",
     "@types/node": "14.18.33",
     "@types/semver": "6.0.0",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/routing-utils": "5.0.4",
     "execa": "3.2.0",
     "fs-extra": "11.1.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "27.5.1",
     "@types/node": "14.18.33",
     "@types/semver": "7.3.13",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "glob": "10.3.16",
     "jest-junit": "16.0.0",
     "semver": "7.5.2",

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -24,7 +24,7 @@
     "@types/fs-extra": "8.0.0",
     "@types/semver": "6.0.0",
     "@types/which": "3.0.0",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "execa": "2.0.4",
     "fs-extra": "^7.0.1",
     "jest-junit": "16.0.0",

--- a/packages/static-build/package.json
+++ b/packages/static-build/package.json
@@ -35,7 +35,7 @@
     "@types/node-fetch": "2.5.4",
     "@types/promise-timeout": "1.3.0",
     "@types/semver": "7.3.13",
-    "@vercel/build-utils": "10.0.1",
+    "@vercel/build-utils": "10.1.0",
     "@vercel/error-utils": "2.0.3",
     "@vercel/frameworks": "3.6.1",
     "@vercel/fs-detectors": "5.3.8",


### PR DESCRIPTION
I recently added a check in `@vercel/build-utils` to look for `VERCEL_TARGET_ENV` as a prefix-able env var (`NEXT_PUBLIC_VERCEL_TARGET_ENV`), but didn't bump dependencies in the previous release.