### PR TITLE
[detect-agent] handle `AI_AGENT` env var for custom agent detection

### DIFF
--- a/.changeset/big-hotels-whisper.md
+++ b/.changeset/big-hotels-whisper.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': minor
+---
+
+Handle custom AI_AGENT env var values

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -9,6 +9,10 @@ const DEVIN = 'devin';
 const REPLIT = 'replit';
 
 export async function determineAgent(): Promise<string | false> {
+  if (process.env.AI_AGENT) {
+    return process.env.AI_AGENT;
+  }
+
   if (process.env.CURSOR_TRACE_ID) {
     return CURSOR;
   }

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -10,6 +10,26 @@ describe('checkTelemetryStatus', () => {
     mockFs.restore();
   });
 
+  describe('custom agent detection from `AI_AGENT`', () => {
+    describe('AI_AGENT not set', () => {
+      it('is false', async () => {
+        const agent = await determineAgent();
+        expect(agent).to.eq(false);
+      });
+    });
+
+    describe('AI_AGENT set', () => {
+      beforeEach(() => {
+        vi.stubEnv('AI_AGENT', 'custom-agent');
+      });
+
+      it('detects', async () => {
+        const agent = await determineAgent();
+        expect(agent).to.eq('custom-agent');
+      });
+    });
+  });
+
   describe('cursor detection', () => {
     describe('CURSOR_TRACE_ID not set', () => {
       it('is false', async () => {


### PR DESCRIPTION
Allows tools to specify custom agent names with the `AI_AGENT` env var. Dependent on https://github.com/vercel/vercel/pull/13760 merging first so that versioning works correctly