### PR TITLE
Force all resource creation to use web UI to use authorization flow

### DIFF
--- a/.changeset/seven-pumpkins-sort.md
+++ b/.changeset/seven-pumpkins-sort.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Force all integration resource creation to use web UI for authorization flow

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -118,22 +118,25 @@ export async function add(client: Client, args: string[]) {
   // However, when we introduce new categories, we avoid breaking this version of the CLI by linking all
   // non-storage categories to the dashboard.
   // product.type is the old way of defining categories, while the protocols are the new way.
-  const isPreProtocolStorageProduct = product.type === 'storage';
-  const isPostProtocolStorageProduct =
-    product.protocols?.storage?.status === 'enabled';
-  const isVideoProduct = product.protocols?.video?.status;
-  const isStorageProduct =
-    isPreProtocolStorageProduct || isPostProtocolStorageProduct;
-  const isSupportedProductType = isStorageProduct || isVideoProduct;
+  // const isPreProtocolStorageProduct = product.type === 'storage';
+  // const isPostProtocolStorageProduct =
+  //   product.protocols?.storage?.status === 'enabled';
+  // const isVideoProduct = product.protocols?.video?.status;
+  // const isStorageProduct =
+  //   isPreProtocolStorageProduct || isPostProtocolStorageProduct;
+  // const isSupportedProductType = isStorageProduct || isVideoProduct;
 
   // The provisioning via cli is possible when
   // 1. The integration was installed once (terms have been accepted)
   // 2. The provider-defined metadata is supported (does not use metadata expressions etc.)
   // 3. The product type is supported
-  const provisionResourceViaCLIIsSupported =
-    installation && metadataWizard.isSupported && isSupportedProductType;
+  // const provisionResourceViaCLIIsSupported =
+  //   installation && metadataWizard.isSupported && isSupportedProductType;
 
-  if (!provisionResourceViaCLIIsSupported) {
+  // INC-2151: this functionality is being disabled until the CLI supports the new authorization flow for resource creation
+  const provisionResourceViaCLIIsSupported = false;
+
+  if (!provisionResourceViaCLIIsSupported || !installation) {
     const projectLink = await getOptionalLinkedProject(client);
 
     if (projectLink?.status === 'error') {

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -184,41 +184,55 @@ describe('integration', () => {
           await expect(client.stderr).toOutput(
             `Installing Acme Product by Acme Integration under ${team.slug}`
           );
-          await expect(client.stderr).toOutput(
-            'What is the name of the resource?'
-          );
-          client.stdin.write('test-resource\n');
-          await expect(client.stderr).toOutput(
-            'Choose your region (Use arrow keys)'
-          );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            'Choose a billing plan (Use arrow keys)'
-          );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            `Selected product:
-- Name: test-resource
-- Primary Region: us-west-1
-- Plan: Pro Plan
-? Confirm selection? (Y/n)`
-          );
-          client.stdin.write('y\n');
-          await expect(client.stderr).toOutput(
-            'Acme Product successfully provisioned'
-          );
+
+          // INC-2151: forcing all resource creation to the web UI
           await expect(client.stderr).toOutput(
             'Do you want to link this resource to the current project? (Y/n)'
           );
-          client.stdin.write('y\n');
-          await expect(client.stderr).toOutput('Select environments');
-          client.stdin.write('\n');
+          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
-            'test-resource successfully connected to vercel-integration-add'
+            'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
           );
-          const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
-          expect(openMock).not.toHaveBeenCalled();
+          client.stdin.write('Y\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+          expect(openMock).toHaveBeenCalledWith(
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+          );
+          //           await expect(client.stderr).toOutput(
+          //             'What is the name of the resource?'
+          //           );
+          //           client.stdin.write('test-resource\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose your region (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose a billing plan (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             `Selected product:
+          // - Name: test-resource
+          // - Primary Region: us-west-1
+          // - Plan: Pro Plan
+          // ? Confirm selection? (Y/n)`
+          //           );
+          //           client.stdin.write('y\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Acme Product successfully provisioned'
+          //           );
+          //           await expect(client.stderr).toOutput(
+          //             'Do you want to link this resource to the current project? (Y/n)'
+          //           );
+          //           client.stdin.write('y\n');
+          //           await expect(client.stderr).toOutput('Select environments');
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             'test-resource successfully connected to vercel-integration-add'
+          //           );
+          //           const exitCode = await exitCodePromise;
+          //           expect(exitCode, 'exit code for "integration"').toEqual(0);
+          //           expect(openMock).not.toHaveBeenCalled();
         });
 
         it('should handle provisioning resource on team-level in project context', async () => {
@@ -234,36 +248,51 @@ describe('integration', () => {
           await expect(client.stderr).toOutput(
             `Installing Acme Product by Acme Integration under ${team.slug}`
           );
-          await expect(client.stderr).toOutput(
-            'What is the name of the resource?'
-          );
-          client.stdin.write('test-resource\n');
-          await expect(client.stderr).toOutput(
-            'Choose your region (Use arrow keys)'
-          );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            'Choose a billing plan (Use arrow keys)'
-          );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            `Selected product:
-- Name: test-resource
-- Primary Region: us-west-1
-- Plan: Pro Plan
-? Confirm selection? (Y/n)`
-          );
-          client.stdin.write('y\n');
-          await expect(client.stderr).toOutput(
-            'Acme Product successfully provisioned'
-          );
+
+          // INC-2151: forcing all resource creation to the web UI
           await expect(client.stderr).toOutput(
             'Do you want to link this resource to the current project? (Y/n)'
           );
           client.stdin.write('n\n');
-          const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
-          expect(openMock).not.toHaveBeenCalled();
+          await expect(client.stderr).toOutput(
+            'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
+          );
+          client.stdin.write('Y\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+          expect(openMock).toHaveBeenCalledWith(
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+          );
+
+          //           await expect(client.stderr).toOutput(
+          //             'What is the name of the resource?'
+          //           );
+          //           client.stdin.write('test-resource\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose your region (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose a billing plan (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             `Selected product:
+          // - Name: test-resource
+          // - Primary Region: us-west-1
+          // - Plan: Pro Plan
+          // ? Confirm selection? (Y/n)`
+          //           );
+          //           client.stdin.write('y\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Acme Product successfully provisioned'
+          //           );
+          //           await expect(client.stderr).toOutput(
+          //             'Do you want to link this resource to the current project? (Y/n)'
+          //           );
+          //           client.stdin.write('n\n');
+          //           const exitCode = await exitCodePromise;
+          //           expect(exitCode, 'exit code for "integration"').toEqual(0);
+          //           expect(openMock).not.toHaveBeenCalled();
         });
 
         it('should handle provisioning resource without project context', async () => {
@@ -272,32 +301,43 @@ describe('integration', () => {
           await expect(client.stderr).toOutput(
             `Installing Acme Product by Acme Integration under ${team.slug}`
           );
+
+          // INC-2151: forcing all resource creation to the web UI
           await expect(client.stderr).toOutput(
-            'What is the name of the resource?'
+            'This resource must be provisioned through the Web UI. Open Vercel Dashboard?'
           );
-          client.stdin.write('test-resource\n');
-          await expect(client.stderr).toOutput(
-            'Choose your region (Use arrow keys)'
+          client.stdin.write('Y\n');
+          await expect(exitCodePromise).resolves.toEqual(0);
+          expect(openMock).toHaveBeenCalledWith(
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
           );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            'Choose a billing plan (Use arrow keys)'
-          );
-          client.stdin.write('\n');
-          await expect(client.stderr).toOutput(
-            `Selected product:
-- Name: test-resource
-- Primary Region: us-west-1
-- Plan: Pro Plan
-? Confirm selection? (Y/n)`
-          );
-          client.stdin.write('y\n');
-          await expect(client.stderr).toOutput(
-            'Acme Product successfully provisioned'
-          );
-          const exitCode = await exitCodePromise;
-          expect(exitCode, 'exit code for "integration"').toEqual(0);
-          expect(openMock).not.toHaveBeenCalled();
+
+          //           await expect(client.stderr).toOutput(
+          //             'What is the name of the resource?'
+          //           );
+          //           client.stdin.write('test-resource\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose your region (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Choose a billing plan (Use arrow keys)'
+          //           );
+          //           client.stdin.write('\n');
+          //           await expect(client.stderr).toOutput(
+          //             `Selected product:
+          // - Name: test-resource
+          // - Primary Region: us-west-1
+          // - Plan: Pro Plan
+          // ? Confirm selection? (Y/n)`
+          //           );
+          //           client.stdin.write('y\n');
+          //           await expect(client.stderr).toOutput(
+          //             'Acme Product successfully provisioned'
+          //           );
+          //           const exitCode = await exitCodePromise;
+          //           expect(exitCode, 'exit code for "integration"').toEqual(0);
+          //           expect(openMock).not.toHaveBeenCalled();
         });
 
         it('should require the vercel dashboard for expressions in UI wizard', async () => {


### PR DESCRIPTION
Due to a change in how we handle resource creation, our CLI does not currently handle marketplace integration resource creation. It will instead always fail due to missing authorization.

As a temporary fix until the CLI can handle authorization, I'm sending all resource creation to the web UI so that the command doesn't take the user through the full creation flow just to fail them. The web UI properly handles the authorization flow, and thus doesn't have this issue.