### PR TITLE
feat(auth): add hostname to the device auth user agent

### DIFF
--- a/.changeset/sweet-wasps-bow.md
+++ b/.changeset/sweet-wasps-bow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+feat(vas): add hostname to the device auth user agent

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -1,9 +1,11 @@
 import fetch, { type Response } from 'node-fetch';
 import { createRemoteJWKSet, type JWTPayload, jwtVerify } from 'jose';
 import ua from './ua';
+import { hostname } from 'os';
 
 const VERCEL_ISSUER = new URL('https://vercel.com');
 export const VERCEL_CLI_CLIENT_ID = 'cl_HYyOPBNtFMfHhaUn9L4QPfTZz6TP47bp';
+const userAgent = `${hostname()} @ ${ua}`;
 
 interface AuthorizationServerMetadata {
   issuer: URL;
@@ -37,7 +39,7 @@ export async function as(): Promise<AuthorizationServerMetadata> {
  */
 async function discoveryEndpointRequest(issuer: URL): Promise<Response> {
   return await fetch(new URL('.well-known/openid-configuration', issuer), {
-    headers: { 'Content-Type': 'application/json', 'user-agent': ua },
+    headers: { 'Content-Type': 'application/json', 'user-agent': userAgent },
   });
 }
 
@@ -97,11 +99,11 @@ export async function deviceAuthorizationRequest(): Promise<Response> {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'user-agent': ua,
+      'user-agent': userAgent,
     },
     body: new URLSearchParams({
       client_id: VERCEL_CLI_CLIENT_ID,
-      scope: 'openid',
+      scope: 'openid offline_access',
     }),
   });
 }
@@ -204,7 +206,7 @@ export async function deviceAccessTokenRequest(options: {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'user-agent': ua,
+          'user-agent': userAgent,
         },
         body: new URLSearchParams({
           client_id: VERCEL_CLI_CLIENT_ID,
@@ -289,7 +291,7 @@ export async function revocationRequest(options: {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'user-agent': ua,
+      'user-agent': userAgent,
     },
     body: new URLSearchParams({ ...options, client_id: VERCEL_CLI_CLIENT_ID }),
   });

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -5,7 +5,7 @@ import { hostname } from 'os';
 
 const VERCEL_ISSUER = new URL('https://vercel.com');
 export const VERCEL_CLI_CLIENT_ID = 'cl_HYyOPBNtFMfHhaUn9L4QPfTZz6TP47bp';
-const userAgent = `${hostname()} @ ${ua}`;
+export const userAgent = `${hostname()} @ ${ua}`;
 
 interface AuthorizationServerMetadata {
   issuer: URL;
@@ -103,7 +103,7 @@ export async function deviceAuthorizationRequest(): Promise<Response> {
     },
     body: new URLSearchParams({
       client_id: VERCEL_CLI_CLIENT_ID,
-      scope: 'openid offline_access',
+      scope: 'openid',
     }),
   });
 }

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -3,8 +3,11 @@ import { login } from '../../../../src/commands/login/future';
 import { client } from '../../../mocks/client';
 import { vi } from 'vitest';
 import fetch, { Headers, type Response } from 'node-fetch';
-import { as, VERCEL_CLI_CLIENT_ID } from '../../../../src/util/oauth';
-import ua from '../../../../src/util/ua';
+import {
+  as,
+  VERCEL_CLI_CLIENT_ID,
+  userAgent,
+} from '../../../../src/util/oauth';
 import { randomUUID } from 'node:crypto';
 import { jwtVerify } from 'jose';
 
@@ -111,7 +114,7 @@ describe('login --future', () => {
       // TODO: Drop `Headers` wrapper when `node-fetch` is dropped
       new Headers(fetchMock.mock.calls[0][1]?.headers).get('user-agent'),
       'Passing the correct user agent so the user can verify'
-    ).toBe(ua);
+    ).toBe(userAgent);
 
     expect(
       fetchMock.mock.calls[1][1]?.body?.toString(),
@@ -131,7 +134,7 @@ describe('login --future', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'user-agent': ua,
+            'user-agent': userAgent,
           },
           body: expect.any(URLSearchParams),
         })

--- a/packages/cli/test/unit/commands/logout/future.test.ts
+++ b/packages/cli/test/unit/commands/logout/future.test.ts
@@ -3,9 +3,12 @@ import { logout } from '../../../../src/commands/logout/future';
 import { client } from '../../../mocks/client';
 import { vi } from 'vitest';
 import fetch, { type Response } from 'node-fetch';
-import { as, VERCEL_CLI_CLIENT_ID } from '../../../../src/util/oauth';
+import {
+  as,
+  VERCEL_CLI_CLIENT_ID,
+  userAgent,
+} from '../../../../src/util/oauth';
 import { randomUUID } from 'node:crypto';
-import ua from '../../../../src/util/ua';
 
 const fetchMock = fetch as unknown as MockInstance<typeof fetch>;
 
@@ -58,7 +61,7 @@ describe('logout --future', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'user-agent': ua,
+          'user-agent': userAgent,
         },
         body: expect.any(URLSearchParams),
       })


### PR DESCRIPTION
This PR appends the `hostname` to the sent user agent in the device flow. We use this information to list the token on the user's account for visibility.

Related: https://github.com/vercel/api/pull/40881