### PR TITLE
[rewrites] fix base path not rewriting

### DIFF
--- a/packages/cli/test/dev/fixtures/test-external-rewrites-and-redirects/vercel.json
+++ b/packages/cli/test/dev/fixtures/test-external-rewrites-and-redirects/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "rewrites": [
+    { "source": "/", "destination": "https://vercel.com/robots.txt" },
     { "source": "/rewrite", "destination": "https://vercel.com/robots.txt" }
   ],
   "redirects": [

--- a/packages/cli/test/dev/fixtures/test-rewrites/vercel.json
+++ b/packages/cli/test/dev/fixtures/test-rewrites/vercel.json
@@ -11,6 +11,10 @@
   ],
   "rewrites": [
     {
+      "source": "/",
+      "destination": "index.html"
+    },
+    {
       "source": "/hello",
       "destination": "index.html"
     },

--- a/packages/cli/test/dev/integration-2.test.ts
+++ b/packages/cli/test/dev/integration-2.test.ts
@@ -76,6 +76,7 @@ test(
 test(
   '[vercel dev] test rewrites serve correct content',
   testFixtureStdio('test-rewrites', async (testPath: any) => {
+    await testPath(200, '/', 'Hello World');
     await testPath(200, '/hello', 'Hello World');
     await testPath(425, '/status-rewrite-425', 'Hello World');
   })


### PR DESCRIPTION
`vercel.json` rewrites that target the path `/` aren't rewriting correctly