### PR TITLE
[node] [next] Add support for triggers

### DIFF
--- a/.changeset/fresh-flowers-yell.md
+++ b/.changeset/fresh-flowers-yell.md
@@ -1,0 +1,9 @@
+---
+'@vercel/static-config': patch
+'@vercel/build-utils': patch
+'@vercel/next': patch
+'@vercel/node': patch
+'vercel': patch
+---
+
+add support for triggers to node/next builder

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -31,6 +31,7 @@ import {
   detectPackageManager,
   BUILDER_INSTALLER_STEP,
   BUILDER_COMPILE_STEP,
+  CloudEventTrigger,
 } from '@vercel/build-utils';
 import { Route, RouteWithHandle, RouteWithSrc } from '@vercel/routing-utils';
 import {
@@ -1964,6 +1965,8 @@ export const build: BuildV2 = async buildOptions => {
             architecture?: NodejsLambda['architecture'];
             memory?: number;
             maxDuration?: number;
+            experimentalPrivate?: boolean;
+            experimentalTriggers?: CloudEventTrigger[];
           } = {};
 
           if (config && config.functions) {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1965,7 +1965,6 @@ export const build: BuildV2 = async buildOptions => {
             architecture?: NodejsLambda['architecture'];
             memory?: number;
             maxDuration?: number;
-            experimentalPrivate?: boolean;
             experimentalTriggers?: CloudEventTrigger[];
           } = {};
 

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -475,6 +475,8 @@ export const build: BuildV3 = async ({
       awsLambdaHandler,
       supportsResponseStreaming,
       maxDuration: staticConfig?.maxDuration,
+      experimentalPrivate: staticConfig?.experimentalPrivate,
+      experimentalTriggers: staticConfig?.experimentalTriggers,
       regions: normalizeRequestedRegions(
         staticConfig?.preferredRegion ?? staticConfig?.regions
       ),

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -475,7 +475,6 @@ export const build: BuildV3 = async ({
       awsLambdaHandler,
       supportsResponseStreaming,
       maxDuration: staticConfig?.maxDuration,
-      experimentalPrivate: staticConfig?.experimentalPrivate,
       experimentalTriggers: staticConfig?.experimentalTriggers,
       regions: normalizeRequestedRegions(
         staticConfig?.preferredRegion ?? staticConfig?.regions


### PR DESCRIPTION
### TL;DR

Added support for triggers in Next.js and Node.js runtimes.

### What changed?

- Added `experimentalTriggers` property to the lambda configuration object in Next.js
- Passed the `experimentalTriggers` property from static configuration to the lambda in the Node.js runtime
- Imported the `CloudEventTrigger` type from `@vercel/build-utils` in Next.js
- Added a changeset to update multiple packages with trigger support

### How to test?

1. Create a Next.js or Node.js project with a function that uses triggers
2. Add the following to your configuration:
   ```js
   {
     functions: {
       'api/example.js': {
         experimentalTriggers: [/* your triggers here */]
       }
     }
   }
   ```
3. Deploy the project and verify that the function responds to the configured triggers

### Why make this change?

This change enables support for cloud event triggers in Vercel Functions, allowing developers to define when and how their serverless functions are executed beyond just HTTP requests. This provides more flexibility in building event-driven architectures and responding to various cloud events.