### PR TITLE
[routing-utils] Support Conditions and Mitigate in vercel.json

### DIFF
--- a/.changeset/slow-yaks-attend.md
+++ b/.changeset/slow-yaks-attend.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': minor
+---
+
+Adds support for conditionValues for `has` and `missing` and `mitigate` in your `vercel.json` file.

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -1,3 +1,63 @@
+export const mitigateSchema = {
+  description: 'Mitigation action to take on a route',
+  type: 'object',
+  additionalProperties: false,
+  required: ['action'],
+  properties: {
+    action: {
+      description: 'The mitigation action to take',
+      type: 'string',
+      enum: ['log', 'challenge', 'deny', 'bypass', 'rate_limit', 'redirect'],
+    },
+    erl: {
+      description: 'Edge rate limit configuration',
+      type: 'object',
+      additionalProperties: false,
+      required: ['algo', 'window', 'limit', 'keys'],
+      properties: {
+        algo: {
+          description: 'The rate limiting algorithm to use',
+          type: 'string',
+          enum: ['fixed_window', 'token_bucket'],
+        },
+        window: {
+          description: 'Time window for rate limit in seconds',
+          type: 'number',
+          minimum: 10,
+          maximum: 600,
+          default: 60,
+        },
+        limit: {
+          description: 'Request limit.',
+          type: 'number',
+          minimum: 1,
+          maximum: 10_000_000,
+          default: 100,
+        },
+        keys: {
+          description: 'Keys to rate limit by',
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          minItems: 1,
+          maxItems: 3,
+        },
+      },
+    },
+  },
+  if: {
+    properties: {
+      action: {
+        const: 'rate_limit',
+      },
+    },
+  },
+  then: {
+    required: ['action', 'erl'],
+  },
+} as const;
+
 export const conditionValueSchema = {
   anyOf: [
     {
@@ -246,6 +306,7 @@ export const routesSchema = {
           },
           has: hasSchema,
           missing: hasSchema,
+          mitigate: mitigateSchema,
         },
       },
       {

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -7,54 +7,8 @@ export const mitigateSchema = {
     action: {
       description: 'The mitigation action to take',
       type: 'string',
-      enum: ['log', 'challenge', 'deny', 'bypass', 'rate_limit', 'redirect'],
+      enum: ['log', 'challenge', 'deny'],
     },
-    erl: {
-      description: 'Edge rate limit configuration',
-      type: 'object',
-      additionalProperties: false,
-      required: ['algo', 'window', 'limit', 'keys'],
-      properties: {
-        algo: {
-          description: 'The rate limiting algorithm to use',
-          type: 'string',
-          enum: ['fixed_window', 'token_bucket'],
-        },
-        window: {
-          description: 'Time window for rate limit in seconds',
-          type: 'number',
-          minimum: 10,
-          maximum: 600,
-          default: 60,
-        },
-        limit: {
-          description: 'Request limit.',
-          type: 'number',
-          minimum: 1,
-          maximum: 10_000_000,
-          default: 100,
-        },
-        keys: {
-          description: 'Keys to rate limit by',
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-          minItems: 1,
-          maxItems: 3,
-        },
-      },
-    },
-  },
-  if: {
-    properties: {
-      action: {
-        const: 'rate_limit',
-      },
-    },
-  },
-  then: {
-    required: ['action', 'erl'],
   },
 } as const;
 

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -12,7 +12,9 @@ export const mitigateSchema = {
   },
 } as const;
 
