### PR TITLE
Fix issue where install scripts from project settings didn't pick up the appropriate pnpm version

### DIFF
--- a/.changeset/olive-mugs-wait.md
+++ b/.changeset/olive-mugs-wait.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Fix issue where install scripts from project settings didn't pick up the appropriate pnpm version

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -29,6 +29,8 @@ import {
   isSymbolicLink,
   walkParentDirs,
   execCommand,
+  getEnvForPackageManager,
+  scanParentDirs,
 } from '@vercel/build-utils';
 import type {
   File,
@@ -80,6 +82,23 @@ async function downloadInstallAndBundle({
     meta
   );
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
+
+  const {
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    turboSupportsCorepackHome,
+  } = await scanParentDirs(entrypointFsDirname, true);
+
+  spawnOpts.env = getEnvForPackageManager({
+    cliType,
+    lockfileVersion,
+    packageJsonPackageManager,
+    nodeVersion,
+    env: spawnOpts.env || {},
+    turboSupportsCorepackHome,
+    projectCreatedAt: config.projectSettings?.createdAt,
+  });
 
   const installCommand = config.projectSettings?.installCommand;
   if (typeof installCommand === 'string' && considerBuildCommand) {


### PR DESCRIPTION
I missed [this](https://github.com/vercel/vercel/blob/1b5c53642abca43ce6223f1f58d1586ee2fd87b1/packages/static-build/src/index.ts#L493-L501) step before running the custom install script from other builders, so this causes pnpm to use version 6, ignoring lock files