### PR TITLE
Fix issue where .mjs files weren't transpiled properly for Hono

### DIFF
--- a/.changeset/large-plants-flash.md
+++ b/.changeset/large-plants-flash.md
@@ -1,0 +1,7 @@
+---
+'@vercel/frameworks': patch
+'@vercel/hono': patch
+'@vercel/node': patch
+---
+
+Fix issue where .mjs files weren't transpiled properly for Hono

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2287,12 +2287,22 @@ export const frameworks = [
             '(?:from|require|import)\\s*(?:\\(\\s*)?["\']hono["\']\\s*(?:\\))?',
         },
         {
+          path: 'index.mjs',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']hono["\']\\s*(?:\\))?',
+        },
+        {
           path: 'src/index.ts',
           matchContent:
             '(?:from|require|import)\\s*(?:\\(\\s*)?["\']hono["\']\\s*(?:\\))?',
         },
         {
           path: 'src/index.js',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']hono["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'src/index.mjs',
           matchContent:
             '(?:from|require|import)\\s*(?:\\(\\s*)?["\']hono["\']\\s*(?:\\))?',
         },

--- a/packages/hono/test/fixtures/10-src-index-mjs-on-node/other/stuff.mjs
+++ b/packages/hono/test/fixtures/10-src-index-mjs-on-node/other/stuff.mjs
@@ -1,0 +1,1 @@
+export const stuff = "stuff";

--- a/packages/hono/test/fixtures/10-src-index-mjs-on-node/package.json
+++ b/packages/hono/test/fixtures/10-src-index-mjs-on-node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hono-app",
+  "type": "module",
+  "scripts": {
+    "start": "vercel dev",
+    "deploy": "vercel"
+  },
+  "dependencies": {
+    "hono": "^4.8.5"
+  },
+  "devDependencies": {
+    "vercel": "^32.4.1"
+  },
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+}

--- a/packages/hono/test/fixtures/10-src-index-mjs-on-node/src/index.mjs
+++ b/packages/hono/test/fixtures/10-src-index-mjs-on-node/src/index.mjs
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { stuff } from "../other/stuff.js";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  console.log("GET /");
+  return c.json({ message: `Hello Hono! from ${stuff}` });
+});
+app.get("/path/:id", (c) => {
+  console.log("GET /path/:id");
+  return c.json({ message: `Hello Hono! from ${c.req.param("id")}` });
+});
+
+export default app;

--- a/packages/hono/test/unit/build.test.ts
+++ b/packages/hono/test/unit/build.test.ts
@@ -74,11 +74,11 @@ const fixtures = {
   },
   '05-indexmjs-on-node': {
     function: 'Lambda',
-    entrypoint: 'shim.js',
+    entrypoint: 'shim.mjs',
   },
   '06-indexcjs-on-node': {
     function: 'Lambda',
-    entrypoint: 'shim.js',
+    entrypoint: 'shim.cjs',
   },
   '07-index-on-edge': {
     function: 'EdgeFunction',
@@ -95,6 +95,10 @@ const fixtures = {
   '09-server-on-node': {
     function: 'Lambda',
     entrypoint: 'shim.js',
+  },
+  '10-src-index-mjs-on-node': {
+    function: 'Lambda',
+    entrypoint: 'src/shim.mjs',
   },
 };
 

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -9,6 +9,7 @@ import {
   resolve,
   sep,
   parse as parsePath,
+  extname,
 } from 'path';
 import { Project } from 'ts-morph';
 import { nodeFileTrace } from '@vercel/nft';
@@ -453,8 +454,21 @@ export const build = async ({
   if (shim) {
     const handlerFilename = basename(handler);
     const handlerDir = dirname(handler);
+    const extension = extname(handlerFilename);
+    const extMap: Record<string, string> = {
+      '.ts': '.js',
+      '.mts': '.mjs',
+      '.mjs': '.mjs',
+      '.cjs': '.cjs',
+      '.js': '.js',
+    };
+    const ext = extMap[extension];
+    if (!ext) {
+      throw new Error(`Unsupported extension for ${entrypoint}`);
+    }
+    const filename = `shim${ext}`;
     const shimHandler =
-      handlerDir === '.' ? 'shim.js' : join(handlerDir, 'shim.js');
+      handlerDir === '.' ? filename : join(handlerDir, filename);
     preparedFiles[shimHandler] = new FileBlob({
       data: shim(handlerFilename),
     });


### PR DESCRIPTION
Note: `.mts` files aren't currently supported by the node builder so that one isn't as easy to fix. For now, just add support for `.mjs`