### PR TITLE
[cli] avoid fetching a deployment's project in a loop

### DIFF
--- a/.changeset/hungry-numbers-explain.md
+++ b/.changeset/hungry-numbers-explain.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] avoid fetching a deployment's project in a loop


### PR DESCRIPTION
https://github.com/vercel/vercel/pull/13482 introduced a subtle bug that causes some customer's to hit an API rate limit for `api-projects-list`. This fetches the value once and stores for later use.