### PR TITLE
Remove `@trek` individual entry for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,16 @@
 # https://help.github.com/en/articles/about-code-owners
 
 # Restricted Paths
-*                                        @vercel/ci-cd @trek
-/.github/workflows                       @vercel/ci-cd @ijjk @trek
-/packages/fs-detectors                   @vercel/ci-cd @agadzik @chloetedder @trek
+*                                        @vercel/ci-cd
+/.github/workflows                       @vercel/ci-cd @ijjk
+/packages/fs-detectors                   @vercel/ci-cd @agadzik @chloetedder
 /packages/next                           @vercel/ci-cd @timneutkens @ijjk @ztanner @huozhi
-/packages/routing-utils                  @vercel/ci-cd @ijjk @trek
-/packages/static-build                   @vercel/ci-cd @trek
+/packages/routing-utils                  @vercel/ci-cd @ijjk
+/packages/static-build                   @vercel/ci-cd
 /packages/edge                           @vercel/ci-cd @vercel/compute
 /packages/functions                      @vercel/ci-cd @vercel/compute
 /packages/firewall                       @vercel/ci-cd @cramforce @sueplex
-/examples                                @vercel/ci-cd @leerob @trek
+/examples                                @vercel/ci-cd @leerob
 /examples/create-react-app               @vercel/ci-cd @Timer
 /examples/nextjs                         @vercel/ci-cd @ijjk @ztanner @huozhi
 /packages/node                           @vercel/ci-cd @Kikobeats


### PR DESCRIPTION
I've had luck with more finely tuned `ci-cd` alerts finally.