### PR TITLE
[build-utils] Add pnpm 10 detection to next builder metrics

### DIFF
--- a/.changeset/loud-pants-appear.md
+++ b/.changeset/loud-pants-appear.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add pnpm 10 detection to next metrics

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -344,7 +344,11 @@ export const build: BuildV2 = async buildOptions => {
   }
 
   const { detectedPackageManager } =
-    detectPackageManager(cliType, lockfileVersion) ?? {};
+    detectPackageManager(
+      cliType,
+      lockfileVersion,
+      config.projectSettings?.createdAt
+    ) ?? {};
 
   const trimmedInstallCommand = installCommand?.trim();
 


### PR DESCRIPTION
`pnpm@10` is only detected for new projects, so `detectPackageManagers` needs the project's `createdAt`.