### PR TITLE
[python] support `/_vercel/ping` endpoint for Fluid

### DIFF
--- a/.changeset/neat-dragons-knock.md
+++ b/.changeset/neat-dragons-knock.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+Improve Fluid support

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -171,6 +171,11 @@ if 'VERCEL_IPC_PATH' in os.environ:
             if not self.parse_request():
                 return
 
+            if self.path == '/_vercel/ping':
+                self.send_response(200)
+                self.end_headers()
+                return
+
             invocationId = self.headers.get('x-vercel-internal-invocation-id')
             requestId = int(self.headers.get('x-vercel-internal-request-id'))
             del self.headers['x-vercel-internal-invocation-id']


### PR DESCRIPTION
Add support for the `/_vercel/ping` endpoint to replace the `handler-started` IPC message introduced in https://github.com/vercel/vercel/pull/12850.

We first need to land this change (no-op), then allow our runtime to use this new endpoint instead of the `handler-started` message, then clean up the previous logic. We cannot test this change in CI yet (until we land the runtime change), but I've tested it manually.