### PR TITLE
[gatsby-plugin-vercel-builder] Use Route type from @vercel/routing-utils

### DIFF
--- a/.changeset/fifty-rockets-sniff.md
+++ b/.changeset/fifty-rockets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@vercel/gatsby-plugin-vercel-builder': patch
+---
+
+do not redefine Route type in gatsby plugin (use @vercel/routing-utils)

--- a/packages/gatsby-plugin-vercel-builder/src/types.d.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { Images } from '@vercel/build-utils';
+import type { Images, Route } from '@vercel/build-utils';
 
 export type Config = {
   version: 3;
@@ -7,68 +7,6 @@ export type Config = {
   wildcard?: WildcardConfig;
   overrides?: OverrideConfig;
   cache?: string[];
-};
-
-type Route = Source | Handler;
-
-type Source = {
-  src: string;
-  dest?: string;
-  headers?: Record<string, string>;
-  methods?: string[];
-  continue?: boolean;
-  caseSensitive?: boolean;
-  check?: boolean;
-  status?: number;
-  has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
-  missing?: Array<
-    HostHasField | HeaderHasField | CookieHasField | QueryHasField
-  >;
-  locale?: Locale;
-  middlewarePath?: string;
-};
-
-type Locale = {
-  redirect?: Record<string, string>;
-  cookie?: string;
-};
-
-type HostHasField = {
-  type: 'host';
-  value: string;
-};
-
-type HeaderHasField = {
-  type: 'header';
-  key: string;
-  value?: string;
-};
-
-type CookieHasField = {
-  type: 'cookie';
-  key: string;
-  value?: string;
-};
-
-type QueryHasField = {
-  type: 'query';
-  key: string;
-  value?: string;
-};
-
-type HandleValue =
-  | 'rewrite'
-  | 'filesystem' // check matches after the filesystem misses
-  | 'resource'
-  | 'miss' // check matches after every filesystem miss
-  | 'hit'
-  | 'error'; //  check matches after error (500, 404, etc.)
-
-type Handler = {
-  handle: HandleValue;
-  src?: string;
-  dest?: string;
-  status?: number;
 };
 
 type WildCard = {


### PR DESCRIPTION
### TL;DR

Updated the Gatsby plugin to use the Route type from @vercel/routing-utils instead of redefining it locally.

### What changed?

- Removed the locally defined Route type and all related type definitions in `packages/gatsby-plugin-vercel-builder/src/types.d.ts`
- Imported the Route type from `@vercel/build-utils` instead
- Added a changeset file indicating this is a major version change for `@vercel/gatsby-plugin-vercel-builder`

### How to test?

1. Build a Gatsby project using the updated plugin
2. Verify that routing functionality works as expected
3. Check that TypeScript compilation succeeds with the imported Route type

### Why make this change?

This change eliminates duplicate type definitions by leveraging the existing Route type from @vercel/routing-utils. This improves maintainability by ensuring consistency across the codebase and reduces the risk of type definition drift between packages.