### PR TITLE
Add condition operations to routing has/missing fields

### DIFF
--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -1,3 +1,81 @@
+const conditionValueSchema = {
+  anyOf: [
+    {
+      description:
+        'A string value for backward compatibility (treated as regex)',
+      type: 'string',
+      maxLength: 4096,
+    },
+    {
+      description: 'A condition operation object',
+      type: 'object',
+      additionalProperties: false,
+      minProperties: 1,
+      maxProperties: 1,
+      properties: {
+        eq: {
+          description: 'Equal',
+          anyOf: [{ type: 'string', maxLength: 4096 }, { type: 'number' }],
+        },
+        neq: {
+          description: 'Not equal',
+          type: 'string',
+          maxLength: 4096,
+        },
+        inc: {
+          description: 'In array',
+          type: 'array',
+          items: {
+            type: 'string',
+            maxLength: 4096,
+          },
+          maxItems: 100,
+        },
+        ninc: {
+          description: 'Not in array',
+          type: 'array',
+          items: {
+            type: 'string',
+            maxLength: 4096,
+          },
+          maxItems: 100,
+        },
+        pre: {
+          description: 'Has prefix',
+          type: 'string',
+          maxLength: 4096,
+        },
+        suf: {
+          description: 'Has suffix',
+          type: 'string',
+          maxLength: 4096,
+        },
+        re: {
+          description: 'Match regex pattern',
+          type: 'string',
+          maxLength: 4096,
+        },
+        gt: {
+          description: 'Greater than',
+          type: 'number',
+        },
+        gte: {
+          description: 'Greater than or equal to',
+          type: 'number',
+        },
+        lt: {
+          description: 'Less than',
+          type: 'number',
+        },
+        lte: {
+          description: 'Less than or equal to',
+          type: 'number',
+        },
+      },
+    },
+  ],
+} as const;
+
 export const hasSchema = {
   description: 'An array of requirements that are needed to match',
   type: 'array',
@@ -16,9 +94,8 @@ export const hasSchema = {
           },
           value: {
             description:
-              'A regular expression used to match the value. Named groups can be used in the destination',
-            type: 'string',
-            maxLength: 4096,
+              'A value to match against the request element. Can be a string (treated as regex) or a condition operation object',
+            ...conditionValueSchema,
           },
         },
       },
@@ -40,9 +117,8 @@ export const hasSchema = {
           },
           value: {
             description:
-              'A regular expression used to match the value. Named groups can be used in the destination',
-            type: 'string',
-            maxLength: 4096,
+              'A value to match against the request element. Can be a string (treated as regex) or a condition operation object',
+            ...conditionValueSchema,
           },
         },
       },

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -9,15 +9,31 @@ export type RouteApiError = {
   errors?: string[]; // array of all error messages
 };
 
+export type ConditionValue =
+  | string
+  | {
+      eq?: string | number;
+      neq?: string;
+      inc?: string[];
+      ninc?: string[];
+      pre?: string;
+      suf?: string;
+      re?: string;
+      gt?: number;
+      gte?: number;
+      lt?: number;
+      lte?: number;
+    };
+
 export type HasField = Array<
   | {
       type: 'host';
-      value: string;
+      value: ConditionValue;
     }
   | {
       type: 'header' | 'cookie' | 'query';
       key: string;
-      value?: string;
+      value?: ConditionValue;
     }
 >;
 


### PR DESCRIPTION
### TL;DR

Added support for condition operations in routing rules, allowing for more advanced matching beyond regex patterns.

### What changed?

- Introduced a new `ConditionValue` type that supports various comparison operations:
  - `eq` / `neq`: Equal / not equal
  - `inc` / `ninc`: In array / not in array
  - `pre` / `suf`: Has prefix / has suffix
  - `re`: Match regex pattern
  - `gt` / `gte` / `lt` / `lte`: Numeric comparisons
- Updated the JSON schema to validate these new condition operations
- Modified the `collectHasSegments` function to extract named groups from regex operations
- Maintained backward compatibility with string values (treated as regex)

### How to test?

- Create routing rules using the new condition operations:
```json
{
  "rewrites": [
    {
      "source": "/api/:path*",
      "destination": "/backend/:path*",
      "has": [
        { "type": "header", "key": "authorization", "value": { "pre": "Bearer " } },
        { "type": "query", "key": "version", "value": { "neq": "v1" } },
        { "type": "header", "key": "role", "value": { "inc": ["admin", "moderator"] } }
      ]
    }
  ]
}
```
- Verify that existing string-based conditions continue to work
- Test that named groups in regex patterns are properly extracted

### Why make this change?

The existing regex-only approach for condition matching was limited and could be difficult to use for common comparison operations. This change provides a more intuitive and powerful way to define routing conditions with specific operations like equality, array inclusion, and numeric comparisons, while maintaining backward compatibility with existing regex patterns.