### PR TITLE
[client][cli] Improve microfrontends config handling

### DIFF
--- a/.changeset/breezy-guests-travel.md
+++ b/.changeset/breezy-guests-travel.md
@@ -1,0 +1,6 @@
+---
+'@vercel/client': minor
+'vercel': minor
+---
+
+Infer microfrontends.json and microfrontends.jsonc if rootDirectory not specified

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -140,6 +140,7 @@
     "jest-junit": "16.0.0",
     "jest-matcher-utils": "29.3.1",
     "json-parse-better-errors": "1.0.2",
+    "jsonc-parser": "3.3.1",
     "jsonlines": "0.1.1",
     "line-async-iterator": "3.0.0",
     "load-json-file": "3.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -140,7 +140,6 @@
     "jest-junit": "16.0.0",
     "jest-matcher-utils": "29.3.1",
     "json-parse-better-errors": "1.0.2",
-    "jsonc-parser": "3.3.1",
     "jsonlines": "0.1.1",
     "line-async-iterator": "3.0.0",
     "load-json-file": "3.0.0",

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -32,11 +32,8 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const externals = Object.keys(pkg.dependencies || {});
 await esbuild({
   bundle: true,
-  external: [
-    ...externals,
-    // https://github.com/evanw/esbuild/issues/1619
-    'jsonc-parser',
-  ],
+  external: externals,
+  mainFields: ['module', 'main'],
 });
 
 // Copy a few static files into `dist`

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -32,7 +32,11 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const externals = Object.keys(pkg.dependencies || {});
 await esbuild({
   bundle: true,
-  external: externals,
+  external: [
+    ...externals,
+    // https://github.com/evanw/esbuild/issues/1619
+    'jsonc-parser',
+  ],
 });
 
 // Copy a few static files into `dist`

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -2,6 +2,8 @@ import { join } from 'node:path';
 import { copyFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { esbuild } from '../../../utils/build.mjs';
 import { compileDevTemplates } from './compile-templates.mjs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 
 const repoRoot = new URL('../', import.meta.url);
 
@@ -30,11 +32,30 @@ await compileDevTemplates();
 const pkgPath = join(process.cwd(), 'package.json');
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const externals = Object.keys(pkg.dependencies || {});
+const require = createRequire(import.meta.url);
 await esbuild({
   bundle: true,
   external: externals,
-  // https://github.com/evanw/esbuild/issues/1619
-  mainFields: ['module', 'main'],
+  plugins: [
+    // plugin required to handle jsonc-parser
+    // https://github.com/evanw/esbuild/issues/1619
+    {
+      name: 'jsonc-parser-module-first',
+      setup(build) {
+        build.onResolve({ filter: /^jsonc-parser$/ }, args => {
+          const pkgJsonPath = require.resolve('jsonc-parser/package.json', {
+            paths: [args.resolveDir],
+          });
+          const { module, main } = JSON.parse(
+            readFileSync(pkgJsonPath, 'utf8')
+          );
+          const entryRel = module ?? main ?? 'index.js';
+          const entryAbs = path.join(path.dirname(pkgJsonPath), entryRel);
+          return { path: entryAbs, namespace: 'file' };
+        });
+      },
+    },
+  ],
 });
 
 // Copy a few static files into `dist`

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -33,6 +33,7 @@ const externals = Object.keys(pkg.dependencies || {});
 await esbuild({
   bundle: true,
   external: externals,
+  // https://github.com/evanw/esbuild/issues/1619
   mainFields: ['module', 'main'],
 });
 

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -99,6 +99,7 @@ export default async function processDeployment({
     skipAutoDetectionConfirmation,
     archive,
     agent,
+    projectName,
   };
 
   const deployingSpinnerVal = isSettingUpProject

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,12 +35,13 @@
     "@types/recursive-readdir": "2.2.0",
     "@types/tar-fs": "1.16.1",
     "jest-junit": "16.0.0",
-    "vitest": "2.0.1",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "vitest": "2.0.1"
   },
   "dependencies": {
     "@vercel/build-utils": "10.5.1",
     "@vercel/error-utils": "2.0.3",
+    "@vercel/microfrontends": "1.2.2",
     "@vercel/routing-utils": "5.0.4",
     "async-retry": "1.2.3",
     "async-sema": "3.0.0",

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -34,6 +34,7 @@ export interface VercelClientOptions {
   skipAutoDetectionConfirmation?: boolean;
   archive?: ArchiveFormat;
   agent?: Agent;
+  projectName?: string;
 }
 
 /** @deprecated Use VercelClientOptions instead. */

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -151,7 +151,7 @@ export async function buildFileTree(
           refs.add(microfrontendConfigPath);
         }
       } catch (e) {
-        console.error(`Error finding microfrontend config: ${e}`);
+        debug(`Error detecting microfrontend config: ${e}`);
       }
 
       if (refs.size > 0) {

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -7,8 +7,12 @@ import { pkgVersion } from '../pkg';
 import { NowBuildError } from '@vercel/build-utils';
 import { VercelClientOptions, VercelConfig } from '../types';
 import { Sema } from 'async-sema';
-import { pathExists, readFile } from 'fs-extra';
+import { readFile } from 'fs-extra';
 import readdir from './readdir-recursive';
+import {
+  findConfig,
+  inferMicrofrontendsLocation,
+} from '@vercel/microfrontends/microfrontends/utils';
 
 type Ignore = ReturnType<typeof ignore>;
 
@@ -83,9 +87,14 @@ export async function buildFileTree(
     prebuilt,
     vercelOutputDir,
     rootDirectory,
+    projectName,
   }: Pick<
     VercelClientOptions,
-    'isDirectory' | 'prebuilt' | 'vercelOutputDir' | 'rootDirectory'
+    | 'isDirectory'
+    | 'prebuilt'
+    | 'vercelOutputDir'
+    | 'rootDirectory'
+    | 'projectName'
   >,
   debug: Debug
 ): Promise<{ fileList: string[]; ignoreList: string[] }> {
@@ -126,13 +135,23 @@ export async function buildFileTree(
         })
       );
 
