### PR TITLE
[cli] Warn if system env vars are not available

### DIFF
--- a/.changeset/gold-rice-cry.md
+++ b/.changeset/gold-rice-cry.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Warn when system environment variables are not available

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -275,6 +275,12 @@ export default async function main(client: Client): Promise<number> {
     argv: scrubArgv(process.argv),
   };
 
+  if (!process.env.VERCEL_BUILD_IMAGE) {
+    output.warn(
+      'Build not running on Vercel. System environment variables will not be available.'
+    );
+  }
+
   const envToUnset = new Set<string>(['VERCEL', 'NOW_BUILDER']);
 
   try {


### PR DESCRIPTION
Features like skew protection are not supported without system environment variables, so `vc build` should warn when running outside of Vercel.  [Linear issue](https://linear.app/vercel/issue/FLOW-3548/could-we-add-a-warning-when-vc-build-is-run-outside-of-vercel-to).

The `VERCEL=1` env var gets set by the cli in all contexts, so we can't use that. I used `VERCEL_BUILD_IMAGE` because it is defined in the build container.

