### PR TITLE
[fs-detectors] Fix bug in DetectorFilesystem.readdir

### DIFF
--- a/.changeset/new-shirts-wave.md
+++ b/.changeset/new-shirts-wave.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': patch
+---
+
+Fix incorrect caching for DetectorFilesystem.readdir

--- a/packages/fs-detectors/src/detectors/filesystem.ts
+++ b/packages/fs-detectors/src/detectors/filesystem.ts
@@ -1,4 +1,4 @@
-import { posix as posixPath } from 'path';
+import { basename, posix as posixPath } from 'path';
 
 export interface DetectorFilesystemStat {
   name: string;
@@ -104,8 +104,11 @@ export abstract class DetectorFilesystem {
     }
 
     if (options?.potentialFiles) {
+      const filesInReaddirDir = options.potentialFiles.filter(
+        path => basename(path) === path
+      );
       // calculate the set of paths that truly do not exist
-      const filesThatDoNotExist = options.potentialFiles.filter(
+      const filesThatDoNotExist = filesInReaddirDir.filter(
         path => !directoryFiles.has(path)
       );
       for (const filePath of filesThatDoNotExist) {

--- a/packages/fs-detectors/test/unit.framework-detector.test.ts
+++ b/packages/fs-detectors/test/unit.framework-detector.test.ts
@@ -90,6 +90,16 @@ describe('DetectorFilesystem', () => {
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
+  it('should ignore nested potential files for caching', async () => {
+    const files = {
+      'package.json': '{}',
+      'packages/app1/package.json': '{}',
+    };
+    const fs = new VirtualFilesystem(files);
+    await fs.readdir('packages', { potentialFiles: ['app1/package.json'] });
+    expect(await fs.hasPath('packages/app1/package.json')).toEqual(true);
+  });
+
   it('should be able to change directories', async () => {
     const nextPackageJson = JSON.stringify({
       dependencies: {


### PR DESCRIPTION
`readdir` is not recursive, so it will not see nested files. We should not cache nested files as missing from `readdir`.

Fixes the root problem from https://github.com/vercel/api/pull/46213, and adds a regression test.