### PR TITLE
Lower version of @vercel/oidc so it stops breaking releases

### DIFF
--- a/.changeset/nine-poems-visit.md
+++ b/.changeset/nine-poems-visit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Lower version of @vercel/oidc so it stops breaking releases

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -14,7 +14,7 @@
       "require": "./dist/index.js"
     }
   },
-  "version": "2.1.0",
+  "version": "2.0.0",
   "repository": {
     "directory": "packages/oidc",
     "type": "git",


### PR DESCRIPTION
The failure [here](https://github.com/vercel/vercel/actions/runs/16942013232/job/48013317221) has been blocking us from releasing code for the past day so manually dropping the version down to the last good published version