### PR TITLE
feat(cli): add env pull prompt after successful project linking

### DIFF
--- a/.changeset/small-parents-provide.md
+++ b/.changeset/small-parents-provide.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Prompt to pull environment variables after successful project linking

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
     "vitest-run": "vitest --config ./vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
-    "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
+    "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts test/integration-link-env-pull.test.ts",
     "test-dev": "pnpm test test/dev/",
     "coverage": "codecov",
     "build": "node scripts/build.mjs",

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -58,7 +58,11 @@ const VARIABLES_TO_IGNORE = [
   'VERCEL_WEB_ANALYTICS_ID',
 ];
 
-export default async function pull(client: Client, argv: string[]) {
+export default async function pull(
+  client: Client,
+  argv: string[],
+  source: EnvRecordsSource = 'vercel-cli:env:pull'
+) {
   const telemetryClient = new EnvPullTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
@@ -122,7 +126,7 @@ export default async function pull(client: Client, argv: string[]) {
     link,
     gitBranch,
     client.cwd,
-    'vercel-cli:env:pull'
+    source
   );
 
   return 0;

--- a/packages/cli/src/util/env/get-env-records.ts
+++ b/packages/cli/src/util/env/get-env-records.ts
@@ -11,7 +11,8 @@ export type EnvRecordsSource =
   | 'vercel-cli:env:update'
   | 'vercel-cli:env:pull'
   | 'vercel-cli:dev'
-  | 'vercel-cli:pull';
+  | 'vercel-cli:pull'
+  | 'vercel-cli:link';
 
 export default async function getEnvRecords(
   client: Client,

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -149,7 +149,8 @@ export default async function setupAndLink(
       },
       project.name,
       org.slug,
-      successEmoji
+      successEmoji,
+      autoConfirm
     );
     return { status: 'linked', org, project };
   }
@@ -243,7 +244,8 @@ export default async function setupAndLink(
       },
       project.name,
       org.slug,
-      successEmoji
+      successEmoji,
+      autoConfirm
     );
 
     await connectGitRepository(client, path, project, autoConfirm, org);

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -354,7 +354,6 @@ export async function linkFolderToProject(
     ));
 
   if (pullEnvConfirmed) {
-    const originalCwd = client.cwd;
     try {
       client.cwd = path;
 
@@ -370,8 +369,6 @@ export async function linkFolderToProject(
       output.error(
         'Failed to pull environment variables. You can run `vc env pull` manually.'
       );
-    } finally {
-      client.cwd = originalCwd;
     }
   }
 }

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -354,6 +354,7 @@ export async function linkFolderToProject(
     ));
 
   if (pullEnvConfirmed) {
+    const originalCwd = client.cwd;
     try {
       client.cwd = path;
 
@@ -369,6 +370,8 @@ export async function linkFolderToProject(
       output.error(
         'Failed to pull environment variables. You can run `vc env pull` manually.'
       );
+    } finally {
+      client.cwd = originalCwd;
     }
   }
 }

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -461,421 +461,413 @@ test('deploy using --local-config flag above target', async () => {
   expect(host).toMatch(/root-level/gm);
 });
 
