### PR TITLE
feat(next): add filterRegexMatches support for query parameter filtering

### DIFF
--- a/.changeset/query-parameter-filtering.md
+++ b/.changeset/query-parameter-filtering.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": minor
+"@vercel/next": minor
+---
+
+Add filterRegexMatches support for query parameter filtering in prerender routes. This feature allows filtering query parameters from named regular expression matches based on the allowQuery configuration, ensuring only allowed parameters are passed to resume lambda calls.

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -597,6 +597,12 @@ export interface Chain {
    * The headers to send when making the request to append to the response.
    */
   headers: Record<string, string>;
+
+  /**
+   * This is used to filter the query parameters that are added from the named
+   * regular expression matches.
+   */
+  filterRegexMatches: string[];
 }
 
 /**

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2836,6 +2836,14 @@ export const onPrerenderRoute =
         }
       }
 
+      // Using the allowQuery configuration based on the routes manifest keys,
+      // we will use it's values to filter the query parameters that are added
+      // from the named regular expression matches to the resume lambda call.
+      // This ensures that the resume lambda will only receive the query
+      // parameters that are allowed and not other query parameters that might
+      // pollute the regular expression that's used to facilitate matching.
+      const filterRegexMatches = allowQuery ? [...allowQuery] : [];
+
       const rscEnabled = !!routesManifest?.rsc;
       const rscVaryHeader =
         routesManifest?.rsc?.varyHeader ||
@@ -2861,6 +2869,7 @@ export const onPrerenderRoute =
         chain = {
           outputPath: pathnameToOutputName(entryDirectory, routeKey),
           headers: routesManifest.ppr.chain.headers,
+          filterRegexMatches,
         };
       } else if (
         renderingMode === RenderingMode.PARTIALLY_STATIC &&
@@ -2899,6 +2908,7 @@ export const onPrerenderRoute =
         chain = {
           outputPath: paths.output,
           headers: { 'x-matched-path': paths.pathname },
+          filterRegexMatches,
         };
       }
 
@@ -3094,6 +3104,7 @@ export const onPrerenderRoute =
             chain: {
               outputPath: normalizePathData(outputPathData),
               headers: routesManifest.ppr.chain.headers,
+              filterRegexMatches,
             },
             ...(isNotFound ? { initialStatus: 404 } : {}),
             initialHeaders: {


### PR DESCRIPTION
## What?

This PR adds query parameter filtering support in prerender routes through a new `filterRegexMatches` field in the `Chain` interface. The implementation allows filtering of query parameters based on the `allowQuery` configuration.

## Why?

Currently, all query parameters from named regular expression matches are passed to resume lambda calls, which can pollute the regular expressions used for route matching. This change ensures that only allowed query parameters (as defined in the `allowQuery` configuration) are included, providing better control over query parameter handling in PPR (Partial Prerendering) chains.

## How?

- Added `filterRegexMatches: string[]` field to the `Chain` interface in `packages/build-utils/src/types.ts`
- Updated `onPrerenderRoute` function in `packages/next/src/utils.ts` to:
  - Extract allowed query parameters from the `allowQuery` configuration
  - Populate the `filterRegexMatches` array based on this configuration
  - Include the field in all chain objects created for PPR routes
- Added appropriate changeset documenting the minor version bump for both affected packages

The implementation ensures backward compatibility while providing the new filtering capability for improved query parameter management.