### PR TITLE
[frameworks] updated Docusaurus to match out framework naming standards

### DIFF
--- a/.changeset/perfect-berries-impress.md
+++ b/.changeset/perfect-berries-impress.md
@@ -2,4 +2,4 @@
 "@vercel/frameworks": patch
 ---
 
-[frameworks] updated Docusaurus to match out framweowkr naming standards
+[frameworks] updated Docusaurus to match out framework naming standards

--- a/.changeset/perfect-berries-impress.md
+++ b/.changeset/perfect-berries-impress.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[frameworks] updated Docusaurus to match out framweowkr naming standards

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -415,7 +415,7 @@ export const frameworks = [
     cachePattern: '.cache/**',
   },
   {
-    name: 'Docusaurus (v2)',
+    name: 'Docusaurus (v2+)',
     slug: 'docusaurus-2',
     demo: 'https://docusaurus-2-template.vercel.app',
     logo: 'https://api-frameworks.vercel.sh/framework-logos/docusaurus.svg',


### PR DESCRIPTION
Part of https://github.com/vercel/vercel/issues/13329