### PR TITLE
[next]: fix erroneous source file warning when using dynamic not-found

### DIFF
--- a/.changeset/gorgeous-shoes-boil.md
+++ b/.changeset/gorgeous-shoes-boil.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+fix erroneous source file warning when using dynamic not-found

--- a/packages/next/src/constants.ts
+++ b/packages/next/src/constants.ts
@@ -12,3 +12,5 @@ export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE = 250 * MIB;
 // we need to leave wiggle room as other files are added
 // post build so we don't want to completely pack the function
 export const LAMBDA_RESERVED_UNCOMPRESSED_SIZE = 25 * MIB;
+
+export const INTERNAL_PAGES = ['_app.js', '_error.js', '_document.js'];

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -56,6 +56,7 @@ import {
   getPostponeResumeOutput,
   getNodeMiddleware,
 } from './utils';
+import { INTERNAL_PAGES } from './constants';
 import {
   nodeFileTrace,
   NodeFileTraceReasons,
@@ -210,7 +211,7 @@ export async function serverBuild({
   const lambdas: { [key: string]: Lambda } = {};
   const prerenders: { [key: string]: Prerender } = {};
   const lambdaPageKeys = Object.keys(lambdaPages);
-  const internalPages = ['_app.js', '_error.js', '_document.js'];
+  const internalPages = INTERNAL_PAGES;
   const pageBuildTraces = await glob('**/*.js.nft.json', pagesDir);
   const isEmptyAllowQueryForPrendered = semver.gte(
     nextVersion,

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -211,7 +211,7 @@ export async function serverBuild({
   const lambdas: { [key: string]: Lambda } = {};
   const prerenders: { [key: string]: Prerender } = {};
   const lambdaPageKeys = Object.keys(lambdaPages);
-  const internalPages = INTERNAL_PAGES;
+  const internalPages = [...INTERNAL_PAGES];
   const pageBuildTraces = await glob('**/*.js.nft.json', pagesDir);
   const isEmptyAllowQueryForPrendered = semver.gte(
     nextVersion,

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -47,6 +47,7 @@ import {
   KIB,
   LAMBDA_RESERVED_UNCOMPRESSED_SIZE,
   DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE,
+  INTERNAL_PAGES,
 } from './constants';
 
 type stringMap = { [key: string]: string };
@@ -1666,11 +1667,14 @@ async function getSourceFilePathFromPage({
     return '';
   }
 
-  console.log(
-    `WARNING: Unable to find source file for page ${page} with extensions: ${extensionsToTry.join(
-      ', '
-    )}, this can cause functions config from \`vercel.json\` to not be applied`
-  );
+  // Skip warning for internal pages (_app.js, _error.js, _document.js)
+  if (!INTERNAL_PAGES.includes(page)) {
+    console.log(
+      `WARNING: Unable to find source file for page ${page} with extensions: ${extensionsToTry.join(
+        ', '
+      )}, this can cause functions config from \`vercel.json\` to not be applied`
+    );
+  }
   return '';
 }
 

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/api/route.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/api/route.js
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ message: 'Hello World' });
+}

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/layout.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/not-found.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/not-found.js
@@ -1,0 +1,10 @@
+export const dynamic = 'force-dynamic';
+
+export default function NotFound() {
+  return (
+    <div>
+      <h1>404 - Page Not Found</h1>
+      <p>This is a dynamic not-found page</p>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/page.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Home Page</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/package.json
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-dynamic-not-found-warning/vercel.json
@@ -1,0 +1,21 @@
+{
+  "functions": {
+    "app/api/route.js": {
+      "maxDuration": 30,
+      "memory": 1024
+    }
+  },
+  "probes": [
+    {
+      "path": "/",
+      "status": 200
+    },
+    {
+      "path": "/non-existent-page",
+      "status": 404
+    },
+    {
+      "logMustNotContain": "WARNING: Unable to find source file"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes a warning that appears when using a dynamic not-found.js page in App Router with functions configuration in vercel.json.

When an App Router application has a dynamic not-found page (e.g., `export const dynamic = 'force-dynamic'`), the build process logs:

> WARNING: Unable to find source file for page _error.js with extensions: tsx, ts, jsx, js, this can cause functions config from `vercel.json` to not be applied

This warning is misleading since _error.js is an internal Next.js page that shouldn't have functions config applied to it.

**Solution**

  - Hoisted the `INTERNAL_PAGES` constant to a shared location in constants.ts
  - Updated getSourceFilePathFromPage to skip the warning for internal pages (_app.js, _error.js, _document.js)
  - Added a test to ensure the warning doesn't appear in this scenario
  
Closes NDX-453
Closes FLOW-4654