### PR TITLE
Trigger cli release

### DIFF
--- a/.changeset/nice-geese-act.md
+++ b/.changeset/nice-geese-act.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update dependencies


### PR DESCRIPTION
The NPM release [only triggers when there's a Publish Packages](https://github.com/vercel/vercel/blob/7a9ae0900b46a3248f52245fad00f752823eccc2/.github/workflows/release.yml#L63) merge from changesets. Add a simple patch here, but I expect that this will release any unreleased packages, not just the CLI