### PR TITLE
Get dev server working for hono

### DIFF
--- a/.changeset/chilled-donkeys-explain.md
+++ b/.changeset/chilled-donkeys-explain.md
@@ -1,0 +1,6 @@
+---
+"vercel": patch
+"@vercel/hono": patch
+---
+
+Support `vc dev` for hono framework

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -418,6 +418,15 @@ export async function getBuildMatches(
       // of Vercel deployments.
       src = src.substring(1);
     }
+    // FIXME: hono-cleanup - we need to specify a src that we know exists
+    // so the rest of the script doesn't choke on it. But the framework preset
+    // needs to `index.js` so the BOA entry is index.func. BuildResultV2 allows
+    // us to return a different value from what the preset provides, but we need
+    // to use BuildResultV3 so that we can run the dev server with the startDevServer
+    // function exported from Hono.
+    if (buildConfig.config?.framework === 'hono') {
+      src = 'package.json';
+    }
 
     // lambda function files are trimmed of their file extension
     const mapToEntrypoint = new Map<string, string>();

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -1,2 +1,39 @@
 export const version = 3;
 export * from './build';
+// @ts-expect-error - FIXME: startDevServer types are not exported
+import { startDevServer as nodeStartDevServer } from '@vercel/node';
+import { findEntrypoint, shim } from './build';
+import { mkdir, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+import type { ShouldServe, StartDevServer } from '@vercel/build-utils';
+
+export const shouldServe: ShouldServe = async opts => {
+  const requestPath = opts.requestPath.replace(/\/$/, ''); // sanitize trailing '/'
+  // Don't override API routes, otherwise serve it
+  if (requestPath.startsWith('api')) {
+    return false;
+  }
+  // NOTE: public assets are served by the default handler
+  return true;
+};
+
+/**
+ * The dev server works essentially the same as the build command, it creates
+ * a shim file, but it places it in a gitignored location so as to not pollute
+ * the users git index. For this reason, the shim's import statement will
+ * need to be relative to the shim's location.
+ */
+export const startDevServer: StartDevServer = async opts => {
+  const entrypoint = findEntrypoint(opts.files);
+  const entrypointExtension = entrypoint.split('.').pop();
+  // FIXME: for CJS the shim will need to use `require` instead of `import`
+  const shimString = shim(entrypoint, '../..');
+  const shimEntrypoint = `.vercel/dev/shim.${entrypointExtension}`;
+  await mkdir(dirname(shimEntrypoint), { recursive: true });
+  await writeFile(shimEntrypoint, shimString);
+
+  return nodeStartDevServer({
+    ...opts,
+    entrypoint: shimEntrypoint,
+  });
+};


### PR DESCRIPTION
The Hono preset needs to use the `version: 3` for BOA so that we can use the `startDevServer` function, which isn't supported for version 2. However, build result version 3 does not let us remap the built output's location like it does in version 2. So other frameworks like `@vercel/next` specify `package.json` as their [preset entrypoint](https://github.com/vercel/vercel/blob/4e1731ead55caeb5e51b45b4dab3a6c9bb1d63e9/packages/frameworks/src/frameworks.ts#L30), even though the resulting BOA entry is actually `.vercel/output/functions/index.func`. 

We're caught in the middle, we need the BOA entry to be `.vercel/output/functions/index.func`  so the Hono preset's `useRuntime.src` is `index.js`. However, the actual entrypoint isn't know until we run the build or dev command, so we need to override it. I don't anticipate this being permanent and have added a ticket to track improvements here.