### PR TITLE
[@vercel/functions] update api to support generics

### DIFF
--- a/.changeset/brown-crabs-carry.md
+++ b/.changeset/brown-crabs-carry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Add generics support for runtime cache api

--- a/packages/functions/docs/interfaces/index.RuntimeCache.md
+++ b/packages/functions/docs/interfaces/index.RuntimeCache.md
@@ -1,8 +1,14 @@
-# Interface: RuntimeCache
+# Interface: RuntimeCache<T\>
 
 [index](../modules/index.md).RuntimeCache
 
 Interface representing the runtime cache.
+
+## Type parameters
+
+| Name | Type      |
+| :--- | :-------- |
+| `T`  | `unknown` |
 
 ## Table of contents
 
@@ -67,43 +73,43 @@ A promise that resolves when the cache entries expiration request is received.
 
 #### Defined in
 
-[packages/functions/src/cache/types.ts:46](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L46)
+[packages/functions/src/cache/types.ts:44](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L44)
 
 ---
 
 ### get
 
-• **get**: (`key`: `string`, `options?`: { `tags?`: `string`[] }) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`unknown`\>
+• **get**: (`key`: `string`, `options?`: { `tags?`: `string`[] }) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`null` \| `T`\>
 
 #### Type declaration
 
-▸ (`key`, `options?`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`unknown`\>
+▸ (`key`, `options?`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`null` \| `T`\>
 
 Retrieves a value from the cache.
 
 ##### Parameters
 
-| Name            | Type       | Description                                     |
-| :-------------- | :--------- | :---------------------------------------------- |
-| `key`           | `string`   | The key of the value to retrieve.               |
-| `options?`      | `Object`   | Optional settings for the cache entry.          |
-| `options.tags?` | `string`[] | Optional tags to associate wit the cache entry. |
+| Name            | Type       | Description                       |
+| :-------------- | :--------- | :-------------------------------- |
+| `key`           | `string`   | The key of the value to retrieve. |
+| `options?`      | `Object`   | -                                 |
+| `options.tags?` | `string`[] | -                                 |
 
 ##### Returns
 
-[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`unknown`\>
+[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`null` \| `T`\>
 
 A promise that resolves to the value, or null if not found.
 
 #### Defined in
 
-[packages/functions/src/cache/types.ts:21](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L21)
+[packages/functions/src/cache/types.ts:19](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L19)
 
 ---
 
 ### set
 
-• **set**: (`key`: `string`, `value`: `unknown`, `options?`: { `name?`: `string` ; `tags?`: `string`[] ; `ttl?`: `number` }) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+• **set**: (`key`: `string`, `value`: `T`, `options?`: { `name?`: `string` ; `tags?`: `string`[] ; `ttl?`: `number` }) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
 
 #### Type declaration
 
@@ -116,7 +122,7 @@ Sets a value in the cache.
 | Name            | Type       | Description                                                    |
 | :-------------- | :--------- | :------------------------------------------------------------- |
 | `key`           | `string`   | The key of the value to set.                                   |
-| `value`         | `unknown`  | The value to set.                                              |
+| `value`         | `T`        | The value to set.                                              |
 | `options?`      | `Object`   | Optional settings for the cache entry.                         |
 | `options.name?` | `string`   | Optional user-friendly name for the cache entry used for o11y. |
 | `options.tags?` | `string`[] | Optional tags to associate with the cache entry.               |
@@ -130,4 +136,4 @@ A promise that resolves when the value is set.
 
 #### Defined in
 
-[packages/functions/src/cache/types.ts:34](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L34)
+[packages/functions/src/cache/types.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/types.ts#L32)

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -70,7 +70,7 @@ The location information of the request, in this way:
 
 ### getCache
 
-▸ **getCache**(`cacheOptions?`): [`RuntimeCache`](../interfaces/index.RuntimeCache.md)
+▸ **getCache**<`T`\>(`cacheOptions?`): [`RuntimeCache`](../interfaces/index.RuntimeCache.md)<`T`\>
 
 Retrieves the Vercel Runtime Cache.
 
@@ -85,6 +85,12 @@ namespaceSeparator can also be customized using the `namespaceSeparator` option.
 
 If no cache is available in the context and `InMemoryCache` cannot be created.
 
+#### Type parameters
+
+| Name | Type      |
+| :--- | :-------- |
+| `T`  | `unknown` |
+
 #### Parameters
 
 | Name            | Type           | Description                           |
@@ -93,7 +99,7 @@ If no cache is available in the context and `InMemoryCache` cannot be created.
 
 #### Returns
 
-[`RuntimeCache`](../interfaces/index.RuntimeCache.md)
+[`RuntimeCache`](../interfaces/index.RuntimeCache.md)<`T`\>
 
 An instance of the Vercel Runtime Cache.
 

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -1,19 +1,16 @@
 import { RuntimeCache } from './types';
 
-interface CacheEntry {
-  value: unknown;
+interface CacheEntry<T = unknown> {
+  value: T;
   tags: Set<string>;
   lastModified: number; // Timestamp of when the entry was last modified in epoch milliseconds
   ttl?: number; // Time to live in seconds
 }
 
-export class InMemoryCache implements RuntimeCache {
-  private cache: Record<string, CacheEntry> = {};
+export class InMemoryCache<T = unknown> implements RuntimeCache<T> {
+  private cache: Record<string, CacheEntry<T>> = {};
 
-  async get(
-    key: string,
-    options?: { tags?: string[] }
-  ): Promise<unknown | null> {
+  async get(key: string, options?: { tags?: string[] }): Promise<T | null> {
     const entry = this.cache[key];
     if (entry) {
       if (entry.ttl && entry.lastModified + entry.ttl * 1000 < Date.now()) {
@@ -34,7 +31,7 @@ export class InMemoryCache implements RuntimeCache {
 
   async set(
     key: string,
-    value: unknown,
+    value: T,
     options?: { ttl?: number; tags?: string[] }
   ): Promise<void> {
     this.cache[key] = {

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -29,16 +29,17 @@ let inMemoryCacheInstance: InMemoryCache | null = null;
  * @returns An instance of the Vercel Runtime Cache.
  * @throws {Error} If no cache is available in the context and `InMemoryCache` cannot be created.
  */
-export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
-  let cache: RuntimeCache;
+export const getCache = <T = unknown>(
+  cacheOptions?: CacheOptions
+): RuntimeCache<T> => {
+  let cache: RuntimeCache<T>;
   if (getContext().cache) {
-    cache = getContext().cache as RuntimeCache;
+    cache = getContext().cache as RuntimeCache<T>;
   } else {
-    // Create InMemoryCache instance only once
     if (!inMemoryCacheInstance) {
       inMemoryCacheInstance = new InMemoryCache();
     }
-    cache = inMemoryCacheInstance;
+    cache = inMemoryCacheInstance as RuntimeCache<T>;
   }
 
   const hashFunction = cacheOptions?.keyHashFunction || defaultKeyHashFunction;
@@ -58,7 +59,7 @@ export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
     },
     set: (
       key: string,
-      value: unknown,
+      value: T,
       options?: { name?: string; tags?: string[]; ttl?: number }
     ) => {
       return cache.set(makeKey(key), value, options);

--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -1,7 +1,7 @@
 /**
  * Interface representing the runtime cache.
  */
-export interface RuntimeCache {
+export interface RuntimeCache<T = unknown> {
   /**
    * Deletes a value from the cache.
    *
@@ -16,15 +16,15 @@ export interface RuntimeCache {
    * @param {string} key - The key of the value to retrieve.
    * @param {Object} [options] - Optional settings for the cache entry.
    * @param {string[]} [options.tags] - Optional tags to associate wit the cache entry.
-   * @returns {Promise<unknown | null>} A promise that resolves to the value, or null if not found.
+   * @returns {Promise<T | null>} A promise that resolves to the value, or null if not found.
    */
-  get: (key: string, options?: { tags?: string[] }) => Promise<unknown | null>;
+  get: (key: string, options?: { tags?: string[] }) => Promise<T | null>;
 
   /**
    * Sets a value in the cache.
    *
    * @param {string} key - The key of the value to set.
-   * @param {unknown} value - The value to set.
+   * @param {T} value - The value to set.
    * @param {Object} [options] - Optional settings for the cache entry.
    * @param {string} [options.name] - Optional user-friendly name for the cache entry used for o11y.
    * @param {string[]} [options.tags] - Optional tags to associate with the cache entry.
@@ -33,7 +33,7 @@ export interface RuntimeCache {
    */
   set: (
     key: string,
-    value: unknown,
+    value: T,
     options?: { name?: string; tags?: string[]; ttl?: number }
   ) => Promise<void>;
 


### PR DESCRIPTION
# problem

Current runtime cache api doesn't support generics

# solution

Implement generic support