### PR TITLE
[build-utils] Move back pnpm@10 preferred date

### DIFF
--- a/.changeset/lovely-fans-smash.md
+++ b/.changeset/lovely-fans-smash.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Delay pnpm@10 preferred date

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -874,7 +874,7 @@ type DetectedPnpmVersion =
   | 'pnpm 10'
   | 'corepack_enabled';
 
-export const PNPM_10_PREFERRED_AT = new Date('2025-02-24T20:00:00Z');
+export const PNPM_10_PREFERRED_AT = new Date('2025-02-27T20:00:00Z');
 
 function detectPnpmVersion(
   lockfileVersion: number | undefined,


### PR DESCRIPTION
The goal was to roll this out in the build container before the date to avoid breaking existing projects, but the build container rollout was blocked for various reasons. This moves the date to Thursday to allow time for making a CLI release and doing a build container rollout.