### PR TITLE
Allow all integration categories for resource provision, send to dashboard on non-subscription plan selection

### DIFF
--- a/.changeset/purple-suns-grow.md
+++ b/.changeset/purple-suns-grow.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Allow all integration categories for resource provision, send to dashboard on non-subscription plan selection

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -418,6 +418,75 @@ const integrationPlans: Record<string, unknown> = {
       },
     ],
   },
+  'acme-prepayment': {
+    plans: [
+      {
+        id: 'pro',
+        type: 'prepayment',
+        name: 'Pro Plan',
+        scope: 'installation',
+        description:
+          'Dedicated CPU • 1 GB RAM • 100K MAU • 8 GB database space • 250 GB bandwidth • 100 GB file storage',
+        paymentMethodRequired: true,
+        details: [
+          {
+            label: 'New Project - Micro Compute',
+            value: '$10/m',
+          },
+          {
+            label: 'Pro Plan',
+            value: '$25/m',
+          },
+          {
+            label: 'Compute Credits',
+            value: '-$10/m',
+          },
+        ],
+        highlightedDetails: [],
+      },
+      {
+        id: 'team',
+        type: 'prepayment',
+        name: 'Team Plan',
+        scope: 'installation',
+        description:
+          'SOC2 • SSO for Supabase Dashboard • Priority email support & SLAs • 28-day log retention',
+        paymentMethodRequired: true,
+        details: [
+          {
+            label: 'New Project - Micro Compute',
+            value: '$10/m',
+          },
+          {
+            label: 'Team Plan',
+            value: '$599/m',
+          },
+          {
+            label: 'Compute Credits',
+            value: '-$10/m',
+          },
+        ],
+        highlightedDetails: [],
+      },
+      {
+        id: 'free',
+        type: 'subscription',
+        name: 'Free Plan',
+        scope: 'installation',
+        description:
+          'Unlimited API requests • Shared CPU • 500 MB RAM • 50K MAU • 500 MB database space • 5 GB bandwidth • 1 GB file storage',
+        paymentMethodRequired: false,
+        details: [],
+        highlightedDetails: [
+          {
+            label:
+              'Unavailable - The following members have reached their 2 project Free Plan limit: luka.hartwig@vercel.com. All active projects in Free Plan organizations count towards this limit.',
+          },
+        ],
+        disabled: true,
+      },
+    ],
+  },
 };
 
 const configurationPrepaymentInformation: Record<

--- a/packages/cli/test/unit/commands/integration-resource/create-threshold.test.ts
+++ b/packages/cli/test/unit/commands/integration-resource/create-threshold.test.ts
@@ -281,7 +281,7 @@ describe('integration-resource', () => {
 
           await expect(client.stderr).toOutput('Creating threshold…');
           await expect(client.stderr).toOutput(
-            `Success! Threshold for installation Acme Prepayment created successfully.`
+            'Success! Threshold for installation Acme Prepayment created successfully.'
           );
           await expect(exitCodePromise).resolves.toEqual(0);
         });
@@ -344,7 +344,7 @@ describe('integration-resource', () => {
           );
 
           await expect(client.stderr).toOutput(
-            `The installation Acme Prepayment already has a threshold. (minimum: $10, \nspend: $10, limit: $50). Do you want to overwrite it? (Y/n)`
+            'The installation Acme Prepayment already has a threshold. (minimum: $10, \nspend: $10, limit: $50). Do you want to overwrite it? (Y/n)'
           );
           client.stdin.write('n\n');
 
@@ -378,7 +378,7 @@ describe('integration-resource', () => {
           );
 
           await expect(client.stderr).toOutput(
-            `The installation Acme Prepayment already has a threshold. (minimum: $10, \nspend: $10, limit: $50). Do you want to overwrite it? (Y/n)`
+            'The installation Acme Prepayment already has a threshold. (minimum: $10, \nspend: $10, limit: $50). Do you want to overwrite it? (Y/n)'
           );
           client.stdin.write('y\n');
 
@@ -389,7 +389,7 @@ describe('integration-resource', () => {
 
           await expect(client.stderr).toOutput('Creating threshold…');
           await expect(client.stderr).toOutput(
-            `Success! Threshold for installation Acme Prepayment created successfully.`
+            'Success! Threshold for installation Acme Prepayment created successfully.'
           );
           await expect(exitCodePromise).resolves.toEqual(0);
         });


### PR DESCRIPTION
Previously we were filtering which integrations could be installed via the CLI based on their product type. This is problematic as we scale, as it requires a CLI change & deployment every time a new type rolls out.

Originally, we set it up this way to prevent breaking the CLI as new requirements were discovered in different integration product types. What we've found instead is that the generic integration concept is fine across products, but the billing plan structure & system may change. So instead of having to make changes every time a new product type comes out that should be supported by default, we're instead switching to sending users to the dashboard for unsupported billing plan types.

Today, the `prepayment` billing plan type requires additional work to support provisioning via the CLI, as it has a different flow from subscription-based plans. It is also the only other plan type beyond `subscription`, but we'll filter all non-subscription plans to future proof against potential future plan types.