### PR TITLE
[routing-utils]: fix for generating literal types

### DIFF
--- a/.changeset/beige-schools-dress.md
+++ b/.changeset/beige-schools-dress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+Fixed TS literal type inference for compatibility with json-schema-to-ts

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -95,7 +95,7 @@ const matchableValueSchema = {
       },
     },
   ],
-};
+} as const;
 
 export const hasSchema = {
   description: 'An array of requirements that are needed to match',


### PR DESCRIPTION
# [routing-utils]: fix for generating literal types

Fixed TS literal type inference for compatibility with json-schema-to-ts by adding `as const` to the matchableValueSchema.

This caused downstream validation issues in `vercel/api` because of validation using json-schema-to-ts