### PR TITLE
[run-user-scripts] return a more verbose error

### DIFF
--- a/.changeset/honest-kids-drop.md
+++ b/.changeset/honest-kids-drop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+provide a more verbose error when package.json is not valid

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -357,7 +357,7 @@ export async function scanParentDirs(
       packageJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'));
     } catch (err) {
       throw new Error(
-        `Could not read package.json: ${(err as Error).message}.`
+        `Could not read ${pkgJsonPath}: ${(err as Error).message}.`
       );
     }
   }

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -350,10 +350,17 @@ export async function scanParentDirs(
     start: destPath,
     filename: 'package.json',
   });
-  const packageJson: PackageJson | undefined =
-    readPackageJson && pkgJsonPath
-      ? JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'))
-      : undefined;
+
+  let packageJson: PackageJson | undefined;
+  if (readPackageJson && pkgJsonPath) {
+    try {
+      packageJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'));
+    } catch (err) {
+      throw new Error(
+        `Could not read package.json: ${(err as Error).message}.`
+      );
+    }
+  }
   const {
     paths: [
       yarnLockPath,

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
@@ -15,6 +15,6 @@ describe(`${__dirname.split(path.sep).pop()}`, () => {
       error = err;
     }
 
-    expect(err).toBeUndefined();
+    expect(error).toBeUndefined();
   });
 });

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
@@ -6,7 +6,15 @@ const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
   it('should deploy and pass probe checks', async () => {
-    const info = await deployAndTest(__dirname);
-    Object.assign(ctx, info);
+    let error = undefined;
+
+    try {
+      const info = await deployAndTest(__dirname);
+      Object.assign(ctx, info);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(err).toBeUndefined();
   });
 });

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/index.test.js
@@ -6,15 +6,7 @@ const ctx = {};
 
 describe(`${__dirname.split(path.sep).pop()}`, () => {
   it('should deploy and pass probe checks', async () => {
-    let error = undefined;
-
-    try {
-      const info = await deployAndTest(__dirname);
-      Object.assign(ctx, info);
-    } catch (err) {
-      error = err;
-    }
-
-    expect(error).toBeUndefined();
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
   });
 });

--- a/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-segment-prefetch-incremental-conflicting-routes/next.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   experimental: {
     ppr: 'incremental',
-    dynamicIO: true,
+    dynamicIO: false,
     clientSegmentCache: true,
   },
 };


### PR DESCRIPTION
Return an error that is more verbose and clearly states we errored when parsing the `package.json`.

As can be seen in this image, it is hard to know in which JSON file we have the error:
![image](https://github.com/user-attachments/assets/babb156d-4e6b-4ee2-bb18-6728eb03923b)
