### PR TITLE
[rate limit SDK] await headers() for next.js 15 and above 

### DIFF
--- a/.changeset/proud-eggs-report.md
+++ b/.changeset/proud-eggs-report.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+Fix headers being awaited for nextjs 15+

--- a/packages/firewall/src/rate-limit.ts
+++ b/packages/firewall/src/rate-limit.ts
@@ -65,7 +65,8 @@ export async function checkRateLimit(
   if (!requestHeaders && isUsingNextJs) {
     const { headers } = await import('next/headers');
     try {
-      requestHeaders = headers();
+      // await for next.js >15
+      requestHeaders = await headers();
     } catch {
       // Ignore
     }


### PR DESCRIPTION
```
Error: Route "/api/ai/gateway-playground/chat/logged-out" used `headers().get('host')`. `headers()` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
vercel-site:dev:     at async POST (app/api/ai/gateway-playground/chat/logged-out/route.ts:64:27)
vercel-site:dev:   62 |   const sessionId = cookieStore.get(SESSION_RATE_LIMIT_COOKIE)?.value as string;
vercel-site:dev:   63 |
vercel-site:dev: > 64 |   const { rateLimited } = await checkRateLimit(SESSION_RATE_LIMIT_ID, {
vercel-site:dev:      |                           ^
vercel-site:dev:   65 |     rateLimitKey: sessionId,
vercel-site:dev:   66 |     firewallHostForDevelopment: '[vercel.com](http://vercel.com/)',
vercel-site:dev:   67 |   });
```