### PR TITLE
Python lambda: always use predefined exclusion list

### DIFF
--- a/.changeset/funny-brooms-smoke.md
+++ b/.changeset/funny-brooms-smoke.md
@@ -1,0 +1,15 @@
+---
+'@vercel/python': major
+---
+
+By default, the Python builder excludes certain directories from the zip output.
+In vercel.json it's also possible to specify a custom `excludeFiles` rule.
+Previously `excludeFiles` would replace the default exclusions entirely. Now the
+default exclusions will always apply. The default exclusions consist of:
+
+- .git
+- .vercel
+- .pnpm-store
+- node_modules (also excluded when nested)
+- .next
+- .nuxt

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -194,19 +194,21 @@ export const build: BuildV3 = async ({
     .replace(/__VC_HANDLER_MODULE_NAME/g, moduleName)
     .replace(/__VC_HANDLER_ENTRYPOINT/g, entrypointWithSuffix);
 
+  const predefinedExcludes = [
+    '.git/**',
+    '.vercel/**',
+    '.pnpm-store/**',
+    '**/node_modules/**',
+    '**/.next/**',
+    '**/.nuxt/**',
+  ];
+
   const globOptions: GlobOptions = {
     cwd: workPath,
     ignore:
       config && typeof config.excludeFiles === 'string'
-        ? config.excludeFiles
-        : [
-            '.git/**',
-            '.vercel/**',
-            '.pnpm-store/**',
-            '**/node_modules/**',
-            '**/.next/**',
-            '**/.nuxt/**',
-          ],
+        ? [...predefinedExcludes, config.excludeFiles]
+        : predefinedExcludes,
   };
 
   const files: Files = await glob('**', globOptions);

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -1,7 +1,9 @@
 import { getSupportedPythonVersion } from '../src/version';
+import { build } from '../src/index';
 import fs from 'fs-extra';
 import path from 'path';
 import { tmpdir } from 'os';
+import { FileBlob } from '@vercel/build-utils';
 
 const tmpPythonDir = path.join(
   tmpdir(),
@@ -11,6 +13,8 @@ let warningMessages: string[];
 const originalConsoleWarn = console.warn;
 const realDateNow = Date.now.bind(global.Date);
 const origPath = process.env.PATH;
+
+jest.setTimeout(30 * 1000);
 
 beforeEach(() => {
   warningMessages = [];
@@ -109,3 +113,93 @@ function makeMockPython(version: string) {
   }
   process.env.PATH = `${tmpPythonDir}${path.delimiter}${process.env.PATH}`;
 }
+
+describe('file exclusions', () => {
+  let mockWorkPath: string;
+
+  beforeEach(() => {
+    mockWorkPath = path.join(tmpdir(), `python-test-${Date.now()}`);
+    fs.mkdirSync(mockWorkPath, { recursive: true });
+    makeMockPython('3.9');
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(mockWorkPath)) {
+      fs.removeSync(mockWorkPath);
+    }
+  });
+
+  it('should exclude predefined files by default', async () => {
+    // Test with one excluded directory
+    const excludedDir = '.pnpm-store';
+    const testFiles = {
+      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+    };
+
+    // Add files that should be excluded
+    const dirPath = path.join(mockWorkPath, excludedDir);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.writeFileSync(path.join(dirPath, 'test.txt'), 'should be excluded');
+
+    // Add a nested node_modules that should also be excluded
+    const nestedNodeModules = path.join(mockWorkPath, 'src', 'node_modules');
+    fs.mkdirSync(nestedNodeModules, { recursive: true });
+    fs.writeFileSync(path.join(nestedNodeModules, 'package.json'), '{}');
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files: testFiles,
+      entrypoint: 'handler.py',
+      meta: { isDev: true },
+      config: {},
+      repoRootPath: mockWorkPath,
+    });
+
+    const outputFiles = Object.keys(result.output.files || {});
+
+    // Should include the handler
+    expect(outputFiles.some(f => f.includes('handler'))).toBe(true);
+
+    // Should not include any excluded directories
+    expect(outputFiles.some(f => f.includes(excludedDir))).toBe(false);
+  });
+
+  it('should add config.excludeFiles to predefined exclusions', async () => {
+    const testFiles = {
+      'handler.py': new FileBlob({ data: 'def handler(): pass' }),
+      'secret.txt': new FileBlob({ data: 'secret data' }),
+      'config.ini': new FileBlob({ data: '[settings]' }),
+      'public.txt': new FileBlob({ data: 'public data' }),
+    };
+
+    // Create the files in workPath
+    fs.writeFileSync(path.join(mockWorkPath, 'secret.txt'), 'secret data');
+    fs.writeFileSync(path.join(mockWorkPath, 'config.ini'), '[settings]');
+    fs.writeFileSync(path.join(mockWorkPath, 'public.txt'), 'public data');
+
+    // Should still exclude predefined files (test with .git if it exists)
+    const gitDir = path.join(mockWorkPath, '.git');
+    fs.mkdirSync(gitDir, { recursive: true });
+    fs.writeFileSync(path.join(gitDir, 'config'), 'git config');
+
+    const result = await build({
+      workPath: mockWorkPath,
+      files: testFiles,
+      entrypoint: 'handler.py',
+      meta: { isDev: true },
+      config: { excludeFiles: 'secret.txt' },
+      repoRootPath: mockWorkPath,
+    });
+
+    const outputFiles = Object.keys(result.output.files || {});
+
+    // Should not include the user-excluded file
+    expect(outputFiles.some(f => f.includes('secret.txt'))).toBe(false);
+
+    // Should still include other files
+    expect(outputFiles.some(f => f.includes('public.txt'))).toBe(true);
+    expect(outputFiles.some(f => f.includes('config.ini'))).toBe(true);
+
+    expect(outputFiles.some(f => f.includes('.git'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Python lambdas have a predefined list of excluded files (e.g. `.git`).
- Current behavior: when `excludeFiles` is specified, this overrides the predefined list. This is confusing: excluding files results in more files being included.
- Proposed behavior: `excludeFiles` is added to the predefined list.