### PR TITLE
[react-router] Add support for Vercel Skew Protection

### DIFF
--- a/.changeset/forty-beers-jam.md
+++ b/.changeset/forty-beers-jam.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': minor
+---
+
+Add support for Vercel Skew Protection

--- a/packages/react-router/edge/entry.server.ts
+++ b/packages/react-router/edge/entry.server.ts
@@ -13,6 +13,10 @@ export type RenderOptions = {
     keyof RenderToPipeableStreamOptions]?: RenderToReadableStreamOptions[K];
 };
 
+const vercelDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+const vercelSkewProtectionEnabled =
+  process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1';
+
 export async function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -42,6 +46,11 @@ export async function handleRequest(
   }
 
   responseHeaders.set('Content-Type', 'text/html');
+
+  if (vercelSkewProtectionEnabled && vercelDeploymentId) {
+    responseHeaders.set('x-deployment-id', vercelDeploymentId);
+  }
+
   return new Response(body, {
     headers: responseHeaders,
     status: responseStatusCode,

--- a/packages/react-router/entry.server.ts
+++ b/packages/react-router/entry.server.ts
@@ -18,6 +18,10 @@ export type RenderOptions = {
     keyof RenderToPipeableStreamOptions]?: RenderToReadableStreamOptions[K];
 };
 
+const vercelDeploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+const vercelSkewProtectionEnabled =
+  process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1';
+
 export function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -52,6 +56,10 @@ export function handleRequest(
           const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set('Content-Type', 'text/html');
+
+          if (vercelSkewProtectionEnabled && vercelDeploymentId) {
+            responseHeaders.set('x-deployment-id', vercelDeploymentId);
+          }
 
           resolve(
             new Response(stream, {


### PR DESCRIPTION
Adds support for [Vercel Skew Protection](https://vercel.com/docs/skew-protection#supported-frameworks) for React Router v7, with similar implementation as [Astro](https://github.com/withastro/astro/pull/10761).

Requested by @dieDeMiguel.