-      const microfrontendConfigPath = join(
-        path,
-        rootDirectory || '',
-        'microfrontends.json'
-      );
-      if (await pathExists(microfrontendConfigPath)) {
-        refs.add(microfrontendConfigPath);
+      try {
+        let microfrontendConfigPath = findConfig({
+          dir: join(path, rootDirectory || ''),
+        });
+        if (!microfrontendConfigPath && !rootDirectory && projectName) {
+          microfrontendConfigPath = findConfig({
+            dir: inferMicrofrontendsLocation({
+              repositoryRoot: path,
+              applicationName: projectName,
+            }),
+          });
+        }
+        if (microfrontendConfigPath) {
+          refs.add(microfrontendConfigPath);
+        }
+      } catch (e) {
+        console.error(`Error finding microfrontend config: ${e}`);
       }
 
       if (refs.size > 0) {

--- a/packages/client/tests/fixtures/microfrontend/marketing-app/microfrontends.json
+++ b/packages/client/tests/fixtures/microfrontend/marketing-app/microfrontends.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "applications": {
+    "marketing-app": {
+      "development": {
+        "local": 3000,
+        "fallback": "nextjs-app-marketing.vercel.app"
+      }
+    }
+  }
+}

--- a/packages/client/tests/fixtures/microfrontend/marketing-app/package.json
+++ b/packages/client/tests/fixtures/microfrontend/marketing-app/package.json
@@ -1,0 +1,4 @@
+
+{
+  "name": "marketing-app"
+}

--- a/packages/client/tests/fixtures/microfrontend/marketing-app/package.json
+++ b/packages/client/tests/fixtures/microfrontend/marketing-app/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "marketing-app"
 }

--- a/packages/client/tests/unit.utils.test.ts
+++ b/packages/client/tests/unit.utils.test.ts
@@ -205,4 +205,62 @@ describe('buildFileTree()', () => {
       normalizeWindowsPaths(ignoreList).sort()
     );
   });
