### PR TITLE
Type-check build-utils tests

### DIFF
--- a/.changeset/cool-dolphins-deliver.md
+++ b/.changeset/cool-dolphins-deliver.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Type-check tests

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -56,6 +56,10 @@ export const NODE_VERSIONS: NodeVersion[] = [
   }),
 ];
 
+export function getNodeVersionByMajor(major: number): NodeVersion | undefined {
+  return NODE_VERSIONS.find(v => v.major === major);
+}
+
 function getOptions() {
   return NODE_VERSIONS;
 }

--- a/packages/build-utils/test/unit.get-env-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-env-for-package-manager.test.ts
@@ -10,6 +10,7 @@ import {
 import { delimiter } from 'path';
 import { getEnvForPackageManager } from '../src';
 import { PNPM_10_PREFERRED_AT } from '../src/fs/run-user-scripts';
+import { getNodeVersionByMajor } from '../src/fs/node-version';
 
 describe('Test `getEnvForPackageManager()`', () => {
   let consoleLogSpy: MockInstance<typeof console.log>;
@@ -44,7 +45,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should do nothing to env for npm < 6 and node < 16',
         args: {
           cliType: 'npm',
-          nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+          nodeVersion: getNodeVersionByMajor(14),
           packageJsonPackageManager: undefined,
           lockfileVersion: 1,
           env: {
@@ -61,7 +62,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not set npm path if corepack enabled',
         args: {
           cliType: 'npm',
-          nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+          nodeVersion: getNodeVersionByMajor(14),
           packageJsonPackageManager: 'npm@10.5.0',
           lockfileVersion: 2,
           env: {
@@ -80,7 +81,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not prepend npm path again if already detected',
         args: {
           cliType: 'npm',
-          nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+          nodeVersion: getNodeVersionByMajor(14),
           packageJsonPackageManager: undefined,
           lockfileVersion: 2,
           env: {
@@ -99,7 +100,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not set path if node is 16 and npm 7+ is detected',
         args: {
           cliType: 'npm',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: undefined,
           lockfileVersion: 2,
           env: {
@@ -161,7 +162,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set path if pnpm 7+ is detected',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: undefined,
           lockfileVersion: 5.4,
           env: {
@@ -181,7 +182,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set path if pnpm 8 is detected',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+          nodeVersion: getNodeVersionByMajor(18),
           packageJsonPackageManager: undefined,
           lockfileVersion: 6.0,
           env: {
@@ -201,7 +202,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set path if pnpm 9 is detected',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+          nodeVersion: getNodeVersionByMajor(18),
           packageJsonPackageManager: undefined,
           lockfileVersion: 7.0,
           env: {
@@ -221,7 +222,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set path if pnpm 10 is detected',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+          nodeVersion: getNodeVersionByMajor(18),
           packageJsonPackageManager: undefined,
           lockfileVersion: 9.0,
           env: {
@@ -242,7 +243,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should detect pnpm 10 with packageManager field pnpm 9',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+          nodeVersion: getNodeVersionByMajor(18),
           packageJsonPackageManager: 'pnpm@9.5.0',
           lockfileVersion: 9.0,
           env: {
@@ -263,7 +264,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not set pnpm path if corepack is enabled',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: 'pnpm@6.35.1',
           lockfileVersion: 5.4,
           env: {
@@ -282,7 +283,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not prepend pnpm path again if already detected',
         args: {
           cliType: 'pnpm',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: undefined,
           lockfileVersion: 5.4,
           env: {
@@ -336,7 +337,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set YARN_NODE_LINKER w/yarn if it is not already defined',
         args: {
           cliType: 'yarn',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: undefined,
           lockfileVersion: 2,
           env: {
@@ -354,7 +355,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should not set YARN_NODE_LINKER if it already exists',
         args: {
           cliType: 'yarn',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonPackageManager: undefined,
           lockfileVersion: 2,
           env: {
@@ -408,7 +409,7 @@ describe('Test `getEnvForPackageManager()`', () => {
         name: 'should set path if bun v1 is detected',
         args: {
           cliType: 'bun',
-          nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+          nodeVersion: getNodeVersionByMajor(18),
           packageJsonPackageManager: undefined,
           lockfileVersion: 0,
           env: {

--- a/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
@@ -1,6 +1,7 @@
 import { delimiter } from 'path';
 import { getPathForPackageManager } from '../src';
 import { describe, test, expect } from 'vitest';
+import { getNodeVersionByMajor } from '../src/fs/node-version';
 
 describe('Test `getPathForPackageManager()`', () => {
   test.each<{
@@ -12,7 +13,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should do nothing to env for npm < 6 and node < 16',
       args: {
         cliType: 'npm',
-        nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+        nodeVersion: getNodeVersionByMajor(14),
         lockfileVersion: 1,
         env: {
           FOO: 'bar',

--- a/packages/build-utils/test/unit.get-path-override-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-path-override-for-package-manager.test.ts
@@ -11,6 +11,7 @@ import {
   MockInstance,
   afterEach,
 } from 'vitest';
+import { getNodeVersionByMajor } from '../src/fs/node-version';
 
 describe('Test `getPathOverrideForPackageManager()`', () => {
   describe('with no corepack package manger', () => {
@@ -19,7 +20,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         cliType: 'pnpm',
         lockfileVersion: 9.0,
         corepackPackageManager: undefined,
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
       });
       expect(result).toStrictEqual({
         detectedLockfile: 'pnpm-lock.yaml',
@@ -36,7 +37,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         cliType: 'pnpm',
         lockfileVersion: undefined,
         corepackPackageManager: 'pnpm@9.5.0',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
       });
       expect(result).toStrictEqual({
         detectedLockfile: undefined,
@@ -53,7 +54,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 9.0,
           corepackPackageManager: 'pnpm@9.5.0',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           corepackEnabled: false,
           projectCreatedAt: PNPM_10_PREFERRED_AT.getTime() - 1000,
         });
@@ -70,7 +71,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 9.0,
           corepackPackageManager: 'pnpm@9.5.0',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           corepackEnabled: false,
           projectCreatedAt: PNPM_10_PREFERRED_AT.getTime() + 1000,
         });
@@ -90,7 +91,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         cliType: 'pnpm',
         lockfileVersion: 9.0,
         corepackPackageManager: 'pnpm@9.5.0',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
       });
       expect(result).toStrictEqual({
         detectedLockfile: undefined,
@@ -108,7 +109,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
             cliType: 'pnpm',
             lockfileVersion: 6.1,
             corepackPackageManager: undefined,
-            nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+            nodeVersion: getNodeVersionByMajor(16),
             packageJsonEngines: { pnpm: '>=9.0.0' },
           });
         }).toThrow(
@@ -122,7 +123,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
             cliType: 'pnpm',
             lockfileVersion: 6.1,
             corepackPackageManager: 'pnpm@8.15.9',
-            nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+            nodeVersion: getNodeVersionByMajor(16),
             packageJsonEngines: { pnpm: '>=9.0.0' },
           });
         }).toThrow(
@@ -135,7 +136,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 9.0,
           corepackPackageManager: 'pnpm@9.5.0',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           packageJsonEngines: { pnpm: '>=9.0.0' },
         });
         expect(result).toStrictEqual({
@@ -152,7 +153,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           getPathOverrideForPackageManager({
             cliType: 'pnpm',
             lockfileVersion: 6.1,
-            nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+            nodeVersion: getNodeVersionByMajor(16),
             corepackEnabled: false,
             packageJsonEngines: { pnpm: '>=9.0.0' },
             corepackPackageManager: undefined,
@@ -168,8 +169,9 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
             getPathOverrideForPackageManager({
               cliType: 'pnpm',
               lockfileVersion: 9.0,
-              nodeVersion: { major: 20, range: '20.x', runtime: 'nodejs20.x' },
+              nodeVersion: getNodeVersionByMajor(20),
               corepackEnabled: false,
+              corepackPackageManager: undefined,
               packageJsonEngines: { pnpm: '9.x' },
               projectCreatedAt: PNPM_10_PREFERRED_AT.getTime() + 1000,
             });
@@ -182,7 +184,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           const result = getPathOverrideForPackageManager({
             cliType: 'pnpm',
             lockfileVersion: 9.0,
-            nodeVersion: { major: 20, range: '20.x', runtime: 'nodejs20.x' },
+            nodeVersion: getNodeVersionByMajor(20),
             corepackEnabled: false,
             packageJsonEngines: { pnpm: '9.x' },
             corepackPackageManager: 'pnpm@9.5.0',
@@ -201,7 +203,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         getPathOverrideForPackageManager({
           cliType: 'pnpm',
           lockfileVersion: 9.0,
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           corepackEnabled: false,
           packageJsonEngines: { pnpm: '>=9.0.0' },
           corepackPackageManager: undefined,
@@ -217,7 +219,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
         getPathOverrideForPackageManager({
           cliType: 'pnpm',
           lockfileVersion: 9.0,
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
           corepackEnabled: false,
           packageJsonEngines: { pnpm: '>=9.0.0' },
           corepackPackageManager: undefined,
@@ -247,7 +249,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 5.0,
           corepackPackageManager: 'pnpm@9.5.0',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
         });
       }).toThrow(
         'Detected lockfile "5" which is not compatible with the intended corepack package manager "pnpm@9.5.0". Update your lockfile or change to a compatible corepack version.'
@@ -260,7 +262,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 5.1,
           corepackPackageManager: 'pnpm@8.15.9',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
         })
       ).toThrow(
         'Detected lockfile "5.1" which is not compatible with the intended corepack package manager "pnpm@8.15.9". Update your lockfile or change to a compatible corepack version.'
@@ -273,7 +275,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'npm',
           lockfileVersion: 9.0,
           corepackPackageManager: 'pnpm@9.5.0',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
         })
       ).toThrow(
         'Detected package manager "npm" does not match intended corepack defined package manager "pnpm". Change your lockfile or "package.json#packageManager" value to match.'
@@ -286,7 +288,7 @@ describe('Test `getPathOverrideForPackageManager()`', () => {
           cliType: 'pnpm',
           lockfileVersion: 9.0,
           corepackPackageManager: 'pnpm@invalid',
-          nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+          nodeVersion: getNodeVersionByMajor(16),
         })
       ).toThrow(
         'Intended corepack defined package manager "pnpm@invalid" is not a valid semver value.'

--- a/packages/build-utils/tsconfig.json
+++ b/packages/build-utils/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["node"]
   },
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "**/fixtures/**"]
 }


### PR DESCRIPTION
This fixes existing type errors and enables type-checking for `build-utils` tests.