### PR TITLE
[build-utils] increase max memory limit

### DIFF
--- a/.changeset/proud-cobras-bow.md
+++ b/.changeset/proud-cobras-bow.md
@@ -1,0 +1,7 @@
+---
+'@vercel/fs-detectors': patch
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+[build-utils] increase max memory limit

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -14,7 +14,7 @@ export const functionsSchema = {
         },
         memory: {
           minimum: 128,
-          maximum: 3009,
+          maximum: 10240,
         },
         maxDuration: {
           type: 'number',

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -254,12 +254,12 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          memory: 3010,
+          memory: 10241,
         },
       },
     });
     expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].memory` should be <= 3009."
+      "Invalid vercel.json - `functions['api/test.js'].memory` should be <= 10240."
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -628,11 +628,11 @@ function validateFunctions({ functions = {} }: Options) {
 
     if (
       func.memory !== undefined &&
-      (func.memory < 128 || func.memory > 3009)
+      (func.memory < 128 || func.memory > 10240)
     ) {
       return {
         code: 'invalid_function_memory',
-        message: 'Functions must have a memory value between 128 and 3009',
+        message: 'Functions must have a memory value between 128 and 10240',
       };
     }
 


### PR DESCRIPTION
Similar to #11209, this PR increases the maximum permitted memory to 10240 MB. It **does not change the default** from 3009.

Despite validation permitting 10240MB, the Vercel API may enforce different limits for free/paid for abuse-prevention purposes.