### PR TITLE
Add license to @vercel/gatsby-plugin-vercel-builder

### DIFF
--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vercel/gatsby-plugin-vercel-builder",
   "version": "2.0.80",
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "files": [
     "dist",


### PR DESCRIPTION
🔗 https://www.npmjs.com/package/@vercel/gatsby-plugin-vercel-builder

<img width="389" alt="@vercel/gatsby-plugin-vercel-builder" src="https://github.com/user-attachments/assets/39163d3a-18cd-4818-8dcc-0b153ea21c7f" />

I confirmed that every package.json in the other packages includes a "license" field.
e.g., @vercel/build-utils
