### PR TITLE
Switch from `npm` to `pnpm` as default package manager

### DIFF
--- a/.changeset/sixty-ads-draw.md
+++ b/.changeset/sixty-ads-draw.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': major
+---
+
+Switch from `npm` to `pnpm` as default package manager

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -522,7 +522,7 @@ export function turboVersionSpecifierSupportsCorepack(
 function detectPackageManagerNameWithoutLockfile(
   packageJsonPackageManager: string | undefined,
   turboSupportsCorepackHome: boolean | undefined
-) {
+): CliType {
   if (
     usingCorepack(
       process.env,
@@ -540,14 +540,14 @@ function detectPackageManagerNameWithoutLockfile(
       case 'bun':
         return corepackPackageManager.packageName;
       case undefined:
-        return 'npm';
+        return 'pnpm';
       default:
         throw new Error(
           `Unknown package manager "${corepackPackageManager?.packageName}". Change your package.json "packageManager" field to a known package manager: npm, pnpm, yarn, bun.`
         );
     }
   }
-  return 'npm';
+  return 'pnpm';
 }
 
 export function usingCorepack(


### PR DESCRIPTION
# Overview

Vercel's build system is all about iterating and shipping as quickly as possible. We are heavily invested in `pnpm` as a package manager and believe that it's the right bet for performance for our build ecosystem at the moment, and so this PR introduces a change to out _default_ package manager. In cases where a project has not committed a lockfile, or configured an `installCommand` for their project, we will now use `pnpm` to run an install. In [benchmarks](https://pnpm.io/benchmarks) this is shown to be nearly 4x faster than `npm`.
