### PR TITLE
[next] Enable blocking fallback routes to provide fallback root params

### DIFF
--- a/.changeset/nasty-feet-cover.md
+++ b/.changeset/nasty-feet-cover.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Support fallback blocking routes to provide a fallback root params configuration

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1037,6 +1037,7 @@ export type NextPrerenderedRoutes = {
     [route: string]: {
       routeRegex: string;
       dataRoute: string | null;
+      fallbackRootParams?: string[];
       dataRouteRegex: string | null;
       prefetchDataRoute?: string | null;
       prefetchDataRouteRegex?: string | null;
@@ -1508,6 +1509,7 @@ export async function getPrerenderManifest(
             prefetchDataRouteRegex,
             renderingMode,
             allowHeader,
+            fallbackRootParams,
           };
         } else {
           ret.omittedRoutes[lazyRoute] = {
@@ -2736,9 +2738,13 @@ export const onPrerenderRoute =
       // cache key vary based on the route parameters to ensure that we always
       // have a HIT for the fallback page.
       let htmlAllowQuery = allowQuery;
-      if (renderingMode === RenderingMode.PARTIALLY_STATIC && isFallback) {
-        const { fallbackRootParams } =
-          prerenderManifest.fallbackRoutes[routeKey];
+      if (
+        renderingMode === RenderingMode.PARTIALLY_STATIC &&
+        (isFallback || isBlocking)
+      ) {
+        const { fallbackRootParams } = isFallback
+          ? prerenderManifest.fallbackRoutes[routeKey]
+          : prerenderManifest.blockingFallbackRoutes[routeKey];
 
         htmlAllowQuery = fallbackRootParams ?? [];
       }


### PR DESCRIPTION
This makes it so that blocking fallback routes when PPR is enabled (those routes with unknown root params) can provide the right metadata to the prerender configuration. Previously the old code created route shells for each page when the fallback root shell was used, this now just generates new root shells to be used.