### PR TITLE
chore(release): add flow to manually publish canary CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit (full) SHA to release the CLI from'
+        required: true
 
 env:
   TURBO_REMOTE_ONLY: 'true'
@@ -14,6 +19,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
+    if: github.event_name == 'push'
     name: Release
     runs-on: ubuntu-latest
     permissions:
@@ -76,7 +82,61 @@ jobs:
           script: |
             const script = require('./utils/update-latest-release.js')
             await script({ github, context })
+  manual-cli-release:
+    if: github.event_name == 'workflow_dispatch'
+    name: Manual CLI Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          ref: ${{ github.event.inputs.commit }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: install npm@9
+        run: npm i -g npm@9
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm build
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Version CLI, publish and comment on PR
+        run: |
+          cd packages/cli &&
+          PR_NUMBER="$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${{ github.repository }}/commits/${{github.event.inputs.commit}}/pulls" \
+              --jq '.[0].number' || true)" &&
+          VERSION=$(node -p "require('./package.json').version")-canary.${{ github.event.inputs.commit }} &&
+          pnpm version $VERSION --no-git-tag-version &&
+          pnpm publish --access public --tag canary --dry-run &&
+          gh pr comment $PR_NUMBER --body "🚀 Published canary version:
+          \`\`\`bash
+          pnpm add vercel@$VERSION
+          \`\`\`
+          "
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   summary:
     name: Summary (release)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
       commit:
         description: 'Commit (full) SHA to release the CLI from'
         required: true
+      dryRun:
+        description: 'Whether to run the publish process in dry run mode.'
+        type: boolean
+        required: true
+        default: true
 
 env:
   TURBO_REMOTE_ONLY: 'true'
@@ -119,18 +124,10 @@ jobs:
       - name: Version CLI, publish and comment on PR
         run: |
           cd packages/cli &&
-          PR_NUMBER="$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${{ github.repository }}/commits/${{github.event.inputs.commit}}/pulls" \
-              --jq '.[0].number' || true)" &&
           VERSION=$(node -p "require('./package.json').version")-canary.${{ github.event.inputs.commit }} &&
           pnpm version $VERSION --no-git-tag-version &&
-          pnpm publish --access public --tag canary --dry-run --no-git-checks &&
-          gh pr comment $PR_NUMBER --body "🚀 Published canary version:
-          \`\`\`bash
-          pnpm add vercel@$VERSION
-          \`\`\`
-          "
+          pnpm publish --access public --tag canary ${ github.event.inputs.dryRun ? '--dry-run' : '' } --no-git-checks &&
+          echo "🚀 Published canary version, install via: \`pnpm add vercel@$VERSION\`"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
             await script({ github, context })
   manual-cli-release:
     if: github.event_name == 'workflow_dispatch'
-    name: Manual CLI Release
+    name: Manual CLI Release ${{github.event.inputs.dryRun == 'true' && '(--dry-run)' || ''}}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -125,7 +125,7 @@ jobs:
           cd packages/cli &&
           VERSION=$(node -p "require('./package.json').version")-canary.${{ github.event.inputs.commit }} &&
           pnpm version $VERSION --no-git-tag-version &&
-          pnpm publish --access public --tag canary ${ github.event.inputs.dryRun ? '--dry-run' : '' } --no-git-checks &&
+          pnpm publish --access public --tag canary ${{ github.event.inputs.dryRun == 'true' && '--dry-run' || '' }} --no-git-checks &&
           echo "🚀 Published canary version, install via: \`pnpm add vercel@$VERSION\`"
 
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       commit:
-        description: 'Commit SHA to release the CLI from'
+        description: 'Commit (full) SHA to release the CLI from'
         required: true
       dryRun:
         description: 'Whether to run the publish process in dry run mode.'
@@ -123,12 +123,13 @@ jobs:
       - name: Version CLI, publish and comment on PR
         run: |
           cd packages/cli &&
-          VERSION=$(node -p "require('./package.json').version")-canary.${{ github.event.inputs.commit }} &&
+          VERSION=$(node -p "require('./package.json').version")-canary.${COMMIT_SHA:0:8} &&
           pnpm version $VERSION --no-git-tag-version &&
           pnpm publish --access public --tag canary ${{ github.event.inputs.dryRun == 'true' && '--dry-run' || '' }} --no-git-checks &&
           echo "🚀 Published canary version, install via: \`pnpm add vercel@$VERSION\`"
 
         env:
+          COMMIT_SHA: ${{ github.event.inputs.commit }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           NPM_CONFIG_PROVENANCE: 'true'
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
               --jq '.[0].number' || true)" &&
           VERSION=$(node -p "require('./package.json').version")-canary.${{ github.event.inputs.commit }} &&
           pnpm version $VERSION --no-git-tag-version &&
-          pnpm publish --access public --tag canary --dry-run &&
+          pnpm publish --access public --tag canary --dry-run --no-git-checks &&
           gh pr comment $PR_NUMBER --body "🚀 Published canary version:
           \`\`\`bash
           pnpm add vercel@$VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       commit:
-        description: 'Commit (full) SHA to release the CLI from'
+        description: 'Commit SHA to release the CLI from'
         required: true
       dryRun:
         description: 'Whether to run the publish process in dry run mode.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Version CLI, publish and comment on PR
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc &&
           cd packages/cli &&
           VERSION=$(node -p "require('./package.json').version")-canary.${COMMIT_SHA:0:8} &&
           pnpm version $VERSION --no-git-tag-version &&


### PR DESCRIPTION
**Notes:**

- limited to CLI only, to solve the problem I was having, and not need to think about cross-dependency releases
- it creates a canary tag that includes the commit SHA (eg. vercel@46.0.2-canary.40a86f9314769b41ca7a153a415c4a8aa7b21b60)
- [comments back to the PR](https://github.com/vercel/vercel/pull/13802#issuecomment-3257627618)