### PR TITLE
fix(cli): clarify logs when logging in and potentially have no account

### DIFF
--- a/.changeset/healthy-starfishes-compete.md
+++ b/.changeset/healthy-starfishes-compete.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+clarify logs when logging in and potentially have no account

--- a/packages/cli/src/util/login/email.ts
+++ b/packages/cli/src/util/login/email.ts
@@ -33,11 +33,11 @@ export default async function doEmailLogin(
   output.print(eraseLines(1));
 
   output.print(
-    `We sent an email to ${highlight(
+    `If you have an account, we sent an email to ${highlight(
       email
     )}. Please follow the steps provided inside it and make sure the security code matches ${highlight(
       securityCode
-    )}.\n`
+    )}. If you do not have an account yet, please sign up: https://vercel.com/signup\n`
   );
 
   output.spinner('Waiting for your confirmation');


### PR DESCRIPTION
If a user starts the login flow and enters a non-existent email, we should let the user know that they might need to sign up potentially.