### PR TITLE
fix(oauth): improve unexpected error handling

### DIFF
--- a/.changeset/sixty-deers-carry.md
+++ b/.changeset/sixty-deers-carry.md
@@ -1,0 +1,9 @@
+---
+'vercel': patch
+---
+
+fix(oauth): improve unexpected error handling #13138
+
+This is a follow-up on #12098
+
+In case of an unexpected server response, we will now gracefully exit and log the error response for the user.

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -58,7 +58,7 @@ export async function login(client: Client): Promise<number> {
     `
   ▲ Sign in to the Vercel CLI
 
-  Visit ${chalk.bold(o.link(verification_uri, verification_uri_complete, { color: false }))} to enter ${chalk.bold(user_code)}
+  Visit ${chalk.bold(o.link(verification_uri.replace('https://', ''), verification_uri_complete, { color: false }))} to enter ${chalk.bold(user_code)}
   ${chalk.grey('Press [ENTER] to open the browser')}
 `,
     () => {
@@ -126,12 +126,19 @@ export async function login(client: Client): Promise<number> {
       client.authConfig.token = token.access_token;
       error = undefined;
 
-      const { team_id } = await verifyJWT(token.access_token);
+      const [accessTokenError, accessToken] = await verifyJWT(
+        token.access_token
+      );
+
+      if (accessTokenError) {
+        return accessTokenError;
+      }
+
       o.debug('access_token verified');
 
-      if (team_id) {
+      if (accessToken.team_id) {
         o.debug('Current team updated');
-        client.config.currentTeam = team_id;
+        client.config.currentTeam = accessToken.team_id;
       } else {
         o.debug('Current team deleted');
         delete client.config.currentTeam;

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -352,9 +352,9 @@ export class OAuthError extends Error {
   constructor(message: string, response: unknown) {
     const error = processOAuthErrorResponse(response);
     if (error instanceof TypeError) {
-      // This means the server returned an unexpected error response
+      const message = `Unexpected server response: ${JSON.stringify(response)}`;
       super(message);
-      this.cause = new Error(error.message, { cause: response });
+      this.cause = new Error(message, { cause: error });
       this.code = 'server_error';
       return;
     }

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -1,5 +1,5 @@
 import fetch, { type Response } from 'node-fetch';
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, type JWTPayload, jwtVerify } from 'jose';
 import ua from './ua';
 
 const VERCEL_ISSUER = new URL('https://vercel.com');
@@ -316,7 +316,8 @@ type OAuthErrorCode =
   | 'unauthorized_client'
   | 'unsupported_grant_type'
   | 'invalid_scope'
-  // Device Athorization Response Errors
+  | 'server_error'
+  // Device Authorization Response Errors
   | 'authorization_pending'
   | 'slow_down'
   | 'access_denied'
@@ -330,15 +331,17 @@ interface OAuthErrorResponse {
   error_uri?: string;
 }
 
-function processOAuthErrorResponse(json: unknown): OAuthErrorResponse {
+function processOAuthErrorResponse(
+  json: unknown
+): OAuthErrorResponse | TypeError {
   if (typeof json !== 'object' || json === null)
-    throw new TypeError('Expected response to be an object');
+    return new TypeError('Expected response to be an object');
   if (!('error' in json) || typeof json.error !== 'string')
-    throw new TypeError('Expected `error` to be a string');
+    return new TypeError('Expected `error` to be a string');
   if ('error_description' in json && typeof json.error_description !== 'string')
-    throw new TypeError('Expected `error_description` to be a string');
+    return new TypeError('Expected `error_description` to be a string');
   if ('error_uri' in json && typeof json.error_uri !== 'string')
-    throw new TypeError('Expected `error_uri` to be a string');
+    return new TypeError('Expected `error_uri` to be a string');
 
   return json as OAuthErrorResponse;
 }
@@ -348,6 +351,13 @@ export class OAuthError extends Error {
   cause: Error;
   constructor(message: string, response: unknown) {
     const error = processOAuthErrorResponse(response);
+    if (error instanceof TypeError) {
+      // This means the server returned an unexpected error response
+      super(message);
+      this.cause = new Error(error.message, { cause: response });
+      this.code = 'server_error';
+      return;
+    }
     let cause = error.error;
     if (error.error_description) cause += `: ${error.error_description}`;
     if (error.error_uri) cause += ` (${error.error_uri})`;
@@ -370,11 +380,22 @@ function canParseURL(url: string) {
   }
 }
 
-export async function verifyJWT(token: string) {
-  const JWKS = createRemoteJWKSet((await as()).jwks_uri);
-  const { payload } = await jwtVerify<{ team_id?: string }>(token, JWKS, {
-    issuer: 'https://vercel.com',
-    audience: ['https://api.vercel.com', 'https://vercel.com/api'],
-  });
-  return payload;
+interface VercelAccessToken extends JWTPayload {
+  team_id?: string;
+}
+
+export async function verifyJWT(
+  token: string
+): Promise<[Error] | [null, VercelAccessToken]> {
+  try {
+    const JWKS = createRemoteJWKSet((await as()).jwks_uri);
+    const { payload } = await jwtVerify<VercelAccessToken>(token, JWKS, {
+      issuer: 'https://vercel.com',
+      audience: ['https://api.vercel.com', 'https://vercel.com/api'],
+    });
+    return [null, payload];
+  } catch (error) {
+    if (error instanceof Error) return [error];
+    return [new Error('Could not verify JWT.', { cause: error })];
+  }
 }


### PR DESCRIPTION
This is a follow-up on #12098

In case of an unexpected server response, we will now gracefully exit and log the error response for the user.