### PR TITLE
[build-utils] Use routing-utils HasField

### DIFF
--- a/.changeset/cyan-comics-run.md
+++ b/.changeset/cyan-comics-run.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+next package uses @vercel/routing-utils HasField rather than redefining & stricter validation.

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -35,6 +35,7 @@
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.2",
     "@vercel/error-utils": "2.0.3",
+    "@vercel/routing-utils": "5.0.4",
     "aggregate-error": "3.0.1",
     "async-retry": "1.2.3",
     "async-sema": "2.1.4",

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -120,7 +120,11 @@ export class Prerender {
             // host doesn't need a key
             (field.type !== 'host' && typeof field.key !== 'string') ||
             typeof field.type !== 'string' ||
-            (field.value !== undefined && typeof field.value !== 'string')
+            (field.value !== undefined &&
+              typeof field.value !== 'string' &&
+              (typeof field.value !== 'object' ||
+                field.value === null ||
+                Array.isArray(field.value)))
         )
       ) {
         throw new Error(

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -5,6 +5,7 @@ import type { Lambda, LambdaArchitecture } from './lambda';
 import type { Prerender } from './prerender';
 import type { EdgeFunction } from './edge-function';
 import type { Span } from './trace';
+import type { HasField } from '@vercel/routing-utils';
 
 export interface Env {
   [name: string]: string | undefined;
@@ -46,17 +47,7 @@ export interface Config {
   [key: string]: unknown;
 }
 
-export type HasField = Array<
-  | {
-      type: 'host';
-      value: string;
-    }
-  | {
-      type: 'header' | 'cookie' | 'query';
-      key: string;
-      value?: string;
-    }
->;
+export type { HasField };
 
 export interface Meta {
   isDev?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@vercel/error-utils':
         specifier: 2.0.3
         version: link:../error-utils
+      '@vercel/routing-utils':
+        specifier: 5.0.4
+        version: link:../routing-utils
       aggregate-error:
         specifier: 3.0.1
         version: 3.0.1


### PR DESCRIPTION
### TL;DR

Allow object values in prerender HasField conditions

### What changed?

Modified the validation logic in the `Prerender` class to accept object values in HasField conditions. Previously, the validation only allowed string values, but now it also accepts non-null, non-array objects.

Additionally, moved the `HasField` type definition from `types.ts` to be imported from `@vercel/routing-utils` instead of being defined locally.

### How to test?

1. Create a prerender configuration with an object value in a HasField condition
2. Verify that the validation passes and the prerender works as expected
3. Test with various types of object values to ensure proper validation

### Why make this change?

This change enables more complex and structured condition values in prerender configurations. Object values provide more flexibility for defining sophisticated routing conditions, allowing developers to create more powerful and precise prerendering rules.