### PR TITLE
[cli] Added "allowUseNodeVersion" option and automatic cleanup of use-node-version in .npmrc

### DIFF
--- a/.changeset/neat-dolphins-retire.md
+++ b/.changeset/neat-dolphins-retire.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+[cli] Added "allowUseNodeVersion" option to suppress .npmrc use-node-version error

--- a/packages/build-utils/src/validate-npmrc.ts
+++ b/packages/build-utils/src/validate-npmrc.ts
@@ -20,7 +20,7 @@ export async function validateNpmrc(cwd: string): Promise<void> {
   const nodeRegExp = /(?<!#.*)use-node-version/;
   if (npmrc?.match(nodeRegExp)) {
     throw new Error(
-      'Detected unsupported "use-node-version" in your ".npmrc". Please use "engines" in your "package.json" instead.'
+      'Detected unsupported "use-node-version" in your ".npmrc". Please use "engines" in your "package.json" instead, or set`"allowUseNodeVersion": true` in your `vercel.json` to suppress this error.'
     );
   }
 }

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -191,13 +191,6 @@ export default async function main(client: Client): Promise<number> {
 
   const yes = Boolean(parsedArgs.flags['--yes']);
 
-  try {
-    await validateNpmrc(cwd);
-  } catch (err) {
-    output.prettyError(err);
-    return 1;
-  }
-
   // If repo linked, update `cwd` to the repo root
   const link = await getProjectLink(client, cwd);
   const projectRootDirectory = link?.projectRootDirectory ?? '';
@@ -404,6 +397,10 @@ async function doBuild(
 
   if (validateError) {
     throw validateError;
+  }
+
+  if (!localConfig.allowUseNodeVersion) {
+    await validateNpmrc(cwd);
   }
 
   const projectSettings = {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -586,6 +586,8 @@ async function doBuild(
             nodeVersion: projectSettings.nodeVersion,
           }
         : build.config || {};
+      // This option is used in packages/cli/src/util/build/static-builder.ts.
+      buildConfig.allowUseNodeVersion = localConfig.allowUseNodeVersion;
 
       const builderSpan = span.child('vc.builder', {
         name: builderPkg.name,

--- a/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/.npmrc
+++ b/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/.npmrc
@@ -1,0 +1,3 @@
+foo=bar
+# the next line is not supported
+use-node-version=16.16.0

--- a/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/allow-npmrc-use-node-version/vercel.json
@@ -1,0 +1,3 @@
+{
+  "allowUseNodeVersion": true
+}

--- a/packages/cli/test/fixtures/unit/commands/build/npmrc-use-node-version/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/npmrc-use-node-version/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null
+  }
+}

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1308,6 +1308,18 @@ describe.skipIf(flakey)('build', () => {
     expect(exitCode, 'exit code for "build"').toEqual(1);
   });
 
+  it('should build successfully when vercel.json has allowUseNodeVersion enabled', async () => {
+    const cwd = fixture('allow-npmrc-use-node-version');
+    const output = join(cwd, '.vercel/output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    // Verify that no error is recorded in builds.json
+    const builds = await fs.readJSON(join(output, 'builds.json'));
+    expect(builds.error).toBeUndefined();
+  });
+
   it('should ignore `.env` for static site', async () => {
     const cwd = fixture('static-env');
     const output = join(cwd, '.vercel/output');

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1318,6 +1318,11 @@ describe.skipIf(flakey)('build', () => {
     // Verify that no error is recorded in builds.json
     const builds = await fs.readJSON(join(output, 'builds.json'));
     expect(builds.error).toBeUndefined();
+
+    // Confirm that .npmrc in the static output does not contain "use-node-version"
+    const npmrcPath = join(output, 'static', '.npmrc');
+    const npmrcContent = await fs.readFile(npmrcPath, 'utf8');
+    expect(npmrcContent).not.toMatch(/use-node-version/);
   });
 
   it('should ignore `.env` for static site', async () => {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -163,6 +163,7 @@ export interface VercelConfig {
   outputDirectory?: string | null;
   images?: Images;
   crons?: Cron[];
+  allowUseNodeVersion?: boolean;
 }
 
 export interface GitMetadata {


### PR DESCRIPTION
When a .npmrc file contains the use-node-version flag, vercel build currently fails with a hard error.
This pull request adds a boolean flag, allowUseNodeVersion, to vercel.json that lets teams temporarily suppress the error, proceed with the build, and automatically strip the use-node-version entry from .npmrc during the build process.