### PR TITLE
[vercel/functions] in memory cache should be singleton

### DIFF
--- a/.changeset/giant-rings-brake.md
+++ b/.changeset/giant-rings-brake.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Update in memory cache to use a singleton instance

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -149,7 +149,7 @@ An instance of the Vercel Function Cache.
 
 #### Defined in
 
-[packages/functions/src/cache/index.ts:29](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L29)
+[packages/functions/src/cache/index.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L32)
 
 ---
 

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -12,6 +12,9 @@ const defaultKeyHashFunction = (key: string) => {
 
 const defaultNamespaceSeparator = '$';
 
+// Singleton instance of InMemoryCache
+let inMemoryCacheInstance: InMemoryCache | null = null;
+
 /**
  * Retrieves the Vercel Function Cache.
  *
@@ -33,7 +36,11 @@ export const getFunctionCache = (
   if (getContext().cache) {
     cache = getContext().cache as FunctionCache;
   } else {
-    cache = new InMemoryCache();
+    // Create InMemoryCache instance only once
+    if (!inMemoryCacheInstance) {
+      inMemoryCacheInstance = new InMemoryCache();
+    }
+    cache = inMemoryCacheInstance;
   }
 
   const hashFunction = cacheOptions?.keyHashFunction || defaultKeyHashFunction;

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -39,6 +39,29 @@ describe('getRuntimeCache', () => {
     expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
   });
 
+  test('should return the same cache instance for multiple calls to getFunctionCache when no context cache is available', async () => {
+    // Mock getContext to return an empty object (no context cache)
+    (getContext as Mock).mockReturnValue({});
+
+    // Get two cache instances
+    const cache1 = getFunctionCache();
+    const cache2 = getFunctionCache();
+
+    // Set a value in the first cache
+    await cache1.set('test-key', 'test-value');
+
+    // Verify the second cache has access to the same data
+    const result = await cache2.get('test-key');
+
+    // The second cache should be able to access data set by the first cache
+    expect(result).toBe('test-value');
+
+    // Additional verification: setting a value in cache2 should be visible in cache1
+    await cache2.set('another-key', 'another-value');
+    const anotherResult = await cache1.get('another-key');
+    expect(anotherResult).toBe('another-value');
+  });
+
   test('should use InMemoryCache if context cache is not available', async () => {
     (getContext as Mock).mockReturnValue({});
     const cache = getFunctionCache();


### PR DESCRIPTION
# Problem

When running locally, getFunctionCache() returns a new instance of the in-memory cache. This is inconsistent behavior, given the same cache is returned when running on vercel.

# Solution

Store in memory instance as a singleton