### PR TITLE
trace writeBuildResult

### DIFF
--- a/.changeset/six-icons-taste.md
+++ b/.changeset/six-icons-taste.md
@@ -1,0 +1,4 @@
+---
+---
+
+add a trace to the writeBuildResult operation

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -670,7 +670,7 @@ async function doBuild(
           .child('vc.builder.writeBuildResult', {
             buildOutputLength: String(buildOutputLength),
           })
-          .trace<Promise<Record<string, PathOverride> | undefined | void>>(() =>
+          .trace<Record<string, PathOverride> | undefined | void>(() =>
             writeBuildResult(
               repoRootPath,
               outputDir,
@@ -682,7 +682,7 @@ async function doBuild(
             )
           )
           .then(
-            (override: PathOverride | undefined) => {
+            (override: Record<string, PathOverride> | undefined | void) => {
               if (override) overrides.push(override);
             },
             (err: Error) => err

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -657,10 +657,17 @@ async function doBuild(
       // all builds have completed
       buildResults.set(build, buildResult);
 
+      let buildOutputLength = 0;
+      if ('output' in buildResult) {
+        buildOutputLength = Array.isArray(buildResult.output)
+          ? buildResult.output.length
+          : 1;
+      }
+
       // Start flushing the file outputs to the filesystem asynchronously
       ops.push(
         builderSpan
-          .child('vc.builder.writeBuildResult')
+          .child('vc.builder.writeBuildResult', { buildOutputLength })
           .trace<Record<string, PathOverride> | undefined>(() =>
             writeBuildResult(
               repoRootPath,

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -659,20 +659,25 @@ async function doBuild(
 
       // Start flushing the file outputs to the filesystem asynchronously
       ops.push(
-        writeBuildResult(
-          repoRootPath,
-          outputDir,
-          buildResult,
-          build,
-          builder,
-          builderPkg,
-          localConfig
-        ).then(
-          override => {
-            if (override) overrides.push(override);
-          },
-          err => err
-        )
+        builderSpan
+          .child('vc.builder.writeBuildResult')
+          .trace<Record<string, PathOverride> | undefined>(() =>
+            writeBuildResult(
+              repoRootPath,
+              outputDir,
+              buildResult,
+              build,
+              builder,
+              builderPkg,
+              localConfig
+            )
+          )
+          .then(
+            (override: PathOverride | undefined) => {
+              if (override) overrides.push(override);
+            },
+            (err: Error) => err
+          )
       );
     } catch (err: any) {
       const buildJsonBuild = buildsJsonBuilds.get(build);

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -667,8 +667,10 @@ async function doBuild(
       // Start flushing the file outputs to the filesystem asynchronously
       ops.push(
         builderSpan
-          .child('vc.builder.writeBuildResult', { buildOutputLength })
-          .trace<Record<string, PathOverride> | undefined>(() =>
+          .child('vc.builder.writeBuildResult', {
+            buildOutputLength: String(buildOutputLength),
+          })
+          .trace<Promise<Record<string, PathOverride> | undefined | void>>(() =>
             writeBuildResult(
               repoRootPath,
               outputDir,


### PR DESCRIPTION
Add a trace to the `writeBuildResult` operation. After finishing the build, in some cases, where we have lots of build results, we can spend quite some time (I've seen some projects where we spend up to 20 seconds).

<img width="1444" alt="Screenshot 2025-03-31 at 14 36 56" src="https://github.com/user-attachments/assets/87a473bb-9681-459c-942d-b4369ddee770" />

I do not think we will be able to improve it, although I will check it later on. The first step is getting observability.