-export const conditionValueSchema = {
+export const hasConditionValueSchema = {
+  description:
+    'A value to match against. Can be a string (regex) or a condition operation object',
   anyOf: [
     {
       description: 'A string value (treated as regex)',
@@ -111,9 +113,7 @@ export const hasSchema = {
             enum: ['host'],
           },
           value: {
-            description:
-              'A value to match against. Can be a string (regex) or a condition operation object',
-            ...conditionValueSchema,
+            ...hasConditionValueSchema,
           },
         },
       },
@@ -134,9 +134,7 @@ export const hasSchema = {
             maxLength: 4096,
           },
           value: {
-            description:
-              'A value to match against. Can be a string (regex) or a condition operation object',
-            ...conditionValueSchema,
+            ...hasConditionValueSchema,
           },
         },
       },

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -1,3 +1,85 @@
+export const conditionValueSchema = {
+  anyOf: [
+    {
+      description: 'A string value (treated as regex)',
+      type: 'string',
+      maxLength: 4096,
+    },
+    {
+      description: 'A condition operation object',
+      type: 'object',
+      additionalProperties: false,
+      minProperties: 1,
+      properties: {
+        eq: {
+          description: 'Equal to',
+          anyOf: [
+            {
+              type: 'string',
+              maxLength: 4096,
+            },
+            {
+              type: 'number',
+            },
+          ],
+        },
+        neq: {
+          description: 'Not equal',
+          type: 'string',
+          maxLength: 4096,
+        },
+        inc: {
+          description: 'In array',
+          type: 'array',
+          items: {
+            type: 'string',
+            maxLength: 4096,
+          },
+        },
+        ninc: {
+          description: 'Not in array',
+          type: 'array',
+          items: {
+            type: 'string',
+            maxLength: 4096,
+          },
+        },
+        pre: {
+          description: 'Starts with',
+          type: 'string',
+          maxLength: 4096,
+        },
+        suf: {
+          description: 'Ends with',
+          type: 'string',
+          maxLength: 4096,
+        },
+        re: {
+          description: 'Regex',
+          type: 'string',
+          maxLength: 4096,
+        },
+        gt: {
+          description: 'Greater than',
+          type: 'number',
+        },
+        gte: {
+          description: 'Greater than or equal to',
+          type: 'number',
+        },
+        lt: {
+          description: 'Less than',
+          type: 'number',
+        },
+        lte: {
+          description: 'Less than or equal to',
+          type: 'number',
+        },
+      },
+    },
+  ],
+};
+
 export const hasSchema = {
   description: 'An array of requirements that are needed to match',
   type: 'array',
@@ -16,9 +98,8 @@ export const hasSchema = {
           },
           value: {
             description:
-              'A regular expression used to match the value. Named groups can be used in the destination',
-            type: 'string',
-            maxLength: 4096,
+              'A value to match against. Can be a string (regex) or a condition operation object',
+            ...conditionValueSchema,
           },
         },
       },
@@ -40,9 +121,8 @@ export const hasSchema = {
           },
           value: {
             description:
-              'A regular expression used to match the value. Named groups can be used in the destination',
-            type: 'string',
-            maxLength: 4096,
+              'A value to match against. Can be a string (regex) or a condition operation object',
+            ...conditionValueSchema,
           },
         },
       },

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -1,4 +1,4 @@
-export const mitigateSchema = {
+const mitigateSchema = {
   description: 'Mitigation action to take on a route',
   type: 'object',
   additionalProperties: false,
@@ -12,7 +12,7 @@ export const mitigateSchema = {
   },
 } as const;
 
-export const hasConditionValueSchema = {
+const matchableValueSchema = {
   description:
     'A value to match against. Can be a string (regex) or a condition operation object',
   anyOf: [
@@ -113,7 +113,7 @@ export const hasSchema = {
             type: 'string',
             enum: ['host'],
           },
-          value: hasConditionValueSchema,
+          value: matchableValueSchema,
         },
       },
       {
@@ -132,7 +132,7 @@ export const hasSchema = {
             type: 'string',
             maxLength: 4096,
           },
-          value: hasConditionValueSchema,
+          value: matchableValueSchema,
         },
       },
     ],

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -17,7 +17,8 @@ export const hasConditionValueSchema = {
     'A value to match against. Can be a string (regex) or a condition operation object',
   anyOf: [
     {
-      description: 'A string value (treated as regex)',
+      description:
+        'A regular expression used to match thev value. Named groups can be used in the destination.',
       type: 'string',
       maxLength: 4096,
     },
@@ -112,9 +113,7 @@ export const hasSchema = {
             type: 'string',
             enum: ['host'],
           },
-          value: {
-            ...hasConditionValueSchema,
-          },
+          value: hasConditionValueSchema,
         },
       },
       {
@@ -133,9 +132,7 @@ export const hasSchema = {
             type: 'string',
             maxLength: 4096,
           },
-          value: {
-            ...hasConditionValueSchema,
-          },
+          value: hasConditionValueSchema,
         },
       },
     ],

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -7,7 +7,7 @@ const mitigateSchema = {
     action: {
       description: 'The mitigation action to take',
       type: 'string',
-      enum: ['log', 'challenge', 'deny'],
+      enum: ['challenge', 'deny'],
     },
   },
 } as const;

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -3,14 +3,7 @@
  * See https://github.com/firebase/superstatic#configuration
  */
 import { parse as parseUrl, format as formatUrl } from 'url';
