### PR TITLE
Upgrade @vercel/microfrontends to 1.3.0

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@vercel/build-utils": "10.6.1",
     "@vercel/error-utils": "2.0.3",
-    "@vercel/microfrontends": "1.2.2",
+    "@vercel/microfrontends": "1.3.0",
     "@vercel/routing-utils": "5.0.7",
     "async-retry": "1.2.3",
     "async-sema": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,8 +767,8 @@ importers:
         specifier: 2.0.3
         version: link:../error-utils
       '@vercel/microfrontends':
-        specifier: 1.2.2
-        version: 1.2.2(vite@5.1.8)
+        specifier: 1.3.0
+        version: 1.3.0(vite@5.1.8)
       '@vercel/routing-utils':
         specifier: 5.0.7
         version: link:../routing-utils
@@ -7759,8 +7759,8 @@ packages:
       - supports-color
     dev: false
 
-  /@vercel/microfrontends@1.2.2(vite@5.1.8):
-    resolution: {integrity: sha512-QzcR5wVsz654XlCGT/HnxjgSkQMpeaEuj7bI1EeukwL/2D3kFkL5J68LMqA68HHSbbLvx32o7n5scSoB7a+3IQ==}
+  /@vercel/microfrontends@1.3.0(vite@5.1.8):
+    resolution: {integrity: sha512-7hvza7+osdfowUllyDthk3QerhoU/8kQgr9QNsIxOJQxpbpwGlN3mMNvYG7CaPB41kQutY6D7StCiOg0E0xGFg==}
     hasBin: true
     peerDependencies:
       '@sveltejs/kit': '>=1'


### PR DESCRIPTION
This PR moves `vercel/vercel` to `@vercel/microfrontends@1.3.0`, the latest release published 25 days ago.