### PR TITLE
[functions] Only warn runtime cache unavailable once

### DIFF
--- a/.changeset/blue-years-explode.md
+++ b/.changeset/blue-years-explode.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Only warn runtime cache unavailable once

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -86,6 +86,8 @@ function wrapWithKeyTransformation(
   };
 }
 
+let warnedCacheUnavailable = false;
+
 function getCacheImplementation(debug?: boolean): RuntimeCache {
   if (!inMemoryCacheInstance) {
     inMemoryCacheInstance = new InMemoryCache();
@@ -106,9 +108,12 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
   }
 
   if (!RUNTIME_CACHE_ENDPOINT || !RUNTIME_CACHE_HEADERS) {
-    console.warn(
-      'Runtime Cache unavailable in this environment. Falling back to in-memory cache.'
-    );
+    if (!warnedCacheUnavailable) {
+      console.warn(
+        'Runtime Cache unavailable in this environment. Falling back to in-memory cache.'
+      );
+      warnedCacheUnavailable = true;
+    }
     return inMemoryCacheInstance;
   }
 


### PR DESCRIPTION
This gets pretty noisy if calling `getCache` multiple times where not available. 

<img width="1696" height="896" alt="CleanShot 2025-07-11 at 15 17 26@2x" src="https://github.com/user-attachments/assets/7bf49d43-a952-45e0-9820-5803c91d3e8e" />
