### PR TITLE
[errors] improve 'not found' error messaging to include scope

### DIFF
--- a/.changeset/khaki-wasps-smoke.md
+++ b/.changeset/khaki-wasps-smoke.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[errors] improve 'not found' error messaging to include scope

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -106,7 +106,7 @@ export default async function remove(client: Client) {
 
     const [deploymentList, projectList] = await Promise.all<any>([
       Promise.all(
-        ids.map(idOrHost => {
+        ids.map(async idOrHost => {
           if (!contextName) {
             throw new Error('Context name is not defined');
           }

--- a/packages/cli/src/util/alias/create-alias.ts
+++ b/packages/cli/src/util/alias/create-alias.ts
@@ -74,7 +74,7 @@ async function performCreateAlias(
       if (err.status === 409) {
         return { uid: err.uid, alias: err.alias } as AliasRecord;
       }
-      if (err.code === 'deployment_not_found') {
+      if (err.code === 'deployment_not_found' || err.code === 'not_found') {
         return new ERRORS.DeploymentNotFound({
           context: contextName,
           id: deployment.id,

--- a/packages/cli/src/util/alias/get-aliases.ts
+++ b/packages/cli/src/util/alias/get-aliases.ts
@@ -1,5 +1,12 @@
 import type { Alias, PaginationOptions } from '@vercel-internals/types';
 import type Client from '../client';
+import {
+  DeploymentNotFound,
+  DeploymentPermissionDenied,
+  InvalidDeploymentId,
+} from '../errors-ts';
+import { isAPIError } from '../errors-ts';
+import getScope from '../get-scope';
 
 type Response = {
   aliases: Alias[];
@@ -20,6 +27,29 @@ export default async function getAliases(
   const to = deploymentId
     ? `/now/deployments/${deploymentId}/aliases`
     : aliasUrl;
-  const payload = await client.fetch<Response>(to);
-  return payload;
+
+  try {
+    const payload = await client.fetch<Response>(to);
+    return payload;
+  } catch (err) {
+    if (isAPIError(err)) {
+      const contextName = await getScope(client).then(
+        scope => scope.contextName
+      );
+      if (err.status === 404) {
+        throw new DeploymentNotFound({
+          id: deploymentId,
+          context: contextName,
+        });
+      }
+      if (err.status === 403 && deploymentId) {
+        throw new DeploymentPermissionDenied(deploymentId, contextName);
+      }
+      if (err.status === 400 && err.message.includes('`id`') && deploymentId) {
+        throw new InvalidDeploymentId(deploymentId);
+      }
+    }
+
+    throw err;
+  }
 }


### PR DESCRIPTION
There's some spots, currently, that obfuscate that you need to provide the `--scope` to the command, namely `vc remove` and `vc alias`. We _do_ have good messaging, but it wasn't being caught because of incorrect checks. Now, when the user doesn't provide the scope when they need to, we tell them that the deployment under scope `scope name` can't be found, rather than just the deployment