### PR TITLE
Rename experimental maxAttempts to maxDeliveries

### DIFF
--- a/.changeset/eleven-dragons-smile.md
+++ b/.changeset/eleven-dragons-smile.md
@@ -1,0 +1,6 @@
+---
+'@vercel/build-utils': patch
+'vercel': patch
+---
+
+rename experimental maxAttempts to maxDeliveries

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -269,14 +269,15 @@ export class Lambda {
         );
 
         // Validate optional queue configuration
-        if (trigger.maxAttempts !== undefined) {
+        if (trigger.maxDeliveries !== undefined) {
           assert(
-            typeof trigger.maxAttempts === 'number',
-            `${prefix}.maxAttempts must be a number`
+            typeof trigger.maxDeliveries === 'number',
+            `${prefix}.maxDeliveries must be a number`
           );
           assert(
-            Number.isInteger(trigger.maxAttempts) && trigger.maxAttempts >= 0,
-            `${prefix}.maxAttempts must be a non-negative integer`
+            Number.isInteger(trigger.maxDeliveries) &&
+              trigger.maxDeliveries >= 1,
+            `${prefix}.maxDeliveries must be at least 1`
           );
         }
 

--- a/packages/build-utils/src/schemas.ts
+++ b/packages/build-utils/src/schemas.ts
@@ -13,9 +13,9 @@ const triggerEventSchema = {
       type: 'string',
       minLength: 1,
     },
-    maxAttempts: {
+    maxDeliveries: {
       type: 'number',
-      minimum: 0,
+      minimum: 1,
     },
     retryAfterSeconds: {
       type: 'number',

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -608,10 +608,12 @@ export interface TriggerEvent {
   consumer: string;
 
   /**
-   * Maximum number of retry attempts for failed executions (OPTIONAL)
+   * Maximum number of delivery attempts for message processing (OPTIONAL)
+   * This represents the total number of times a message can be delivered,
+   * not the number of retries. Must be at least 1 if specified.
    * Behavior when not specified depends on the server's default configuration.
    */
-  maxAttempts?: number;
+  maxDeliveries?: number;
 
   /**
    * Delay in seconds before retrying failed executions (OPTIONAL)

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -127,7 +127,7 @@ describe('Lambda', () => {
         type: 'queue/v1beta',
         topic: 'system-events',
         consumer: 'system-processors',
-        maxAttempts: 3,
+        maxDeliveries: 3,
         retryAfterSeconds: 10,
         initialDelaySeconds: 60,
       };
@@ -144,7 +144,7 @@ describe('Lambda', () => {
       expect(lambda.experimentalTriggers![0].consumer).toBe(
         'system-processors'
       );
-      expect(lambda.experimentalTriggers![0].maxAttempts).toBe(3);
+      expect(lambda.experimentalTriggers![0].maxDeliveries).toBe(3);
       expect(lambda.experimentalTriggers![0].retryAfterSeconds).toBe(10);
       expect(lambda.experimentalTriggers![0].initialDelaySeconds).toBe(60);
     });
@@ -160,7 +160,7 @@ describe('Lambda', () => {
           type: 'queue/v1beta',
           topic: 'system-events',
           consumer: 'system-processors',
-          maxAttempts: 5,
+          maxDeliveries: 5,
         },
       ];
 
@@ -174,7 +174,7 @@ describe('Lambda', () => {
       expect(lambda.experimentalTriggers).toHaveLength(2);
       expect(lambda.experimentalTriggers![0].topic).toBe('user-events');
       expect(lambda.experimentalTriggers![1].topic).toBe('system-events');
-      expect(lambda.experimentalTriggers![1].maxAttempts).toBe(5);
+      expect(lambda.experimentalTriggers![1].maxDeliveries).toBe(5);
     });
 
     describe('Validation Errors', () => {
@@ -256,7 +256,7 @@ describe('Lambda', () => {
         ).toThrow('"experimentalTriggers[0]" is not an object');
       });
 
-      it('should throw error for invalid maxAttempts', () => {
+      it('should throw error for invalid maxDeliveries', () => {
         expect(
           () =>
             new Lambda({
@@ -268,13 +268,11 @@ describe('Lambda', () => {
                   type: 'queue/v1beta',
                   topic: 'test-topic',
                   consumer: 'test-consumer',
-                  maxAttempts: -1,
+                  maxDeliveries: 0,
                 },
               ],
             })
-        ).toThrow(
-          '"experimentalTriggers[0]".maxAttempts must be a non-negative integer'
-        );
+        ).toThrow('"experimentalTriggers[0]".maxDeliveries must be at least 1');
       });
 
       it('should throw error for invalid retryAfterSeconds', () => {

--- a/packages/cli/test/unit/util/dev/validate.test.ts
+++ b/packages/cli/test/unit/util/dev/validate.test.ts
@@ -409,7 +409,7 @@ describe('validateConfig', () => {
               type: 'queue/v1beta',
               topic: 'user-events',
               consumer: 'webhook-processors',
-              maxAttempts: 3,
+              maxDeliveries: 3,
               retryAfterSeconds: 10,
               initialDelaySeconds: 0,
             },
@@ -541,7 +541,7 @@ describe('validateConfig', () => {
     );
   });
 
-  it('should error with invalid maxAttempts type', () => {
+  it('should error with invalid maxDeliveries type', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
@@ -550,22 +550,22 @@ describe('validateConfig', () => {
               type: 'queue/v1beta',
               topic: 'test-topic',
               consumer: 'test-consumer',
-              // @ts-expect-error - Testing invalid maxAttempts type
-              maxAttempts: 'three',
+              // @ts-expect-error - Testing invalid maxDeliveries type
+              maxDeliveries: 'three',
             },
           ],
         },
       },
     });
     expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].maxAttempts` should be number."
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].maxDeliveries` should be number."
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'
     );
   });
 
-  it('should error with negative maxAttempts', () => {
+  it('should error with invalid maxDeliveries value', () => {
     const error = validateConfig({
       functions: {
         'api/test.js': {
@@ -574,14 +574,14 @@ describe('validateConfig', () => {
               type: 'queue/v1beta',
               topic: 'test-topic',
               consumer: 'test-consumer',
-              maxAttempts: -1,
+              maxDeliveries: 0,
             },
           ],
         },
       },
     });
     expect(error!.message).toEqual(
-      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].maxAttempts` should be >= 0."
+      "Invalid vercel.json - `functions['api/test.js'].experimentalTriggers[0].maxDeliveries` should be >= 1."
     );
     expect(error!.link).toEqual(
       'https://vercel.com/docs/concepts/projects/project-configuration#functions'


### PR DESCRIPTION
### TL;DR

Renamed the experimental `maxAttempts` parameter to `maxDeliveries` in queue triggers to better reflect its purpose.

### What changed?

- Renamed `maxAttempts` to `maxDeliveries` in the queue trigger configuration
- Updated validation logic to require `maxDeliveries` to be at least 1 (previously `maxAttempts` could be 0)
- Updated documentation comments to clarify that `maxDeliveries` represents the total number of delivery attempts, not just retries
- Updated all related tests to use the new parameter name

### How to test?

1. Create a function with queue triggers using the new `maxDeliveries` parameter:
```json
{
  "functions": {
    "api/queue-handler.js": {
      "experimentalTriggers": [
        {
          "type": "queue/v1beta",
          "topic": "test-topic",
          "consumer": "test-consumer",
          "maxDeliveries": 3
        }
      ]
    }
  }
}
```
2. Verify that the configuration is accepted and properly validated
3. Confirm that setting `maxDeliveries` to 0 or a negative number results in a validation error

### Why make this change?

The name `maxDeliveries` more accurately describes the parameter's purpose - it represents the total number of times a message can be delivered, not just the number of retry attempts. This change improves clarity and prevents confusion about how the parameter affects message processing behavior.