### PR TITLE
[cli] Add support for piping data to `blob put` command via stdin

### DIFF
--- a/.changeset/chilled-books-hug.md
+++ b/.changeset/chilled-books-hug.md
@@ -1,0 +1,11 @@
+---
+'vercel': minor
+---
+
+Add stdin and pipe support to `vc blob put` command.
+
+Usage:
+
+```sh
+cat file.txt | vc blob put --pathname file-from-stdin.txt
+```

--- a/packages/cli/src/commands/blob/put.ts
+++ b/packages/cli/src/commands/blob/put.ts
@@ -33,13 +33,6 @@ export default async function put(
     return 1;
   }
 
-  if (!parsedArgs.args.length) {
-    printError(
-      `Missing required arguments: ${getCommandName('blob put pathToFile')}`
-    );
-    return 1;
-  }
-
   const {
     flags,
     args: [filePath],
@@ -53,7 +46,10 @@ export default async function put(
     '--force': force,
   } = flags;
 
-  telemetryClient.trackCliArgumentPathToFile(filePath);
+  // Only track file path if one was provided
+  if (filePath) {
+    telemetryClient.trackCliArgumentPathToFile(filePath);
+  }
   telemetryClient.trackCliFlagAddRandomSuffix(addRandomSuffix);
   telemetryClient.trackCliOptionPathname(pathnameFlag);
   telemetryClient.trackCliFlagMultipart(multipart);
@@ -61,41 +57,68 @@ export default async function put(
   telemetryClient.trackCliOptionCacheControlMaxAge(cacheControlMaxAge);
   telemetryClient.trackCliFlagForce(force);
 
-  let putBody: NodeJS.ReadableStream;
+  // ReadableStream works for both stdin and ReadStream
+  let putBody: ReadableStream;
   let pathname: string;
 
-  try {
-    const stats = statSync(filePath);
-    const isFile = stats.isFile();
-
-    if (isFile) {
-      // we first open the file so we can handle errors with promises
-      const file = await open(filePath, 'r');
-      putBody = file.createReadStream();
-      putBody.once('error', err => {
-        output.error(`Error while reading file: ${err}`);
-      });
-      pathname = pathnameFlag ?? basename(filePath);
-    } else {
-      output.error('Path to upload is not a file');
-      return 1;
-    }
-  } catch (err) {
-    output.debug(`Error reading file: ${err}`);
-
-    if (isErrnoException(err)) {
-      output.error(`File doesn't exist at '${filePath}'`);
+  if (!filePath) {
+    // Check if stdin is a TTY (user is typing directly in terminal)
+    if (client.stdin.isTTY) {
+      output.error(
+        `Missing input. Usage: ${chalk.cyan(
+          `${getCommandName('blob put <file>')}`
+        )} or pipe data: ${chalk.cyan('cat file.txt | vercel blob put --pathname <pathname>')}`
+      );
       return 1;
     }
 
-    output.error('Error while reading file');
-    return 1;
+    // Reading from stdin - pathname is required
+    if (!pathnameFlag) {
+      output.error(
+        `Missing pathname. When reading from stdin, you must specify --pathname. Usage: ${chalk.cyan(
+          'cat file.txt | vercel blob put --pathname <pathname>'
+        )}`
+      );
+      return 1;
+    }
+
+    putBody = process.stdin;
+    pathname = pathnameFlag;
+    telemetryClient.trackCliInputSourceStdin();
+  } else {
+    // Reading from file (existing logic)
+    try {
+      const stats = statSync(filePath);
+      const isFile = stats.isFile();
+
+      if (isFile) {
+        // we first open the file so we can handle errors with promises
+        const file = await open(filePath, 'r');
+        putBody = file.createReadStream();
+        pathname = pathnameFlag ?? basename(filePath);
+      } else {
+        output.error('Path to upload is not a file');
+        return 1;
+      }
+    } catch (err) {
+      output.debug(`Error reading file: ${err}`);
+
+      if (isErrnoException(err)) {
+        output.error(`File doesn't exist at '${filePath}'`);
+        return 1;
+      }
+
+      output.error('Error while reading file');
+      return 1;
+    }
   }
 
   if (!pathname || !putBody) {
     output.error(
-      `Missing pathname or file. Usage: ${chalk.cyan(
-        `${getCommandName('blob put <file> [--pathname <pathname>]')}`
+      `Missing pathname or input. Usage: ${chalk.cyan(
+        `${getCommandName('blob put <file>')}`
+      )} or ${chalk.cyan(
+        `cat file.txt | ${getCommandName('blob put --pathname <pathname>')}`
       )}`
     );
     return 1;

--- a/packages/cli/src/util/telemetry/commands/blob/put.ts
+++ b/packages/cli/src/util/telemetry/commands/blob/put.ts
@@ -15,6 +15,13 @@ export class BlobPutTelemetryClient
     }
   }
 
+  trackCliInputSourceStdin() {
+    this.trackCliArgument({
+      arg: 'pathToFile',
+      value: '__vercel_stdin__',
+    });
+  }
+
   trackCliFlagAddRandomSuffix(addRandomSuffix: boolean | undefined) {
     if (addRandomSuffix) {
       this.trackCliFlag('add-random-suffix');


### PR DESCRIPTION
This PR adds support for:

```sh
cat file.txt | vc blob put
```

Just like any Unix command line tool accepting files, it should accept stdin.