-import {
-  Route,
-  Redirect,
-  Rewrite,
-  HasField,
-  Header,
-  HasConditionValue,
-} from './types';
+import { Route, Redirect, Rewrite, HasField, Header } from './types';
 
 /*
   [START] Temporary double-install of path-to-regexp to compare the impact of the update
@@ -309,12 +302,14 @@ const normalizeHasKeys = (hasItems: HasField = []) => {
   return hasItems;
 };
 
-function getStringValueForRegex(value: HasConditionValue): string | null {
+function getStringValueForRegex(
+  value: HasField[number]['value'] | undefined
+): string | null {
   if (typeof value === 'string') {
     return value;
   }
 
-  if (typeof value === 'object' && value !== null) {
+  if (value && typeof value === 'object' && value !== null) {
     if ('re' in value && typeof value.re === 'string') {
       return value.re;
     }
@@ -331,13 +326,11 @@ export function collectHasSegments(has?: HasField) {
       hasSegments.add(hasItem.key);
     }
 
-    if (hasItem.value) {
-      const stringValue = getStringValueForRegex(hasItem.value);
-      if (stringValue) {
-        for (const match of stringValue.matchAll(namedGroupsRegex)) {
-          if (match[1]) {
-            hasSegments.add(match[1]);
-          }
+    const stringValue = getStringValueForRegex(hasItem.value);
+    if (stringValue) {
+      for (const match of stringValue.matchAll(namedGroupsRegex)) {
+        if (match[1]) {
+          hasSegments.add(match[1]);
         }
       }
 

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -3,7 +3,14 @@
  * See https://github.com/firebase/superstatic#configuration
  */
 import { parse as parseUrl, format as formatUrl } from 'url';
