### PR TITLE
[next] Enable source page lambda support

### DIFF
--- a/.changeset/sixty-trains-jog.md
+++ b/.changeset/sixty-trains-jog.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Added support for partial routes defining a source page by adding lambdas for these routes

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1810,11 +1810,11 @@ export async function serverBuild({
     // RSC header is present
     const edgeFunctions = middleware.edgeFunctions;
 
-    for (const route of Object.values(appPathRoutesManifest)) {
+    for (const page of Object.values(appPathRoutesManifest)) {
       const pathname = path.posix.join(
         './',
         entryDirectory,
-        route === '/' ? '/index' : route
+        page === '/' ? '/index' : page
       );
 
       if (lambdas[pathname]) {
@@ -1832,6 +1832,41 @@ export async function serverBuild({
           edgeFunctions[`${pathname}${RSC_PREFETCH_SUFFIX}`] =
             edgeFunctions[pathname];
         }
+      }
+    }
+
+    for (const route of routesManifest.dynamicRoutes) {
+      // Skip any routes that don't have the sourcePage property defined. Only
+      // the dynamic routes that are partials will have their sourcePage
+      // defined so we can skip the usual isAppPPREnabled check.
+      if (!('sourcePage' in route)) continue;
+      if (typeof route.sourcePage !== 'string') continue;
+
+      // Skip this addition when the routes are the same, no need to alias them
+      // again!
+      if (route.sourcePage === route.page) continue;
+
+      const sourcePathname = path.posix.join(
+        './',
+        entryDirectory,
+        route.sourcePage === '/' ? '/index' : route.sourcePage
+      );
+
+      const pathname = path.posix.join(
+        './',
+        entryDirectory,
+        route.page === '/' ? '/index' : route.page
+      );
+
+      if (lambdas[sourcePathname]) {
+        lambdas[`${pathname}.rsc`] = lambdas[sourcePathname];
+        lambdas[`${pathname}${RSC_PREFETCH_SUFFIX}`] = lambdas[sourcePathname];
+      }
+
+      if (edgeFunctions[sourcePathname]) {
+        edgeFunctions[`${pathname}.rsc`] = edgeFunctions[sourcePathname];
+        edgeFunctions[`${pathname}${RSC_PREFETCH_SUFFIX}`] =
+          edgeFunctions[sourcePathname];
       }
     }
   }

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -313,7 +313,10 @@ type RoutesManifestOld = {
 
 type RoutesManifestV4 = Omit<RoutesManifestOld, 'dynamicRoutes' | 'version'> & {
   version: 4;
-  dynamicRoutes: (RoutesManifestRoute | { page: string; isMiddleware: true })[];
+  dynamicRoutes: (
+    | RoutesManifestRoute
+    | { sourcePage: string | undefined; page: string; isMiddleware: true }
+  )[];
 };
 
 export type RoutesManifest = RoutesManifestV4 | RoutesManifestOld;


### PR DESCRIPTION
### Summary

This PR adds support for dynamic routes that define a `sourcePage` property by creating lambda aliases that point to the source page's lambda. This enhancement is specifically designed to support partial routes in Next.js applications using Partial Pre-Rendering (PPR).

### Problem

When Next.js dynamic routes use partial pre-rendering, they may reference a source page that contains the actual implementation. However, the build system wasn't creating the necessary lambda function aliases for these partial routes, which meant requests to these routes wouldn't be properly handled.

### Solution

The implementation adds a new loop in the server build process that:
1. Iterates through all dynamic routes in the routes manifest
2. Identifies routes that have a `sourcePage` property (indicating they are partial routes)
3. Creates lambda and edge function aliases that point from the partial route to the source page's lambda
4. Handles both `.rsc` (React Server Component) and prefetch variants of these routes

### Technical Details

- **Modified Files**:
  - `packages/next/src/server-build.ts`: Added logic to create lambda aliases for partial routes
  - `packages/next/src/utils.ts`: Updated the `RoutesManifestV4` type to include `sourcePage` property for dynamic routes
  - Added a changeset for version tracking

- **Key Implementation Points**:
  - Only processes routes with a defined `sourcePage` property
  - Skips routes where `sourcePage` equals `page` (no aliasing needed)
  - Creates both RSC and prefetch suffix variants for each lambda/edge function
  - Works seamlessly with the existing PPR infrastructure

### Impact

This change enables proper request handling for partial routes in Next.js applications using PPR, ensuring that dynamic routes that reference a source page implementation are correctly routed to the appropriate lambda function.

### Testing

The change is minimal and focused on build-time lambda aliasing. It extends existing functionality without modifying the core routing behavior.

### Related

https://github.com/vercel/next.js/pull/81781
[NAR-159](https://linear.app/vercel/issue/NAR-159/high-cardinality-params-fixes)