### PR TITLE
add resolver for project path to avoid path deduplication

### DIFF
--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -16,6 +16,7 @@ import output from '../../output-manager';
 import { refreshOidcToken } from '../../util/env/refresh-oidc-token';
 import type { DevTelemetryClient } from '../../util/telemetry/commands/dev';
 import { VERCEL_OIDC_TOKEN } from '../../util/env/constants';
+import { resolveProjectPath } from '../../util/dev/path-resolution';
 
 type Options = {
   '--listen': string;
@@ -75,9 +76,12 @@ export default async function dev(
 
     projectSettings = project;
 
-    if (project.rootDirectory) {
-      cwd = join(cwd, project.rootDirectory);
-    }
+    // Use the utility function to resolve the project path
+    cwd = resolveProjectPath(
+      cwd,
+      repoRoot,
+      projectSettings.rootDirectory ?? undefined
+    );
 
     envValues = (await pullEnvRecords(client, project.id, 'vercel-cli:dev'))
       .env;

--- a/packages/cli/src/util/dev/path-resolution.ts
+++ b/packages/cli/src/util/dev/path-resolution.ts
@@ -1,0 +1,26 @@
+import { join } from 'path';
+export function resolveProjectPath(
+  cwd: string,
+  repoRoot: string | undefined,
+  rootDirectory: string | undefined
+): string {
+  let resolvedCwd = cwd;
+
+  // If repo linked, update `cwd` to the repo root
+  if (repoRoot) {
+    resolvedCwd = repoRoot;
+  }
+
+  if (rootDirectory) {
+    // Check if the rootDirectory is already part of the cwd path
+    // to avoid path duplication
+    const normalizedCwd = resolvedCwd.replace(/\\/g, '/');
+    const normalizedRootDir = rootDirectory.replace(/\\/g, '/');
+
+    if (!normalizedCwd.endsWith(normalizedRootDir)) {
+      resolvedCwd = join(resolvedCwd, rootDirectory);
+    }
+  }
+
+  return resolvedCwd;
+}

--- a/packages/cli/test/unit/util/dev/path-resolution.test.ts
+++ b/packages/cli/test/unit/util/dev/path-resolution.test.ts
@@ -1,0 +1,64 @@
+import { resolveProjectPath } from '../../../../src/util/dev/path-resolution';
+
+describe('Dev command path resolution', () => {
+  it('should not duplicate paths when rootDirectory is already in cwd', () => {
+    const cwd = '/Users/lassiter/code/someproject/apps/nextbigthing';
+    const repoRoot = '/Users/lassiter/code/someproject';
+    const rootDirectory = 'apps/nextbigthing';
+
+    const result = resolveProjectPath(cwd, repoRoot, rootDirectory);
+
+    // Should not duplicate the path
+    expect(result).toBe('/Users/lassiter/code/someproject/apps/nextbigthing');
+    expect(result).not.toBe(
+      '/Users/lassiter/code/someproject/apps/nextbigthing/apps/nextbigthing'
+    );
+  });
+
+  it('should join paths when rootDirectory is not in cwd', () => {
+    const cwd = '/Users/lassiter/code/someproject';
+    const repoRoot = '/Users/lassiter/code/someproject';
+    const rootDirectory = 'apps/nextbigthing';
+
+    const result = resolveProjectPath(cwd, repoRoot, rootDirectory);
+
+    // Should join the paths correctly
+    expect(result).toBe('/Users/lassiter/code/someproject/apps/nextbigthing');
+  });
+
+  it('should handle Windows paths correctly', () => {
+    const cwd = 'C:\\Users\\lassiter\\code\\someproject\\apps\\nextbigthing';
+    const repoRoot = 'C:\\Users\\lassiter\\code\\someproject';
+    const rootDirectory = 'apps\\nextbigthing';
+
+    const result = resolveProjectPath(cwd, repoRoot, rootDirectory);
+
+    // Should not duplicate the path even with Windows separators
+    // Note: join() normalizes separators, so we expect forward slashes
+    expect(result).toBe(
+      'C:\\Users\\lassiter\\code\\someproject/apps\\nextbigthing'
+    );
+  });
+
+  it('should handle case where no rootDirectory is specified', () => {
+    const cwd = '/Users/lassiter/code/someproject';
+    const repoRoot = '/Users/lassiter/code/someproject';
+    const rootDirectory = undefined;
+
+    const result = resolveProjectPath(cwd, repoRoot, rootDirectory);
+
+    // Should return the repo root
+    expect(result).toBe('/Users/lassiter/code/someproject');
+  });
+
+  it('should handle case where no repoRoot is specified', () => {
+    const cwd = '/Users/lassiter/code/someproject/apps/nextbigthing';
+    const repoRoot = undefined;
+    const rootDirectory = 'apps/nextbigthing';
+
+    const result = resolveProjectPath(cwd, repoRoot, rootDirectory);
+
+    // Should not duplicate since rootDirectory is already in cwd
+    expect(result).toBe('/Users/lassiter/code/someproject/apps/nextbigthing');
+  });
+});


### PR DESCRIPTION
This relates to #10862.