### PR TITLE
[cli] Fix `vc domain inspect` when there is no "production" target alias

### DIFF
--- a/.changeset/modern-penguins-check.md
+++ b/.changeset/modern-penguins-check.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix `vc domain inspect` when there is no "production" target alias

--- a/packages/cli/src/util/projects/find-projects-for-domain.ts
+++ b/packages/cli/src/util/projects/find-projects-for-domain.ts
@@ -14,7 +14,7 @@ export async function findProjectsForDomain(
     )) {
       for (const project of chunk.projects) {
         if (
-          project.targets?.production?.alias?.some(alias =>
+          project.targets?.production?.alias?.some?.(alias =>
             alias.endsWith(domainName)
           )
         ) {


### PR DESCRIPTION
Fixes an issue causing the CLI command to fail with error:

```
$ vc domain inspect example.com
Vercel CLI 41.3.1
Error: An unexpected error occurred in domain: TypeError: project.targets?.production?.alias?.some is not a function
```