### PR TITLE
Ignore pnpm global store in Python lambdas

### DIFF
--- a/.changeset/nice-rivers-kiss.md
+++ b/.changeset/nice-rivers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Ignore .pnpm_store in Python lambdas

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -202,6 +202,7 @@ export const build: BuildV3 = async ({
         : [
             '.git/**',
             '.vercel/**',
+            '.pnpm-store/**',
             '**/node_modules/**',
             '**/.next/**',
             '**/.nuxt/**',


### PR DESCRIPTION
### TL;DR

Add `.pnpm-store/**` to the list of excluded paths in Python builds. That directory contains all pnpm installed packages. Python doesn't use it, it only bloats the lambda.