### PR TITLE
feat(next): improve fallback root params handling with hasFallbackRootParams flag

### DIFF
--- a/.changeset/improve-fallback-root-params.md
+++ b/.changeset/improve-fallback-root-params.md
@@ -1,0 +1,9 @@
+---
+'@vercel/next': minor
+---
+
+Improve fallback root params handling with hasFallbackRootParams flag
+
+- Add hasFallbackRootParams flag to RoutesManifestRoute type for simplified route regex generation
+- Update route handling logic to conditionally apply fallback root params processing
+- Enhance prerender manifest structure with fallback root params support


### PR DESCRIPTION
## Summary
This PR improves the handling of fallback root parameters by introducing a `hasFallbackRootParams` flag to simplify route regex generation and enhance prerender manifest processing.

## Changes
- Add `hasFallbackRootParams` flag to `RoutesManifestRoute` type for better type safety
- Simplify route regex generation when `hasFallbackRootParams` is true by using a more direct `.rsc` suffix
- Update prerender manifest handling for both fallback and blocking fallback routes
- Improve conditional logic for fallback root params processing in the prerender route handler

## Test plan
- [ ] Verify existing tests pass
- [ ] Test route generation with and without fallback root params
- [ ] Validate prerender manifest structure includes new fields

Related Pull Request: https://github.com/vercel/next.js/pull/82282