### PR TITLE
[cli] Add framework detection text styling

### DIFF
--- a/.changeset/tall-singers-occur.md
+++ b/.changeset/tall-singers-occur.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Make framework detection text prettier

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -83,11 +83,25 @@ export async function editProjectSettings(
     return settings;
   }
 
+  const styledFramework = (frameworkName: string) => {
+    const frameworkStyle = {
+      text: frameworkName,
+      color: chalk.blue,
+    };
+
+    if (frameworkName === 'Hono') {
+      frameworkStyle.text = '🔥 Hono';
+      frameworkStyle.color = chalk.hex('#FFA500');
+    }
+
+    return chalk.bold(frameworkStyle.color(frameworkStyle.text));
+  };
+
   // A missing framework slug implies the "Other" framework was selected
   output.print(
     !framework.slug
       ? `No framework detected. Default Project Settings:\n`
-      : `Auto-detected Project Settings (${chalk.bold(framework.name)}):\n`
+      : `Auto-detected Project Settings (${styledFramework(framework.name)}):\n`
   );
 
   settings.framework = framework.slug;


### PR DESCRIPTION
### Before

<img width="428" height="73" alt="image" src="https://github.com/user-attachments/assets/586d17dc-4b26-4097-943b-36ee89ec6057" />

### After

<img width="421" height="75" alt="image" src="https://github.com/user-attachments/assets/1020afa3-a87e-471a-b7de-bf985551b2b7" />

<img width="423" height="76" alt="image" src="https://github.com/user-attachments/assets/ae9d954f-ad21-41d9-9a7c-8c7a87e7f5dd" />

### Potential future work

If there are more places than detection text we would like to use this, `color` and `specialText` could be an optional field we add to frameworks in [`frameworks.ts`](https://github.com/vercel/vercel/blob/1d14ffeb867eccc1279cd7276b786cae00bd94c8/packages/frameworks/src/frameworks.ts).