### PR TITLE
feat(next): extend getRequestHandlerWithMetadata export to support cacheComponents

### DIFF
--- a/.changeset/server-launcher-cache-components.md
+++ b/.changeset/server-launcher-cache-components.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add cacheComponents support for getRequestHandlerWithMetadata export

--- a/packages/next/src/server-launcher.ts
+++ b/packages/next/src/server-launcher.ts
@@ -66,7 +66,7 @@ module.exports = serve(nextServer.getRequestHandler());
 // If available, add `getRequestHandlerWithMetadata` to the export if it's
 // required by the configuration.
 if (
-  conf.experimental?.ppr &&
+  (conf.experimental?.ppr || conf.experimental?.cacheComponents) &&
   'getRequestHandlerWithMetadata' in nextServer &&
   typeof nextServer.getRequestHandlerWithMetadata === 'function'
 ) {


### PR DESCRIPTION
## Summary
This PR extends the condition for exporting `getRequestHandlerWithMetadata` in the Next.js server launcher to also support the experimental `cacheComponents` feature, not just PPR.

## Changes
- Modified the condition in `packages/next/src/server-launcher.ts` to check for either `conf.experimental?.ppr` OR `conf.experimental?.cacheComponents`
- This follows up on PR #13585 that added cacheComponents support for PPR detection

## Test plan
- [x] Existing tests should continue to pass
- [x] The `getRequestHandlerWithMetadata` export should be available when either `ppr` or `cacheComponents` is enabled in the experimental config