### PR TITLE
feat(next): add cacheComponents support for PPR detection

### DIFF
--- a/.changeset/cache-components-ppr-support.md
+++ b/.changeset/cache-components-ppr-support.md
@@ -1,0 +1,7 @@
+---
+'@vercel/next': patch
+---
+
+Add support for experimental.cacheComponents in PPR detection
+
+Enables the experimental.cacheComponents configuration option to activate PPR (Partial Pre-Rendering) alongside existing ppr configuration options (true and 'incremental').

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1457,7 +1457,10 @@ export const build: BuildV2 = async buildOptions => {
 
     const isAppPPREnabled = requiredServerFilesManifest
       ? requiredServerFilesManifest.config.experimental?.ppr === true ||
-        requiredServerFilesManifest.config.experimental?.ppr === 'incremental'
+        requiredServerFilesManifest.config.experimental?.ppr ===
+          'incremental' ||
+        requiredServerFilesManifest.config.experimental?.cacheComponents ===
+          true
       : false;
 
     const isAppClientSegmentCacheEnabled = requiredServerFilesManifest


### PR DESCRIPTION
## Summary
- Adds support for `experimental.cacheComponents` configuration to enable PPR (Partial Pre-Rendering)
- Extends existing PPR detection logic to include the new cacheComponents option alongside existing `ppr: true` and `ppr: 'incremental'` configurations

## Changes
- Modified `isAppPPREnabled` check in `packages/next/src/index.ts` to include `experimental.cacheComponents === true`
- Added changeset documenting the new feature

## Test plan
- [ ] Verify existing PPR functionality remains unchanged
- [ ] Test that setting `experimental.cacheComponents = true` enables PPR detection
- [ ] Confirm integration with Next.js apps using the new configuration