### PR TITLE
perf test createZip with sema 4 instead of 10

### DIFF
--- a/.changeset/cyan-nails-decide.md
+++ b/.changeset/cyan-nails-decide.md
@@ -1,0 +1,4 @@
+---
+---
+
+Create 4 zips in parallel instead of 10

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -224,7 +224,7 @@ export class Lambda {
   }
 }
 
-const sema = new Sema(10);
+const sema = new Sema(4);
 const mtime = new Date(1540000000000);
 
 /**


### PR DESCRIPTION
Do not merge. For now, testing if there is a performance improvemennt.

Setting the Sema for createZip, which is a resource sensitive operation, to 4 (default value for `UV_THREADPOOL_SIZE`)