### PR TITLE
Fix build-utils type-check

### DIFF
--- a/.changeset/short-wolves-beg.md
+++ b/.changeset/short-wolves-beg.md
@@ -2,4 +2,4 @@
 '@vercel/build-utils': patch
 ---
 
-Fix build-utils type-check
+Fix build-utils test types

--- a/.changeset/short-wolves-beg.md
+++ b/.changeset/short-wolves-beg.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Fix build-utils type-check

--- a/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
+++ b/packages/build-utils/test/unit.get-path-for-package-manager.test.ts
@@ -30,7 +30,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not set npm path if corepack enabled',
       args: {
         cliType: 'npm',
-        nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+        nodeVersion: getNodeVersionByMajor(14),
         lockfileVersion: 2,
         env: {
           FOO: 'bar',
@@ -48,7 +48,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not prepend npm path again if already detected',
       args: {
         cliType: 'npm',
-        nodeVersion: { major: 14, range: '14.x', runtime: 'nodejs14.x' },
+        nodeVersion: getNodeVersionByMajor(14),
         lockfileVersion: 2,
         env: {
           FOO: 'bar',
@@ -66,7 +66,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not set path if node is 16 and npm 7+ is detected',
       args: {
         cliType: 'npm',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 2,
         env: {
           FOO: 'bar',
@@ -84,7 +84,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should set YARN_NODE_LINKER w/yarn if it is not already defined',
       args: {
         cliType: 'yarn',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 2,
         env: {
           FOO: 'bar',
@@ -101,7 +101,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not set YARN_NODE_LINKER if it already exists',
       args: {
         cliType: 'yarn',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 2,
         env: {
           FOO: 'bar',
@@ -119,7 +119,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should set path if pnpm 7+ is detected',
       args: {
         cliType: 'pnpm',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 5.4,
         env: {
           FOO: 'bar',
@@ -138,7 +138,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should set path if bun v1 is detected',
       args: {
         cliType: 'bun',
-        nodeVersion: { major: 18, range: '18.x', runtime: 'nodejs18.x' },
+        nodeVersion: getNodeVersionByMajor(18),
         lockfileVersion: 0,
         env: {
           FOO: 'bar',
@@ -156,7 +156,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not set pnpm path if corepack is enabled',
       args: {
         cliType: 'pnpm',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 5.4,
         env: {
           FOO: 'bar',
@@ -174,7 +174,7 @@ describe('Test `getPathForPackageManager()`', () => {
       name: 'should not prepend pnpm path again if already detected',
       args: {
         cliType: 'pnpm',
-        nodeVersion: { major: 16, range: '16.x', runtime: 'nodejs16.x' },
+        nodeVersion: getNodeVersionByMajor(16),
         lockfileVersion: 5.4,
         env: {
           FOO: 'bar',

--- a/packages/build-utils/test/unit.get-spawn-options.test.ts
+++ b/packages/build-utils/test/unit.get-spawn-options.test.ts
@@ -1,6 +1,7 @@
 import { delimiter } from 'path';
 import { getSpawnOptions } from '../src';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getNodeVersionByMajor } from '../src/fs/node-version';
 
 describe('Test `getSpawnOptions()`', () => {
   const origProcessEnvPath = process.env.PATH;
@@ -21,82 +22,55 @@ describe('Test `getSpawnOptions()`', () => {
   }> = [
     {
       name: 'should do nothing when isDev and node14',
-      args: [
-        { isDev: true },
-        { major: 14, range: '14.x', runtime: 'nodejs14.x' },
-      ],
+      args: [{ isDev: true }, getNodeVersionByMajor(14)!],
       envPath: '/foo',
       want: '/foo',
     },
     {
       name: 'should do nothing when isDev and node16',
-      args: [
-        { isDev: true },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: true }, getNodeVersionByMajor(16)!],
       envPath: '/foo',
       want: '/foo',
     },
     {
       name: 'should replace 14 with 16 when only path',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: '/node14/bin',
       want: '/node16/bin',
     },
     {
       name: 'should replace 14 with 16 at beginning',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: `/node14/bin${delimiter}/foo`,
       want: `/node16/bin${delimiter}/foo`,
     },
     {
       name: 'should replace 14 with 16 at end',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: `/foo${delimiter}/node14/bin`,
       want: `/foo${delimiter}/node16/bin`,
     },
     {
       name: 'should replace 14 with 16 in middle',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: `/foo${delimiter}/node14/bin${delimiter}/bar`,
       want: `/foo${delimiter}/node16/bin${delimiter}/bar`,
     },
     {
       name: 'should prepend 16 at beginning when nothing to replace',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: `/foo`,
       want: `/node16/bin${delimiter}/foo`,
     },
     {
       name: 'should prepend 16 at beginning no path input',
-      args: [
-        { isDev: false },
-        { major: 16, range: '16.x', runtime: 'nodejs16.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(16)!],
       envPath: '',
       want: `/node16/bin`,
     },
     {
       name: 'should replace 12 with 14 when only path',
-      args: [
-        { isDev: false },
-        { major: 14, range: '14.x', runtime: 'nodejs14.x' },
-      ],
+      args: [{ isDev: false }, getNodeVersionByMajor(14)!],
       envPath: '/node12/bin',
       want: '/node14/bin',
     },

--- a/packages/build-utils/tsconfig.json
+++ b/packages/build-utils/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["node"]
   },
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "**/fixtures/**"]
 }

--- a/packages/build-utils/tsconfig.json
+++ b/packages/build-utils/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["node"]
   },
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*", "test/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "**/fixtures/**"]
 }


### PR DESCRIPTION
Missed a few things in my previous attempt to fix build-utils' `type-check`.

Fixes `tests/**/*` -> `test/**/*`, and fixes more type errors.