### PR TITLE
fix(next): ensure RSC headers have exact value '1'

### DIFF
--- a/.changeset/ensure-rsc-headers-exact.md
+++ b/.changeset/ensure-rsc-headers-exact.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Ensure RSC headers have exact value '1' for proper routing and prefetch handling consistency

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2252,6 +2252,7 @@ export async function serverBuild({
                 {
                   type: 'header',
                   key: rscHeader,
+                  value: '1',
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/index.rsc'),
@@ -2269,6 +2270,7 @@ export async function serverBuild({
                 {
                   type: 'header',
                   key: rscHeader,
+                  value: '1',
                 },
               ],
               dest: path.posix.join('/', entryDirectory, '/$1.rsc'),


### PR DESCRIPTION
## Summary
- Sets explicit value '1' for RSC header configurations in server-build.ts
- Ensures proper routing and prefetch handling consistency
- Aligns with recent work on routing prefetches when header is '1'

## Changes
- Added `value: '1'` to RSC header configurations in two locations
- Added corresponding changeset for patch release

## Test plan
- [ ] Verify RSC routing works correctly with explicit header value
- [ ] Test prefetch behavior is consistent
- [ ] Ensure no regression in existing functionality