### PR TITLE
fix(oidc): use released version in dependencies

### DIFF
--- a/.changeset/orange-steaks-live.md
+++ b/.changeset/orange-steaks-live.md
@@ -1,0 +1,6 @@
+---
+'@vercel/oidc-aws-credentials-provider': patch
+'@vercel/functions': patch
+---
+
+Fix dependency

--- a/packages/functions/docs/modules/oidc.md
+++ b/packages/functions/docs/modules/oidc.md
@@ -45,13 +45,9 @@ Do not cache this value, as it is subject to change in production!
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
 
-Unlike the `getVercelOidcTokenSync` function, this function will refresh the token if it is expired in a development environment.
-
 **`Throws`**
 
-If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set. If the token
-is expired in a development environment, will also throw an error if the token cannot be refreshed: no CLI credentials are available, CLI credentials are expired, no project configuration is available
-or the token refresh request fails.
+If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
 
 **`Example`**
 
@@ -74,7 +70,7 @@ A promise that resolves to the OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:27
+node_modules/.pnpm/@vercel+oidc@2.0.0/node_modules/@vercel/oidc/dist/get-vercel-oidc-token.d.ts:23
 
 ---
 
@@ -88,8 +84,6 @@ Do not cache this value, as it is subject to change in production!
 
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
-
-This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
 
 **`Throws`**
 
@@ -111,4 +105,4 @@ The OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:49
+node_modules/.pnpm/@vercel+oidc@2.0.0/node_modules/@vercel/oidc/dist/get-vercel-oidc-token.d.ts:43

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -79,6 +79,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@vercel/oidc": "2.1.0"
+    "@vercel/oidc": "2.0.0"
   }
 }

--- a/packages/oidc-aws-credentials-provider/package.json
+++ b/packages/oidc-aws-credentials-provider/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "@aws-sdk/credential-provider-web-identity": "^3.609.0",
-    "@vercel/oidc": "2.1.0"
+    "@vercel/oidc": "2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,8 +1065,8 @@ importers:
   packages/functions:
     dependencies:
       '@vercel/oidc':
-        specifier: 2.1.0
-        version: link:../oidc
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: 3.609.0
@@ -1585,8 +1585,8 @@ importers:
         specifier: ^3.609.0
         version: 3.609.0(@aws-sdk/client-sts@3.806.0)
       '@vercel/oidc':
-        specifier: 2.1.0
-        version: link:../oidc
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@smithy/types':
         specifier: 3.3.0
@@ -7969,6 +7969,11 @@ packages:
       - encoding
       - rollup
       - supports-color
+    dev: false
+
+  /@vercel/oidc@2.0.0:
+    resolution: {integrity: sha512-U0hncpXof7gC9xtmSrjz6vrDqdwJXi8z/zSc9FyS80AoXKfCZtpkBz9gtL3x30Agmpxpwe35P1W2dP9Epa/RGA==}
+    engines: {node: '>= 18'}
     dev: false
 
   /@vercel/style-guide@4.0.2(eslint@8.24.0)(jest@29.5.0)(prettier@3.3.3)(typescript@4.9.4):


### PR DESCRIPTION
This was modified here, but it was updated to a version that doesn't exist. This should fix the release pipeline. 

https://github.com/vercel/vercel/pull/13722/files