### PR TITLE
[next] Fix operationType for mixed app router slug with ISR/SSR

### DIFF
--- a/.changeset/eight-rockets-swim.md
+++ b/.changeset/eight-rockets-swim.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix operationType for mixed app router slug with ISR/SSR

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -522,10 +522,7 @@ export async function serverBuild({
     ...(canUsePreviewMode ? omittedPrerenderRoutes : []),
     ...Object.keys(prerenderManifest.blockingFallbackRoutes),
     ...Object.keys(prerenderManifest.fallbackRoutes),
-    ...Object.keys(prerenderManifest.staticRoutes).map(route => {
-      const staticRoute = prerenderManifest.staticRoutes[route];
-      return staticRoute.srcRoute || route;
-    }),
+    ...Object.keys(prerenderManifest.staticRoutes),
   ]);
 
   const experimentalStreamingLambdaPaths = new Map<

--- a/packages/next/test/integration/app-mixed-static-dynamic-slug/app/[...slug]/page.js
+++ b/packages/next/test/integration/app-mixed-static-dynamic-slug/app/[...slug]/page.js
@@ -1,0 +1,26 @@
+import { headers } from 'next/headers';
+
+export function generateStaticParams() {
+  return [
+    {
+      slug: ['static'],
+    },
+    {
+      slug: ['dynamic'],
+    },
+  ];
+}
+
+export default function Page({ params }) {
+  if (params.slug?.[0] === 'dynamic') {
+    console.log('calling headers to trigger dynamic for', params);
+    headers();
+  }
+
+  return (
+    <>
+      <p>catch-all /[[...slug]]</p>
+      <p>{JSON.stringify(params)}</p>
+    </>
+  );
+}

--- a/packages/next/test/integration/app-mixed-static-dynamic-slug/app/layout.js
+++ b/packages/next/test/integration/app-mixed-static-dynamic-slug/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/integration/app-mixed-static-dynamic-slug/app/page.js
+++ b/packages/next/test/integration/app-mixed-static-dynamic-slug/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>This is the page</div>;
+}

--- a/packages/next/test/integration/app-mixed-static-dynamic-slug/package.json
+++ b/packages/next/test/integration/app-mixed-static-dynamic-slug/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "14.2.25",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/integration/app-mixed-static-dynamic-slug/vercel.json
+++ b/packages/next/test/integration/app-mixed-static-dynamic-slug/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -461,6 +461,20 @@ it('should not generate lambdas that conflict with static index route in app wit
   expect(lambdas.size).toBe(1);
 });
 
+it('should correct operationType for mixed dynamic/ssg slug', async () => {
+  const {
+    buildResult: { output },
+  } = await runBuildLambda(
+    path.join(__dirname, 'app-mixed-static-dynamic-slug')
+  );
+
+  expect(output['static'].type).toBe('Prerender');
+  expect(output['dynamic']).toBeFalsy();
+
+  expect(output['[...slug]'].type).toBe('Lambda');
+  expect(output['[...slug]'].operationType).toBe('Page');
+});
+
 describe('PPR', () => {
   describe('legacy', () => {
     it('should have the same lambda for revalidation and resume', async () => {


### PR DESCRIPTION
This fixes incorrect `operationType` when an app router project has a slug that creates both dynamic paths and ISR paths since previously in pages router we assumed if a dynamic route had any prerendered paths then it's source route was ISR itself but this isn't the case for app router since some paths can be prerendered but then if any bail to dynamic the source route itself is dynamic. 

x-ref: [slack thread](https://vercel.slack.com/archives/C08J1UU858V/p1742252573040089?thread_ts=1742235138.645789&cid=C08J1UU858V)