### PR TITLE
Ensure that root spans always finish even if the build step errors

### DIFF
--- a/.changeset/wet-clocks-grow.md
+++ b/.changeset/wet-clocks-grow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Ensure that traces are always flushed during build commands

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -313,13 +313,15 @@ export default async function main(client: Client): Promise<number> {
     process.env.VERCEL = '1';
     process.env.NOW_BUILDER = '1';
 
-    await rootSpan
-      .child('vc.doBuild')
-      .trace(span =>
-        doBuild(client, project, buildsJson, cwd, outputDir, span)
-      );
-
-    await rootSpan.stop();
+    try {
+      await rootSpan
+        .child('vc.doBuild')
+        .trace(span =>
+          doBuild(client, project, buildsJson, cwd, outputDir, span)
+        );
+    } finally {
+      await rootSpan.stop();
+    }
 
     return 0;
   } catch (err: any) {


### PR DESCRIPTION
# Overview 

Ensure that when a build runs we always flush the root span so that we get appropriate traces.
