### PR TITLE
fix(vercel): exit dev command on error

### DIFF
--- a/.changeset/dull-cougars-greet.md
+++ b/.changeset/dull-cougars-greet.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix bug where `vercel dev` would not exit on error

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -108,7 +108,11 @@ export default async function dev(
         telemetry.trackOidcTokenRefresh(++refreshCount);
       }
     } catch (error) {
-      output.debug(`Failed to refresh OIDC token: ${error}`);
+      // Throw any error aside from an abort error.
+      if (!(error instanceof Error && error.name === 'AbortError')) {
+        throw error;
+      }
+      output.debug('OIDC token refresh was aborted');
     }
   });
 

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -93,18 +93,22 @@ export default async function dev(
   const timeout = setTimeout(async () => {
     if (link.status !== 'linked') return;
 
-    let refreshCount = 0;
-    for await (const token of refreshOidcToken(
-      controller.signal,
-      client,
-      link.project.id,
-      envValues,
-      'vercel-cli:dev'
-    )) {
-      output.debug(`Refreshing ${chalk.green(VERCEL_OIDC_TOKEN)}`);
-      envValues[VERCEL_OIDC_TOKEN] = token;
-      await devServer.runDevCommand(true);
-      telemetry.trackOidcTokenRefresh(++refreshCount);
+    try {
+      let refreshCount = 0;
+      for await (const token of refreshOidcToken(
+        controller.signal,
+        client,
+        link.project.id,
+        envValues,
+        'vercel-cli:dev'
+      )) {
+        output.debug(`Refreshing ${chalk.green(VERCEL_OIDC_TOKEN)}`);
+        envValues[VERCEL_OIDC_TOKEN] = token;
+        await devServer.runDevCommand(true);
+        telemetry.trackOidcTokenRefresh(++refreshCount);
+      }
+    } catch (error) {
+      output.debug(`Failed to refresh OIDC token: ${error}`);
     }
   });
 
@@ -126,5 +130,10 @@ export default async function dev(
     }
   }
 
-  await devServer.start(...listen);
+  try {
+    await devServer.start(...listen);
+  } finally {
+    clearTimeout(timeout);
+    controller.abort();
+  }
 }

--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -724,9 +724,7 @@ test('[vercel dev] should support custom 404 routes', async () => {
   }
 });
 
-// Test is correctly showing broken behavior, skipping to unblock all PRs until we get time to fix
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip('[vercel dev] prints `npm install` errors', async () => {
+test('[vercel dev] prints `npm install` errors', async () => {
   const dir = fixture('runtime-not-installed');
   const result = await exec(dir);
   expect(stripAnsi(result.stderr.toString())).toContain(


### PR DESCRIPTION
Reenable test disabled in #13436

According to `git bisect` https://github.com/vercel/vercel/pull/13226 broke this behavior. Unsure of how the passed on CI/up until recently as it was definitely broken.

It looks like the `AbortController` prevented the process from exiting.