### PR TITLE
[mcp-adapter] Allow configuring the /message endpoint for when the server is not hosted on /

### DIFF
--- a/.changeset/nervous-meals-wave.md
+++ b/.changeset/nervous-meals-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/mcp-adapter': patch
+---
+
+update readme with consistent docs

--- a/.changeset/tasty-donkeys-build.md
+++ b/.changeset/tasty-donkeys-build.md
@@ -1,0 +1,5 @@
+---
+'@vercel/mcp-adapter': patch
+---
+
+Fix message endpoint not being settable

--- a/packages/mcp-adapter/README.md
+++ b/packages/mcp-adapter/README.md
@@ -43,6 +43,7 @@ const handler = createMcpHandler(
     // If /api/[transport]/route.ts, then /api/mcp
     streamableHttpEndpoint: '/api/mcp',
     sseEndpoint: '/api/sse',
+    sseMessageEndpoint: '/api/message',
     maxDuration: 60,
     verboseLogs: true,
   }
@@ -73,6 +74,7 @@ interface Config {
   redisUrl?: string; // Redis connection URL for pub/sub
   streamableHttpEndpoint?: string; // Endpoint for streamable HTTP transport
   sseEndpoint?: string; // Endpoint for SSE transport
+  sseMessageEndpoint?: string; // Endpoint for SSE message transport
   maxDuration?: number; // Maximum duration for SSE connections in seconds
 }
 ```

--- a/packages/mcp-adapter/README.md
+++ b/packages/mcp-adapter/README.md
@@ -39,8 +39,10 @@ const handler = createMcpHandler(
   {
     // Optional configuration
     redisUrl: process.env.REDIS_URL,
-    streamableHttpEndpoint: '/mcp',
-    sseEndpoint: '/sse',
+    // The endpoint path that that the createMcpHandler is hosted on
+    // If /api/[transport]/route.ts, then /api/mcp
+    streamableHttpEndpoint: '/api/mcp',
+    sseEndpoint: '/api/sse',
     maxDuration: 60,
     verboseLogs: true,
   }

--- a/packages/mcp-adapter/example/route.ts
+++ b/packages/mcp-adapter/example/route.ts
@@ -21,6 +21,7 @@ const handler = createMcpRouteHandler(
   {
     streamableHttpEndpoint: '/mcp',
     sseEndpoint: '/sse',
+    sseMessageEndpoint: '/message',
     redisUrl: process.env.REDIS_URL,
   }
 );

--- a/packages/mcp-adapter/src/next/mcp-api-handler.ts
+++ b/packages/mcp-adapter/src/next/mcp-api-handler.ts
@@ -11,6 +11,7 @@ import { Readable } from 'node:stream';
 import type { ServerOptions } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { BodyType } from './server-response-adapter';
+import assert from 'node:assert';
 
 interface SerializedRequest {
   requestId: string;
@@ -190,8 +191,8 @@ export function initializeMcpApiHandler(
       }
     } else if (url.pathname === sseEndpoint) {
       logger.log('Got new SSE connection');
-
-      const transport = new SSEServerTransport('/message', res);
+      assert(sseMessageEndpoint, 'sseMessageEndpoint is required');
+      const transport = new SSEServerTransport(sseMessageEndpoint, res);
       const sessionId = transport.sessionId;
       const server = new McpServer(
         {

--- a/packages/mcp-adapter/src/next/mcp-api-handler.ts
+++ b/packages/mcp-adapter/src/next/mcp-api-handler.ts
@@ -65,6 +65,11 @@ export type Config = {
    */
   sseEndpoint?: string;
   /**
+   * The endpoint to use for the SSE messages transport.
+   * @default "/message"
+   */
+  sseMessageEndpoint?: string;
+  /**
    * The maximum duration of an MCP request in seconds.
    * @default 60
    */
@@ -83,6 +88,7 @@ export function initializeMcpApiHandler(
     redisUrl: process.env.REDIS_URL || process.env.KV_URL,
     streamableHttpEndpoint: '/mcp',
     sseEndpoint: '/sse',
+    sseMessageEndpoint: '/message',
     maxDuration: 60,
     verboseLogs: false,
   }
@@ -91,6 +97,7 @@ export function initializeMcpApiHandler(
     redisUrl,
     streamableHttpEndpoint,
     sseEndpoint,
+    sseMessageEndpoint,
     maxDuration,
     verboseLogs,
   } = config;
@@ -303,7 +310,7 @@ export function initializeMcpApiHandler(
       const closeReason = await waitPromise;
       logger.log(closeReason);
       await cleanup();
-    } else if (url.pathname === '/message') {
+    } else if (url.pathname === sseMessageEndpoint) {
       logger.log('Received message');
 
       const body = await req.text();


### PR DESCRIPTION
The sse and mcp endpoints can be put behind arbitrary routes, like /api/server/... but the messages endpoint needed the same configuration