### PR TITLE
Fix: Resolve tsc Path Dynamically for Type Checking in start-dev-server.ts (#13145)

### DIFF
--- a/packages/node/src/start-dev-server.ts
+++ b/packages/node/src/start-dev-server.ts
@@ -21,9 +21,32 @@ import {
 import { fixConfig } from './typescript';
 import { getRegExpFromMatchers } from './utils';
 
+const resolveTypescript = (p: string): string => {
+  try {
+    return require_.resolve('typescript', {
+      paths: [p],
+    });
+  } catch (_) {
+    return '';
+  }
+};
+
+const requireTypescript = (p: string): TypescriptModule => require_(p);
+
+let ts: TypescriptModule | null = null;
+let compiler = resolveTypescript(process.cwd());
+
+if (compiler) {
+  ts = requireTypescript(compiler);
+}
+
+if (!ts) {
+  compiler = resolveTypescript(join(__dirname, '..'));
+  ts = requireTypescript(compiler);
+}
+
 const require_ = createRequire(__filename);
 const treeKill = promisify(_treeKill);
-const tscPath = resolve(dirname(require_.resolve('typescript')), '../bin/tsc');
 
 type TypescriptModule = typeof import('typescript');
 
@@ -160,7 +183,7 @@ export const startDevServer: StartDevServer = async opts => {
     if (isTypeScript) {
       // Invoke `tsc --noEmit` asynchronously in the background, so
       // that the HTTP request is not blocked by the type checking.
-      doTypeCheck(opts, pathToTsConfig).catch((err: Error) => {
+      doTypeCheck(opts, pathToTsConfig, compiler).catch((err: Error) => {
         console.error('Type check for %j failed:', entrypoint, err);
       });
     }
@@ -190,16 +213,12 @@ export const startDevServer: StartDevServer = async opts => {
 
 async function doTypeCheck(
   { entrypoint, workPath, meta = {} }: StartDevServerOptions,
-  projectTsConfig: string | null
+  projectTsConfig: string | null,
+  compiler?: string
 ): Promise<void> {
   const { devCacheDir = join(workPath, '.vercel', 'cache') } = meta;
   const entrypointCacheDir = join(devCacheDir, 'node', entrypoint);
 
-  // In order to type-check a single file, a standalone tsconfig
-  // file needs to be created that inherits from the base one :(
-  // See: https://stackoverflow.com/a/44748041/376773
-  //
-  // A different filename needs to be used for different `extends` tsconfig.json
   const tsconfigName = projectTsConfig
     ? `tsconfig-with-${relative(workPath, projectTsConfig).replace(
         /[\\/.]/g,
@@ -222,6 +241,10 @@ async function doTypeCheck(
     if (isErrnoException(error) && error.code !== 'EEXIST') throw error;
   }
 
+  const tscPath = compiler
+    ? resolve(dirname(compiler), '../bin/tsc')
+    : resolve(dirname(require_.resolve('typescript')), '../bin/tsc');
+
   const child = spawn(
     process.execPath,
     [
@@ -237,5 +260,6 @@ async function doTypeCheck(
       stdio: 'inherit',
     }
   );
+
   await once.spread<[number, string | null]>(child, 'close');
 }


### PR DESCRIPTION
This PR addresses issue #13145 where the tsc path in node/src/start-dev-server.ts was incorrectly resolved for type checking. The previous implementation used a hardcoded path:


```start

const tscPath = resolve(dirname(require_.resolve('typescript')), '../bin/tsc');

```
This approach always pointed to the TypeScript version installed alongside @vercel/node, which could differ from the project's locally installed TypeScript version. As a result, type checking could fail or produce inconsistent results if the versions mismatched.

Fix Details:
Modified doTypeCheck function to accept a compiler argument representing the project's TypeScript path if available.
Updated tscPath to dynamically resolve based on the passed compiler path:


```ts
const tscPath = resolve(dirname(compiler), '../bin/tsc');

// Ensured that the TypeScript version used for type checking is consistent with the version used by ts-node for transpilation.

```
Impact:
Aligns the type checking TypeScript version with the one used for transpilation, ensuring consistent and expected behavior.
Fixes the issue reported in #13145, making local development more reliable.
Let me know if you need any adjustments! 🚀