### PR TITLE
feat(cli): microfrontends pull configuration

### DIFF
--- a/.changeset/lazy-kings-smile.md
+++ b/.changeset/lazy-kings-smile.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Introduces the `vercel microfrontends pull` command to pull your Vercel Microfrontends configuration from your default application and run your `@vercel/microfrontends` local proxy when using a polyrepo setup

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -40,6 +40,7 @@ export const help = () => `
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
       logs                 [url]       Displays the logs for a deployment
+      microfrontends                   Manages your Microfrontends
       projects                         Manages your Projects
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -40,7 +40,7 @@ export const help = () => `
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
       logs                 [url]       Displays the logs for a deployment
-      microfrontends                   Manages your Microfrontends
+      microfrontends                   Manages your microfrontends
       projects                         Manages your Projects
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -18,6 +18,7 @@ import { listCommand } from './list/command';
 import { loginCommand } from './login/command';
 import { logoutCommand } from './logout/command';
 import { logsCommand } from './logs/command';
+import { microfrontendsCommand } from './microfrontends/command';
 import { projectCommand } from './project/command';
 import { promoteCommand } from './promote/command';
 import { pullCommand } from './pull/command';
@@ -55,6 +56,7 @@ const commandsStructs = [
   loginCommand,
   logoutCommand,
   logsCommand,
+  microfrontendsCommand,
   projectCommand,
   promoteCommand,
   pullCommand,

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -30,7 +30,7 @@ export const pullSubcommand = {
 export const microfrontendsCommand = {
   name: 'microfrontends',
   aliases: ['mf'],
-  description: 'Manage your Vercel Microfrontends',
+  description: 'Manages your microfrontends',
   arguments: [],
   subcommands: [pullSubcommand],
   options: [],

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -1,0 +1,39 @@
+import { packageName } from '../../util/pkg-name';
+
+export const pullSubcommand = {
+  name: 'pull',
+  aliases: [],
+  description: 'Pull a Vercel Microfrontend configuration into your project',
+  arguments: [],
+  options: [
+    {
+      name: 'dpl',
+      shorthand: null,
+      deprecated: false,
+      type: String,
+      description:
+        'The deploymentId to use for pulling the Microfrontend configuration',
+      required: true,
+    },
+  ],
+  examples: [
+    {
+      name: 'Pull a Microfrontend configuration',
+      value: `${packageName} microfrontends pull`,
+    },
+    {
+      name: 'Pull a Microfrontend configuration for a specific deployment',
+      value: `${packageName} microfrontends pull --dpl=<deployment-id>`,
+    },
+  ],
+} as const;
+
+export const microfrontendsCommand = {
+  name: 'microfrontends',
+  aliases: ['mf'],
+  description: 'Manage your Vercel Microfrontends',
+  arguments: [],
+  subcommands: [pullSubcommand],
+  options: [],
+  examples: [],
+} as const;

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -13,7 +13,6 @@ export const pullSubcommand = {
       type: String,
       description:
         'The deploymentId to use for pulling the Microfrontend configuration',
-      required: true,
     },
   ],
   examples: [

--- a/packages/cli/src/commands/microfrontends/command.ts
+++ b/packages/cli/src/commands/microfrontends/command.ts
@@ -3,7 +3,7 @@ import { packageName } from '../../util/pkg-name';
 export const pullSubcommand = {
   name: 'pull',
   aliases: [],
-  description: 'Pull a Vercel Microfrontend configuration into your project',
+  description: 'Pull a Vercel Microfrontends configuration into your project',
   arguments: [],
   options: [
     {
@@ -12,16 +12,16 @@ export const pullSubcommand = {
       deprecated: false,
       type: String,
       description:
-        'The deploymentId to use for pulling the Microfrontend configuration',
+        'The deploymentId to use for pulling the microfrontends configuration',
     },
   ],
   examples: [
     {
-      name: 'Pull a Microfrontend configuration',
+      name: 'Pull a microfrontends configuration',
       value: `${packageName} microfrontends pull`,
     },
     {
-      name: 'Pull a Microfrontend configuration for a specific deployment',
+      name: 'Pull a microfrontends configuration for a specific deployment',
       value: `${packageName} microfrontends pull --dpl=<deployment-id>`,
     },
   ],

--- a/packages/cli/src/commands/microfrontends/index.ts
+++ b/packages/cli/src/commands/microfrontends/index.ts
@@ -1,0 +1,79 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import { printError } from '../../util/error';
+import { type Command, help } from '../help';
+import pull from './pull';
+import { microfrontendsCommand, pullSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandAliases } from '..';
+import getSubcommand from '../../util/get-subcommand';
+import { MicrofrontendsTelemetryClient } from '../../util/telemetry/commands/microfrontends';
+
+const COMMAND_CONFIG = {
+  pull: getCommandAliases(pullSubcommand),
+};
+
+export default async function main(client: Client) {
+  const telemetry = new MicrofrontendsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    microfrontendsCommand.options
+  );
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  // eslint-disable-next-line prefer-const
+  let { subcommand, subcommandOriginal } = getSubcommand(
+    parsedArgs.args.slice(1),
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('microfrontends');
+    output.print(
+      help(microfrontendsCommand, { columns: client.stderr.columns })
+    );
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        parent: microfrontendsCommand,
+        columns: client.stderr.columns,
+      })
+    );
+    return 2;
+  }
+
+  switch (subcommand) {
+    case 'pull':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('microfrontends', subcommandOriginal);
+        return printHelp(pullSubcommand);
+      }
+      telemetry.trackCliSubcommandPull(subcommandOriginal);
+      return pull(client);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(
+        help(microfrontendsCommand, { columns: client.stderr.columns })
+      );
+      return 2;
+  }
+}

