### PR TITLE
Deprecate Node 18.x with warning

### DIFF
--- a/.changeset/kind-rocks-yawn.md
+++ b/.changeset/kind-rocks-yawn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Deprecate Node.js 18.x with warning

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -23,6 +23,7 @@ export const NODE_VERSIONS: NodeVersion[] = [
     major: 18,
     range: '18.x',
     runtime: 'nodejs18.x',
+    discontinueDate: new Date('2025-09-01'),
   }),
   new NodeVersion({
     major: 16,

--- a/packages/build-utils/test/pkg-engine-node-exact/package.json
+++ b/packages/build-utils/test/pkg-engine-node-exact/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "engines": {
-    "node": "18.2.0"
+    "node": "22.11.0"
   }
 }

--- a/packages/build-utils/test/pkg-engine-node/package.json
+++ b/packages/build-utils/test/pkg-engine-node/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   }
 }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -167,20 +167,20 @@ it('should ignore node version in vercel dev getNodeVersion()', async () => {
 
 it('should select project setting from config when no package.json is found and fallback undefined', async () => {
   expect(
-    await getNodeVersion('/tmp', undefined, { nodeVersion: '18.x' }, {})
-  ).toHaveProperty('range', '18.x');
+    await getNodeVersion('/tmp', undefined, { nodeVersion: '22.x' }, {})
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 });
 
 it('should select project setting from config when no package.json is found and fallback is null', async () => {
   expect(
-    await getNodeVersion('/tmp', null as any, { nodeVersion: '18.x' }, {})
-  ).toHaveProperty('range', '18.x');
+    await getNodeVersion('/tmp', null as any, { nodeVersion: '22.x' }, {})
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 });
 
 it('should select project setting from fallback when no package.json is found', async () => {
-  expect(await getNodeVersion('/tmp', '18.x')).toHaveProperty('range', '18.x');
+  expect(await getNodeVersion('/tmp', '22.x')).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 });
 
@@ -192,9 +192,9 @@ it('should prefer package.json engines over project setting from config and warn
       { nodeVersion: '12.x' },
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([
-    'Warning: Due to "engines": { "node": "18.x" } in your `package.json` file, the Node.js Version defined in your Project Settings ("12.x") will not apply, Node.js Version "18.x" will be used instead. Learn More: http://vercel.link/node-version',
+    'Warning: Due to "engines": { "node": "22.x" } in your `package.json` file, the Node.js Version defined in your Project Settings ("12.x") will not apply, Node.js Version "22.x" will be used instead. Learn More: http://vercel.link/node-version',
   ]);
 });
 
@@ -206,9 +206,9 @@ it('should warn when package.json engines is exact version', async () => {
       {},
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([
-    'Warning: Detected "engines": { "node": "18.2.0" } in your `package.json` with major.minor.patch, but only major Node.js Version can be selected. Learn More: http://vercel.link/node-version',
+    'Warning: Detected "engines": { "node": "22.11.0" } in your `package.json` with major.minor.patch, but only major Node.js Version can be selected. Learn More: http://vercel.link/node-version',
   ]);
 });
 
@@ -246,30 +246,30 @@ it('should not warn when package.json engines matches project setting from confi
     await getNodeVersion(
       path.join(__dirname, 'pkg-engine-node'),
       undefined,
-      { nodeVersion: '18' },
+      { nodeVersion: '22' },
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 
   expect(
     await getNodeVersion(
       path.join(__dirname, 'pkg-engine-node'),
       undefined,
-      { nodeVersion: '18.x' },
+      { nodeVersion: '22.x' },
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 
   expect(
     await getNodeVersion(
       path.join(__dirname, 'pkg-engine-node'),
       undefined,
-      { nodeVersion: '<19' },
+      { nodeVersion: '<23' },
       {}
     )
-  ).toHaveProperty('range', '18.x');
+  ).toHaveProperty('range', '22.x');
   expect(warningMessages).toStrictEqual([]);
 });
 
@@ -288,10 +288,10 @@ it('should get latest node version with Node 22.x in build-container', async () 
 });
 
 it('should throw for discontinued versions', async () => {
-  // Mock a future date so that Node 16 becomes discontinued
+  // Mock a future date so that Node 18 becomes discontinued
   const realDateNow = Date.now;
   try {
-    global.Date.now = () => new Date('2025-03-01').getTime();
+    global.Date.now = () => new Date('2025-10-01').getTime();
 
     expect(getSupportedNodeVersion('8.10.x', false)).rejects.toThrow();
     expect(getSupportedNodeVersion('8.10.x', true)).rejects.toThrow();
@@ -303,14 +303,17 @@ it('should throw for discontinued versions', async () => {
     expect(getSupportedNodeVersion('14.x', true)).rejects.toThrow();
     expect(getSupportedNodeVersion('16.x', false)).rejects.toThrow();
     expect(getSupportedNodeVersion('16.x', true)).rejects.toThrow();
+    expect(getSupportedNodeVersion('18.x', false)).rejects.toThrow();
+    expect(getSupportedNodeVersion('18.x', true)).rejects.toThrow();
 
     const discontinued = getDiscontinuedNodeVersions();
-    expect(discontinued.length).toBe(5);
-    expect(discontinued[0]).toHaveProperty('range', '16.x');
-    expect(discontinued[1]).toHaveProperty('range', '14.x');
-    expect(discontinued[2]).toHaveProperty('range', '12.x');
-    expect(discontinued[3]).toHaveProperty('range', '10.x');
-    expect(discontinued[4]).toHaveProperty('range', '8.10.x');
+    expect(discontinued.length).toBe(6);
+    expect(discontinued[0]).toHaveProperty('range', '18.x');
+    expect(discontinued[1]).toHaveProperty('range', '16.x');
+    expect(discontinued[2]).toHaveProperty('range', '14.x');
+    expect(discontinued[3]).toHaveProperty('range', '12.x');
+    expect(discontinued[4]).toHaveProperty('range', '10.x');
+    expect(discontinued[5]).toHaveProperty('range', '8.10.x');
   } finally {
     global.Date.now = realDateNow;
   }
@@ -325,22 +328,21 @@ it('should only allow nodejs22.x when env var is set', async () => {
 });
 
 it('should warn for deprecated versions, soon to be discontinued', async () => {
-  // Mock a future date so that Node 16 warns
   const realDateNow = Date.now;
   try {
-    global.Date.now = () => new Date('2021-02-23').getTime();
+    global.Date.now = () => new Date('2025-08-31').getTime();
 
-    expect(await getSupportedNodeVersion('16.x', false)).toHaveProperty(
+    expect(await getSupportedNodeVersion('18.x', false)).toHaveProperty(
       'major',
-      16
+      18
     );
-    expect(await getSupportedNodeVersion('16.x', true)).toHaveProperty(
+    expect(await getSupportedNodeVersion('18.x', true)).toHaveProperty(
       'major',
-      16
+      18
     );
     expect(warningMessages).toStrictEqual([
-      'Error: Node.js version 16.x is deprecated. Deployments created on or after 2025-02-03 will fail to build. Please set "engines": { "node": "22.x" } in your `package.json` file to use Node.js 22.',
-      'Error: Node.js version 16.x is deprecated. Deployments created on or after 2025-02-03 will fail to build. Please set Node.js Version to 22.x in your Project Settings to use Node.js 22.',
+      'Error: Node.js version 18.x is deprecated. Deployments created on or after 2025-09-01 will fail to build. Please set "engines": { "node": "22.x" } in your `package.json` file to use Node.js 22.',
+      'Error: Node.js version 18.x is deprecated. Deployments created on or after 2025-09-01 will fail to build. Please set Node.js Version to 22.x in your Project Settings to use Node.js 22.',
     ]);
   } finally {
     global.Date.now = realDateNow;


### PR DESCRIPTION
Node.js 18 is EOL and will be discontinued on September 1, 2025. Add a warning when Node 18 is used today and error after discontinuation date.