-import { Route, Redirect, Rewrite, HasField, Header } from './types';
+import {
+  Route,
+  Redirect,
+  Rewrite,
+  HasField,
+  Header,
+  ConditionValue,
+} from './types';
 
 /*
   [START] Temporary double-install of path-to-regexp to compare the impact of the update
@@ -302,6 +309,21 @@ const normalizeHasKeys = (hasItems: HasField = []) => {
   return hasItems;
 };
 
+function getStringValueForRegex(value: ConditionValue): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if ('re' in value && typeof value.re === 'string') {
+      return value.re;
+    }
+    return null;
+  }
+
+  return null;
+}
+
 export function collectHasSegments(has?: HasField) {
   const hasSegments = new Set<string>();
 
@@ -311,9 +333,12 @@ export function collectHasSegments(has?: HasField) {
     }
 
     if (hasItem.value) {
-      for (const match of hasItem.value.matchAll(namedGroupsRegex)) {
-        if (match[1]) {
-          hasSegments.add(match[1]);
+      const stringValue = getStringValueForRegex(hasItem.value);
+      if (stringValue) {
+        for (const match of stringValue.matchAll(namedGroupsRegex)) {
+          if (match[1]) {
+            hasSegments.add(match[1]);
+          }
         }
       }
 

--- a/packages/routing-utils/src/superstatic.ts
+++ b/packages/routing-utils/src/superstatic.ts
@@ -9,7 +9,7 @@ import {
   Rewrite,
   HasField,
   Header,
-  ConditionValue,
+  HasConditionValue,
 } from './types';
 
 /*
@@ -309,7 +309,7 @@ const normalizeHasKeys = (hasItems: HasField = []) => {
   return hasItems;
 };
 
-function getStringValueForRegex(value: ConditionValue): string | null {
+function getStringValueForRegex(value: HasConditionValue): string | null {
   if (typeof value === 'string') {
     return value;
   }
@@ -318,7 +318,6 @@ function getStringValueForRegex(value: ConditionValue): string | null {
     if ('re' in value && typeof value.re === 'string') {
       return value.re;
     }
-    return null;
   }
 
   return null;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -25,6 +25,20 @@ export type ConditionValue =
       lte?: number;
     };
 
+export type MitigateAction =
+  | 'log'
+  | 'challenge'
+  | 'deny'
+  | 'bypass'
+  | 'rate_limit';
+
+export type EdgeRateLimit = {
+  algo: 'fixed_window' | 'token_bucket';
+  window: number;
+  limit: number;
+  keys: string[];
+};
+
 export type HasField = Array<
   | {
       type: 'host';
@@ -50,6 +64,10 @@ export type RouteWithSrc = {
   status?: number;
   has?: HasField;
   missing?: HasField;
+  mitigate?: {
+    action: MitigateAction;
+    erl?: EdgeRateLimit;
+  };
   locale?: {
     redirect?: Record<string, string>;
     cookie?: string;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -25,7 +25,7 @@ type MatchableValue =
       lte?: number;
     };
 
-type MitigateAction = 'log' | 'challenge' | 'deny';
+type MitigateAction = 'challenge' | 'deny';
 
 export type HasField = Array<
   | {

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -9,7 +9,7 @@ export type RouteApiError = {
   errors?: string[]; // array of all error messages
 };
 
-export type HasConditionValue =
+type MatchableValue =
   | string
   | {
       eq?: string | number;
@@ -25,17 +25,17 @@ export type HasConditionValue =
       lte?: number;
     };
 
-export type MitigateAction = 'log' | 'challenge' | 'deny';
+type MitigateAction = 'log' | 'challenge' | 'deny';
 
 export type HasField = Array<
   | {
       type: 'host';
-      value: HasConditionValue;
+      value: MatchableValue;
     }
   | {
       type: 'header' | 'cookie' | 'query';
       key: string;
-      value?: HasConditionValue;
+      value?: MatchableValue;
     }
 >;
 

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -27,13 +27,6 @@ export type ConditionValue =
 
 export type MitigateAction = 'log' | 'challenge' | 'deny';
 
-export type EdgeRateLimit = {
-  algo: 'fixed_window' | 'token_bucket';
-  window: number;
-  limit: number;
-  keys: string[];
-};
-
 export type HasField = Array<
   | {
       type: 'host';

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -25,12 +25,7 @@ export type ConditionValue =
       lte?: number;
     };
 
-export type MitigateAction =
-  | 'log'
-  | 'challenge'
-  | 'deny'
-  | 'bypass'
-  | 'rate_limit';
+export type MitigateAction = 'log' | 'challenge' | 'deny';
 
 export type EdgeRateLimit = {
   algo: 'fixed_window' | 'token_bucket';
@@ -66,7 +61,6 @@ export type RouteWithSrc = {
   missing?: HasField;
   mitigate?: {
     action: MitigateAction;
-    erl?: EdgeRateLimit;
   };
   locale?: {
     redirect?: Record<string, string>;

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -9,7 +9,7 @@ export type RouteApiError = {
   errors?: string[]; // array of all error messages
 };
 
-export type ConditionValue =
+export type HasConditionValue =
   | string
   | {
       eq?: string | number;
@@ -30,12 +30,12 @@ export type MitigateAction = 'log' | 'challenge' | 'deny';
 export type HasField = Array<
   | {
       type: 'host';
-      value: ConditionValue;
+      value: HasConditionValue;
     }
   | {
       type: 'header' | 'cookie' | 'query';
       key: string;
-      value?: ConditionValue;
+      value?: HasConditionValue;
     }
 >;
 

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -9,15 +9,31 @@ export type RouteApiError = {
   errors?: string[]; // array of all error messages
 };
 
+export type ConditionValue =
+  | string
+  | {
+      eq?: string | number;
+      neq?: string;
+      inc?: string[];
+      ninc?: string[];
+      pre?: string;
+      suf?: string;
+      re?: string;
+      gt?: number;
+      gte?: number;
+      lt?: number;
+      lte?: number;
+    };
+
 export type HasField = Array<
   | {
       type: 'host';
-      value: string;
+      value: ConditionValue;
     }
   | {
       type: 'header' | 'cookie' | 'query';
       key: string;
-      value?: string;
+      value?: ConditionValue;
     }
 >;
 

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -1373,67 +1373,9 @@ describe('getTransformedRoutes', () => {
           action: 'log',
         },
       },
-      {
-        src: '/api/testy/(.*)',
-        mitigate: {
-          action: 'rate_limit',
-          erl: {
-            algo: 'fixed_window',
-            window: 60,
-            limit: 100,
-            keys: ['ip', 'ja4'],
-          },
-        },
-      },
     ];
 
     assertValid(routes, routesSchema);
-  });
-
-  test('should fail validation when missing erl for rate_limit action', () => {
-    const routes = [
-      {
-        src: '/source',
-        mitigate: {
-          action: 'rate_limit',
-        },
-      },
-    ];
-
-    assertError(
-      routes,
-      [
-        {
-          dataPath: '[0].mitigate',
-          keyword: 'required',
-          message: "should have required property '.erl'",
-          params: { missingProperty: '.erl' },
-          schemaPath: '#/items/anyOf/0/properties/mitigate/then/required',
-        },
-        {
-          dataPath: '[0].mitigate',
-          keyword: 'if',
-          message: 'should match "then" schema',
-          params: { failingKeyword: 'then' },
-          schemaPath: '#/items/anyOf/0/properties/mitigate/if',
-        },
-        {
-          dataPath: '[0]',
-          keyword: 'additionalProperties',
-          message: 'should NOT have additional properties',
-          params: { additionalProperty: 'src' },
-          schemaPath: '#/items/anyOf/1/additionalProperties',
-        },
-        {
-          dataPath: '[0]',
-          keyword: 'anyOf',
-          message: 'should match some schema in anyOf',
-          params: {},
-          schemaPath: '#/items/anyOf',
-        },
-      ],
-      routesSchema
-    );
   });
 
   test('should fail validation for invalid mitigate action', () => {

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -1396,14 +1396,7 @@ describe('getTransformedRoutes', () => {
           keyword: 'enum',
           message: 'should be equal to one of the allowed values',
           params: {
-            allowedValues: [
-              'log',
-              'challenge',
-              'deny',
-              'bypass',
-              'rate_limit',
-              'redirect',
-            ],
+            allowedValues: ['log', 'challenge', 'deny'],
           },
           schemaPath:
             '#/items/anyOf/0/properties/mitigate/properties/action/enum',

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -1223,7 +1223,7 @@ describe('getTransformedRoutes', () => {
     ]);
   });
 
-  test('should validate condition operations for has and missing', () => {
+  test('should validate all condition operations for has and missing', () => {
     const vercelConfig = {
       rewrites: [
         {
@@ -1232,15 +1232,57 @@ describe('getTransformedRoutes', () => {
           has: [
             { type: 'header', key: 'authorization', value: 'Bearer .*' },
             { type: 'host', value: 'api\\.example\\.com' },
+            { type: 'header', key: 'x-string-eq', value: { eq: 'test' } },
+            { type: 'header', key: 'x-number-eq', value: { eq: 123 } },
+            { type: 'header', key: 'x-neq', value: { neq: 'test' } },
             { type: 'cookie', key: 'theme', value: { inc: ['light', 'dark'] } },
-            { type: 'query', key: 'page', value: { neq: '1' } },
             {
               type: 'header',
               key: 'x-role',
-              value: { ninc: ['admin', 'superadmin'], pre: 'user-' },
+              value: { ninc: ['admin', 'superadmin'] },
+            },
+            { type: 'header', key: 'x-prefix', value: { pre: 'test-' } },
+            { type: 'header', key: 'x-suffix', value: { suf: '-test' } },
+            { type: 'header', key: 'x-regex', value: { re: '^test.*' } },
+            { type: 'header', key: 'x-gt', value: { gt: 10 } },
+            { type: 'header', key: 'x-gte', value: { gte: 10 } },
+            { type: 'header', key: 'x-lt', value: { lt: 10 } },
+            { type: 'header', key: 'x-lte', value: { lte: 10 } },
+            {
+              type: 'header',
+              key: 'x-multi-condition',
+              value: {
+                pre: 'test-',
+                suf: '-end',
+                inc: ['a', 'b'],
+                ninc: ['c', 'd'],
+              },
             },
           ],
-          missing: [{ type: 'cookie', key: 'disabled', value: { eq: 'true' } }],
+          missing: [
+            { type: 'header', key: 'x-missing-header', value: 'test' },
+            { type: 'cookie', key: 'missing-cookie', value: 'test' },
+            { type: 'query', key: 'missing-query', value: 'test' },
+            { type: 'host', value: 'missing.example.com' },
+
+            {
+              type: 'header',
+              key: 'x-missing-all',
+              value: {
+                eq: 'test',
+                neq: 'wrong',
+                inc: ['a', 'b'],
+                ninc: ['c', 'd'],
+                pre: 'test-',
+                suf: '-test',
+                re: '^test',
+                gt: 10,
+                gte: 10,
+                lt: 20,
+                lte: 20,
+              },
+            },
+          ],
         },
       ],
     };
@@ -1362,6 +1404,12 @@ describe('getTransformedRoutes', () => {
         src: '/api/testy/(.*)',
         mitigate: {
           action: 'log',
+        },
+      },
+      {
+        src: '/api/testy/(.*)',
+        mitigate: {
+          action: 'deny',
         },
       },
     ];

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -1403,12 +1403,6 @@ describe('getTransformedRoutes', () => {
       {
         src: '/api/testy/(.*)',
         mitigate: {
-          action: 'log',
-        },
-      },
-      {
-        src: '/api/testy/(.*)',
-        mitigate: {
           action: 'deny',
         },
       },
@@ -1435,7 +1429,7 @@ describe('getTransformedRoutes', () => {
           keyword: 'enum',
           message: 'should be equal to one of the allowed values',
           params: {
-            allowedValues: ['log', 'challenge', 'deny'],
+            allowedValues: ['challenge', 'deny'],
           },
           schemaPath:
             '#/items/anyOf/0/properties/mitigate/properties/action/enum',

--- a/packages/routing-utils/test/index.spec.ts
+++ b/packages/routing-utils/test/index.spec.ts
@@ -1077,15 +1077,6 @@ describe('getTransformedRoutes', () => {
     assertValid(vercelConfig.redirects, redirectsSchema);
     assertValid(vercelConfig.headers, headersSchema);
     assertValid(vercelConfig.trailingSlashSchema, trailingSlashSchema);
-    for (const item of [
-      ...vercelConfig.rewrites,
-      ...vercelConfig.redirects,
-      ...vercelConfig.headers,
-    ]) {
-      if (item.has) {
-        assertValid(item.has, hasSchema);
-      }
-    }
   });
 
   test('should return null routes if no transformations are performed', () => {


### PR DESCRIPTION
This PR adds support for conditions in `has` and `missing` and  `mitigate` in your `vercel.json` file, previously only manageable through the Vercel Firewall dashboard page. 
