### PR TITLE
[oidc] add file extension to dynamic imports

### DIFF
--- a/.changeset/thin-buckets-speak.md
+++ b/.changeset/thin-buckets-speak.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+fix "Cannot find module" error caused by dynamically importing files without their extensions

--- a/packages/oidc/src/get-vercel-oidc-token.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.ts
@@ -40,8 +40,8 @@ export async function getVercelOidcToken(): Promise<string> {
   try {
     const [{ getTokenPayload, isExpired }, { refreshToken }] =
       await Promise.all([
-        await import('./token-util'),
-        await import('./token'),
+        await import('./token-util.js'),
+        await import('./token.js'),
       ]);
 
     if (!token || isExpired(getTokenPayload(token))) {


### PR DESCRIPTION
it seems that the lack of file extensions in the dynamic imports breaks bundlers that assume this file is ESM-compatible (as in ESM you must specify file extensions in imports):

```
Cannot find module '[PROJECT]/node_modules/.pnpm/@vercel+oidc@2.0.1/node_modules/@vercel/oidc/dist/token-util' imported from [PROJECT]/node_modules/.pnpm/@vercel+oidc@2.0.1/node_modules/@vercel/oidc/dist/get-vercel-oidc-token.js
```