### PR TITLE
[cli] make `--logs` the default behavior for `vercel deploy`

### DIFF
--- a/.changeset/odd-crabs-cheat.md
+++ b/.changeset/odd-crabs-cheat.md
@@ -1,0 +1,5 @@
+---
+"vercel": major
+---
+
+[cli] make `--logs` the default behavior for `vercel deploy`

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -115,8 +115,15 @@ export const deployCommand = {
       name: 'logs',
       shorthand: 'l',
       type: Boolean,
-      deprecated: false,
+      deprecated: true,
       description: 'Print the build logs',
+    },
+    {
+      name: 'no-logs',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Do not print the build logs',
     },
     {
       name: 'name',

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -102,6 +102,7 @@ export default async (client: Client): Promise<number> => {
     );
     telemetryClient.trackCliFlagPublic(parsedArguments.flags['--public']);
     telemetryClient.trackCliFlagLogs(parsedArguments.flags['--logs']);
+    telemetryClient.trackCliFlagNoLogs(parsedArguments.flags['--no-logs']);
     telemetryClient.trackCliFlagForce(parsedArguments.flags['--force']);
     telemetryClient.trackCliFlagWithCache(
       parsedArguments.flags['--with-cache']
@@ -111,6 +112,10 @@ export default async (client: Client): Promise<number> => {
       telemetryClient.trackCliFlagConfirm(parsedArguments.flags['--confirm']);
       output.warn('`--confirm` is deprecated, please use `--yes` instead');
       parsedArguments.flags['--yes'] = parsedArguments.flags['--confirm'];
+    }
+
+    if ('--logs' in parsedArguments.flags) {
+      output.warn('`--logs` is deprecated and now the default behavior.');
     }
   } catch (error) {
     printError(error);
@@ -463,6 +468,7 @@ export default async (client: Client): Promise<number> => {
   const deployStamp = stamp();
   let deployment = null;
   const noWait = !!parsedArguments.flags['--no-wait'];
+  const withLogs = '--no-logs' in parsedArguments.flags ? false : true;
 
   const localConfigurationOverrides = pickOverrides(localConfig);
 
@@ -505,7 +511,7 @@ export default async (client: Client): Promise<number> => {
       target,
       skipAutoDetectionConfirmation: autoConfirm,
       noWait,
-      withLogs: parsedArguments.flags['--logs'],
+      withLogs: withLogs,
       autoAssignCustomDomains,
     };
 

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -511,7 +511,7 @@ export default async (client: Client): Promise<number> => {
       target,
       skipAutoDetectionConfirmation: autoConfirm,
       noWait,
-      withLogs: withLogs,
+      withLogs,
       autoAssignCustomDomains,
     };
 

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -94,6 +94,11 @@ export class DeployTelemetryClient
       this.trackCliFlag('logs');
     }
   }
+  trackCliFlagNoLogs(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('no-logs');
+    }
+  }
   trackCliFlagNoClipboard(flag: boolean | undefined) {
     if (flag) {
       this.trackCliFlag('no-clipboard');

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -749,9 +749,13 @@ test('deploys with only vercel.json and README.md', async () => {
     'deploy-with-only-readme-vercel-json'
   );
 
-  const { exitCode, stdout, stderr } = await execCli(binaryPath, ['--yes'], {
-    cwd: directory,
-  });
+  const { exitCode, stdout, stderr } = await execCli(
+    binaryPath,
+    ['--yes', '--no-logs'],
+    {
+      cwd: directory,
+    }
+  );
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,10 +753,6 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 nothing 
                                 has     
                                 changed 
-  -l,  --logs                   Print   
-                                the     
-                                build   
-                                logs    
   -m,  --meta <KEY=VALUE>       Specify 
                                 metadata
                                 for the 
@@ -766,6 +762,11 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 KEY1=va…
                                 -m      
                                 KEY2=va…
+       --no-logs                Do not  
+                                print   
+                                the     
+                                build   
+                                logs    
        --no-wait                Don't   
                                 wait for
                                 the     
@@ -921,9 +922,9 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 (e.g. \`-e KEY1=value1 -e KEY2=value2\`)          
   -f,  --force                  Force a new deployment even if nothing has      
                                 changed                                         
-  -l,  --logs                   Print the build logs                            
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m   
                                 KEY1=value1 -m KEY2=value2\`)                    
+       --no-logs                Do not print the build logs                     
        --no-wait                Don't wait for the deployment to finish         
        --prebuilt               Use in combination with \`vc build\`. Deploy an   
                                 existing build                                  
@@ -993,8 +994,8 @@ exports[`help command > deploy help output snapshots > deploy help column width 
   -b,  --build-env <KEY=VALUE>  Specify environment variables during build-time (e.g. \`-b KEY1=value1 -b KEY2=value2\`)  
   -e,  --env <KEY=VALUE>        Specify environment variables during run-time (e.g. \`-e KEY1=value1 -e KEY2=value2\`)    
   -f,  --force                  Force a new deployment even if nothing has changed                                      
-  -l,  --logs                   Print the build logs                                                                    
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m KEY1=value1 -m KEY2=value2\`)              
+       --no-logs                Do not print the build logs                                                             
        --no-wait                Don't wait for the deployment to finish                                                 
        --prebuilt               Use in combination with \`vc build\`. Deploy an existing build                            
        --prod                   Create a production deployment (shorthand for \`--target=production\`)                    

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -65,9 +65,9 @@ describe('deploy', () => {
     client.setArgv('deploy', badName);
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error: Could not find "${humanizePath(
+      `Error: Could not find “${humanizePath(
         join(client.cwd, 'does-not-exist')
-      )}"\n`
+      )}”\n`
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "deploy"').toEqual(1);
@@ -1305,7 +1305,7 @@ describe('deploy', () => {
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(
-          `What's your project's name? (${nameOption})`
+          `What’s your project’s name? (${nameOption})`
         );
         client.stdin.write('\n');
 
@@ -1340,7 +1340,7 @@ describe('deploy', () => {
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(
-          `What's your project's name? (${directoryName})`
+          `What’s your project’s name? (${directoryName})`
         );
         client.stdin.write('\n');
 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -65,9 +65,9 @@ describe('deploy', () => {
     client.setArgv('deploy', badName);
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error: Could not find “${humanizePath(
+      `Error: Could not find "${humanizePath(
         join(client.cwd, 'does-not-exist')
-      )}”\n`
+      )}"\n`
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "deploy"').toEqual(1);
@@ -665,73 +665,147 @@ describe('deploy', () => {
     });
   });
 
