### PR TITLE
chore(cli): telemetry on login state

### DIFF
--- a/.changeset/famous-beds-rescue.md
+++ b/.changeset/famous-beds-rescue.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+chore(cli): telemetry on login state

--- a/packages/cli/src/commands/login/future.ts
+++ b/packages/cli/src/commands/login/future.ts
@@ -53,7 +53,10 @@ export async function login(
       output: process.stdout,
     })
     // HACK: https://github.com/SBoudrias/Inquirer.js/issues/293#issuecomment-172282009, https://github.com/SBoudrias/Inquirer.js/pull/569
-    .on('SIGINT', () => process.exit(0));
+    .on('SIGINT', () => {
+      telemetry.trackState('canceled');
+      process.exit(0);
+    });
 
   rl.question(
     `

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -37,6 +37,7 @@ export default async function login(client: Client): Promise<number> {
   const telemetry = new LoginTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
+      isDebug: output.isDebugEnabled(),
     },
   });
 
@@ -50,7 +51,17 @@ export default async function login(client: Client): Promise<number> {
 
   if (parsedArgs.flags['--future']) {
     telemetry.trackCliFlagFuture('login');
-    return await future(client);
+    telemetry.trackState('started');
+    const status = await future(client);
+    telemetry.trackState(status);
+    switch (status) {
+      // Intentionally return 0 on canceled, to avoid printing "ELIFECYCLE Command failed."
+      case 'canceled':
+      case 'success':
+        return 0;
+      case 'error':
+        return 1;
+    }
   }
 
   if (parsedArgs.flags['--help']) {

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -37,7 +37,6 @@ export default async function login(client: Client): Promise<number> {
   const telemetry = new LoginTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
-      isDebug: output.isDebugEnabled(),
     },
   });
 
@@ -52,16 +51,7 @@ export default async function login(client: Client): Promise<number> {
   if (parsedArgs.flags['--future']) {
     telemetry.trackCliFlagFuture('login');
     telemetry.trackState('started');
-    const status = await future(client);
-    telemetry.trackState(status);
-    switch (status) {
-      // Intentionally return 0 on canceled, to avoid printing "ELIFECYCLE Command failed."
-      case 'canceled':
-      case 'success':
-        return 0;
-      case 'error':
-        return 1;
-    }
+    return await future(client, telemetry);
   }
 
   if (parsedArgs.flags['--help']) {

--- a/packages/cli/src/util/telemetry/commands/login/index.ts
+++ b/packages/cli/src/util/telemetry/commands/login/index.ts
@@ -1,3 +1,14 @@
 import { TelemetryClient } from '../..';
 
-export class LoginTelemetryClient extends TelemetryClient {}
+export class LoginTelemetryClient extends TelemetryClient {
+  /**
+   * Tracks the state of the login process.
+   * - `started` when the user initiates the login process.
+   * - `canceled` when the user cancels the login process.
+   * - `error` when the user encounters an error during the login process.
+   * - `success` when the user successfully logs in.
+   */
+  trackState(...args: Parameters<TelemetryClient['trackLoginState']>) {
+    this.trackLoginState(...args);
+  }
+}

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -184,7 +184,9 @@ export class TelemetryClient {
     state: 'started' | 'error' | 'canceled' | 'success'
   ) {
     if (state === 'started') this.loginAttempt = randomUUID();
-    this.track({ key: `login:attempt:${this.loginAttempt}`, value: state });
+    if (this.loginAttempt) {
+      this.track({ key: `login:attempt:${this.loginAttempt}`, value: state });
+    }
     if (state !== 'started') this.loginAttempt = undefined;
   }
 

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -179,6 +179,15 @@ export class TelemetryClient {
     });
   }
 
+  protected loginAttempt?: string;
+  protected trackLoginState(
+    state: 'started' | 'error' | 'canceled' | 'success'
+  ) {
+    if (state === 'started') this.loginAttempt = randomUUID();
+    this.track({ key: `login:attempt:${this.loginAttempt}`, value: state });
+    if (state !== 'started') this.loginAttempt = undefined;
+  }
+
   trackCliFlagHelp(command: string, subcommands?: string | string[]) {
     let subcommand: string | undefined;
     if (subcommands) {

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { login } from '../../../../src/commands/login/future';
+import login from '../../../../src/commands/login';
 import { client } from '../../../mocks/client';
 import { vi } from 'vitest';
 import _fetch, { Headers, type Response } from 'node-fetch';


### PR DESCRIPTION
This re-lands #13855 with a different approach. We had to revert (#13872) the original approach as it caused the login process to hang after a successful login for some reason, which I suspect was due to some changes in the interruption handling.

This PR passes the `telemetry` client to the `future` function instead. Note that there is a refactor coming in #13802 and this approach plays nicer with that anyway.