### PR TITLE
[packages/routing-utils] do not throw when convertRewrites fails

### DIFF
--- a/.changeset/seven-dolls-return.md
+++ b/.changeset/seven-dolls-return.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+Do not throw an error when convertRewrites fail

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -425,7 +425,7 @@ export function getTransformedRoutes(
         routes,
         error: createError(
           code,
-          'Failed to parse rewrite',
+          (err as Error).message, // Error: Failed to parse rewrite: <which rewrite>
           'https://vercel.link/invalid-route-source-pattern',
           'Learn More'
         ),

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -416,7 +416,23 @@ export function getTransformedRoutes(
         ),
       };
     }
-    const normalized = normalizeRoutes(convertRewrites(rewrites));
+
+    let convertedRewrites: Route[] = [];
+    try {
+      convertedRewrites = convertRewrites(rewrites);
+    } catch (err) {
+      return {
+        routes,
+        error: createError(
+          code,
+          'Failed to parse rewrite',
+          'https://vercel.link/invalid-route-source-pattern',
+          'Learn More'
+        ),
+      };
+    }
+
+    const normalized = normalizeRoutes(convertedRewrites);
     if (normalized.error) {
       normalized.error.code = code;
       return { routes, error: normalized.error };


### PR DESCRIPTION
Do not throw when we fail to convert a rewrite and return a proper error. I am seeing this errors:

```
[error reporter]: Failed to parse rewrite: {"source":"REDACTED","destination":"REDACTED"}
```

This error is thrown inside convertRewrites: https://github.com/vercel/vercel/blob/826539f0236c5532c473e2490da6ea797d363423/packages/routing-utils/src/superstatic.ts#L196