### PR TITLE
fix(gitlab): support linking projects that belong to subgroups

### DIFF
--- a/.changeset/nervous-geckos-glow.md
+++ b/.changeset/nervous-geckos-glow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix linking GitLab repositories that belong to subgroups

--- a/packages/cli/src/util/git/connect-git-provider.ts
+++ b/packages/cli/src/util/git/connect-git-provider.ts
@@ -113,9 +113,10 @@ export function parseRepoUrl(originUrl: string): RepoInfo | null {
   const provider = hostParts[hostParts.length - 2];
 
   const pathParts = url.pathname.split('/').filter(Boolean);
-  if (pathParts.length !== 2) return null;
-  const org = pathParts[0];
-  const repo = pathParts[1].replace(/\.git$/, '');
+  if (pathParts.length < 2) return null;
+  const repo = pathParts.pop()?.replace(/\.git$/, '');
+  if (!repo) return null;
+  const org = pathParts.join('/');
   return { url: originUrl, provider, org, repo };
 }
 

--- a/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
+++ b/packages/cli/test/unit/util/deploy/create-git-meta.test.ts
@@ -145,6 +145,15 @@ describe('parseRepoUrl', () => {
     expect(repoInfo?.org).toEqual('gitlab-examples');
     expect(repoInfo?.repo).toEqual('knative-kotlin-app');
   });
+  it('should parse gitlab subgroup https url', () => {
+    const repoInfo = parseRepoUrl(
+      'https://gitlab.com/group/subgroup/project.git'
+    );
+    expect(repoInfo).toBeTruthy();
+    expect(repoInfo?.provider).toEqual('gitlab');
+    expect(repoInfo?.org).toEqual('group/subgroup');
+    expect(repoInfo?.repo).toEqual('project');
+  });
 
   it('should parse bitbucket https url', () => {
     const repoInfo = parseRepoUrl(


### PR DESCRIPTION
GitLab projects can belong to [subgroups up to 20 deep](https://docs.gitlab.com/user/group/subgroups/), our logic for parsing repo paths would not allow for this.

Added unit tests

Manual test against own repository that belongs to a subgroup (failed due to my personal account not being pro):

Before:
```
[1 olszewski@macbookpro] /Users/olszewski/code/vercel/vercel/packages/cli $ pnpm run vc --cwd /tmp/great-monorepo git connect https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo

> vercel@41.7.0 vc /Users/olszewski/code/vercel/vercel/packages/cli
> pnpm vercel "--cwd" "/tmp/great-monorepo" "git" "connect" "https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo"


> vercel@41.7.0 vercel /Users/olszewski/code/vercel/vercel/packages/cli
> ts-node ./src/index.ts "--cwd" "/tmp/great-monorepo" "git" "connect" "https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo"

Vercel CLI 41.7.0
Error: Failed to parse URL "https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo". Please ensure the URL is valid.
```
After:
```
[0 olszewski@macbookpro] /Users/olszewski/code/vercel/vercel/packages/cli $ pnpm run vc --cwd /tmp/great-monorepo git connect https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo

> vercel@41.7.0 vc /Users/olszewski/code/vercel/vercel/packages/cli
> pnpm vercel "--cwd" "/tmp/great-monorepo" "git" "connect" "https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo"


> vercel@41.7.0 vercel /Users/olszewski/code/vercel/vercel/packages/cli
> ts-node ./src/index.ts "--cwd" "/tmp/great-monorepo" "git" "connect" "https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo"

Vercel CLI 41.7.0
> Found a repository in your local Git Config: git@gitlab.com:top-level8063919/middle-level/bottom-level/great-monorepo.git
? Do you still want to connect https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo? yes
> Connecting Git remote: https://gitlab.com/top-level8063919/middle-level/bottom-level/great-monorepo
Error: Failed to connect the GitLab repository top-level8063919/middle-level/bottom-level/great-monorepo.
Error: The repository "top-level8063919/middle-level/bottom-level/great-monorepo" is owned by a group. Please link it to a Vercel Pro team instead. (409)
```