### PR TITLE
feat(cli): add blob token option and env variable

### DIFF
--- a/.changeset/yellow-cars-cross.md
+++ b/.changeset/yellow-cars-cross.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-feat(cli) optimize blob token retrieval
+feat(cli): optimize blob token retrieval

--- a/.changeset/yellow-cars-cross.md
+++ b/.changeset/yellow-cars-cross.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+feat(cli) optimize blob token retrieval

--- a/.changeset/yellow-cars-cross.md
+++ b/.changeset/yellow-cars-cross.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-feat(cli): optimize blob token retrieval
+feat(cli): add blob token option and env variable

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -235,6 +235,7 @@ export const blobCommand = {
   options: [
     {
       name: 'rw-token',
+      shorthand: null,
       type: String,
       deprecated: false,
       description: 'Read/write token for the Blob store',

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -238,7 +238,7 @@ export const blobCommand = {
       shorthand: null,
       type: String,
       deprecated: false,
-      description: 'Read/write token for the Blob store',
+      description: 'Read_Write_Token for the Blob store',
       argument: 'String',
     },
   ],

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -232,6 +232,14 @@ export const blobCommand = {
     copySubcommand,
     storeSubcommand,
   ],
-  options: [],
+  options: [
+    {
+      name: 'rw-token',
+      type: String,
+      deprecated: false,
+      description: 'Read/write token for the Blob store',
+      argument: 'String',
+    },
+  ],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/blob/copy.ts
+++ b/packages/cli/src/commands/blob/copy.ts
@@ -29,7 +29,7 @@ export default async function copy(
     return 1;
   }
 
-  if (!parsedArgs.args.length) {
+  if (!parsedArgs.args || parsedArgs.args.length < 2) {
     printError(
       `Missing required arguments: ${getCommandName(
         'blob copy fromUrlOrPathname toPathname'

--- a/packages/cli/src/commands/blob/copy.ts
+++ b/packages/cli/src/commands/blob/copy.ts
@@ -5,13 +5,13 @@ import * as blob from '@vercel/blob';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { copySubcommand } from './command';
-import { getBlobRWToken } from '../../util/blob/token';
 import { BlobCopyTelemetryClient } from '../../util/telemetry/commands/blob/copy';
 import { getCommandName } from '../../util/pkg-name';
 
 export default async function copy(
   client: Client,
-  argv: string[]
+  argv: string[],
+  rwToken: string
 ): Promise<number> {
   const telemetryClient = new BlobCopyTelemetryClient({
     opts: {
@@ -53,12 +53,6 @@ export default async function copy(
   telemetryClient.trackCliOptionContentType(contentType);
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
 
-  const token = await getBlobRWToken(client);
-  if (!token.success) {
-    printError(token.error);
-    return 1;
-  }
-
   let result: blob.PutBlobResult;
   try {
     output.debug('Copying blob');
@@ -66,7 +60,7 @@ export default async function copy(
     output.spinner('Copying blob');
 
     result = await blob.copy(fromUrl, toPathname, {
-      token: token.token,
+      token: rwToken,
       access: 'public',
       addRandomSuffix: addRandomSuffix ?? false,
       contentType,

--- a/packages/cli/src/commands/blob/del.ts
+++ b/packages/cli/src/commands/blob/del.ts
@@ -4,14 +4,14 @@ import * as blob from '@vercel/blob';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { delSubcommand } from './command';
-import { getBlobRWToken } from '../../util/blob/token';
 import { BlobDelTelemetryClient } from '../../util/telemetry/commands/blob/del';
 import { printError } from '../../util/error';
 import { getCommandName } from '../../util/pkg-name';
 
 export default async function del(
   client: Client,
-  argv: string[]
+  argv: string[],
+  rwToken: string
 ): Promise<number> {
   const telemetryClient = new BlobDelTelemetryClient({
     opts: {
@@ -40,18 +40,12 @@ export default async function del(
 
   telemetryClient.trackCliArgumentUrlsOrPathnames(args[0]);
 
-  const token = await getBlobRWToken(client);
-  if (!token.success) {
-    printError(token.error);
-    return 1;
-  }
-
   try {
     output.debug('Deleting blob');
 
     output.spinner('Deleting blob');
 
-    await blob.del(args, { token: token.token });
+    await blob.del(args, { token: rwToken });
   } catch (err) {
     output.error(`Error deleting blob: ${err}`);
     return 1;

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -21,6 +21,7 @@ import del from './del';
 import copy from './copy';
 import { store } from './store';
 import { printError } from '../../util/error';
+import { getBlobRWToken } from '../../util/blob/token';
 
 const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
@@ -68,6 +69,12 @@ export default async function main(client: Client) {
     );
   }
 
+  const token = await getBlobRWToken(client, client.argv.slice(2));
+  if (!token.success) {
+    printError(token.error);
+    return 1;
+  }
+
   switch (subcommand) {
     case 'list':
       if (needHelp) {
@@ -77,7 +84,7 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandList(subcommandOriginal);
-      return list(client, args);
+      return list(client, args, token.token);
     case 'put':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
@@ -86,14 +93,14 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandPut(subcommandOriginal);
-      return put(client, args);
+      return put(client, args, token.token);
     case 'del':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
         printHelp(delSubcommand);
         return 2;
       }
-      return del(client, args);
+      return del(client, args, token.token);
     case 'copy':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob', subcommandOriginal);
@@ -102,7 +109,7 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandCopy(subcommandOriginal);
-      return copy(client, args);
+      return copy(client, args, token.token);
     case 'store':
       telemetry.trackCliSubcommandStore(subcommandOriginal);
       return store(client);

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -69,11 +69,8 @@ export default async function main(client: Client) {
     );
   }
 
-  const token = await getBlobRWToken(client, client.argv.slice(2));
-  if (!token.success) {
-    printError(token.error);
-    return 1;
-  }
+  const token = await getBlobRWToken(client, client.argv);
+  telemetry.trackCliOptionRwToken();
 
   switch (subcommand) {
     case 'list':
@@ -84,6 +81,12 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandList(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
       return list(client, args, token.token);
     case 'put':
       if (needHelp) {
@@ -93,6 +96,12 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandPut(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
       return put(client, args, token.token);
     case 'del':
       if (needHelp) {
@@ -100,6 +109,14 @@ export default async function main(client: Client) {
         printHelp(delSubcommand);
         return 2;
       }
+
+      telemetry.trackCliSubcommandDel(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
       return del(client, args, token.token);
     case 'copy':
       if (needHelp) {
@@ -109,6 +126,12 @@ export default async function main(client: Client) {
       }
 
       telemetry.trackCliSubcommandCopy(subcommandOriginal);
+
+      if (!token.success) {
+        printError(token.error);
+        return 1;
+      }
+
       return copy(client, args, token.token);
     case 'store':
       telemetry.trackCliSubcommandStore(subcommandOriginal);

--- a/packages/cli/src/commands/blob/index.ts
+++ b/packages/cli/src/commands/blob/index.ts
@@ -135,7 +135,7 @@ export default async function main(client: Client) {
       return copy(client, args, token.token);
     case 'store':
       telemetry.trackCliSubcommandStore(subcommandOriginal);
-      return store(client);
+      return store(client, token);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(blobCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/blob/list.ts
+++ b/packages/cli/src/commands/blob/list.ts
@@ -9,7 +9,6 @@ import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { listSubcommand } from './command';
 import { getCommandName } from '../../util/pkg-name';
-import { getBlobRWToken } from '../../util/blob/token';
 import { BlobListTelemetryClient } from '../../util/telemetry/commands/blob/list';
 import { printError } from '../../util/error';
 
@@ -19,7 +18,8 @@ function isMode(mode: string): mode is 'folded' | 'expanded' {
 
 export default async function list(
   client: Client,
-  argv: string[]
+  argv: string[],
+  rwToken: string
 ): Promise<number> {
   const telemetryClient = new BlobListTelemetryClient({
     opts: {
@@ -49,12 +49,6 @@ export default async function list(
   telemetryClient.trackCliOptionPrefix(prefix);
   telemetryClient.trackCliOptionMode(modeFlag);
 
-  const token = await getBlobRWToken(client);
-  if (!token.success) {
-    printError(token.error);
-    return 1;
-  }
-
   const mode = modeFlag ?? 'expanded';
   if (!isMode(mode)) {
     output.error(
@@ -70,7 +64,7 @@ export default async function list(
 
     output.spinner('Fetching blobs');
     list = await blob.list({
-      token: token.token,
+      token: rwToken,
       limit: limit ?? 10,
       cursor,
       mode,

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -35,7 +35,7 @@ export default async function getStore(
     args: [storeId],
   } = parsedArgs;
 
-  const token = await getBlobRWToken(client);
+  const token = await getBlobRWToken(client, argv);
 
   if (!storeId && token.success) {
     const [, , , id] = token.token.split('_');

--- a/packages/cli/src/commands/blob/store-get.ts
+++ b/packages/cli/src/commands/blob/store-get.ts
@@ -1,6 +1,6 @@
 import bytes from 'bytes';
 import output from '../../output-manager';
-import { getBlobRWToken } from '../../util/blob/token';
+import type { BlobRWToken } from '../../util/blob/token';
 import type Client from '../../util/client';
 import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
@@ -13,7 +13,8 @@ import { BlobGetStoreTelemetryClient } from '../../util/telemetry/commands/blob/
 
 export default async function getStore(
   client: Client,
-  argv: string[]
+  argv: string[],
+  rwToken: BlobRWToken
 ): Promise<number> {
   const telemetryClient = new BlobGetStoreTelemetryClient({
     opts: {
@@ -35,10 +36,8 @@ export default async function getStore(
     args: [storeId],
   } = parsedArgs;
 
-  const token = await getBlobRWToken(client, argv);
-
-  if (!storeId && token.success) {
-    const [, , , id] = token.token.split('_');
+  if (!storeId && rwToken.success) {
+    const [, , , id] = rwToken.token.split('_');
 
     storeId = `store_${id}`;
   }

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -27,7 +27,7 @@ export default async function removeStore(
     args: [storeId],
   } = parsedArgs;
 
-  const token = await getBlobRWToken(client);
+  const token = await getBlobRWToken(client, argv);
 
   if (!storeId && token.success) {
     const [, , , id] = token.token.split('_');

--- a/packages/cli/src/commands/blob/store-remove.ts
+++ b/packages/cli/src/commands/blob/store-remove.ts
@@ -5,11 +5,12 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { removeStoreSubcommand } from './command';
 import { parseArguments } from '../../util/get-args';
 import { getLinkedProject } from '../../util/projects/link';
-import { getBlobRWToken } from '../../util/blob/token';
+import type { BlobRWToken } from '../../util/blob/token';
 
 export default async function removeStore(
   client: Client,
-  argv: string[]
+  argv: string[],
+  rwToken: BlobRWToken
 ): Promise<number> {
   const flagsSpecification = getFlagsSpecification(
     removeStoreSubcommand.options
@@ -27,10 +28,8 @@ export default async function removeStore(
     args: [storeId],
   } = parsedArgs;
 
-  const token = await getBlobRWToken(client, argv);
-
-  if (!storeId && token.success) {
-    const [, , , id] = token.token.split('_');
+  if (!storeId && rwToken.success) {
+    const [, , , id] = rwToken.token.split('_');
 
     storeId = `store_${id}`;
   }

--- a/packages/cli/src/commands/blob/store.ts
+++ b/packages/cli/src/commands/blob/store.ts
@@ -17,6 +17,7 @@ import removeStore from './store-remove';
 import { BlobStoreTelemetryClient } from '../../util/telemetry/commands/blob/store';
 import { printError } from '../../util/error';
 import getStore from './store-get';
+import type { BlobRWToken } from '../../util/blob/token';
 
 const COMMAND_CONFIG = {
   add: getCommandAliases(addStoreSubcommand),
@@ -24,7 +25,7 @@ const COMMAND_CONFIG = {
   get: getCommandAliases(getStoreSubcommand),
 };
 
-export async function store(client: Client) {
+export async function store(client: Client, rwToken: BlobRWToken) {
   const telemetry = new BlobStoreTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
@@ -80,7 +81,7 @@ export async function store(client: Client) {
       }
 
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
-      return removeStore(client, args);
+      return removeStore(client, args, rwToken);
     case 'get':
       if (needHelp) {
         telemetry.trackCliFlagHelp('blob store', subcommandOriginal);
@@ -89,7 +90,7 @@ export async function store(client: Client) {
       }
 
       telemetry.trackCliSubcommandGet(subcommandOriginal);
-      return getStore(client, args);
+      return getStore(client, args, rwToken);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(storeSubcommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -12,7 +12,7 @@ import listItem from '../output/list-item';
 
 const ErrorMessage = `No Vercel Blob token found. To fix this issue, choose one of the following options:
 ${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 1)}
-${listItem(`Pass the token directly as an option: ${getCommandName('blob list --token BLOB_TOKEN')}`, 2)}
+${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_TOKEN')}`, 2)}
 ${listItem(`Set the Token as an environment variable: ${cmd(`VERCEL_BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 3)}`;
 
 export async function getBlobRWToken(

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -1,4 +1,3 @@
-import type { Dictionary } from '@vercel/client';
 import { resolve } from 'node:path';
 import { createEnvObject } from '../env/diff-env-files';
 
@@ -11,34 +10,31 @@ import cmd from '../output/cmd';
 import listItem from '../output/list-item';
 
 const ErrorMessage = `No Vercel Blob token found. To fix this issue, choose one of the following options:
-${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 1)}
-${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_TOKEN')}`, 2)}
-${listItem(`Set the Token as an environment variable: ${cmd(`VERCEL_BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 3)}`;
+${listItem(`Pass the token directly as an option: ${getCommandName('blob list --rw-token BLOB_TOKEN')}`, 1)}
+${listItem(`Set the Token as an environment variable: ${cmd(`VERCEL_BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 2)}
+${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 3)}`;
+
+export type BlobRWToken =
+  | { token: string; success: true }
+  | { error: string; success: false };
 
 export async function getBlobRWToken(
   client: Client,
   argv: string[]
-): Promise<
-  { token: string; success: true } | { error: string; success: false }
-> {
+): Promise<BlobRWToken> {
   const flagsSpecification = getFlagsSpecification(blobCommand.options);
 
-  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
   try {
-    parsedArgs = parseArguments(argv, flagsSpecification);
+    const parsedArgs = parseArguments(argv, flagsSpecification);
+    const {
+      flags: { '--rw-token': rwToken },
+    } = parsedArgs;
+
+    if (rwToken) {
+      return { token: rwToken, success: true };
+    }
   } catch (err) {
-    return {
-      error: ErrorMessage,
-      success: false,
-    };
-  }
-
-  const {
-    flags: { '--rw-token': rwToken },
-  } = parsedArgs;
-
-  if (rwToken) {
-    return { token: rwToken, success: true };
+    // continue with token hierarchy
   }
 
   if (process.env.BLOB_READ_WRITE_TOKEN) {
@@ -48,29 +44,18 @@ export async function getBlobRWToken(
   const filename = '.env.local';
   const fullPath = resolve(client.cwd, filename);
 
-  let env: Dictionary<string | undefined> | undefined;
   try {
-    env = await createEnvObject(fullPath);
+    const env = await createEnvObject(fullPath);
+
+    if (env?.BLOB_READ_WRITE_TOKEN) {
+      return { token: env.BLOB_READ_WRITE_TOKEN, success: true };
+    }
   } catch (error) {
-    return {
-      error: ErrorMessage,
-      success: false,
-    };
+    // continue with token hierarchy
   }
 
-  if (!env) {
-    return {
-      error: ErrorMessage,
-      success: false,
-    };
-  }
-
-  if (!env.BLOB_READ_WRITE_TOKEN) {
-    return {
-      error: ErrorMessage,
-      success: false,
-    };
-  }
-
-  return { token: env.BLOB_READ_WRITE_TOKEN, success: true };
+  return {
+    error: ErrorMessage,
+    success: false,
+  };
 }

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -6,6 +6,14 @@ import type Client from '../client';
 import { getFlagsSpecification } from '../get-flags-specification';
 import { blobCommand } from '../../commands/blob/command';
 import { parseArguments } from '../get-args';
+import { getCommandName, packageName } from '../pkg-name';
+import cmd from '../output/cmd';
+import listItem from '../output/list-item';
+
+const ErrorMessage = `No Vercel Blob token found. To fix this issue, choose one of the following options:
+${listItem('Link your current folder to a Vercel Project that has a Vercel Blob store connected', 1)}
+${listItem(`Pass the token directly as an option: ${getCommandName('blob list --token BLOB_TOKEN')}`, 2)}
+${listItem(`Set the Token as an environment variable: ${cmd(`VERCEL_BLOB_READ_WRITE_TOKEN=BLOB_TOKEN ${packageName} blob list`)}`, 3)}`;
 
 export async function getBlobRWToken(
   client: Client,
@@ -20,7 +28,7 @@ export async function getBlobRWToken(
     parsedArgs = parseArguments(argv, flagsSpecification);
   } catch (err) {
     return {
-      error: "Couldn't parse arguments",
+      error: ErrorMessage,
       success: false,
     };
   }
@@ -45,21 +53,21 @@ export async function getBlobRWToken(
     env = await createEnvObject(fullPath);
   } catch (error) {
     return {
-      error: "Couldn't read .env.local file. Please check if it exists.",
+      error: ErrorMessage,
       success: false,
     };
   }
 
   if (!env) {
     return {
-      error: `No environment variables found in ${filename}`,
+      error: ErrorMessage,
       success: false,
     };
   }
 
   if (!env.BLOB_READ_WRITE_TOKEN) {
     return {
-      error: `No BLOB_READ_WRITE_TOKEN found in ${filename}`,
+      error: ErrorMessage,
       success: false,
     };
   }

--- a/packages/cli/src/util/blob/token.ts
+++ b/packages/cli/src/util/blob/token.ts
@@ -3,12 +3,40 @@ import { resolve } from 'node:path';
 import { createEnvObject } from '../env/diff-env-files';
 
 import type Client from '../client';
+import { getFlagsSpecification } from '../get-flags-specification';
+import { blobCommand } from '../../commands/blob/command';
+import { parseArguments } from '../get-args';
 
 export async function getBlobRWToken(
-  client: Client
+  client: Client,
+  argv: string[]
 ): Promise<
   { token: string; success: true } | { error: string; success: false }
 > {
+  const flagsSpecification = getFlagsSpecification(blobCommand.options);
+
+  let parsedArgs: ReturnType<typeof parseArguments<typeof flagsSpecification>>;
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    return {
+      error: "Couldn't parse arguments",
+      success: false,
+    };
+  }
+
+  const {
+    flags: { '--rw-token': rwToken },
+  } = parsedArgs;
+
+  if (rwToken) {
+    return { token: rwToken, success: true };
+  }
+
+  if (process.env.BLOB_READ_WRITE_TOKEN) {
+    return { token: process.env.BLOB_READ_WRITE_TOKEN, success: true };
+  }
+
   const filename = '.env.local';
   const fullPath = resolve(client.cwd, filename);
 

--- a/packages/cli/src/util/telemetry/commands/blob/index.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/index.ts
@@ -40,4 +40,11 @@ export class BlobTelemetryClient
       value: actual,
     });
   }
+
+  trackCliOptionRwToken() {
+    this.trackCliOption({
+      option: '--rw-token',
+      value: this.redactedValue,
+    });
+  }
 }

--- a/packages/cli/test/unit/commands/blob/copy.test.ts
+++ b/packages/cli/test/unit/commands/blob/copy.test.ts
@@ -15,13 +15,15 @@ const mockedGetBlobRWToken = vi.mocked(getBlobRWTokenModule.getBlobRWToken);
 const mockedOutput = vi.mocked(output);
 
 describe('blob copy', () => {
+  const testToken = 'vercel_blob_rw_test_token_123';
+
   beforeEach(() => {
     vi.clearAllMocks();
     client.reset();
 
     // Default successful mocks
     mockedGetBlobRWToken.mockResolvedValue({
-      token: 'test-token',
+      token: testToken,
       success: true,
     });
     mockedBlob.copy.mockResolvedValue({
@@ -37,12 +39,15 @@ describe('blob copy', () => {
     it('should copy blob successfully and track telemetry', async () => {
       client.setArgv('blob', 'copy', 'source.txt', 'dest.txt');
 
-      const exitCode = await copy(client, ['source.txt', 'dest.txt']);
+      const exitCode = await copy(
+        client,
+        ['source.txt', 'dest.txt'],
+        testToken
+      );
 
       expect(exitCode).toBe(0);
-      expect(mockedGetBlobRWToken).toHaveBeenCalledWith(client);
       expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
-        token: 'test-token',
+        token: testToken,
         access: 'public',
         addRandomSuffix: false,
         contentType: undefined,
@@ -79,19 +84,23 @@ describe('blob copy', () => {
         'dest.png'
       );
 
-      const exitCode = await copy(client, [
-        '--add-random-suffix',
-        '--content-type',
-        'image/png',
-        '--cache-control-max-age',
-        '86400',
-        'source.png',
-        'dest.png',
-      ]);
+      const exitCode = await copy(
+        client,
+        [
+          '--add-random-suffix',
+          '--content-type',
+          'image/png',
+          '--cache-control-max-age',
+          '86400',
+          'source.png',
+          'dest.png',
+        ],
+        testToken
+      );
 
       expect(exitCode).toBe(0);
       expect(mockedBlob.copy).toHaveBeenCalledWith('source.png', 'dest.png', {
-        token: 'test-token',
+        token: testToken,
         access: 'public',
         addRandomSuffix: true,
         contentType: 'image/png',
@@ -126,11 +135,31 @@ describe('blob copy', () => {
       const sourceUrl = 'https://example.com/source.txt';
       client.setArgv('blob', 'copy', sourceUrl, 'dest.txt');
 
-      const exitCode = await copy(client, [sourceUrl, 'dest.txt']);
+      const exitCode = await copy(client, [sourceUrl, 'dest.txt'], testToken);
 
       expect(exitCode).toBe(0);
       expect(mockedBlob.copy).toHaveBeenCalledWith(sourceUrl, 'dest.txt', {
-        token: 'test-token',
+        token: testToken,
+        access: 'public',
+        addRandomSuffix: false,
+        contentType: undefined,
+        cacheControlMaxAge: undefined,
+      });
+    });
+
+    it('should use provided token directly', async () => {
+      const customToken = 'vercel_blob_rw_custom_456';
+      client.setArgv('blob', 'copy', 'source.txt', 'dest.txt');
+
+      const exitCode = await copy(
+        client,
+        ['source.txt', 'dest.txt'],
+        customToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+        token: customToken,
         access: 'public',
         addRandomSuffix: false,
         contentType: undefined,
@@ -148,27 +177,19 @@ describe('blob copy', () => {
         }),
       }));
 
-      const exitCode = await copy(client, ['--invalid-flag']);
+      const exitCode = await copy(client, ['--invalid-flag'], testToken);
       expect(exitCode).toBe(1);
-    });
-
-    it('should return 1 when token is not available', async () => {
-      mockedGetBlobRWToken.mockResolvedValue({
-        error: 'No token found',
-        success: false,
-      });
-
-      const exitCode = await copy(client, ['source.txt', 'dest.txt']);
-
-      expect(exitCode).toBe(1);
-      expect(mockedBlob.copy).not.toHaveBeenCalled();
     });
 
     it('should return 1 when blob copy fails', async () => {
       const copyError = new Error('Blob copy failed');
       mockedBlob.copy.mockRejectedValue(copyError);
 
-      const exitCode = await copy(client, ['source.txt', 'dest.txt']);
+      const exitCode = await copy(
+        client,
+        ['source.txt', 'dest.txt'],
+        testToken
+      );
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.spinner).toHaveBeenCalledWith('Copying blob');
@@ -177,7 +198,14 @@ describe('blob copy', () => {
     });
 
     it('should return 1 when no arguments are provided', async () => {
-      const exitCode = await copy(client, []);
+      const exitCode = await copy(client, [], testToken);
+
+      expect(exitCode).toBe(1);
+      expect(mockedOutput.success).not.toHaveBeenCalled();
+    });
+
+    it('should return 1 when only one argument is provided', async () => {
+      const exitCode = await copy(client, ['source.txt'], testToken);
 
       expect(exitCode).toBe(1);
       expect(mockedOutput.success).not.toHaveBeenCalled();
@@ -188,7 +216,7 @@ describe('blob copy', () => {
     it('should not track optional flags when not provided', async () => {
       client.setArgv('blob', 'copy', 'source.txt', 'dest.txt');
 
-      await copy(client, ['source.txt', 'dest.txt']);
+      await copy(client, ['source.txt', 'dest.txt'], testToken);
 
       // Should only have argument events, no flag or option events
       expect(client.telemetryEventStore).not.toHaveTelemetryEvents([
@@ -215,12 +243,11 @@ describe('blob copy', () => {
         'dest.json'
       );
 
-      await copy(client, [
-        '--content-type',
-        'application/json',
-        'source.json',
-        'dest.json',
-      ]);
+      await copy(
+        client,
+        ['--content-type', 'application/json', 'source.json', 'dest.json'],
+        testToken
+      );
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
@@ -248,12 +275,11 @@ describe('blob copy', () => {
         'dest.txt'
       );
 
-      await copy(client, [
-        '--cache-control-max-age',
-        '3600',
-        'source.txt',
-        'dest.txt',
-      ]);
+      await copy(
+        client,
+        ['--cache-control-max-age', '3600', 'source.txt', 'dest.txt'],
+        testToken
+      );
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
@@ -274,11 +300,15 @@ describe('blob copy', () => {
 
   describe('flag variations', () => {
     it('should handle addRandomSuffix flag correctly when false', async () => {
-      const exitCode = await copy(client, ['source.txt', 'dest.txt']);
+      const exitCode = await copy(
+        client,
+        ['source.txt', 'dest.txt'],
+        testToken
+      );
 
       expect(exitCode).toBe(0);
       expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
-        token: 'test-token',
+        token: testToken,
         access: 'public',
         addRandomSuffix: false,
         contentType: undefined,
@@ -287,20 +317,149 @@ describe('blob copy', () => {
     });
 
     it('should handle addRandomSuffix flag correctly when true', async () => {
-      const exitCode = await copy(client, [
-        '--add-random-suffix',
-        'source.txt',
-        'dest.txt',
-      ]);
+      const exitCode = await copy(
+        client,
+        ['--add-random-suffix', 'source.txt', 'dest.txt'],
+        testToken
+      );
 
       expect(exitCode).toBe(0);
       expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
-        token: 'test-token',
+        token: testToken,
         access: 'public',
         addRandomSuffix: true,
         contentType: undefined,
         cacheControlMaxAge: undefined,
       });
+    });
+  });
+
+  describe('token handling', () => {
+    it('should work with different token formats', async () => {
+      const tokenFormats = [
+        'vercel_blob_rw_abc_def123',
+        'vercel_blob_rw_xyz_789ghi',
+        'vercel_blob_rw_test_token_456',
+      ];
+
+      for (const token of tokenFormats) {
+        const exitCode = await copy(client, ['source.txt', 'dest.txt'], token);
+
+        expect(exitCode).toBe(0);
+        expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+          token,
+          access: 'public',
+          addRandomSuffix: false,
+          contentType: undefined,
+          cacheControlMaxAge: undefined,
+        });
+      }
+    });
+
+    it('should handle empty token', async () => {
+      const exitCode = await copy(client, ['source.txt', 'dest.txt'], '');
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith('source.txt', 'dest.txt', {
+        token: '',
+        access: 'public',
+        addRandomSuffix: false,
+        contentType: undefined,
+        cacheControlMaxAge: undefined,
+      });
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle copying files with special characters in names', async () => {
+      const specialFiles = [
+        'file with spaces.txt',
+        'file-with-hyphens.txt',
+        'file_with_underscores.txt',
+        'file.with.dots.txt',
+        'file@with@symbols.txt',
+      ];
+
+      for (const filename of specialFiles) {
+        const exitCode = await copy(client, [filename, 'dest.txt'], testToken);
+        expect(exitCode).toBe(0);
+        expect(mockedBlob.copy).toHaveBeenCalledWith(
+          filename,
+          'dest.txt',
+          expect.any(Object)
+        );
+      }
+    });
+
+    it('should handle copying to different destination formats', async () => {
+      const destinations = [
+        'simple-dest.txt',
+        'folder/nested/dest.txt',
+        'dest-with-timestamp-2023.txt',
+        'dest.backup.txt',
+      ];
+
+      for (const dest of destinations) {
+        const exitCode = await copy(client, ['source.txt', dest], testToken);
+        expect(exitCode).toBe(0);
+        expect(mockedBlob.copy).toHaveBeenCalledWith(
+          'source.txt',
+          dest,
+          expect.any(Object)
+        );
+      }
+    });
+
+    it('should handle copying with multiple options simultaneously', async () => {
+      const exitCode = await copy(
+        client,
+        [
+          '--add-random-suffix',
+          '--content-type',
+          'application/pdf',
+          '--cache-control-max-age',
+          '7200',
+          'document.pdf',
+          'backup/document-copy.pdf',
+        ],
+        testToken
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockedBlob.copy).toHaveBeenCalledWith(
+        'document.pdf',
+        'backup/document-copy.pdf',
+        {
+          token: testToken,
+          access: 'public',
+          addRandomSuffix: true,
+          contentType: 'application/pdf',
+          cacheControlMaxAge: 7200,
+        }
+      );
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'argument:fromUrlOrPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'argument:toPathname',
+          value: '[REDACTED]',
+        },
+        {
+          key: 'flag:add-random-suffix',
+          value: 'TRUE',
+        },
+        {
+          key: 'option:content-type',
+          value: 'application/pdf',
+        },
+        {
+          key: 'option:cache-control-max-age',
+          value: '7200',
+        },
+      ]);
     });
   });
 });

--- a/packages/cli/test/unit/util/blob/token.test.ts
+++ b/packages/cli/test/unit/util/blob/token.test.ts
@@ -1,0 +1,286 @@
+import { describe, beforeEach, expect, it, vi, afterEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import { getBlobRWToken } from '../../../../src/util/blob/token';
+import * as envDiffModule from '../../../../src/util/env/diff-env-files';
+
+// Mock dependencies
+vi.mock('../../../../src/util/env/diff-env-files');
+
+const mockedCreateEnvObject = vi.mocked(envDiffModule.createEnvObject);
+
+describe('getBlobRWToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+
+    // Reset environment variables
+    process.env = { ...originalEnv };
+    process.env.BLOB_READ_WRITE_TOKEN = undefined;
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  describe('--rw-token flag priority', () => {
+    it('should use --rw-token flag when provided', async () => {
+      const tokenFromFlag = 'vercel_blob_rw_flag_token_456';
+      const argv = [
+        'blob',
+        'copy',
+        '--rw-token',
+        tokenFromFlag,
+        'source.txt',
+        'dest.txt',
+      ];
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: tokenFromFlag,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).not.toHaveBeenCalled();
+    });
+
+    it('should prioritize --rw-token over environment variables', async () => {
+      process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_env_token_789';
+      const tokenFromFlag = 'vercel_blob_rw_flag_token_456';
+      const argv = [
+        'blob',
+        'copy',
+        '--rw-token',
+        tokenFromFlag,
+        'source.txt',
+        'dest.txt',
+      ];
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: tokenFromFlag,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).not.toHaveBeenCalled();
+    });
+
+    it('should prioritize --rw-token over .env.local file', async () => {
+      const tokenFromFlag = 'vercel_blob_rw_flag_token_456';
+      const argv = [
+        'blob',
+        'copy',
+        '--rw-token',
+        tokenFromFlag,
+        'source.txt',
+        'dest.txt',
+      ];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_env_file_token_123',
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: tokenFromFlag,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('BLOB_READ_WRITE_TOKEN environment variable', () => {
+    it('should use BLOB_READ_WRITE_TOKEN environment variable when no flag provided', async () => {
+      const envToken = 'vercel_blob_rw_env_token_789';
+      process.env.BLOB_READ_WRITE_TOKEN = envToken;
+      const argv = ['blob', 'copy', 'source.txt', 'dest.txt'];
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: envToken,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).not.toHaveBeenCalled();
+    });
+
+    it('should prioritize environment variable over .env.local file', async () => {
+      const envToken = 'vercel_blob_rw_env_token_priority';
+      process.env.BLOB_READ_WRITE_TOKEN = envToken;
+      const argv = ['blob', 'del', 'file.txt'];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_env_file_token_123',
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: envToken,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('.env.local file fallback', () => {
+    it('should read token from .env.local file when no flag or env var provided', async () => {
+      const envFileToken = 'vercel_blob_rw_env_file_token_123';
+      const argv = ['blob', 'copy', 'source.txt', 'dest.txt'];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        BLOB_READ_WRITE_TOKEN: envFileToken,
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: envFileToken,
+        success: true,
+      });
+      expect(mockedCreateEnvObject).toHaveBeenCalledWith(
+        expect.stringMatching(/\.env\.local$/)
+      );
+    });
+
+    it('should return error when .env.local file cannot be read', async () => {
+      const argv = ['blob', 'list'];
+
+      mockedCreateEnvObject.mockRejectedValue(new Error('File not found'));
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        error: expect.any(String),
+        success: false,
+      });
+    });
+
+    it('should return error when .env.local file returns no environment variables', async () => {
+      const argv = ['blob', 'list'];
+
+      mockedCreateEnvObject.mockResolvedValue(undefined);
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        error: expect.any(String),
+        success: false,
+      });
+    });
+
+    it('should return error when BLOB_READ_WRITE_TOKEN is not in .env.local', async () => {
+      const argv = ['blob', 'list'];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        OTHER_VAR: 'some-value',
+        ANOTHER_VAR: 'another-value',
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        error: expect.any(String),
+        success: false,
+      });
+    });
+
+    it('should handle .env.local with empty BLOB_READ_WRITE_TOKEN', async () => {
+      const argv = ['blob', 'list'];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        BLOB_READ_WRITE_TOKEN: '',
+        OTHER_VAR: 'some-value',
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        error: expect.any(String),
+        success: false,
+      });
+    });
+
+    it('should handle .env.local with undefined BLOB_READ_WRITE_TOKEN', async () => {
+      const argv = ['blob', 'list'];
+
+      mockedCreateEnvObject.mockResolvedValue({
+        BLOB_READ_WRITE_TOKEN: undefined,
+        OTHER_VAR: 'some-value',
+      });
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        error: expect.any(String),
+        success: false,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle multiple --rw-token flags (last one wins)', async () => {
+      const firstToken = 'vercel_blob_rw_first_token';
+      const lastToken = 'vercel_blob_rw_last_token';
+      const argv = [
+        'blob',
+        'copy',
+        '--rw-token',
+        firstToken,
+        '--rw-token',
+        lastToken,
+        'source.txt',
+        'dest.txt',
+      ];
+
+      const result = await getBlobRWToken(client, argv);
+
+      expect(result).toEqual({
+        token: lastToken,
+        success: true,
+      });
+    });
+  });
+
+  describe('integration with different blob commands', () => {
+    it('should work with all blob subcommands', async () => {
+      const token = 'vercel_blob_rw_integration_token';
+      const subcommands = [
+        ['blob', 'list', '--rw-token', token],
+        ['blob', 'put', '--rw-token', token, 'file.txt'],
+        ['blob', 'copy', '--rw-token', token, 'source.txt', 'dest.txt'],
+        ['blob', 'del', '--rw-token', token, 'file.txt'],
+        ['blob', 'store', 'get', '--rw-token', token],
+      ];
+
+      for (const argv of subcommands) {
+        const result = await getBlobRWToken(client, argv);
+        expect(result).toEqual({
+          token,
+          success: true,
+        });
+      }
+    });
+
+    it('should handle mixed flag positions', async () => {
+      const token = 'vercel_blob_rw_position_test';
+      const argvVariations = [
+        ['blob', '--rw-token', token, 'copy', 'source.txt', 'dest.txt'],
+        ['blob', 'copy', '--rw-token', token, 'source.txt', 'dest.txt'],
+        ['blob', 'copy', 'source.txt', '--rw-token', token, 'dest.txt'],
+        ['blob', 'copy', 'source.txt', 'dest.txt', '--rw-token', token],
+      ];
+
+      for (const argv of argvVariations) {
+        const result = await getBlobRWToken(client, argv);
+        expect(result).toEqual({
+          token,
+          success: true,
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Prev the token was only read from .env.local. For better ci and local experience you can also pass the token as an option or as an env var now