### PR TITLE
feat(cli): hide other project settings opts

### DIFF
--- a/.changeset/lovely-keys-pump.md
+++ b/.changeset/lovely-keys-pump.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add project settings option on link

--- a/packages/cli/src/util/input/vercel-auth.ts
+++ b/packages/cli/src/util/input/vercel-auth.ts
@@ -1,6 +1,26 @@
 import type Client from '../client';
 import chalk from 'chalk';
 
+export type VercelAuthSetting = 'standard' | 'none';
+export const DEFAULT_VERCEL_AUTH_SETTING: VercelAuthSetting = 'standard';
+
+const OPTIONS = {
+  message: `What setting do you want to use for Vercel Authentication?`,
+  default: DEFAULT_VERCEL_AUTH_SETTING,
+  choices: [
+    {
+      description: 'Standard Protection (recommended)',
+      name: 'standard',
+      value: 'standard' as VercelAuthSetting,
+    },
+    {
+      description: 'No Protection (all deployments will be public)',
+      name: 'none',
+      value: 'none' as VercelAuthSetting,
+    },
+  ],
+};
+
 export async function vercelAuth(
   client: Client,
   {
@@ -8,7 +28,7 @@ export async function vercelAuth(
   }: {
     autoConfirm?: boolean;
   }
-): Promise<'standard' | 'none'> {
+): Promise<VercelAuthSetting> {
   if (
     autoConfirm ||
     (await client.input.confirm(
@@ -16,25 +36,10 @@ export async function vercelAuth(
       true
     ))
   ) {
-    return 'standard';
+    return DEFAULT_VERCEL_AUTH_SETTING;
   }
 
-  const vercelAuth = await client.input.select<'standard' | 'none'>({
-    message: `What setting do you want to use for Vercel Authentication?`,
-    default: 'standard',
-    choices: [
-      {
-        description: 'Standard Protection (recommended)',
-        name: 'standard',
-        value: 'standard',
-      },
-      {
-        description: 'No Protection (all deployments will be public)',
-        name: 'none',
-        value: 'none',
-      },
-    ],
-  });
+  const vercelAuth = await client.input.select<VercelAuthSetting>(OPTIONS);
 
   return vercelAuth;
 }

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -32,7 +32,11 @@ import output from '../../output-manager';
 import { detectProjects } from '../projects/detect-projects';
 import readConfig from '../config/read-config';
 import { frameworkList } from '@vercel/frameworks';
-import { vercelAuth } from '../input/vercel-auth';
+import {
+  vercelAuth,
+  type VercelAuthSetting,
+  DEFAULT_VERCEL_AUTH_SETTING,
+} from '../input/vercel-auth';
 
 export interface SetupAndLinkOptions {
   autoConfirm?: boolean;
@@ -198,9 +202,21 @@ export default async function setupAndLink(
       );
     }
 
-    const vercelAuthSetting = await vercelAuth(client, {
-      autoConfirm,
-    });
+    // Support for changing additional, less frequently used project settings.
+    let changeAdditionalSettings = false;
+    if (!autoConfirm) {
+      changeAdditionalSettings = await client.input.confirm(
+        'Do you want to change additional project settings?',
+        false
+      );
+    }
+
+    let vercelAuthSetting: VercelAuthSetting = DEFAULT_VERCEL_AUTH_SETTING;
+    if (changeAdditionalSettings) {
+      vercelAuthSetting = await vercelAuth(client, {
+        autoConfirm,
+      });
+    }
 
     if (rootDirectory) {
       settings.rootDirectory = rootDirectory;

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -83,20 +83,31 @@ async function setupProject(
     process.stdin?.write('no\n');
   }
 
+  const hasAdditionalProjectSettingsToChange = vercelAuth !== 'standard';
   await waitForPrompt(
     process,
-    'Want to use the default Deployment Protection settings?'
+    'Do you want to change additional project settings?'
   );
 
+  if (hasAdditionalProjectSettingsToChange) {
+    process.stdin?.write('y\n');
+  } else {
+    process.stdin?.write('\n');
+  }
+
   if (vercelAuth === 'none') {
+    await waitForPrompt(
+      process,
+      'Want to use the default Deployment Protection settings?'
+    );
     process.stdin?.write('n\n');
+
     await waitForPrompt(
       process,
       'What setting do you want to use for Vercel Authentication?'
     );
+    // select "none"
     process.stdin?.write('\x1b[B'); // Down Arrow
-    process.stdin?.write('\n');
-  } else {
     process.stdin?.write('\n');
   }
 
@@ -312,7 +323,7 @@ test('should prefill "project name" prompt with now.json `name`', async () => {
 
   await waitForPrompt(
     now,
-    'Want to use the default Deployment Protection settings?'
+    'Do you want to change additional project settings?'
   );
   now.stdin?.write('\n');
 
@@ -1103,10 +1114,7 @@ test('[vc link] should show project prompts but not framework when `builds` defi
   await waitForPrompt(vc, 'In which directory is your code located?');
   vc.stdin?.write('\n');
 
-  await waitForPrompt(
-    vc,
-    'Want to use the default Deployment Protection settings?'
-  );
+  await waitForPrompt(vc, 'Do you want to change additional project settings?');
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'Linked to');
@@ -1294,10 +1302,7 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   // otherwise the output from the build command will not be the index route and the page text assertion below will fail.
   await waitForPrompt(vc, "What's your Output Directory?");
   vc.stdin?.write('output\n');
-  await waitForPrompt(
-    vc,
-    'Want to use the default Deployment Protection settings?'
-  );
+  await waitForPrompt(vc, 'Do you want to change additional project settings?');
   vc.stdin?.write('n\n');
   await waitForPrompt(
     vc,
@@ -1412,7 +1417,7 @@ test.each([
     expectedStatus: 401,
   },
 ] as const)(
-  '[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts',
+  '[vc deploy] should allow a project to be created with Vercel Auth disabled or enabled with prompts - vercelAuth: %s',
   async ({ vercelAuth, expectedStatus }) => {
     const dir = await setupE2EFixture('project-vercel-auth');
     const projectName = `project-vercel-auth-${

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1325,7 +1325,7 @@ describe('deploy', () => {
         client.stdin.write('\n');
 
         await expect(client.stderr).toOutput(
-          'Want to use the default Deployment Protection settings?'
+          'Do you want to change additional project settings?'
         );
         client.stdin.write('\n');
 
@@ -1365,7 +1365,7 @@ describe('deploy', () => {
         client.stdin.write('\n');
 
         await expect(client.stderr).toOutput(
-          'Want to use the default Deployment Protection settings?'
+          'Do you want to change additional project settings?'
         );
         client.stdin.write('\n');
 

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -506,7 +506,7 @@ describe('link', () => {
     client.stdin.write('\n');
 
     await expect(client.stderr).toOutput(
-      'Want to use the default Deployment Protection settings?'
+      'Do you want to change additional project settings?'
     );
     client.stdin.write('\n');
 


### PR DESCRIPTION
Don't _always_ prompt for the auth option. Instead, allow the user to choose when they want to change additional project settings, and walk them through the available options. 