### PR TITLE
[frameworks] use correct output dir for nitro

### DIFF
--- a/.changeset/funny-experts-clean.md
+++ b/.changeset/funny-experts-clean.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[frameworks] use correct output dir for nitro

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2241,7 +2241,7 @@ export const frameworks = [
       },
     },
     dependency: 'nitropack',
-    getOutputDirName: () => Promise<string>,
+    getOutputDirName: () => 'public',
   },
   {
     name: 'Other',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2241,7 +2241,7 @@ export const frameworks = [
       },
     },
     dependency: 'nitropack',
-    getOutputDirName: () => 'public',
+    getOutputDirName: async () => 'public',
   },
   {
     name: 'Other',


### PR DESCRIPTION
Unsure _why_ but starting in `44.2.9` Nitro deploys stopped working correctly. I believe this is the root cause of the error:

```
***CLI Stack Trace:***
Error: The "path" argument must be of type string. Received function Promise
at Now.handleDeploymentError 
```

The current configuration returns the `Promise` constructor when it should return a string value that is a path.

What in  `44.2.9`  is beyond my ken, but I believe this addresses it. If not, customers can set `'public'` as their Output Directory value in their project's `settings/build-and-deployment` page. I verified that works correctly.