### PR TITLE
[cli] Formatting tweaks to `vc target ls`

### DIFF
--- a/.changeset/seven-steaks-mix.md
+++ b/.changeset/seven-steaks-mix.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Formatting tweaks to `vc target ls`

--- a/packages/cli/src/commands/target/list.ts
+++ b/packages/cli/src/commands/target/list.ts
@@ -21,9 +21,9 @@ function formatBranchMatcher(
   if (branchMatcher?.type === 'equals') {
     return branchMatcher.pattern;
   } else if (branchMatcher?.type === 'startsWith') {
-    return `${branchMatcher.pattern}*`;
+    return `${branchMatcher.pattern}${chalk.dim('*')}`;
   } else if (branchMatcher?.type === 'endsWith') {
-    return `*${branchMatcher.pattern}`;
+    return `${chalk.dim('*')}${branchMatcher.pattern}`;
   }
   return chalk.dim('No branch configuration');
 }

--- a/packages/cli/src/util/target/format-environment.ts
+++ b/packages/cli/src/util/target/format-environment.ts
@@ -20,7 +20,7 @@ export function formatEnvironment(
   );
   return output.link(
     boldName,
-    `${projectUrl}/settings/environments/${environment.id}`,
+    `${projectUrl}/settings/environments/${environment.slug}`,
     { fallback: () => boldName, color: false }
   );
 }


### PR DESCRIPTION
* Render the "starts with" and "ends with" asterisk as dim
* Use the environment slug (instead of ID) in the clickable link URL