### PR TITLE
[cli] Add experimental trigger support

### DIFF
--- a/.changeset/good-olives-live.md
+++ b/.changeset/good-olives-live.md
@@ -1,0 +1,7 @@
+---
+'@vercel/static-config': patch
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+add experimental trigger to cli

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -382,6 +382,8 @@ export interface BuilderFunctions {
     runtime?: string;
     includeFiles?: string;
     excludeFiles?: string;
+    experimentalPrivate?: boolean;
+    experimentalTriggers?: CloudEventTrigger[];
   };
 }
 

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -382,7 +382,6 @@ export interface BuilderFunctions {
     runtime?: string;
     includeFiles?: string;
     excludeFiles?: string;
-    experimentalPrivate?: boolean;
     experimentalTriggers?: CloudEventTrigger[];
   };
 }

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -44,7 +44,6 @@ interface FunctionConfiguration {
   architecture?: string;
   memory?: number;
   maxDuration?: number;
-  experimentalPrivate?: boolean;
   experimentalTriggers?: Array<{
     triggerVersion: 1;
     specversion: '1.0';
@@ -492,8 +491,6 @@ async function writeLambda(
     functionConfiguration?.architecture ?? lambda.architecture;
   const memory = functionConfiguration?.memory ?? lambda.memory;
   const maxDuration = functionConfiguration?.maxDuration ?? lambda.maxDuration;
-  const experimentalPrivate =
-    functionConfiguration?.experimentalPrivate ?? lambda.experimentalPrivate;
   const experimentalTriggers =
     functionConfiguration?.experimentalTriggers ?? lambda.experimentalTriggers;
 
@@ -503,7 +500,6 @@ async function writeLambda(
     architecture,
     memory,
     maxDuration,
-    experimentalPrivate,
     experimentalTriggers,
     filePathMap,
     type: undefined,

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -44,6 +44,24 @@ interface FunctionConfiguration {
   architecture?: string;
   memory?: number;
   maxDuration?: number;
+  experimentalPrivate?: boolean;
+  experimentalTriggers?: Array<{
+    triggerVersion: 1;
+    specversion: '1.0';
+    type: string;
+    httpBinding: {
+      mode: 'structured';
+      method?: 'GET' | 'POST' | 'HEAD';
+      pathname?: string;
+    };
+    queue?: {
+      topic: string;
+      consumer: string;
+      maxAttempts?: number;
+      retryAfterSeconds?: number;
+      initialDelaySeconds?: number;
+    };
+  }>;
 }
 
 export async function writeBuildResult(
@@ -474,6 +492,10 @@ async function writeLambda(
     functionConfiguration?.architecture ?? lambda.architecture;
   const memory = functionConfiguration?.memory ?? lambda.memory;
   const maxDuration = functionConfiguration?.maxDuration ?? lambda.maxDuration;
+  const experimentalPrivate =
+    functionConfiguration?.experimentalPrivate ?? lambda.experimentalPrivate;
+  const experimentalTriggers =
+    functionConfiguration?.experimentalTriggers ?? lambda.experimentalTriggers;
 
   const config = {
     ...lambda,
@@ -481,6 +503,8 @@ async function writeLambda(
     architecture,
     memory,
     maxDuration,
+    experimentalPrivate,
+    experimentalTriggers,
     filePathMap,
     type: undefined,
     files: undefined,

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -400,11 +400,10 @@ describe('validateConfig', () => {
     );
   });
 
-  it('should not error with valid experimentalPrivate and experimentalTriggers', () => {
+  it('should not error with valid experimentalTriggers', () => {
     const error = validateConfig({
       functions: {
         'api/webhook.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -434,7 +433,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/trigger.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -449,21 +447,6 @@ describe('validateConfig', () => {
       },
     });
     expect(error).toBeNull();
-  });
-
-  it('should error with invalid experimentalPrivate type', () => {
-    const error = validateConfig({
-      functions: {
-        // @ts-ignore
-        'api/test.js': { experimentalPrivate: 'true' },
-      },
-    });
-    expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].experimentalPrivate` should be boolean."
-    );
-    expect(error!.link).toEqual(
-      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
-    );
   });
 
   it('should error with invalid experimentalTriggers type', () => {
@@ -485,7 +468,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               // @ts-ignore
@@ -510,7 +492,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -535,12 +516,11 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
+            // @ts-ignore - intentionally missing type property for testing
             {
               triggerVersion: 1,
               specversion: '1.0',
-              // @ts-ignore
               httpBinding: { mode: 'structured' },
             },
           ],
@@ -559,7 +539,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -584,7 +563,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -612,7 +590,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -637,16 +614,15 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
               httpBinding: { mode: 'structured' },
+              // @ts-ignore - intentionally missing consumer property for testing
               queue: {
                 topic: 'test-topic',
-                // @ts-ignore - missing consumer
               },
             },
           ],
@@ -665,7 +641,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -695,7 +670,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -724,7 +698,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -753,7 +726,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,
@@ -782,7 +754,6 @@ describe('validateConfig', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
-          experimentalPrivate: true,
           experimentalTriggers: [
             {
               triggerVersion: 1,

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -399,4 +399,406 @@ describe('validateConfig', () => {
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'
     );
   });
+
+  it('should not error with valid experimentalPrivate and experimentalTriggers', () => {
+    const error = validateConfig({
+      functions: {
+        'api/webhook.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: {
+                mode: 'structured',
+                method: 'POST',
+                pathname: '/webhook',
+              },
+              queue: {
+                topic: 'user-events',
+                consumer: 'webhook-processors',
+                maxAttempts: 3,
+                retryAfterSeconds: 10,
+                initialDelaySeconds: 0,
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error).toBeNull();
+  });
+
+  it('should not error with minimal experimentalTriggers configuration', () => {
+    const error = validateConfig({
+      functions: {
+        'api/trigger.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'v1.test.vercel.com',
+              httpBinding: {
+                mode: 'structured',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error).toBeNull();
+  });
+
+  it('should error with invalid experimentalPrivate type', () => {
+    const error = validateConfig({
+      functions: {
+        // @ts-ignore
+        'api/test.js': { experimentalPrivate: 'true' },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalPrivate` should be boolean."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid experimentalTriggers type', () => {
+    const error = validateConfig({
+      functions: {
+        // @ts-ignore
+        'api/test.js': { experimentalTriggers: 'invalid' },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers` should be array."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid triggerVersion', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              // @ts-ignore
+              triggerVersion: 2,
+              specversion: '1.0',
+              type: 'v1.test.vercel.com',
+              httpBinding: { mode: 'structured' },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].triggerVersion` should be equal to constant."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid specversion', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              // @ts-ignore
+              specversion: '2.0',
+              type: 'v1.test.vercel.com',
+              httpBinding: { mode: 'structured' },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].specversion` should be equal to constant."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with missing type', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              // @ts-ignore
+              httpBinding: { mode: 'structured' },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0]` missing required property `type`."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid httpBinding mode', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'v1.test.vercel.com',
+              // @ts-ignore
+              httpBinding: { mode: 'binary' },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].httpBinding.mode` should be equal to constant."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid HTTP method', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'v1.test.vercel.com',
+              httpBinding: {
+                mode: 'structured',
+                // @ts-ignore
+                method: 'PUT',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].httpBinding.method` should be equal to one of the allowed values."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with queue trigger missing required fields', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              // @ts-ignore - missing queue configuration
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0]` missing required property `.queue`."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid queue configuration', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                // @ts-ignore - missing consumer
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].queue` missing required property `consumer`."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with invalid maxAttempts type', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                consumer: 'test-consumer',
+                // @ts-ignore
+                maxAttempts: 'three',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].queue.maxAttempts` should be number."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with negative maxAttempts', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                consumer: 'test-consumer',
+                maxAttempts: -1,
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].queue.maxAttempts` should be >= 0."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with zero retryAfterSeconds', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                consumer: 'test-consumer',
+                retryAfterSeconds: 0,
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].queue.retryAfterSeconds` should be > 0."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with negative initialDelaySeconds', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                consumer: 'test-consumer',
+                initialDelaySeconds: -1,
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].queue.initialDelaySeconds` should be >= 0."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should allow zero initialDelaySeconds', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalPrivate: true,
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'com.vercel.queue.v1',
+              httpBinding: { mode: 'structured' },
+              queue: {
+                topic: 'test-topic',
+                consumer: 'test-consumer',
+                initialDelaySeconds: 0,
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error).toBeNull();
+  });
 });


### PR DESCRIPTION
# Added experimental triggers support for Vercel functions

## What changed?

- Added `experimentalTriggers` property to the `BuilderFunctions` interface in `types.ts`
- Updated the `FunctionConfiguration` interface in `write-build-result.ts` to include the new `experimentalTriggers` property
- Added comprehensive validation for the new trigger configurations in the CLI validation tests
- Added support for CloudEvent triggers with HTTP bindings and queue configurations

## How to test?

You can configure a function with experimental triggers in your `vercel.json`:

```json
{
  "functions": {
    "api/webhook.js": {
      "experimentalTriggers": [
        {
          "triggerVersion": 1,
          "specversion": "1.0",
          "type": "com.vercel.queue.v1",
          "httpBinding": {
            "mode": "structured",
            "method": "POST",
            "pathname": "/webhook"
          },
          "queue": {
            "topic": "user-events",
            "consumer": "webhook-processors",
            "maxAttempts": 3,
            "retryAfterSeconds": 10,
            "initialDelaySeconds": 0
          }
        }
      ]
    }
  }
}
```

The validation system will check:
- Required properties (`triggerVersion`, `specversion`, `type`, etc.)
- Valid values for HTTP methods (only `GET`, `POST`, `HEAD` allowed)
- Queue configuration parameters (topic, consumer, retry settings)
- Numeric constraints (non-negative values for attempts, positive values for retry intervals)