### PR TITLE
[@vercel/functions] add warning message to indicate in-memory cache is being used

### DIFF
--- a/.changeset/big-bottles-explain.md
+++ b/.changeset/big-bottles-explain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Add warning when calling getCache to indicate that in-memory cache is being used.

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -37,6 +37,9 @@ export const getCache = (cacheOptions?: CacheOptions): RuntimeCache => {
     // Create InMemoryCache instance only once
     if (!inMemoryCacheInstance) {
       inMemoryCacheInstance = new InMemoryCache();
+      console.warn(
+        'Runtime Cache unavailable in this environment. Falling back to in-memory cache.'
+      );
     }
     cache = inMemoryCacheInstance;
   }


### PR DESCRIPTION
Warn when falling back to in-memory caching to prevent invalid expectations if for some reason runtime cache is not available in the current context.