### PR TITLE
remove duplicate teamId query param

### DIFF
--- a/.changeset/shaggy-bats-hear.md
+++ b/.changeset/shaggy-bats-hear.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove duplicate teamId param when fetching stores

--- a/packages/cli/src/util/integration-resource/get-resources.ts
+++ b/packages/cli/src/util/integration-resource/get-resources.ts
@@ -9,7 +9,7 @@ export async function getResources(
   searchParams.set('teamId', teamId);
 
   const storesResponse = await client.fetch<{ stores: Resource[] }>(
-    `/v1/storage/stores?teamId=${searchParams}`,
+    `/v1/storage/stores?${searchParams}`,
     {
       json: true,
     }


### PR DESCRIPTION
There was [a community report](https://github.com/vercel/vercel/issues/13663) on 403 for `vercel integration list`, which includes a GET stores call.

teamId was specificed both inline in the url string and in the `URLSearchParams`. Opting to preserve the latter due to similar implementations elsewhere in the repo.