### PR TITLE
feat(cli): load env vars to memory via `vc env`

### DIFF
--- a/.changeset/hot-cows-share.md
+++ b/.changeset/hot-cows-share.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+feat(cli): load env vars to memory via `vc env`

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -148,7 +148,7 @@ export const pullSubcommand = {
       required: false,
     },
     {
-      name: 'process',
+      name: 'command',
       required: false,
     },
   ],
@@ -194,7 +194,7 @@ export const pullSubcommand = {
     },
     {
       name: 'Run a process with the pulled Environment Variables without writing to a file',
-      value: [`${packageName} env <process>`, `${packageName} env next dev`],
+      value: [`${packageName} env <command>`, `${packageName} env next dev`],
     },
   ],
 } as const;

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -141,10 +141,14 @@ export const pullSubcommand = {
   name: 'pull',
   aliases: [],
   description:
-    'Pull all Development Environment Variables from the cloud and write to a file [.env.local]',
+    'Load all Development Environment Variables from the cloud to a file [.env.local] or a process',
   arguments: [
     {
       name: 'filename',
+      required: false,
+    },
+    {
+      name: 'process',
       required: false,
     },
   ],
@@ -169,7 +173,15 @@ export const pullSubcommand = {
     {
       ...yesOption,
       description:
-        'Skip the confirmation prompt when removing an environment variable',
+        'Skip the confirmation prompt when updating an existing environment variable file',
+    },
+    {
+      name: 'memory',
+      shorthand: null,
+      description:
+        'Load Environment Variables into memory instead of a file. When this command exits, the variables are lost.',
+      type: Boolean,
+      deprecated: false,
     },
   ],
   examples: [
@@ -179,6 +191,10 @@ export const pullSubcommand = {
         `${packageName} env pull <file>`,
         `${packageName} env pull .env.development.local`,
       ],
+    },
+    {
+      name: 'Run a process with the pulled Environment Variables without writing to a file',
+      value: [`${packageName} env <process>`, `${packageName} env next dev`],
     },
   ],
 } as const;

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -199,6 +199,20 @@ export const pullSubcommand = {
   ],
 } as const;
 
+export const commandSubcommand = {
+  name: '<command>',
+  aliases: [],
+  description: 'The subcommand to run with the pulled Environment Variables',
+  arguments: [],
+  options: [],
+  examples: [
+    {
+      name: 'Run a process with the pulled Environment Variables without writing to a file',
+      value: [`${packageName} env <command>`, `${packageName} env next dev`],
+    },
+  ],
+} as const;
+
 export const envCommand = {
   name: 'env',
   aliases: [],
@@ -209,6 +223,7 @@ export const envCommand = {
     listSubcommand,
     pullSubcommand,
     removeSubcommand,
+    commandSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -62,28 +62,39 @@ export default async function main(client: Client) {
     output.print(
       help(command, { parent: envCommand, columns: client.stderr.columns })
     );
-    return 2;
-  }
-
-  if (needHelp && subcommand) {
-    telemetry.trackCliFlagHelp('env', subcommandOriginal);
   }
 
   switch (subcommand) {
     case 'ls':
-      if (needHelp) return printHelp(listSubcommand);
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
+        printHelp(listSubcommand);
+        return 2;
+      }
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
     case 'add':
-      if (needHelp) return printHelp(addSubcommand);
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
+        printHelp(addSubcommand);
+        return 2;
+      }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
     case 'rm':
-      if (needHelp) return printHelp(removeSubcommand);
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
+        printHelp(removeSubcommand);
+        return 2;
+      }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
     case 'pull':
-      if (needHelp) return printHelp(pullSubcommand);
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('env', subcommandOriginal);
+        printHelp(pullSubcommand);
+        return 2;
+      }
       telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -98,6 +98,6 @@ export default async function main(client: Client) {
       telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:
-      return pull(client, args.concat('--memory'));
+      return pull(client, args.concat('--memory'), true);
   }
 }

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -87,7 +87,6 @@ export default async function main(client: Client) {
       telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:
-      telemetry.trackCliFlag('--memory', 'env');
       return pull(client, args.concat('--memory'));
   }
 }

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -1,6 +1,5 @@
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
-import getInvalidSubcommand from '../../util/get-invalid-subcommand';
 import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
 import { type Command, help } from '../help';
