### PR TITLE
Bump Vercel CLI version with minor.

### DIFF
--- a/.changeset/heavy-suits-happen.md
+++ b/.changeset/heavy-suits-happen.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Version bump to respect dependency updates


### PR DESCRIPTION
This PR ensures a new version in accordance with the changes in https://github.com/vercel/vercel/pull/13385.