### PR TITLE
#13224 : Typo in README: "insructions" → "instructions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The logs of this deployment will contain the actual error which may help you to 
 
 While running the full integration suite locally is not recommended, it's sometimes useful to isolate a failing test by running it on your machine. To do so, you'll need to ensure you have the appropriate credentials sourced in your shell:
 
-1. Create an access token. Follow the insructions here https://vercel.com/docs/rest-api#creating-an-access-token. Ensure the token scope is for your personal
+1. Create an access token. Follow the instructions here https://vercel.com/docs/rest-api#creating-an-access-token. Ensure the token scope is for your personal
    account.
 2. Grab the team ID from the Vercel dashboard at `https://vercel.com/<MY-TEAM>/~/settings`.
 3. Source these into your shell rc file: `echo 'export VERCEL_TOKEN=<MY-TOKEN> VERCEL_TEAM_ID=<MY-TEAM-ID>' >> ~/.zshrc`


### PR DESCRIPTION
Issue - #13224
Detail : In The Read Me The Typo Mistake is There insructions  => instructions the issue Is Solved  Line Number - 122