### PR TITLE
Change the order of loading the OIDC token

### DIFF
--- a/.changeset/pink-vans-retire.md
+++ b/.changeset/pink-vans-retire.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Change the load order of the OIDC token

--- a/packages/functions/docs/modules/oidc.md
+++ b/packages/functions/docs/modules/oidc.md
@@ -66,8 +66,9 @@ A function that provides AWS credentials.
 
 Returns the OIDC token from the request context or the environment variable.
 
-This function first checks if the OIDC token is available in the environment variable
-`VERCEL_OIDC_TOKEN`. If it is not found there, it retrieves the token from the request
+This function is used to retrieve the OIDC token from the request context or the environment variable.
+It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
+
 context headers.
 
 **`Throws`**
@@ -95,4 +96,4 @@ A promise that resolves to the OIDC token.
 
 #### Defined in
 
-[packages/functions/src/oidc/get-vercel-oidc-token.ts:24](https://github.com/vercel/vercel/blob/main/packages/functions/src/oidc/get-vercel-oidc-token.ts#L24)
+[packages/functions/src/oidc/get-vercel-oidc-token.ts:25](https://github.com/vercel/vercel/blob/main/packages/functions/src/oidc/get-vercel-oidc-token.ts#L25)

--- a/packages/functions/src/oidc/get-vercel-oidc-token.ts
+++ b/packages/functions/src/oidc/get-vercel-oidc-token.ts
@@ -3,8 +3,9 @@ import { getContext } from '../get-context';
 /**
  * Returns the OIDC token from the request context or the environment variable.
  *
- * This function first checks if the OIDC token is available in the environment variable
- * `VERCEL_OIDC_TOKEN`. If it is not found there, it retrieves the token from the request
+ * This function is used to retrieve the OIDC token from the request context or the environment variable.
+ * It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
+ *
  * context headers.
  *
  * @returns {Promise<string>} A promise that resolves to the OIDC token.
@@ -22,9 +23,7 @@ import { getContext } from '../get-context';
  * ```
  */
 export async function getVercelOidcToken(): Promise<string> {
-  if (process.env.VERCEL_OIDC_TOKEN) return process.env.VERCEL_OIDC_TOKEN;
-
-  const token = getContext().headers?.['x-vercel-oidc-token'];
+  const token = getContext().headers?.['x-vercel-oidc-token'] ?? process.env.VERCEL_OIDC_TOKEN;
 
   if (!token) {
     throw new Error(

--- a/packages/functions/src/oidc/get-vercel-oidc-token.ts
+++ b/packages/functions/src/oidc/get-vercel-oidc-token.ts
@@ -23,7 +23,9 @@ import { getContext } from '../get-context';
  * ```
  */
 export async function getVercelOidcToken(): Promise<string> {
-  const token = getContext().headers?.['x-vercel-oidc-token'] ?? process.env.VERCEL_OIDC_TOKEN;
+  const token =
+    getContext().headers?.['x-vercel-oidc-token'] ??
+    process.env.VERCEL_OIDC_TOKEN;
 
   if (!token) {
     throw new Error(

--- a/packages/functions/test/unit/oidc/get-vercel-oidc-token.test.ts
+++ b/packages/functions/test/unit/oidc/get-vercel-oidc-token.test.ts
@@ -10,7 +10,7 @@ describe('getVercelOidcToken', () => {
       process.env.VERCEL_OIDC_TOKEN = token;
     });
     afterEach(() => {
-      // biome-ignore lint/performance/noDelete: <explanation>
+      // biome-ignore lint/performance/noDelete: necessary for test cleanup
       delete process.env.VERCEL_OIDC_TOKEN;
     });
 
@@ -63,7 +63,7 @@ describe('getVercelOidcToken', () => {
       };
     });
     afterEach(() => {
-      // biome-ignore lint/performance/noDelete: <explanation>
+      // biome-ignore lint/performance/noDelete: necessary for test cleanup
       delete process.env.VERCEL_OIDC_TOKEN;
       delete globalThis[
         Symbol.for(

--- a/packages/functions/test/unit/oidc/get-vercel-oidc-token.test.ts
+++ b/packages/functions/test/unit/oidc/get-vercel-oidc-token.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { getVercelOidcToken } from '../../../src/oidc';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 describe('getVercelOidcToken', () => {
   describe('when VERCEL_OIDC_TOKEN is present in the environment variables', () => {
@@ -10,6 +10,7 @@ describe('getVercelOidcToken', () => {
       process.env.VERCEL_OIDC_TOKEN = token;
     });
     afterEach(() => {
+      // biome-ignore lint/performance/noDelete: <explanation>
       delete process.env.VERCEL_OIDC_TOKEN;
     });
 
@@ -42,6 +43,37 @@ describe('getVercelOidcToken', () => {
 
     it('returns the OIDC token', async () => {
       await expect(getVercelOidcToken()).resolves.toEqual(token);
+    });
+  });
+
+  describe('load order', () => {
+    const tokenFromEnv = randomUUID();
+    const tokenFromContext = randomUUID();
+
+    beforeEach(() => {
+      process.env.VERCEL_OIDC_TOKEN = tokenFromEnv;
+
+      globalThis[
+        // @ts-ignore
+        Symbol.for(
+          '@vercel/request-context'
+        ) as unknown as keyof typeof globalThis
+      ] = {
+        get: () => ({ headers: { 'x-vercel-oidc-token': tokenFromContext } }),
+      };
+    });
+    afterEach(() => {
+      // biome-ignore lint/performance/noDelete: <explanation>
+      delete process.env.VERCEL_OIDC_TOKEN;
+      delete globalThis[
+        Symbol.for(
+          '@vercel/request-context'
+        ) as unknown as keyof typeof globalThis
+      ];
+    });
+
+    it('prefers the request context over the environment variable', async () => {
+      await expect(getVercelOidcToken()).resolves.toEqual(tokenFromContext);
     });
   });
 


### PR DESCRIPTION
In the event build the `VERCEL_OIDC_TOKEN` value bundled into the output. The Vercel runtime value from the headers will be overwritten.

This PR changes the load order, first from the `x-vercel-oidc-token` header, then the `VERCEL_OIDC_TOKEN` environment variable.