### PR TITLE
fix(react-router): avoid injecting 404 route if additional runtimes are found

### DIFF
--- a/.changeset/green-dryers-shave.md
+++ b/.changeset/green-dryers-shave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+No longer inject 404 route for react router

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -252,6 +252,7 @@ export const frameworks = [
     sort: 7,
     supersedes: ['hydrogen', 'vite'],
     useRuntime: { src: 'package.json', use: '@vercel/remix-builder' },
+    ignoreRuntimes: ['@vercel/node'],
     detectors: {
       some: [
         {


### PR DESCRIPTION
Currently if additional functions are declared with other runtimes e.g. Python we inject a `/api(/.*)? -> 404` route to prevent `/api` from returning the directory (https://github.com/vercel/vercel/pull/5064). This is unnecessary for React Router which handles this for us and overfits resulting in declared React Router routes returning a 404.