### PR TITLE
[next]: Fix case for _next/data for i18n-basepath-middleware

### DIFF
--- a/.changeset/silly-pumas-complain.md
+++ b/.changeset/silly-pumas-complain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix case for \_next/data for i18n-basepath-middleware

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2533,7 +2533,7 @@ export async function serverBuild({
               if (routesManifest.i18n) {
                 for (const locale of routesManifest.i18n?.locales || []) {
                   const prerenderPathname = pathname.replace(
-                    /^\/\$nextLocale/,
+                    /\/\$nextLocale/,
                     `/${locale}`
                   );
                   if (prerenders[path.join('./', prerenderPathname)]) {

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/index.test.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/middleware.js
@@ -1,3 +1,5 @@
+import { NextResponse } from 'next/server' 
+
 export function middleware(req) {
   return NextResponse.next();
 }

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/middleware.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/middleware.js
@@ -1,0 +1,7 @@
+export function middleware(req) {
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/next.config.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+  basePath: '/docs',
+  i18n: {
+    locales: ['en', 'fr', 'nl'],
+    defaultLocale: 'en',
+  },
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/package.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/404.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/404.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return 'not found page';
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/_app.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/_app.js
@@ -1,0 +1,5 @@
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/another.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/another.js
@@ -1,0 +1,11 @@
+export default function Another() {
+  return 'another page';
+}
+
+export const getStaticProps = ({ locale }) => ({
+  props: {
+    locale,
+    hello: 'world',
+  },
+  revalidate: 1,
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/blog/[slug].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/blog/[slug].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.json({ slug: req.query.slug });
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/catchall/[...rest].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/catchall/[...rest].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.json({ rest: req.query.rest.join('/') });
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/hello.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/api/hello.js
@@ -1,0 +1,6 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  res.statusCode = 200;
+  res.json({ name: 'John Doe' });
+};

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/dynamic/[slug].js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/dynamic/[slug].js
@@ -1,0 +1,24 @@
+export default function Page(props) {
+  return (
+    <>
+      <p>/dynamic/[slug]</p>
+      <p>{JSON.stringify(props)}</p>
+    </>
+  );
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { slug: 'first' } }],
+    fallback: 'blocking',
+  };
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  };
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/hello.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/hello.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'hello page';
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/index.js
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/pages/index.js
@@ -1,0 +1,11 @@
+export default function Home() {
+  return 'index page';
+}
+
+export const getServerSideProps = ({ locale }) => ({
+  props: {
+    locale,
+    hello: 'world',
+    gsspData: true,
+  },
+});

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
@@ -1,0 +1,89 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }],
+  "probes": [
+    {
+      "path": "/docs/non-existent",
+      "status": 404,
+      "mustContain": "not found page"
+    },
+    {
+      "path": "/docs/non-existent",
+      "status": 404,
+      "mustContain": "lang=\"en\""
+    },
+    {
+      "path": "/docs/fr/non-existent",
+      "status": 404,
+      "mustContain": "not found page"
+    },
+    {
+      "path": "/docs/fr/non-existent",
+      "status": 404,
+      "mustContain": "lang=\"fr\""
+    },
+
+    {
+      "path": "/docs",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/docs/fr",
+      "status": 200,
+      "mustContain": "index page"
+    },
+
+    {
+      "path": "/docs/another",
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/docs/fr/another",
+      "status": 200,
+      "mustContain": "another page"
+    },
+    {
+      "path": "/docs/fr/another",
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+
+    {
+      "path": "/docs/hello",
+      "status": 200,
+      "mustContain": "hello page"
+    },
+    {
+      "path": "/docs/hello",
+      "status": 200,
+      "mustContain": "lang=\"en\""
+    },
+    {
+      "path": "/docs/fr/hello",
+      "status": 200,
+      "mustContain": "hello page"
+    },
+    {
+      "path": "/docs/fr/hello",
+      "status": 200,
+      "mustContain": "lang=\"fr\""
+    },
+    {
+      "path": "/docs/api/hello",
+      "status": 200,
+      "mustContain": "John Doe"
+    },
+    {
+      "path": "/docs/api/blog/first",
+      "status": 200,
+      "mustContain": "\"slug\":\"first\""
+    },
+    {
+      "path": "/docs/api/catchall/hello/world",
+      "status": 200,
+      "mustContain": "\"rest\":\"hello/world\""
+    }
+  ]
+}

--- a/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
+++ b/packages/next/test/fixtures/00-i18n-basepath-middleware/vercel.json
@@ -2,6 +2,18 @@
   "version": 2,
   "builds": [{ "src": "package.json", "use": "@vercel/next" }],
   "probes": [
+     {
+      "path": "/docs/_next/data/testing-build-id/en/dynamic/first.json?slug=first",
+      "status": 200,
+      "mustContain": "slug\":\"first\"",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/docs/_next/data/testing-build-id/en/dynamic/123.json?slug=123",
+      "status": 200,
+      "mustContain": "slug\":\"123\"",
+      "mustNotContain": "<html"
+    },
     {
       "path": "/docs/non-existent",
       "status": 404,


### PR DESCRIPTION
This fixes an issue with generating `_next/data` routes when `basePath` is used with `i18n` and middleware. We were failing to detect if a route is a prerender due to anchoring a regex replace which fails when a `basePath` causes the locale not to be at the start. 