### PR TITLE
feat(next): optimize segment prerender with blank allowQuery for client parsing

### DIFF
--- a/.changeset/optimize-segment-prerender-query.md
+++ b/.changeset/optimize-segment-prerender-query.md
@@ -1,0 +1,7 @@
+---
+"@vercel/next": patch
+---
+
+Optimize segment prerender with blank allowQuery for client parsing
+
+When client segment cache, parsing, and PPR are enabled, use empty allowQuery for segment prerenders since segments don't vary based on route parameters. This ensures both RSC and segment prerenders are in the same group and revalidated together, improving cache efficiency.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3064,11 +3064,23 @@ export const onPrerenderRoute =
             rscContentTypeHeader
           )}`;
 
+          // If the application has client segment cache, client segment
+          // parsing, and ppr enabled, then we can use a blank allowQuery
+          // for the segment prerenders. This is because we know that the
+          // segments do not vary based on the route parameters. It's important
+          // that this mirrors the logic in the segment prerender below so that
+          // they are both part of the same prerender group and are revalidated
+          // together.
+          let rdcRSCAllowQuery = allowQuery;
+          if (isAppClientParamParsingEnabled && (isFallback || isBlocking)) {
+            rdcRSCAllowQuery = [];
+          }
+
           prerenders[normalizePathData(outputPathData)] = new Prerender({
             expiration: initialRevalidate,
             staleExpiration: initialExpire,
             lambda,
-            allowQuery,
+            allowQuery: rdcRSCAllowQuery,
             fallback: isFallback
               ? null
               : new FileBlob({


### PR DESCRIPTION
## What?

Optimizes segment prerendering by using blank `allowQuery` arrays when client segment cache, parsing, and PPR are enabled.

## Why?

When client segment parsing is enabled with PPR, segments don't vary based on route parameters. Using a blank `allowQuery` for segment prerenders ensures that both RSC and segment prerenders are part of the same prerender group and get revalidated together, improving cache efficiency.

## How?

- Added conditional logic to set `rdcRSCAllowQuery` to an empty array when `isAppClientParamParsingEnabled` is true and route is a fallback or blocking route
- Mirrors the same logic pattern used in segment prerender handling below
- This ensures consistent grouping and revalidation behavior for prerenders

## Testing

- [ ] Verified the change mirrors existing segment prerender logic
- [ ] Confirmed prerender groups are properly aligned for cache efficiency