### PR TITLE
[@vercel/functions] prevent stale copy of cache being used in runtime cache

### DIFF
--- a/.changeset/heavy-wasps-occur.md
+++ b/.changeset/heavy-wasps-occur.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Update runtime cache to always use the current cache instance to prevent holding a stale copy

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -30,16 +30,14 @@ let inMemoryCacheInstance: InMemoryCache | null = null;
  * @throws {Error} If no cache is available in the context and `InMemoryCache` cannot be created.
  */
 export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
-  let cache: RuntimeCache;
-  if (getContext().cache) {
-    cache = getContext().cache as RuntimeCache;
-  } else {
-    // Create InMemoryCache instance only once
+  const resolveCache = () => {
+    const ctxCache = getContext().cache;
+    if (ctxCache) return ctxCache as RuntimeCache;
     if (!inMemoryCacheInstance) {
       inMemoryCacheInstance = new InMemoryCache();
     }
-    cache = inMemoryCacheInstance;
-  }
+    return inMemoryCacheInstance;
+  };
 
   const hashFunction = cacheOptions?.keyHashFunction || defaultKeyHashFunction;
   const makeKey = (key: string) => {
@@ -54,20 +52,20 @@ export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
 
   return {
     get: (key: string, options?: { tags?: string[] }) => {
-      return cache.get(makeKey(key), options);
+      return resolveCache().get(makeKey(key), options);
     },
     set: (
       key: string,
       value: unknown,
       options?: { name?: string; tags?: string[]; ttl?: number }
     ) => {
-      return cache.set(makeKey(key), value, options);
+      return resolveCache().set(makeKey(key), value, options);
     },
     delete: (key: string) => {
-      return cache.delete(makeKey(key));
+      return resolveCache().delete(makeKey(key));
     },
     expireTag: (tag: string | string[]) => {
-      return cache.expireTag(tag);
+      return resolveCache().expireTag(tag);
     },
   };
 };


### PR DESCRIPTION
# problem

If the result of getCache() is saved outside of the scope of a function, the cache object can persist for longer than the lifetime of the associated jwt, resulting in 401 auth errors.

# solution

For every cache method, always retrieve the latest cache object from the context.