### PR TITLE
Revert "[next]: skip vary header for Next.js >= 13.4.6"

### DIFF
--- a/.changeset/plenty-planes-accept.md
+++ b/.changeset/plenty-planes-accept.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+reinstate Vary header

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2272,9 +2272,6 @@ export const build: BuildV2 = async buildOptions => {
       canUsePreviewMode,
       isAppPPREnabled: false,
       isAppClientSegmentCacheEnabled: false,
-      // Relevant Next.js versions will be handled by server-build.ts, which
-      // does correctly configure this variable.
-      shouldSkipVaryHeader: false,
     });
 
     await Promise.all(

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -105,14 +105,6 @@ const BUNDLED_SERVER_NEXT_VERSION = 'v13.5.4';
 const BUNDLED_SERVER_NEXT_PATH =
   'next/dist/compiled/next-server/server.runtime.prod.js';
 
-// Next.js 13.4.6 removed the need for the vary header because it generates a
-// hash of the request headers and adds that to the request URL.
-//
-// See:
-// https://github.com/vercel/next.js/pull/49140
-// https://github.com/vercel/next.js/pull/50970
-const NEXT_VARY_INERT_VERSION = 'v13.4.6';
-
 export async function serverBuild({
   dynamicPages,
   pagesDir,
@@ -225,7 +217,6 @@ export async function serverBuild({
     nextVersion,
     EMPTY_ALLOW_QUERY_FOR_PRERENDERED_VERSION
   );
-  const shouldSkipVaryHeader = semver.gte(nextVersion, NEXT_VARY_INERT_VERSION);
   const projectDir = requiredServerFilesManifest.relativeAppDir
     ? path.join(baseDir, requiredServerFilesManifest.relativeAppDir)
     : requiredServerFilesManifest.appDir || entryPath;
@@ -1548,7 +1539,6 @@ export async function serverBuild({
     isEmptyAllowQueryForPrendered,
     isAppPPREnabled,
     isAppClientSegmentCacheEnabled,
-    shouldSkipVaryHeader,
   });
 
   await Promise.all(
@@ -2256,9 +2246,7 @@ export async function serverBuild({
                       entryDirectory,
                       `/__index${RSC_PREFETCH_SUFFIX}`
                     ),
-                    headers: shouldSkipVaryHeader
-                      ? undefined
-                      : { vary: rscVaryHeader },
+                    headers: { vary: rscVaryHeader },
                     continue: true,
                     override: true,
                   },
@@ -2279,9 +2267,7 @@ export async function serverBuild({
                       entryDirectory,
                       `/$1${RSC_PREFETCH_SUFFIX}`
                     ),
-                    headers: shouldSkipVaryHeader
-                      ? undefined
-                      : { vary: rscVaryHeader },
+                    headers: { vary: rscVaryHeader },
                     continue: true,
                     override: true,
                   },
@@ -2296,9 +2282,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
-              headers: shouldSkipVaryHeader
-                ? undefined
-                : { vary: rscVaryHeader },
+              headers: { vary: rscVaryHeader },
               continue: true,
               override: true,
             },
@@ -2315,9 +2299,7 @@ export async function serverBuild({
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),
-              headers: shouldSkipVaryHeader
-                ? undefined
-                : { vary: rscVaryHeader },
+              headers: { vary: rscVaryHeader },
               continue: true,
               override: true,
             },

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2224,7 +2224,6 @@ type OnPrerenderRouteArgs = {
   isEmptyAllowQueryForPrendered?: boolean;
   isAppPPREnabled: boolean;
   isAppClientSegmentCacheEnabled: boolean;
-  shouldSkipVaryHeader: boolean;
 };
 let prerenderGroup = 1;
 
@@ -2263,7 +2262,6 @@ export const onPrerenderRoute =
       isEmptyAllowQueryForPrendered,
       isAppPPREnabled,
       isAppClientSegmentCacheEnabled,
-      shouldSkipVaryHeader,
     } = prerenderRouteArgs;
 
     if (isBlocking && isFallback) {
@@ -2847,7 +2845,7 @@ export const onPrerenderRoute =
           ? {
               initialHeaders: {
                 ...initialHeaders,
-                ...(shouldSkipVaryHeader ? {} : { vary: rscVaryHeader }),
+                vary: rscVaryHeader,
               },
             }
           : {}),
@@ -2895,7 +2893,7 @@ export const onPrerenderRoute =
             ? {
                 initialHeaders: {
                   ...initialHeaders,
-                  ...(shouldSkipVaryHeader ? {} : { vary: rscVaryHeader }),
+                  vary: rscVaryHeader,
                   ...((outputPathData || outputPathPrefetchData)?.endsWith(
                     '.json'
                   )

--- a/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-base-path/vercel.json
@@ -42,7 +42,7 @@
         "Next-Router-Prefetch": 1
       }
     },
-
+    
     {
       "path": "/hello/world/dashboard/hello",
       "status": 200,
@@ -65,11 +65,17 @@
     {
       "path": "/hello/world/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg"
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/hello/world/ssg",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -99,11 +105,17 @@
     {
       "path": "/hello/world/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/hello/world/dashboard/deployments/123/settings",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -113,11 +125,17 @@
     {
       "path": "/hello/world/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall"
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/hello/world/dashboard/deployments/catchall/something",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -127,7 +145,10 @@
     {
       "path": "/hello/world/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard"
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/hello/world/dashboard",
@@ -145,7 +166,8 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-middleware/vercel.json
@@ -21,6 +21,9 @@
       "fetchOptions": {
         "redirect": "manual"
       },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -42,6 +45,9 @@
       "fetchOptions": {
         "redirect": "manual"
       },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -62,6 +68,9 @@
       "status": 200,
       "fetchOptions": {
         "redirect": "manual"
+      },
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       },
       "headers": {
         "RSC": "1"

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -267,7 +267,10 @@
     {
       "path": "/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg"
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/client-nested",
@@ -294,6 +297,9 @@
     {
       "path": "/ssg",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -304,6 +310,7 @@
       "path": "/ssg",
       "status": 200,
       "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch",
         "content-type": "text/x-component"
       },
       "headers": {
@@ -336,11 +343,17 @@
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -350,11 +363,17 @@
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall"
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -364,7 +383,10 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard"
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard",
@@ -382,7 +404,8 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-ppr/vercel.json
@@ -145,7 +145,10 @@
     {
       "path": "/ssg",
       "status": 200,
-      "mustContain": "hello from /ssg"
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/client-nested",
@@ -159,6 +162,9 @@
     {
       "path": "/ssg",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -169,6 +175,7 @@
       "path": "/ssg",
       "status": 200,
       "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch",
         "content-type": "text/x-component"
       },
       "headers": {
@@ -201,11 +208,17 @@
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/123/settings",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -215,11 +228,17 @@
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
-      "mustContain": "catchall"
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/catchall/something",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -229,7 +248,10 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard"
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard",
@@ -247,7 +269,8 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-static/vercel.json
@@ -9,7 +9,10 @@
     {
       "path": "/dashboard",
       "status": 200,
-      "mustContain": "hello from app/dashboard"
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard",
@@ -27,7 +30,8 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       }
     },
     {

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash/vercel.json
@@ -45,11 +45,17 @@
     {
       "path": "/ssg/",
       "status": 200,
-      "mustContain": "hello from /ssg"
+      "mustContain": "hello from /ssg",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/ssg/",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -79,11 +85,17 @@
     {
       "path": "/dashboard/deployments/123/settings/",
       "status": 200,
-      "mustContain": "hello from app/dashboard/deployments/[id]/settings"
+      "mustContain": "hello from app/dashboard/deployments/[id]/settings",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/123/settings/",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -93,11 +105,17 @@
     {
       "path": "/dashboard/deployments/catchall/something/",
       "status": 200,
-      "mustContain": "catchall"
+      "mustContain": "catchall",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/deployments/catchall/something/",
       "status": 200,
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      },
       "headers": {
         "RSC": "1"
       },
@@ -107,7 +125,10 @@
     {
       "path": "/dashboard/",
       "status": 200,
-      "mustContain": "hello from app/dashboard"
+      "mustContain": "hello from app/dashboard",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/dashboard/",
@@ -125,7 +146,8 @@
         "RSC": "1"
       },
       "responseHeaders": {
-        "content-type": "text/x-component"
+        "content-type": "text/x-component",
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
       }
     },
     {

--- a/packages/next/test/fixtures/01-app-dir-static/vercel.json
+++ b/packages/next/test/fixtures/01-app-dir-static/vercel.json
@@ -9,7 +9,10 @@
     {
       "path": "/blog/about",
       "status": 200,
-      "mustContain": "about"
+      "mustContain": "about",
+      "responseHeaders": {
+        "vary": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+      }
     },
     {
       "path": "/404",


### PR DESCRIPTION
Reverts vercel/vercel#13011
Reinstate the `Vary` header to prevent browsers from incorrectly reusing RSC responses during bfcache restores.