### PR TITLE
[vercel/functions] rename function cache to runtime cache

### DIFF
--- a/.changeset/good-moose-reflect.md
+++ b/.changeset/good-moose-reflect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Rename FunctionCache / getFunctionCache to RuntimeCache / getRuntimeCache

--- a/packages/functions/docs/interfaces/index.RuntimeCache.md
+++ b/packages/functions/docs/interfaces/index.RuntimeCache.md
@@ -1,17 +1,17 @@
-# Interface: FunctionCache
+# Interface: RuntimeCache
 
-[index](../modules/index.md).FunctionCache
+[index](../modules/index.md).RuntimeCache
 
-Interface representing the function cache.
+Interface representing the runtime cache.
 
 ## Table of contents
 
 ### Properties
 
-- [delete](index.FunctionCache.md#delete)
-- [expireTag](index.FunctionCache.md#expiretag)
-- [get](index.FunctionCache.md#get)
-- [set](index.FunctionCache.md#set)
+- [delete](index.RuntimeCache.md#delete)
+- [expireTag](index.RuntimeCache.md#expiretag)
+- [get](index.RuntimeCache.md#get)
+- [set](index.RuntimeCache.md#set)
 
 ## Properties
 

--- a/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
+++ b/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
@@ -40,7 +40,7 @@ Omit.clientConfig
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
 
 ---
 
@@ -56,7 +56,7 @@ Omit.clientPlugins
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
 
 ---
 
@@ -202,7 +202,7 @@ Omit.roleAssumerWithWebIdentity
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
 
 ---
 
@@ -218,4 +218,4 @@ Omit.roleSessionName
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123

--- a/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
+++ b/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
@@ -40,7 +40,7 @@ Omit.clientConfig
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
 
 ---
 
@@ -56,7 +56,7 @@ Omit.clientPlugins
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
 
 ---
 
@@ -202,7 +202,7 @@ Omit.roleAssumerWithWebIdentity
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
 
 ---
 
@@ -218,4 +218,4 @@ Omit.roleSessionName
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.731.1/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -4,15 +4,15 @@
 
 ### Interfaces
 
-- [FunctionCache](../interfaces/index.FunctionCache.md)
 - [Geo](../interfaces/index.Geo.md)
 - [Request](../interfaces/index.Request.md)
+- [RuntimeCache](../interfaces/index.RuntimeCache.md)
 
 ### Functions
 
 - [geolocation](index.md#geolocation)
 - [getEnv](index.md#getenv)
-- [getFunctionCache](index.md#getfunctioncache)
+- [getRuntimeCache](index.md#getruntimecache)
 - [ipAddress](index.md#ipaddress)
 - [next](index.md#next)
 - [rewrite](index.md#rewrite)
@@ -118,11 +118,11 @@ https://vercel.com/docs/projects/environment-variables/system-environment-variab
 
 ---
 
-### getFunctionCache
+### getRuntimeCache
 
-▸ **getFunctionCache**(`cacheOptions?`): [`FunctionCache`](../interfaces/index.FunctionCache.md)
+▸ **getRuntimeCache**(`cacheOptions?`): [`RuntimeCache`](../interfaces/index.RuntimeCache.md)
 
-Retrieves the Vercel Function Cache.
+Retrieves the Vercel Runtime Cache.
 
 Keys are hashed to ensure they are unique and consistent. The hashing function can be overridden by providing a custom
 `keyHashFunction` in the `cacheOptions` parameter.
@@ -143,9 +143,9 @@ If no cache is available in the context and `InMemoryCache` cannot be created.
 
 #### Returns
 
-[`FunctionCache`](../interfaces/index.FunctionCache.md)
+[`RuntimeCache`](../interfaces/index.RuntimeCache.md)
 
-An instance of the Vercel Function Cache.
+An instance of the Vercel Runtime Cache.
 
 #### Defined in
 

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -1,4 +1,4 @@
-import { FunctionCache } from './types';
+import { RuntimeCache } from './types';
 
 interface CacheEntry {
   value: unknown;
@@ -7,7 +7,7 @@ interface CacheEntry {
   ttl?: number; // Time to live in seconds
 }
 
-export class InMemoryCache implements FunctionCache {
+export class InMemoryCache implements RuntimeCache {
   private cache: Record<string, CacheEntry> = {};
 
   async get(

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -1,5 +1,5 @@
 import { getContext } from '../get-context';
-import { CacheOptions, FunctionCache } from './types';
+import { CacheOptions, RuntimeCache } from './types';
 import { InMemoryCache } from './in-memory-cache';
 
 const defaultKeyHashFunction = (key: string) => {
@@ -16,7 +16,7 @@ const defaultNamespaceSeparator = '$';
 let inMemoryCacheInstance: InMemoryCache | null = null;
 
 /**
- * Retrieves the Vercel Function Cache.
+ * Retrieves the Vercel Runtime Cache.
  *
  * Keys are hashed to ensure they are unique and consistent. The hashing function can be overridden by providing a custom
  * `keyHashFunction` in the `cacheOptions` parameter.
@@ -26,15 +26,13 @@ let inMemoryCacheInstance: InMemoryCache | null = null;
  * namespaceSeparator can also be customized using the `namespaceSeparator` option.
  *
  * @param cacheOptions - Optional configuration for the cache.
- * @returns An instance of the Vercel Function Cache.
+ * @returns An instance of the Vercel Runtime Cache.
  * @throws {Error} If no cache is available in the context and `InMemoryCache` cannot be created.
  */
-export const getFunctionCache = (
-  cacheOptions?: CacheOptions
-): FunctionCache => {
-  let cache: FunctionCache;
+export const getRuntimeCache = (cacheOptions?: CacheOptions): RuntimeCache => {
+  let cache: RuntimeCache;
   if (getContext().cache) {
-    cache = getContext().cache as FunctionCache;
+    cache = getContext().cache as RuntimeCache;
   } else {
     // Create InMemoryCache instance only once
     if (!inMemoryCacheInstance) {

--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -1,7 +1,7 @@
 /**
- * Interface representing the function cache.
+ * Interface representing the runtime cache.
  */
-export interface FunctionCache {
+export interface RuntimeCache {
   /**
    * Deletes a value from the cache.
    *

--- a/packages/functions/src/get-context.ts
+++ b/packages/functions/src/get-context.ts
@@ -1,8 +1,8 @@
-import { FunctionCache } from './cache/types';
+import { RuntimeCache } from './cache/types';
 
 type Context = {
   waitUntil?: (promise: Promise<unknown>) => void;
-  cache?: FunctionCache;
+  cache?: RuntimeCache;
   headers?: Record<string, string>;
 };
 

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -3,5 +3,5 @@ export { geolocation, ipAddress } from './headers';
 export { getEnv } from './get-env';
 export { waitUntil } from './wait-until';
 export { rewrite, next } from './middleware';
-export { getFunctionCache } from './cache';
-export type { FunctionCache } from './cache/types';
+export { getRuntimeCache } from './cache';
+export type { RuntimeCache } from './cache/types';

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -8,7 +8,7 @@ import {
   vitest,
 } from 'vitest';
 
-import { getFunctionCache } from '../../../src/cache/index';
+import { getRuntimeCache } from '../../../src/cache/index';
 import { InMemoryCache } from '../../../src/cache/in-memory-cache';
 import { getContext } from '../../../src/get-context';
 
@@ -31,7 +31,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the context cache if available', async () => {
-    const cache = getFunctionCache();
+    const cache = getRuntimeCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -39,13 +39,13 @@ describe('getRuntimeCache', () => {
     expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
   });
 
-  test('should return the same cache instance for multiple calls to getFunctionCache when no context cache is available', async () => {
+  test('should return the same cache instance for multiple calls to getRuntimeCache when no context cache is available', async () => {
     // Mock getContext to return an empty object (no context cache)
     (getContext as Mock).mockReturnValue({});
 
     // Get two cache instances
-    const cache1 = getFunctionCache();
-    const cache2 = getFunctionCache();
+    const cache1 = getRuntimeCache();
+    const cache2 = getRuntimeCache();
 
     // Set a value in the first cache
     await cache1.set('test-key', 'test-value');
@@ -64,7 +64,7 @@ describe('getRuntimeCache', () => {
 
   test('should use InMemoryCache if context cache is not available', async () => {
     (getContext as Mock).mockReturnValue({});
-    const cache = getFunctionCache();
+    const cache = getRuntimeCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -72,7 +72,7 @@ describe('getRuntimeCache', () => {
 
   test('should use the provided key hash function', async () => {
     const customHashFunction = vitest.fn((key: string) => `custom-${key}`);
-    const cache = getFunctionCache({
+    const cache = getRuntimeCache({
       keyHashFunction: customHashFunction,
     });
     await cache.set('key', 'value');
@@ -85,7 +85,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the default key hash function if none is provided', async () => {
-    const cache = getFunctionCache();
+    const cache = getRuntimeCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -93,7 +93,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the provided namespace and separator', async () => {
-    const cache = getFunctionCache({
+    const cache = getRuntimeCache({
       namespace: 'test',
       namespaceSeparator: ':',
     });
@@ -110,7 +110,7 @@ describe('getRuntimeCache', () => {
 
   test('should use the default namespace separator if none is provided', async () => {
     const namespace = 'test';
-    const cache = getFunctionCache({ namespace });
+    const cache = getRuntimeCache({ namespace });
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');


### PR DESCRIPTION
Jumped the gun renaming to function cache so switching back to the original name, Runtime Cache

NOTE: This isn't a documented api yet, so considering this only a patch release