### PR TITLE
[next]: Read expire values from prerender manifest

### DIFF
--- a/.changeset/lemon-ghosts-drop.md
+++ b/.changeset/lemon-ghosts-drop.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"@vercel/next": patch
+---
+
+Add support for expire values in Next.js prerender manifest

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -3,6 +3,7 @@ import { Lambda } from './lambda';
 
 interface PrerenderOptions {
   expiration: number | false;
+  staleExpiration?: number;
   lambda?: Lambda;
   fallback: File | null;
   group?: number;
@@ -20,7 +21,17 @@ interface PrerenderOptions {
 
 export class Prerender {
   public type: 'Prerender';
+  /**
+   * `expiration` is `revalidate` in Next.js terms, and `s-maxage` in
+   * `cache-control` terms.
+   */
   public expiration: number | false;
+  /**
+   * `staleExpiration` is `expire` in Next.js terms, and
+   * `stale-while-revalidate` + `s-maxage` in `cache-control` terms. It's
+   * expected to be undefined if `expiration` is `false`.
+   */
+  public staleExpiration?: number;
   public lambda?: Lambda;
   public fallback: File | null;
   public group?: number;
@@ -37,6 +48,7 @@ export class Prerender {
 
   constructor({
     expiration,
+    staleExpiration,
     lambda,
     fallback,
     group,
@@ -53,6 +65,7 @@ export class Prerender {
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
+    this.staleExpiration = staleExpiration;
     this.sourcePath = sourcePath;
 
     this.lambda = lambda;

--- a/packages/next/test/integration/use-cache/app/[slug]/page.js
+++ b/packages/next/test/integration/use-cache/app/[slug]/page.js
@@ -1,0 +1,11 @@
+import { unstable_cacheLife } from 'next/cache';
+
+async function getCachedValue() {
+  'use cache';
+  unstable_cacheLife('weeks');
+  return Math.random();
+}
+
+export default async function Page() {
+  return <div>This is a cached value: {await getCachedValue()}</div>;
+}

--- a/packages/next/test/integration/use-cache/app/layout.js
+++ b/packages/next/test/integration/use-cache/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/integration/use-cache/app/page.js
+++ b/packages/next/test/integration/use-cache/app/page.js
@@ -1,0 +1,11 @@
+import { unstable_cacheLife } from 'next/cache';
+
+async function getCachedValue() {
+  'use cache';
+  unstable_cacheLife('weeks');
+  return Math.random();
+}
+
+export default async function Page() {
+  return <div>This is a cached value: {await getCachedValue()}</div>;
+}

--- a/packages/next/test/integration/use-cache/app/static/page.js
+++ b/packages/next/test/integration/use-cache/app/static/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>This is the page</div>;
+}

--- a/packages/next/test/integration/use-cache/next.config.js
+++ b/packages/next/test/integration/use-cache/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    ppr: true,
+    useCache: true,
+  },
+};

--- a/packages/next/test/integration/use-cache/package.json
+++ b/packages/next/test/integration/use-cache/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "15.2.0-canary.33",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/integration/use-cache/package.json
+++ b/packages/next/test/integration/use-cache/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "15.2.0-canary.33",
+    "next": "15.2.1-canary.5",
     "react": "latest",
     "react-dom": "latest"
   }

--- a/packages/next/test/integration/use-cache/vercel.json
+++ b/packages/next/test/integration/use-cache/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}

--- a/utils/determine-turbo-hit-or-miss.js
+++ b/utils/determine-turbo-hit-or-miss.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 async function main(turboRunDirectory, turboRunDirectoryParent) {
   const turboRunDir = path.join(turboRunDirectoryParent, turboRunDirectory);
-  const turboRunFiles = await fs.readdir(turboRunDir);
+  const turboRunFiles = await fs.readdir(turboRunDir).catch(() => []);
 
   let missCount = 0;
 


### PR DESCRIPTION
In https://github.com/vercel/next.js/pull/76207 we've added `initialExpireSeconds` (and `fallbackExpire`) to the prerender manifest, analogous to `initialRevalidateSeconds` (or `fallbackRevalidate`). Both the revalidate and expire values together allow stale-while-revalidate semantics to be applied to static routes and fallback routes for ISR.

The configured expire values are added as `staleExpiration` property to the prerender outputs. The naming is a bit unfortunate, but that's a result from the revalidate value being transferred to the `expiration` property.

- [x] The added integration tests depend on a new Next.js canary version being released after https://github.com/vercel/next.js/pull/76207 is merged.