+
+  it('microfrontend monorepo - should find `microfrontends.json` when prebuilt=true', async () => {
+    const cwd = fixture('microfrontend');
+
+    {
+      const { fileList } = await buildFileTree(
+        cwd,
+        {
+          isDirectory: true,
+          prebuilt: true,
+          vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
+          rootDirectory: 'marketing-app',
+        },
+        noop
+      );
+      const expectedFileList = toAbsolutePaths(cwd, [
+        'marketing-app/.vercel/output/functions/api/another.func/.vc-config.json',
+        'marketing-app/.vercel/output/functions/api/example.func/.vc-config.json',
+        'marketing-app/.vercel/output/static/baz.txt',
+        'marketing-app/.vercel/output/static/sub/qux.txt',
+        'node_modules/another/index.js',
+        'node_modules/example/index.js',
+        'marketing-app/microfrontends.json',
+      ]);
+      expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
+        normalizeWindowsPaths(fileList).sort()
+      );
+    }
+  });
+
+  it('microfrontend monorepo - should infer `microfrontends.json` when prebuilt=true', async () => {
+    const cwd = fixture('microfrontend');
+    {
+      const { fileList } = await buildFileTree(
+        cwd,
+        {
+          isDirectory: true,
+          prebuilt: true,
+          vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
+          projectName: 'marketing-app',
+        },
+        noop
+      );
+
+      const expectedFileList = toAbsolutePaths(cwd, [
+        'marketing-app/.vercel/output/functions/api/another.func/.vc-config.json',
+        'marketing-app/.vercel/output/functions/api/example.func/.vc-config.json',
+        'marketing-app/.vercel/output/static/baz.txt',
+        'marketing-app/.vercel/output/static/sub/qux.txt',
+        'node_modules/another/index.js',
+        'node_modules/example/index.js',
+        'marketing-app/microfrontends.json',
+      ]);
+      expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
+        normalizeWindowsPaths(fileList).sort()
+      );
+    }
+  });
 });

