### PR TITLE
fix(go): Respect patch version 0 and update minor version entries

### DIFF
--- a/.changeset/moody-drinks-turn.md
+++ b/.changeset/moody-drinks-turn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Respect patch version of 0

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -22,8 +22,9 @@ import type { Env } from '@vercel/build-utils';
 const streamPipeline = promisify(pipeline);
 
 const versionMap = new Map([
-  ['1.23', '1.23.2'],
-  ['1.22', '1.22.8'],
+  ['1.24', '1.24.5'],
+  ['1.23', '1.23.11'],
+  ['1.22', '1.22.12'],
   ['1.21', '1.21.13'],
   ['1.20', '1.20.14'],
   ['1.19', '1.19.13'],

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -484,7 +484,8 @@ export function parseGoModVersion(content: string): GoVersions | undefined {
     );
   const toolchain = toolchainMatches ? toolchainMatches[1] : undefined;
   if (major >= GO_MIN_MAJOR_VERSION && minor >= GO_MIN_MINOR_VERSION) {
-    if (patch) {
+    // Special case handle `patch` is provided and 0
+    if (patch || patch === 0) {
       return {
         go: `${major}.${minor}.${patch}`,
         toolchain,

--- a/packages/go/test/fixtures/01-cowsay/vercel.json
+++ b/packages/go/test/fixtures/01-cowsay/vercel.json
@@ -5,10 +5,10 @@
     { "src": "subdirectory/index.go", "use": "@vercel/go" }
   ],
   "probes": [
-    { "path": "/", "mustContain": "cow:go1.23.2:RANDOMNESS_PLACEHOLDER" },
+    { "path": "/", "mustContain": "cow:go1.24.5:RANDOMNESS_PLACEHOLDER" },
     {
       "path": "/subdirectory",
-      "mustContain": "subcow:go1.23.2:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "subcow:go1.24.5:RANDOMNESS_PLACEHOLDER"
     }
   ]
 }

--- a/packages/go/test/parse-go-mod-version.test.ts
+++ b/packages/go/test/parse-go-mod-version.test.ts
@@ -68,4 +68,8 @@ describe('parseGoModVersion', function () {
     const version = parseGoModVersion('toolchain go1.22.1');
     expect(version).toBeUndefined();
   });
+  it('uses 0 patch version if provided', () => {
+    const version = parseGoModVersion('go 1.24.0');
+    expect(version?.go).toEqual('1.24.0');
+  });
 });


### PR DESCRIPTION
This PR fixes a bug in our parsing of exact go versions in `go.mod`. If the user specified a version with a zero patch e.g. `1.24.0` we would not respect it and instead lookup a patch in the minor version map.

This PR also bumps our minor version map to their latest patches.