### PR TITLE
fix(cli): correct regex usage for stderr line splitting in builder installation

### DIFF
--- a/packages/cli/src/util/build/import-builders.ts
+++ b/packages/cli/src/util/build/import-builders.ts
@@ -223,7 +223,7 @@ async function installBuilders(
       }
     );
     stderr
-      .split('/\r?\n/')
+      .split(/\r?\n/)
       .filter(line => line.includes('npm WARN deprecated'))
       .forEach(line => {
         output.warn(line);


### PR DESCRIPTION
## Description
Fixes an incorrect usage of string splitting when parsing `npm` stderr output during builder installation.

## Problem
In `import-builders.ts`, the code incorrectly used `.split('/\r?\n/')` (a plain string) instead of `.split(/\r?\n/)` (a regular expression).  
This prevented npm warning messages (e.g., `npm WARN deprecated`) from being correctly parsed and filtered line-by-line.

## Solution
Updated the `.split()` call to use a proper regex: `.split(/\r?\n/)`, ensuring line breaks are correctly handled for both Unix (`\n`) and Windows (`\r\n`) environments.

## Impact
- ✅ npm deprecation warnings are now correctly detected and shown to users
- ✅ Proper handling of stderr output across platforms (cross-platform line ending support)

## Files Changed
- `packages/cli/src/util/build/import-builders.ts`

## Testing
- [x] Verified that `npm WARN deprecated` warnings are now correctly parsed and displayed
- [x] Confirmed handling of both `\n` and `\r\n` line endings using mocked stderr input