### PR TITLE
Add `--json` flag to projects list command

### DIFF
--- a/.changeset/popular-apples-marry.md
+++ b/.changeset/popular-apples-marry.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add --json flag to projects list

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { nextOption, yesOption } from '../../util/arg-common';
+import { nextOption, yesOption, jsonOption } from '../../util/arg-common';
 
 export const addSubcommand = {
   name: 'add',
@@ -51,6 +51,7 @@ export const listSubcommand = {
   arguments: [],
   options: [
     nextOption,
+    jsonOption,
     {
       name: 'update-required',
       description: 'A list of projects affected by an upcoming deprecation',
@@ -63,6 +64,10 @@ export const listSubcommand = {
     {
       name: 'Paginate projects, where `1584722256178` is the time in milliseconds since the UNIX epoch',
       value: `${packageName} project ls --next 1584722256178`,
+    },
+    {
+      name: 'List projects using a deprecated Node.js version in JSON format',
+      value: `${packageName} project ls --update-required --json`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -53,7 +53,6 @@ export const listSubcommand = {
     nextOption,
     {
       name: 'json',
-      shorthand: 'j',
       type: Boolean,
       deprecated: false,
       description: 'Output in JSON format',

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -53,6 +53,7 @@ export const listSubcommand = {
     nextOption,
     {
       name: 'json',
+      shorthand: null,
       type: Boolean,
       deprecated: false,
       description: 'Output in JSON format',

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -51,7 +51,6 @@ export const listSubcommand = {
   arguments: [],
   options: [
     nextOption,
-    jsonOption,
     {
       name: 'json',
       shorthand: 'j',

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -52,6 +52,13 @@ export const listSubcommand = {
   options: [
     nextOption,
     {
+      name: 'json',
+      shorthand: 'j',
+      type: Boolean,
+      deprecated: false,
+      description: 'Output in JSON format',
+    },
+    {
       name: 'update-required',
       description: 'A list of projects affected by an upcoming deprecation',
       shorthand: null,
@@ -63,6 +70,10 @@ export const listSubcommand = {
     {
       name: 'Paginate projects, where `1584722256178` is the time in milliseconds since the UNIX epoch',
       value: `${packageName} project ls --next 1584722256178`,
+    },
+    {
+      name: 'List projects using a deprecated Node.js version in JSON format',
+      value: `${packageName} project ls --update-required --json`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/project/command.ts
+++ b/packages/cli/src/commands/project/command.ts
@@ -1,5 +1,5 @@
 import { packageName } from '../../util/pkg-name';
-import { nextOption, yesOption, jsonOption } from '../../util/arg-common';
+import { nextOption, yesOption } from '../../util/arg-common';
 
 export const addSubcommand = {
   name: 'add',

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -27,7 +27,6 @@ const PAGINATION_FLAGS_TO_EXCLUDE = [
   '-d',
   '-y',
   '--json',
-  '-j',
 ];
 const BASE_PROJECTS_URL = '/v9/projects?limit=20';
 

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -13,6 +13,24 @@ import getScope from '../../util/get-scope';
 import type Client from '../../util/client';
 import type { Project } from '@vercel-internals/types';
 
+// Constants
+const TABLE_HEADERS = [
+  'Project Name',
+  'Latest Production URL',
+  'Updated',
+  'Node Version',
+];
+const PAGINATION_FLAGS_TO_EXCLUDE = [
+  '_',
+  '--next',
+  '-N',
+  '-d',
+  '-y',
+  '--json',
+  '-j',
+];
+const BASE_PROJECTS_URL = '/v9/projects?limit=20';
+
 export default async function list(
   client: Client,
   argv: string[]
@@ -47,22 +65,9 @@ export default async function list(
   const { contextName } = await getScope(client);
   output.spinner(`Fetching projects in ${chalk.bold(contextName)}`);
 
-  let projectsUrl = '/v9/projects?limit=20';
-
-  const deprecated = opts['--update-required'] || false;
-  telemetryClient.trackCliFlagUpdateRequired(deprecated);
-  if (deprecated) {
-    projectsUrl += `&deprecated=${deprecated}`;
-  }
-
-  const next = opts['--next'];
-  telemetryClient.trackCliOptionNext(next);
-  if (next) {
-    projectsUrl += `&until=${next}`;
-  }
-
-  const json = opts['--json'] || false;
-  telemetryClient.trackCliFlagJson(json);
+  // Process flags and build URL
+  const flags = processFlags(opts, telemetryClient);
+  const projectsUrl = buildProjectsUrl(flags);
 
   const {
     projects: projectList,
@@ -78,68 +83,145 @@ export default async function list(
 
   const elapsed = ms(Date.now() - start);
 
-  if (json) {
-    const jsonOutput = {
-      projects: projectList.map(project => ({
-        name: project.name,
-        id: project.id,
-        latestProductionUrl: getLatestProdUrl(project),
-        updatedAt: project.updatedAt,
-        nodeVersion: project.nodeVersion ?? null,
-        deprecated: deprecated,
-      })),
-      pagination: pagination,
-      contextName: contextName,
-      elapsed: elapsed,
-    };
-    output.print(JSON.stringify(jsonOutput, null, 2));
+  if (flags.json) {
+    outputJson(projectList, {
+      pagination,
+      contextName,
+      elapsed,
+      deprecated: flags.deprecated,
+    });
   } else {
-    output.log(
-      `${
-        projectList.length > 0 ? 'Projects' : 'No projects'
-      } found under ${chalk.bold(contextName)} ${
-        deprecated ? 'that are using a deprecated Node.js version' : '\b'
-      } ${chalk.gray(`[${elapsed}]`)}`
-    );
-
-    if (projectList.length > 0) {
-      const tablePrint = table(
-        [
-          [
-            'Project Name',
-            'Latest Production URL',
-            'Updated',
-            'Node Version',
-          ].map(header => chalk.bold(chalk.cyan(header))),
-          ...projectList.flatMap(project => [
-            [
-              chalk.bold(project.name),
-              getLatestProdUrl(project),
-              chalk.gray(ms(Date.now() - project.updatedAt)),
-              project.nodeVersion ?? '',
-            ],
-          ]),
-        ],
-        { hsep: 3 }
-      ).replace(/^/gm, '  ');
-      output.print(`\n${tablePrint}\n\n`);
-
-      if (pagination && pagination.count === 20) {
-        const flags = getCommandFlags(opts, [
-          '_',
-          '--next',
-          '-N',
-          '-d',
-          '-y',
-          '--json',
-          '-j',
-        ]);
-        const nextCmd = `project ls${flags} --next ${pagination.next}`;
-        output.log(`To display the next page, run ${getCommandName(nextCmd)}`);
-      }
-    }
+    outputTable(projectList, {
+      contextName,
+      elapsed,
+      deprecated: flags.deprecated,
+      opts,
+      pagination,
+    });
   }
+
   return 0;
+}
+
+// Helper function to process flags and track telemetry
+function processFlags(
+  opts: Record<string, any>,
+  telemetryClient: ProjectListTelemetryClient
+) {
+  const deprecated = opts['--update-required'] || false;
+  const next = opts['--next'];
+  const json = opts['--json'] || false;
+
+  telemetryClient.trackCliFlagUpdateRequired(deprecated);
+  telemetryClient.trackCliOptionNext(next);
+  telemetryClient.trackCliFlagJson(json);
+
+  return { deprecated, next, json };
+}
+
+// Helper function to build projects URL
+function buildProjectsUrl(flags: { deprecated: boolean; next?: number }) {
+  let url = BASE_PROJECTS_URL;
+
+  if (flags.deprecated) {
+    url += `&deprecated=${flags.deprecated}`;
+  }
+  if (flags.next) {
+    url += `&until=${flags.next}`;
+  }
+
+  return url;
+}
+
+// Helper function to create project JSON representation
+function createProjectJson(project: Project, deprecated: boolean) {
+  return {
+    name: project.name,
+    id: project.id,
+    latestProductionUrl: getLatestProdUrl(project),
+    updatedAt: project.updatedAt,
+    nodeVersion: project.nodeVersion ?? null,
+    deprecated: deprecated,
+  };
+}
+
+// Helper function for JSON output
+function outputJson(
+  projectList: Project[],
+  metadata: {
+    pagination: any;
+    contextName: string;
+    elapsed: string;
+    deprecated: boolean;
+  }
+) {
+  const jsonOutput = {
+    projects: projectList.map(project =>
+      createProjectJson(project, metadata.deprecated)
+    ),
+    pagination: metadata.pagination,
+    contextName: metadata.contextName,
+    elapsed: metadata.elapsed,
+  };
+  output.print(JSON.stringify(jsonOutput, null, 2));
+}
+
+// Helper function for table output
+function outputTable(
+  projectList: Project[],
+  options: {
+    contextName: string;
+    elapsed: string;
+    deprecated: boolean;
+    opts: Record<string, any>;
+    pagination: { count: number; next: number };
+  }
+) {
+  const { contextName, elapsed, deprecated, opts, pagination } = options;
+
+  output.log(
+    `${
+      projectList.length > 0 ? 'Projects' : 'No projects'
+    } found under ${chalk.bold(contextName)} ${
+      deprecated ? 'that are using a deprecated Node.js version' : '\b'
+    } ${chalk.gray(`[${elapsed}]`)}`
+  );
+
+  if (projectList.length > 0) {
+    printProjectsTable(projectList);
+    printPaginationInstructions(opts, pagination);
+  }
+}
+
+// Helper function to print projects table
+function printProjectsTable(projectList: Project[]) {
+  const tablePrint = table(
+    [
+      TABLE_HEADERS.map(header => chalk.bold(chalk.cyan(header))),
+      ...projectList.flatMap(project => [
+        [
+          chalk.bold(project.name),
+          getLatestProdUrl(project),
+          chalk.gray(ms(Date.now() - project.updatedAt)),
+          project.nodeVersion ?? '',
+        ],
+      ]),
+    ],
+    { hsep: 3 }
+  ).replace(/^/gm, '  ');
+  output.print(`\n${tablePrint}\n\n`);
+}
+
+// Helper function to print pagination instructions
+function printPaginationInstructions(
+  opts: Record<string, any>,
+  pagination: { count: number; next: number }
+) {
+  if (pagination && pagination.count === 20) {
+    const flags = getCommandFlags(opts, PAGINATION_FLAGS_TO_EXCLUDE);
+    const nextCmd = `project ls${flags} --next ${pagination.next}`;
+    output.log(`To display the next page, run ${getCommandName(nextCmd)}`);
+  }
 }
 
 function getLatestProdUrl(project: Project): string {

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -20,14 +20,7 @@ const TABLE_HEADERS = [
   'Updated',
   'Node Version',
 ];
-const PAGINATION_FLAGS_TO_EXCLUDE = [
-  '_',
-  '--next',
-  '-N',
-  '-d',
-  '-y',
-  '--json',
-];
+const PAGINATION_FLAGS_TO_EXCLUDE = ['_', '--next', '-N', '-d', '-y', '--json'];
 const BASE_PROJECTS_URL = '/v9/projects?limit=20';
 
 export default async function list(
@@ -83,7 +76,7 @@ export default async function list(
   const elapsed = ms(Date.now() - start);
 
   if (flags.json) {
-    outputJson(projectList, {
+    outputJson(client, projectList, {
       pagination,
       contextName,
       elapsed,
@@ -146,6 +139,7 @@ function createProjectJson(project: Project, deprecated: boolean) {
 
 // Helper function for JSON output
 function outputJson(
+  client: Client,
   projectList: Project[],
   metadata: {
     pagination: any;
@@ -162,7 +156,7 @@ function outputJson(
     contextName: metadata.contextName,
     elapsed: metadata.elapsed,
   };
-  output.print(JSON.stringify(jsonOutput, null, 2));
+  client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
 }
 
 // Helper function for table output

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -116,11 +116,3 @@ export const forceOption = {
   type: Boolean,
   deprecated: false,
 } as const;
-
-export const jsonOption = {
-  name: 'json',
-  shorthand: 'j',
-  type: Boolean,
-  deprecated: false,
-  description: 'Output in JSON format',
-} as const;

--- a/packages/cli/src/util/arg-common.ts
+++ b/packages/cli/src/util/arg-common.ts
@@ -116,3 +116,11 @@ export const forceOption = {
   type: Boolean,
   deprecated: false,
 } as const;
+
+export const jsonOption = {
+  name: 'json',
+  shorthand: 'j',
+  type: Boolean,
+  deprecated: false,
+  description: 'Output in JSON format',
+} as const;

--- a/packages/cli/src/util/telemetry/commands/project/list.ts
+++ b/packages/cli/src/util/telemetry/commands/project/list.ts
@@ -20,4 +20,10 @@ export class ProjectListTelemetryClient
       });
     }
   }
+
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3768,6 +3768,7 @@ exports[`help command > project help output snapshots > project list help output
 
   Options:
 
+       --json             Output in JSON format                                                                              
   -N,  --next <MS>        Show next page of results                                                                          
        --update-required  A list of projects affected by an upcoming deprecation                                             
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3768,6 +3768,7 @@ exports[`help command > project help output snapshots > project list help output
 
   Options:
 
+  -j,  --json             Output in JSON format                                                                              
   -N,  --next <MS>        Show next page of results                                                                          
        --update-required  A list of projects affected by an upcoming deprecation                                             
 
@@ -3790,6 +3791,10 @@ exports[`help command > project help output snapshots > project list help output
   - Paginate projects, where \`1584722256178\` is the time in milliseconds since the UNIX epoch
 
     $ vercel project ls --next 1584722256178
+
+  - List projects using a deprecated Node.js version in JSON format
+
+    $ vercel project ls --update-required --json
 
 "
 `;

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -3768,7 +3768,6 @@ exports[`help command > project help output snapshots > project list help output
 
   Options:
 
-  -j,  --json             Output in JSON format                                                                              
   -N,  --next <MS>        Show next page of results                                                                          
        --update-required  A list of projects affected by an upcoming deprecation                                             
 

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -120,8 +120,7 @@ describe('list', () => {
       client.setArgv('project', 'ls', '--json');
       await projects(client);
 
-      const output = client.stderr.getFullOutput();
-
+      const output = client.stdout.getFullOutput();
 
       const parsedOutput = JSON.parse(output);
       expect(parsedOutput).toMatchObject({

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -87,6 +87,74 @@ describe('list', () => {
     });
   });
 
+  describe('--json', () => {
+    it('should track flag', async () => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+      });
+
+      client.setArgv('project', 'ls', '--json');
+      await projects(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: `subcommand:list`,
+          value: 'ls',
+        },
+        {
+          key: `flag:json`,
+          value: 'TRUE',
+        },
+      ]);
+    });
+
+    it('should output projects in JSON format', async () => {
+      const user = useUser();
+      useTeams('team_dummy');
+      const project = useProject({
+        ...defaultProject,
+      });
+
+      client.setArgv('project', 'ls', '--json');
+      await projects(client);
+
+      const output = client.stderr.getFullOutput();
+
+      // Should not contain table formatting
+      expect(output).not.toContain('Project Name');
+      expect(output).not.toContain('Latest Production URL');
+
+      // Should contain JSON output
+      expect(output).toContain('"projects":');
+      expect(output).toContain('"pagination":');
+      expect(output).toContain('"contextName":');
+      expect(output).toContain('"elapsed":');
+
+      // Parse JSON to validate structure
+      const jsonMatch = output.match(/\{[\s\S]*\}/);
+      expect(jsonMatch).toBeTruthy();
+
+      const parsedOutput = JSON.parse(jsonMatch![0]);
+      expect(parsedOutput).toMatchObject({
+        projects: expect.arrayContaining([
+          expect.objectContaining({
+            name: project.project.name,
+            id: project.project.id,
+            latestProductionUrl: expect.any(String),
+            updatedAt: expect.any(Number),
+            nodeVersion: null,
+            deprecated: false,
+          }),
+        ]),
+        pagination: expect.any(Object),
+        contextName: user.username,
+        elapsed: expect.any(String),
+      });
+    });
+  });
+
   it('should list projects', async () => {
     const user = useUser();
     useTeams('team_dummy');

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -122,19 +122,6 @@ describe('list', () => {
 
       const output = client.stderr.getFullOutput();
 
-      // Should not contain table formatting
-      expect(output).not.toContain('Project Name');
-      expect(output).not.toContain('Latest Production URL');
-
-      // Should contain JSON output
-      expect(output).toContain('"projects":');
-      expect(output).toContain('"pagination":');
-      expect(output).toContain('"contextName":');
-      expect(output).toContain('"elapsed":');
-
-      // Parse JSON to validate structure
-      const jsonMatch = output.match(/\{[\s\S]*\}/);
-      expect(jsonMatch).toBeTruthy();
 
       const parsedOutput = JSON.parse(jsonMatch![0]);
       expect(parsedOutput).toMatchObject({

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -123,7 +123,7 @@ describe('list', () => {
       const output = client.stderr.getFullOutput();
 
 
-      const parsedOutput = JSON.parse(jsonMatch![0]);
+      const parsedOutput = JSON.parse(output);
       expect(parsedOutput).toMatchObject({
         projects: expect.arrayContaining([
           expect.objectContaining({


### PR DESCRIPTION
Add `--json` flag to `vercel projects ls` command to enable structured JSON output. This allows for easier programmatic consumption of project data, especially when filtering for projects requiring updates.