### PR TITLE
Fix issue with hono support in monorepos

### DIFF
--- a/.changeset/old-wombats-taste.md
+++ b/.changeset/old-wombats-taste.md
@@ -1,0 +1,6 @@
+---
+"@vercel/hono": patch
+"@vercel/node": patch
+---
+
+Fix issue with hono support in monorepos

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -2,22 +2,14 @@ import { Files, type BuildV3 } from '@vercel/build-utils';
 // @ts-expect-error - FIXME: hono-framework build is not exported
 import { build as nodeBuild } from '@vercel/node';
 
-export const build: BuildV3 = async ({
-  files,
-  workPath,
-  config,
-  meta = {},
-}) => {
-  const entrypoint = findEntrypoint(files);
+export const build: BuildV3 = async args => {
+  const entrypoint = findEntrypoint(args.files);
 
   return nodeBuild({
+    ...args,
     entrypoint,
-    files,
-    shim,
-    workPath,
     useWebApi: true,
-    config,
-    meta,
+    shim,
   });
 };
 

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -3,8 +3,8 @@ export * from './build';
 // @ts-expect-error - FIXME: startDevServer types are not exported
 import { startDevServer as nodeStartDevServer } from '@vercel/node';
 import { findEntrypoint, shim } from './build';
-import { mkdir, writeFile } from 'fs/promises';
-import { dirname } from 'path';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 import type { ShouldServe, StartDevServer } from '@vercel/build-utils';
 
 export const shouldServe: ShouldServe = async opts => {
@@ -29,8 +29,11 @@ export const startDevServer: StartDevServer = async opts => {
   // FIXME: for CJS the shim will need to use `require` instead of `import`
   const shimString = shim(entrypoint, '../..');
   const shimEntrypoint = `.vercel/dev/shim.${entrypointExtension}`;
-  await mkdir(dirname(shimEntrypoint), { recursive: true });
-  await writeFile(shimEntrypoint, shimString);
+  const shimEntrypointPath = join(opts.workPath, shimEntrypoint);
+  const shimEntrypointDir = dirname(shimEntrypointPath);
+  await rm(shimEntrypointDir, { force: true, recursive: true });
+  await mkdir(shimEntrypointDir, { recursive: true });
+  await writeFile(shimEntrypointPath, shimString);
 
   return nodeStartDevServer({
     ...opts,

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -451,10 +451,13 @@ export const build = async ({
   }
 
   if (shim) {
-    preparedFiles['shim.js'] = new FileBlob({
+    const handlerDir = dirname(handler);
+    const shimHandler =
+      handlerDir === '.' ? 'shim.js' : join(handlerDir, 'shim.js');
+    preparedFiles[shimHandler] = new FileBlob({
       data: shim(handler),
     });
-    handler = 'shim.js';
+    handler = shimHandler;
   }
 
   if (isEdgeFunction) {


### PR DESCRIPTION
For monorepos, the build output still needs to go into the `.vercel` folder of the project root (eg "apps/web"). Before this change they were being dropped into the top-level `.vercel` folder