### PR TITLE
[build-utils] Automatically cache deps for yarn 3+

### DIFF
--- a/.changeset/strong-ways-decide.md
+++ b/.changeset/strong-ways-decide.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Disable yarn global cache before installs so build cache caches deps

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -738,6 +738,18 @@ export async function runNpmInstall(
       meta.runNpmInstallSet = runNpmInstallSet;
     }
 
+    // if yarn 3 or 4, disable global cache so build cache can cache deps
+    if (cliType === 'yarn') {
+      const yarnVersion = detectYarnVersion(lockfileVersion);
+      if (['yarn@3.x', 'yarn@4.x'].includes(yarnVersion)) {
+        await spawnAsync(
+          'yarn',
+          ['set', 'config', 'enableGlobalCache', 'false'],
+          { cwd: destPath }
+        );
+      }
+    }
+
     const installTime = Date.now();
     console.log('Installing dependencies...');
     debug(`Installing to ${destPath}`);

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -744,7 +744,7 @@ export async function runNpmInstall(
       if (['yarn@3.x', 'yarn@4.x'].includes(yarnVersion)) {
         await spawnAsync(
           'yarn',
-          ['set', 'config', 'enableGlobalCache', 'false'],
+          ['config', 'set', 'enableGlobalCache', 'false'],
           { cwd: destPath }
         );
       }

--- a/packages/build-utils/test/unit.run-npm-install.test.ts
+++ b/packages/build-utils/test/unit.run-npm-install.test.ts
@@ -110,3 +110,33 @@ it('should throw error when install failed - npm', async () => {
     message: 'Command "npm install" exited with 1',
   });
 });
+
+it('should disable global cache for yarn 3+', async () => {
+  const fixture = path.join(__dirname, 'fixtures', '44-yarn-v4');
+  expect(await runNpmInstall(fixture, [], undefined, {})).toEqual(true);
+
+  expect(spawnMock.mock.calls.length).toBe(2);
+  const yarnConfig = spawnMock.mock.calls[0];
+  expect(yarnConfig[0]).toEqual('yarn');
+  expect(yarnConfig[1]).toEqual([
+    'config',
+    'set',
+    'enableGlobalCache',
+    'false',
+  ]);
+
+  const yarnInstall = spawnMock.mock.calls[1];
+  expect(yarnInstall[0]).toEqual('yarn');
+  expect(yarnInstall[1]).toEqual(['install']);
+});
+
+it('should not disable global cache for yarn 1', async () => {
+  const fixture = path.join(__dirname, 'fixtures', '45-yarn-v1');
+  expect(await runNpmInstall(fixture, [], undefined, {})).toEqual(true);
+
+  expect(spawnMock.mock.calls.length).toBe(1);
+
+  const yarnInstall = spawnMock.mock.calls[0];
+  expect(yarnInstall[0]).toEqual('yarn');
+  expect(yarnInstall[1]).toEqual(['install']);
+});


### PR DESCRIPTION
By default, yarn 3 and 4 use a global cache for deps, but the build cache only handles the local project yarn cache. This meant yarn 3 and 4 projects needed to turn off the global cache for their project manually.

 This PR detects yarn 3 and 4, and executes `yarn config set enableGlobalCache false` automatically before installing deps.