### PR TITLE
[mcp-adapte] Set the version to exact match 1.10.2 until 1.11.1 is fixed

### DIFF
--- a/.changeset/ten-drinks-rest.md
+++ b/.changeset/ten-drinks-rest.md
@@ -1,0 +1,5 @@
+---
+'@vercel/mcp-adapter': patch
+---
+
+pin exact version rather than any version over

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -41,7 +41,7 @@
   "author": "Vercel",
   "license": "Apache-2.0",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.10.2",
+    "@modelcontextprotocol/sdk": "1.10.2",
     "redis": "^4.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1184,7 +1184,7 @@ importers:
   packages/mcp-adapter:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.2
+        specifier: 1.10.2
         version: 1.10.2
       next:
         specifier: '>=13.0.0'


### PR DESCRIPTION
anything greater than 1.10.2 is broken right now, pin this exact version until it gets fixed