### PR TITLE
[cli] Bump @vercel/fun to remove deprecated package warning

### DIFF
--- a/.changeset/wild-pants-wash.md
+++ b/.changeset/wild-pants-wash.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Bump @vercel/fun to remove deprecated package warning

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@vercel/build-utils": "10.5.1",
-    "@vercel/fun": "1.1.5",
+    "@vercel/fun": "1.1.6",
     "@vercel/go": "3.2.1",
     "@vercel/hydrogen": "1.2.0",
     "@vercel/next": "4.7.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
         specifier: 10.5.1
         version: link:../build-utils
       '@vercel/fun':
-        specifier: 1.1.5
-        version: 1.1.5
+        specifier: 1.1.6
+        version: 1.1.6
       '@vercel/go':
         specifier: 3.2.1
         version: link:../go
@@ -7771,8 +7771,8 @@ packages:
     dev: true
     optional: true
 
-  /@vercel/fun@1.1.5:
-    resolution: {integrity: sha512-vRuR7qlsl8CgdeQIhfgLDtbMEuxqltx6JWFahB7Q5VOKMo/sFZV1rCxIHsHsJP4yYY2hoZqlT/EUkfG1tfPicg==}
+  /@vercel/fun@1.1.6:
+    resolution: {integrity: sha512-xDiM+bD0fSZyzcjsAua3D+guXclvHOSTzr03UcZEQwYzIjwWjLduT7bl2gAaeNIe7fASAIZd0P00clcj0On4rQ==}
     engines: {node: '>= 18'}
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -7791,7 +7791,6 @@ packages:
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
-      uuid: 3.3.2
       xdg-app-paths: 5.1.0
       yauzl-promise: 2.1.3
     transitivePeerDependencies:
@@ -17136,12 +17135,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: true
-
-  /uuid@3.3.2:
-    resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}


### PR DESCRIPTION
This should be the final deprecation warning from https://github.com/vercel/vercel/issues/13117