### PR TITLE
[next] support more specific route keys for prefetch segments

### DIFF
--- a/.changeset/smart-penguins-occur.md
+++ b/.changeset/smart-penguins-occur.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Added support for more specific route keys for prefetch segments

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -226,6 +226,7 @@ type RoutesManifestRoute = {
   prefetchSegmentDataRoutes?: {
     source: string;
     destination: string;
+    routeKeys?: { [named: string]: string };
   }[];
 };
 
@@ -480,13 +481,11 @@ export async function getDynamicRoutes({
                         prefetchSegmentDataRoute.destination
                       )
                     : prefetchSegmentDataRoute.destination
-                }${
-                  routeKeys
-                    ? `?${Object.entries(routeKeys)
-                        .map(([key, value]) => `${value}=$${key}`)
-                        .join('&')}`
-                    : ''
-                }`,
+                }?${Object.entries(
+                  prefetchSegmentDataRoute.routeKeys ?? routeKeys ?? {}
+                )
+                  .map(([key, value]) => `${value}=$${key}`)
+                  .join('&')}`,
                 check: true,
               });
             }


### PR DESCRIPTION
This pull request introduces support for more specific route keys for prefetch segments in the `@vercel/next` package. The changes include updates to the type definition for `RoutesManifestRoute` and modifications to the logic for constructing dynamic route URLs.

### Type Definition Updates:
* [`packages/next/src/utils.ts`](diffhunk://#diff-8a1ad8977fae4b63ee7eefd263160b523c75c7d337f373f7a1146ef9667adb67R229): Updated the `RoutesManifestRoute` type to include an optional `routeKeys` property, which maps named keys to their string values.

### Logic Updates for Route Construction:
* [`packages/next/src/utils.ts`](diffhunk://#diff-8a1ad8977fae4b63ee7eefd263160b523c75c7d337f373f7a1146ef9667adb67L483-R488): Modified the `getDynamicRoutes` function to handle `routeKeys` more flexibly by prioritizing `prefetchSegmentDataRoute.routeKeys`, falling back to `routeKeys` if necessary, and ensuring the query string is constructed correctly.