### PR TITLE
[remix] Use proper npm package name for React Router in Preset error message

### DIFF
--- a/.changeset/fresh-falcons-float.md
+++ b/.changeset/fresh-falcons-float.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Use proper npm package name for React Router in Preset error message

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -476,7 +476,7 @@ export const build: BuildV2 = async ({
 
   if (!buildResult) {
     throw new Error(
-      'Could not determine build output directory. Please configure the `vercelPreset()` Preset from the `@vercel/remix` npm package'
+      `Could not determine build output directory. Please configure the \`vercelPreset()\` Preset from the \`@vercel/${frameworkSettings.slug}\` npm package`
     );
   }
 


### PR DESCRIPTION
Use the `@vercel/react-router` package name in the error message when the server build output directory is not detected.