### PR TITLE
[cli] correct log checking suggestion for failed `deploy` runs

### DIFF
--- a/.changeset/famous-days-peel.md
+++ b/.changeset/famous-days-peel.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] correct log checking suggestion for failed `deploy` runs

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -668,11 +668,13 @@ export default async (client: Client): Promise<number> => {
 
     if (err instanceof BuildError) {
       output.error(err.message || 'Build failed');
-      output.error(
-        `Check your logs at https://${now.url}/_logs or run ${getCommandName(
-          `logs ${now.url}`
+      output.log('\n');
+      output.log(
+        `To check build logs run: ${getCommandName(
+          `inspect ${now.url} --logs`
         )}`
       );
+      output.log(`Or inspect them in your browser at https://${now.url}/_logs`);
 
       return 1;
     }


### PR DESCRIPTION
We shifted `vercel logs` to mean only _runtime_ logs about 11 months ago, but have been advising people to check them for build errors. 🧹 to correct the output.

Also decided to change the suggestion's order to prefer CLI interactions, where before we suggested looking in the UI first.