### PR TITLE
Undo change that set min node verion to node 20 since Vercel CLI still needs to work on Node 18 for upgrade paths

### DIFF
--- a/.changeset/violet-panthers-cough.md
+++ b/.changeset/violet-panthers-cough.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+---
+
+Undo change that set min node verion to node 20 since Vercel CLI still needs to work on Node 18 for upgrade paths.
+

--- a/.changeset/violet-panthers-cough.md
+++ b/.changeset/violet-panthers-cough.md
@@ -2,5 +2,5 @@
 'vercel': patch
 ---
 
-Undo change that set min node verion to node 20 since Vercel CLI still needs to work on Node 18 for upgrade paths.
+Undo change that set min node version to node 20 since Vercel CLI still needs to work on Node 18 for upgrade paths.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">= 20"
+    "node": ">= 18"
   },
   "dependencies": {
     "@vercel/blob": "1.0.2",


### PR DESCRIPTION
There are still scenarios where the CLI needs to work with Node 18, it's rare but should technically still work to assist in migrating to 20.