### PR TITLE
chore(release): fix dist tag script

### DIFF
--- a/utils/update-canary-tags.mjs
+++ b/utils/update-canary-tags.mjs
@@ -13,7 +13,7 @@ for (const name of fs.readdirSync(packagesDir)) {
     fs.readFileSync(new URL(`${name}/package.json`, packagesDir), 'utf8')
   );
   spawnSync(
-    'npm',
+    'pnpm',
     `dist-tag add ${pkg.name}@${pkg.version} canary`.split(' '),
     { stdio: 'inherit' }
   );


### PR DESCRIPTION
This should use pnpm to be aware of the monorepo internal packages