### PR TITLE
[functions] Add cache method to RuntimeCache and ttl to get

### DIFF
--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -11,14 +11,34 @@ export interface RuntimeCache {
   delete: (key: string) => Promise<void>;
 
   /**
+   * Wraps a function call with caching.
+   *
+   * @param {string} key - The key to use for the cache entry.
+   * @param {Function} fn - The function to wrap with caching.
+   * @param {Object} [options] - Optional settings for the cache entry.
+   * @param {string[]} [options.tags] - Optional tags to associate with the cache entry.
+   * @param {number} [options.ttl] - Optional time-to-live for the cache entry, in seconds. Default is 1 year.
+   * @returns {Promise<unknown | null>} A promise that resolves to the value.
+   */
+  cache: (
+    key: string,
+    fn: (...args: any[]) => Promise<unknown>,
+    options?: { tags?: string[]; ttl?: number }
+  ) => Promise<unknown | null>;
+
+  /**
    * Retrieves a value from the cache.
    *
    * @param {string} key - The key of the value to retrieve.
    * @param {Object} [options] - Optional settings for the cache entry.
-   * @param {string[]} [options.tags] - Optional tags to associate wit the cache entry.
+   * @param {string[]} [options.tags] - Optional tags to associate with the cache entry. If provided on set, this must also be provided to ensure cross-deployment cache consistency.
+   * @param {number} [options.ttl] - Optional time-to-live for the cache entry, in seconds. If provided on set, this must also be provided to ensure cross-deployment cache consistency.
    * @returns {Promise<unknown | null>} A promise that resolves to the value, or null if not found.
    */
-  get: (key: string, options?: { tags?: string[] }) => Promise<unknown | null>;
+  get: (
+    key: string,
+    options?: { tags?: string[]; ttl?: number }
+  ) => Promise<unknown | null>;
 
   /**
    * Sets a value in the cache.
@@ -27,8 +47,8 @@ export interface RuntimeCache {
    * @param {unknown} value - The value to set.
    * @param {Object} [options] - Optional settings for the cache entry.
    * @param {string} [options.name] - Optional user-friendly name for the cache entry used for o11y.
-   * @param {string[]} [options.tags] - Optional tags to associate with the cache entry.
-   * @param {number} [options.ttl] - Optional time-to-live for the cache entry, in seconds.
+   * @param {string[]} [options.tags] - Optional tags to associate with the cache entry. This must also be provided on get to ensure cross-deployment cache consistency.
+   * @param {number} [options.ttl] - Optional time-to-live for the cache entry, in seconds. Default is 1 year. This must also be provided on get to ensure cross-deployment cache consistency.
    * @returns {Promise<void>} A promise that resolves when the value is set.
    */
   set: (


### PR DESCRIPTION
### TL;DR

Added a new `cache` method to the RuntimeCache interface to simplify caching function results. Also added ttl to get method so cross deployment changes in ttl are respected.

### What changed?

- Added a new `cache` method to the `RuntimeCache` interface that wraps a function call with caching logic
- Implemented the `cache` method in both the `InMemoryCache` class and the cache factory
- Updated the `get` method signature to include the optional `ttl` parameter for consistency
- Enhanced JSDoc comments to better explain the purpose and usage of cache methods, particularly noting cross-deployment cache consistency requirements
- Renamed `cache` variable to `runtimeCache` to avoid naming conflicts with the new method

### How to test?

Test the new `cache` method by:

1. Creating a cache instance
2. Using the `cache` method with a key and an async function
3. Verify the function is only executed once when called multiple times with the same key
4. Verify the cached result is returned on subsequent calls

```typescript
const cache = getCache();
const expensiveOperation = async () => {
  console.log('Executing expensive operation');
  return { data: 'result' };
};

// First call should execute the function
await cache.cache('test-key', expensiveOperation);

// Second call should return cached result without executing the function
await cache.cache('test-key', expensiveOperation);
```

### Why make this change?

This change simplifies the common pattern of checking the cache before executing a function and then storing the result. The new `cache` method encapsulates this pattern, reducing boilerplate code and potential errors in implementations. It also ensures consistent handling of cache misses and updates across the codebase.