### PR TITLE
[next] Support blocking static shells

### DIFF
--- a/.changeset/quick-deers-doubt.md
+++ b/.changeset/quick-deers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Support blocking static shells by not loading a fallback when none is present. Also updated the allowQuery logic to support this case.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2360,7 +2360,11 @@ export const onPrerenderRoute =
     // system and use it to assemble the prerender.
     let postponedPrerender: string | undefined;
     let didPostpone = false;
-    if (renderingMode === RenderingMode.PARTIALLY_STATIC && appDir) {
+    if (
+      renderingMode === RenderingMode.PARTIALLY_STATIC &&
+      appDir &&
+      !isBlocking
+    ) {
       const htmlPath = path.join(appDir, `${routeFileNoExt}.html`);
       const metaPath = path.join(appDir, `${routeFileNoExt}.meta`);
       if (fs.existsSync(htmlPath) && fs.existsSync(metaPath)) {
@@ -2745,7 +2749,11 @@ export const onPrerenderRoute =
           ? prerenderManifest.fallbackRoutes[routeKey]
           : prerenderManifest.blockingFallbackRoutes[routeKey];
 
-        htmlAllowQuery = fallbackRootParams ?? [];
+        if (fallbackRootParams && fallbackRootParams.length > 0) {
+          htmlAllowQuery = fallbackRootParams;
+        } else if (postponedPrerender) {
+          htmlAllowQuery = [];
+        }
       }
 
       prerenders[outputPathPage] = new Prerender({


### PR DESCRIPTION
Support blocking static shells properly for PPR. A blocking page is when there is no fallback configured in the manifest and therefore shouldn't provide a fallback in those cases. This also modifies the allow query logic so that it can handle this case even when fallback root params are provided.