### PR TITLE
[cli] Move to v3 of `/env/pull`

### DIFF
--- a/.changeset/little-llamas-doubt.md
+++ b/.changeset/little-llamas-doubt.md
@@ -1,0 +1,5 @@
+---
+"vercel": major
+---
+
+[cli] Move to v3 of `/env/pull`

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -73,7 +73,7 @@ export async function pullEnvRecords(
   );
   const query = new URLSearchParams();
 
-  let url = `/v2/env/pull/${projectId}`;
+  let url = `/v3/env/pull/${projectId}`;
 
   if (target) {
     url += `/${encodeURIComponent(target)}`;

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -226,7 +226,7 @@ export function useProject(
     res.json(project);
   });
   client.scenario.get(
-    `/v2/env/pull/${project.id}/:target?/:gitBranch?`,
+    `/v3/env/pull/${project.id}/:target?/:gitBranch?`,
     (req, res) => {
       const target =
         typeof req.params.target === 'string'

--- a/packages/cli/test/unit/util/env/refresh-oidc-token.test.ts
+++ b/packages/cli/test/unit/util/env/refresh-oidc-token.test.ts
@@ -26,7 +26,7 @@ describe('refreshOidcToken', () => {
 
     client.setArgv('--debug');
 
-    client.scenario.get(`/v2/env/pull/${projectId}`, (_, res) => {
+    client.scenario.get(`/v3/env/pull/${projectId}`, (_, res) => {
       if (omitJwt) {
         return res.json({ env: {} });
       }


### PR DESCRIPTION
`v3` of this API changes the behavior around custom environments and `VERCEL_ENV`. The new behavior will match our docs and fixes a bug https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_ENV

This is, however, a breaking change, so bumping CLI major version.