@@ -63,44 +62,32 @@ export default async function main(client: Client) {
     output.print(
       help(command, { parent: envCommand, columns: client.stderr.columns })
     );
+    return 2;
+  }
+
+  if (needHelp && subcommand) {
+    telemetry.trackCliFlagHelp('env', subcommandOriginal);
   }
 
   switch (subcommand) {
     case 'ls':
-      if (needHelp) {
-        telemetry.trackCliFlagHelp('env', subcommandOriginal);
-        printHelp(listSubcommand);
-        return 2;
-      }
+      if (needHelp) return printHelp(listSubcommand);
       telemetry.trackCliSubcommandList(subcommandOriginal);
       return ls(client, args);
     case 'add':
-      if (needHelp) {
-        telemetry.trackCliFlagHelp('env', subcommandOriginal);
-        printHelp(addSubcommand);
-        return 2;
-      }
+      if (needHelp) return printHelp(addSubcommand);
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
     case 'rm':
-      if (needHelp) {
-        telemetry.trackCliFlagHelp('env', subcommandOriginal);
-        printHelp(removeSubcommand);
-        return 2;
-      }
+      if (needHelp) return printHelp(removeSubcommand);
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return rm(client, args);
     case 'pull':
-      if (needHelp) {
-        telemetry.trackCliFlagHelp('env', subcommandOriginal);
-        printHelp(pullSubcommand);
-        return 2;
-      }
+      if (needHelp) return printHelp(pullSubcommand);
       telemetry.trackCliSubcommandPull(subcommandOriginal);
       return pull(client, args);
     default:
-      output.error(getInvalidSubcommand(COMMAND_CONFIG));
-      output.print(help(envCommand, { columns: client.stderr.columns }));
-      return 2;
+      telemetry.trackCliFlag('--memory', 'env');
+      return pull(client, args.concat('--memory'));
   }
 }

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -70,7 +70,9 @@ export default async function pull(client: Client, argv: string[]) {
   let parsedArgs;
   const flagsSpecification = getFlagsSpecification(pullSubcommand.options);
   try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
+    parsedArgs = parseArguments(argv, flagsSpecification, {
+      permissive: argv.includes('--memory'),
+    });
   } catch (err) {
     printError(err);
     return 1;

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -93,6 +93,14 @@ export default async function pull(client: Client, argv: string[]) {
     return 1;
   }
 
+  if (opts['--memory'] && !args.length) {
+    output.error(
+      `Invalid number of arguments. Usage: ${getCommandName(`env next dev`)}
+       See also: ${getCommandName(`env --help`)}`
+    );
+    return 1;
+  }
+
   // handle relative or absolute filename
   const [rawFilename] = args;
   const filename = rawFilename || '.env.local';
@@ -198,16 +206,6 @@ export async function envPullCommandLogic(
 
   if (memory) {
     output.stopSpinner();
-
-    if (!args.length) {
-      output.error(
-        `No command provided to run.
-
-       Example: ${getCommandName(`env next dev`)}
-       Or check out ${getCommandName(`env --help`)} for more information.`
-      );
-      return 1;
-    }
 
     const [command, ...rest] = args;
 

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -95,7 +95,7 @@ export default async function pull(client: Client, argv: string[]) {
 
   if (opts['--memory'] && !args.length) {
     output.error(
-      `Invalid number of arguments. Usage: ${getCommandName(`env next dev`)}
+      `Invalid number of arguments. Usage: ${getCommandName(`env <process>`)}
        See also: ${getCommandName(`env --help`)}`
     );
     return 1;
@@ -244,7 +244,7 @@ export async function envPullCommandLogic(
   const contents =
     CONTENTS_PREFIX +
     Object.entries(environmentVariables)
-      .map(entry => entry.join('='))
+      .map(([key, value]) => `${key}="${value}"`)
       .join('\n') +
     '\n';
 

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -241,15 +241,6 @@ export async function envPullCommandLogic(
     });
   }
 
-  const contents =
-    CONTENTS_PREFIX +
-    Object.entries(environmentVariables)
-      .map(([key, value]) => `${key}="${value}"`)
-      .join('\n') +
-    '\n';
-
-  await outputFile(fullPath, contents, 'utf8');
-
   let deltaString = '';
   let oldEnv;
   if (exists) {
@@ -263,11 +254,21 @@ export async function envPullCommandLogic(
       deltaString = buildDeltaString(oldEnv, newEnv);
     }
   }
+
   if (deltaString) {
     output.print('\n' + deltaString);
   } else if (oldEnv && exists) {
     output.log('No changes found.');
   }
+
+  const contents =
+    CONTENTS_PREFIX +
+    Object.entries(environmentVariables)
+      .map(([key, value]) => `${key}="${value}"`)
+      .join('\n') +
+    '\n';
+
+  await outputFile(fullPath, contents, 'utf8');
 
   let isGitIgnoreUpdated = false;
   if (filename === '.env.local') {

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -78,6 +78,14 @@ export default async function pull(client: Client, argv: string[]) {
 
   const { args, flags: opts } = parsedArgs;
 
+  if (opts['--memory']) {
+    telemetryClient.trackCliFlagMemory();
+
+    if (args.length) {
+      telemetryClient.trackCliArgumentProcess(args[0]);
+    }
+  }
+
   if (!opts['--memory'] && args.length > 1) {
     output.error(
       `Invalid number of arguments. Usage: ${getCommandName(`env pull <file>`)}`

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -44,4 +44,17 @@ export class EnvPullTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliFlagMemory() {
+    this.trackCliFlag('memory');
+  }
+
+  trackCliArgumentProcess(value: string | undefined) {
+    if (value) {
+      this.trackCliArgument({
+        arg: 'process',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/env/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/env/pull.ts
@@ -49,10 +49,10 @@ export class EnvPullTelemetryClient
     this.trackCliFlag('memory');
   }
 
-  trackCliArgumentProcess(value: string | undefined) {
+  trackCliArgumentCommand(value: string | undefined) {
     if (value) {
       this.trackCliArgument({
-        arg: 'process',
+        arg: 'command',
         value: this.redactedValue,
       });
     }

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -103,10 +103,10 @@ export class TelemetryClient {
     });
   }
 
-  protected trackCliFlag(flag: string) {
+  trackCliFlag(flag: string, command?: string) {
     this.track({
       key: `flag:${flag}`,
-      value: 'TRUE',
+      value: command ?? 'TRUE',
     });
   }
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -103,10 +103,10 @@ export class TelemetryClient {
     });
   }
 
-  trackCliFlag(flag: string, command?: string) {
+  protected trackCliFlag(flag: string) {
     this.track({
       key: `flag:${flag}`,
-      value: command ?? 'TRUE',
+      value: 'TRUE',
     });
   }
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1859,9 +1859,7 @@ exports[`help command > env help output snapshots > env help column width 40 1`]
                                       …
                                       a
                                       …
-  pull    [filename]                  …
-                                      …
-                                      …
+  pull    [filename] [process]        …
                                       …
                                       …
                                       …
@@ -1872,6 +1870,9 @@ exports[`help command > env help output snapshots > env help column width 40 1`]
                                       …
                                       a
                                       …
+                                      …
+                                      …
+                                      a
                                       …
   remove  name [environment]          …
                                       …
@@ -1935,9 +1936,9 @@ exports[`help command > env help output snapshots > env help column width 80 1`]
                                       examples below)                     
   list    [environment] [git-branch]  List all Environment Variables for a
                                       Project                             
-  pull    [filename]                  Pull all Development Environment    
-                                      Variables from the cloud and write  
-                                      to a file [.env.local]              
+  pull    [filename] [process]        Load all Development Environment    
+                                      Variables from the cloud to a file  
+                                      [.env.local] or a process           
   remove  name [environment]          Remove an Environment Variable (see 
                                       examples below)                     
 
@@ -1969,8 +1970,8 @@ exports[`help command > env help output snapshots > env help column width 120 1`
 
   add     name [environment]          Add an Environment Variable (see examples below)                            
   list    [environment] [git-branch]  List all Environment Variables for a Project                                
-  pull    [filename]                  Pull all Development Environment Variables from the cloud and write to a    
-                                      file [.env.local]                                                           
+  pull    [filename] [process]        Load all Development Environment Variables from the cloud to a file         
+                                      [.env.local] or a process                                                   
   remove  name [environment]          Remove an Environment Variable (see examples below)                         
 
 
@@ -2014,15 +2015,17 @@ exports[`help command > env help output snapshots > env list help output snapsho
 
 exports[`help command > env help output snapshots > env pull help output snapshots > env pull help column width 120 1`] = `
 "
-  ▲ vercel env pull [filename] [options]
+  ▲ vercel env pull [filename] [process] [options]
 
-  Pull all Development Environment Variables from the cloud and write to a file [.env.local]                            
+  Load all Development Environment Variables from the cloud to a file [.env.local] or a process                         
 
   Options:
 
        --environment <TARGET>  Set the Environment when pulling Environment Variables                                        
        --git-branch <NAME>     Specify the Git branch to pull specific Environment Variables for                             
-  -y,  --yes                   Skip the confirmation prompt when removing an environment variable                            
+       --memory                Load Environment Variables into memory instead of a file. When this command exits, the        
+                               variables are lost.                                                                           
+  -y,  --yes                   Skip the confirmation prompt when updating an existing environment variable file              
 
 
   Global Options:
@@ -2044,6 +2047,11 @@ exports[`help command > env help output snapshots > env pull help output snapsho
 
     $ vercel env pull <file>
     $ vercel env pull .env.development.local
+
+  - Run a process with the pulled Environment Variables without writing to a file
+
+    $ vercel env <process>
+    $ vercel env next dev
 
 "
 `;

--- a/packages/cli/test/unit/commands/env/index.test.ts
+++ b/packages/cli/test/unit/commands/env/index.test.ts
@@ -24,13 +24,16 @@ describe('env', () => {
     });
   });
 
-  it('errors when invoked without subcommand', async () => {
+  it('Show subprocess help when invoked without subcommand', async () => {
     client.setArgv('env');
     const exitCodePromise = env(client);
-    await expect(exitCodePromise).resolves.toBe(2);
+    await expect(exitCodePromise).resolves.toBe(1);
+    expect(client.stderr).toOutput(
+      'Invalid number of arguments. Usage: `vercel env <process>`'
+    );
   });
 
-  describe('unrecognized subcommand', () => {
+  describe('subprocess', () => {
     beforeEach(() => {
       useUser();
       useTeams('team_dummy');
@@ -59,12 +62,12 @@ describe('env', () => {
       client.cwd = cwd;
     });
 
-    it('shows help', async () => {
-      const args: string[] = ['not-a-command'];
+    it('inherits variables', async () => {
+      const args = ['not-a-command'];
 
       client.setArgv('env', ...args);
       const exitCode = await env(client);
-      expect(exitCode).toEqual(2);
+      expect(exitCode).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Right now, when you want to copy environment variables to your machine, your only option is to pull them into a file via `vc env pull .env.local`.

Also, `vc env` is just printing what `vc env --help` would.

We could utilize this command to load the environment variables for a subprocess, instead of having to write them to a file.

**Example:**
```sh
vc env next dev
```

_This has a **security benefit** since we do not preserve the environment variables after the process exits._

The implementation reuses `vc env pull` and introduces a new `--memory` flag, which is added if the `vc env` command is called without any known subcommand.

Usage:

[Screencast from 2025-06-11 15-47-39.webm](https://github.com/user-attachments/assets/210f6a52-c7fd-44b0-80ac-cf8858db715c)

You can test it via 

```sh 
cd packages/cli &&
  pnpm vercel link &&
  pnpm vercel env node -e 'console.log(Boolean(process.env.VERCEL_OIDC_TOKEN))'` // true
```

