### PR TITLE
[functions] Add invalidateByTag and dangerouslyDeleteByTag APIs

### DIFF
--- a/.changeset/famous-cougars-notice.md
+++ b/.changeset/famous-cougars-notice.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Introduces Vercel Purge APIs: invalidateByTag, dangerouslyDeleteByTag

--- a/packages/functions/docs/interfaces/index.DangerouslyDeleteOptions.md
+++ b/packages/functions/docs/interfaces/index.DangerouslyDeleteOptions.md
@@ -1,0 +1,22 @@
+# Interface: DangerouslyDeleteOptions
+
+[index](../modules/index.md).DangerouslyDeleteOptions
+
+## Table of contents
+
+### Properties
+
+- [revalidationDeadlineSeconds](index.DangerouslyDeleteOptions.md#revalidationdeadlineseconds)
+
+## Properties
+
+### revalidationDeadlineSeconds
+
+• `Optional` **revalidationDeadlineSeconds**: `number`
+
+The time in seconds for how long the stale content can be served while revalidating the new content in the background.
+If none is provided, the default is 0 and the content will be deleted immediately.
+
+#### Defined in
+
+[packages/functions/src/purge/types.ts:6](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/types.ts#L6)

--- a/packages/functions/docs/interfaces/index.PurgeApi.md
+++ b/packages/functions/docs/interfaces/index.PurgeApi.md
@@ -1,0 +1,72 @@
+# Interface: PurgeApi
+
+[index](../modules/index.md).PurgeApi
+
+Vercel Cache Purge APIs.
+
+## Table of contents
+
+### Properties
+
+- [dangerouslyDeleteByTag](index.PurgeApi.md#dangerouslydeletebytag)
+- [invalidateByTag](index.PurgeApi.md#invalidatebytag)
+
+## Properties
+
+### dangerouslyDeleteByTag
+
+• **dangerouslyDeleteByTag**: (`tag`: `string` \| `string`[], `options?`: [`DangerouslyDeleteOptions`](index.DangerouslyDeleteOptions.md)) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Type declaration
+
+▸ (`tag`, `options?`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+Delete all content associated with a tag or tags after a specified revalidation deadline.
+If accessed prior to the revalidation deadline, the stale content will be served and a background revalidation will be triggered. After the revalidation deadline is reached, the content will be deleted.
+The default revalidation deadline is 0 and the content will be deleted immediately.
+
+##### Parameters
+
+| Name       | Type                                                            | Description                                                        |
+| :--------- | :-------------------------------------------------------------- | :----------------------------------------------------------------- |
+| `tag`      | `string` \| `string`[]                                          | The tag or tags to delete.                                         |
+| `options?` | [`DangerouslyDeleteOptions`](index.DangerouslyDeleteOptions.md) | The options for the delete that specify the revalidation deadline. |
+
+##### Returns
+
+[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+A promise that resolves when the delete is complete.
+
+#### Defined in
+
+[packages/functions/src/purge/types.ts:31](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/types.ts#L31)
+
+---
+
+### invalidateByTag
+
+• **invalidateByTag**: (`tag`: `string` \| `string`[]) => [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Type declaration
+
+▸ (`tag`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+Invalidate all content associated with a tag or tags by marking them as stale.
+On the next access to content associated with any of the tags, the stale content will be served and a background revalidation will be triggered.
+
+##### Parameters
+
+| Name  | Type                   | Description                    |
+| :---- | :--------------------- | :----------------------------- |
+| `tag` | `string` \| `string`[] | The tag or tags to invalidate. |
+
+##### Returns
+
+[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+A promise that resolves when the invalidate is complete.
+
+#### Defined in
+
+[packages/functions/src/purge/types.ts:20](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/types.ts#L20)

--- a/packages/functions/docs/modules/index.md
+++ b/packages/functions/docs/modules/index.md
@@ -4,17 +4,21 @@
 
 ### Interfaces
 
+- [DangerouslyDeleteOptions](../interfaces/index.DangerouslyDeleteOptions.md)
 - [Geo](../interfaces/index.Geo.md)
+- [PurgeApi](../interfaces/index.PurgeApi.md)
 - [Request](../interfaces/index.Request.md)
 - [RuntimeCache](../interfaces/index.RuntimeCache.md)
 
 ### Functions
 
 - [attachDatabasePool](index.md#attachdatabasepool)
+- [dangerouslyDeleteByTag](index.md#dangerouslydeletebytag)
 - [experimental_attachDatabasePool](index.md#experimental_attachdatabasepool)
 - [geolocation](index.md#geolocation)
 - [getCache](index.md#getcache)
 - [getEnv](index.md#getenv)
+- [invalidateByTag](index.md#invalidatebytag)
 - [ipAddress](index.md#ipaddress)
 - [next](index.md#next)
 - [rewrite](index.md#rewrite)
@@ -53,6 +57,27 @@ attachDatabasePool(pgPool);
 #### Defined in
 
 [packages/functions/src/db-connections/index.ts:221](https://github.com/vercel/vercel/blob/main/packages/functions/src/db-connections/index.ts#L221)
+
+---
+
+### dangerouslyDeleteByTag
+
+▸ **dangerouslyDeleteByTag**(`tag`, `options?`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Parameters
+
+| Name       | Type                                                                          |
+| :--------- | :---------------------------------------------------------------------------- |
+| `tag`      | `string` \| `string`[]                                                        |
+| `options?` | [`DangerouslyDeleteOptions`](../interfaces/index.DangerouslyDeleteOptions.md) |
+
+#### Returns
+
+[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Defined in
+
+[packages/functions/src/purge/index.ts:13](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L13)
 
 ---
 
@@ -210,6 +235,26 @@ https://vercel.com/docs/projects/environment-variables/system-environment-variab
 #### Defined in
 
 [packages/functions/src/get-env.ts:6](https://github.com/vercel/vercel/blob/main/packages/functions/src/get-env.ts#L6)
+
+---
+
+### invalidateByTag
+
+▸ **invalidateByTag**(`tag`): [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Parameters
+
+| Name  | Type                   |
+| :---- | :--------------------- |
+| `tag` | `string` \| `string`[] |
+
+#### Returns
+
+[`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<`void`\>
+
+#### Defined in
+
+[packages/functions/src/purge/index.ts:5](https://github.com/vercel/vercel/blob/main/packages/functions/src/purge/index.ts#L5)
 
 ---
 

--- a/packages/functions/src/get-context.ts
+++ b/packages/functions/src/get-context.ts
@@ -1,8 +1,10 @@
 import { RuntimeCache } from './cache/types';
+import { PurgeApi } from './purge/types';
 
 type Context = {
   waitUntil?: (promise: Promise<unknown>) => void;
   cache?: RuntimeCache;
+  purge?: PurgeApi;
   headers?: Record<string, string>;
 };
 

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -9,3 +9,5 @@ export {
   experimental_attachDatabasePool,
 } from './db-connections';
 export type { RuntimeCache } from './cache/types';
+export { invalidateByTag, dangerouslyDeleteByTag } from './purge';
+export type { PurgeApi, DangerouslyDeleteOptions } from './purge/types';

--- a/packages/functions/src/purge/index.ts
+++ b/packages/functions/src/purge/index.ts
@@ -1,0 +1,22 @@
+import { getContext } from '../get-context';
+import { DangerouslyDeleteOptions } from './types';
+export * from './types';
+
+export const invalidateByTag = (tag: string | string[]) => {
+  const api = getContext().purge;
+  if (api) {
+    return api.invalidateByTag(tag);
+  }
+  return Promise.resolve();
+};
+
+export const dangerouslyDeleteByTag = (
+  tag: string | string[],
+  options?: DangerouslyDeleteOptions
+) => {
+  const api = getContext().purge;
+  if (api) {
+    return api.dangerouslyDeleteByTag(tag, options);
+  }
+  return Promise.resolve();
+};

--- a/packages/functions/src/purge/types.ts
+++ b/packages/functions/src/purge/types.ts
@@ -1,0 +1,35 @@
+export interface DangerouslyDeleteOptions {
+  /**
+   * The time in seconds for how long the stale content can be served while revalidating the new content in the background.
+   * If none is provided, the default is 0 and the content will be deleted immediately.
+   */
+  revalidationDeadlineSeconds?: number;
+}
+
+/**
+ * Vercel Cache Purge APIs.
+ */
+export interface PurgeApi {
+  /**
+   * Invalidate all content associated with a tag or tags by marking them as stale.
+   * On the next access to content associated with any of the tags, the stale content will be served and a background revalidation will be triggered.
+   *
+   * @param tag The tag or tags to invalidate.
+   * @returns A promise that resolves when the invalidate is complete.
+   */
+  invalidateByTag: (tag: string | string[]) => Promise<void>;
+
+  /**
+   * Delete all content associated with a tag or tags after a specified revalidation deadline.
+   * If accessed prior to the revalidation deadline, the stale content will be served and a background revalidation will be triggered. After the revalidation deadline is reached, the content will be deleted.
+   * The default revalidation deadline is 0 and the content will be deleted immediately.
+   *
+   * @param tag The tag or tags to delete.
+   * @param options The options for the delete that specify the revalidation deadline.
+   * @returns A promise that resolves when the delete is complete.
+   */
+  dangerouslyDeleteByTag: (
+    tag: string | string[],
+    options?: DangerouslyDeleteOptions
+  ) => Promise<void>;
+}


### PR DESCRIPTION
### TL;DR

Added Vercel Purge APIs to the functions package.

### What changed?

- Introduced new Purge APIs: `invalidateByTag` and `dangerouslyDeleteByTag`
- Added a new `purge` directory with implementation files and type definitions
- Updated the Context type in `get-context.ts` to include the new `purge` property
- Added a changeset file to document the minor version change

### How to test?

1. Import the purge functions in a serverless function:
   ```typescript
   import { invalidateByTag, dangerouslyDeleteByTag } from '@vercel/functions';
   ```

2. Test invalidating by tag:
   ```typescript
   await invalidateByTag('my-tag');
   ```

3. Test dangerous deletion with stale-while-revalidate revalidation deadline of 1 day:
   ```typescript
   await dangerouslyDeleteByTag('my-tag', { 
     revalidationDeadlineSeconds: 86400
   });
   ```

### Why make this change?

This change provides a standardized API for cache purging within the functions package, allowing developers to invalidate or delete cached content by tag. The API includes both safer invalidation methods that mark content as stale and trigger background revalidation, as well as more aggressive deletion methods with configurable revalidation deadlines.