### PR TITLE
Fix oidc workspace:* usage in dependencies

### DIFF
--- a/.changeset/short-suits-approve.md
+++ b/.changeset/short-suits-approve.md
@@ -1,0 +1,6 @@
+---
+'@vercel/oidc-aws-credentials-provider': patch
+'@vercel/functions': patch
+---
+
+Update dependency

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -79,6 +79,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@vercel/oidc": "workspace:*"
+    "@vercel/oidc": "2.1.0"
   }
 }

--- a/packages/oidc-aws-credentials-provider/package.json
+++ b/packages/oidc-aws-credentials-provider/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "@aws-sdk/credential-provider-web-identity": "^3.609.0",
-    "@vercel/oidc": "workspace:*"
+    "@vercel/oidc": "2.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,7 +1065,7 @@ importers:
   packages/functions:
     dependencies:
       '@vercel/oidc':
-        specifier: workspace:*
+        specifier: 2.1.0
         version: link:../oidc
     devDependencies:
       '@aws-sdk/client-s3':
@@ -1585,7 +1585,7 @@ importers:
         specifier: ^3.609.0
         version: 3.609.0(@aws-sdk/client-sts@3.806.0)
       '@vercel/oidc':
-        specifier: workspace:*
+        specifier: 2.1.0
         version: link:../oidc
     devDependencies:
       '@smithy/types':


### PR DESCRIPTION
This has been failing for a bit now https://github.com/vercel/vercel/actions/runs/16923679943/job/47955079051