### PR TITLE
[cli][feature-flagged] adds stub `vercel guidance` command

### DIFF
--- a/.changeset/wise-cars-judge.md
+++ b/.changeset/wise-cars-judge.md
@@ -1,0 +1,6 @@
+---
+"vercel": patch
+"@vercel-internals/types": patch
+---
+
+[cli][feature-flagged] adds stub `vercel guidance` command

--- a/.changeset/wise-cars-judge.md
+++ b/.changeset/wise-cars-judge.md
@@ -1,6 +1,5 @@
 ---
 "vercel": patch
-"@vercel-internals/types": patch
 ---
 
 [cli][feature-flagged] adds stub `vercel guidance` command

--- a/internals/types/index.d.ts
+++ b/internals/types/index.d.ts
@@ -62,6 +62,9 @@ export interface GlobalConfig {
   telemetry?: {
     enabled?: boolean;
   };
+  guidance?: {
+    enabled?: boolean;
+  };
 }
 
 type Billing = {

--- a/packages/cli/src/commands/guidance/command.ts
+++ b/packages/cli/src/commands/guidance/command.ts
@@ -1,0 +1,36 @@
+export const statusSubcommand = {
+  name: 'status',
+  aliases: [],
+  description: 'Shows whether guidance messages are enabled or disabled',
+  arguments: [],
+  options: [],
+  examples: [],
+} as const;
+
+export const enableSubcommand = {
+  name: 'enable',
+  aliases: [],
+  description: 'Enables guidance messages',
+  arguments: [],
+  options: [],
+  examples: [],
+} as const;
+
+export const disableSubcommand = {
+  name: 'disable',
+  aliases: [],
+  description: 'Disables guidance messages',
+  arguments: [],
+  options: [],
+  examples: [],
+} as const;
+
+export const guidanceCommand = {
+  name: 'guidance',
+  aliases: [],
+  description: 'Allows you to enable or disable guidance messages',
+  arguments: [],
+  subcommands: [enableSubcommand, disableSubcommand, statusSubcommand],
+  options: [],
+  examples: [],
+} as const;

--- a/packages/cli/src/commands/guidance/disable.ts
+++ b/packages/cli/src/commands/guidance/disable.ts
@@ -5,7 +5,7 @@ import status from './status';
 export default async function disable(client: Client) {
   client.config = {
     ...client.config,
-    telemetry: {
+    guidance: {
       ...client.config.guidance,
       enabled: false,
     },

--- a/packages/cli/src/commands/guidance/disable.ts
+++ b/packages/cli/src/commands/guidance/disable.ts
@@ -1,0 +1,17 @@
+import type Client from '../../util/client';
+import { writeToConfigFile } from '../../util/config/files';
+import status from './status';
+
+export default async function disable(client: Client) {
+  client.config = {
+    ...client.config,
+    telemetry: {
+      ...client.config.guidance,
+      enabled: false,
+    },
+  };
+
+  writeToConfigFile(client.config);
+  await status(client);
+  return 0;
+}

--- a/packages/cli/src/commands/guidance/enable.ts
+++ b/packages/cli/src/commands/guidance/enable.ts
@@ -5,7 +5,7 @@ import status from './status';
 export default async function enable(client: Client) {
   client.config = {
     ...client.config,
-    telemetry: {
+    guidance: {
       ...client.config.guidance,
       enabled: true,
     },

--- a/packages/cli/src/commands/guidance/enable.ts
+++ b/packages/cli/src/commands/guidance/enable.ts
@@ -1,0 +1,17 @@
+import type Client from '../../util/client';
+import { writeToConfigFile } from '../../util/config/files';
+import status from './status';
+
+export default async function enable(client: Client) {
+  client.config = {
+    ...client.config,
+    telemetry: {
+      ...client.config.guidance,
+      enabled: true,
+    },
+  };
+
+  writeToConfigFile(client.config);
+  await status(client);
+  return 0;
+}

--- a/packages/cli/src/commands/guidance/index.ts
+++ b/packages/cli/src/commands/guidance/index.ts
@@ -24,6 +24,13 @@ const COMMAND_CONFIG = {
 };
 
 export default async function guidance(client: Client) {
+  if (!process.env.FF_GUIDANCE_MODE) {
+    // technically unreachable because `main` will not call this.
+    // present here to allow us to unit test.
+    output.error('The guidance subcommand does not exist');
+    return 1;
+  }
+
   const telemetryClient = new GuidanceTelemetryClient({
     opts: {
       store: client.telemetryEventStore,

--- a/packages/cli/src/commands/guidance/index.ts
+++ b/packages/cli/src/commands/guidance/index.ts
@@ -1,0 +1,94 @@
+import { printError } from '../../util/error';
+import { parseArguments } from '../../util/get-args';
+import getSubcommand from '../../util/get-subcommand';
+import { type Command, help } from '../help';
+import status from './status';
+import enable from './enable';
+import disable from './disable';
+import {
+  disableSubcommand,
+  enableSubcommand,
+  statusSubcommand,
+  guidanceCommand,
+} from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { GuidanceTelemetryClient } from '../../util/telemetry/commands/guidance';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import { getCommandAliases } from '..';
+
+const COMMAND_CONFIG = {
+  status: getCommandAliases(statusSubcommand),
+  enable: getCommandAliases(enableSubcommand),
+  disable: getCommandAliases(disableSubcommand),
+};
+
+export default async function guidance(client: Client) {
+  const telemetryClient = new GuidanceTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+  let parsedArguments;
+
+  const flagsSpecification = getFlagsSpecification(guidanceCommand.options);
+
+  try {
+    parsedArguments = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { subcommand, subcommandOriginal } = getSubcommand(
+    parsedArguments.args.slice(1),
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArguments.flags['--help'];
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, {
+        columns: client.stderr.columns,
+        parent: guidanceCommand,
+      })
+    );
+  }
+
+  if (!subcommand && needHelp) {
+    telemetryClient.trackCliFlagHelp('telemetry', subcommand);
+    output.print(help(guidanceCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  switch (subcommand) {
+    case 'status':
+      if (needHelp) {
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        printHelp(statusSubcommand);
+        return 2;
+      }
+      telemetryClient.trackCliSubcommandStatus(subcommandOriginal);
+      return status(client);
+    case 'enable':
+      if (needHelp) {
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        printHelp(enableSubcommand);
+        return 2;
+      }
+      telemetryClient.trackCliSubcommandEnable(subcommandOriginal);
+      return enable(client);
+    case 'disable':
+      if (needHelp) {
+        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        printHelp(disableSubcommand);
+        return 2;
+      }
+      return disable(client);
+    default: {
+      output.print(help(guidanceCommand, { columns: client.stderr.columns }));
+      return 2;
+    }
+  }
+}

--- a/packages/cli/src/commands/guidance/index.ts
+++ b/packages/cli/src/commands/guidance/index.ts
@@ -64,7 +64,7 @@ export default async function guidance(client: Client) {
   }
 
   if (!subcommand && needHelp) {
-    telemetryClient.trackCliFlagHelp('telemetry', subcommand);
+    telemetryClient.trackCliFlagHelp('guidance', subcommand);
     output.print(help(guidanceCommand, { columns: client.stderr.columns }));
     return 2;
   }
@@ -72,7 +72,7 @@ export default async function guidance(client: Client) {
   switch (subcommand) {
     case 'status':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(statusSubcommand);
         return 2;
       }
@@ -80,7 +80,7 @@ export default async function guidance(client: Client) {
       return status(client);
     case 'enable':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(enableSubcommand);
         return 2;
       }
@@ -88,7 +88,7 @@ export default async function guidance(client: Client) {
       return enable(client);
     case 'disable':
       if (needHelp) {
-        telemetryClient.trackCliFlagHelp('telemetry', subcommandOriginal);
+        telemetryClient.trackCliFlagHelp('guidance', subcommandOriginal);
         printHelp(disableSubcommand);
         return 2;
       }

--- a/packages/cli/src/commands/guidance/status.ts
+++ b/packages/cli/src/commands/guidance/status.ts
@@ -1,0 +1,13 @@
+import chalk from 'chalk';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+
+export default async function status(client: Client) {
+  const enabled = client.config.guidance?.enabled !== false;
+
+  const status = enabled ? chalk.green('Enabled') : chalk.red('Disabled');
+  output.print('\n');
+  output.log(`${chalk.bold('Guidance status')}: ${status}\n`);
+
+  return 0;
+}

--- a/packages/cli/src/commands/guidance/status.ts
+++ b/packages/cli/src/commands/guidance/status.ts
@@ -7,7 +7,8 @@ export default async function status(client: Client) {
 
   const status = enabled ? chalk.green('Enabled') : chalk.red('Disabled');
   output.print('\n');
-  output.log(`${chalk.bold('Guidance status')}: ${status}\n`);
+  output.log(`${chalk.bold('Guidance status')}: ${status}`);
+  output.print('\n');
 
   return 0;
 }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -8,6 +8,7 @@ import { dnsCommand } from './dns/command';
 import { domainsCommand } from './domains/command';
 import { envCommand } from './env/command';
 import { gitCommand } from './git/command';
+import { guidanceCommand } from './guidance/command';
 import { initCommand } from './init/command';
 import { inspectCommand } from './inspect/command';
 import { installCommand } from './install/command';
@@ -71,6 +72,10 @@ const commandsStructs = [
   // added because we don't have a full help command
   { name: 'help', aliases: [] },
 ];
+
+if (process.env.FF_GUIDANCE_MODE) {
+  commandsStructs.push(guidanceCommand);
+}
 
 export function getCommandAliases(command: Pick<Command, 'name' | 'aliases'>) {
   return [command.name].concat(command.aliases);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -75,6 +75,7 @@ import { help } from './args';
 import { updateCurrentTeamAfterLogin } from './util/login/update-current-team-after-login';
 import { checkTelemetryStatus } from './util/telemetry/check-status';
 import output from './output-manager';
+import { checkGuidanceStatus } from './util/guidance/check-status';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -265,6 +266,12 @@ const main = async () => {
   checkTelemetryStatus({
     config,
   });
+
+  if (process.env.FF_GUIDANCE_MODE) {
+    checkGuidanceStatus({
+      config,
+    });
+  }
 
   const telemetry = new RootTelemetryClient({
     opts: {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -376,6 +376,10 @@ const main = async () => {
     'telemetry',
   ];
 
+  if (process.env.FF_GUIDANCE_MODE) {
+    subcommandsWithoutToken.push('guidance');
+  }
+
   // Prompt for login if there is no current token
   if (
     (!authConfig || !authConfig.token) &&
@@ -639,6 +643,15 @@ const main = async () => {
           telemetry.trackCliCommandGit(userSuppliedSubCommand);
           func = require('./commands/git').default;
           break;
+        case 'guidance':
+          if (process.env.FF_GUIDANCE_MODE) {
+            telemetry.trackCliCommandGuidance(userSuppliedSubCommand);
+            func = require('./commands/guidance').default;
+            break;
+          } else {
+            func = null;
+            break;
+          }
         case 'init':
           telemetry.trackCliCommandInit(userSuppliedSubCommand);
           func = require('./commands/init').default;

--- a/packages/cli/src/util/guidance/check-status.ts
+++ b/packages/cli/src/util/guidance/check-status.ts
@@ -5,6 +5,13 @@ import output from '../../output-manager';
 
 export function checkGuidanceStatus({ config }: { config: GlobalConfig }) {
   if (!process.env.FF_GUIDANCE_MODE) {
+    // disabling guidance if not flagged into experimenting with it.
+    return;
+  }
+
+  if (process.env.CI) {
+    // disabling guidance initial enabling if in a CI environment
+    // which includes Vercel's build container.
     return;
   }
 

--- a/packages/cli/src/util/guidance/check-status.ts
+++ b/packages/cli/src/util/guidance/check-status.ts
@@ -3,20 +3,20 @@ import * as configFiles from '../config/files';
 
 import output from '../../output-manager';
 
-export function checkTelemetryStatus({ config }: { config: GlobalConfig }) {
+export function checkGuidanceStatus({ config }: { config: GlobalConfig }) {
   if (!process.env.FF_GUIDANCE_MODE) {
-    return;
-  }
-
-  if (config.guidance) {
-    // telemetry has been set previously by this check of
-    // user running vercel telemetry commands
     return;
   }
 
   if (process.env.VERCEL_GUIDANCE_DISABLED) {
     // disabling guidance with the environment variable
     // implies the user has already been informed
+    return;
+  }
+
+  if (config.guidance) {
+    // telemetry has been set previously by this check of
+    // user running vercel telemetry commands
     return;
   }
 

--- a/packages/cli/src/util/guidance/check-status.ts
+++ b/packages/cli/src/util/guidance/check-status.ts
@@ -1,0 +1,35 @@
+import type { GlobalConfig } from '@vercel-internals/types';
+import * as configFiles from '../config/files';
+
+import output from '../../output-manager';
+
+export function checkTelemetryStatus({ config }: { config: GlobalConfig }) {
+  if (!process.env.FF_GUIDANCE_MODE) {
+    return;
+  }
+
+  if (config.guidance) {
+    // telemetry has been set previously by this check of
+    // user running vercel telemetry commands
+    return;
+  }
+
+  if (process.env.VERCEL_GUIDANCE_DISABLED) {
+    // disabling guidance with the environment variable
+    // implies the user has already been informed
+    return;
+  }
+
+  output.note(
+    'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
+  );
+  output.log('You cand disable this feature by running:');
+  output.log('vercel guidance disable');
+  output.log('or by setting VERCEL_GUIDANCE_DISABLED=1');
+
+  config.guidance = {
+    enabled: true,
+  };
+
+  configFiles.writeToConfigFile(config);
+}

--- a/packages/cli/src/util/guidance/check-status.ts
+++ b/packages/cli/src/util/guidance/check-status.ts
@@ -30,7 +30,7 @@ export function checkGuidanceStatus({ config }: { config: GlobalConfig }) {
   output.note(
     'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
   );
-  output.log('You cand disable this feature by running:');
+  output.log('You can disable this feature by running:');
   output.log('vercel guidance disable');
   output.log('or by setting VERCEL_GUIDANCE_DISABLED=1');
 

--- a/packages/cli/src/util/telemetry/commands/guidance/index.ts
+++ b/packages/cli/src/util/telemetry/commands/guidance/index.ts
@@ -1,0 +1,29 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { guidanceCommand } from '../../../../commands/guidance/command';
+
+export class GuidanceTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof guidanceCommand>
+{
+  trackCliSubcommandStatus(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'status',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandEnable(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'enable',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDisable(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'disable',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -89,6 +89,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandGuidance(actual: string) {
+    this.trackCliCommand({
+      command: 'guidance',
+      value: actual,
+    });
+  }
+
   trackCliCommandHelp(actual: string) {
     this.trackCliCommand({
       command: 'help',

--- a/packages/cli/test/unit/commands/guidance/index.test.ts
+++ b/packages/cli/test/unit/commands/guidance/index.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import guidance from '../../../../src/commands/guidance';
+import { client } from '../../../mocks/client';
+import * as configFilesUtil from '../../../../src/util/config/files';
+
+describe('guidance', () => {
+  const setSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
+
+  afterEach(() => {
+    setSpy.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe('FF_GUIDANCE_MODE unset', () => {
+    it('exits with error', async () => {
+      const command = 'guidance';
+
+      client.setArgv(command, '--help');
+      const exitCodePromise = guidance(client);
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+  });
+
+  describe('FF_GUIDANCE_MODE set', () => {
+    beforeEach(() => {
+      vi.stubEnv('FF_GUIDANCE_MODE', '1');
+    });
+
+    describe('--help', () => {
+      it('tracks guidance', async () => {
+        const command = 'guidance';
+
+        client.setArgv(command, '--help');
+        const exitCodePromise = guidance(client);
+        await expect(exitCodePromise).resolves.toEqual(2);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'flag:help',
+            value: command,
+          },
+        ]);
+      });
+    });
+
+    it('should show an error with the guidance help menu when no subcommands are passed', async () => {
+      const args: string[] = [];
+
+      client.setArgv('guidance', ...args);
+      const exitCode = await guidance(client);
+      expect(client.stdout).toOutput(
+        `Error: No subcommand provided. See help instructions for usage`
+      );
+      expect(exitCode).toBe(2);
+    });
+
+    it('should show an error with the guidance help menu when an invalid command is passed', async () => {
+      const args = ['invalid-command'];
+
+      client.setArgv('guidance', ...args);
+      const exitCode = await guidance(client);
+      expect(client.stdout).toOutput(
+        `Error: Invalid subcommand. See help instructions for usage`
+      );
+      expect(exitCode).toBe(2);
+    });
+
+    describe('status', () => {
+      it('should show enabled if there is no guidance value in the global config file', async () => {
+        client.config = {};
+
+        const args = ['status'];
+
+        client.setArgv('guidance', ...args);
+        const exitCode = await guidance(client);
+        expect(client.getFullOutput()).toMatchInlineSnapshot(`
+          "
+          > Guidance status: Enabled
+
+          "
+        `);
+        expect(exitCode).toBe(0);
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:status',
+            value: 'status',
+          },
+        ]);
+      });
+
+      it('should show enabled if guidance.enabled = true in the global config file', async () => {
+        const args = ['status'];
+        client.config = { guidance: { enabled: true } };
+
+        client.setArgv('guidance', ...args);
+        const exitCode = await guidance(client);
+        expect(client.getFullOutput()).toMatchInlineSnapshot(`
+          "
+          > Guidance status: Enabled
+
+          "
+        `);
+        expect(exitCode).toBe(0);
+      });
+
+      it('should show disabled if guidance.enabled = false in the global config file', async () => {
+        client.config = { guidance: { enabled: false } };
+
+        const args = ['status'];
+
+        client.setArgv('guidance', ...args);
+        const exitCode = await guidance(client);
+        expect(client.getFullOutput()).toMatchInlineSnapshot(`
+          "
+          > Guidance status: Disabled
+
+          "
+        `);
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    describe('enable', () => {
+      it('should update the global config file', async () => {
+        const args = ['enable'];
+
+        client.setArgv('guidance', ...args);
+        const exitCode = await guidance(client);
+        expect(client.config?.guidance?.enabled).toBe(true);
+        expect(setSpy).toHaveBeenCalledWith({
+          guidance: { enabled: true },
+        });
+        expect(exitCode).toBe(0);
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: 'subcommand:enable',
+            value: 'enable',
+          },
+        ]);
+      });
+    });
+
+    describe('disable', () => {
+      it('should update the global config file', async () => {
+        const args = ['disable'];
+
+        client.setArgv('guidance', ...args);
+        const exitCode = await guidance(client);
+        expect(client.config?.guidance?.enabled).toBe(false);
+        expect(setSpy).toHaveBeenCalledWith({
+          guidance: { enabled: false },
+        });
+        expect(exitCode).toBe(0);
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/util/guidance-check-status.test.ts
+++ b/packages/cli/test/unit/util/guidance-check-status.test.ts
@@ -83,7 +83,7 @@ describe('checkGuidanceStatus', () => {
             'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
           );
           await expect(client.stderr).toOutput(
-            'You cand disable this feature by running:'
+            'You can disable this feature by running:'
           );
           await expect(client.stderr).toOutput('vercel guidance disable');
           await expect(client.stderr).toOutput(

--- a/packages/cli/test/unit/util/guidance-check-status.test.ts
+++ b/packages/cli/test/unit/util/guidance-check-status.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { checkGuidanceStatus } from '../../../src/util/guidance/check-status';
+import * as configFilesUtil from '../../../src/util/config/files';
+
+import { client } from '../../mocks/client';
+import '../../mocks/matchers';
+vi.setConfig({ testTimeout: 6 * 60 * 1000 });
+
+describe('checkGuidanceStatus', () => {
+  const fileWriterSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
+
+  afterEach(() => {
+    fileWriterSpy.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe('FF_GUIDANCE_MODE unset', () => {
+    beforeEach(() => {
+      checkGuidanceStatus({
+        config: {},
+      });
+    });
+
+    it('does not inform the user', async () => {
+      await expect(client.stderr).not.toOutput(
+        'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
+      );
+      await expect(client.stderr).not.toOutput(
+        'You cand disable this feature by running:'
+      );
+      await expect(client.stderr).not.toOutput('vercel guidance disable');
+      await expect(client.stderr).not.toOutput(
+        'or by setting VERCEL_GUIDANCE_DISABLED=1'
+      );
+    });
+  });
+
+  describe('FF_GUIDANCE_MODE set', () => {
+    beforeEach(() => {
+      vi.stubEnv('FF_GUIDANCE_MODE', '1');
+    });
+
+    describe('first invocation', () => {
+      describe('VERCEL_GUIDANCE_DISABLED set', () => {
+        beforeEach(() => {
+          vi.stubEnv('VERCEL_GUIDANCE_DISABLED', '1');
+          checkGuidanceStatus({
+            config: {},
+          });
+        });
+        it('does not inform the user', async () => {
+          await expect(client.stderr).not.toOutput(
+            'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
+          );
+          await expect(client.stderr).not.toOutput(
+            'You cand disable this feature by running:'
+          );
+          await expect(client.stderr).not.toOutput('vercel guidance disable');
+          await expect(client.stderr).not.toOutput(
+            'or by setting VERCEL_GUIDANCE_DISABLED=1'
+          );
+        });
+
+        it('does not change opt out status the customer in', async () => {
+          expect(fileWriterSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('VERCEL_GUIDANCE_DISABLED unset', () => {
+        beforeEach(() => {
+          vi.stubEnv('VERCEL_GUIDANCE_DISABLED', undefined);
+          checkGuidanceStatus({
+            config: {},
+          });
+        });
+
+        it('informs the user', async () => {
+          await expect(client.stderr).toOutput(
+            'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
+          );
+          await expect(client.stderr).toOutput(
+            'You cand disable this feature by running:'
+          );
+          await expect(client.stderr).toOutput('vercel guidance disable');
+          await expect(client.stderr).toOutput(
+            'or by setting VERCEL_GUIDANCE_DISABLED=1'
+          );
+        });
+
+        it('opts the customer in', async () => {
+          expect(fileWriterSpy).toHaveBeenCalledWith({
+            guidance: {
+              enabled: true,
+            },
+          });
+        });
+      });
+
+      describe('subsequent invocations', () => {
+        beforeEach(() => {
+          checkGuidanceStatus({
+            config: {
+              guidance: {
+                enabled: true,
+              },
+            },
+          });
+        });
+
+        it('does not inform the user', async () => {
+          expect(client.getFullOutput()).toEqual('');
+        });
+
+        it('does not change opt out status the customer in', async () => {
+          expect(fileWriterSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('subsequent invocations after opting status change', () => {
+        beforeEach(() => {
+          checkGuidanceStatus({
+            config: {
+              guidance: {
+                enabled: false,
+              },
+            },
+          });
+        });
+
+        it('does not inform the user', async () => {
+          expect(client.getFullOutput()).toEqual('');
+        });
+
+        it('does not change opt out status the customer in', async () => {
+          expect(fileWriterSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/packages/cli/test/unit/util/guidance-check-status.test.ts
+++ b/packages/cli/test/unit/util/guidance-check-status.test.ts
@@ -9,6 +9,10 @@ vi.setConfig({ testTimeout: 6 * 60 * 1000 });
 describe('checkGuidanceStatus', () => {
   const fileWriterSpy = vi.spyOn(configFilesUtil, 'writeToConfigFile');
 
+  beforeEach(() => {
+    vi.stubEnv('CI', undefined);
+  });
+
   afterEach(() => {
     fileWriterSpy.mockClear();
     vi.unstubAllEnvs();

--- a/packages/cli/test/unit/util/guidance-check-status.test.ts
+++ b/packages/cli/test/unit/util/guidance-check-status.test.ts
@@ -57,7 +57,7 @@ describe('checkGuidanceStatus', () => {
             'The Vercel CLI can suggest common follow-up commands and steps to help guide new users.'
           );
           await expect(client.stderr).not.toOutput(
-            'You cand disable this feature by running:'
+            'You can disable this feature by running:'
           );
           await expect(client.stderr).not.toOutput('vercel guidance disable');
           await expect(client.stderr).not.toOutput(


### PR DESCRIPTION
Adds the base behavior for a "guidance" mode that will suggest to customers and agents common followup steps to commands.

For example, if you ran `vercel deploy` guidance might be something like (totally made up at the moment):

```
To check runtime logs run of your deployed application

vercel logs dpl_123

If these logs contain errors you can revert to the previous deployment with

vercel rollback

If these logs also contain errors, consider

vercel bisect

```

No output is suggested as part of this PR. These proposed changes introduce 

* `vercel guidance enable` to turn this behavior on
* `vercel guidance disable` to turn this behavior off
* `vercel guidance status` to see the current on/off status

Like the CLI's telemetry behavior, this may also be turned off with an environment variable `VERCEL_GUIDANCE_DISABLED=1`

This behavior is additionally disabled where we detect the CLI running in CI or on Vercel itself (identified by `CI=1`)

One first run in non-CI environment, the CLI will inform the user that the feature is on and provide steps for disabling if they choose.

A `patch` mostly because this is all behind a local env var flag `FF_GUIDANCE_MODE`.