### PR TITLE
[build-utils] detect yarn version from lockfile version

### DIFF
--- a/.changeset/slimy-buttons-crash.md
+++ b/.changeset/slimy-buttons-crash.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Detect yarn version from lockfile version

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -914,6 +914,21 @@ function detectPnpmVersion(
   }
 }
 
+function detectYarnVersion(lockfileVersion: number | undefined) {
+  if (lockfileVersion) {
+    if ([1].includes(lockfileVersion)) {
+      return 'yarn@1.x';
+    } else if ([4, 5].includes(lockfileVersion)) {
+      return 'yarn@2.x';
+    } else if ([6, 7].includes(lockfileVersion)) {
+      return 'yarn@3.x';
+    } else if ([8].includes(lockfileVersion)) {
+      return 'yarn@4.x';
+    }
+  }
+  return 'unknown yarn';
+}
+
 function validLockfileForPackageManager(
   cliType: CliType,
   lockfileVersion: number,
@@ -1194,7 +1209,7 @@ export function detectPackageManager(
       return {
         path: undefined,
         detectedLockfile: 'yarn.lock',
-        detectedPackageManager: 'yarn',
+        detectedPackageManager: detectYarnVersion(lockfileVersion),
       };
   }
 }

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -885,8 +885,7 @@ type DetectedPnpmVersion =
   | 'pnpm 7'
   | 'pnpm 8'
   | 'pnpm 9'
-  | 'pnpm 10'
-  | 'corepack_enabled';
+  | 'pnpm 10';
 
 export const PNPM_10_PREFERRED_AT = new Date('2025-02-27T20:00:00Z');
 

--- a/packages/build-utils/test/unit.detect-package-manager.test.ts
+++ b/packages/build-utils/test/unit.detect-package-manager.test.ts
@@ -135,39 +135,39 @@ describe('Test `detectPackageManager()`', () => {
       want: unknown;
     }>([
       {
-        name: 'yarn 1 does not return a path',
+        name: 'yarn@1.x does not return a path',
         args: ['yarn', 1],
         want: {
           path: undefined,
           detectedLockfile: 'yarn.lock',
-          detectedPackageManager: 'yarn 1',
+          detectedPackageManager: 'yarn@1.x',
         },
       },
       {
-        name: 'yarn 2 does not return a path',
+        name: 'yarn@2.x does not return a path',
         args: ['yarn', 4],
         want: {
           path: undefined,
           detectedLockfile: 'yarn.lock',
-          detectedPackageManager: 'yarn 2',
+          detectedPackageManager: 'yarn@2.x',
         },
       },
       {
-        name: 'does not return a path',
+        name: 'yarn@3.x does not return a path',
         args: ['yarn', 6],
         want: {
           path: undefined,
           detectedLockfile: 'yarn.lock',
-          detectedPackageManager: 'yarn 3',
+          detectedPackageManager: 'yarn@3.x',
         },
       },
       {
-        name: 'does not return a path',
+        name: 'yarn@4.x does not return a path',
         args: ['yarn', 8],
         want: {
           path: undefined,
           detectedLockfile: 'yarn.lock',
-          detectedPackageManager: 'yarn 4',
+          detectedPackageManager: 'yarn@4.x',
         },
       },
     ])('$name', ({ args, want }) => {

--- a/packages/build-utils/test/unit.detect-package-manager.test.ts
+++ b/packages/build-utils/test/unit.detect-package-manager.test.ts
@@ -135,12 +135,39 @@ describe('Test `detectPackageManager()`', () => {
       want: unknown;
     }>([
       {
-        name: 'does not return a path',
+        name: 'yarn 1 does not return a path',
         args: ['yarn', 1],
         want: {
           path: undefined,
           detectedLockfile: 'yarn.lock',
-          detectedPackageManager: 'yarn',
+          detectedPackageManager: 'yarn 1',
+        },
+      },
+      {
+        name: 'yarn 2 does not return a path',
+        args: ['yarn', 4],
+        want: {
+          path: undefined,
+          detectedLockfile: 'yarn.lock',
+          detectedPackageManager: 'yarn 2',
+        },
+      },
+      {
+        name: 'does not return a path',
+        args: ['yarn', 6],
+        want: {
+          path: undefined,
+          detectedLockfile: 'yarn.lock',
+          detectedPackageManager: 'yarn 3',
+        },
+      },
+      {
+        name: 'does not return a path',
+        args: ['yarn', 8],
+        want: {
+          path: undefined,
+          detectedLockfile: 'yarn.lock',
+          detectedPackageManager: 'yarn 4',
         },
       },
     ])('$name', ({ args, want }) => {

--- a/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
@@ -92,7 +92,7 @@ describe('Test `getPathForPackageManager()`', () => {
       },
       want: {
         detectedLockfile: 'yarn.lock',
-        detectedPackageManager: 'yarn',
+        detectedPackageManager: 'unknown yarn',
         path: undefined,
         yarnNodeLinker: 'node-modules',
       },


### PR DESCRIPTION
Similar to https://github.com/vercel/vercel/pull/13114. Now that we have lockfile versions, we can assign a yarn version. This adds another metric for the next builder. 