--- a/packages/client/tests/unit.utils.test.ts
+++ b/packages/client/tests/unit.utils.test.ts
@@ -209,58 +209,44 @@ describe('buildFileTree()', () => {
   it('microfrontend monorepo - should find `microfrontends.json` when prebuilt=true', async () => {
     const cwd = fixture('microfrontend');
 
-    {
-      const { fileList } = await buildFileTree(
-        cwd,
-        {
-          isDirectory: true,
-          prebuilt: true,
-          vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
-          rootDirectory: 'marketing-app',
-        },
-        noop
-      );
-      const expectedFileList = toAbsolutePaths(cwd, [
-        'marketing-app/.vercel/output/functions/api/another.func/.vc-config.json',
-        'marketing-app/.vercel/output/functions/api/example.func/.vc-config.json',
-        'marketing-app/.vercel/output/static/baz.txt',
-        'marketing-app/.vercel/output/static/sub/qux.txt',
-        'node_modules/another/index.js',
-        'node_modules/example/index.js',
-        'marketing-app/microfrontends.json',
-      ]);
-      expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
-        normalizeWindowsPaths(fileList).sort()
-      );
-    }
+    const { fileList } = await buildFileTree(
+      cwd,
+      {
+        isDirectory: true,
+        prebuilt: true,
+        vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
+        rootDirectory: 'marketing-app',
+      },
+      noop
+    );
+
+    const microfrontendsConfig = toAbsolutePaths(cwd, [
+      'marketing-app/microfrontends.json',
+    ]);
+    expect(normalizeWindowsPaths(fileList)).toContain(
+      normalizeWindowsPaths(microfrontendsConfig)[0]
+    );
   });
 
   it('microfrontend monorepo - should infer `microfrontends.json` when prebuilt=true', async () => {
     const cwd = fixture('microfrontend');
-    {
-      const { fileList } = await buildFileTree(
-        cwd,
-        {
-          isDirectory: true,
-          prebuilt: true,
-          vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
-          projectName: 'marketing-app',
-        },
-        noop
-      );
 
-      const expectedFileList = toAbsolutePaths(cwd, [
-        'marketing-app/.vercel/output/functions/api/another.func/.vc-config.json',
-        'marketing-app/.vercel/output/functions/api/example.func/.vc-config.json',
-        'marketing-app/.vercel/output/static/baz.txt',
-        'marketing-app/.vercel/output/static/sub/qux.txt',
-        'node_modules/another/index.js',
-        'node_modules/example/index.js',
-        'marketing-app/microfrontends.json',
-      ]);
-      expect(normalizeWindowsPaths(expectedFileList).sort()).toEqual(
-        normalizeWindowsPaths(fileList).sort()
-      );
-    }
+    const { fileList } = await buildFileTree(
+      cwd,
+      {
+        isDirectory: true,
+        prebuilt: true,
+        vercelOutputDir: join(cwd, 'marketing-app/.vercel/output'),
+        projectName: 'marketing-app',
+      },
+      noop
+    );
+
+    const microfrontendsConfig = toAbsolutePaths(cwd, [
+      'marketing-app/microfrontends.json',
+    ]);
+    expect(normalizeWindowsPaths(fileList)).toContain(
+      normalizeWindowsPaths(microfrontendsConfig)[0]
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,9 +646,6 @@ importers:
       json-parse-better-errors:
         specifier: 1.0.2
         version: 1.0.2
-      jsonc-parser:
-        specifier: 3.3.1
-        version: 3.3.1
       jsonlines:
         specifier: 0.1.1
         version: 0.1.1
@@ -10700,7 +10697,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
       debug: 3.2.7
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.9
@@ -10731,7 +10728,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.3
@@ -10879,7 +10876,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.24.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.4)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.24.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@vercel/error-utils':
         specifier: 2.0.3
         version: link:../error-utils
+      '@vercel/microfrontends':
+        specifier: 1.2.2
+        version: 1.2.2(vite@5.1.8)
       '@vercel/routing-utils':
         specifier: 5.0.4
         version: link:../routing-utils
@@ -3648,7 +3651,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/aix-ppc64@0.21.5:
@@ -3675,7 +3677,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.19.2:
@@ -3711,7 +3712,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.19.2:
@@ -3747,7 +3747,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.19.2:
@@ -3783,7 +3782,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.19.2:
@@ -3819,7 +3817,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.2:
@@ -3855,7 +3852,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.2:
@@ -3891,7 +3887,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.2:
@@ -3927,7 +3922,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.19.2:
@@ -3963,7 +3957,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.19.2:
@@ -3999,7 +3992,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.19.2:
@@ -4035,7 +4027,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.2:
@@ -4071,7 +4062,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.19.2:
@@ -4107,7 +4097,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.2:
@@ -4143,7 +4132,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.19.2:
@@ -4179,7 +4167,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.2:
@@ -4215,7 +4202,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.19.2:
@@ -4251,7 +4237,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.2:
@@ -4287,7 +4272,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.19.2:
@@ -4323,7 +4307,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.2:
@@ -4359,7 +4342,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.19.2:
@@ -4395,7 +4377,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.19.2:
@@ -4431,7 +4412,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.19.2:
@@ -5000,6 +4980,10 @@ packages:
     resolution: {integrity: sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A==}
     dev: true
 
+  /@next/env@15.1.6:
+    resolution: {integrity: sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==}
+    dev: false
+
   /@next/swc-darwin-arm64@14.2.21:
     resolution: {integrity: sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==}
     engines: {node: '>= 10'}
@@ -5259,7 +5243,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.28.1:
@@ -5267,7 +5250,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.28.1:
@@ -5275,7 +5257,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.28.1:
@@ -5283,7 +5264,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.28.1:
@@ -5291,7 +5271,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.28.1:
@@ -5299,7 +5278,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.28.1:
@@ -5307,7 +5285,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.28.1:
@@ -5315,7 +5292,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.28.1:
@@ -5323,7 +5299,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.28.1:
@@ -5331,7 +5306,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-loongarch64-gnu@4.28.1:
@@ -5339,7 +5313,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-powerpc64le-gnu@4.28.1:
@@ -5347,7 +5320,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.28.1:
@@ -5355,7 +5327,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.28.1:
@@ -5363,7 +5334,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.28.1:
@@ -5371,7 +5341,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.28.1:
@@ -5379,7 +5348,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.28.1:
@@ -5387,7 +5355,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.28.1:
@@ -5395,7 +5362,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.28.1:
@@ -5403,7 +5369,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rtsao/scc@1.1.0:
@@ -7124,7 +7089,6 @@ packages:
 
   /@types/node@14.18.33:
     resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
-    dev: true
 
   /@types/node@16.18.11:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
@@ -7862,6 +7826,47 @@ packages:
       - supports-color
     dev: false
 
+  /@vercel/microfrontends@1.2.2(vite@5.1.8):
+    resolution: {integrity: sha512-QzcR5wVsz654XlCGT/HnxjgSkQMpeaEuj7bI1EeukwL/2D3kFkL5J68LMqA68HHSbbLvx32o7n5scSoB7a+3IQ==}
+    hasBin: true
+    peerDependencies:
+      '@sveltejs/kit': '>=1'
+      '@vercel/analytics': '>=1.5.0'
+      '@vercel/speed-insights': '>=1.2.0'
+      next: '>=13'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+      vite: '>=5'
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      '@vercel/analytics':
+        optional: true
+      '@vercel/speed-insights':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@next/env': 15.1.6
+      ajv: 8.17.1
+      commander: 12.1.0
+      cookie: 0.4.0
+      fast-glob: 3.3.2
+      http-proxy: 1.18.1(debug@3.1.0)
+      jsonc-parser: 3.3.1
+      nanoid: 3.3.11
+      path-to-regexp: 6.2.1
+      vite: 5.1.8(@types/node@14.18.33)
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@vercel/nft@0.27.10:
     resolution: {integrity: sha512-zbaF9Wp/NsZtKLE4uVmL3FyfFwlpDyuymQM1kPbeT0mVOHKDQQNjnnfslB3REg3oZprmNFJuh3pkHBk2qAaizg==}
     engines: {node: '>=16'}
@@ -8368,6 +8373,15 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
 
   /ajv@8.6.3:
     resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
@@ -9430,6 +9444,11 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
+  /commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+    dev: false
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -9487,6 +9506,11 @@ packages:
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: true
+
+  /cookie@0.4.0:
+    resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookie@0.7.0:
     resolution: {integrity: sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==}
@@ -9698,7 +9722,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
-    dev: true
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -10500,7 +10523,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
-    dev: true
 
   /esbuild@0.19.2:
     resolution: {integrity: sha512-G6hPax8UbFakEj3hWO0Vs52LQ8k3lnBhxZWomUJDxfz3rZTLqF5k/FCzuNdLx2RbpBiQQF9H9onlDDH1lZsnjg==}
@@ -10675,7 +10697,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.9
@@ -10706,7 +10728,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.3
@@ -10854,7 +10876,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.24.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
     dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.24.0):
@@ -11111,7 +11133,6 @@ packages:
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-    dev: true
 
   /events-intercept@2.0.0:
     resolution: {integrity: sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==}
@@ -11327,6 +11348,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+    dev: false
+
   /fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
     dependencies:
@@ -11472,7 +11497,6 @@ packages:
         optional: true
     dependencies:
       debug: 3.1.0
-    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -11601,7 +11625,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind@1.1.2:
@@ -12070,7 +12093,6 @@ packages:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -13436,7 +13458,6 @@ packages:
 
   /jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
-    dev: true
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -13997,7 +14018,6 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
 
   /ms@2.1.1:
     resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
@@ -14029,14 +14049,13 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+  /nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
-  /nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
+  /nanoid@3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -14677,6 +14696,10 @@ packages:
     resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
     dev: false
 
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+    dev: false
+
   /path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
     dev: false
@@ -14720,7 +14743,6 @@ packages:
 
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -14799,7 +14821,7 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
@@ -14808,10 +14830,9 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    dev: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -15232,7 +15253,6 @@ packages:
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: true
 
   /resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -15374,7 +15394,6 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.28.1
       '@rollup/rollup-win32-x64-msvc': 4.28.1
       fsevents: 2.3.3
-    dev: true
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -15704,7 +15723,6 @@ packages:
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map-support@0.5.12:
     resolution: {integrity: sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==}
@@ -17238,7 +17256,6 @@ packages:
       rollup: 4.28.1
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@5.1.8(@types/node@20.17.10):
     resolution: {integrity: sha512-mB8ToUuSmzODSpENgvpFk2fTiU/YQ1tmcVJJ4WZbq4fPdGJkFNVcmVL5k7iDug6xzWjjuGDKAuSievIsD6H7Xw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       json-parse-better-errors:
         specifier: 1.0.2
         version: 1.0.2
+      jsonc-parser:
+        specifier: 3.3.1
+        version: 3.3.1
       jsonlines:
         specifier: 0.1.1
         version: 0.1.1


### PR DESCRIPTION
Follow up PR for https://github.com/vercel/vercel/pull/13258

- Uses `findConfig` and `inferMicrofrontendsLocation` from `@vercel/microfrontends` for better detection
  - `@vercel/microfrontends` depends on `jsonc-parser` which does not work well with esbuild: https://github.com/evanw/esbuild/issues/1619, so added a custom plugin to handle that
- Adds unit test tests

