### PR TITLE
Update CODEOWNERS to reflect new organizational structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,20 +2,20 @@
 # https://help.github.com/en/articles/about-code-owners
 
 # Restricted Paths
-*                                        @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads
-/.github/workflows                       @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @ijjk
-/packages/fs-detectors                   @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @agadzik @chloetedder
-/packages/next                           @timneutkens @ijjk @ztanner @huozhi
-/packages/routing-utils                  @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @ijjk
-/packages/static-build                   @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads
+*                                        @vercel/ci-cd
+/.github/workflows                       @vercel/ci-cd @ijjk
+/packages/fs-detectors                   @vercel/ci-cd @agadzik @chloetedder
+/packages/next                           @vercel/ci-cd @timneutkens @ijjk @ztanner @huozhi
+/packages/routing-utils                  @vercel/ci-cd @ijjk
+/packages/static-build                   @vercel/ci-cd
 /packages/edge                           @vercel/compute
 /packages/functions                      @vercel/compute
 /packages/firewall                       @cramforce @sueplex
-/examples                                @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @leerob
-/examples/create-react-app               @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @Timer
-/examples/nextjs                         @ijjk @ztanner @huozhi
-/packages/node                           @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @Kikobeats
-/packages/related-projects               @TooTallNate @EndangeredMassa @trek @onsclom @jeffsee55 @erikareads @Kikobeats @tknickman @mknichel
+/examples                                @vercel/ci-cd @leerob
+/examples/create-react-app               @vercel/ci-cd @Timer
+/examples/nextjs                         @vercel/ci-cd @ijjk @ztanner @huozhi
+/packages/node                           @vercel/ci-cd @Kikobeats
+/packages/related-projects               @vercel/ci-cd @Kikobeats @mknichel
 
 # Unrestricted Paths
 .changeset/


### PR DESCRIPTION
# Overview 

Update the CODEOWNERS for this repository to reflect the new combined teams to stop individuals being relied upon for approvals to the repo.
