### PR TITLE
Add `.next/turbopack` file into diagnostics glob

### DIFF
--- a/.changeset/young-bees-confess.md
+++ b/.changeset/young-bees-confess.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add .next/turbopack file into diagnostics output

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2876,6 +2876,11 @@ export const diagnostics: Diagnostics = async ({
       'trace',
       path.join(basePath, diagnosticsEntrypoint, outputDirectory)
     )),
+    // Collect `.next/turbopack` file
+    ...(await glob(
+      'turbopack',
+      path.join(basePath, diagnosticsEntrypoint, outputDirectory)
+    )),
   };
 };
 


### PR DESCRIPTION
# Overview

Add the `turbopack` marker file into the diagnostics glob of files so that we can process this in the Vercel build pipeline to indicate to users that their build was run with turbopack.
