### PR TITLE
feat(next): add clientParamParsingOrigins support for external rewrite headers

### DIFF
--- a/.changeset/strong-ladybugs-joke.md
+++ b/.changeset/strong-ladybugs-joke.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add clientParamParsingOrigins configuration for secure external rewrite headers

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1484,6 +1484,11 @@ export const build: BuildV2 = async buildOptions => {
     const isAppClientParamParsingEnabled =
       routesManifest?.rsc?.clientParamParsing ?? false;
 
+    const clientParamParsingOrigins = requiredServerFilesManifest
+      ? requiredServerFilesManifest.config.experimental
+          ?.clientParamParsingOrigins
+      : undefined;
+
     if (requiredServerFilesManifest) {
       if (!routesManifest) {
         throw new Error(
@@ -1543,6 +1548,7 @@ export const build: BuildV2 = async buildOptions => {
         isAppFullPPREnabled,
         isAppClientSegmentCacheEnabled,
         isAppClientParamParsingEnabled,
+        clientParamParsingOrigins,
       });
     }
 


### PR DESCRIPTION
This change introduces a new experimental configuration option `clientParamParsingOrigins` that allows controlling which external origins can receive rewrite headers during client parameter parsing. Previously, all external rewrites were blocked from receiving these headers for security reasons.

The implementation adds origin extraction logic and regex-based matching against the configured allowed origins list, enabling secure cross-origin rewrite header forwarding for trusted domains while maintaining security for untrusted external destinations.

