### PR TITLE
[react-router] Use cookie method for Vercel Skew Protection

### DIFF
--- a/.changeset/fast-ravens-exercise.md
+++ b/.changeset/fast-ravens-exercise.md
@@ -1,0 +1,5 @@
+---
+'@vercel/react-router': patch
+---
+
+Use cookie method for Vercel Skew Protection

--- a/packages/react-router/edge/entry.server.ts
+++ b/packages/react-router/edge/entry.server.ts
@@ -48,7 +48,10 @@ export async function handleRequest(
   responseHeaders.set('Content-Type', 'text/html');
 
   if (vercelSkewProtectionEnabled && vercelDeploymentId) {
-    responseHeaders.set('x-deployment-id', vercelDeploymentId);
+    responseHeaders.append(
+      'Set-Cookie',
+      `__vdpl=${vercelDeploymentId}; HttpOnly`
+    );
   }
 
   return new Response(body, {

--- a/packages/react-router/entry.server.ts
+++ b/packages/react-router/entry.server.ts
@@ -58,7 +58,10 @@ export function handleRequest(
           responseHeaders.set('Content-Type', 'text/html');
 
           if (vercelSkewProtectionEnabled && vercelDeploymentId) {
-            responseHeaders.set('x-deployment-id', vercelDeploymentId);
+            responseHeaders.append(
+              'Set-Cookie',
+              `__vdpl=${vercelDeploymentId}; HttpOnly`
+            );
           }
 
           resolve(


### PR DESCRIPTION
The `x-deployment-id` method is for _request_ headers (client-side), not response headers (server-side). Using the cookie method allows for the SSR pages in React Router to enable Vercel Skew Protection.