### PR TITLE
[build-utils] Add vlt support for package manager detection

### DIFF
--- a/.changeset/strange-fireants-worry.md
+++ b/.changeset/strange-fireants-worry.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': major
+---
+
+Add support for vlt as a package manager

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -398,9 +398,7 @@ export async function scanParentDirs(
         : null,
       bunLockPath ? fs.readFile(bunLockPath) : null,
       yarnLockPath ? fs.readFile(yarnLockPath, 'utf8') : null,
-      vltLockPath
-        ? readConfigFile<{ lockfileVersion: number }>(vltLockPath)
-        : null,
+      vltLockPath ? readConfigFile(vltLockPath) : null,
     ]);
 
   const rootProjectInfo = readPackageJson
@@ -442,7 +440,6 @@ export async function scanParentDirs(
   } else if (vltLock) {
     cliType = 'vlt';
     lockfilePath = vltLockPath;
-    lockfileVersion = Number(vltLock.lockfileVersion);
   } else {
     cliType = detectPackageManagerNameWithoutLockfile(
       packageJsonPackageManager,


### PR DESCRIPTION
# Overview

Add support for vlt package manager detection and installation for customers who want to use it via our zero config detection.
