### PR TITLE
[remix] Fix build failure when using an index route with a pathless layout

### DIFF
--- a/.changeset/two-shoes-work.md
+++ b/.changeset/two-shoes-work.md
@@ -1,0 +1,5 @@
+---
+'@vercel/remix-builder': patch
+---
+
+Fix build failure when using an index route with a pathless layout

--- a/packages/remix/src/utils.ts
+++ b/packages/remix/src/utils.ts
@@ -221,16 +221,15 @@ export function* getRouteIterator(
 }
 
 export function getPathFromRoute(
-  route: RouteManifestEntry,
+  input: RouteManifestEntry,
   routes: RouteManifest
 ): ResolvedRoutePaths {
+  let route = input;
   if (
     route.id === 'root' ||
-    (route.parentId === 'root' &&
-      (!route.path || route.path === '/') &&
-      route.index)
+    ((!route.path || route.path === '/') && route.index)
   ) {
-    return { path: 'index', rePath: '/index' };
+    route = { ...route, path: 'index' };
   }
 
   const pathParts: string[] = [];
@@ -256,6 +255,13 @@ export function getPathFromRoute(
         rePathParts.push(part);
       }
     }
+  }
+
+  // If the route is an index route and has a parent, then
+  // we can remove the "index" from the path since it's implied
+  if (pathParts.length > 1 && pathParts[0] === 'index') {
+    pathParts.shift();
+    rePathParts.shift();
   }
 
   const path = pathParts.reverse().join('/');

--- a/packages/remix/test/unit.get-path-from-route.test.ts
+++ b/packages/remix/test/unit.get-path-from-route.test.ts
@@ -1,6 +1,6 @@
-import { getPathFromRoute } from '../src/utils';
-import type { RouteManifest } from '@remix-run/dev/dist/config/routes';
 import { describe, it, expect } from 'vitest';
+import { getPathFromRoute } from '../src/utils';
+import type { RouteManifest } from '../src/types';
 
 describe('getPathFromRoute()', () => {
   const routes: RouteManifest = {
@@ -121,6 +121,19 @@ describe('getPathFromRoute()', () => {
       parentId: 'root',
       file: 'manual.tsx',
     },
+
+    'layouts/app-layout': {
+      id: 'layouts/app-layout',
+      parentId: 'root',
+      file: './layouts/app-layout.tsx',
+    },
+    'routes/home': {
+      id: 'routes/home',
+      parentId: 'layouts/app-layout',
+      file: './routes/home.tsx',
+      path: '/',
+      index: true,
+    },
   };
 
   it.each([
@@ -177,6 +190,10 @@ describe('getPathFromRoute()', () => {
     {
       id: 'routes/admin.(lol)',
       expected: { path: 'admin/(lol)', rePath: '/admin/(lol)?' },
+    },
+    {
+      id: 'routes/home',
+      expected: { path: 'index', rePath: '/index' },
     },
   ])('should return `$expected` for "$id" route', ({ id, expected }) => {
     const route = routes[id];

--- a/packages/remix/test/unit.get-resolved-route-config.test.ts
+++ b/packages/remix/test/unit.get-resolved-route-config.test.ts
@@ -1,13 +1,13 @@
-import { getResolvedRouteConfig } from '../src/utils';
-import type {
-  ConfigRoute,
-  RouteManifest,
-} from '@remix-run/dev/dist/config/routes';
-import type { BaseFunctionConfig } from '@vercel/static-config';
 import { describe, it, expect } from 'vitest';
+import { getResolvedRouteConfig } from '../src/utils';
+import type { RouteManifest, RouteManifestEntry } from '../src/types';
+import type { BaseFunctionConfig } from '@vercel/static-config';
 
 describe('getResolvedRouteConfig()', () => {
-  const staticConfigsMap = new Map<ConfigRoute, BaseFunctionConfig | null>([
+  const staticConfigsMap = new Map<
+    RouteManifestEntry,
+    BaseFunctionConfig | null
+  >([
     [{ id: 'root', file: 'root.tsx' }, null],
     [
       { id: 'routes/edge', file: 'routes/edge.tsx', parentId: 'root' },


### PR DESCRIPTION
Handle the case when an index route is used within a layout route. For example, with React Router:

```ts
import {
  type RouteConfig,
  index,
  layout,
  prefix,
} from '@react-router/dev/routes';

export default [
  layout('./layouts/app-layout.tsx', [
    ...prefix('/', [
      index('./routes/home.tsx'),
    ]),
  ]),
] satisfies RouteConfig;
```

Previously this would be failing at build time with the error:

> #### Build Failed
>
> An unexpected error happened when running this build. We have been notified of the problem. If you have any questions, please contact Vercel Support https://vercel.com/help

The failure was caused by a function with an empty path attempting to be created, which is not handled on the build side and causes the deployment to fail.