### PR TITLE
Fix workspace detection with workspace key in node_modules

### DIFF
--- a/packages/cli/test/unit/util/projects/detect-projects.test.ts
+++ b/packages/cli/test/unit/util/projects/detect-projects.test.ts
@@ -41,4 +41,12 @@ describe('detectProjects()', () => {
       ['packages/frontend/b', ['ember']],
     ]);
   });
+
+  // This fixture specifically checks that we don't traverse into `node_modules` for workspace matching.
+  // If it traverses into `node_modules` for this fixture it will result in not matching Next.js as a framework.
+  it('should match "70-node-modules-with-workspace"', async () => {
+    const dir = join(FS_DETECTORS_FIXTURES, '70-node-modules-with-workspace');
+    const detected = await detectProjects(dir);
+    expect(mapDetected(detected)).toEqual([['', ['nextjs']]]);
+  });
 });

--- a/packages/fs-detectors/src/workspaces/get-workspaces.ts
+++ b/packages/fs-detectors/src/workspaces/get-workspaces.ts
@@ -34,7 +34,10 @@ export async function getWorkspaces({
   if (workspaceType === null) {
     const directoryContents = await fs.readdir('./');
     const childDirectories = directoryContents.filter(
-      stat => stat.type === 'dir'
+      stat =>
+        stat.type === 'dir' &&
+        // Skip `node_modules` directory as we don't want to detect workspaces there.
+        stat.name !== 'node_modules'
     );
 
     return (

--- a/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/.gitignore
+++ b/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/node_modules/my-package/package.json
+++ b/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/node_modules/my-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-package",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/node_modules/my-package/packages/hello-world/package.json
+++ b/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/node_modules/my-package/packages/hello-world/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/package.json
+++ b/packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "70-node-modules-with-workspace",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "next": "15.4.4"
+  }
+}


### PR DESCRIPTION
This pull request introduces changes to improve workspace detection by preventing traversal into `node_modules` directories. The updates include modifications to the detection logic, new test cases, and supporting fixture files.

### Improvements to workspace detection:

* [`packages/fs-detectors/src/workspaces/get-workspaces.ts`](diffhunk://#diff-9e6aa6c64755856773916380022b7eeea39d1eaa4682f490825d80dc82785bf7L37-R40): Updated the workspace detection logic to skip the `node_modules` directory when filtering child directories. This ensures that workspace matching does not incorrectly include workspaces from `node_modules`.

### Test additions:

* [`packages/cli/test/unit/util/projects/detect-projects.test.ts`](diffhunk://#diff-49466ba8e71d182c59e092ee3dca5bf90ab0cc3ed0180fe504669863821e45bcR44-R51): Added a new test case to verify that the detection logic correctly excludes `node_modules` during workspace matching. This test specifically checks for Next.js framework detection in a fixture setup.

### Fixture updates:

* [`packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/.gitignore`](diffhunk://#diff-1d26f42ae701bb3f117b904971f93a7535c55986233ed7a91cf7c6cf28b8d564R1): Added an entry to ensure `node_modules` is included in the fixture for testing purposes.
* [`packages/fs-detectors/test/fixtures/70-node-modules-with-workspace/package.json`](diffhunk://#diff-de964309cf686829f4361ed1a71b14f0417b922e26da0a0264b0d6c0437fb086R1-R8): Created a fixture `package.json` file with Next.js as a dependency to validate the detection logic.