### PR TITLE
Update MCP SDK version as the MCP bug has been resolved

### DIFF
--- a/packages/mcp-adapter/CHANGELOG.md
+++ b/packages/mcp-adapter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vercel/mcp-adapter
 
+## 0.3.2
+
+### Patch Changes
+
+- unpin exact version of mcp as the newest version has been fixed ([#13315](https://github.com/vercel/vercel/pull/13315))
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/mcp-adapter/package.json
+++ b/packages/mcp-adapter/package.json
@@ -41,7 +41,7 @@
   "author": "Vercel",
   "license": "Apache-2.0",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.10.2",
+    "@modelcontextprotocol/sdk": "^1.11.2",
     "redis": "^4.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1184,7 +1184,7 @@ importers:
   packages/mcp-adapter:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.10.2
+        specifier: ^1.10.2
         version: 1.10.2
       next:
         specifier: '>=13.0.0'


### PR DESCRIPTION
Bug https://github.com/modelcontextprotocol/typescript-sdk/issues/467 (https://github.com/vercel-labs/mcp-for-next.js/issues/9) has been resolved in this PR, and the new version has been released (https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/1.11.2).