### PR TITLE
[next] Ensure we await node middleware import for TLA

### DIFF
--- a/.changeset/spotty-buckets-clean.md
+++ b/.changeset/spotty-buckets-clean.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Ensure we await node middleware import for top-level await

--- a/packages/next/src/middleware-launcher.ts
+++ b/packages/next/src/middleware-launcher.ts
@@ -29,7 +29,7 @@ const conf = __NEXT_CONFIG__;
 (globalThis as any).AsyncLocalStorage =
   require('async_hooks').AsyncLocalStorage;
 
-const middlewareHandler = require('__NEXT_MIDDLEWARE_PATH__').default;
+const middlewareModule = require('__NEXT_MIDDLEWARE_PATH__');
 
 // Returns a wrapped handler that runs with "@next/request-context"
 // and will crash the lambda if an error isn't caught.
@@ -39,6 +39,10 @@ const serve = async (request: Request): Promise<Response> => {
     return await withNextRequestContext(
       { waitUntil: context.waitUntil },
       async () => {
+        // we need to await as it could use top-level await
+        let middlewareHandler = await middlewareModule;
+        middlewareHandler = middlewareHandler.default || middlewareHandler;
+
         const result = await middlewareHandler({
           request: {
             url: request.url,


### PR DESCRIPTION
This ensures we await loading the middleware module as it can be a promise due to top-level await. This matches the handling we have here https://github.com/vercel/next.js/blob/8324d8108c33e2a92d66c59bfa15b0a97cd99ef7/packages/next/src/server/next-server.ts#L1697