### PR TITLE
[routing-utils]: Update routes to support transforms

### DIFF
--- a/.changeset/little-foxes-heal.md
+++ b/.changeset/little-foxes-heal.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+support transform rules in vercel.json

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -251,26 +251,86 @@ const transformsSchema = {
         anyOf: [
           {
             type: 'string',
+            maxLength: 4096,
           },
           {
             type: 'array',
+            minItems: 1,
             items: {
               type: 'string',
+              maxLength: 4096,
             },
           },
         ],
       },
     },
-    if: {
-      properties: {
-        op: {
-          enum: ['append', 'set'],
+    allOf: [
+      {
+        if: {
+          properties: {
+            op: {
+              enum: ['append', 'set'],
+            },
+          },
+        },
+        then: {
+          required: ['args'],
         },
       },
-    },
-    then: {
-      required: ['args'],
-    },
+      {
+        if: {
+          allOf: [
+            {
+              properties: {
+                type: {
+                  enum: ['request.headers', 'response.headers'],
+                },
+              },
+            },
+            {
+              properties: {
+                op: {
+                  enum: ['set', 'append'],
+                },
+              },
+            },
+          ],
+        },
+        then: {
+          properties: {
+            target: {
+              properties: {
+                key: {
+                  if: {
+                    type: 'string',
+                  },
+                  then: {
+                    pattern: '^[a-zA-Z0-9_-]+$',
+                  },
+                },
+              },
+            },
+            args: {
+              anyOf: [
+                {
+                  type: 'string',
+                  pattern:
+                    '^[a-zA-Z0-9_ :;.,"\'?!(){}\\[\\]@<>=+*#$&`|~\\^%/-]+$',
+                },
+                {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                    pattern:
+                      '^[a-zA-Z0-9_ :;.,"\'?!(){}\\[\\]@<>=+*#$&`|~\\^%/-]+$',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
   },
 } as const;
 

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -39,6 +39,29 @@ export type HasField = Array<
     }
 >;
 
+type Transform = {
+  type: 'request.headers' | 'request.query' | 'response.headers';
+  op: 'append' | 'set' | 'delete';
+  target: {
+    // re is not supported for transforms. Once supported, replace key with MatchableValue.
+    key:
+      | string
+      | {
+          eq?: string | number;
+          neq?: string;
+          inc?: string[];
+          ninc?: string[];
+          pre?: string;
+          suf?: string;
+          gt?: number;
+          gte?: number;
+          lt?: number;
+          lte?: number;
+        };
+  };
+  args?: string | string[];
+};
+
 export type RouteWithSrc = {
   src: string;
   dest?: string;
@@ -55,6 +78,7 @@ export type RouteWithSrc = {
   mitigate?: {
     action: MitigateAction;
   };
+  transforms?: Transform[];
   locale?: {
     redirect?: Record<string, string>;
     cookie?: string;


### PR DESCRIPTION
### TL;DR

Added support for transforms in routing configuration to modify request/response headers and query parameters.

### What changed?

- Added a new `transformsSchema` to validate transform rules in route configurations
- Extended the `RouteWithSrc` type to include an optional `transforms` property
- Added a new `Transform` type that defines the structure for transform operations
- Added comprehensive test cases to validate the transforms functionality

The transforms feature allows three operations:
- `append`: Add values to headers or query parameters
- `set`: Replace values in headers or query parameters
- `delete`: Remove headers or query parameters

These operations can target:
- `request.headers`: HTTP headers in the incoming request
- `request.query`: Query parameters in the URL
- `response.headers`: HTTP headers in the outgoing response

### How to test?

`pnpm test` in `packages/routing-utils`. 

### Why make this change?

This change enables more flexible request and response manipulation in routing configurations. Users can now modify headers and query parameters directly in their routing rules without requiring custom middleware or serverless functions, improving performance and simplifying configuration.