### PR TITLE
[cli] use `dot` directly instead of `dot-packer` cli

### DIFF
--- a/.changeset/beige-tigers-relax.md
+++ b/.changeset/beige-tigers-relax.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Use dot directly for Vercel CLI build

--- a/packages/cli/scripts/compile-templates.mjs
+++ b/packages/cli/scripts/compile-templates.mjs
@@ -1,25 +1,19 @@
-import execa from 'execa';
-import { fileURLToPath } from 'node:url';
 import { readFile, writeFile, readdir, unlink } from 'node:fs/promises';
+import doT from 'dot';
+import { fileURLToPath } from 'node:url';
 
 export async function compileDevTemplates() {
   const dirRoot = new URL('../', import.meta.url);
 
   // Compile the `doT.js` template files for `vercel dev`
-  const templatesDir = new URL('src/util/dev/templates/', dirRoot);
-  const dotPacker = fileURLToPath(
-    new URL('../../node_modules/dot/bin/dot-packer', dirRoot)
-  );
-  await execa(process.execPath, [dotPacker], {
-    cwd: templatesDir,
-    stdio: ['ignore', 'ignore', 'inherit'],
-  });
+  const templatesDirURL = new URL('src/util/dev/templates/', dirRoot);
+  doT.process({ path: fileURLToPath(templatesDirURL) });
 
-  const files = await readdir(templatesDir);
+  const files = await readdir(templatesDirURL);
   const compiledFiles = files.filter(f => f.endsWith('.js'));
 
   for (const file of compiledFiles) {
-    const fnPath = new URL(file, templatesDir);
+    const fnPath = new URL(file, templatesDirURL);
     const tsPath = fnPath.href.replace(/\.js$/, '.ts');
     const def = await readFile(
       new URL(fnPath.href.replace(/\.js$/, '.tsdef')),


### PR DESCRIPTION
This `dot-packer` cli usage is blocking https://github.com/vercel/vercel/pull/13263. Not totally sure why this was using the `dot-packer` cli instead of `dot.process()` before, but I manually checked the compiled templates in `packages/cli/src/dev/templates` are the same before and after.