### PR TITLE
docs: rename community links to dot com

### DIFF
--- a/.changeset/curly-doors-punch.md
+++ b/.changeset/curly-doors-punch.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+docs: rename community links to dot com

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -4,7 +4,7 @@ body:
       value: |
         # Please go to Vercel Community
         > [!IMPORTANT]  
-        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://vercel.community).**
+        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://community.vercel.com).**
   - type: textarea
     attributes:
       label: Description

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -4,7 +4,7 @@ body:
       value: |
         # Please go to Vercel Community
         > [!IMPORTANT]  
-        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://vercel.community).**
+        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://community.vercel.com).**
   - type: textarea
     attributes:
       label: Idea

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -4,7 +4,7 @@ body:
       value: |
         # Please go to Vercel Community
         > [!IMPORTANT]  
-        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://vercel.community).**
+        > **New Discussions in this repo are no longer actively monitored and will be automatically closed. Please go to the new [Vercel Community](https://community.vercel.com).**
   - type: textarea
     attributes:
       label: Description

--- a/.github/ISSUE_TEMPLATE/cli_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/cli_bug_report.md
@@ -6,4 +6,4 @@ title: ''
 
 **Thanks for reaching out!** We use this Issue tracker for issues with the Vercel CLI and related open source libraries. If you are experiencing an issue with the Vercel CLI please delete this text and describe your issue.
 
-_For general platform help and feedback please open a new discussion at https://vercel.community._
+_For general platform help and feedback please open a new discussion at https://community.vercel.com._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,8 +5,8 @@ contact_links:
     url: https://vercel.com/help
     about: Reach out to our support team
   - name: Vercel Platform Feature Request
-    url: https://vercel.community
+    url: https://community.vercel.com
     about: Share ideas for new features
   - name: Ask a Question
-    url: https://vercel.community
+    url: https://community.vercel.com
     about: Ask the community for help

--- a/.github/workflows/discussions-auto-close.yml
+++ b/.github/workflows/discussions-auto-close.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           lockSucceeded="$(gh api graphql -F discussionId=$DISCUSSION_ID -f query=' 
           mutation lock($discussionId:ID!) {
-            addDiscussionComment(input:{discussionId:$discussionId, body:"This discussion was automatically closed because the community moved to [vercel.community](https://vercel.community)"}) {
+            addDiscussionComment(input:{discussionId:$discussionId, body:"This discussion was automatically closed because the community moved to [community.vercel.com](https://community.vercel.com)"}) {
               comment{
                 url
               }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project uses [pnpm](https://pnpm.io/) to install dependencies and run scrip
 
 You can use the `vercel` script to run local changes as if you were invoking Vercel CLI. For example, `vercel deploy --cwd=/path/to/project` could be run with local changes with `pnpm vercel deploy --cwd=/path/to/project`.
 
-When contributing to this repository, please first discuss the change you wish to make via [Vercel Community](https://vercel.community/tags/c/community/4/cli) with the owners of this repository before submitting a Pull Request.
+When contributing to this repository, please first discuss the change you wish to make via [Vercel Community](https://community.vercel.com/tags/c/community/4/cli) with the owners of this repository before submitting a Pull Request.
 
 Please read our [Code of Conduct](./.github/CODE_OF_CONDUCT.md) and follow it in all your interactions with the project.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Contributing examples should be an enjoyable experience, as such we have created
 
 The guidelines cover important information such as the requirements for new examples and where to get help if you have any questions.
 
-We have tried to make contributing to examples as easy as possible, especially for those new to Open Source. If anything is unclear or you have any questions then please reach out to us on [https://vercel.community/](https://vercel.community/) where we will do our best to help you.
+We have tried to make contributing to examples as easy as possible, especially for those new to Open Source. If anything is unclear or you have any questions then please reach out to us on [https://community.vercel.com/](https://community.vercel.com/) where we will do our best to help you.
 
 ## Reporting Issues
 
@@ -34,6 +34,6 @@ When submitting an issue, please thoroughly and concisely describe the problem y
 
 ## Get In Touch
 
-If you have any questions that are not covered by raising an issue then please get in touch with us on [https://vercel.community/](https://vercel.community/). There you will find both members of the community and staff who are happy to help answer questions on anything Vercel related.
+If you have any questions that are not covered by raising an issue then please get in touch with us on [https://community.vercel.com/](https://community.vercel.com/). There you will find both members of the community and staff who are happy to help answer questions on anything Vercel related.
 
-[Join the Vercel Community](https://vercel.community/)
+[Join the Vercel Community](https://community.vercel.com/)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
   <p align="center">Develop. Preview. Ship.</p>
 </p>
 
-[Join the Vercel Community](https://vercel.community/)
+[Join the Vercel Community](https://community.vercel.com/)
 
 ## Usage
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,6 +1,6 @@
 # @vercel/client
 
-[Join the Vercel Community](https://vercel.community/)
+[Join the Vercel Community](https://community.vercel.com/)
 
 The official Node.js client for deploying to [Vercel](https://vercel.com).
 


### PR DESCRIPTION
Replaces links to the old `vercel.community` domain to the updated https://community.vercel.com/