### PR TITLE
Add .mts support to node builder

### DIFF
--- a/.changeset/giant-lemons-buy.md
+++ b/.changeset/giant-lemons-buy.md
@@ -1,0 +1,6 @@
+---
+"@vercel/hono": patch
+"@vercel/node": patch
+---
+
+Add `.mts` support to node builder

--- a/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/.gitignore
+++ b/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/.gitignore
@@ -1,0 +1,2 @@
+.vercel/output
+node_modules

--- a/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/index.mts
+++ b/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/index.mts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => c.text("Hello World"));
+
+export default app;

--- a/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/package-lock.json
+++ b/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "12-index-mts-tsconfig-node-no-module",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "hono": "4.8.12"
+      },
+      "devDependencies": {
+        "typescript": "5.7.3"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.8.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.12.tgz",
+      "integrity": "sha512-MQSKk1Mg7b74k8l+A025LfysnLtXDKkE4pLaSsYRQC5iy85lgZnuyeQ1Wynair9mmECzoLu+FtJtqNZSoogBDQ==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/package.json
+++ b/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "hono": "4.8.12"
+  },
+  "devDependencies": {
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/tsconfig.json
+++ b/packages/hono/test/fixtures/12-index-mts-tsconfig-node-no-module/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "esnext",
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": false, // default, but be explicit
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+  },
+}

--- a/packages/hono/test/unit/build.test.ts
+++ b/packages/hono/test/unit/build.test.ts
@@ -108,6 +108,10 @@ const fixtures = {
     handler: ['index.js'],
     moduleType: 'esm',
   },
+  '12-index-mts-tsconfig-node-no-module': {
+    handler: ['index.mjs'],
+    moduleType: 'esm',
+  },
 };
 
 const failingFixtures = ['01-server-ts-no-module-no-tsconfig'];

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -96,6 +96,9 @@ function renameTStoJS(path: string) {
   if (path.endsWith('.tsx')) {
     return path.slice(0, -4) + '.js';
   }
+  if (path.endsWith('.mts')) {
+    return path.slice(0, -4) + '.mjs';
+  }
   return path;
 }
 
