### PR TITLE
[next] improve error message for "No Next.js version"

### DIFF
--- a/.changeset/silly-apples-try.md
+++ b/.changeset/silly-apples-try.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] improve error message for "No Next.js version"

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -427,7 +427,7 @@ export const build: BuildV2 = async buildOptions => {
     throw new NowBuildError({
       code: 'NEXT_NO_VERSION',
       message:
-        'No Next.js version could be detected in your project. Make sure `"next"` is installed in "dependencies" or "devDependencies"',
+        'No Next.js version detected. Make sure your package.json has "next" in either "dependencies" or "devDependencies". Also check your Root Directory setting matches the directory of your package.json file.',
     });
   }
 


### PR DESCRIPTION
I've seen a few deployments fail because the Root Directory needed to be updated so we can improve this error message to include that use case.