### PR TITLE
[cli] refresh `VERCEL_OIDC_TOKEN`

### DIFF
--- a/.changeset/shy-rice-allow.md
+++ b/.changeset/shy-rice-allow.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+`vercel dev` will automatically refresh the `VERCEL_OIDC_TOKEN` environment variable when it expires.

--- a/.changeset/shy-rice-allow.md
+++ b/.changeset/shy-rice-allow.md
@@ -2,4 +2,7 @@
 'vercel': minor
 ---
 
-`vercel dev` will automatically refresh the `VERCEL_OIDC_TOKEN` environment variable when it expires.
+`vercel dev` can now automatically refresh the `VERCEL_OIDC_TOKEN` environment
+variable before it expires in `.env.local` files. This feature is currently
+opt-in. Set the local environment variable `REFRESH_VERCEL_OIDC_TOKEN` to enable
+it.

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -81,10 +81,6 @@ export default async function dev(
     envValues = (await pullEnvRecords(client, project.id, 'vercel-cli:dev'))
       .env;
 
-    // Linked environment variables are normally static; however, we want to
-    // refresh VERCEL_OIDC_TOKEN, since it can expire. Therefore, we need to
-    // exclude it from `envValues` passed to DevServer. If we don't, then
-    // updating VERCEL_OIDC_TOKEN in .env.local will have no effect.
     stopRefreshOidcToken = await refreshOidcToken(
       client,
       link,

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -10,7 +10,6 @@ import setupAndLink from '../../util/link/setup-and-link';
 import { getCommandName } from '../../util/pkg-name';
 import param from '../../util/output/param';
 import { OUTPUT_DIR } from '../../util/build/write-build-result';
-import { VERCEL_OIDC_TOKEN } from '../../util/env/constants';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import { refreshOidcToken } from '../../util/env/refresh-oidc-token';
 import output from '../../output-manager';
@@ -84,16 +83,12 @@ export default async function dev(
     // refresh VERCEL_OIDC_TOKEN, since it can expire. Therefore, we need to
     // exclude it from `envValues` passed to DevServer. If we don't, then
     // updating VERCEL_OIDC_TOKEN in .env.local will have no effect.
-    const oidcToken = envValues[VERCEL_OIDC_TOKEN];
-    if (oidcToken) {
-      delete envValues[VERCEL_OIDC_TOKEN];
-      stopRefreshOidcToken = await refreshOidcToken(
-        client,
-        link.project.id,
-        oidcToken,
-        'vercel-cli:dev'
-      );
-    }
+    stopRefreshOidcToken = await refreshOidcToken(
+      client,
+      link.project.id,
+      envValues,
+      'vercel-cli:dev'
+    );
   }
 
   const devServer = new DevServer(cwd, {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -85,7 +85,7 @@ export default async function dev(
     // updating VERCEL_OIDC_TOKEN in .env.local will have no effect.
     stopRefreshOidcToken = await refreshOidcToken(
       client,
-      link.project.id,
+      link,
       envValues,
       'vercel-cli:dev'
     );

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -12,6 +12,7 @@ import param from '../../util/output/param';
 import { OUTPUT_DIR } from '../../util/build/write-build-result';
 import { pullEnvRecords } from '../../util/env/get-env-records';
 import { refreshOidcToken } from '../../util/env/refresh-oidc-token';
+import type { DevTelemetryClient } from '../../util/telemetry/commands/dev';
 import output from '../../output-manager';
 
 type Options = {
@@ -22,7 +23,8 @@ type Options = {
 export default async function dev(
   client: Client,
   opts: Partial<Options>,
-  args: string[]
+  args: string[],
+  telemetry: DevTelemetryClient
 ) {
   const [dir = '.'] = args;
   let cwd = resolve(dir);
@@ -87,7 +89,8 @@ export default async function dev(
       client,
       link,
       envValues,
-      'vercel-cli:dev'
+      'vercel-cli:dev',
+      telemetry
     );
   }
 

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -126,7 +126,7 @@ export default async function main(client: Client) {
   }
 
   try {
-    return await dev(client, parsedArgs.flags, args);
+    return await dev(client, parsedArgs.flags, args, telemetry);
   } catch (err) {
     if (isErrnoException(err) && err.code === 'ENOTFOUND') {
       // Error message will look like the following:

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -7,6 +7,7 @@ import { emoji, prependEmoji } from '../../util/emoji';
 import param from '../../util/output/param';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
+import { CONTENTS_PREFIX } from '../../util/env/constants';
 import {
   type EnvRecordsSource,
   pullEnvRecords,
@@ -28,8 +29,6 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
-
-const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
 
 function readHeadSync(path: string, length: number) {
   const buffer = Buffer.alloc(length);

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -6,7 +6,7 @@ import { emoji, prependEmoji } from '../../util/emoji';
 import param from '../../util/output/param';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
-import { CONTENTS_PREFIX } from '../../util/env/constants';
+import { CONTENTS_PREFIX, VARIABLES_TO_IGNORE } from '../../util/env/constants';
 import { escapeValue } from '../../util/env/escape-value';
 import {
   type EnvRecordsSource,
@@ -29,12 +29,6 @@ import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
 import { wasCreatedByVercel } from '../../util/env/was-created-by-vercel';
-
-const VARIABLES_TO_IGNORE = [
-  'VERCEL_ANALYTICS_ID',
-  'VERCEL_SPEED_INSIGHTS_ID',
-  'VERCEL_WEB_ANALYTICS_ID',
-];
 
 export default async function pull(client: Client, argv: string[]) {
   const telemetryClient = new EnvPullTelemetryClient({

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -7,6 +7,7 @@ import param from '../../util/output/param';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
 import { CONTENTS_PREFIX } from '../../util/env/constants';
+import { escapeValue } from '../../util/env/escape-value';
 import {
   type EnvRecordsSource,
   pullEnvRecords,
@@ -201,12 +202,4 @@ export async function envPullCommandLogic(
       emoji('success')
     )}\n`
   );
-}
-
-function escapeValue(value: string | undefined) {
-  return value
-    ? value
-        .replace(new RegExp('\n', 'g'), '\\n') // combine newlines (unix) into one line
-        .replace(new RegExp('\r', 'g'), '\\r') // combine newlines (windows) into one line
-    : '';
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -1,13 +1,10 @@
 import chalk from 'chalk';
-import { outputFile } from 'fs-extra';
 import { resolve } from 'path';
 import type Client from '../../util/client';
 import { emoji, prependEmoji } from '../../util/emoji';
 import param from '../../util/output/param';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
-import { CONTENTS_PREFIX, VARIABLES_TO_IGNORE } from '../../util/env/constants';
-import { escapeValue } from '../../util/env/escape-value';
 import {
   type EnvRecordsSource,
   pullEnvRecords,
@@ -29,6 +26,7 @@ import { printError } from '../../util/error';
 import parseTarget from '../../util/parse-target';
 import { getLinkedProject } from '../../util/projects/link';
 import { wasCreatedByVercel } from '../../util/env/was-created-by-vercel';
+import { writeEnvFile } from '../../util/env/write-env-file';
 
 export default async function pull(client: Client, argv: string[]) {
   const telemetryClient = new EnvPullTelemetryClient({
@@ -160,16 +158,7 @@ export async function envPullCommandLogic(
     }
   }
 
-  const contents =
-    CONTENTS_PREFIX +
-    Object.keys(records)
-      .sort()
-      .filter(key => !VARIABLES_TO_IGNORE.includes(key))
-      .map(key => `${key}="${escapeValue(records[key])}"`)
-      .join('\n') +
-    '\n';
-
-  await outputFile(fullPath, contents, 'utf8');
+  await writeEnvFile(fullPath, records);
 
   if (deltaString) {
     output.print('\n' + deltaString);

--- a/packages/cli/src/util/env/constants.ts
+++ b/packages/cli/src/util/env/constants.ts
@@ -1,0 +1,3 @@
+export const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
+
+export const VERCEL_OIDC_TOKEN = 'VERCEL_OIDC_TOKEN';

--- a/packages/cli/src/util/env/constants.ts
+++ b/packages/cli/src/util/env/constants.ts
@@ -1,1 +1,7 @@
 export const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
+
+export const VARIABLES_TO_IGNORE = [
+  'VERCEL_ANALYTICS_ID',
+  'VERCEL_SPEED_INSIGHTS_ID',
+  'VERCEL_WEB_ANALYTICS_ID',
+];

--- a/packages/cli/src/util/env/constants.ts
+++ b/packages/cli/src/util/env/constants.ts
@@ -1,3 +1,1 @@
 export const CONTENTS_PREFIX = '# Created by Vercel CLI\n';
-
-export const VERCEL_OIDC_TOKEN = 'VERCEL_OIDC_TOKEN';

--- a/packages/cli/src/util/env/escape-value.ts
+++ b/packages/cli/src/util/env/escape-value.ts
@@ -1,0 +1,7 @@
+export function escapeValue(value: string | undefined) {
+  return value
+    ? value
+        .replace(new RegExp('\n', 'g'), '\\n') // combine newlines (unix) into one line
+        .replace(new RegExp('\r', 'g'), '\\r') // combine newlines (windows) into one line
+    : '';
+}

--- a/packages/cli/src/util/env/patch-env-file.ts
+++ b/packages/cli/src/util/env/patch-env-file.ts
@@ -1,0 +1,80 @@
+import { outputFile } from 'fs-extra';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { isErrnoException } from '@vercel/error-utils';
+import { CONTENTS_PREFIX, VARIABLES_TO_IGNORE } from './constants';
+import { escapeValue } from './escape-value';
+import { wasCreatedByVercel } from './was-created-by-vercel';
+import { writeEnvFile } from './write-env-file';
+
+async function tryRead(fullPath: string): Promise<string | undefined> {
+  try {
+    return await readFile(fullPath, { encoding: 'utf8' });
+  } catch (err) {
+    if (!isErrnoException(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Patch an env file to contain the specified records.
+ *
+ *   1. If the env file does not exist, create it.
+ *   2. If the env file is not managed by Vercel CLI, abort.
+ *   3. If the env file already contains a key with the expected value, skip the key.
+ *   4. If the env file contains a key with a stale value, overwrite it.
+ *   5. If the env file lacks a key, append it it.
+ *
+ */
+export async function patchEnvFile(
+  cwd: string,
+  filename: string,
+  records: Record<string, string>
+): Promise<void> {
+  const fullPath = resolve(cwd, filename);
+  const createdByVercel = await wasCreatedByVercel(fullPath);
+  const exists = createdByVercel !== undefined;
+
+  // Case 1.
+  if (!exists) {
+    // TODO(mroberts): Update .gitignore.
+    return writeEnvFile(fullPath, records);
+  }
+
+  let contents = createdByVercel ? ((await tryRead(fullPath)) ?? '') : '';
+
+  // Case 2.
+  if (!contents.startsWith(CONTENTS_PREFIX)) return;
+
+  const kvs = Object.keys(records)
+    .sort()
+    .filter(key => !VARIABLES_TO_IGNORE.includes(key))
+    .map(key => [key, escapeValue(records[key])]);
+
+  let shouldWrite = false;
+
+  for (const [key, value] of kvs) {
+    const regExp = new RegExp(`^ *${key} *= *"(?.*)"? *$`, 'm');
+
+    // Case 3.
+    const match = contents.match(regExp);
+    if (match?.[1] === value) continue;
+
+    const newKv = `${key}="${value}"`;
+    shouldWrite = true;
+
+    // Case 4.
+    const newContents = contents.replace(regExp, newKv);
+    if (newContents !== contents) {
+      contents = newContents;
+      continue;
+    }
+
+    // Case 5.
+    if (!contents.endsWith('\n')) contents += '\n';
+    contents += `${newKv}\n`;
+  }
+
+  if (shouldWrite) await outputFile(fullPath, contents);
+}

--- a/packages/cli/src/util/env/patch-env-file.ts
+++ b/packages/cli/src/util/env/patch-env-file.ts
@@ -74,7 +74,7 @@ export async function patchEnvFile(
   let didUpdate = false;
 
   for (const [key, value] of kvs) {
-    const regExp = new RegExp(`^ *${key} *= *"(?.*)"? *$`, 'm');
+    const regExp = new RegExp(`^ *${key} *= *"?(.*)"? *$`, 'm');
 
     // Case 3.
     const match = contents.match(regExp);

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -1,10 +1,6 @@
-import { outputFile } from 'fs-extra';
-import { readFile } from 'fs/promises';
 import { decodeJwt } from 'jose';
 import ms from 'ms';
-import { resolve } from 'path';
 import { performance } from 'perf_hooks';
-import { isErrnoException } from '@vercel/error-utils';
 import output from '../../output-manager';
 import type Client from '../../util/client';
 import {
@@ -12,8 +8,7 @@ import {
   pullEnvRecords,
 } from '../../util/env/get-env-records';
 import sleep from '../../util/sleep';
-import { CONTENTS_PREFIX } from './constants';
-import { wasCreatedByVercel } from './was-created-by-vercel';
+import { patchEnvFile } from './patch-env-file';
 
 const REFRESH_BEFORE_EXPIRY_MS = ms('15m');
 const THROTTLE_MS = ms('1m');
@@ -92,7 +87,9 @@ export async function refreshOidcToken(
     const filename = '.env.local';
     if (expiresAfterMs > 0) {
       try {
-        await patchLocalEnv(client.cwd, filename, VERCEL_OIDC_TOKEN, oidcToken);
+        await patchEnvFile(client.cwd, filename, {
+          [VERCEL_OIDC_TOKEN]: oidcToken,
+        });
       } catch (error) {
         output.debug(`Failed to patch ${VERCEL_OIDC_TOKEN} in ${filename}`);
       }
@@ -155,86 +152,6 @@ async function pullEnvValuesUntilSuccessful(
     }
   }
   return null;
-}
-
-async function tryRead(fullPath: string): Promise<string | undefined> {
-  try {
-    return await readFile(fullPath, { encoding: 'utf8' });
-  } catch (err) {
-    if (!isErrnoException(err) || err.code !== 'ENOENT') {
-      throw err;
-    }
-  }
-}
-
-/**
- * Patch a local env file to contain the specified key/value pair.
- *
- *   1. If the env file does not exist, create it.
- *   2. If the env file is not managed by Vercel CLI, abort.
- *   3. If the env file already contains the key with the expected value, abort.
- *   4. If the env file contains the key with an unexpected value, overwrite it.
- *   5. If the env file lacks the key, append it it.
- *
- */
-async function patchLocalEnv(
-  cwd: string,
-  filename: string,
-  key: string,
-  value: string
-): Promise<void> {
-  const fullPath = resolve(cwd, filename);
-
-  // Case 1.
-  const createdByVercel = await wasCreatedByVercel(fullPath);
-  const exists = createdByVercel !== undefined;
-  if (!exists) {
-    output.debug(
-      `File ${filename} does not exist; creating it and setting ${key}`
-    );
-    const contents = `${CONTENTS_PREFIX}${key}="${value}"\n`;
-    await outputFile(fullPath, contents, 'utf8');
-    return;
-  }
-
-  // Case 2.
-  const current = createdByVercel ? await tryRead(fullPath) : undefined;
-  if (!current?.startsWith(CONTENTS_PREFIX)) {
-    output.debug(
-      `File ${filename} does not start with "${CONTENTS_PREFIX}"; will not update ${key}`
-    );
-    return;
-  }
-
-  // Case 3.
-  let regExp = new RegExp(
-    `^ *${key} *= *"?${value.replaceAll('.', '.')}"? *$`,
-    'm'
-  );
-  if (regExp.test(current)) {
-    output.debug(
-      `File ${filename} already contains the expected value for ${key}`
-    );
-    return;
-  }
-
-  regExp = new RegExp(`^ *${key} *= *"?.*"? *$`, 'm');
-  let contents = current.replace(regExp, `${key}="${value}"`);
-
-  // Case 4.
-  if (contents !== current) {
-    output.debug(`File ${filename} contains ${key}; updating it`);
-    await outputFile(fullPath, contents, 'utf8');
-    return;
-  }
-
-  // Case 5.
-  output.debug(`File ${filename} does not contain ${key}; appending it`);
-  if (!contents.endsWith('\n')) {
-    contents += '\n';
-  }
-  contents += `${key}="${value}"\n`;
-  await outputFile(fullPath, contents, 'utf8');
 }
 
 function clock(): number {

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -138,7 +138,7 @@ export async function refreshOidcToken(
     }
 
     // If the OIDC token isn't already expired, patch .env.local.
-    if (oidcToken !== initialOidcToken && expiresAfterMs > 0) {
+    if (oidcToken !== localOidcToken && expiresAfterMs > 0) {
       let result: PatchEnvFileResult | undefined;
 
       try {

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -116,6 +116,7 @@ export async function refreshOidcToken(
             [VERCEL_OIDC_TOKEN]: oidcToken,
           }
         );
+
         telemetry.trackOidcTokenRefresh(refreshCount);
       } catch (error) {
         output.debug(`Failed to patch ${VERCEL_OIDC_TOKEN} in ${FILENAME}`);
@@ -138,7 +139,7 @@ export async function refreshOidcToken(
               isGitIgnoreUpdated ? 'and added it to .gitignore' : ''
             } ${chalk.gray(pullStamp())}`,
             emoji('success')
-          )}\n`
+          )}\n\n`
         );
       }
     } else {

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -1,0 +1,255 @@
+import { outputFile } from 'fs-extra';
+import { readFile } from 'fs/promises';
+import ms from 'ms';
+import { resolve } from 'path';
+import { performance } from 'perf_hooks';
+import { isErrnoException } from '@vercel/error-utils';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import {
+  type EnvRecordsSource,
+  pullEnvRecords,
+} from '../../util/env/get-env-records';
+import sleep from '../../util/sleep';
+import { CONTENTS_PREFIX, VERCEL_OIDC_TOKEN } from './constants';
+
+const REFRESH_BEFORE_EXPIRY_MS = ms('15m');
+const THROTTLE_MS = ms('1m');
+
+export async function refreshOidcToken(
+  client: Client,
+  projectId: string,
+  oidcToken: string,
+  source: EnvRecordsSource
+): Promise<() => void> {
+  const controller = new AbortController();
+  let lastPulledEnvAt: number | undefined;
+  let timeout: NodeJS.Timeout;
+
+  async function go(oidcToken?: string) {
+    // The first time `go` is invoked, `oidcToken` will be defined and so we
+    // won't pull environment variables again. We only pull environment
+    // variables on subsequent invocations.
+    if (!oidcToken) {
+      // If we fail to pull environment variables (for example, because we are
+      // temporarily offline), then we will continue trying once every minute
+      // until successful or aborted.
+      const envValues = await pullEnvValuesUntilSuccessful(
+        controller.signal,
+        client,
+        projectId,
+        source,
+        THROTTLE_MS
+      );
+      if (!envValues) {
+        return;
+      }
+      oidcToken = envValues[VERCEL_OIDC_TOKEN];
+      lastPulledEnvAt = clock();
+    }
+
+    if (!oidcToken) {
+      output.debug(
+        `${VERCEL_OIDC_TOKEN} is absent from environment variables; will not attempt to refresh it`
+      );
+      return;
+    }
+
+    const now = clock();
+
+    const exp = getExpFromOidcToken(oidcToken);
+    if (exp === null) {
+      output.debug(
+        `Cannot get "exp" claim from ${VERCEL_OIDC_TOKEN}; will not attempt to refresh it`
+      );
+      return;
+    }
+
+    const expiresAfterMs = exp * 1000 - now;
+    if (!Number.isFinite(expiresAfterMs)) {
+      output.debug(
+        `${VERCEL_OIDC_TOKEN} "exp" claim is invalid; will not attempt to refresh it`
+      );
+      return;
+    }
+
+    // If the OIDC token isn't already expired, patch .env.local.
+    // TODO(mroberts): Is this the only file we should care about?
+    const filename = '.env.local';
+    if (expiresAfterMs > 0) {
+      try {
+        await patchLocalEnv(client.cwd, filename, VERCEL_OIDC_TOKEN, oidcToken);
+      } catch (error) {
+        output.debug(`Failed to patch ${VERCEL_OIDC_TOKEN} in ${filename}`);
+      }
+      if (controller.signal.aborted) {
+        return;
+      }
+    } else {
+      output.debug(
+        `${VERCEL_OIDC_TOKEN} is already expired; skip writing to ${filename}`
+      );
+    }
+
+    // Schedule to refresh the OIDC token shortly before it expires.
+    let refreshAfterMs = Math.max(0, expiresAfterMs - REFRESH_BEFORE_EXPIRY_MS);
+
+    // Avoid invoking ourselves too frequently (wait at least one minute).
+    if (
+      lastPulledEnvAt !== undefined &&
+      now + refreshAfterMs - lastPulledEnvAt < THROTTLE_MS
+    ) {
+      refreshAfterMs = THROTTLE_MS;
+    }
+
+    if (expiresAfterMs < 0) {
+      output.debug(
+        `${VERCEL_OIDC_TOKEN} expired ${Math.abs(expiresAfterMs)} milliseconds ago; attempting to refresh it in ${refreshAfterMs} milliseconds`
+      );
+    } else {
+      output.debug(
+        `${VERCEL_OIDC_TOKEN} expires in ${expiresAfterMs} milliseconds; will attempt to refresh it in ${refreshAfterMs} milliseconds`
+      );
+    }
+
+    timeout = setTimeout(() => void go(), refreshAfterMs);
+  }
+
+  await go(oidcToken);
+
+  return () => {
+    controller.abort();
+    clearTimeout(timeout);
+  };
+}
+
+/**
+ * The OIDC token is a JSON Web Token (JWT). Decode the JWT and get its numeric
+ * "exp" claim, returning `null` on error.
+ */
+function getExpFromOidcToken(oidcToken: string): number | null {
+  const payloadBase64 = oidcToken.split('.')[1];
+  if (!payloadBase64) {
+    return null;
+  }
+
+  let payloadJson: unknown;
+  try {
+    const payloadString = Buffer.from(payloadBase64, 'base64').toString('utf8');
+    payloadJson = JSON.parse(payloadString);
+  } catch (error) {
+    return null;
+  }
+
+  if (typeof payloadJson !== 'object' || payloadJson === null) {
+    return null;
+  }
+
+  if (!('exp' in payloadJson) || typeof payloadJson.exp !== 'number') {
+    return null;
+  }
+
+  return payloadJson.exp;
+}
+
+async function pullEnvValuesUntilSuccessful(
+  signal: AbortSignal,
+  client: Client,
+  projectId: string,
+  source: EnvRecordsSource,
+  ms: number
+): Promise<Record<string, string> | null> {
+  while (!signal.aborted) {
+    try {
+      return (await pullEnvRecords(client, projectId, source)).env;
+    } catch (error) {
+      output.debug(
+        `Failed to download environment variables; trying again in ${ms} milliseconds`
+      );
+      await sleep(ms);
+    }
+  }
+  return null;
+}
+
+async function tryRead(fullPath: string): Promise<string | undefined> {
+  try {
+    return await readFile(fullPath, { encoding: 'utf8' });
+  } catch (err) {
+    if (!isErrnoException(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Patch a local env file to contain the specified key/value pair.
+ *
+ *   1. If the env file does not exist, create it.
+ *   2. If the env file is not managed by Vercel CLI, abort.
+ *   3. If the env file already contains the key with the expected value, abort.
+ *   4. If the env file contains the key with an unexpected value, overwrite it.
+ *   5. If the env file lacks the key, append it it.
+ *
+ */
+async function patchLocalEnv(
+  cwd: string,
+  filename: string,
+  key: string,
+  value: string
+): Promise<void> {
+  const fullPath = resolve(cwd, filename);
+
+  // Case 1.
+  const current = await tryRead(fullPath);
+  if (current === undefined) {
+    output.debug(
+      `File ${filename} does not exist; creating it and setting ${key}`
+    );
+    const contents = `${CONTENTS_PREFIX}${key}="${value}"\n`;
+    await outputFile(fullPath, contents, 'utf8');
+    return;
+  }
+
+  // Case 2.
+  if (!current.startsWith(CONTENTS_PREFIX)) {
+    output.debug(
+      `File ${filename} does not start with "${CONTENTS_PREFIX}"; will not update ${key}`
+    );
+    return;
+  }
+
+  // Case 3.
+  let regExp = new RegExp(
+    `^ *${key} *= *"?${value.replaceAll('.', '.')}"? *$`,
+    'm'
+  );
+  if (regExp.test(current)) {
+    output.debug(
+      `File ${filename} already contains the expected value for ${key}`
+    );
+    return;
+  }
+
+  regExp = new RegExp(`^ *${key} *= *"?.*"? *$`, 'm');
+  let contents = current.replace(regExp, `${key}="${value}"`);
+
+  // Case 4.
+  if (contents !== current) {
+    output.debug(`File ${filename} contains ${key}; updating it`);
+    await outputFile(fullPath, contents, 'utf8');
+    return;
+  }
+
+  // Case 5.
+  output.debug(`File ${filename} does not contain ${key}; appending it`);
+  if (!contents.endsWith('\n')) {
+    contents += '\n';
+  }
+  contents += `${key}="${value}"\n`;
+  await outputFile(fullPath, contents, 'utf8');
+}
+
+function clock(): number {
+  return performance.timeOrigin + performance.now();
+}

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -29,6 +29,11 @@ export async function refreshOidcToken(
 ): Promise<() => void> {
   const fullPath = resolve(client.cwd, FILENAME);
 
+  // If refreshes are not enabled.
+  if (!process.env.VERCEL_REFRESH_OIDC_TOKEN) {
+    return () => {};
+  }
+
   // If the user has OIDC disabled, do nothing.
   const oidcToken = envValues[VERCEL_OIDC_TOKEN];
   if (!oidcToken) {

--- a/packages/cli/src/util/env/refresh-oidc-token.ts
+++ b/packages/cli/src/util/env/refresh-oidc-token.ts
@@ -36,7 +36,8 @@ export async function refreshOidcToken(
   let timeout: NodeJS.Timeout;
 
   // If refreshes are not enabled.
-  if (!process.env.VERCEL_REFRESH_OIDC_TOKEN) {
+  if (!process.env.REFRESH_VERCEL_OIDC_TOKEN) {
+    output.debug(`REFRESH_VERCEL_OIDC_TOKEN is not set; disabling refreshes`);
     return () => {};
   }
 

--- a/packages/cli/src/util/env/was-created-by-vercel.ts
+++ b/packages/cli/src/util/env/was-created-by-vercel.ts
@@ -1,0 +1,36 @@
+import { closeSync, openSync, readSync } from 'fs';
+import { isErrnoException } from '@vercel/error-utils';
+import { CONTENTS_PREFIX } from './constants';
+
+function readHeadSync(path: string, length: number) {
+  const buffer = Buffer.alloc(length);
+  const fd = openSync(path, 'r');
+  try {
+    readSync(fd, buffer, 0, buffer.length, null);
+  } finally {
+    closeSync(fd);
+  }
+  return buffer.toString();
+}
+
+function tryReadHeadSync(path: string, length: number) {
+  try {
+    return readHeadSync(path, length);
+  } catch (err: unknown) {
+    if (!isErrnoException(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Returns true if the file was created by Vercel CLI and undefined if it does
+ * not exist.
+ */
+export async function wasCreatedByVercel(
+  path: string
+): Promise<boolean | undefined> {
+  const head = tryReadHeadSync(path, Buffer.byteLength(CONTENTS_PREFIX));
+  if (head === undefined) return undefined;
+  return head === CONTENTS_PREFIX;
+}

--- a/packages/cli/src/util/env/write-env-file.ts
+++ b/packages/cli/src/util/env/write-env-file.ts
@@ -1,0 +1,19 @@
+import { outputFile } from 'fs-extra';
+import { CONTENTS_PREFIX, VARIABLES_TO_IGNORE } from './constants';
+import { escapeValue } from './escape-value';
+
+export async function writeEnvFile(
+  fullPath: string,
+  records: Record<string, string>
+): Promise<void> {
+  const contents =
+    CONTENTS_PREFIX +
+    Object.keys(records)
+      .sort()
+      .filter(key => !VARIABLES_TO_IGNORE.includes(key))
+      .map(key => `${key}="${escapeValue(records[key])}"`)
+      .join('\n') +
+    '\n';
+
+  await outputFile(fullPath, contents, 'utf8');
+}

--- a/packages/cli/src/util/telemetry/commands/dev/index.ts
+++ b/packages/cli/src/util/telemetry/commands/dev/index.ts
@@ -46,6 +46,6 @@ export class DevTelemetryClient
   }
 
   trackOidcTokenRefresh(count: number) {
-    this.trackOidcTokenRefresh(count);
+    super.trackOidcTokenRefresh(count);
   }
 }

--- a/packages/cli/src/util/telemetry/commands/dev/index.ts
+++ b/packages/cli/src/util/telemetry/commands/dev/index.ts
@@ -44,4 +44,8 @@ export class DevTelemetryClient
       this.trackCliFlag('confirm');
     }
   }
+
+  trackOidcTokenRefresh(count: number) {
+    this.trackOidcTokenRefresh(count);
+  }
 }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -110,6 +110,13 @@ export class TelemetryClient {
     });
   }
 
+  protected trackOidcTokenRefresh(count: number) {
+    this.track({
+      key: 'oidc-token-refresh',
+      value: `${count}`,
+    });
+  }
+
   protected trackCPUs() {
     this.track({
       key: 'cpu_count',


### PR DESCRIPTION
There are two challenges using the VERCEL_OIDC_TOKEN environment variable today:

- **It contains a token which expires after 12 hours in development.** This means, if `vc dev` is left running for longer than 12 hours, the token expires, leading to errors in the project.
- **It is not possible to update the token in `.env.local` for linked projects,** because the value pulled from Vercel takes precedent.

This PR addresses these challenges by

- **Excluding VERCEL_OIDC_TOKEN from the environment variables passed to DevServer.** Instead, the token can be read from and updated in `.env.local`.
- **Setting up background refreshes of the VERCEL_OIDC_TOKEN.** We parse the "exp" claim out of the token and set a timeout to update VERCEL_OIDC_TOKEN in `.env.local`.

In order to be as minimally invasive as possible only `.env.local` files beginning with "# Created by Vercel CLI" are considered. If a `.env.local` does not exist, it will be created.

TODO

- [x] Changeset
- [x] If a `.env.local` is created, we should perform the same `.gitignore` logic as `vc env pull`.
- [x] If there is a `.env.local`, but it doesn't begin with "# Created by Vercel CLI", we shouldn't delete the VERCEL_OIDC_TOKEN from the `envValues` passed to DevServer, because we aren't assuming we can update it.
- [x] Do we need to consider any files other than `.env.local`? No.
- [x] Should any of these logs be non-debug logs? Yes. We will print the delta string and `.gitignore` notice that `vc env pull` does.