### PR TITLE
[build-utils] Require POST method for CloudEventTrigger HTTP bindings

### DIFF
--- a/.changeset/chilly-items-remain.md
+++ b/.changeset/chilly-items-remain.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+make POST method required

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -321,16 +321,12 @@ export class Lambda {
           binding.mode === 'structured',
           `${bindingPrefix}.mode must be "structured"`
         );
+        assert(
+          binding.method === 'POST',
+          `${bindingPrefix}.method must be "POST"`
+        );
 
         // Validate optional HTTP configuration within httpBinding
-        if (binding.method !== undefined) {
-          const validMethods = ['GET', 'POST', 'HEAD'];
-          assert(
-            validMethods.includes(binding.method),
-            `${bindingPrefix}.method must be one of: ${validMethods.join(', ')}`
-          );
-        }
-
         if (binding.pathname !== undefined) {
           assert(
             typeof binding.pathname === 'string',

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -22,7 +22,7 @@ const cloudEventTriggerSchema = {
         },
         method: {
           type: 'string',
-          enum: ['GET', 'POST', 'HEAD'],
+          const: 'POST',
         },
         pathname: {
           type: 'string',
@@ -30,7 +30,7 @@ const cloudEventTriggerSchema = {
           pattern: '^/',
         },
       },
-      required: ['mode'],
+      required: ['mode', 'method'],
       additionalProperties: false,
     },
     queue: {

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -616,8 +616,8 @@ export interface CloudEventTriggerBase<T extends string = string> {
     /** HTTP binding mode - only structured mode is supported (REQUIRED) */
     mode: 'structured';
 
-    /** HTTP method for this trigger endpoint (OPTIONAL, default: 'POST') */
-    method?: 'GET' | 'POST' | 'HEAD';
+    /** HTTP method for this trigger endpoint - only POST is supported (REQUIRED) */
+    method: 'POST';
 
     /** HTTP pathname for this trigger endpoint (OPTIONAL) */
     pathname?: string;

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -440,6 +440,7 @@ describe('validateConfig', () => {
               type: 'v1.test.vercel.com',
               httpBinding: {
                 mode: 'structured',
+                method: 'POST',
               },
             },
           ],
@@ -474,7 +475,7 @@ describe('validateConfig', () => {
               triggerVersion: 2,
               specversion: '1.0',
               type: 'v1.test.vercel.com',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
             },
           ],
         },
@@ -498,7 +499,7 @@ describe('validateConfig', () => {
               // @ts-ignore
               specversion: '2.0',
               type: 'v1.test.vercel.com',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
             },
           ],
         },
@@ -521,7 +522,7 @@ describe('validateConfig', () => {
             {
               triggerVersion: 1,
               specversion: '1.0',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
             },
           ],
         },
@@ -545,7 +546,7 @@ describe('validateConfig', () => {
               specversion: '1.0',
               type: 'v1.test.vercel.com',
               // @ts-ignore
-              httpBinding: { mode: 'binary' },
+              httpBinding: { mode: 'binary', method: 'POST' },
             },
           ],
         },
@@ -579,7 +580,33 @@ describe('validateConfig', () => {
       },
     });
     expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].httpBinding.method` should be equal to one of the allowed values."
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].httpBinding.method` should be equal to constant."
+    );
+    expect(error!.link).toEqual(
+      'https://vercel.com/docs/concepts/projects/project-configuration#functions'
+    );
+  });
+
+  it('should error with missing HTTP method', () => {
+    const error = validateConfig({
+      functions: {
+        'api/test.js': {
+          experimentalTriggers: [
+            {
+              triggerVersion: 1,
+              specversion: '1.0',
+              type: 'v1.test.vercel.com',
+              // @ts-ignore - intentionally missing method property
+              httpBinding: {
+                mode: 'structured',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(error!.message).toEqual(
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].httpBinding` missing required property `method`."
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'
@@ -595,7 +622,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               // @ts-ignore - missing queue configuration
             },
           ],
@@ -619,7 +646,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               // @ts-ignore - intentionally missing consumer property for testing
               queue: {
                 topic: 'test-topic',
@@ -646,7 +673,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               queue: {
                 topic: 'test-topic',
                 consumer: 'test-consumer',
@@ -675,7 +702,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               queue: {
                 topic: 'test-topic',
                 consumer: 'test-consumer',
@@ -703,7 +730,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               queue: {
                 topic: 'test-topic',
                 consumer: 'test-consumer',
@@ -731,7 +758,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               queue: {
                 topic: 'test-topic',
                 consumer: 'test-consumer',
@@ -759,7 +786,7 @@ describe('validateConfig', () => {
               triggerVersion: 1,
               specversion: '1.0',
               type: 'com.vercel.queue.v1',
-              httpBinding: { mode: 'structured' },
+              httpBinding: { mode: 'structured', method: 'POST' },
               queue: {
                 topic: 'test-topic',
                 consumer: 'test-consumer',


### PR DESCRIPTION
# [build-utils] Require POST method for CloudEventTrigger HTTP bindings

This PR updates the CloudEventTrigger HTTP binding configuration to make the POST method required rather than optional. The changes include:

- Making `method: 'POST'` a required property in the HTTP binding configuration
- Removing support for GET and HEAD methods
- Updating the JSON schema to enforce the POST method requirement
- Updating type definitions to reflect the required POST method
- Updating tests to include the required POST method in all test cases
- Adding a changeset to document this change