### PR TITLE
Upgrade Vue example to Node 22

### DIFF
--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "eslintConfig": {
     "extends": "preact",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -6,7 +6,7 @@
     "lint": "vue-cli-service lint"
   },
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "dependencies": {
     "core-js": "^3.30.2",


### PR DESCRIPTION
### Summary

Upgrade Vue examples from Node 18 to Node 22.

### Context

Node 18 is End of Life and new builds will fail on September 1. Upgrade this example to Node 22.