### PR TITLE
docs: add deprecation notice for @vercel/edge

### DIFF
--- a/.changeset/plenty-monkeys-juggle.md
+++ b/.changeset/plenty-monkeys-juggle.md
@@ -1,0 +1,9 @@
+---
+'@vercel/edge': patch
+---
+
+This package was introduced to add helpful methods related to Edge Functions.
+
+Nowadays, as much as Node.js and Edge support the same primitives, there is no necessity to continue maintaining a separate package.
+
+We're going to use [@vercel/functions](https://github.com/vercel/vercel/tree/main/packages/functions) for all the runtimes!

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -1,4 +1,6 @@
 # `@vercel/edge`
 
+> ⚠️ Deprecation Notice: This package has been unified in [@vercel/functions](https://www.npmjs.com/package/@vercel/functions). Use it instead!
+
 A set of utilities to help you deploy any framework on the Edge using Vercel.
 Please [follow the documentation](https://vercel.com/docs/concepts/functions/edge-functions/vercel-edge-package) for examples and usage.


### PR DESCRIPTION
This package was introduced to add helpful methods related to Edge Functions.

Nowadays, as much as Node.js and Edge support the same primitives, there is no necessity to continue maintaining a separate package.

We're going to use [@vercel/functions](https://github.com/vercel/vercel/tree/main/packages/functions) for all the runtimes!
