### PR TITLE
fix(cli): do not require `--future` for `logout`

### DIFF
--- a/.changeset/healthy-sloths-sit.md
+++ b/.changeset/healthy-sloths-sit.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+fix(cli): do not require `--future` for `logout`

--- a/packages/cli/src/commands/logout/future.ts
+++ b/packages/cli/src/commands/logout/future.ts
@@ -9,7 +9,7 @@ export async function logout(client: Client): Promise<number> {
 
   if (!authConfig.token) {
     o.note(
-      `Not currently logged in, so ${getCommandName('logout --future')} did nothing`
+      `Not currently logged in, so ${getCommandName('logout')} did nothing`
     );
     return 0;
   }

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -42,8 +42,7 @@ export default async function logout(client: Client): Promise<number> {
     return 2;
   }
 
-  // TODO: Remove the `--future` flag
-  if (authConfig.type === 'oauth' || parsedArgs.flags['--future']) {
+  if (authConfig.type === 'oauth') {
     return await future(client);
   }
 

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -36,15 +36,15 @@ export default async function logout(client: Client): Promise<number> {
     return 1;
   }
 
-  if (parsedArgs.flags['--future']) {
-    telemetry.trackCliFlagFuture('logout');
-    return await future(client);
-  }
-
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('logout');
     output.print(help(logoutCommand, { columns: client.stderr.columns }));
     return 2;
+  }
+
+  // TODO: Remove the `--future` flag
+  if (authConfig.type === 'oauth' || parsedArgs.flags['--future']) {
+    return await future(client);
   }
 
   if (!authConfig.token) {

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -182,7 +182,7 @@ export class TelemetryClient {
     });
   }
 
-  trackCliFlagFuture(command: 'login' | 'logout') {
+  trackCliFlagFuture(command: 'login') {
     this.track({ key: 'flag:future', value: command });
   }
 }

--- a/packages/cli/test/unit/commands/logout/future.test.ts
+++ b/packages/cli/test/unit/commands/logout/future.test.ts
@@ -51,7 +51,7 @@ describe('logout', () => {
     client.config.currentTeam = randomUUID();
     const teamBefore = client.config.currentTeam;
     const exitCode = await logout(client);
-    expect(exitCode, 'exit code for "logout --future"').toBe(0);
+    expect(exitCode, 'exit code for "logout"').toBe(0);
     await expect(client.stderr).toOutput('Success! Logged out!');
 
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -103,7 +103,7 @@ describe('logout', () => {
     const teamBefore = client.config.currentTeam;
 
     const exitCode = await logout(client);
-    expect(exitCode, 'exit code for "login --future"').toBe(1);
+    expect(exitCode, 'exit code for "login"').toBe(1);
 
     const output = await client.stderr.getFullOutput();
     expect(output).toMatch(invalidResponse.error);
@@ -129,9 +129,9 @@ describe('logout', () => {
     expect(client.authConfig.token).toBeUndefined();
 
     const exitCode = await logout(client);
-    expect(exitCode, 'exit code for "login --future"').toBe(0);
+    expect(exitCode, 'exit code for "login"').toBe(0);
     await expect(client.stderr).toOutput(
-      'Not currently logged in, so `vercel logout --future` did nothing'
+      'Not currently logged in, so `vercel logout` did nothing'
     );
     expect(client.authConfig.token).toBeUndefined();
   });

--- a/packages/cli/test/unit/commands/logout/future.test.ts
+++ b/packages/cli/test/unit/commands/logout/future.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { logout } from '../../../../src/commands/logout/future';
+import logout from '../../../../src/commands/logout';
 import { client } from '../../../mocks/client';
 import { vi } from 'vitest';
 import _fetch, { type Response } from 'node-fetch';
@@ -26,9 +26,10 @@ function mockResponse(data: unknown, ok = true): Response {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  client.emptyAuthConfig();
 });
 
-describe('logout --future', () => {
+describe('logout', () => {
   it('successful logout', async () => {
     fetch.mockResolvedValueOnce(
       mockResponse({
@@ -43,7 +44,8 @@ describe('logout --future', () => {
 
     fetch.mockResolvedValueOnce(mockResponse({}));
 
-    client.setArgv('logout', '--future');
+    client.setArgv('logout');
+    client.authConfig.type = 'oauth';
     client.authConfig.token = randomUUID();
     const tokenBefore = client.authConfig.token;
     client.config.currentTeam = randomUUID();
@@ -93,8 +95,9 @@ describe('logout --future', () => {
     };
     fetch.mockResolvedValueOnce(mockResponse(invalidResponse, false));
 
-    client.setArgv('logout', '--future', '--debug');
+    client.setArgv('logout', '--debug');
     client.authConfig.token = randomUUID();
+    client.authConfig.type = 'oauth';
     const tokenBefore = client.authConfig.token;
     client.config.currentTeam = randomUUID();
     const teamBefore = client.config.currentTeam;
@@ -120,8 +123,9 @@ describe('logout --future', () => {
   });
 
   it('if no token, do nothing', async () => {
-    client.setArgv('logout', '--future');
+    client.setArgv('logout');
     delete client.authConfig.token;
+    client.authConfig.type = 'oauth';
     expect(client.authConfig.token).toBeUndefined();
 
     const exitCode = await logout(client);


### PR DESCRIPTION
Instead of asking the user to remember the `--future` flag, we can rely on the set type to switch on the logout method