### PR TITLE
[next] Added response to prerender chain

### DIFF
--- a/.changeset/chilled-chairs-vanish.md
+++ b/.changeset/chilled-chairs-vanish.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': patch
+'@vercel/next': patch
+---
+
+Adds a new response field to the prerender chain for the response headers that should be added.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -599,4 +599,14 @@ export interface Chain {
    * The headers to send when making the request to append to the response.
    */
   headers: Record<string, string>;
+
+  /**
+   * The response configuration, currently only headers are supported.
+   */
+  response?: {
+    /**
+     * The headers to set on the response prior to chaining.
+     */
+    headers: Record<string, string>;
+  };
 }

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2765,6 +2765,11 @@ export const onPrerenderRoute =
         chain = {
           outputPath: pathnameToOutputName(entryDirectory, routeKey),
           headers: routesManifest.ppr.chain.headers,
+          response: {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+            },
+          },
         };
       } else if (
         renderingMode === RenderingMode.PARTIALLY_STATIC &&
@@ -2803,6 +2808,11 @@ export const onPrerenderRoute =
         chain = {
           outputPath: paths.output,
           headers: { 'x-matched-path': paths.pathname },
+          response: {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+            },
+          },
         };
       }
 


### PR DESCRIPTION
This adds a new `response` field on the prerender `chain` object that contains the response headers that should be added to the outgoing chained response. Previously the `Content-Type` header was automatically set to `text/html; charset=utf-8` but this new `response` field enables this to be overridden. This enables the content type to be set based on the prerender configuration rather than defaulting to the HTML content type.