### PR TITLE
Return the correct exit code in the Vercel command

### DIFF
--- a/.changeset/gentle-fans-burn.md
+++ b/.changeset/gentle-fans-burn.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Return the correct exit code in the Vercel command

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -44,7 +44,7 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp(cacheCommand.name);
     output.print(help(cacheCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {

--- a/packages/cli/src/commands/link/index.ts
+++ b/packages/cli/src/commands/link/index.ts
@@ -32,7 +32,7 @@ export default async function link(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('link');
     output.print(help(linkCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   telemetry.trackCliFlagRepo(parsedArgs.flags['--repo']);

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -67,7 +67,7 @@ export default async function list(client: Client) {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('list');
     print(help(listCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   if (parsedArgs.args.length > 2) {

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -56,7 +56,7 @@ export default async function login(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('login');
     output.print(help(loginCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   if (parsedArgs.flags['--token']) {

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -39,7 +39,7 @@ export default async function logout(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('logout');
     output.print(help(logoutCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   if (authConfig.type === 'oauth') {

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -56,14 +56,14 @@ export default async function main(client: Client) {
   if (!subcommand && needHelp) {
     telemetry.trackCliFlagHelp('project');
     output.print(help(projectCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   function printHelp(command: Command) {
     output.print(
       help(command, { parent: projectCommand, columns: client.stderr.columns })
     );
-    return 2;
+    return 0;
   }
 
   if (!parsedArgs.args[1]) {

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -31,7 +31,7 @@ export default async function whoami(client: Client): Promise<number> {
   if (parsedArgs.flags['--help']) {
     telemetry.trackCliFlagHelp('whoami');
     output.print(help(whoamiCommand, { columns: client.stderr.columns }));
-    return 2;
+    return 0;
   }
 
   const { contextName } = await getScope(client, { getTeam: false });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -192,7 +192,7 @@ const main = async () => {
   const bareHelpSubcommand = targetOrSubcommand === 'help' && !subSubCommand;
   if (bareHelpOption || bareHelpSubcommand) {
     output.print(help());
-    return 2;
+    return 0;
   }
 
   // Ensure that the Vercel global configuration directory exists

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -131,7 +131,7 @@ test('deploy with metadata containing "=" in the value', async () => {
 test('print the deploy help message', async () => {
   const { stderr, stdout, exitCode } = await execCli(binaryPath, ['help']);
 
-  expect(exitCode, formatOutput({ stdout, stderr })).toBe(2);
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
   expect(stderr).toContain(deployHelpMessage);
   expect(stderr).not.toContain('ExperimentalWarning');
 });

--- a/packages/cli/test/unit/commands/cache/index.test.ts
+++ b/packages/cli/test/unit/commands/cache/index.test.ts
@@ -8,7 +8,7 @@ describe('cache', () => {
   it('should track telemetry with --help', async () => {
     client.setArgv(command, '--help');
     const exitCodePromise = cache(client);
-    await expect(exitCodePromise).resolves.toEqual(2);
+    await expect(exitCodePromise).resolves.toEqual(0);
 
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       {

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -33,7 +33,7 @@ describe('link', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = link(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/list/index.test.ts
+++ b/packages/cli/test/unit/commands/list/index.test.ts
@@ -37,7 +37,7 @@ describe('list', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = list(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -20,7 +20,7 @@ describe('login', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = login(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/add.test.ts
+++ b/packages/cli/test/unit/commands/project/add.test.ts
@@ -12,7 +12,7 @@ describe('add', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/index.test.ts
+++ b/packages/cli/test/unit/commands/project/index.test.ts
@@ -17,7 +17,7 @@ describe('project', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = project(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/inspect.test.ts
+++ b/packages/cli/test/unit/commands/project/inspect.test.ts
@@ -27,7 +27,7 @@ describe('inspect', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/list.test.ts
+++ b/packages/cli/test/unit/commands/project/list.test.ts
@@ -28,7 +28,7 @@ describe('list', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/project/rm.test.ts
+++ b/packages/cli/test/unit/commands/project/rm.test.ts
@@ -12,7 +12,7 @@ describe('rm', () => {
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = projects(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/whoami/index.test.ts
+++ b/packages/cli/test/unit/commands/whoami/index.test.ts
@@ -10,7 +10,7 @@ describe('whoami', () => {
 
       client.setArgv(command, '--help');
       const exitCodePromise = whoami(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {


### PR DESCRIPTION
Few Vercel commands exits with a status code of 2, making it look like something is wrong.

<img width="1446" height="866" alt="image" src="https://github.com/user-attachments/assets/1537e26e-f8ec-4071-bd0a-358717e2f8be" />
