### PR TITLE
Migrate pnpm@6 to a standardized location

### DIFF
--- a/.changeset/chilly-bikes-study.md
+++ b/.changeset/chilly-bikes-study.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Expose pnpm6 within the detected package manager path for future versions of the build container

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -1189,7 +1189,7 @@ export function detectPackageManager(
         case 'pnpm 6':
           return {
             // undefined because pnpm@6 is the current default in the build container
-            path: undefined,
+            path: '/pnpm6/node_modules/.bin',
             detectedLockfile: 'pnpm-lock.yaml',
             detectedPackageManager: 'pnpm@6.x',
             pnpmVersionRange: '6.x',

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -1188,7 +1188,6 @@ export function detectPackageManager(
           };
         case 'pnpm 6':
           return {
-            // undefined because pnpm@6 is the current default in the build container
             path: '/pnpm6/node_modules/.bin',
             detectedLockfile: 'pnpm-lock.yaml',
             detectedPackageManager: 'pnpm@6.x',

--- a/packages/build-utils/test/unit.detect-package-manager.test.ts
+++ b/packages/build-utils/test/unit.detect-package-manager.test.ts
@@ -37,7 +37,7 @@ describe('Test `detectPackageManager()`', () => {
           detectedLockfile: 'pnpm-lock.yaml',
           detectedPackageManager: 'pnpm@6.x',
           pnpmVersionRange: '6.x',
-          path: undefined,
+          path: '/pnpm6/node_modules/.bin',
         },
       },
       {


### PR DESCRIPTION
# Overview

Expose the new location to PNPM within the Vercel build system so that it can be picked automatically as we migrate users.

This is so that we support arbitary upgrades of the default version of `pnpm` without needing to change the versions we support by our zero config builds.
