### PR TITLE
chore: silence "Refreshing VERCEL_OIDC_TOKEN" log

### DIFF
--- a/.changeset/eighty-mice-try.md
+++ b/.changeset/eighty-mice-try.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Silence the "Refreshing VERCEL_OIDC_TOKEN" log message by default (moves it to debug)

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -101,7 +101,7 @@ export default async function dev(
       envValues,
       'vercel-cli:dev'
     )) {
-      output.log(`Refreshing ${chalk.green(VERCEL_OIDC_TOKEN)}`);
+      output.debug(`Refreshing ${chalk.green(VERCEL_OIDC_TOKEN)}`);
       envValues[VERCEL_OIDC_TOKEN] = token;
       await devServer.runDevCommand(true);
       telemetry.trackOidcTokenRefresh(++refreshCount);


### PR DESCRIPTION
Silence the "Refreshing VERCEL_OIDC_TOKEN" log message by default (moves it to debug).