### PR TITLE
[vercel/functions] shorten getRuntimeCache() to getCache()

### DIFF
--- a/.changeset/ten-turkeys-reply.md
+++ b/.changeset/ten-turkeys-reply.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Rename getRuntimeCache to getCache

--- a/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
+++ b/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
@@ -40,7 +40,7 @@ Omit.clientConfig
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
 
 ---
 
@@ -56,7 +56,7 @@ Omit.clientPlugins
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
 
 ---
 
@@ -202,7 +202,7 @@ Omit.roleAssumerWithWebIdentity
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
 
 ---
 
@@ -218,4 +218,4 @@ Omit.roleSessionName
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123

--- a/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
+++ b/packages/functions/docs/interfaces/oidc.AwsCredentialsProviderInit.md
@@ -40,7 +40,7 @@ Omit.clientConfig
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:135
 
 ---
 
@@ -56,7 +56,7 @@ Omit.clientPlugins
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:139
 
 ---
 
@@ -202,7 +202,7 @@ Omit.roleAssumerWithWebIdentity
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:130
 
 ---
 
@@ -218,4 +218,4 @@ Omit.roleSessionName
 
 #### Defined in
 
-node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.803.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123
+node*modules/.pnpm/@aws-sdk+credential-provider-web-identity@3.609.0*@aws-sdk+client-sts@3.806.0/node_modules/@aws-sdk/credential-provider-web-identity/dist-types/fromWebToken.d.ts:123

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -11,8 +11,8 @@
 ### Functions
 
 - [geolocation](index.md#geolocation)
+- [getCache](index.md#getcache)
 - [getEnv](index.md#getenv)
-- [getRuntimeCache](index.md#getruntimecache)
 - [ipAddress](index.md#ipaddress)
 - [next](index.md#next)
 - [rewrite](index.md#rewrite)
@@ -68,6 +68,41 @@ The location information of the request, in this way:
 
 ---
 
+### getCache
+
+▸ **getCache**(`cacheOptions?`): [`RuntimeCache`](../interfaces/index.RuntimeCache.md)
+
+Retrieves the Vercel Runtime Cache.
+
+Keys are hashed to ensure they are unique and consistent. The hashing function can be overridden by providing a custom
+`keyHashFunction` in the `cacheOptions` parameter.
+
+To specify a namespace for the cache keys, you can pass a `namespace` option in the `cacheOptions` parameter. If
+a namespace is provided, the cache keys will be prefixed with the namespace followed by a separator (default is `$`). The
+namespaceSeparator can also be customized using the `namespaceSeparator` option.
+
+**`Throws`**
+
+If no cache is available in the context and `InMemoryCache` cannot be created.
+
+#### Parameters
+
+| Name            | Type           | Description                           |
+| :-------------- | :------------- | :------------------------------------ |
+| `cacheOptions?` | `CacheOptions` | Optional configuration for the cache. |
+
+#### Returns
+
+[`RuntimeCache`](../interfaces/index.RuntimeCache.md)
+
+An instance of the Vercel Runtime Cache.
+
+#### Defined in
+
+[packages/functions/src/cache/index.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L32)
+
+---
+
 ### getEnv
 
 ▸ **getEnv**(`env?`): `Object`
@@ -115,41 +150,6 @@ https://vercel.com/docs/projects/environment-variables/system-environment-variab
 #### Defined in
 
 [packages/functions/src/get-env.ts:6](https://github.com/vercel/vercel/blob/main/packages/functions/src/get-env.ts#L6)
-
----
-
-### getRuntimeCache
-
-▸ **getRuntimeCache**(`cacheOptions?`): [`RuntimeCache`](../interfaces/index.RuntimeCache.md)
-
-Retrieves the Vercel Runtime Cache.
-
-Keys are hashed to ensure they are unique and consistent. The hashing function can be overridden by providing a custom
-`keyHashFunction` in the `cacheOptions` parameter.
-
-To specify a namespace for the cache keys, you can pass a `namespace` option in the `cacheOptions` parameter. If
-a namespace is provided, the cache keys will be prefixed with the namespace followed by a separator (default is `$`). The
-namespaceSeparator can also be customized using the `namespaceSeparator` option.
-
-**`Throws`**
-
-If no cache is available in the context and `InMemoryCache` cannot be created.
-
-#### Parameters
-
-| Name            | Type           | Description                           |
-| :-------------- | :------------- | :------------------------------------ |
-| `cacheOptions?` | `CacheOptions` | Optional configuration for the cache. |
-
-#### Returns
-
-[`RuntimeCache`](../interfaces/index.RuntimeCache.md)
-
-An instance of the Vercel Runtime Cache.
-
-#### Defined in
-
-[packages/functions/src/cache/index.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L32)
 
 ---
 

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -29,7 +29,7 @@ let inMemoryCacheInstance: InMemoryCache | null = null;
  * @returns An instance of the Vercel Runtime Cache.
  * @throws {Error} If no cache is available in the context and `InMemoryCache` cannot be created.
  */
-export const getRuntimeCache = (cacheOptions?: CacheOptions): RuntimeCache => {
+export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
   let cache: RuntimeCache;
   if (getContext().cache) {
     cache = getContext().cache as RuntimeCache;

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -3,5 +3,5 @@ export { geolocation, ipAddress } from './headers';
 export { getEnv } from './get-env';
 export { waitUntil } from './wait-until';
 export { rewrite, next } from './middleware';
-export { getRuntimeCache } from './cache';
+export { getCache } from './cache';
 export type { RuntimeCache } from './cache/types';

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -8,7 +8,7 @@ import {
   vitest,
 } from 'vitest';
 
-import { getRuntimeCache } from '../../../src/cache/index';
+import { getCache } from '../../../src/cache/index';
 import { InMemoryCache } from '../../../src/cache/in-memory-cache';
 import { getContext } from '../../../src/get-context';
 
@@ -16,7 +16,7 @@ vitest.mock('../../../src/get-context', () => ({
   getContext: vitest.fn(),
 }));
 
-describe('getRuntimeCache', () => {
+describe('getCache', () => {
   let mockCache: InMemoryCache;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the context cache if available', async () => {
-    const cache = getRuntimeCache();
+    const cache = getCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -39,13 +39,13 @@ describe('getRuntimeCache', () => {
     expect(mockCache.get).toHaveBeenCalledWith('b876d32', undefined);
   });
 
-  test('should return the same cache instance for multiple calls to getRuntimeCache when no context cache is available', async () => {
+  test('should return the same cache instance for multiple calls to getCache when no context cache is available', async () => {
     // Mock getContext to return an empty object (no context cache)
     (getContext as Mock).mockReturnValue({});
 
     // Get two cache instances
-    const cache1 = getRuntimeCache();
-    const cache2 = getRuntimeCache();
+    const cache1 = getCache();
+    const cache2 = getCache();
 
     // Set a value in the first cache
     await cache1.set('test-key', 'test-value');
@@ -64,7 +64,7 @@ describe('getRuntimeCache', () => {
 
   test('should use InMemoryCache if context cache is not available', async () => {
     (getContext as Mock).mockReturnValue({});
-    const cache = getRuntimeCache();
+    const cache = getCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -72,7 +72,7 @@ describe('getRuntimeCache', () => {
 
   test('should use the provided key hash function', async () => {
     const customHashFunction = vitest.fn((key: string) => `custom-${key}`);
-    const cache = getRuntimeCache({
+    const cache = getCache({
       keyHashFunction: customHashFunction,
     });
     await cache.set('key', 'value');
@@ -85,7 +85,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the default key hash function if none is provided', async () => {
-    const cache = getRuntimeCache();
+    const cache = getCache();
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');
@@ -93,7 +93,7 @@ describe('getRuntimeCache', () => {
   });
 
   test('should use the provided namespace and separator', async () => {
-    const cache = getRuntimeCache({
+    const cache = getCache({
       namespace: 'test',
       namespaceSeparator: ':',
     });
@@ -110,7 +110,7 @@ describe('getRuntimeCache', () => {
 
   test('should use the default namespace separator if none is provided', async () => {
     const namespace = 'test';
-    const cache = getRuntimeCache({ namespace });
+    const cache = getCache({ namespace });
     await cache.set('key', 'value');
     const result = await cache.get('key');
     expect(result).toBe('value');


### PR DESCRIPTION
As a follow-up to [this](https://vercel.slack.com/archives/C042LHPJ1NX/p1746893072857759) conversation, use shorter name `getCache`
