### PR TITLE
[@vercel/functions] prefix tags in runtime cache

### DIFF
--- a/.changeset/hip-spiders-crash.md
+++ b/.changeset/hip-spiders-crash.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Add namespace for runtime cache tags to keep separate from ISR tags

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -99,7 +99,7 @@ An instance of the Vercel Runtime Cache.
 
 #### Defined in
 
-[packages/functions/src/cache/index.ts:32](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L32)
+[packages/functions/src/cache/index.ts:33](https://github.com/vercel/vercel/blob/main/packages/functions/src/cache/index.ts#L33)
 
 ---
 

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -11,7 +11,7 @@ const defaultKeyHashFunction = (key: string) => {
 };
 
 const defaultNamespaceSeparator = '$';
-const defaultTagNamespace = 'rc:';
+const tagNamespace = 'rc:';
 
 // Singleton instance of InMemoryCache
 let inMemoryCacheInstance: InMemoryCache | null = null;
@@ -52,12 +52,6 @@ export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
     }
     return `${prefix}${hashFunction(key)}`;
   };
-
-  // Tag namespace logic
-  const tagNamespace =
-    typeof cacheOptions?.tagNamespace === 'string'
-      ? cacheOptions.tagNamespace
-      : defaultTagNamespace;
 
   const prefixTagOrTags = (tagOrTags?: string | string[]) => {
     if (!tagOrTags) return [];

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -11,6 +11,7 @@ const defaultKeyHashFunction = (key: string) => {
 };
 
 const defaultNamespaceSeparator = '$';
+const defaultTagNamespace = 'rc:';
 
 // Singleton instance of InMemoryCache
 let inMemoryCacheInstance: InMemoryCache | null = null;
@@ -52,22 +53,40 @@ export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
     return `${prefix}${hashFunction(key)}`;
   };
 
+  // Tag namespace logic
+  const tagNamespace =
+    typeof cacheOptions?.tagNamespace === 'string'
+      ? cacheOptions.tagNamespace
+      : defaultTagNamespace;
+
+  const prefixTagOrTags = (tagOrTags?: string | string[]) => {
+    if (!tagOrTags) return [];
+    return Array.isArray(tagOrTags)
+      ? tagOrTags.map(tag => tagNamespace + tag)
+      : [tagNamespace + tagOrTags];
+  };
+
   return {
-    get: (key: string, options?: { tags?: string[] }) => {
-      return cache.get(makeKey(key), options);
+    get: (key: string) => {
+      return cache.get(makeKey(key));
     },
     set: (
       key: string,
       value: unknown,
       options?: { name?: string; tags?: string[]; ttl?: number }
     ) => {
-      return cache.set(makeKey(key), value, options);
+      const tags = options?.tags ? prefixTagOrTags(options.tags) : undefined;
+      return cache.set(
+        makeKey(key),
+        value,
+        tags ? { ...options, tags } : options
+      );
     },
     delete: (key: string) => {
       return cache.delete(makeKey(key));
     },
     expireTag: (tag: string | string[]) => {
-      return cache.expireTag(tag);
+      return cache.expireTag(prefixTagOrTags(tag));
     },
   };
 };

--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -67,4 +67,9 @@ export interface CacheOptions {
    * Optional separator string for the namespace.
    */
   namespaceSeparator?: string;
+
+  /**
+   * Optional tag namespace to prefix cache tags. Defaults to `rc:`
+   */
+  tagNamespace?: string;
 }

--- a/packages/functions/src/cache/types.ts
+++ b/packages/functions/src/cache/types.ts
@@ -67,9 +67,4 @@ export interface CacheOptions {
    * Optional separator string for the namespace.
    */
   namespaceSeparator?: string;
-
-  /**
-   * Optional tag namespace to prefix cache tags. Defaults to `rc:`
-   */
-  tagNamespace?: string;
 }

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -133,44 +133,9 @@ describe('getCache', () => {
     );
   });
 
-  test('should prefix tags with explicit tagNamespace override', async () => {
-    const cache = getCache({ tagNamespace: 'custom:' });
-    await cache.set('tag-key', 'tag-value', { tags: ['foo', 'bar'] });
-    expect(mockCache.set).toHaveBeenCalledWith(
-      expect.any(String),
-      'tag-value',
-      expect.objectContaining({ tags: ['custom:foo', 'custom:bar'] })
-    );
-  });
-
-  test('should use default tagNamespace when tagNamespace is empty string', async () => {
-    const cache = getCache({ tagNamespace: '' });
-    await cache.set('tag-key', 'tag-value', { tags: ['foo', 'bar'] });
-    expect(mockCache.set).toHaveBeenCalledWith(
-      expect.any(String),
-      'tag-value',
-      expect.objectContaining({ tags: ['foo', 'bar'] })
-    );
-  });
-
   test('should prefix tags with default tagNamespace in expireTag', async () => {
     const cache = getCache();
     await cache.expireTag(['foo', 'bar']);
     expect(mockCache.expireTag).toHaveBeenCalledWith(['rc:foo', 'rc:bar']);
-  });
-
-  test('should prefix tags with explicit tagNamespace override in expireTag', async () => {
-    const cache = getCache({ tagNamespace: 'custom:' });
-    await cache.expireTag(['foo', 'bar']);
-    expect(mockCache.expireTag).toHaveBeenCalledWith([
-      'custom:foo',
-      'custom:bar',
-    ]);
-  });
-
-  test('should use default tagNamespace when tagNamespace is empty string in expireTag', async () => {
-    const cache = getCache({ tagNamespace: '' });
-    await cache.expireTag(['foo', 'bar']);
-    expect(mockCache.expireTag).toHaveBeenCalledWith(['foo', 'bar']);
   });
 });


### PR DESCRIPTION
# problem

We want to keep existing ISR tags separate from the runtime cache tags because currently there is not good support for using runtime cache tags with ISR pages

# solution

Namespace tags by default