### PR TITLE
refactor: don't decode access token to get team ID

### DIFF
--- a/.changeset/cold-tables-carry.md
+++ b/.changeset/cold-tables-carry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+`vc login --future` no longer parses `teamId` out of the access token

--- a/packages/cli/src/util/oauth.ts
+++ b/packages/cli/src/util/oauth.ts
@@ -1,5 +1,4 @@
 import fetch, { type Response } from 'node-fetch';
-import { decodeJwt } from 'jose';
 import ua from './ua';
 import { hostname } from 'os';
 
@@ -399,34 +398,3 @@ function canParseURL(url: string) {
     return false;
   }
 }
-
-/** @see https://datatracker.ietf.org/doc/html/rfc7662#section-2.2 */
-interface AccessToken {
-  /**
-   * Integer timestamp, measured in the number of seconds
-   * since January 1 1970 UTC, indicating when this token will expire.
-   */
-  exp: number;
-  /** Whether or not the presented token is active. */
-  active: boolean;
-  token_type: 'access_token';
-  /** The authorizing principal's team. */
-  team_id?: string;
-}
-
-/**
- * Inspects and returns the content of an access_token.
- * If the token is invalid, an {@link InspectionError} is returned.
- * @todo Use [Introspection Endpoint](https://datatracker.ietf.org/doc/html/rfc7662)
- */
-export function inspectToken(
-  token: TokenSet['access_token']
-): [InspectionError] | [null, AccessToken] {
-  try {
-    return [null, decodeJwt<AccessToken>(token)];
-  } catch (cause) {
-    return [new InspectionError('Could not inspect token.', { cause })];
-  }
-}
-
-class InspectionError extends Error {}

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -79,7 +79,7 @@ describe('login --future', () => {
     expect(await exitCodePromise, 'exit code for "login --future"').toBe(0);
     await expect(client.stderr).toOutput('Congratulations!');
 
-    expect(fetch).toHaveBeenCalledTimes(pollCount + 3);
+    expect(fetch).toHaveBeenCalledTimes(pollCount + 4);
 
     expect(fetch).toHaveBeenNthCalledWith(
       2,
@@ -109,21 +109,6 @@ describe('login --future', () => {
         scope: tokenResult.scope,
       }).toString()
     );
-
-    for (let i = 3; i <= fetch.mock.calls.length; i++) {
-      expect(fetch).toHaveBeenNthCalledWith(
-        i,
-        _as.token_endpoint,
-        expect.objectContaining({
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'user-agent': oauth.userAgent,
-          },
-          body: expect.any(URLSearchParams),
-        })
-      );
-    }
 
     expect(
       fetch.mock.calls[pollCount + 1][1]?.body?.toString(),

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -121,10 +121,6 @@ describe('login --future', () => {
       }).toString()
     );
 
-    const teamAfter = client.config.currentTeam;
-    expect(teamAfter, 'Team id differs from original').not.toBe(teamBefore);
-    expect(teamAfter).toBe(undefined);
-
     const tokenAfter = client.authConfig.token;
     expect(tokenAfter, 'Token differs from original').not.toBe(tokenBefore);
     expect(tokenAfter).toBe(tokenResult.access_token);

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -6,12 +6,6 @@ import _fetch, { Headers, type Response } from 'node-fetch';
 import * as oauth from '../../../../src/util/oauth';
 import { randomUUID } from 'node:crypto';
 
-const inspectToken = vi.mocked(oauth.inspectToken);
-vi.mock('../../../../src/util/oauth', async () => ({
-  ...(await vi.importActual('../../../../src/util/oauth')),
-  inspectToken: vi.fn(),
-}));
-
 const fetch = vi.mocked(_fetch);
 vi.mock('node-fetch', async () => ({
   ...(await vi.importActual('node-fetch')),
@@ -52,14 +46,6 @@ describe('login --future', () => {
       })
     );
     const _as = await oauth.as();
-    const accessTokenPayload = {
-      active: true,
-      team_id: randomUUID(),
-      token_type: 'access_token',
-      exp: Number.POSITIVE_INFINITY,
-    } as const;
-
-    inspectToken.mockReturnValueOnce([null, accessTokenPayload]);
 
     const authorizationResult = {
       device_code: randomUUID(),
@@ -152,7 +138,7 @@ describe('login --future', () => {
 
     const teamAfter = client.config.currentTeam;
     expect(teamAfter, 'Team id differs from original').not.toBe(teamBefore);
-    expect(teamAfter).toBe(accessTokenPayload.team_id);
+    expect(teamAfter).toBe(undefined);
 
     const tokenAfter = client.authConfig.token;
     expect(tokenAfter, 'Token differs from original').not.toBe(tokenBefore);

--- a/packages/cli/test/unit/util/login/token-refresh.test.ts
+++ b/packages/cli/test/unit/util/login/token-refresh.test.ts
@@ -5,18 +5,11 @@ import _fetch, { Request, Response } from 'node-fetch';
 
 import whoami from '../../../../src/commands/whoami';
 import { Chance } from 'chance';
-import { inspectToken as inspectTokenActual } from '../../../../src/util/oauth';
 
 const fetch = vi.mocked(_fetch);
 vi.mock('node-fetch', async () => ({
   ...(await vi.importActual('node-fetch')),
   default: vi.fn(),
-}));
-
-const inspectToken = vi.mocked(inspectTokenActual);
-vi.mock('../../../../src/util/oauth', async () => ({
-  ...(await vi.importActual('../../../../src/util/oauth')),
-  inspectToken: vi.fn(),
 }));
 
 describe('OAuth Token Refresh', () => {
@@ -69,15 +62,6 @@ describe('OAuth Token Refresh', () => {
 
       throw new Error(`Unexpected URL: ${url}`);
     });
-
-    inspectToken.mockReturnValueOnce([
-      null,
-      {
-        active: true,
-        token_type: 'access_token',
-        exp: Number.POSITIVE_INFINITY,
-      },
-    ]);
 
     const exitCode = await whoami(client);
     expect(exitCode).toBe(0);


### PR DESCRIPTION
I don't think we need to decode the access token to get the team ID.