### PR TITLE
Add license field to gatsby-plugin-vercel-builder

### DIFF
--- a/.changeset/lucky-baths-love.md
+++ b/.changeset/lucky-baths-love.md
@@ -1,0 +1,5 @@
+---
+'@vercel/gatsby-plugin-vercel-builder': patch
+---
+
+Add license field to package metadata

--- a/packages/gatsby-plugin-vercel-builder/package.json
+++ b/packages/gatsby-plugin-vercel-builder/package.json
@@ -37,5 +37,6 @@
   },
   "pnpm": {
     "neverBuiltDependencies": []
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Description

The `gatsby-plugin-vercel-builder` package has no `license` field.

https://www.npmjs.com/package/@vercel/gatsby-plugin-vercel-builder

<img width="376" height="182" alt="image" src="https://github.com/user-attachments/assets/4bacd486-bc92-44b2-9a12-6a173afe2c50" />

This is causing problems with automated compliance scanning tools.

I confirmed that other packages are using `Apache-2.0`, which is consistent with [the LICENSE at the project root](https://github.com/vercel/vercel/blob/main/LICENSE). Some examples:

- [fs-detectors](https://github.com/vercel/vercel/blob/205cba1c42ecaa2aec92a9839d2162557f44662e/packages/fs-detectors/package.json#L15)
- [cli](https://github.com/vercel/vercel/blob/205cba1c42ecaa2aec92a9839d2162557f44662e/packages/cli/package.json#L5)
- [react-router](https://github.com/vercel/vercel/blob/205cba1c42ecaa2aec92a9839d2162557f44662e/packages/react-router/package.json#L5)