### PR TITLE
[react-router] Use underscore in server bundle ID for compatibility with Vite Environments API

### DIFF
--- a/.changeset/orange-cats-sip.md
+++ b/.changeset/orange-cats-sip.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': minor
+---
+
+Use underscore for server bundle ID for compatibility with Vite Environments API

--- a/packages/react-router/vite.ts
+++ b/packages/react-router/vite.ts
@@ -136,7 +136,7 @@ export function vercelPreset(): Preset {
       }
 
       config = flattenAndSort(config);
-      const id = `${config.runtime}-${hashConfig(config)}`;
+      const id = `${config.runtime}_${hashConfig(config)}`;
       if (!bundleConfigs.has(id)) {
         bundleConfigs.set(id, config);
       }


### PR DESCRIPTION
See this upcoming change in React Router: https://github.com/remix-run/react-router/pull/13107

From the changeset:

> Note that for consumers using the `future.unstable_viteEnvironmentApi` and `serverBundles` options together, hyphens are no longer supported in server bundle IDs since they also need to be valid Vite environment names.