### PR TITLE
[next] serve static metadata files from `_next/static` dir

### DIFF
--- a/.changeset/lazy-coats-bow.md
+++ b/.changeset/lazy-coats-bow.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[next] serve static metadata files from `_next/static` dir

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -979,6 +979,112 @@ export const build: BuildV2 = async buildOptions => {
           continue: true,
         },
 
+        // Rewrite metadata routes to _next/static/metadata/...
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(favicon\\.ico)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(icon\\.[^/?]+)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(apple-icon\\.[^/?]+)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(opengraph-image\\.[^/?]+)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(twitter-image\\.[^/?]+)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(sitemap\\.xml)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(robots\\.txt)(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$3'
+          ),
+          check: true,
+        },
+        {
+          src: path.posix.join(
+            '/',
+            entryDirectory,
+            '((?:.*/)?)(manifest\\.(json|webmanifest))(\\?.*)?$'
+          ),
+          dest: path.posix.join(
+            '/',
+            entryDirectory,
+            '_next/static/metadata/$1$2$4'
+          ),
+          check: true,
+        },
+
         // Next.js pages, `static/` folder, reserved assets, and `public/`
         // folder
         { handle: 'filesystem' },
@@ -1050,7 +1156,7 @@ export const build: BuildV2 = async buildOptions => {
           src: path.posix.join(
             '/',
             entryDirectory,
-            `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|${escapedBuildId})/.+`
+            `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|metadata|${escapedBuildId})/.+`
           ),
           // Next.js assets contain a hash or entropy in their filenames, so they
           // are guaranteed to be unique and cacheable indefinitely.

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2362,6 +2362,112 @@ export async function serverBuild({
           ]
         : []),
 
+      // Rewrite metadata routes to _next/static/metadata/...
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(favicon\\.ico)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(icon\\.[^/?]+)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(apple-icon\\.[^/?]+)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(opengraph-image\\.[^/?]+)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(twitter-image\\.[^/?]+)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(sitemap\\.xml)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(robots\\.txt)(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$3'
+        ),
+        check: true,
+      },
+      {
+        src: path.posix.join(
+          '/',
+          entryDirectory,
+          '((?:.*/)?)(manifest\\.(json|webmanifest))(\\?.*)?$'
+        ),
+        dest: path.posix.join(
+          '/',
+          entryDirectory,
+          '_next/static/metadata/$1$2$4'
+        ),
+        check: true,
+      },
+
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },
@@ -2694,7 +2800,7 @@ export async function serverBuild({
         src: path.posix.join(
           '/',
           entryDirectory,
-          `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|${escapedBuildId})/.+`
+          `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|metadata|${escapedBuildId})/.+`
         ),
         // Next.js assets contain a hash or entropy in their filenames, so they
         // are guaranteed to be unique and cacheable indefinitely.

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -152,6 +152,7 @@ export async function serverBuild({
   isAppClientSegmentCacheEnabled,
   isAppClientParamParsingEnabled,
   clientParamParsingOrigins,
+  staticMetadataRewrites,
 }: {
   appPathRoutesManifest?: Record<string, string>;
   dynamicPages: string[];
@@ -202,6 +203,7 @@ export async function serverBuild({
   isAppClientSegmentCacheEnabled: boolean;
   isAppClientParamParsingEnabled: boolean;
   clientParamParsingOrigins: string[] | undefined;
+  staticMetadataRewrites: Route[];
 }): Promise<BuildResult> {
   if (isAppPPREnabled) {
     debug(
@@ -2362,115 +2364,12 @@ export async function serverBuild({
           ]
         : []),
 
-      // Rewrite metadata routes to _next/static/metadata/...
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(favicon\\.ico)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(icon\\.[^/?]+)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(apple-icon\\.[^/?]+)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(opengraph-image\\.[^/?]+)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(twitter-image\\.[^/?]+)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(sitemap\\.xml)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(robots\\.txt)(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$3'
-        ),
-        check: true,
-      },
-      {
-        src: path.posix.join(
-          '/',
-          entryDirectory,
-          '((?:.*/)?)(manifest\\.(json|webmanifest))(\\?.*)?$'
-        ),
-        dest: path.posix.join(
-          '/',
-          entryDirectory,
-          '_next/static/metadata/$1$2$4'
-        ),
-        check: true,
-      },
-
       // Next.js page lambdas, `static/` folder, reserved assets, and `public/`
       // folder
       { handle: 'filesystem' },
+
+      // Rewrite metadata routes to _next/static/metadata/...
+      ...staticMetadataRewrites,
 
       // ensure the basePath prefixed _next/image is rewritten to the root
       // _next/image path

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -4434,3 +4434,32 @@ export async function getServerActionMetaRoutes(
     return [];
   }
 }
+
+type StaticMetadataRoutesManifest = {
+  [page: string]: {
+    regex: string;
+    sourcePage: string;
+  };
+};
+
+export async function getStaticMetadataRoutesManifest(
+  entryPath: string,
+  outputDirectory: string
+): Promise<StaticMetadataRoutesManifest | undefined> {
+  const manifestPath = path.join(
+    entryPath,
+    outputDirectory,
+    'static-metadata-routes-manifest.json'
+  );
+
+  const hasManifest = await fs
+    .access(manifestPath)
+    .then(() => true)
+    .catch(() => false);
+
+  if (!hasManifest) {
+    return;
+  }
+
+  return fs.readJson(manifestPath);
+}


### PR DESCRIPTION
Previously, the static metadata files were generated as `route.js` files, which were deployed to Vercel as ISR functions. This caused a very small but unnecessary cost to the users.

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1732704119786829)

PR https://github.com/vercel/next.js/pull/82030 in Next.js changes to not generate route handlers for the static metadata files but to copy the content inside the `_next/static/metadata` dir.

This PR rewrites metadata routes to `_next/static/metadata` dir. Since `check: true`, will continue to routing for dynamic metadata file, e.g., `icon.tsx` if FS check fails.

### Testing Plan

Since this PR checks for a metadata manifest, this should work for both BEFORE and AFTER the change of Next.js.

**Before** the change:

https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app

Try visiting the asset routes below:

- https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app/favicon.ico
- https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app/dynamic/123/icon.png
- https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app/group/apple-icon-131tc6.png
- https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app/parallel/sitemap-kzjltp.xml
- https://next-vercel-test-fepc65ast-jiwon-vc.vercel.app/intercepting/(..)intercept-me/twitter-image.png

**After** the change:

https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app

Try visiting the asset routes below:

- https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app/favicon.ico
- https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app/dynamic/123/icon.png
- https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app/group/apple-icon-131tc6.png
- https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app/parallel/sitemap-kzjltp.xml
- https://next-vercel-test-axdegbl87-jiwon-vc.vercel.app/intercepting/(..)intercept-me/twitter-image.png

Navigate the routes and see the network tabs if the metadata assets are correctly loaded.