--- a/packages/cli/src/commands/microfrontends/pull.ts
+++ b/packages/cli/src/commands/microfrontends/pull.ts
@@ -103,7 +103,7 @@ export default async function pull(client: Client): Promise<number> {
     const microfrontendsStamp = stamp();
     output.print(
       `${prependEmoji(
-        `Downloaded Microfrontends configuration to ${chalk.bold(
+        `Downloaded microfrontends configuration to ${chalk.bold(
           humanizePath(
             join(currentDirectory, VERCEL_DIR, VERCEL_DIR_MICROFRONTENDS)
           )

--- a/packages/cli/src/commands/microfrontends/pull.ts
+++ b/packages/cli/src/commands/microfrontends/pull.ts
@@ -45,7 +45,7 @@ export default async function pull(client: Client): Promise<number> {
 
   const { contextName } = await getScope(client);
   output.spinner(
-    `Fetching Microfrontends configuration in ${chalk.bold(contextName)}`
+    `Fetching microfrontends configuration in ${chalk.bold(contextName)}`
   );
 
   let parsedArgs;

--- a/packages/cli/src/commands/microfrontends/pull.ts
+++ b/packages/cli/src/commands/microfrontends/pull.ts
@@ -1,0 +1,121 @@
+import chalk from 'chalk';
+import { join } from 'node:path';
+import output from '../../output-manager';
+import getScope from '../../util/get-scope';
+import type Client from '../../util/client';
+import { ensureLink } from '../../util/link/ensure-link';
+import { emoji, prependEmoji } from '../../util/emoji';
+import humanizePath from '../../util/humanize-path';
+import stamp from '../../util/output/stamp';
+import { outputJSON } from 'fs-extra';
+import { pullSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+
+interface MicrofrontendsConfig {
+  $schema: string;
+  applications: Record<
+    string,
+    {
+      projectId?: string;
+    }
+  >;
+}
+
+const VERCEL_DIR = '.vercel';
+const VERCEL_DIR_MICROFRONTENDS = 'microfrontends.json';
+
+export default async function pull(client: Client): Promise<number> {
+  const link = await ensureLink('microfrontends', client, client.cwd);
+  if (typeof link === 'number') {
+    return link;
+  }
+
+  const { project, org, repoRoot } = link;
+
+  let currentDirectory: string;
+  if (repoRoot) {
+    currentDirectory = join(repoRoot, project.rootDirectory || '');
+  } else {
+    currentDirectory = client.cwd;
+  }
+
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+
+  const { contextName } = await getScope(client);
+  output.spinner(
+    `Fetching Microfrontends configuration in ${chalk.bold(contextName)}`
+  );
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(pullSubcommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (error) {
+    printError(error);
+    return 1;
+  }
+
+  const dpl =
+    parsedArgs.flags['--dpl'] ??
+    project.targets?.production?.id ??
+    project.latestDeployments?.[0]?.id;
+
+  if (!dpl) {
+    output.stopSpinner();
+    output.error(`No deployment found for project ${chalk.bold(project.name)}`);
+    return 1;
+  }
+
+  const microfrontendsConfigUrl = `/v1/microfrontends/${dpl}/config`;
+
+  try {
+    const { config } = await client.fetch<{
+      config: MicrofrontendsConfig;
+    }>(microfrontendsConfigUrl, {
+      method: 'GET',
+    });
+
+    // remove projectId from each application
+    const sanitizedConfig: MicrofrontendsConfig = {
+      ...config,
+      applications: Object.fromEntries(
+        Object.entries(config.applications).map(([name, app]) => [
+          name,
+          {
+            ...app,
+            projectId: undefined, // remove projectId
+          },
+        ])
+      ),
+    };
+
+    output.stopSpinner();
+
+    const path = join(currentDirectory, VERCEL_DIR, VERCEL_DIR_MICROFRONTENDS);
+    await outputJSON(path, sanitizedConfig, {
+      spaces: 2,
+    });
+
+    const microfrontendsStamp = stamp();
+    output.print(
+      `${prependEmoji(
+        `Downloaded Microfrontends configuration to ${chalk.bold(
+          humanizePath(
+            join(currentDirectory, VERCEL_DIR, VERCEL_DIR_MICROFRONTENDS)
+          )
+        )} ${chalk.gray(microfrontendsStamp())}`,
+        emoji('success')
+      )}\n`
+    );
+
+    return 0;
+  } catch (error) {
+    output.stopSpinner();
+    printError(error);
+    return 1;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -679,6 +679,10 @@ const main = async () => {
           telemetry.trackCliCommandLogout(userSuppliedSubCommand);
           func = require('./commands/logout').default;
           break;
+        case 'microfrontends':
+          telemetry.trackCliCommandMicrofrontends(userSuppliedSubCommand);
+          func = require('./commands/microfrontends').default;
+          break;
         case 'project':
           telemetry.trackCliCommandProject(userSuppliedSubCommand);
           func = require('./commands/project').default;

--- a/packages/cli/src/util/telemetry/commands/microfrontends/index.ts
+++ b/packages/cli/src/util/telemetry/commands/microfrontends/index.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { microfrontendsCommand } from '../../../../commands/microfrontends/command';
+
+export class MicrofrontendsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof microfrontendsCommand>
+{
+  trackCliSubcommandPull(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'pull',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { pullSubcommand } from '../../../../commands/microfrontends/command';
+
+export class MicrofrontendsPullTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof pullSubcommand>
+{
+  trackCliOptionDpl(value: string | undefined) {
+    this.trackCliOption({
+      option: '--dpl',
+      value: value ?? '',
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
@@ -8,10 +8,10 @@ export class MicrofrontendsPullTelemetryClient
 {
   trackCliOptionDpl(value: string | undefined) {
     if (value) {
-        this.trackCliOption({
-	      option: 'dpl',
-	      value: this.redactedValue,
-	    });
+      this.trackCliOption({
+        option: 'dpl',
+        value: this.redactedValue,
+      });
     }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
+++ b/packages/cli/src/util/telemetry/commands/microfrontends/pull.ts
@@ -7,9 +7,11 @@ export class MicrofrontendsPullTelemetryClient
   implements TelemetryMethods<typeof pullSubcommand>
 {
   trackCliOptionDpl(value: string | undefined) {
-    this.trackCliOption({
-      option: '--dpl',
-      value: value ?? '',
-    });
+    if (value) {
+        this.trackCliOption({
+	      option: 'dpl',
+	      value: this.redactedValue,
+	    });
+    }
   }
 }

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -166,6 +166,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandMicrofrontends(actual: string) {
+    this.trackCliCommand({
+      command: 'microfrontends',
+      value: actual,
+    });
+  }
+
   trackCliCommandProject(actual: string) {
     this.trackCliCommand({
       command: 'project',

--- a/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/.gitignore
+++ b/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/.gitignore
@@ -1,0 +1,3 @@
+.next
+yarn.lock
+!.vercel

--- a/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_dummy",
+  "projectId": "vercel-microfrontends-pull"
+}

--- a/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/package.json
+++ b/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "build": "next build",
+    "dev": "next",
+    "now-build": "next build"
+  },
+  "dependencies": {
+    "next": "^8.0.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/pages/index.js
+++ b/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/pages/index.js
@@ -1,0 +1,11 @@
+import { withRouter } from 'next/router';
+
+function Index({ router }) {
+  const data = {
+    pathname: router.pathname,
+    query: router.query,
+  };
+  return <div>{JSON.stringify(data)}</div>;
+}
+
+export default withRouter(Index);

--- a/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/vercel.json
+++ b/packages/cli/test/fixtures/unit/vercel-microfrontends-pull/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "name": "vercel-microfrontends-pull",
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index?route-param=b"
+    }
+  ]
+}

--- a/packages/cli/test/mocks/microfrontends.ts
+++ b/packages/cli/test/mocks/microfrontends.ts
@@ -1,0 +1,44 @@
+import { client } from './client';
+
+export function useMicrofrontends() {
+  const config = {
+    $schema: 'https://openapi.vercel.sh/microfrontends.json',
+    applications: {
+      'app-1': {
+        development: {
+          local: 3000,
+          fallback: 'app-1.vercel.app',
+        },
+      },
+      'app-2': {
+        development: {
+          local: 3001,
+        },
+        routing: [
+          {
+            group: 'group-1',
+            paths: ['/app-2', '/app-2/:path*'],
+          },
+        ],
+      },
+    },
+  };
+
+  client.scenario.get('/v1/microfrontends/:dpl/config', (req, res) => {
+    const { dpl } = req.params;
+
+    if (dpl === 'dpl_non_existent') {
+      res.status(404).json({
+        message: 'Deployment not found',
+        code: 'deployment_not_found',
+      });
+      return;
+    }
+
+    res.json({
+      config,
+    });
+  });
+
+  return config;
+}

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -38,6 +38,7 @@ exports[`base level help output > help 1`] = `
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
       logs                 [url]       Displays the logs for a deployment
+      microfrontends                   Manages your Microfrontends
       projects                         Manages your Projects
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -38,7 +38,7 @@ exports[`base level help output > help 1`] = `
       dns                  [name]      Manages your DNS records
       domains              [name]      Manages your domain names
       logs                 [url]       Displays the logs for a deployment
-      microfrontends                   Manages your Microfrontends
+      microfrontends                   Manages your microfrontends
       projects                         Manages your Projects
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -35,6 +35,8 @@ describe('index', () => {
         ['logout', 'logout'],
         ['logs', 'logs'],
         ['ls', 'list'],
+        ['mf', 'microfrontends'],
+        ['microfrontends', 'microfrontends'],
         ['project', 'project'],
         ['projects', 'project'],
         ['promote', 'promote'],

--- a/packages/cli/test/unit/commands/microfrontends/index.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import microfrontends from '../../../../src/commands/microfrontends';
+import * as pull from '../../../../src/commands/microfrontends/pull';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+
+describe('microfrontends', () => {
+  const pullSpy = vi.spyOn(pull, 'default').mockResolvedValue(0);
+
+  afterEach(() => {
+    pullSpy.mockClear();
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'microfrontends';
+
+      client.setArgv(command, '--help');
+      const exitCodePromise = microfrontends(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: command,
+        },
+      ]);
+    });
+  });
+
+  it('routes to pull subcommand', async () => {
+    useUser();
+    client.setArgv('microfrontends', 'pull');
+    await microfrontends(client);
+    expect(pullSpy).toHaveBeenCalledWith(client);
+  });
+
+  describe('unrecognized subcommand', () => {
+    it('shows help', async () => {
+      useUser();
+      const args: string[] = ['not-a-command'];
+
+      client.setArgv('microfrontends', ...args);
+      const exitCode = await microfrontends(client);
+      expect(exitCode).toEqual(2);
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/microfrontends/pull.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/pull.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { useUser } from '../../../mocks/user';
+import microfrontends from '../../../../src/commands/microfrontends';
+import { client } from '../../../mocks/client';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { useMicrofrontends } from '../../../mocks/microfrontends';
+
+describe('microfrontends pull', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'microfrontends';
+      const subcommand = 'pull';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = microfrontends(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('should pull microfrontends configuration', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-microfrontends-pull',
+      name: 'vercel-microfrontends-pull',
+    });
+    useMicrofrontends();
+    const cwd = setupUnitFixture('vercel-microfrontends-pull');
+
+    client.cwd = cwd;
+    client.setArgv('microfrontends', 'pull');
+    const microfrontendsPromise = microfrontends(client);
+
+    await expect(client.stderr).toOutput(
+      `Fetching Microfrontends configuration`
+    );
+
+    const exitCode = await microfrontendsPromise;
+    expect(exitCode).toEqual(0);
+
+    await expect(client.stderr).toOutput(
+      `Downloaded Microfrontends configuration to`
+    );
+  });
+
+  it('should fail with no deployment found', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-microfrontends-pull',
+      name: 'vercel-microfrontends-pull',
+      latestDeployments: [],
+      targets: {},
+    });
+    useMicrofrontends();
+    const cwd = setupUnitFixture('vercel-microfrontends-pull');
+
+    client.cwd = cwd;
+    client.setArgv('microfrontends', 'pull');
+    const microfrontendsPromise = microfrontends(client);
+
+    const exitCode = await microfrontendsPromise;
+    expect(exitCode).toEqual(1);
+
+    await expect(client.stderr).toOutput(
+      `No deployment found for project vercel-microfrontends-pull`
+    );
+  });
+
+  describe('--dpl', () => {
+    it('should use the provided deployment ID', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-microfrontends-pull',
+        name: 'vercel-microfrontends-pull',
+      });
+      useMicrofrontends();
+      const cwd = setupUnitFixture('vercel-microfrontends-pull');
+
+      client.cwd = cwd;
+      client.setArgv('microfrontends', 'pull', '--dpl=dpl_12345');
+      const microfrontendsPromise = microfrontends(client);
+
+      await expect(client.stderr).toOutput(
+        `Fetching Microfrontends configuration`
+      );
+
+      const exitCode = await microfrontendsPromise;
+      expect(exitCode).toEqual(0);
+
+      await expect(client.stderr).toOutput(
+        `Downloaded Microfrontends configuration to`
+      );
+    });
+
+    it('should fail when the provided deployment ID does not exist', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'vercel-microfrontends-pull',
+        name: 'vercel-microfrontends-pull',
+      });
+      useMicrofrontends();
+      const cwd = setupUnitFixture('vercel-microfrontends-pull');
+
+      client.cwd = cwd;
+      client.setArgv('microfrontends', 'pull', '--dpl=dpl_non_existent');
+      const microfrontendsPromise = microfrontends(client);
+
+      const exitCode = await microfrontendsPromise;
+      expect(exitCode).toEqual(1);
+
+      await expect(client.stderr).toOutput(`Deployment not found`);
+    });
+  });
+
+  it('tracks argument', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-microfrontends-pull',
+      name: 'vercel-microfrontends-pull',
+    });
+    useMicrofrontends();
+    const cwd = setupUnitFixture('vercel-microfrontends-pull');
+
+    client.cwd = cwd;
+    client.setArgv('microfrontends', 'pull');
+    const microfrontendsPromise = microfrontends(client);
+
+    const exitCode = await microfrontendsPromise;
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: `subcommand:pull`,
+        value: 'pull',
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/commands/microfrontends/pull.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/pull.test.ts
@@ -42,14 +42,14 @@ describe('microfrontends pull', () => {
     const microfrontendsPromise = microfrontends(client);
 
     await expect(client.stderr).toOutput(
-      `Fetching Microfrontends configuration`
+      `Fetching microfrontends configuration`
     );
 
     const exitCode = await microfrontendsPromise;
     expect(exitCode).toEqual(0);
 
     await expect(client.stderr).toOutput(
-      `Downloaded Microfrontends configuration to`
+      `Downloaded microfrontends configuration to`
     );
   });
 

--- a/packages/cli/test/unit/commands/microfrontends/pull.test.ts
+++ b/packages/cli/test/unit/commands/microfrontends/pull.test.ts
@@ -95,14 +95,14 @@ describe('microfrontends pull', () => {
       const microfrontendsPromise = microfrontends(client);
 
       await expect(client.stderr).toOutput(
-        `Fetching Microfrontends configuration`
+        `Fetching microfrontends configuration`
       );
 
       const exitCode = await microfrontendsPromise;
       expect(exitCode).toEqual(0);
 
       await expect(client.stderr).toOutput(
-        `Downloaded Microfrontends configuration to`
+        `Downloaded microfrontends configuration to`
       );
     });
 


### PR DESCRIPTION
This PR introduces the `microfrontends` command to manage your Vercel Microfrontends.

The only subcommand available is `pull`, which downloads the Vercel Microfrontends configuration for your project to use it with the Vercel Microfrontends local proxy in a polyrepo setup.

Usage:

```sh
vercel microfrontends pull
```

This command downloads and writes the Vercel Microfrontends configuration to `.vercel/microfrontends.json`.

You can also specify the deployment id using the `--dpl` option to fetch the configuration from a specific deployment:

```sh
vercel microfrontends pull --dpl=<deployment-id>
```

A shorthand is also available for the `microfrontends` command, called `mf`, so the shortest format to pull the Vercel Microfrontends configuration is:

```sh
vc mf pull
```