### PR TITLE
Do not terminate due to long running waitUntil warning

### DIFF
--- a/.changeset/rich-lizards-collect.md
+++ b/.changeset/rich-lizards-collect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Do not terminate due to long running waitUntil warning

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -195,7 +195,6 @@ async function createEdgeRuntimeServer(params?: {
       new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           console.warn(waitUntilWarning(params.entrypointPath));
-          resolve();
         }, WAIT_UNTIL_TIMEOUT_MS);
 
         Promise.all([params.awaiter.awaiting(), server.close()])

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -141,7 +141,6 @@ export async function createServerlessEventHandler(
     new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         console.warn(waitUntilWarning(entrypointPath));
-        resolve();
       }, WAIT_UNTIL_TIMEOUT_MS);
 
       Promise.all([awaiter.awaiting(), server.onExit()])


### PR DESCRIPTION
When deployed to vercel, I can use `waitUntil` to let a task run in background for the duration of the configured execution limit. This was not the case when running via `vercel dev`, it terminated exactly after 10s which is the hard-coded time for the waitUntil warning. This PR fixes this.