### PR TITLE
[cli] get maxDuration from function configuration

### DIFF
--- a/.changeset/giant-clouds-double.md
+++ b/.changeset/giant-clouds-double.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+[cli] get maxDuration from function configuration

--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -8,7 +8,7 @@ if (!entrypoint) {
 import { join } from 'path';
 import type { Headers } from 'undici';
 import type { VercelProxyResponse } from './types.js';
-import { Config } from '@vercel/build-utils';
+import { Config, getLambdaOptionsFromFunction } from '@vercel/build-utils';
 import { createEdgeEventHandler } from './edge-functions/edge-handler.mjs';
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import {
@@ -40,6 +40,11 @@ async function createEventHandler(
   const runtime = staticConfig?.runtime;
   validateConfiguredRuntime(runtime, entrypoint);
 
+  const { maxDuration } = await getLambdaOptionsFromFunction({
+    sourceFile: entrypoint,
+    config
+  })
+
   // `middleware.js`/`middleware.ts` file is always run as
   // an Edge Function, otherwise needs to be opted-in via
   // `export const config = { runtime: 'edge' }`
@@ -48,7 +53,8 @@ async function createEventHandler(
       entrypointPath,
       entrypoint,
       config.middleware || false,
-      config.zeroConfig
+      config.zeroConfig,
+      maxDuration
     );
   }
 
@@ -64,6 +70,7 @@ async function createEventHandler(
   return createServerlessEventHandler(entrypointPath, {
     mode: isStreaming ? 'streaming' : 'buffer',
     shouldAddHelpers: options.shouldAddHelpers,
+    maxDuration
   });
 }
 

--- a/packages/node/src/dev-server.mts
+++ b/packages/node/src/dev-server.mts
@@ -42,8 +42,8 @@ async function createEventHandler(
 
   const { maxDuration } = await getLambdaOptionsFromFunction({
     sourceFile: entrypoint,
-    config
-  })
+    config,
+  });
 
   // `middleware.js`/`middleware.ts` file is always run as
   // an Edge Function, otherwise needs to be opted-in via
@@ -70,7 +70,7 @@ async function createEventHandler(
   return createServerlessEventHandler(entrypointPath, {
     mode: isStreaming ? 'streaming' : 'buffer',
     shouldAddHelpers: options.shouldAddHelpers,
-    maxDuration
+    maxDuration,
   });
 }
 

--- a/packages/node/src/edge-functions/edge-handler.mts
+++ b/packages/node/src/edge-functions/edge-handler.mts
@@ -12,7 +12,7 @@ import {
   entrypointToOutputPath,
   logError,
   WAIT_UNTIL_TIMEOUT,
-  waitUntilWarning
+  waitUntilWarning,
 } from '../utils.js';
 import esbuild from 'esbuild';
 import { buildToHeaders } from '@edge-runtime/node-utils';
@@ -134,13 +134,16 @@ async function compileUserCode(
   }
 }
 
-async function createEdgeRuntimeServer(maxDuration: number, params?: {
-  userCode: string;
-  wasmAssets: WasmAssets;
-  nodeCompatBindings: NodeCompatBindings;
-  entrypointPath: string;
-  awaiter: Awaiter;
-}): Promise<
+async function createEdgeRuntimeServer(
+  maxDuration: number,
+  params?: {
+    userCode: string;
+    wasmAssets: WasmAssets;
+    nodeCompatBindings: NodeCompatBindings;
+    entrypointPath: string;
+    awaiter: Awaiter;
+  }
+): Promise<
   { server: EdgeRuntimeServer; onExit: () => Promise<void> } | undefined
 > {
   try {

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -143,7 +143,7 @@ export async function createServerlessEventHandler(
     new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         console.warn(waitUntilWarning(entrypointPath, maxDuration));
-        resolve()
+        resolve();
       }, maxDuration * 1000);
       Promise.all([awaiter.awaiting(), server.onExit()])
         .then(() => resolve())

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -1,9 +1,9 @@
 import { addHelpers } from './helpers.js';
 import { createServer } from 'http';
 import {
-  WAIT_UNTIL_TIMEOUT_MS,
-  waitUntilWarning,
+  WAIT_UNTIL_TIMEOUT,
   serializeBody,
+  waitUntilWarning,
 } from '../utils.js';
 import { type Dispatcher, Headers, request as undiciRequest } from 'undici';
 import { listen } from 'async-listen';
@@ -23,6 +23,7 @@ const toHeaders = buildToHeaders({ Headers });
 type ServerlessServerOptions = {
   shouldAddHelpers: boolean;
   mode: 'streaming' | 'buffer';
+  maxDuration?: number;
 };
 
 type ServerlessFunctionSignature = (
@@ -86,7 +87,8 @@ async function compileUserCode(
 
 export async function createServerlessEventHandler(
   entrypointPath: string,
-  options: ServerlessServerOptions
+  options: ServerlessServerOptions,
+  maxDuration = WAIT_UNTIL_TIMEOUT
 ): Promise<{
   handler: (request: IncomingMessage) => Promise<VercelProxyResponse>;
   onExit: () => Promise<void>;
@@ -140,10 +142,9 @@ export async function createServerlessEventHandler(
   const onExit = () =>
     new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        console.warn(waitUntilWarning(entrypointPath));
-        resolve();
-      }, WAIT_UNTIL_TIMEOUT_MS);
-
+        console.warn(waitUntilWarning(entrypointPath, maxDuration));
+        resolve()
+      }, maxDuration * 1000);
       Promise.all([awaiter.awaiting(), server.onExit()])
         .then(() => resolve())
         .catch(reject)

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -81,16 +81,15 @@ export function pathToRegexp(
 // When exiting this process, wait for Vercel Function server to finish
 // all its work, especially waitUntil promises before exiting this process.
 //
-// Here we use a short timeout (10 seconds) to let the user know that
+// Here we use a short timeout (30 seconds) to let the user know that
 // it has a long-running waitUntil promise.
-const WAIT_UNTIL_TIMEOUT = 10;
-export const WAIT_UNTIL_TIMEOUT_MS = 10 * 1000;
+export const WAIT_UNTIL_TIMEOUT = 30;
 
-export const waitUntilWarning = (entrypointPath: string) =>
+export const waitUntilWarning = (entrypointPath: string, maxDuration: number) =>
   `
 The function \`${entrypointPath
     .split('/')
-    .pop()}\` is still running after ${WAIT_UNTIL_TIMEOUT}s.
+    .pop()}\` is still running after ${maxDuration}s.
 (hint: do you have a long-running waitUntil() promise?)
 `.trim();
 


### PR DESCRIPTION
Before this PR, when we run a `waitUntil` code it's fixed to 10ms max execution time.

After this PR, the max duration associated to `waitUntil` is read from teh function configuration, that can be declared at vercel.json, for example:

```json
{
  "redirects": [
    {
      "source": "/",
      "destination": "https://github.com/nicoalbanese/ai-sdk-slackbot"
    }
  ],
  "functions": {
    "api/events.ts": {
      "maxDuration": 60
    }
  },
  "outputDirectory": "dist"
}
```

So this PR is replacing the fixed value for reading the value from the configuration, and in case the value si not there, it's using the 30s as value which is the up to date value.