### PR TITLE
Implement Turbopack build marker via manifest prop

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -98,7 +98,6 @@ import {
   require_,
   getServerlessPages,
   RenderingMode,
-  isTurbopackBuild,
 } from './utils';
 
 export const version = 2;
@@ -1479,11 +1478,8 @@ export const build: BuildV2 = async buildOptions => {
         ]
       );
 
-      const isTurbopackBuildEnabled = await isTurbopackBuild(outputDirectory);
-
       return serverBuild({
         config,
-        isTurbopackBuildEnabled,
         functionsConfigManifest,
         nextVersion,
         trailingSlash,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -98,6 +98,7 @@ import {
   require_,
   getServerlessPages,
   RenderingMode,
+  isTurbopackBuild,
 } from './utils';
 
 export const version = 2;
@@ -1478,8 +1479,11 @@ export const build: BuildV2 = async buildOptions => {
         ]
       );
 
+      const isTurbopackBuildEnabled = await isTurbopackBuild(outputDirectory);
+
       return serverBuild({
         config,
+        isTurbopackBuildEnabled,
         functionsConfigManifest,
         nextVersion,
         trailingSlash,

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -116,6 +116,7 @@ export async function serverBuild({
   dynamicPages,
   pagesDir,
   config = {},
+  isTurbopackBuildEnabled,
   functionsConfigManifest,
   privateOutputs,
   baseDir,
@@ -160,6 +161,7 @@ export async function serverBuild({
   dynamicPages: string[];
   trailingSlash: boolean;
   config: Config;
+  isTurbopackBuildEnabled: boolean;
   functionsConfigManifest?: FunctionsConfigManifestV1;
   pagesDir: string;
   baseDir: string;
@@ -1379,6 +1381,11 @@ export async function serverBuild({
         isStreaming: group.isStreaming,
         nextVersion,
         experimentalAllowBundling,
+        environment: isTurbopackBuildEnabled
+          ? {
+              TURBOPACK: '1',
+            }
+          : {},
       };
 
       // the app _not-found output should always be included
@@ -1615,6 +1622,7 @@ export async function serverBuild({
     prerenderBypassToken: prerenderManifest.bypassToken || '',
     nextVersion,
     appPathRoutesManifest: appPathRoutesManifest || {},
+    isTurbopackBuildEnabled,
   });
 
   const isNextDataServerResolving =

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -116,7 +116,6 @@ export async function serverBuild({
   dynamicPages,
   pagesDir,
   config = {},
-  isTurbopackBuildEnabled,
   functionsConfigManifest,
   privateOutputs,
   baseDir,
@@ -161,7 +160,6 @@ export async function serverBuild({
   dynamicPages: string[];
   trailingSlash: boolean;
   config: Config;
-  isTurbopackBuildEnabled: boolean;
   functionsConfigManifest?: FunctionsConfigManifestV1;
   pagesDir: string;
   baseDir: string;
@@ -1363,6 +1361,9 @@ export async function serverBuild({
           new FileBlob({ data: launcherData }),
       };
       const operationType = getOperationType({ group, prerenderManifest });
+
+      const isTurbopackBuildEnabled =
+        requiredServerFilesManifest.config.experimental.isTurbopackBuild;
 
       const options: CreateLambdaFromPseudoLayersOptions = {
         files: {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1088,18 +1088,6 @@ export type NextPrerenderedRoutes = {
   isLocalePrefixed: boolean;
 };
 
-export async function isTurbopackBuild(
-  outputDirectory: string
-): Promise<boolean> {
-  const isTurbopackBuildFile = path.join(outputDirectory, 'IS_TURBOPACK_BUILD');
-  const isTurbopackBuild: boolean = await fs
-    .access(isTurbopackBuildFile, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false);
-
-  return isTurbopackBuild;
-}
-
 export async function getExportIntent(
   entryPath: string
 ): Promise<false | { trailingSlash: boolean }> {


### PR DESCRIPTION
Implements detection for `next build --turbopack` to automatically set `TURBOPACK=1`.

When running `next build --turbopack` Next.js will set a property in `.next/required-server-files.json` which can be used to detect if the build used Turbopack.

At runtime Next.js needs `TURBOPACK=1` in order to load the correct JS runtime that is compatible with Turbopack.

The environment variable will be required until Turbopack is the default build output of Next.js.

Requires https://github.com/vercel/next.js/pull/77851
Closes #13211 , which used a separate marker files
