### PR TITLE
Include support for custom build scripts for backend builders (express + hono)

### DIFF
--- a/.changeset/olive-flies-taste.md
+++ b/.changeset/olive-flies-taste.md
@@ -1,0 +1,6 @@
+---
+'@vercel/express': patch
+'@vercel/hono': patch
+---
+
+Include support for custom build scripts for backend builders

--- a/packages/express/src/build.ts
+++ b/packages/express/src/build.ts
@@ -12,6 +12,7 @@ export const build: BuildV3 = async args => {
   return nodeBuild({
     ...args,
     entrypoint,
+    considerBuildCommand: true,
   });
 };
 

--- a/packages/hono/src/build.ts
+++ b/packages/hono/src/build.ts
@@ -1,24 +1,10 @@
-import {
-  BuildOptions,
-  Config,
-  execCommand,
-  Files,
-  getEnvForPackageManager,
-  getNodeVersion,
-  getSpawnOptions,
-  PackageJson,
-  scanParentDirs,
-  type BuildV3,
-} from '@vercel/build-utils';
+import { Files, type BuildV3 } from '@vercel/build-utils';
 // @ts-expect-error - FIXME: hono-framework build is not exported
 import { build as nodeBuild } from '@vercel/node';
-import { readFileSync } from 'fs';
-import path, { sep } from 'path';
+import { sep } from 'path';
 
 export const build: BuildV3 = async args => {
   const entrypoint = findEntrypoint(args.files);
-
-  await handleBuildCommand(entrypoint, args);
 
   // Introducing new behavior for the node builder where Typescript errors always
   // fail the build. Previously, this relied on noEmitOnError being true in the tsconfig.json
@@ -26,6 +12,7 @@ export const build: BuildV3 = async args => {
   return nodeBuild({
     ...args,
     entrypoint,
+    considerBuildCommand: true,
   });
 };
 
@@ -58,90 +45,3 @@ export const findEntrypoint = (files: Files) => {
   }
   return entrypoint.join(sep);
 };
-
-function getPkg(workPath: string) {
-  try {
-    const pkgPath = path.join(workPath, 'package.json');
-    const pkg: PackageJson = JSON.parse(readFileSync(pkgPath, 'utf8'));
-    return pkg;
-  } catch (err: any) {
-    if (err.code !== 'ENOENT') throw err;
-  }
-
-  return null;
-}
-
-function getBuildCommand(pkg: PackageJson, config: Config) {
-  if (config.buildCommand) {
-    return config.buildCommand;
-  }
-
-  return pkg?.scripts?.build;
-}
-
-/**
- * A build command in project settings or package.json is technically supported, but
- * the node builder still needs to run on the entrypoint (src/index.ts, server.ts, etc.)
- * so if the build command compiles source code into a dist directory, we currently
- * wouldn't detect that.
- */
-async function handleBuildCommand(entrypoint: string, args: BuildOptions) {
-  const mountpoint = path.dirname(entrypoint);
-  const entrypointDir = path.join(args.workPath, mountpoint);
-
-  const pkg = getPkg(args.workPath);
-
-  if (!pkg) {
-    return;
-  }
-
-  const buildCommand = getBuildCommand(pkg, args.config);
-
-  /**
-   * Mostly copied from static builder
-   * /vercel/packages/static-build/src/index.ts
-   */
-  const nodeVersion = await getNodeVersion(
-    entrypointDir,
-    undefined,
-    args.config,
-    args.meta
-  );
-  const spawnOpts = getSpawnOptions(args.meta || {}, nodeVersion);
-
-  if (!spawnOpts.env) {
-    spawnOpts.env = {};
-  }
-
-  const {
-    cliType,
-    lockfileVersion,
-    packageJsonPackageManager,
-    turboSupportsCorepackHome,
-  } = await scanParentDirs(entrypointDir, true);
-
-  spawnOpts.env = getEnvForPackageManager({
-    cliType,
-    lockfileVersion,
-    packageJsonPackageManager,
-    nodeVersion,
-    env: spawnOpts.env || {},
-    turboSupportsCorepackHome,
-    projectCreatedAt: args.config.projectSettings?.createdAt,
-  });
-
-  if (typeof buildCommand === 'string') {
-    await execCommand(buildCommand, {
-      ...spawnOpts,
-
-      // Yarn v2 PnP mode may be activated, so force
-      // "node-modules" linker style
-      env: {
-        YARN_NODE_LINKER: 'node-modules',
-        ...spawnOpts.env,
-      },
-
-      cwd: entrypointDir,
-    });
-  }
-}

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -379,6 +379,7 @@ export const build = async ({
 }: Parameters<BuildV3>[0] & {
   shim?: (handler: string) => string;
   useWebApi?: boolean;
+  considerBuildCommand?: boolean;
 }): Promise<BuildResultV3> => {
   const baseDir = repoRootPath || workPath;
   const awsLambdaHandler = getAWSLambdaHandler(entrypoint, config);

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -375,6 +375,7 @@ export const build = async ({
   repoRootPath,
   config = {},
   meta = {},
+  considerBuildCommand = false,
 }: Parameters<BuildV3>[0] & {
   shim?: (handler: string) => string;
   useWebApi?: boolean;
@@ -391,10 +392,15 @@ export const build = async ({
       meta,
     });
 
+  // For traditional api-folder builds, the `build` script isn't used.
+  // but we're reusing the node builder for hono and express, where we do need it
+  const possibleScripts = considerBuildCommand
+    ? ['vercel-build', 'now-build', 'build']
+    : ['vercel-build', 'now-build'];
+
   await runPackageJsonScript(
     entrypointFsDirname,
-    // Don't consider "build" script since its intended for frontend code
-    ['vercel-build', 'now-build'],
+    possibleScripts,
     spawnOpts,
     config.projectSettings?.createdAt
   );


### PR DESCRIPTION
I had [previously](https://github.com/vercel/vercel/pull/13724) ported over `build` command support from the static builder, but the proper fix was much more simple. 