### PR TITLE
Update cli

### DIFF
--- a/.changeset/spotty-zoos-sing.md
+++ b/.changeset/spotty-zoos-sing.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update framework dependencies


### PR DESCRIPTION
Not sure why the frameworks version bump didn't trigger a release for the CLI

https://github.com/vercel/vercel/pull/13756