### PR TITLE
feat(next): add client param parsing support with experimental flag

### DIFF
--- a/.changeset/smart-cats-build.md
+++ b/.changeset/smart-cats-build.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': minor
+---
+
+Add client param parsing support with experimental flag

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2067,6 +2067,7 @@ export const build: BuildV2 = async buildOptions => {
       bypassToken: prerenderManifest.bypassToken || '',
       isServerMode,
       isAppPPREnabled: false,
+      prerenderManifest,
     }).then(arr =>
       localizeDynamicRoutes(
         arr,
@@ -2097,6 +2098,7 @@ export const build: BuildV2 = async buildOptions => {
         bypassToken: prerenderManifest.bypassToken || '',
         isServerMode,
         isAppPPREnabled: false,
+        prerenderManifest,
       }).then(arr =>
         arr.map(route => {
           route.src = route.src.replace('^', `^${dynamicPrefix}`);

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1466,6 +1466,13 @@ export const build: BuildV2 = async buildOptions => {
           true
       : false;
 
+    // When this is true, then it means all routes are PPR enabled.
+    const isAppFullPPREnabled = requiredServerFilesManifest
+      ? requiredServerFilesManifest?.config.experimental?.ppr === true ||
+        requiredServerFilesManifest.config.experimental?.cacheComponents ===
+          true
+      : false;
+
     const isAppClientSegmentCacheEnabled = requiredServerFilesManifest
       ? requiredServerFilesManifest.config.experimental?.clientSegmentCache ===
         true
@@ -1533,6 +1540,7 @@ export const build: BuildV2 = async buildOptions => {
         variantsManifest,
         experimentalPPRRoutes,
         isAppPPREnabled,
+        isAppFullPPREnabled,
         isAppClientSegmentCacheEnabled,
         isAppClientParamParsingEnabled,
       });

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1471,6 +1471,12 @@ export const build: BuildV2 = async buildOptions => {
         true
       : false;
 
+    // We read this from the routes manifest instead of the config because we
+    // expect that the flag will be deprecated in the future and the manifest
+    // will be the source of truth.
+    const isAppClientParamParsingEnabled =
+      routesManifest?.rsc?.clientParamParsing ?? false;
+
     if (requiredServerFilesManifest) {
       if (!routesManifest) {
         throw new Error(
@@ -1528,6 +1534,7 @@ export const build: BuildV2 = async buildOptions => {
         experimentalPPRRoutes,
         isAppPPREnabled,
         isAppClientSegmentCacheEnabled,
+        isAppClientParamParsingEnabled,
       });
     }
 
@@ -2279,8 +2286,10 @@ export const build: BuildV2 = async buildOptions => {
       appPathRoutesManifest,
       isSharedLambdas,
       canUsePreviewMode,
+      // The following flags are not supported in this version of the builder.
       isAppPPREnabled: false,
       isAppClientSegmentCacheEnabled: false,
+      isAppClientParamParsingEnabled: false,
     });
 
     await Promise.all(

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2067,6 +2067,8 @@ export const build: BuildV2 = async buildOptions => {
       bypassToken: prerenderManifest.bypassToken || '',
       isServerMode,
       isAppPPREnabled: false,
+      isAppClientParamParsingEnabled,
+      isAppClientSegmentCacheEnabled,
       prerenderManifest,
     }).then(arr =>
       localizeDynamicRoutes(
@@ -2098,6 +2100,8 @@ export const build: BuildV2 = async buildOptions => {
         bypassToken: prerenderManifest.bypassToken || '',
         isServerMode,
         isAppPPREnabled: false,
+        isAppClientParamParsingEnabled: false,
+        isAppClientSegmentCacheEnabled: false,
         prerenderManifest,
       }).then(arr =>
         arr.map(route => {

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -149,6 +149,7 @@ export async function serverBuild({
   experimentalPPRRoutes,
   isAppPPREnabled,
   isAppClientSegmentCacheEnabled,
+  isAppClientParamParsingEnabled,
 }: {
   appPathRoutesManifest?: Record<string, string>;
   dynamicPages: string[];
@@ -192,6 +193,7 @@ export async function serverBuild({
   experimentalPPRRoutes: ReadonlySet<string>;
   isAppPPREnabled: boolean;
   isAppClientSegmentCacheEnabled: boolean;
+  isAppClientParamParsingEnabled: boolean;
 }): Promise<BuildResult> {
   if (isAppPPREnabled) {
     debug(
@@ -1567,6 +1569,7 @@ export async function serverBuild({
     isEmptyAllowQueryForPrendered,
     isAppPPREnabled,
     isAppClientSegmentCacheEnabled,
+    isAppClientParamParsingEnabled,
   });
 
   await Promise.all(


### PR DESCRIPTION
Enables client-side parameter parsing for Next.js applications when using PPR (Partial Prerendering) with client segment caching. This optimization allows segments to be cached more effectively when route parameters don't affect the segment content.

### What
- Add `isAppClientParamParsingEnabled` flag to build configurations and pipeline
- Thread flag through server build and utils for segment prerender logic
- Use blank `allowQuery` for segment prerenders when client parsing is enabled with PPR
- Refactor variable names for clarity (`htmlFsRef` → `htmlFallbackFsRef`, `jsonFsRef` → `dataFallbackFsRef`)
- Remove strict RSC extension validation for enhanced route compatibility

### Why
When client param parsing is enabled alongside PPR and client segment caching, segments don't need to vary based on route parameters since parsing happens client-side. This allows using empty `allowQuery` arrays for better caching efficiency and enables the same prerendered segment to serve all parameter variations.