-test(
-  'deploy `api-env` fixture and test `vercel env` command',
-  async () => {
-    const target = await setupE2EFixture('api-env');
-    // Randomness is required so that tests can run in
-    // parallel on the same project
-    const promptEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
-    const stdinEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
-    const previewEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+test('deploy `api-env` fixture and test `vercel env` command', async () => {
+  const target = await setupE2EFixture('api-env');
+  // Randomness is required so that tests can run in
+  // parallel on the same project
+  const promptEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+  const stdinEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+  const previewEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
 
-    async function vcLink() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['link', '--yes'],
-        {
-          cwd: target,
-        }
-      );
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcEnvLsDoesNotIncludeVars() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'ls'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-      expect(stdout).not.toContain(previewEnvVar);
-      expect(stdout).not.toContain(stdinEnvVar);
-      expect(stdout).not.toContain(promptEnvVar);
-    }
-
-    async function vcEnvAddWithPrompts() {
-      const vc = execCli(binaryPath, ['env', 'add'], {
+  async function vcLink() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['link', '--yes'],
+      {
         cwd: target,
-      });
-
-      await waitForPrompt(vc, "What's the name of the variable?");
-      vc.stdin?.write(`${promptEnvVar}\n`);
-      await waitForPrompt(
-        vc,
-        chunk =>
-          chunk.includes("What's the value of") && chunk.includes(promptEnvVar)
-      );
-      vc.stdin?.write('my plaintext value\n');
-
-      await waitForPrompt(
-        vc,
-        chunk =>
-          chunk.includes('which Environments') && chunk.includes(promptEnvVar)
-      );
-      vc.stdin?.write('a\n'); // select all
-
-      const { exitCode, stdout, stderr } = await vc;
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcEnvAddFromStdin() {
-      const vc = execCli(
-        binaryPath,
-        ['env', 'add', stdinEnvVar, 'development'],
-        {
-          cwd: target,
-        }
-      );
-      vc.stdin?.end('{"expect":"quotes"}');
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcEnvAddFromStdinPreview() {
-      const vc = execCli(binaryPath, ['env', 'add', previewEnvVar, 'preview'], {
-        cwd: target,
-      });
-      vc.stdin?.end('preview-no-branch');
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcEnvAddFromStdinPreviewWithBranch() {
-      const vc = execCli(
-        binaryPath,
-        ['env', 'add', previewEnvVar, 'preview', 'staging'],
-        {
-          cwd: target,
-        }
-      );
-      vc.stdin?.end('preview-with-branch');
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
-      expect(stderr).toMatch(/does not have a connected Git repository/gm);
-    }
-
-    async function vcEnvLsIncludesVar() {
-      const { exitCode, stderr, stdout } = await execCli(
-        binaryPath,
-        ['env', 'ls'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-      expect(stderr).toMatch(/Environment Variables found for (.*)\/api-env/gm);
-
-      const lines = stdout.split('\n');
-
-      const plaintextEnvs = lines.filter(line => line.includes(promptEnvVar));
-      expect(plaintextEnvs.length).toBe(1);
-      expect(plaintextEnvs[0]).toMatch(/Production, Preview, Development/gm);
-
-      const stdinEnvs = lines.filter(line => line.includes(stdinEnvVar));
-      expect(stdinEnvs.length).toBe(1);
-      expect(stdinEnvs[0]).toMatch(/Development/gm);
-
-      const previewEnvs = lines.filter(line => line.includes(previewEnvVar));
-      expect(previewEnvs.length).toBe(1);
-      expect(previewEnvs[0]).toMatch(/Encrypted .* Preview /gm);
-    }
-
-    async function vcEnvPull() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'pull', '-y'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-      expect(stderr).toMatch(/Updated .env.local file/gm);
-
-      const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
-      expect(contents).toMatch(/^# Created by Vercel CLI\n/);
-      expect(contents).toMatch(
-        new RegExp(`${promptEnvVar}="my plaintext value"`)
-      );
-      expect(contents).toMatch(
-        new RegExp(`${stdinEnvVar}="{"expect":"quotes"}"`)
-      );
-      expect(contents).not.toMatch(new RegExp(`${previewEnvVar}`));
-    }
-
-    async function vcEnvPullOverwrite() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'pull'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-      expect(stderr).toMatch(/Overwriting existing .env.local file/gm);
-      expect(stderr).toMatch(/Updated .env.local file/gm);
-    }
-
-    async function vcEnvPullConfirm() {
-      fs.writeFileSync(path.join(target, '.env.local'), 'hahaha');
-
-      const vc = execCli(binaryPath, ['env', 'pull'], {
-        cwd: target,
-        env: {
-          FORCE_TTY: '1',
-        },
-      });
-
-      await waitForPrompt(
-        vc,
-        'Found existing file ".env.local". Do you want to overwrite?'
-      );
-      vc.stdin?.end('y\n');
-
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcDeployWithVar() {
-      const { exitCode, stdout, stderr } = await execCli(binaryPath, [], {
-        cwd: target,
-      });
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-      const { host } = new URL(stdout);
-
-      const apiUrl = `https://${host}/api/get-env`;
-      const apiRes = await fetch(apiUrl);
-      expect(apiRes.status, apiUrl).toBe(200);
-      const apiJson = await apiRes.json();
-      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-
-      const homeUrl = `https://${host}`;
-      const homeRes = await fetch(homeUrl);
-      expect(homeRes.status, homeUrl).toBe(200);
-      const homeJson = await homeRes.json();
-      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-    }
-
-    async function vcDevWithEnv() {
-      const vc = execCli(binaryPath, ['dev', '--debug'], {
-        cwd: target,
-      });
-
-      const localhost = await getLocalhost(vc);
-      const apiUrl = `${localhost[0]}/api/get-env`;
-      const apiRes = await fetch(apiUrl);
-
-      expect(apiRes.status).toBe(200);
-
-      const apiJson = await apiRes.json();
-
-      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-
-      const homeUrl = localhost[0];
-
-      const homeRes = await fetch(homeUrl);
-      const homeJson = await homeRes.json();
-      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-
-      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-      await sleep(100);
-      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
-
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcDevAndFetchCloudVars() {
-      const vc = execCli(binaryPath, ['dev'], {
-        cwd: target,
-      });
-
-      const localhost = await getLocalhost(vc);
-      const apiUrl = `${localhost[0]}/api/get-env`;
-      const apiRes = await fetch(apiUrl);
-      expect(apiRes.status).toBe(200);
-
-      const apiJson = await apiRes.json();
-      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-      expect(apiJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
-
-      const homeUrl = localhost[0];
-      const homeRes = await fetch(homeUrl);
-      const homeJson = await homeRes.json();
-      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-      expect(homeJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
-
-      // system env vars are hidden in dev
-      expect(apiJson['VERCEL']).toBeUndefined();
-      // though the dev server now has this
-      expect(homeJson['VERCEL']).toBe('1');
-
-      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-      await sleep(100);
-      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
-
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function enableAutoExposeSystemEnvs() {
-      const link = require(path.join(target, '.vercel/project.json'));
-
-      const res = await apiFetch(`/v2/projects/${link.projectId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ autoExposeSystemEnvs: true }),
-      });
-
-      expect(res.status).toBe(200);
-      if (res.status === 200) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `Set autoExposeSystemEnvs=true for project ${link.projectId}`
-        );
       }
-    }
+    );
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
 
-    async function vcEnvPullFetchSystemVars() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'pull', '-y', '--environment', 'production'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-
-      const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
-
-      const lines = new Set(contents.split('\n'));
-
-      expect(lines).toContain('VERCEL="1"');
-      expect(lines).toContain('VERCEL_URL=""');
-      expect(lines).toContain('VERCEL_ENV="production"');
-      expect(lines).toContain('VERCEL_GIT_PROVIDER=""');
-      expect(lines).toContain('VERCEL_GIT_REPO_SLUG=""');
-    }
-
-    async function vcDevAndFetchSystemVars() {
-      const vc = execCli(binaryPath, ['dev'], {
+  async function vcEnvLsDoesNotIncludeVars() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'ls'],
+      {
         cwd: target,
-      });
+      }
+    );
 
-      const localhost = await getLocalhost(vc);
-      const apiUrl = `${localhost[0]}/api/get-env`;
-      const apiRes = await fetch(apiUrl);
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    expect(stdout).not.toContain(previewEnvVar);
+    expect(stdout).not.toContain(stdinEnvVar);
+    expect(stdout).not.toContain(promptEnvVar);
+  }
 
-      const localhostNoProtocol = localhost[0].slice('http://'.length);
+  async function vcEnvAddWithPrompts() {
+    const vc = execCli(binaryPath, ['env', 'add'], {
+      cwd: target,
+    });
 
-      const apiJson = await apiRes.json();
-      // environment variables are not set in dev
-      expect(apiJson['VERCEL']).toBeUndefined();
-      expect(apiJson['VERCEL_ENV']).toBeUndefined();
-      expect(apiJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
-      expect(apiJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
-      // except for these because vc dev
-      expect(apiJson['VERCEL_URL']).toBe(localhostNoProtocol);
-      expect(apiJson['VERCEL_REGION']).toBe('dev1');
+    await waitForPrompt(vc, "What's the name of the variable?");
+    vc.stdin?.write(`${promptEnvVar}\n`);
+    await waitForPrompt(
+      vc,
+      chunk =>
+        chunk.includes("What's the value of") && chunk.includes(promptEnvVar)
+    );
+    vc.stdin?.write('my plaintext value\n');
 
-      const homeUrl = localhost[0];
-      const homeRes = await fetch(homeUrl);
-      const homeJson = await homeRes.json();
-      expect(homeJson['VERCEL']).toBe('1');
-      expect(homeJson['VERCEL_URL']).toBe(localhostNoProtocol);
-      expect(homeJson['VERCEL_ENV']).toBe('development');
-      expect(homeJson['VERCEL_REGION']).toBeUndefined();
-      expect(homeJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
-      expect(homeJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
+    await waitForPrompt(
+      vc,
+      chunk =>
+        chunk.includes('which Environments') && chunk.includes(promptEnvVar)
+    );
+    vc.stdin?.write('a\n'); // select all
 
-      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-      await sleep(100);
-      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+    const { exitCode, stdout, stderr } = await vc;
 
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
 
-    async function vcEnvRemove() {
-      const vc = execCli(binaryPath, ['env', 'rm', '-y'], {
+  async function vcEnvAddFromStdin() {
+    const vc = execCli(binaryPath, ['env', 'add', stdinEnvVar, 'development'], {
+      cwd: target,
+    });
+    vc.stdin?.end('{"expect":"quotes"}');
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcEnvAddFromStdinPreview() {
+    const vc = execCli(binaryPath, ['env', 'add', previewEnvVar, 'preview'], {
+      cwd: target,
+    });
+    vc.stdin?.end('preview-no-branch');
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcEnvAddFromStdinPreviewWithBranch() {
+    const vc = execCli(
+      binaryPath,
+      ['env', 'add', previewEnvVar, 'preview', 'staging'],
+      {
         cwd: target,
-      });
-      await waitForPrompt(vc, "What's the name of the variable?");
-      vc.stdin?.write(`${previewEnvVar}\n`);
-      const { exitCode, stdout, stderr } = await vc;
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
+      }
+    );
+    vc.stdin?.end('preview-with-branch');
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
+    expect(stderr).toMatch(/does not have a connected Git repository/gm);
+  }
 
-    async function vcEnvRemoveWithArgs() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'rm', stdinEnvVar, 'development', '-y'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    async function vcEnvRemoveWithNameOnly() {
-      const { exitCode, stdout, stderr } = await execCli(
-        binaryPath,
-        ['env', 'rm', promptEnvVar, '-y'],
-        {
-          cwd: target,
-        }
-      );
-
-      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    }
-
-    function vcEnvRemoveByName(name: string) {
-      return execCli(binaryPath, ['env', 'rm', name, '-y'], {
+  async function vcEnvLsIncludesVar() {
+    const { exitCode, stderr, stdout } = await execCli(
+      binaryPath,
+      ['env', 'ls'],
+      {
         cwd: target,
-      });
-    }
+      }
+    );
 
-    async function vcEnvRemoveAll() {
-      await vcEnvRemoveByName(previewEnvVar);
-      await vcEnvRemoveByName(stdinEnvVar);
-      await vcEnvRemoveByName(promptEnvVar);
-    }
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    expect(stderr).toMatch(/Environment Variables found for (.*)\/api-env/gm);
 
-    try {
-      await vcEnvRemoveAll();
-      await vcLink();
-      await vcEnvLsDoesNotIncludeVars();
-      await vcEnvAddWithPrompts();
-      await vcEnvAddFromStdin();
-      await vcEnvAddFromStdinPreview();
-      await vcEnvAddFromStdinPreviewWithBranch();
-      await vcEnvLsIncludesVar();
-      await vcEnvPull();
-      await vcEnvPullOverwrite();
-      await vcEnvPullConfirm();
-      await vcDeployWithVar();
-      await vcDevWithEnv();
-      fs.unlinkSync(path.join(target, '.env.local'));
-      await vcDevAndFetchCloudVars();
-      await enableAutoExposeSystemEnvs();
-      await vcEnvPullFetchSystemVars();
-      fs.unlinkSync(path.join(target, '.env.local'));
-      await vcDevAndFetchSystemVars();
-      await vcEnvRemove();
-      await vcEnvRemoveWithArgs();
-      await vcEnvRemoveWithNameOnly();
-      await vcEnvLsDoesNotIncludeVars();
-    } finally {
-      await vcEnvRemoveAll();
+    const lines = stdout.split('\n');
+
+    const plaintextEnvs = lines.filter(line => line.includes(promptEnvVar));
+    expect(plaintextEnvs.length).toBe(1);
+    expect(plaintextEnvs[0]).toMatch(/Production, Preview, Development/gm);
+
+    const stdinEnvs = lines.filter(line => line.includes(stdinEnvVar));
+    expect(stdinEnvs.length).toBe(1);
+    expect(stdinEnvs[0]).toMatch(/Development/gm);
+
+    const previewEnvs = lines.filter(line => line.includes(previewEnvVar));
+    expect(previewEnvs.length).toBe(1);
+    expect(previewEnvs[0]).toMatch(/Encrypted .* Preview /gm);
+  }
+
+  async function vcEnvPull() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'pull', '-y'],
+      {
+        cwd: target,
+      }
+    );
+
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    expect(stderr).toMatch(/Updated .env.local file/gm);
+
+    const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
+    expect(contents).toMatch(/^# Created by Vercel CLI\n/);
+    expect(contents).toMatch(
+      new RegExp(`${promptEnvVar}="my plaintext value"`)
+    );
+    expect(contents).toMatch(
+      new RegExp(`${stdinEnvVar}="{"expect":"quotes"}"`)
+    );
+    expect(contents).not.toMatch(new RegExp(`${previewEnvVar}`));
+  }
+
+  async function vcEnvPullOverwrite() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'pull'],
+      {
+        cwd: target,
+      }
+    );
+
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    expect(stderr).toMatch(/Overwriting existing .env.local file/gm);
+    expect(stderr).toMatch(/Updated .env.local file/gm);
+  }
+
+  async function vcEnvPullConfirm() {
+    fs.writeFileSync(path.join(target, '.env.local'), 'hahaha');
+
+    const vc = execCli(binaryPath, ['env', 'pull'], {
+      cwd: target,
+      env: {
+        FORCE_TTY: '1',
+      },
+    });
+
+    await waitForPrompt(
+      vc,
+      'Found existing file ".env.local". Do you want to overwrite?'
+    );
+    vc.stdin?.end('y\n');
+
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcDeployWithVar() {
+    const { exitCode, stdout, stderr } = await execCli(binaryPath, [], {
+      cwd: target,
+    });
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    const { host } = new URL(stdout);
+
+    const apiUrl = `https://${host}/api/get-env`;
+    const apiRes = await fetch(apiUrl);
+    expect(apiRes.status, apiUrl).toBe(200);
+    const apiJson = await apiRes.json();
+    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+
+    const homeUrl = `https://${host}`;
+    const homeRes = await fetch(homeUrl);
+    expect(homeRes.status, homeUrl).toBe(200);
+    const homeJson = await homeRes.json();
+    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+  }
+
+  async function vcDevWithEnv() {
+    const vc = execCli(binaryPath, ['dev', '--debug'], {
+      cwd: target,
+    });
+
+    const localhost = await getLocalhost(vc);
+    const apiUrl = `${localhost[0]}/api/get-env`;
+    const apiRes = await fetch(apiUrl);
+
+    expect(apiRes.status).toBe(200);
+
+    const apiJson = await apiRes.json();
+
+    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+
+    const homeUrl = localhost[0];
+
+    const homeRes = await fetch(homeUrl);
+    const homeJson = await homeRes.json();
+    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+
+    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+    await sleep(100);
+    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcDevAndFetchCloudVars() {
+    const vc = execCli(binaryPath, ['dev'], {
+      cwd: target,
+    });
+
+    const localhost = await getLocalhost(vc);
+    const apiUrl = `${localhost[0]}/api/get-env`;
+    const apiRes = await fetch(apiUrl);
+    expect(apiRes.status).toBe(200);
+
+    const apiJson = await apiRes.json();
+    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+    expect(apiJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
+
+    const homeUrl = localhost[0];
+    const homeRes = await fetch(homeUrl);
+    const homeJson = await homeRes.json();
+    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+    expect(homeJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
+
+    // system env vars are hidden in dev
+    expect(apiJson['VERCEL']).toBeUndefined();
+    // though the dev server now has this
+    expect(homeJson['VERCEL']).toBe('1');
+
+    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+    await sleep(100);
+    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function enableAutoExposeSystemEnvs() {
+    const link = require(path.join(target, '.vercel/project.json'));
+
+    const res = await apiFetch(`/v2/projects/${link.projectId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ autoExposeSystemEnvs: true }),
+    });
+
+    expect(res.status).toBe(200);
+    if (res.status === 200) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Set autoExposeSystemEnvs=true for project ${link.projectId}`
+      );
     }
-  },
-  10 * 60 * 1000
-);
+  }
+
+  async function vcEnvPullFetchSystemVars() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'pull', '-y', '--environment', 'production'],
+      {
+        cwd: target,
+      }
+    );
+
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+
+    const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
+
+    const lines = new Set(contents.split('\n'));
+
+    expect(lines).toContain('VERCEL="1"');
+    expect(lines).toContain('VERCEL_URL=""');
+    expect(lines).toContain('VERCEL_ENV="production"');
+    expect(lines).toContain('VERCEL_GIT_PROVIDER=""');
+    expect(lines).toContain('VERCEL_GIT_REPO_SLUG=""');
+  }
+
+  async function vcDevAndFetchSystemVars() {
+    const vc = execCli(binaryPath, ['dev'], {
+      cwd: target,
+    });
+
+    const localhost = await getLocalhost(vc);
+    const apiUrl = `${localhost[0]}/api/get-env`;
+    const apiRes = await fetch(apiUrl);
+
+    const localhostNoProtocol = localhost[0].slice('http://'.length);
+
+    const apiJson = await apiRes.json();
+    // environment variables are not set in dev
+    expect(apiJson['VERCEL']).toBeUndefined();
+    expect(apiJson['VERCEL_ENV']).toBeUndefined();
+    expect(apiJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
+    expect(apiJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
+    // except for these because vc dev
+    expect(apiJson['VERCEL_URL']).toBe(localhostNoProtocol);
+    expect(apiJson['VERCEL_REGION']).toBe('dev1');
+
+    const homeUrl = localhost[0];
+    const homeRes = await fetch(homeUrl);
+    const homeJson = await homeRes.json();
+    expect(homeJson['VERCEL']).toBe('1');
+    expect(homeJson['VERCEL_URL']).toBe(localhostNoProtocol);
+    expect(homeJson['VERCEL_ENV']).toBe('development');
+    expect(homeJson['VERCEL_REGION']).toBeUndefined();
+    expect(homeJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
+    expect(homeJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
+
+    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+    await sleep(100);
+    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcEnvRemove() {
+    const vc = execCli(binaryPath, ['env', 'rm', '-y'], {
+      cwd: target,
+    });
+    await waitForPrompt(vc, "What's the name of the variable?");
+    vc.stdin?.write(`${previewEnvVar}\n`);
+    const { exitCode, stdout, stderr } = await vc;
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcEnvRemoveWithArgs() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'rm', stdinEnvVar, 'development', '-y'],
+      {
+        cwd: target,
+      }
+    );
+
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  async function vcEnvRemoveWithNameOnly() {
+    const { exitCode, stdout, stderr } = await execCli(
+      binaryPath,
+      ['env', 'rm', promptEnvVar, '-y'],
+      {
+        cwd: target,
+      }
+    );
+
+    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+  }
+
+  function vcEnvRemoveByName(name: string) {
+    return execCli(binaryPath, ['env', 'rm', name, '-y'], {
+      cwd: target,
+    });
+  }
+
+  async function vcEnvRemoveAll() {
+    await vcEnvRemoveByName(previewEnvVar);
+    await vcEnvRemoveByName(stdinEnvVar);
+    await vcEnvRemoveByName(promptEnvVar);
+  }
+
+  try {
+    await vcEnvRemoveAll();
+    await vcLink();
+    await vcEnvLsDoesNotIncludeVars();
+    await vcEnvAddWithPrompts();
+    await vcEnvAddFromStdin();
+    await vcEnvAddFromStdinPreview();
+    await vcEnvAddFromStdinPreviewWithBranch();
+    await vcEnvLsIncludesVar();
+    await vcEnvPull();
+    await vcEnvPullOverwrite();
+    await vcEnvPullConfirm();
+    await vcDeployWithVar();
+    await vcDevWithEnv();
+    fs.unlinkSync(path.join(target, '.env.local'));
+    await vcDevAndFetchCloudVars();
+    await enableAutoExposeSystemEnvs();
+    await vcEnvPullFetchSystemVars();
+    fs.unlinkSync(path.join(target, '.env.local'));
+    await vcDevAndFetchSystemVars();
+    await vcEnvRemove();
+    await vcEnvRemoveWithArgs();
+    await vcEnvRemoveWithNameOnly();
+    await vcEnvLsDoesNotIncludeVars();
+  } finally {
+    await vcEnvRemoveAll();
+  }
+});

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -461,410 +461,418 @@ test('deploy using --local-config flag above target', async () => {
   expect(host).toMatch(/root-level/gm);
 });
 
-test('deploy `api-env` fixture and test `vercel env` command', async () => {
-  const target = await setupE2EFixture('api-env');
-  // Randomness is required so that tests can run in
-  // parallel on the same project
-  const promptEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
-  const stdinEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
-  const previewEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+test(
+  'deploy `api-env` fixture and test `vercel env` command',
+  async () => {
+    const target = await setupE2EFixture('api-env');
+    // Randomness is required so that tests can run in
+    // parallel on the same project
+    const promptEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+    const stdinEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
+    const previewEnvVar = `VAR_${randomBytes(8).toString('hex')}`;
 
-  async function vcLink() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['link', '--yes'],
-      {
-        cwd: target,
-      }
-    );
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvLsDoesNotIncludeVars() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'ls'],
-      {
-        cwd: target,
-      }
-    );
-
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    expect(stdout).not.toContain(previewEnvVar);
-    expect(stdout).not.toContain(stdinEnvVar);
-    expect(stdout).not.toContain(promptEnvVar);
-  }
-
-  async function vcEnvAddWithPrompts() {
-    const vc = execCli(binaryPath, ['env', 'add'], {
-      cwd: target,
-    });
-
-    await waitForPrompt(vc, "What's the name of the variable?");
-    vc.stdin?.write(`${promptEnvVar}\n`);
-    await waitForPrompt(
-      vc,
-      chunk =>
-        chunk.includes("What's the value of") && chunk.includes(promptEnvVar)
-    );
-    vc.stdin?.write('my plaintext value\n');
-
-    await waitForPrompt(
-      vc,
-      chunk =>
-        chunk.includes('which Environments') && chunk.includes(promptEnvVar)
-    );
-    vc.stdin?.write('a\n'); // select all
-
-    const { exitCode, stdout, stderr } = await vc;
-
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvAddFromStdin() {
-    const vc = execCli(binaryPath, ['env', 'add', stdinEnvVar, 'development'], {
-      cwd: target,
-    });
-    vc.stdin?.end('{"expect":"quotes"}');
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvAddFromStdinPreview() {
-    const vc = execCli(binaryPath, ['env', 'add', previewEnvVar, 'preview'], {
-      cwd: target,
-    });
-    vc.stdin?.end('preview-no-branch');
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvAddFromStdinPreviewWithBranch() {
-    const vc = execCli(
-      binaryPath,
-      ['env', 'add', previewEnvVar, 'preview', 'staging'],
-      {
-        cwd: target,
-      }
-    );
-    vc.stdin?.end('preview-with-branch');
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
-    expect(stderr).toMatch(/does not have a connected Git repository/gm);
-  }
-
-  async function vcEnvLsIncludesVar() {
-    const { exitCode, stderr, stdout } = await execCli(
-      binaryPath,
-      ['env', 'ls'],
-      {
-        cwd: target,
-      }
-    );
-
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    expect(stderr).toMatch(/Environment Variables found for (.*)\/api-env/gm);
-
-    const lines = stdout.split('\n');
-
-    const plaintextEnvs = lines.filter(line => line.includes(promptEnvVar));
-    expect(plaintextEnvs.length).toBe(1);
-    expect(plaintextEnvs[0]).toMatch(/Production, Preview, Development/gm);
-
-    const stdinEnvs = lines.filter(line => line.includes(stdinEnvVar));
-    expect(stdinEnvs.length).toBe(1);
-    expect(stdinEnvs[0]).toMatch(/Development/gm);
-
-    const previewEnvs = lines.filter(line => line.includes(previewEnvVar));
-    expect(previewEnvs.length).toBe(1);
-    expect(previewEnvs[0]).toMatch(/Encrypted .* Preview /gm);
-  }
-
-  async function vcEnvPull() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'pull', '-y'],
-      {
-        cwd: target,
-      }
-    );
-
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    expect(stderr).toMatch(/Created .env.local file/gm);
-
-    const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
-    expect(contents).toMatch(/^# Created by Vercel CLI\n/);
-    expect(contents).toMatch(
-      new RegExp(`${promptEnvVar}="my plaintext value"`)
-    );
-    expect(contents).toMatch(
-      new RegExp(`${stdinEnvVar}="{"expect":"quotes"}"`)
-    );
-    expect(contents).not.toMatch(new RegExp(`${previewEnvVar}`));
-  }
-
-  async function vcEnvPullOverwrite() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'pull'],
-      {
-        cwd: target,
-      }
-    );
-
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    expect(stderr).toMatch(/Overwriting existing .env.local file/gm);
-    expect(stderr).toMatch(/Updated .env.local file/gm);
-  }
-
-  async function vcEnvPullConfirm() {
-    fs.writeFileSync(path.join(target, '.env.local'), 'hahaha');
-
-    const vc = execCli(binaryPath, ['env', 'pull'], {
-      cwd: target,
-    });
-
-    await waitForPrompt(
-      vc,
-      'Found existing file ".env.local". Do you want to overwrite?'
-    );
-    vc.stdin?.end('y\n');
-
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcDeployWithVar() {
-    const { exitCode, stdout, stderr } = await execCli(binaryPath, [], {
-      cwd: target,
-    });
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-    const { host } = new URL(stdout);
-
-    const apiUrl = `https://${host}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
-    expect(apiRes.status, apiUrl).toBe(200);
-    const apiJson = await apiRes.json();
-    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-
-    const homeUrl = `https://${host}`;
-    const homeRes = await fetch(homeUrl);
-    expect(homeRes.status, homeUrl).toBe(200);
-    const homeJson = await homeRes.json();
-    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-  }
-
-  async function vcDevWithEnv() {
-    const vc = execCli(binaryPath, ['dev', '--debug'], {
-      cwd: target,
-    });
-
-    const localhost = await getLocalhost(vc);
-    const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
-
-    expect(apiRes.status).toBe(200);
-
-    const apiJson = await apiRes.json();
-
-    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-
-    const homeUrl = localhost[0];
-
-    const homeRes = await fetch(homeUrl);
-    const homeJson = await homeRes.json();
-    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-
-    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-    await sleep(100);
-    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
-
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcDevAndFetchCloudVars() {
-    const vc = execCli(binaryPath, ['dev'], {
-      cwd: target,
-    });
-
-    const localhost = await getLocalhost(vc);
-    const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
-    expect(apiRes.status).toBe(200);
-
-    const apiJson = await apiRes.json();
-    expect(apiJson[promptEnvVar]).toBe('my plaintext value');
-    expect(apiJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
-
-    const homeUrl = localhost[0];
-    const homeRes = await fetch(homeUrl);
-    const homeJson = await homeRes.json();
-    expect(homeJson[promptEnvVar]).toBe('my plaintext value');
-    expect(homeJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
-
-    // system env vars are hidden in dev
-    expect(apiJson['VERCEL']).toBeUndefined();
-    // though the dev server now has this
-    expect(homeJson['VERCEL']).toBe('1');
-
-    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-    await sleep(100);
-    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
-
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function enableAutoExposeSystemEnvs() {
-    const link = require(path.join(target, '.vercel/project.json'));
-
-    const res = await apiFetch(`/v2/projects/${link.projectId}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ autoExposeSystemEnvs: true }),
-    });
-
-    expect(res.status).toBe(200);
-    if (res.status === 200) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `Set autoExposeSystemEnvs=true for project ${link.projectId}`
+    async function vcLink() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['link', '--yes'],
+        {
+          cwd: target,
+        }
       );
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
     }
-  }
 
-  async function vcEnvPullFetchSystemVars() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'pull', '-y', '--environment', 'production'],
-      {
+    async function vcEnvLsDoesNotIncludeVars() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'ls'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      expect(stdout).not.toContain(previewEnvVar);
+      expect(stdout).not.toContain(stdinEnvVar);
+      expect(stdout).not.toContain(promptEnvVar);
+    }
+
+    async function vcEnvAddWithPrompts() {
+      const vc = execCli(binaryPath, ['env', 'add'], {
         cwd: target,
-      }
-    );
+      });
 
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      await waitForPrompt(vc, "What's the name of the variable?");
+      vc.stdin?.write(`${promptEnvVar}\n`);
+      await waitForPrompt(
+        vc,
+        chunk =>
+          chunk.includes("What's the value of") && chunk.includes(promptEnvVar)
+      );
+      vc.stdin?.write('my plaintext value\n');
 
-    const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
+      await waitForPrompt(
+        vc,
+        chunk =>
+          chunk.includes('which Environments') && chunk.includes(promptEnvVar)
+      );
+      vc.stdin?.write('a\n'); // select all
 
-    const lines = new Set(contents.split('\n'));
+      const { exitCode, stdout, stderr } = await vc;
 
-    expect(lines).toContain('VERCEL="1"');
-    expect(lines).toContain('VERCEL_URL=""');
-    expect(lines).toContain('VERCEL_ENV="production"');
-    expect(lines).toContain('VERCEL_GIT_PROVIDER=""');
-    expect(lines).toContain('VERCEL_GIT_REPO_SLUG=""');
-  }
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
 
-  async function vcDevAndFetchSystemVars() {
-    const vc = execCli(binaryPath, ['dev'], {
-      cwd: target,
-    });
+    async function vcEnvAddFromStdin() {
+      const vc = execCli(
+        binaryPath,
+        ['env', 'add', stdinEnvVar, 'development'],
+        {
+          cwd: target,
+        }
+      );
+      vc.stdin?.end('{"expect":"quotes"}');
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
 
-    const localhost = await getLocalhost(vc);
-    const apiUrl = `${localhost[0]}/api/get-env`;
-    const apiRes = await fetch(apiUrl);
-
-    const localhostNoProtocol = localhost[0].slice('http://'.length);
-
-    const apiJson = await apiRes.json();
-    // environment variables are not set in dev
-    expect(apiJson['VERCEL']).toBeUndefined();
-    expect(apiJson['VERCEL_ENV']).toBeUndefined();
-    expect(apiJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
-    expect(apiJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
-    // except for these because vc dev
-    expect(apiJson['VERCEL_URL']).toBe(localhostNoProtocol);
-    expect(apiJson['VERCEL_REGION']).toBe('dev1');
-
-    const homeUrl = localhost[0];
-    const homeRes = await fetch(homeUrl);
-    const homeJson = await homeRes.json();
-    expect(homeJson['VERCEL']).toBe('1');
-    expect(homeJson['VERCEL_URL']).toBe(localhostNoProtocol);
-    expect(homeJson['VERCEL_ENV']).toBe('development');
-    expect(homeJson['VERCEL_REGION']).toBeUndefined();
-    expect(homeJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
-    expect(homeJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
-
-    // sleep before kill, otherwise the dev process doesn't clean up and exit properly
-    await sleep(100);
-    vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
-
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvRemove() {
-    const vc = execCli(binaryPath, ['env', 'rm', '-y'], {
-      cwd: target,
-    });
-    await waitForPrompt(vc, "What's the name of the variable?");
-    vc.stdin?.write(`${previewEnvVar}\n`);
-    const { exitCode, stdout, stderr } = await vc;
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
-
-  async function vcEnvRemoveWithArgs() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'rm', stdinEnvVar, 'development', '-y'],
-      {
+    async function vcEnvAddFromStdinPreview() {
+      const vc = execCli(binaryPath, ['env', 'add', previewEnvVar, 'preview'], {
         cwd: target,
-      }
-    );
+      });
+      vc.stdin?.end('preview-no-branch');
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
 
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
+    async function vcEnvAddFromStdinPreviewWithBranch() {
+      const vc = execCli(
+        binaryPath,
+        ['env', 'add', previewEnvVar, 'preview', 'staging'],
+        {
+          cwd: target,
+        }
+      );
+      vc.stdin?.end('preview-with-branch');
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
+      expect(stderr).toMatch(/does not have a connected Git repository/gm);
+    }
 
-  async function vcEnvRemoveWithNameOnly() {
-    const { exitCode, stdout, stderr } = await execCli(
-      binaryPath,
-      ['env', 'rm', promptEnvVar, '-y'],
-      {
+    async function vcEnvLsIncludesVar() {
+      const { exitCode, stderr, stdout } = await execCli(
+        binaryPath,
+        ['env', 'ls'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      expect(stderr).toMatch(/Environment Variables found for (.*)\/api-env/gm);
+
+      const lines = stdout.split('\n');
+
+      const plaintextEnvs = lines.filter(line => line.includes(promptEnvVar));
+      expect(plaintextEnvs.length).toBe(1);
+      expect(plaintextEnvs[0]).toMatch(/Production, Preview, Development/gm);
+
+      const stdinEnvs = lines.filter(line => line.includes(stdinEnvVar));
+      expect(stdinEnvs.length).toBe(1);
+      expect(stdinEnvs[0]).toMatch(/Development/gm);
+
+      const previewEnvs = lines.filter(line => line.includes(previewEnvVar));
+      expect(previewEnvs.length).toBe(1);
+      expect(previewEnvs[0]).toMatch(/Encrypted .* Preview /gm);
+    }
+
+    async function vcEnvPull() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'pull', '-y'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      expect(stderr).toMatch(/Updated .env.local file/gm);
+
+      const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
+      expect(contents).toMatch(/^# Created by Vercel CLI\n/);
+      expect(contents).toMatch(
+        new RegExp(`${promptEnvVar}="my plaintext value"`)
+      );
+      expect(contents).toMatch(
+        new RegExp(`${stdinEnvVar}="{"expect":"quotes"}"`)
+      );
+      expect(contents).not.toMatch(new RegExp(`${previewEnvVar}`));
+    }
+
+    async function vcEnvPullOverwrite() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'pull'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      expect(stderr).toMatch(/Overwriting existing .env.local file/gm);
+      expect(stderr).toMatch(/Updated .env.local file/gm);
+    }
+
+    async function vcEnvPullConfirm() {
+      fs.writeFileSync(path.join(target, '.env.local'), 'hahaha');
+
+      const vc = execCli(binaryPath, ['env', 'pull'], {
         cwd: target,
+      });
+
+      await waitForPrompt(
+        vc,
+        'Found existing file ".env.local". Do you want to overwrite?'
+      );
+      vc.stdin?.end('y\n');
+
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function vcDeployWithVar() {
+      const { exitCode, stdout, stderr } = await execCli(binaryPath, [], {
+        cwd: target,
+      });
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+      const { host } = new URL(stdout);
+
+      const apiUrl = `https://${host}/api/get-env`;
+      const apiRes = await fetch(apiUrl);
+      expect(apiRes.status, apiUrl).toBe(200);
+      const apiJson = await apiRes.json();
+      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+
+      const homeUrl = `https://${host}`;
+      const homeRes = await fetch(homeUrl);
+      expect(homeRes.status, homeUrl).toBe(200);
+      const homeJson = await homeRes.json();
+      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+    }
+
+    async function vcDevWithEnv() {
+      const vc = execCli(binaryPath, ['dev', '--debug'], {
+        cwd: target,
+      });
+
+      const localhost = await getLocalhost(vc);
+      const apiUrl = `${localhost[0]}/api/get-env`;
+      const apiRes = await fetch(apiUrl);
+
+      expect(apiRes.status).toBe(200);
+
+      const apiJson = await apiRes.json();
+
+      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+
+      const homeUrl = localhost[0];
+
+      const homeRes = await fetch(homeUrl);
+      const homeJson = await homeRes.json();
+      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+
+      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+      await sleep(100);
+      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function vcDevAndFetchCloudVars() {
+      const vc = execCli(binaryPath, ['dev'], {
+        cwd: target,
+      });
+
+      const localhost = await getLocalhost(vc);
+      const apiUrl = `${localhost[0]}/api/get-env`;
+      const apiRes = await fetch(apiUrl);
+      expect(apiRes.status).toBe(200);
+
+      const apiJson = await apiRes.json();
+      expect(apiJson[promptEnvVar]).toBe('my plaintext value');
+      expect(apiJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
+
+      const homeUrl = localhost[0];
+      const homeRes = await fetch(homeUrl);
+      const homeJson = await homeRes.json();
+      expect(homeJson[promptEnvVar]).toBe('my plaintext value');
+      expect(homeJson[stdinEnvVar]).toBe('{"expect":"quotes"}');
+
+      // system env vars are hidden in dev
+      expect(apiJson['VERCEL']).toBeUndefined();
+      // though the dev server now has this
+      expect(homeJson['VERCEL']).toBe('1');
+
+      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+      await sleep(100);
+      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function enableAutoExposeSystemEnvs() {
+      const link = require(path.join(target, '.vercel/project.json'));
+
+      const res = await apiFetch(`/v2/projects/${link.projectId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ autoExposeSystemEnvs: true }),
+      });
+
+      expect(res.status).toBe(200);
+      if (res.status === 200) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `Set autoExposeSystemEnvs=true for project ${link.projectId}`
+        );
       }
-    );
+    }
 
-    expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
-  }
+    async function vcEnvPullFetchSystemVars() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'pull', '-y', '--environment', 'production'],
+        {
+          cwd: target,
+        }
+      );
 
-  function vcEnvRemoveByName(name: string) {
-    return execCli(binaryPath, ['env', 'rm', name, '-y'], {
-      cwd: target,
-    });
-  }
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
-  async function vcEnvRemoveAll() {
-    await vcEnvRemoveByName(previewEnvVar);
-    await vcEnvRemoveByName(stdinEnvVar);
-    await vcEnvRemoveByName(promptEnvVar);
-  }
+      const contents = fs.readFileSync(path.join(target, '.env.local'), 'utf8');
 
-  try {
-    await vcEnvRemoveAll();
-    await vcLink();
-    await vcEnvLsDoesNotIncludeVars();
-    await vcEnvAddWithPrompts();
-    await vcEnvAddFromStdin();
-    await vcEnvAddFromStdinPreview();
-    await vcEnvAddFromStdinPreviewWithBranch();
-    await vcEnvLsIncludesVar();
-    await vcEnvPull();
-    await vcEnvPullOverwrite();
-    await vcEnvPullConfirm();
-    await vcDeployWithVar();
-    await vcDevWithEnv();
-    fs.unlinkSync(path.join(target, '.env.local'));
-    await vcDevAndFetchCloudVars();
-    await enableAutoExposeSystemEnvs();
-    await vcEnvPullFetchSystemVars();
-    fs.unlinkSync(path.join(target, '.env.local'));
-    await vcDevAndFetchSystemVars();
-    await vcEnvRemove();
-    await vcEnvRemoveWithArgs();
-    await vcEnvRemoveWithNameOnly();
-    await vcEnvLsDoesNotIncludeVars();
-  } finally {
-    await vcEnvRemoveAll();
-  }
-});
+      const lines = new Set(contents.split('\n'));
+
+      expect(lines).toContain('VERCEL="1"');
+      expect(lines).toContain('VERCEL_URL=""');
+      expect(lines).toContain('VERCEL_ENV="production"');
+      expect(lines).toContain('VERCEL_GIT_PROVIDER=""');
+      expect(lines).toContain('VERCEL_GIT_REPO_SLUG=""');
+    }
+
+    async function vcDevAndFetchSystemVars() {
+      const vc = execCli(binaryPath, ['dev'], {
+        cwd: target,
+      });
+
+      const localhost = await getLocalhost(vc);
+      const apiUrl = `${localhost[0]}/api/get-env`;
+      const apiRes = await fetch(apiUrl);
+
+      const localhostNoProtocol = localhost[0].slice('http://'.length);
+
+      const apiJson = await apiRes.json();
+      // environment variables are not set in dev
+      expect(apiJson['VERCEL']).toBeUndefined();
+      expect(apiJson['VERCEL_ENV']).toBeUndefined();
+      expect(apiJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
+      expect(apiJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
+      // except for these because vc dev
+      expect(apiJson['VERCEL_URL']).toBe(localhostNoProtocol);
+      expect(apiJson['VERCEL_REGION']).toBe('dev1');
+
+      const homeUrl = localhost[0];
+      const homeRes = await fetch(homeUrl);
+      const homeJson = await homeRes.json();
+      expect(homeJson['VERCEL']).toBe('1');
+      expect(homeJson['VERCEL_URL']).toBe(localhostNoProtocol);
+      expect(homeJson['VERCEL_ENV']).toBe('development');
+      expect(homeJson['VERCEL_REGION']).toBeUndefined();
+      expect(homeJson['VERCEL_GIT_PROVIDER']).toBeUndefined();
+      expect(homeJson['VERCEL_GIT_REPO_SLUG']).toBeUndefined();
+
+      // sleep before kill, otherwise the dev process doesn't clean up and exit properly
+      await sleep(100);
+      vc.kill('SIGTERM', { forceKillAfterTimeout: 5000 });
+
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function vcEnvRemove() {
+      const vc = execCli(binaryPath, ['env', 'rm', '-y'], {
+        cwd: target,
+      });
+      await waitForPrompt(vc, "What's the name of the variable?");
+      vc.stdin?.write(`${previewEnvVar}\n`);
+      const { exitCode, stdout, stderr } = await vc;
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function vcEnvRemoveWithArgs() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'rm', stdinEnvVar, 'development', '-y'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    async function vcEnvRemoveWithNameOnly() {
+      const { exitCode, stdout, stderr } = await execCli(
+        binaryPath,
+        ['env', 'rm', promptEnvVar, '-y'],
+        {
+          cwd: target,
+        }
+      );
+
+      expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+    }
+
+    function vcEnvRemoveByName(name: string) {
+      return execCli(binaryPath, ['env', 'rm', name, '-y'], {
+        cwd: target,
+      });
+    }
+
+    async function vcEnvRemoveAll() {
+      await vcEnvRemoveByName(previewEnvVar);
+      await vcEnvRemoveByName(stdinEnvVar);
+      await vcEnvRemoveByName(promptEnvVar);
+    }
+
+    try {
+      await vcEnvRemoveAll();
+      await vcLink();
+      await vcEnvLsDoesNotIncludeVars();
+      await vcEnvAddWithPrompts();
+      await vcEnvAddFromStdin();
+      await vcEnvAddFromStdinPreview();
+      await vcEnvAddFromStdinPreviewWithBranch();
+      await vcEnvLsIncludesVar();
+      await vcEnvPull();
+      await vcEnvPullOverwrite();
+      await vcEnvPullConfirm();
+      await vcDeployWithVar();
+      await vcDevWithEnv();
+      fs.unlinkSync(path.join(target, '.env.local'));
+      await vcDevAndFetchCloudVars();
+      await enableAutoExposeSystemEnvs();
+      await vcEnvPullFetchSystemVars();
+      fs.unlinkSync(path.join(target, '.env.local'));
+      await vcDevAndFetchSystemVars();
+      await vcEnvRemove();
+      await vcEnvRemoveWithArgs();
+      await vcEnvRemoveWithNameOnly();
+      await vcEnvLsDoesNotIncludeVars();
+    } finally {
+      await vcEnvRemoveAll();
+    }
+  },
+  10 * 60 * 1000
+);

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -628,6 +628,9 @@ test(
 
       const vc = execCli(binaryPath, ['env', 'pull'], {
         cwd: target,
+        env: {
+          FORCE_TTY: '1',
+        },
       });
 
       await waitForPrompt(

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -1040,9 +1040,9 @@ test('[vc link] should not duplicate paths in .gitignore', async () => {
   // Ensure the message is correct pattern
   expect(stderr).toMatch(/Linked to /m);
 
-  // Ensure .gitignore is created
+  // Ensure .gitignore contains .vercel and .env*.local (from env pull)
   const gitignore = await readFile(path.join(dir, '.gitignore'), 'utf8');
-  expect(gitignore).toBe('.vercel\n');
+  expect(gitignore).toBe('.vercel\n.env*.local\n');
 });
 
 test('[vc dev] should show prompts to set up project', async () => {

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -113,6 +113,12 @@ async function setupProject(
   }
 
   await waitForPrompt(process, 'Linked to');
+
+  await waitForPrompt(
+    process,
+    'Would you like to pull environment variables now?'
+  );
+  process.stdin?.write('n\n');
 }
 
 beforeAll(async () => {
@@ -1123,6 +1129,9 @@ test('[vc link] should show project prompts but not framework when `builds` defi
 
   await waitForPrompt(vc, 'Linked to');
 
+  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
+  vc.stdin?.write('n\n');
+
   const output = await vc;
 
   // Ensure the exit code is right
@@ -1315,6 +1324,8 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   vc.stdin?.write('\x1b[B'); // Down Arrow
   vc.stdin?.write('\n');
   await waitForPrompt(vc, 'Linked to');
+  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
+  vc.stdin?.write('n\n');
   const deployment = await vc;
   expect(deployment.exitCode, formatOutput(deployment)).toBe(0);
   // assert the command were executed

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -334,6 +334,11 @@ test('should prefill "project name" prompt with now.json `name`', async () => {
   );
   now.stdin?.write('\n');
 
+  await waitForPrompt(now, /Linked to/);
+
+  await waitForPrompt(now, 'Would you like to pull environment variables now?');
+  now.stdin?.write('n\n');
+
   const output = await now;
   expect(output.exitCode, formatOutput(output)).toBe(0);
 

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -1,0 +1,159 @@
+import path from 'path';
+import { execCli } from './helpers/exec';
+import fs from 'fs-extra';
+import waitForPrompt from './helpers/wait-for-prompt';
+import { listTmpDirs } from './helpers/get-tmp-dir';
+import { teamPromise } from './helpers/get-account';
+import {
+  setupE2EFixture,
+  prepareE2EFixtures,
+} from './helpers/setup-e2e-fixture';
+import formatOutput from './helpers/format-output';
+
+const TEST_TIMEOUT = 3 * 60 * 1000;
+jest.setTimeout(TEST_TIMEOUT);
+
+const binaryPath = path.resolve(__dirname, '../scripts/start.js');
+
+beforeAll(async () => {
+  try {
+    const team = await teamPromise;
+    await prepareE2EFixtures(team.slug, binaryPath);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log('Failed test suite `beforeAll`');
+    // eslint-disable-next-line no-console
+    console.log(err);
+
+    process.exit(1);
+  }
+});
+
+afterAll(async () => {
+  const allTmpDirs = listTmpDirs();
+  for (const tmpDir of allTmpDirs) {
+    // eslint-disable-next-line no-console
+    console.log('Removing temp dir: ', tmpDir.name);
+    tmpDir.removeCallback();
+  }
+});
+
+test('[vc link] should prompt for env pull and handle acceptance', async () => {
+  const dir = await setupE2EFixture('project-link-gitignore');
+  const projectName = `link-env-pull-${Math.random().toString(36).split('.')[1]}`;
+
+  await fs.remove(path.join(dir, '.vercel'));
+
+  const vc = execCli(binaryPath, ['link', `--project=${projectName}`], {
+    cwd: dir,
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
+
+  await waitForPrompt(vc, /Set up[^?]+\?/);
+  vc.stdin?.write('yes\n');
+
+  await waitForPrompt(vc, 'Which scope should contain your project?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'Link to existing project?');
+  vc.stdin?.write('no\n');
+
+  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'In which directory is your code located?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'Want to modify these settings?');
+  vc.stdin?.write('no\n');
+
+  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, /Linked to/);
+
+  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
+  vc.stdin?.write('y\n');
+
+  const { exitCode, stdout, stderr } = await vc;
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+
+  expect(await fs.pathExists(path.join(dir, '.vercel/project.json'))).toBe(
+    true
+  );
+});
+
+test('[vc link] should handle env pull prompt decline', async () => {
+  const dir = await setupE2EFixture('project-link-gitignore');
+  const projectName = `link-env-decline-${Math.random().toString(36).split('.')[1]}`;
+
+  await fs.remove(path.join(dir, '.vercel'));
+
+  const vc = execCli(binaryPath, ['link', `--project=${projectName}`], {
+    cwd: dir,
+    env: {
+      FORCE_TTY: '1',
+    },
+  });
+
+  await waitForPrompt(vc, /Set up[^?]+\?/);
+  vc.stdin?.write('yes\n');
+
+  await waitForPrompt(vc, 'Which scope should contain your project?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'Link to existing project?');
+  vc.stdin?.write('no\n');
+
+  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'In which directory is your code located?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, 'Want to modify these settings?');
+  vc.stdin?.write('no\n');
+
+  await waitForPrompt(vc, 'Do you want to change additional project settings?');
+  vc.stdin?.write('\n');
+
+  await waitForPrompt(vc, /Linked to/);
+
+  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
+  vc.stdin?.write('n\n');
+
+  const { exitCode, stdout, stderr } = await vc;
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+
+  expect(await fs.pathExists(path.join(dir, '.vercel/project.json'))).toBe(
+    true
+  );
+
+  expect(await fs.pathExists(path.join(dir, '.env.local'))).toBe(false);
+});
+
+test('[vc link] should work with --yes flag and auto-confirm all prompts', async () => {
+  const dir = await setupE2EFixture('project-link-gitignore');
+  const projectName = `link-env-yes-${Math.random().toString(36).split('.')[1]}`;
+
+  await fs.remove(path.join(dir, '.vercel'));
+
+  const { exitCode, stdout, stderr } = await execCli(
+    binaryPath,
+    ['link', `--project=${projectName}`, '--yes'],
+    {
+      cwd: dir,
+      env: {
+        FORCE_TTY: '1',
+      },
+    }
+  );
+
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
+
+  expect(await fs.pathExists(path.join(dir, '.vercel/project.json'))).toBe(
+    true
+  );
+});

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -43,6 +43,7 @@ test('[vc link] should prompt for env pull and handle acceptance', async () => {
   const projectName = `link-env-pull-${Math.random().toString(36).split('.')[1]}`;
 
   await fs.remove(path.join(dir, '.vercel'));
+  await fs.remove(path.join(dir, '.env.local'));
 
   const vc = execCli(binaryPath, ['link', `--project=${projectName}`], {
     cwd: dir,
@@ -90,6 +91,7 @@ test('[vc link] should handle env pull prompt decline', async () => {
   const projectName = `link-env-decline-${Math.random().toString(36).split('.')[1]}`;
 
   await fs.remove(path.join(dir, '.vercel'));
+  await fs.remove(path.join(dir, '.env.local'));
 
   const vc = execCli(binaryPath, ['link', `--project=${projectName}`], {
     cwd: dir,
@@ -139,6 +141,7 @@ test('[vc link] should work with --yes flag and auto-confirm all prompts', async
   const projectName = `link-env-yes-${Math.random().toString(36).split('.')[1]}`;
 
   await fs.remove(path.join(dir, '.vercel'));
+  await fs.remove(path.join(dir, '.env.local'));
 
   const { exitCode, stdout, stderr } = await execCli(
     binaryPath,

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1298,6 +1298,11 @@ describe('deploy', () => {
         );
         client.stdin.write('\n');
 
+        await expect(client.stderr).toOutput(
+          'Would you like to pull environment variables now?'
+        );
+        client.stdin.write('n\n');
+
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
       });
@@ -1337,6 +1342,11 @@ describe('deploy', () => {
           'Do you want to change additional project settings?'
         );
         client.stdin.write('\n');
+
+        await expect(client.stderr).toOutput(
+          'Would you like to pull environment variables now?'
+        );
+        client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -511,6 +511,27 @@ describe('env pull', () => {
     expect(gitignoreAfter).toBe(gitignoreBefore);
   });
 
+  it('should work when called programmatically from link command', async () => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'vercel-env-pull',
+      name: 'vercel-env-pull',
+    });
+    const cwd = setupUnitFixture('vercel-env-pull');
+    client.cwd = cwd;
+
+    // Call env pull programmatically like the link command does
+    client.setArgv('env', 'pull', '--yes');
+    const exitCode = await env(client);
+    expect(exitCode, 'exit code for programmatic env pull').toEqual(0);
+
+    const rawDevEnv = await fs.readFile(path.join(cwd, '.env.local'));
+    const devFileHasDevEnv = rawDevEnv.toString().includes('SPECIAL_FLAG');
+    expect(devFileHasDevEnv).toBeTruthy();
+  });
+
   it('should not pull VERCEL_ANALYTICS_ID', async () => {
     useUser();
     useTeams('team_dummy');

--- a/packages/cli/test/unit/commands/git/connect.test.ts
+++ b/packages/cli/test/unit/commands/git/connect.test.ts
@@ -67,6 +67,11 @@ describe('git connect', () => {
         client.stdin.write('y\n');
 
         await expect(client.stderr).toOutput(
+          'Would you like to pull environment variables now?'
+        );
+        client.stdin.write('n\n');
+
+        await expect(client.stderr).toOutput(
           `Do you still want to connect https://github.com/user2/repo2?`
         );
         client.stdin.write('y\n');
@@ -113,6 +118,10 @@ describe('git connect', () => {
             key: 'flag:yes',
             value: 'TRUE',
           },
+          {
+            key: 'flag:yes',
+            value: 'TRUE',
+          },
         ]);
       });
     });
@@ -139,6 +148,10 @@ describe('git connect', () => {
             key: 'flag:confirm',
             value: 'TRUE',
           },
+          {
+            key: 'flag:yes',
+            value: 'TRUE',
+          },
         ]);
       });
     });
@@ -159,6 +172,11 @@ describe('git connect', () => {
 
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
         `Connecting GitHub repository: https://github.com/user/repo`
@@ -207,6 +225,11 @@ describe('git connect', () => {
 
       await expect(client.stderr).toOutput('Found project');
       client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
 
       await expect(client.stderr).toOutput(
         `Do you still want to connect https://github.com/user2/repo2?`

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -969,22 +969,30 @@ describe('link', () => {
       });
       useUnknownProject();
 
-      const originalCwd = '/some/original/path';
-      client.cwd = originalCwd;
-      client.setArgv('link', '--yes', cwd);
+      client.cwd = cwd;
+      const originalCwd = client.cwd;
+      client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         'Which scope should contain your project?'
       );
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
       );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -1008,22 +1016,30 @@ describe('link', () => {
         throw new Error('Env pull failed');
       });
 
-      const originalCwd = '/some/original/path';
-      client.cwd = originalCwd;
-      client.setArgv('link', '--yes', cwd);
+      client.cwd = cwd;
+      const originalCwd = client.cwd;
+      client.setArgv('--project', project.name!);
       const exitCodePromise = link(client);
 
       await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         'Which scope should contain your project?'
       );
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
       );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
 
       await expect(client.stderr).toOutput(
         'Failed to pull environment variables. You can run `vc env pull` manually.'

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -1,5 +1,5 @@
 import { EOL } from 'node:os';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { basename, join } from 'path';
 import { readFile } from 'fs-extra';
 import {
@@ -11,6 +11,7 @@ import {
   remove,
 } from 'fs-extra';
 import link from '../../../../src/commands/link';
+import pull from '../../../../src/commands/env/pull';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useTeams } from '../../../mocks/team';
@@ -26,7 +27,16 @@ import {
 import getProjectByNameOrId from '../../../../src/util/projects/get-project-by-id-or-name';
 import { ProjectNotFound } from '../../../../src/util/errors-ts';
 
+// Mock the env pull command
+vi.mock('../../../../src/commands/env/pull');
+const mockPull = vi.mocked(pull);
+
 describe('link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock implementation for env pull command
+    mockPull.mockResolvedValue(0);
+  });
   describe('--help', () => {
     it('tracks telemetry', async () => {
       const command = 'link';
@@ -421,6 +431,13 @@ describe('link', () => {
       expect(projectJson.orgId).toEqual(user.id);
       expect(projectJson.projectId).toEqual(project.id);
       expect(projectJson.projectName).toEqual(project.name);
+
+      // Verify env pull was called with --yes flag and correct source
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        ['--yes'],
+        'vercel-cli:link'
+      );
     });
 
     it('should track use of redacted `--project` option', async () => {
@@ -568,6 +585,11 @@ describe('link', () => {
       `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
     );
 
+    await expect(client.stderr).toOutput(
+      'Would you like to pull environment variables now?'
+    );
+    client.stdin.write('n\n');
+
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
 
@@ -620,6 +642,11 @@ describe('link', () => {
     await expect(client.stderr).toOutput(
       `Linked to ${user.username}/awesome-app (created .vercel and added it to .gitignore)`
     );
+
+    await expect(client.stderr).toOutput(
+      'Would you like to pull environment variables now?'
+    );
+    client.stdin.write('n\n');
 
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
@@ -691,5 +718,244 @@ describe('link', () => {
         value: '[REDACTED]',
       },
     ]);
+  });
+
+  describe('environment variable pull prompt', () => {
+    it('should prompt to pull environment variables after successful linking', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        [],
+        'vercel-cli:link'
+      );
+    });
+
+    it('should not call env pull when user declines the prompt', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      // Verify env pull was NOT called
+      expect(mockPull).not.toHaveBeenCalled();
+    });
+
+    it('should handle env pull failure gracefully', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      // Mock env pull to fail
+      mockPull.mockResolvedValue(1);
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Failed to pull environment variables. You can run `vc env pull` manually.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0); // Link should still succeed even if env pull fails
+
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        [],
+        'vercel-cli:link'
+      );
+    });
+
+    it('should handle env pull command throwing an error', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      // Mock env pull to throw an error
+      mockPull.mockRejectedValue(new Error('Network error'));
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Failed to pull environment variables. You can run `vc env pull` manually.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0); // Link should still succeed even if env pull throws
+
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        [],
+        'vercel-cli:link'
+      );
+    });
+
+    it('should pass empty args to env pull when link command does not use --yes', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+      useTeams('team_dummy');
+      const { project } = useProject({
+        ...defaultProject,
+        id: basename(cwd),
+        name: basename(cwd),
+      });
+      useUnknownProject();
+
+      client.cwd = cwd;
+      client.setArgv('--project', project.name!);
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput('Set up');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Link to it?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to ${user.username}/${project.name} (created .vercel and added it to .gitignore)`
+      );
+
+      await expect(client.stderr).toOutput(
+        'Would you like to pull environment variables now?'
+      );
+      client.stdin.write('y\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      // Verify env pull was called with empty args since link didn't use --yes
+      expect(mockPull).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd }),
+        [],
+        'vercel-cli:link'
+      );
+    });
   });
 });


### PR DESCRIPTION
Add an interactive prompt to pull environment variables immediately after successfully linking a project, improving developer experience by reducing the number of manual steps required.

## Changes Made

### Core Functionality:
- **linkFolderToProject**: Added `autoConfirm` parameter and env pull prompt after linking
- **setupAndLink**: Pass through autoConfirm flag to linkFolderToProject
- **EnvRecordsSource**: Added 'vercel-cli:link' as a valid source type

### Prompt Behavior:
- Prompts user with "Would you like to pull environment variables now?" after successful link
- Defaults to "yes" for better UX
- Propagates --yes flag from link command to env pull command for consistency
- Handles errors gracefully - linking succeeds even if env pull fails
- Preserves and restores client.cwd during env pull execution

### Test Coverage:
- **Unit Tests**: Added comprehensive test suite for env pull prompt functionality
  - Tests prompt acceptance/decline scenarios
  - Tests error handling (command failures and exceptions)
  - Tests flag propagation (--yes from link to env pull)
  - Tests programmatic env pull usage
- **Integration Tests**: Added end-to-end tests for complete linking flow
  - Tests interactive prompt with acceptance/decline
  - Tests --yes flag behavior
  - Verifies project linking still works correctly
- **Type Safety**: Added tests for new EnvRecordsSource enum value

### Error Handling:
- Graceful failure when env pull command returns non-zero exit code
- Graceful failure when env pull command throws exceptions
- Clear error messages directing users to manual env pull command
- Link operation always succeeds regardless of env pull outcome