### PR TITLE
fix(auth): fix rendering fallback verification link

### DIFF
--- a/.changeset/many-mice-promise.md
+++ b/.changeset/many-mice-promise.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(auth): fix rendering fallback verification link

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -58,7 +58,13 @@ export async function login(client: Client): Promise<number> {
     `
   ▲ Sign in to the Vercel CLI
 
-  Visit ${chalk.bold(o.link(verification_uri.replace('https://', ''), verification_uri_complete, { color: false }))} to enter ${chalk.bold(user_code)}
+  Visit ${chalk.bold(
+    o.link(
+      verification_uri.replace('https://', ''),
+      verification_uri_complete,
+      { color: false, fallback: () => verification_uri_complete }
+    )
+  )}${o.supportsHyperlink ? '' : ` to enter ${chalk.bold(user_code)}`}
   ${chalk.grey('Press [ENTER] to open the browser')}
 `,
     () => {


### PR DESCRIPTION
If a terminal does not support hyperlinks, we want to render the link with the user code, but only once.

Before:

![image](https://github.com/user-attachments/assets/4e75e802-d277-48e7-877d-76e99f68db1c)

After:

![image](https://github.com/user-attachments/assets/058d2603-62c0-4ac9-913d-44228d5f7046)

[Context](https://vercel.slack.com/archives/C07LMT9LBUZ/p1744124689230729?thread_ts=1743757727.016929&cid=C07LMT9LBUZ)