### PR TITLE
fix(cli): ignore `--git-branch` for non-preview targets

### DIFF
--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -77,7 +77,7 @@ export async function pullEnvRecords(
 
   if (target) {
     url += `/${encodeURIComponent(target)}`;
-    if (gitBranch) {
+    if (target === 'preview' && gitBranch) {
       url += `/${encodeURIComponent(gitBranch)}`;
     }
   }


### PR DESCRIPTION
Since the API will error under these conditions anyways, we might as well strip the branch argument for convenience.