### PR TITLE
[@vercel/functions] Strengthen check for attachDatabasePool to only be active in a function

### DIFF
--- a/.changeset/dull-tables-pump.md
+++ b/.changeset/dull-tables-pump.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Stronger detection of Vercel Runtime to reduce warnings

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -56,7 +56,7 @@ attachDatabasePool(pgPool);
 
 #### Defined in
 
-[packages/functions/src/db-connections/index.ts:221](https://github.com/vercel/vercel/blob/main/packages/functions/src/db-connections/index.ts#L221)
+[packages/functions/src/db-connections/index.ts:225](https://github.com/vercel/vercel/blob/main/packages/functions/src/db-connections/index.ts#L225)
 
 ---
 
@@ -101,7 +101,7 @@ Use attachDatabasePool instead.
 
 #### Defined in
 
-[packages/functions/src/db-connections/index.ts:221](https://github.com/vercel/vercel/blob/main/packages/functions/src/db-connections/index.ts#L221)
+[packages/functions/src/db-connections/index.ts:225](https://github.com/vercel/vercel/blob/main/packages/functions/src/db-connections/index.ts#L225)
 
 ---
 

--- a/packages/functions/docs/modules/oidc.md
+++ b/packages/functions/docs/modules/oidc.md
@@ -45,9 +45,13 @@ Do not cache this value, as it is subject to change in production!
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
 
+Unlike the `getVercelOidcTokenSync` function, this function will refresh the token if it is expired in a development environment.
+
 **`Throws`**
 
-If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
+If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set. If the token
+is expired in a development environment, will also throw an error if the token cannot be refreshed: no CLI credentials are available, CLI credentials are expired, no project configuration is available
+or the token refresh request fails.
 
 **`Example`**
 
@@ -70,7 +74,7 @@ A promise that resolves to the OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:23
+packages/oidc/dist/get-vercel-oidc-token.d.ts:27
 
 ---
 
@@ -84,6 +88,8 @@ Do not cache this value, as it is subject to change in production!
 
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
+
+This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
 
 **`Throws`**
 
@@ -105,4 +111,4 @@ The OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:43
+packages/oidc/dist/get-vercel-oidc-token.d.ts:49

--- a/packages/functions/docs/modules/oidc.md
+++ b/packages/functions/docs/modules/oidc.md
@@ -45,13 +45,9 @@ Do not cache this value, as it is subject to change in production!
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
 
-Unlike the `getVercelOidcTokenSync` function, this function will refresh the token if it is expired in a development environment.
-
 **`Throws`**
 
-If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set. If the token
-is expired in a development environment, will also throw an error if the token cannot be refreshed: no CLI credentials are available, CLI credentials are expired, no project configuration is available
-or the token refresh request fails.
+If the `x-vercel-oidc-token` header is missing from the request context and the environment variable `VERCEL_OIDC_TOKEN` is not set.
 
 **`Example`**
 
@@ -74,7 +70,7 @@ A promise that resolves to the OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:27
+packages/oidc/dist/get-vercel-oidc-token.d.ts:23
 
 ---
 
@@ -88,8 +84,6 @@ Do not cache this value, as it is subject to change in production!
 
 This function is used to retrieve the OIDC token from the request context or the environment variable.
 It checks for the `x-vercel-oidc-token` header in the request context and falls back to the `VERCEL_OIDC_TOKEN` environment variable if the header is not present.
-
-This function will not refresh the token if it is expired. For refreshing the token, use the @{link getVercelOidcToken} function.
 
 **`Throws`**
 
@@ -111,4 +105,4 @@ The OIDC token.
 
 #### Defined in
 
-packages/oidc/dist/get-vercel-oidc-token.d.ts:49
+packages/oidc/dist/get-vercel-oidc-token.d.ts:43

--- a/packages/functions/src/db-connections/index.ts
+++ b/packages/functions/src/db-connections/index.ts
@@ -158,7 +158,11 @@ const bootTime = Date.now();
 const maximumDuration = 15 * 60 * 1000 - 1000; // 15 minutes - 1 second
 
 function waitUntilIdleTimeout(dbPool: DbPool) {
-  if (!process.env.VERCEL_URL || !process.env.VERCEL_REGION) {
+  if (
+    !process.env.VERCEL_URL ||
+    // This is not set during builds where we don't need to wait for idle connections using the mechanism
+    !process.env.VERCEL_REGION
+  ) {
     // We're not running in a Vercel function, so we don't need to wait for idle connections.
     return;
   }

--- a/packages/functions/src/db-connections/index.ts
+++ b/packages/functions/src/db-connections/index.ts
@@ -158,8 +158,8 @@ const bootTime = Date.now();
 const maximumDuration = 15 * 60 * 1000 - 1000; // 15 minutes - 1 second
 
 function waitUntilIdleTimeout(dbPool: DbPool) {
-  if (!process.env.VERCEL_URL) {
-    // We're not running in Vercel, so we don't need to wait for idle connections.
+  if (!process.env.VERCEL_URL || !process.env.VERCEL_REGION) {
+    // We're not running in a Vercel function, so we don't need to wait for idle connections.
     return;
   }
   if (idleTimeout) {

--- a/packages/functions/test/unit/db-connections/index.test.ts
+++ b/packages/functions/test/unit/db-connections/index.test.ts
@@ -4,9 +4,11 @@ import { SYMBOL_FOR_REQ_CONTEXT } from '../../../src/get-context';
 
 describe('db-connections', () => {
   const vercelUrl = process.env.VERCEL_URL;
+  const vercelRegion = process.env.VERCEL_REGION;
 
   beforeEach(() => {
     process.env.VERCEL_URL = 'test.vercel.app';
+    process.env.VERCEL_REGION = 'iad1';
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -18,6 +20,7 @@ describe('db-connections', () => {
     vi.clearAllMocks();
     delete globalThis[SYMBOL_FOR_REQ_CONTEXT];
     process.env.VERCEL_URL = vercelUrl;
+    process.env.VERCEL_REGION = vercelRegion;
   });
 
   describe('supported pool types', () => {


### PR DESCRIPTION
While the current code did exclude local dev, it still ran during builds.