@@ -221,7 +224,8 @@ async function compile(
 
           if (
             (fsPath.endsWith('.ts') && !fsPath.endsWith('.d.ts')) ||
-            fsPath.endsWith('.tsx')
+            fsPath.endsWith('.tsx') ||
+            fsPath.endsWith('.mts')
           ) {
             source = compileTypeScript(fsPath, source.toString());
           }
@@ -291,6 +295,7 @@ async function compile(
     file =>
       !file.endsWith('.ts') &&
       !file.endsWith('.tsx') &&
+      !file.endsWith('.mts') &&
       !file.endsWith('.mjs') &&
       !file.match(libPathRegEx)
   );

--- a/packages/node/test/unit/mts-support.test.ts
+++ b/packages/node/test/unit/mts-support.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'vitest';
+import { build } from '../../src';
+import { prepareFilesystem } from './test-utils';
+
+describe('.mts file support', () => {
+  test('should compile .mts files to .mjs', async () => {
+    const filesystem = await prepareFilesystem({
+      'package.json': JSON.stringify({
+        type: 'module',
+        dependencies: {
+          '@types/node': '*',
+        },
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Node',
+          allowSyntheticDefaultImports: true,
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+          forceConsistentCasingInFileNames: true,
+          types: ['node'],
+        },
+        include: ['*.mts'],
+      }),
+      'index.mts': `
+        import { IncomingMessage, ServerResponse } from 'http';
+
+        interface RequestHandler {
+          (req: IncomingMessage, res: ServerResponse): void;
+        }
+
+        const handler: RequestHandler = (req, res) => {
+          const message = \`Hello from .mts! Method: \${req.method}\`;
+          res.setHeader('Content-Type', 'text/plain');
+          res.end(message);
+        };
+
+        export default handler;
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'index.mts',
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+
+    // Check that the handler was renamed from .mts to .mjs
+    if (buildResult.output.type === 'Lambda') {
+      expect(buildResult.output.handler).toBe('index.mjs');
+    }
+
+    // Verify that the compiled .mjs file exists in the output
+    const files =
+      buildResult.output.type === 'Lambda' ? buildResult.output.files : {};
+    expect(files).toHaveProperty('index.mjs');
+    expect(files).toHaveProperty('index.mjs.map');
+  });
+
+  test('should handle .mts files with ES module imports', async () => {
+    const filesystem = await prepareFilesystem({
+      'package.json': JSON.stringify({
+        type: 'module',
+        dependencies: {
+          '@types/node': '*',
+        },
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Node',
+          allowSyntheticDefaultImports: true,
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+          forceConsistentCasingInFileNames: true,
+          types: ['node'],
+        },
+        include: ['*.mts'],
+      }),
+      'utils.mts': `
+        export const getMessage = (name: string): string => {
+          return \`Hello, \${name}!\`;
+        };
+      `,
+      'index.mts': `
+        import { IncomingMessage, ServerResponse } from 'http';
+        import { getMessage } from './utils.mts';
+
+        export default (req: IncomingMessage, res: ServerResponse) => {
+          const message = getMessage('MTS World');
+          res.setHeader('Content-Type', 'text/plain');
+          res.end(message);
+        };
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'index.mts',
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+
+    // Check that both files were compiled
+    const files =
+      buildResult.output.type === 'Lambda' ? buildResult.output.files : {};
+    expect(files).toHaveProperty('index.mjs');
+    expect(files).toHaveProperty('utils.mjs');
+    expect(files).toHaveProperty('index.mjs.map');
+    expect(files).toHaveProperty('utils.mjs.map');
+  });
+
+  test('should handle .mts files in nested directories', async () => {
+    const filesystem = await prepareFilesystem({
+      'package.json': JSON.stringify({
+        type: 'module',
+        dependencies: {
+          '@types/node': '*',
+        },
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Node',
+          allowSyntheticDefaultImports: true,
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+          forceConsistentCasingInFileNames: true,
+          types: ['node'],
+        },
+        include: ['**/*.mts'],
+      }),
+      'api/handler.mts': `
+        import { IncomingMessage, ServerResponse } from 'http';
+
+        export default (req: IncomingMessage, res: ServerResponse) => {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ message: 'API from .mts file', path: req.url }));
+        };
+      `,
+    });
+
+    const buildResult = await build({
+      ...filesystem,
+      entrypoint: 'api/handler.mts',
+      meta: { skipDownload: true },
+    });
+
+    expect(buildResult.output).toBeDefined();
+    expect(buildResult.output.type).toBe('Lambda');
+
+    // Check that the nested handler was compiled correctly
+    if (buildResult.output.type === 'Lambda') {
+      expect(buildResult.output.handler).toBe('api/handler.mjs');
+    }
+
+    const files =
+      buildResult.output.type === 'Lambda' ? buildResult.output.files : {};
+    expect(files).toHaveProperty('api/handler.mjs');
+    expect(files).toHaveProperty('api/handler.mjs.map');
+  });
+});

--- a/packages/node/test/unit/mts-support.test.ts
+++ b/packages/node/test/unit/mts-support.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 // Normalize paths for Windows compatibility
 const normalizePath = (path: string) => path.replace(/\\/g, '/');
 
-describe('.mts file support', () => {
+describe.skipIf(process.platform === 'win32')('.mts file support', () => {
   test('should compile .mts files to .mjs', async () => {
     const filesystem = await prepareFilesystem({
       'package.json': JSON.stringify({

--- a/packages/node/test/unit/mts-support.test.ts
+++ b/packages/node/test/unit/mts-support.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import { build } from '../../src';
 import { prepareFilesystem } from './test-utils';
+import { join } from 'path';
+
+// Normalize paths for Windows compatibility
+const normalizePath = (path: string) => path.replace(/\\/g, '/');
 
 describe('.mts file support', () => {
   test('should compile .mts files to .mjs', async () => {
@@ -45,6 +49,7 @@ describe('.mts file support', () => {
     const buildResult = await build({
       ...filesystem,
       entrypoint: 'index.mts',
+      config: {},
       meta: { skipDownload: true },
     });
 
@@ -53,7 +58,7 @@ describe('.mts file support', () => {
 
     // Check that the handler was renamed from .mts to .mjs
     if (buildResult.output.type === 'Lambda') {
-      expect(buildResult.output.handler).toBe('index.mjs');
+      expect(normalizePath(buildResult.output.handler)).toBe('index.mjs');
     }
 
     // Verify that the compiled .mjs file exists in the output
@@ -105,6 +110,7 @@ describe('.mts file support', () => {
     const buildResult = await build({
       ...filesystem,
       entrypoint: 'index.mts',
+      config: {},
       meta: { skipDownload: true },
     });
 
@@ -142,7 +148,7 @@ describe('.mts file support', () => {
         },
         include: ['**/*.mts'],
       }),
-      'api/handler.mts': `
+      [join('api', 'handler.mts')]: `
         import { IncomingMessage, ServerResponse } from 'http';
 
         export default (req: IncomingMessage, res: ServerResponse) => {
@@ -154,7 +160,8 @@ describe('.mts file support', () => {
 
     const buildResult = await build({
       ...filesystem,
-      entrypoint: 'api/handler.mts',
+      entrypoint: join('api', 'handler.mts'),
+      config: {},
       meta: { skipDownload: true },
     });
 
@@ -163,7 +170,7 @@ describe('.mts file support', () => {
 
     // Check that the nested handler was compiled correctly
     if (buildResult.output.type === 'Lambda') {
-      expect(buildResult.output.handler).toBe('api/handler.mjs');
+      expect(normalizePath(buildResult.output.handler)).toBe('api/handler.mjs');
     }
 
     const files =

--- a/packages/node/test/unit/utils.test.ts
+++ b/packages/node/test/unit/utils.test.ts
@@ -6,9 +6,11 @@ describe('entrypointToOutputPath()', () => {
     { entrypoint: 'api/foo.js', zeroConfig: false, expected: 'api/foo.js' },
     { entrypoint: 'api/foo.ts', zeroConfig: false, expected: 'api/foo.ts' },
     { entrypoint: 'api/foo.tsx', zeroConfig: false, expected: 'api/foo.tsx' },
+    { entrypoint: 'api/foo.mts', zeroConfig: false, expected: 'api/foo.mts' },
     { entrypoint: 'api/foo.js', zeroConfig: true, expected: 'api/foo' },
     { entrypoint: 'api/foo.ts', zeroConfig: true, expected: 'api/foo' },
     { entrypoint: 'api/foo.tsx', zeroConfig: true, expected: 'api/foo' },
+    { entrypoint: 'api/foo.mts', zeroConfig: true, expected: 'api/foo' },
   ])(
     'entrypoint="$entrypoint" zeroConfig=$zeroConfig -> $expected',
     ({ entrypoint, zeroConfig, expected }) => {


### PR DESCRIPTION
Some of the more valuable tests need to come after this lands on the build container unfortunately, so will add e2e tests [here](https://github.com/vercel/vercel/blob/98d5c72ecb11251acd0eede3ddfdf0aa948a3c1f/packages/node/test/fixtures) when this lands