### PR TITLE
[cli] Output the error code when a user could not be loaded.

### DIFF
--- a/.changeset/few-wombats-attend.md
+++ b/.changeset/few-wombats-attend.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve non-debug error log for user fetch

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -522,7 +522,7 @@ const main = async () => {
         return 1;
       }
 
-      output.error('Not able to load user');
+      output.error(`Not able to load user because ${err.code}`);
       return 1;
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -523,7 +523,7 @@ const main = async () => {
       }
 
       output.error(
-        `Not able to load user because of unexpected error code: ${err.code}`
+        `Not able to load user because of unexpected error: ${errorToString(err)}`
       );
       return 1;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -522,7 +522,9 @@ const main = async () => {
         return 1;
       }
 
-      output.error(`Not able to load user because ${err.code}`);
+      output.error(
+        `Not able to load user because of unexpected error code: ${err.code}`
+      );
       return 1;
     }
 


### PR DESCRIPTION
In https://linear.app/vercel/issue/ENET-1782/intermittent-error-not-able-to-load-user-when-pulling-env-in-github a customer is not able to access Vercel.  It seems like it is a networking issue, but we don't seem to see the problem on the Vercel side.  A better error message may help understand the customer problem without full debug logs.