### PR TITLE
Revert "[gatsby-plugin-vercel-builder] Use Route type from @vercel/routing-utils"

### DIFF
--- a/.changeset/fifty-rockets-sniff.md
+++ b/.changeset/fifty-rockets-sniff.md
@@ -1,5 +1,0 @@
----
-'@vercel/gatsby-plugin-vercel-builder': patch
----
-
-do not redefine Route type in gatsby plugin (use @vercel/routing-utils)

--- a/.changeset/serious-pans-grab.md
+++ b/.changeset/serious-pans-grab.md
@@ -1,0 +1,5 @@
+---
+"@vercel/gatsby-plugin-vercel-builder": patch
+---
+
+Revert "[gatsby-plugin-vercel-builder] Use Route type from @vercel/routing-utils"

--- a/packages/gatsby-plugin-vercel-builder/src/types.d.ts
+++ b/packages/gatsby-plugin-vercel-builder/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { Images, Route } from '@vercel/build-utils';
+import type { Images } from '@vercel/build-utils';
 
 export type Config = {
   version: 3;
@@ -7,6 +7,68 @@ export type Config = {
   wildcard?: WildcardConfig;
   overrides?: OverrideConfig;
   cache?: string[];
+};
+
+type Route = Source | Handler;
+
+type Source = {
+  src: string;
+  dest?: string;
+  headers?: Record<string, string>;
+  methods?: string[];
+  continue?: boolean;
+  caseSensitive?: boolean;
+  check?: boolean;
+  status?: number;
+  has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
+  missing?: Array<
+    HostHasField | HeaderHasField | CookieHasField | QueryHasField
+  >;
+  locale?: Locale;
+  middlewarePath?: string;
+};
+
+type Locale = {
+  redirect?: Record<string, string>;
+  cookie?: string;
+};
+
+type HostHasField = {
+  type: 'host';
+  value: string;
+};
+
+type HeaderHasField = {
+  type: 'header';
+  key: string;
+  value?: string;
+};
+
+type CookieHasField = {
+  type: 'cookie';
+  key: string;
+  value?: string;
+};
+
+type QueryHasField = {
+  type: 'query';
+  key: string;
+  value?: string;
+};
+
+type HandleValue =
+  | 'rewrite'
+  | 'filesystem' // check matches after the filesystem misses
+  | 'resource'
+  | 'miss' // check matches after every filesystem miss
+  | 'hit'
+  | 'error'; //  check matches after error (500, 404, etc.)
+
+type Handler = {
+  handle: HandleValue;
+  src?: string;
+  dest?: string;
+  status?: number;
 };
 
 type WildCard = {


### PR DESCRIPTION
Reverts vercel/vercel#13392. I believe this will resolve https://github.com/vercel/vercel/actions/runs/15333187330/job/43144688468?pr=13391 and let us move forward with correct test coverage.