### PR TITLE
Update @vercel/firewall README with correct Rate Limit SDK link

### DIFF
--- a/.changeset/lovely-apples-heal.md
+++ b/.changeset/lovely-apples-heal.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+fix(readme): updated link to documentation about the SDK

--- a/packages/firewall/README.md
+++ b/packages/firewall/README.md
@@ -2,7 +2,7 @@
 
 ## Programmatic rate limits
 
-[See our Firewall docs for detailed documentation of @vercel/firewall.](https://vercel.com/docs/security/vercel-waf/programmatic-access)
+[See our Firewall docs for detailed documentation of @vercel/firewall.](https://vercel.com/docs/vercel-waf/rate-limiting-sdk)
 
 ```ts
 import { unstable_checkRateLimit as checkRateLimit } from '@vercel/firewall';


### PR DESCRIPTION
Previous link was broken: https://vercel.com/docs/security/vercel-waf/programmatic-access

Proper link for @vercel/firewall: https://vercel.com/docs/vercel-waf/rate-limiting-sdk