### PR TITLE
Fix path for hono builder handler

### DIFF
--- a/.changeset/three-plants-confess.md
+++ b/.changeset/three-plants-confess.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Fix relative path issue when Hono builder uses the Node builder

--- a/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/other/stuff.ts
+++ b/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/other/stuff.ts
@@ -1,0 +1,1 @@
+export const stuff = "stuff";

--- a/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/package.json
+++ b/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hono-app",
+  "type": "module",
+  "scripts": {
+    "start": "vercel dev",
+    "deploy": "vercel"
+  },
+  "dependencies": {
+    "hono": "^4.8.5"
+  },
+  "devDependencies": {
+    "vercel": "^32.4.1"
+  },
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+}

--- a/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/src/index.ts
+++ b/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/src/index.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { stuff } from "../other/stuff.js";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  console.log("GET /");
+  return c.json({ message: `Hello Hono! from ${stuff}` });
+});
+app.get("/path/:id", (c) => {
+  console.log("GET /path/:id");
+  return c.json({ message: `Hello Hono! from ${c.req.param("id")}` });
+});
+
+export default app;

--- a/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/tsconfig.json
+++ b/packages/hono/test/fixtures/08-monorepo-src-index-on-node/apps/my-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+  },
+}

--- a/packages/hono/test/fixtures/09-server-on-node/other/stuff.ts
+++ b/packages/hono/test/fixtures/09-server-on-node/other/stuff.ts
@@ -1,0 +1,1 @@
+export const stuff = "stuff";

--- a/packages/hono/test/fixtures/09-server-on-node/package.json
+++ b/packages/hono/test/fixtures/09-server-on-node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hono-app",
+  "type": "module",
+  "scripts": {
+    "start": "vercel dev",
+    "deploy": "vercel"
+  },
+  "dependencies": {
+    "hono": "^4.8.5"
+  },
+  "devDependencies": {
+    "vercel": "^32.4.1"
+  },
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+}

--- a/packages/hono/test/fixtures/09-server-on-node/server.ts
+++ b/packages/hono/test/fixtures/09-server-on-node/server.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { stuff } from "../other/stuff.js";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  console.log("GET /");
+  return c.json({ message: `Hello Hono! from ${stuff}` });
+});
+app.get("/path/:id", (c) => {
+  console.log("GET /path/:id");
+  return c.json({ message: `Hello Hono! from ${c.req.param("id")}` });
+});
+
+export default app;

--- a/packages/hono/test/fixtures/09-server-on-node/tsconfig.json
+++ b/packages/hono/test/fixtures/09-server-on-node/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+  },
+}

--- a/packages/hono/test/unit/build.test.ts
+++ b/packages/hono/test/unit/build.test.ts
@@ -58,31 +58,53 @@ const readDirectoryRecursively = (dirPath: string, basePath = ''): string[] => {
 const fixtures = {
   '01-src-index-on-edge': {
     function: 'EdgeFunction',
+    entrypoint: 'src/shim.js',
   },
   '02-src-index-on-node': {
     function: 'Lambda',
+    entrypoint: 'src/shim.js',
   },
   '03-index-on-node': {
     function: 'Lambda',
+    entrypoint: 'shim.js',
   },
   '04-indexjs-on-node': {
     function: 'Lambda',
+    entrypoint: 'shim.js',
   },
   '05-indexmjs-on-node': {
     function: 'Lambda',
+    entrypoint: 'shim.js',
   },
   '06-indexcjs-on-node': {
     function: 'Lambda',
+    entrypoint: 'shim.js',
   },
   '07-index-on-edge': {
     function: 'EdgeFunction',
+    entrypoint: 'shim.js',
+  },
+  '08-monorepo-src-index-on-node': {
+    function: 'Lambda',
+    entrypoint: 'src/shim.js',
+    workPath: join(
+      __dirname,
+      '../fixtures/08-monorepo-src-index-on-node/apps/my-app'
+    ),
+  },
+  '09-server-on-node': {
+    function: 'Lambda',
+    entrypoint: 'shim.js',
   },
 };
 
 describe('build', () => {
   for (const [fixtureName, fixtureConfig] of Object.entries(fixtures)) {
     it(`should build ${fixtureName}`, async () => {
-      const workPath = join(__dirname, '../fixtures', fixtureName);
+      const workPath =
+        'workPath' in fixtureConfig
+          ? fixtureConfig.workPath
+          : join(__dirname, '../fixtures', fixtureName);
 
       // Read directory recursively to get all files
       const fileList = readDirectoryRecursively(workPath);
@@ -94,15 +116,16 @@ describe('build', () => {
         config,
         meta,
         // Entrypoint is just used as the BOA function name
-        entrypoint: 'index.ts',
+        entrypoint: 'this value is not used',
         repoRootPath: workPath,
       });
 
       expect(result.output.type).toBe(fixtureConfig.function);
+      // The shim should be adjacent to the entrypoint
       if ('entrypoint' in result.output) {
-        expect(result.output.entrypoint).toBe('shim.js');
+        expect(result.output.entrypoint).toBe(fixtureConfig.entrypoint);
       } else if ('handler' in result.output) {
-        expect(result.output.handler).toBe('shim.js');
+        expect(result.output.handler).toBe(fixtureConfig.entrypoint);
       } else {
         throw new Error('entrypoint is not defined');
       }

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -451,11 +451,12 @@ export const build = async ({
   }
 
   if (shim) {
+    const handlerFilename = basename(handler);
     const handlerDir = dirname(handler);
     const shimHandler =
       handlerDir === '.' ? 'shim.js' : join(handlerDir, 'shim.js');
     preparedFiles[shimHandler] = new FileBlob({
-      data: shim(handler),
+      data: shim(handlerFilename),
     });
     handler = shimHandler;
   }


### PR DESCRIPTION
The `shim` is now adjacent to the entrypoint, so it doesn't need the full path, just the basename