### PR TITLE
[client] Include microfrontend config for prebuilt deploys

### DIFF
--- a/.changeset/late-pets-itch.md
+++ b/.changeset/late-pets-itch.md
@@ -1,0 +1,5 @@
+---
+'@vercel/client': minor
+---
+
+Add special case for including microfrontend config

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -7,7 +7,7 @@ import { pkgVersion } from '../pkg';
 import { NowBuildError } from '@vercel/build-utils';
 import { VercelClientOptions, VercelConfig } from '../types';
 import { Sema } from 'async-sema';
-import { readFile } from 'fs-extra';
+import { pathExists, readFile } from 'fs-extra';
 import readdir from './readdir-recursive';
 
 type Ignore = ReturnType<typeof ignore>;
@@ -82,7 +82,11 @@ export async function buildFileTree(
     isDirectory,
     prebuilt,
     vercelOutputDir,
-  }: Pick<VercelClientOptions, 'isDirectory' | 'prebuilt' | 'vercelOutputDir'>,
+    rootDirectory,
+  }: Pick<
+    VercelClientOptions,
+    'isDirectory' | 'prebuilt' | 'vercelOutputDir' | 'rootDirectory'
+  >,
   debug: Debug
 ): Promise<{ fileList: string[]; ignoreList: string[] }> {
   const ignoreList: string[] = [];
@@ -121,6 +125,16 @@ export async function buildFileTree(
           }
         })
       );
+
+      const microFrontendConfigPath = join(
+        path,
+        rootDirectory || '',
+        'microfrontends.json'
+      );
+      if (await pathExists(microFrontendConfigPath)) {
+        refs.add(microFrontendConfigPath);
+      }
+
       if (refs.size > 0) {
         fileList = fileList.concat(Array.from(refs));
       }

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -126,13 +126,13 @@ export async function buildFileTree(
         })
       );
 
-      const microFrontendConfigPath = join(
+      const microfrontendConfigPath = join(
         path,
         rootDirectory || '',
         'microfrontends.json'
       );
-      if (await pathExists(microFrontendConfigPath)) {
-        refs.add(microFrontendConfigPath);
+      if (await pathExists(microfrontendConfigPath)) {
+        refs.add(microfrontendConfigPath);
       }
 
       if (refs.size > 0) {


### PR DESCRIPTION
Prebuilt microfrontend projects currently see `Warning: This project is in a microfrontends group, but a microfrontends config file (microfrontends.json) was not found.` because the `${projectRoot}/microfrontends.json` is not uploaded. This change includes that file for prebuilt deploys.

Example deployment with this change: https://vercel.com/microfrontends-vtest314/nextjs-app-marketing/Cd3TrmfQUjYibyvSK8zSyD5Ajicy