### PR TITLE
[cli] Update `vercel target ls` to more closely match the Vercel dashboard UI

### DIFF
--- a/.changeset/gorgeous-jars-peel.md
+++ b/.changeset/gorgeous-jars-peel.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Update `vercel target ls` to more closely match the Vercel dashboard UI

--- a/packages/cli/src/commands/target/list.ts
+++ b/packages/cli/src/commands/target/list.ts
@@ -1,14 +1,50 @@
 import ms from 'ms';
 import chalk from 'chalk';
 import table from '../../util/output/table';
-import type Client from '../../util/client';
+import output from '../../output-manager';
 import { targetCommand } from './command';
 import { getCommandName } from '../../util/pkg-name';
 import { ensureLink } from '../../util/link/ensure-link';
 import { formatProject } from '../../util/projects/format-project';
 import { formatEnvironment } from '../../util/target/format-environment';
-import type { CustomEnvironment } from '@vercel-internals/types';
-import output from '../../output-manager';
+import type Client from '../../util/client';
+import type {
+  CustomEnvironment,
+  CustomEnvironmentBranchMatcher,
+  CustomEnvironmentType,
+  Project,
+} from '@vercel-internals/types';
+
+function formatBranchMatcher(
+  branchMatcher?: CustomEnvironmentBranchMatcher
+): string {
+  if (branchMatcher?.type === 'equals') {
+    return branchMatcher.pattern;
+  } else if (branchMatcher?.type === 'startsWith') {
+    return `${branchMatcher.pattern}*`;
+  } else if (branchMatcher?.type === 'endsWith') {
+    return `*${branchMatcher.pattern}`;
+  }
+  return chalk.dim('No branch configuration');
+}
+
+const TYPE_MAP: Record<CustomEnvironmentType, string> = {
+  production: 'Production',
+  preview: 'Preview',
+  development: 'Development',
+};
+
+const BRANCH_TRACKING_MAP: Record<
+  CustomEnvironmentType,
+  (project: Project, target: CustomEnvironment) => string
+> = {
+  production: project => project.link?.productionBranch ?? 'main',
+  preview: (_, env) =>
+    env.slug === 'preview'
+      ? chalk.dim('All unassigned git branches')
+      : formatBranchMatcher(env.branchMatcher),
+  development: () => chalk.dim('Accessible via CLI'),
+};
 
 export default async function list(client: Client, argv: string[]) {
   const { cwd } = client;
@@ -56,22 +92,15 @@ export default async function list(client: Client, argv: string[]) {
 
   const tablePrint = table(
     [
-      ['Target Name', 'Target Slug', 'Target ID', 'Type', 'Updated'].map(
-        header => chalk.bold(chalk.cyan(header))
+      ['Target Name', 'Branch Tracking', 'Type', 'Updated'].map(header =>
+        chalk.bold(chalk.cyan(header))
       ),
       ...result.flatMap(target => {
-        const type =
-          target.type === 'production'
-            ? 'Production'
-            : target.type === 'development'
-              ? 'Development'
-              : 'Preview';
         return [
           [
             formatEnvironment(link.org.slug, link.project.name, target),
-            target.slug,
-            target.id,
-            type,
+            BRANCH_TRACKING_MAP[target.type](link.project, target),
+            TYPE_MAP[target.type],
             chalk.gray(
               target.updatedAt > 0 ? ms(Date.now() - target.updatedAt) : '-'
             ),
@@ -107,7 +136,6 @@ function withDefaultEnvironmentsIncluded(
       description: '',
       domains: [],
     },
-    ...environments,
     {
       id: 'development',
       slug: 'development',
@@ -117,5 +145,6 @@ function withDefaultEnvironmentsIncluded(
       description: '',
       domains: [],
     },
+    ...environments.slice().sort((a, b) => a.slug.localeCompare(b.slug)),
   ];
 }

--- a/packages/cli/src/util/target/format-environment.ts
+++ b/packages/cli/src/util/target/format-environment.ts
@@ -1,6 +1,10 @@
 import chalk from 'chalk';
-import type { CustomEnvironment } from '@vercel-internals/types';
 import output from '../../output-manager';
+import type {
+  CustomEnvironment,
+  CustomEnvironmentType,
+} from '@vercel-internals/types';
+import { STANDARD_ENVIRONMENTS } from './standard-environments';
 import title from 'title';
 
 export function formatEnvironment(
@@ -9,7 +13,11 @@ export function formatEnvironment(
   environment: Pick<CustomEnvironment, 'slug' | 'id'>
 ) {
   const projectUrl = `https://vercel.com/${orgSlug}/${projectSlug}`;
-  const boldName = chalk.bold(title(environment.slug));
+  const boldName = chalk.bold(
+    STANDARD_ENVIRONMENTS.includes(environment.slug as CustomEnvironmentType)
+      ? title(environment.slug)
+      : environment.slug
+  );
   return output.link(
     boldName,
     `${projectUrl}/settings/environments/${environment.id}`,

--- a/packages/cli/src/util/target/standard-environments.ts
+++ b/packages/cli/src/util/target/standard-environments.ts
@@ -1,0 +1,5 @@
+export const STANDARD_ENVIRONMENTS = [
+  'production',
+  'preview',
+  'development',
+] as const;

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -1,6 +1,8 @@
 import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
 import type { TelemetryMethods } from '../../types';
 import type { addSubcommand } from '../../../../commands/env/command';
+import type { CustomEnvironmentType } from '@vercel-internals/types';
 
 export class EnvAddTelemetryClient
   extends TelemetryClient
@@ -16,11 +18,12 @@ export class EnvAddTelemetryClient
   }
 
   trackCliArgumentEnvironment(environment: string | undefined) {
-    const standardEnvironments = ['production', 'preview', 'development'];
     if (environment) {
       this.trackCliArgument({
         arg: 'environment',
-        value: standardEnvironments.includes(environment)
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as CustomEnvironmentType
+        )
           ? environment
           : this.redactedValue,
       });

--- a/packages/cli/src/util/telemetry/commands/env/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/env/ls.ts
@@ -1,6 +1,8 @@
 import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
 import type { TelemetryMethods } from '../../types';
 import type { listSubcommand } from '../../../../commands/env/command';
+import type { CustomEnvironmentType } from '@vercel-internals/types';
 
 export class EnvLsTelemetryClient
   extends TelemetryClient
@@ -8,10 +10,11 @@ export class EnvLsTelemetryClient
 {
   trackCliArgumentEnvironment(environment: string | undefined) {
     if (environment) {
-      const standardEnvironments = ['production', 'preview', 'development'];
       this.trackCliArgument({
         arg: 'environment',
-        value: standardEnvironments.includes(environment)
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as CustomEnvironmentType
+        )
           ? environment
           : this.redactedValue,
       });

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -1,6 +1,8 @@
 import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
 import type { TelemetryMethods } from '../../types';
 import type { pullSubcommand } from '../../../../commands/env/command';
+import type { CustomEnvironmentType } from '@vercel-internals/types';
 
 export class EnvPullTelemetryClient
   extends TelemetryClient
@@ -17,10 +19,11 @@ export class EnvPullTelemetryClient
 
   trackCliOptionEnvironment(environment: string | undefined) {
     if (environment) {
-      const standardEnvironments = ['production', 'preview', 'development'];
       this.trackCliOption({
         option: 'environment',
-        value: standardEnvironments.includes(environment)
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as CustomEnvironmentType
+        )
           ? environment
           : this.redactedValue,
       });

--- a/packages/cli/src/util/telemetry/commands/env/rm.ts
+++ b/packages/cli/src/util/telemetry/commands/env/rm.ts
@@ -1,6 +1,8 @@
 import { TelemetryClient } from '../..';
+import { STANDARD_ENVIRONMENTS } from '../../../target/standard-environments';
 import type { TelemetryMethods } from '../../types';
 import type { removeSubcommand } from '../../../../commands/env/command';
+import type { CustomEnvironmentType } from '@vercel-internals/types';
 
 export class EnvRmTelemetryClient
   extends TelemetryClient
@@ -16,11 +18,12 @@ export class EnvRmTelemetryClient
   }
 
   trackCliArgumentEnvironment(environment: string | undefined) {
-    const standardEnvironments = ['production', 'preview', 'development'];
     if (environment) {
       this.trackCliArgument({
         arg: 'environment',
-        value: standardEnvironments.includes(environment)
+        value: STANDARD_ENVIRONMENTS.includes(
+          environment as CustomEnvironmentType
+        )
           ? environment
           : this.redactedValue,
       });

--- a/packages/cli/test/unit/commands/target/list.test.ts
+++ b/packages/cli/test/unit/commands/target/list.test.ts
@@ -141,8 +141,7 @@ describe('target ls', () => {
     const header = parseSpacedTableRow(line.value!);
     expect(header).toEqual([
       'Target Name',
-      'Target Slug',
-      'Target ID',
+      'Branch Tracking',
       'Type',
       'Updated',
     ]);
@@ -150,8 +149,7 @@ describe('target ls', () => {
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
       'Production',
-      'production',
-      'production',
+      'main',
       'Production',
       '-',
     ]);
@@ -159,37 +157,33 @@ describe('target ls', () => {
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
       'Preview',
-      'preview',
-      'preview',
+      'All unassigned git branches',
       'Preview',
       '-',
     ]);
 
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
-      'Her',
-      'her',
-      'env_8DTiPYD33Rcvu2hQwYAdw0rwLquY',
-      'Preview',
-      String(ms(Date.now() - project.customEnvironments![0].updatedAt)),
+      'Development',
+      'Accessible via CLI',
+      'Development',
+      '-',
     ]);
 
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
-      'Ano',
       'ano',
-      'env_ph1tjPP20xp8VAuiFsYt4rhRYGys',
+      'ano*',
       'Preview',
       String(ms(Date.now() - project.customEnvironments![0].updatedAt)),
     ]);
 
     line = await lines.next();
     expect(parseSpacedTableRow(line.value!)).toEqual([
-      'Development',
-      'development',
-      'development',
-      'Development',
-      '-',
+      'her',
+      '*her',
+      'Preview',
+      String(ms(Date.now() - project.customEnvironments![0].updatedAt)),
     ]);
   });
 });


### PR DESCRIPTION
* Move "Development" environment to below "Preview" (instead of at the very end)
* Remove "Slug" column (the slug is now shown under "Name" column)
* Remove "ID" column
* Add "Branch Tracking" column

<img width="487" alt="Screenshot 2025-03-10 at 15 21 49" src="https://github.com/user-attachments/assets/decc376c-93fc-4862-81f9-b726056ff10f" />

For reference, to compare with the current information provided in the Vercel dashboard:

<img width="939" alt="Screenshot 2025-03-10 at 15 22 04" src="https://github.com/user-attachments/assets/737db59a-2680-4fd7-94c1-639f090b9705" />
