### PR TITLE
[build-utils] support `manage-package-manager-versions` by avoiding engines error

### DIFF
--- a/.changeset/lazy-apes-learn.md
+++ b/.changeset/lazy-apes-learn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Allow pnpm 10 to use package.json#packageManager without an engines error

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -959,25 +959,32 @@ export function getPathOverrideForPackageManager({
     projectCreatedAt
   );
 
-  if (!corepackPackageManager || !corepackEnabled) {
-    if (cliType === 'pnpm' && packageJsonEngines?.pnpm) {
+  const usingCorepack = corepackPackageManager && corepackEnabled;
+  if (usingCorepack) {
+    validateCorepackPackageManager(
+      cliType,
+      lockfileVersion,
+      corepackPackageManager,
+      packageJsonEngines?.pnpm
+    );
+
+    // corepack is going to take care of it; do nothing special
+    return NO_OVERRIDE;
+  }
+
+  if (cliType === 'pnpm' && packageJsonEngines?.pnpm) {
+    const usingDetected =
+      detectedPackageManger?.pnpmVersionRange !== '10.x' ||
+      !corepackPackageManager;
+    if (usingDetected) {
       checkEnginesPnpmAgainstDetected(
         packageJsonEngines.pnpm,
         detectedPackageManger
       );
     }
-    return detectedPackageManger ?? NO_OVERRIDE;
   }
 
-  validateCorepackPackageManager(
-    cliType,
-    lockfileVersion,
-    corepackPackageManager,
-    packageJsonEngines?.pnpm
-  );
-
-  // corepack is going to take care of it; do nothing special
-  return NO_OVERRIDE;
+  return detectedPackageManger ?? NO_OVERRIDE;
 }
 
 function checkEnginesPnpmAgainstDetected(

--- a/packages/build-utils/test/unit.get-path-override-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-path-override-for-package-manager.test.ts
@@ -162,6 +162,40 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         );
       });
 
+      describe('with detected pnpm 10', () => {
+        test('should throw engines error if not using package.json#packageManager', () => {
+          expect(() => {
+            getPathOverrideForPackageManager({
+              cliType: 'pnpm',
+              lockfileVersion: 9.0,
+              nodeVersion: { major: 20, range: '20.x', runtime: 'nodejs20.x' },
+              corepackEnabled: false,
+              packageJsonEngines: { pnpm: '9.x' },
+              projectCreatedAt: PNPM_10_PREFERRED_AT.getTime() + 1000,
+            });
+          }).toThrow(
+            'Detected pnpm "10.x" is not compatible with the engines.pnpm "9.x" in your package.json. Either enable corepack with a valid package.json#packageManager value (https://vercel.com/docs/deployments/configure-a-build#corepack) or remove your package.json#engines.pnpm.'
+          );
+        });
+
+        test('should not throw error if using package.json#packageManager', () => {
+          const result = getPathOverrideForPackageManager({
+            cliType: 'pnpm',
+            lockfileVersion: 9.0,
+            nodeVersion: { major: 20, range: '20.x', runtime: 'nodejs20.x' },
+            corepackEnabled: false,
+            packageJsonEngines: { pnpm: '9.x' },
+            corepackPackageManager: 'pnpm@9.5.0',
+            projectCreatedAt: PNPM_10_PREFERRED_AT.getTime() + 1000,
+          });
+          expect(result).toStrictEqual({
+            detectedLockfile: 'pnpm-lock.yaml',
+            detectedPackageManager: 'pnpm@10.x',
+            path: '/pnpm10/node_modules/.bin',
+            pnpmVersionRange: '10.x',
+          });
+        });
+      });
       test('should warn if detected package manager intersects the engine range', () => {
         const consoleWarnSpy = vi.spyOn(console, 'warn');
         getPathOverrideForPackageManager({


### PR DESCRIPTION
[`pnpm@10` now manages the pnpm version by default based on `package.json#package.manager`.](https://pnpm.io/npmrc#manage-package-manager-versions)

When:
- `pnpm@10` was detected
- `package.json#engines.pnpm` was set to `9.x`
- `package.json#packageManager` was set `pnpm@9.5.0`

Builds would incorrectly error:
```
Detected pnpm "10.x" is not compatible with the engines.pnpm "9.x" in your package.json. Either enable corepack with a valid package.json#packageManager value (https://vercel.com/docs/deployments/configure-a-build#corepack) or remove your package.json#engines.pnpm.
```

This PR fixes that scenario so `pnpm@10` uses `pnpm@9.5.0` without erroring.