### PR TITLE
[functions] Dual publish `.mjs` files as ESM

### DIFF
--- a/.changeset/ninety-pens-begin.md
+++ b/.changeset/ninety-pens-begin.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Dual publish `.mjs` files as ESM

--- a/packages/functions/.gitignore
+++ b/packages/functions/.gitignore
@@ -1,2 +1,4 @@
 *.js
+*.mjs
 *.d.ts
+!build.mjs

--- a/packages/functions/build.mjs
+++ b/packages/functions/build.mjs
@@ -1,0 +1,15 @@
+import { tsc, esbuild } from '../../utils/build.mjs';
+
+await Promise.all([
+  // Type Definitions
+  tsc(),
+
+  // CommonJS build (`.js` extension)
+  esbuild(),
+
+  // ESM build (`.mjs` extension)
+  esbuild({
+    format: 'esm',
+    outExtension: { '.js': '.mjs' },
+  }),
+]);

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -4,29 +4,35 @@
   "homepage": "https://vercel.com",
   "files": [
     "**/*.js",
+    "**/*.mjs",
     "**/*.d.ts",
     "**/*.md"
   ],
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.js",
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
       "require": "./index.js"
     },
     "./headers": {
-      "import": "./headers.js",
+      "types": "./headers.d.ts",
+      "import": "./headers.mjs",
       "require": "./headers.js"
     },
     "./oidc": {
-      "import": "./oidc/index.js",
+      "types": "./oidc/index.d.ts",
+      "import": "./oidc/index.mjs",
       "require": "./oidc/index.js"
     },
     "./db-connections": {
-      "import": "./db-connections/index.js",
+      "types": "./db-connections/index.d.ts",
+      "import": "./db-connections/index.mjs",
       "require": "./db-connections/index.js"
     },
     "./middleware": {
-      "import": "./middleware.js",
+      "types": "./middleware.d.ts",
+      "import": "./middleware.mjs",
       "require": "./middleware.js"
     }
   },
@@ -71,7 +77,7 @@
     "pretest": "pnpm run build:code",
     "test": "vitest",
     "build": "pnpm run build:code && pnpm run build:docs",
-    "build:code": "node ../../utils/build.mjs",
+    "build:code": "node build.mjs",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Similar to #13784 but for the `@vercel/functions` package.