### PR TITLE
Rename SvelteKit (v1)

### DIFF
--- a/.changeset/wild-ways-unite.md
+++ b/.changeset/wild-ways-unite.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+Rename SvelteKit (v1)

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1128,7 +1128,7 @@ export const frameworks = [
     getOutputDirName: async () => 'public',
   },
   {
-    name: 'SvelteKit (v1)',
+    name: 'SvelteKit',
     slug: 'sveltekit-1',
     demo: 'https://sveltekit-1-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/svelte.svg',


### PR DESCRIPTION
Changes the name of the `SvelteKit (v1)` preset to simply `SvelteKit` to avoid confusion as this is the appropriate preset for all non-zero versions.

Requested by the community - https://community.vercel.com/t/update-framework-settings-labeling-to-include-sveltekit-2/8821