-  it('should print and follow build logs while deploying', async () => {
-    const user = useUser();
-    useTeams('team_dummy');
-    useProject({
-      ...defaultProject,
-      name: 'node',
-      id: 'QmbKpqpiUqbcke',
-    });
-    const deployment = useDeployment({ creator: user, state: 'BUILDING' });
-    deployment.aliasAssigned = false;
-    client.scenario.post(`/v13/deployments`, (req, res) => {
-      res.json(
-        res.json({
-          creator: {
-            uid: user.id,
-            username: user.username,
-          },
-          id: deployment.id,
-          readyState: deployment.readyState,
-          aliasAssigned: false,
-          alias: [],
-        })
-      );
-    });
-    useBuildLogs({
-      deployment,
-      logProducer: async function* () {
-        yield { created: 1717426870339, text: 'Hello, world!' };
-        await sleep(100);
-        yield { created: 1717426870439, text: 'slow...' };
-        await sleep(100);
-        yield { created: 1717426870540, text: 'Bye...' };
-      },
-    });
+  describe('build logs', () => {
+    let deployment: ReturnType<typeof useDeployment>;
 
-    let exitCode: number | undefined;
-    const runCommand = async () => {
-      const repoRoot = setupUnitFixture('commands/deploy/node');
-      client.cwd = repoRoot;
-      client.setArgv('deploy', '--logs');
-      exitCode = await deploy(client);
-    };
-
+    const outputLine1 = 'Hello, world!';
+    const outputLine2 = 'slow...';
+    const outputLine3 = 'Bye...';
     const slowlyDeploy = async () => {
       await sleep(500);
       deployment.readyState = 'READY';
       deployment.aliasAssigned = true;
     };
 
-    await Promise.all<void>([runCommand(), slowlyDeploy()]);
+    beforeEach(() => {
+      const user = useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        name: 'node',
+        id: 'QmbKpqpiUqbcke',
+      });
+      deployment = useDeployment({ creator: user, state: 'BUILDING' });
+      deployment.aliasAssigned = false;
+      client.scenario.post(`/v13/deployments`, (req, res) => {
+        res.json(
+          res.json({
+            creator: {
+              uid: user.id,
+              username: user.username,
+            },
+            id: deployment.id,
+            readyState: deployment.readyState,
+            aliasAssigned: false,
+            alias: [],
+          })
+        );
+      });
+      useBuildLogs({
+        deployment,
+        logProducer: async function* () {
+          yield { created: 1717426870339, text: 'Hello, world!' };
+          await sleep(100);
+          yield { created: 1717426870439, text: 'slow...' };
+          await sleep(100);
+          yield { created: 1717426870540, text: 'Bye...' };
+        },
+      });
+    });
 
-    // remove first 3 lines which contains randomized data
-    expect(client.getFullOutput().split('\n').slice(3).join('\n'))
-      .toMatchInlineSnapshot(`
-        "Building
-        2024-06-03T15:01:10.339Z  Hello, world!
-        2024-06-03T15:01:10.439Z  slow...
-        2024-06-03T15:01:10.540Z  Bye...
-        "
-      `);
-    expect(exitCode).toEqual(0);
-    expect(client.telemetryEventStore).toHaveTelemetryEvents([
-      {
-        key: 'flag:logs',
-        value: 'TRUE',
-      },
-    ]);
+    it('should print and follow build logs while deploying with --logs', async () => {
+      let exitCode: number | undefined;
+      const runCommand = async () => {
+        const repoRoot = setupUnitFixture('commands/deploy/node');
+        client.cwd = repoRoot;
+        client.setArgv('deploy', '--logs');
+        exitCode = await deploy(client);
+      };
+
+      const slowlyDeploy = async () => {
+        await sleep(500);
+        deployment.readyState = 'READY';
+        deployment.aliasAssigned = true;
+      };
+
+      await Promise.all<void>([runCommand(), slowlyDeploy()]);
+
+      const outputLines = client.getFullOutput().split('\n');
+      expect(outputLines[0]).toBe(
+        'WARN! `--logs` is deprecated and now the default behavior.'
+      );
+
+      // remove first 4 lines which contain warning and randomized data
+      expect(outputLines.slice(4).join('\n')).toMatchInlineSnapshot(`
+          "Building
+          2024-06-03T15:01:10.339Z  ${outputLine1}
+          2024-06-03T15:01:10.439Z  ${outputLine2}
+          2024-06-03T15:01:10.540Z  ${outputLine3}
+          "
+        `);
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:logs',
+          value: 'TRUE',
+        },
+      ]);
+    });
+
+    it('should print and follow build logs while deploying by default', async () => {
+      let exitCode: number | undefined;
+      const runCommand = async () => {
+        const repoRoot = setupUnitFixture('commands/deploy/node');
+        client.cwd = repoRoot;
+        client.setArgv('deploy');
+        exitCode = await deploy(client);
+      };
+
+      await Promise.all<void>([runCommand(), slowlyDeploy()]);
+
+      // remove first 3 lines which contains randomized data
+      expect(client.getFullOutput().split('\n').slice(3).join('\n'))
+        .toMatchInlineSnapshot(`
+          "Building
+          2024-06-03T15:01:10.339Z  ${outputLine1}
+          2024-06-03T15:01:10.439Z  ${outputLine2}
+          2024-06-03T15:01:10.540Z  ${outputLine3}
+          "
+        `);
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should not print and follow build logs while deploying with --no-logs', async () => {
+      let exitCode: number | undefined;
+      const runCommand = async () => {
+        const repoRoot = setupUnitFixture('commands/deploy/node');
+        client.cwd = repoRoot;
+        client.setArgv('deploy', '--no-logs');
+        exitCode = await deploy(client);
+      };
+
+      const slowlyDeploy = async () => {
+        await sleep(500);
+        deployment.readyState = 'READY';
+        deployment.aliasAssigned = true;
+      };
+
+      await Promise.all<void>([runCommand(), slowlyDeploy()]);
+
+      const output = client.getFullOutput();
+
+      expect(output).not.toContain(outputLine1);
+      expect(output).not.toContain(outputLine2);
+      expect(output).not.toContain(outputLine3);
+
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:no-logs',
+          value: 'TRUE',
+        },
+      ]);
+    });
   });
 
   describe('calls createDeploy with the appropriate arguments', () => {
@@ -1231,7 +1305,7 @@ describe('deploy', () => {
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(
-          `What’s your project’s name? (${nameOption})`
+          `What's your project's name? (${nameOption})`
         );
         client.stdin.write('\n');
 
@@ -1266,7 +1340,7 @@ describe('deploy', () => {
 
         // The one expecation that the test is actually about!
         await expect(client.stderr).toOutput(
-          `What’s your project’s name? (${directoryName})`
+          `What's your project's name? (${directoryName})`
         );
         client.stdin.write('\n');
 


### PR DESCRIPTION
* Updates `vercel deploy` to show build logs by default.
* Makes `vercel deploy --logs` warn about the option being deprecated.
* Introduces `vercel deploy --no-logs` to preserve old behavior as migration path for customers who prefer no logs.