### PR TITLE
[cli] Add guidance mode for deploy command

### DIFF
--- a/.changeset/swift-buttons-occur.md
+++ b/.changeset/swift-buttons-occur.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+Add guidance flag for deploy command

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -119,6 +119,13 @@ export const deployCommand = {
       description: 'Print the build logs',
     },
     {
+      name: 'guidance',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Receive command suggestions once deployment is complete',
+    },
+    {
       name: 'no-logs',
       shorthand: null,
       type: Boolean,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -105,6 +105,7 @@ export default async (client: Client): Promise<number> => {
     telemetryClient.trackCliFlagPublic(parsedArguments.flags['--public']);
     telemetryClient.trackCliFlagLogs(parsedArguments.flags['--logs']);
     telemetryClient.trackCliFlagNoLogs(parsedArguments.flags['--no-logs']);
+    telemetryClient.trackCliFlagGuidance(parsedArguments.flags['--guidance']);
     telemetryClient.trackCliFlagForce(parsedArguments.flags['--force']);
     telemetryClient.trackCliFlagWithCache(
       parsedArguments.flags['--with-cache']

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -711,7 +711,12 @@ export default async (client: Client): Promise<number> => {
     return 1;
   }
 
-  return printDeploymentStatus(deployment, deployStamp, noWait);
+  return printDeploymentStatus(
+    deployment,
+    deployStamp,
+    noWait,
+    parsedArguments.flags['--guidance'] ?? false
+  );
 };
 
 function handleCreateDeployError(error: Error, localConfig: VercelConfig) {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -70,6 +70,7 @@ import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
 import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 import { displayBuildLogs } from '../../util/logs';
+import { determineAgent } from '@vercel/detect-agent';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -711,12 +712,9 @@ export default async (client: Client): Promise<number> => {
     return 1;
   }
 
-  return printDeploymentStatus(
-    deployment,
-    deployStamp,
-    noWait,
-    parsedArguments.flags['--guidance'] ?? false
-  );
+  const guidanceMode =
+    parsedArguments.flags['--guidance'] ?? (await determineAgent()) !== false;
+  return printDeploymentStatus(deployment, deployStamp, noWait, guidanceMode);
 };
 
 function handleCreateDeployError(error: Error, localConfig: VercelConfig) {

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -251,7 +251,7 @@ export default async function redeploy(client: Client): Promise<number> {
       }
     }
 
-    return printDeploymentStatus(deployment, deployStamp, noWait);
+    return printDeploymentStatus(deployment, deployStamp, noWait, false);
   } catch (err: unknown) {
     output.prettyError(err);
     if (isErrnoException(err) && err.code === 'ERR_INVALID_TEAM') {

--- a/packages/cli/src/util/deploy/print-deployment-status.ts
+++ b/packages/cli/src/util/deploy/print-deployment-status.ts
@@ -5,6 +5,7 @@ import { isDeploying } from '../../util/deploy/is-deploying';
 import linkStyle from '../output/link';
 import { prependEmoji, emoji } from '../../util/emoji';
 import output from '../../output-manager';
+import { getCommandName } from '../pkg-name';
 
 /**
  * Prints (to `output`) warnings and errors, if any.
@@ -15,6 +16,8 @@ export async function printDeploymentStatus(
     aliasError,
     indications,
     aliasWarning,
+    url,
+    target,
   }: {
     readyState: Deployment['readyState'];
     alias: string[];
@@ -30,7 +33,8 @@ export async function printDeploymentStatus(
     };
   },
   deployStamp: () => string,
-  noWait: boolean
+  noWait: boolean,
+  guidanceMode: boolean
 ): Promise<number> {
   indications = indications || [];
 
@@ -85,5 +89,28 @@ export async function printDeploymentStatus(
     output.print(message + link);
   }
 
+  if (guidanceMode) {
+    output.print('\n');
+    suggestNextCommands(
+      [
+        getCommandName(`inspect ${url} --logs`),
+        getCommandName(`redeploy ${url}`),
+        target !== 'production' ? getCommandName(`deploy --prod`) : false,
+      ].filter(Boolean) as string[]
+    );
+  }
+
   return 0;
+}
+
+function suggestNextCommands(commands: string[]) {
+  output.print(
+    chalk.dim(
+      [
+        `Common next commands:`,
+        ...commands.map(command => `- ${command}`),
+      ].join('\n')
+    )
+  );
+  output.print('\n');
 }

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -99,6 +99,11 @@ export class DeployTelemetryClient
       this.trackCliFlag('no-logs');
     }
   }
+  trackCliFlagGuidance(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('guidance');
+    }
+  }
   trackCliFlagNoClipboard(flag: boolean | undefined) {
     if (flag) {
       this.trackCliFlag('no-clipboard');

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,6 +753,13 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 nothing 
                                 has     
                                 changed 
+       --guidance               Receive 
+                                command 
+                                suggest…
+                                once    
+                                deploym…
+                                is      
+                                complete
   -l,  --logs                   Print   
                                 the     
                                 build   
@@ -921,6 +928,8 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 (e.g. \`-e KEY1=value1 -e KEY2=value2\`)          
   -f,  --force                  Force a new deployment even if nothing has      
                                 changed                                         
+       --guidance               Receive command suggestions once deployment is  
+                                complete                                        
   -l,  --logs                   Print the build logs                            
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m   
                                 KEY1=value1 -m KEY2=value2\`)                    
@@ -993,6 +1002,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
   -b,  --build-env <KEY=VALUE>  Specify environment variables during build-time (e.g. \`-b KEY1=value1 -b KEY2=value2\`)  
   -e,  --env <KEY=VALUE>        Specify environment variables during run-time (e.g. \`-e KEY1=value1 -e KEY2=value2\`)    
   -f,  --force                  Force a new deployment even if nothing has changed                                      
+       --guidance               Receive command suggestions once deployment is complete                                 
   -l,  --logs                   Print the build logs                                                                    
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m KEY1=value1 -m KEY2=value2\`)              
        --no-wait                Don't wait for the deployment to finish                                                 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1109,6 +1109,16 @@ describe('deploy', () => {
         { key: 'flag:logs', value: 'TRUE' },
       ]);
     });
+    it('--guidance', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--guidance');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:guidance', value: 'TRUE' },
+      ]);
+    });
     it('--name', async () => {
       client.cwd = setupUnitFixture('commands/deploy/static');
       client.setArgv('deploy', '--name', 'okok');


### PR DESCRIPTION
Adds `--guidance` flag to `vercel deploy`. It suggests common next commands based on your deployment. `--guidance` is automatically applied when detecting agents to help avoid hallucinations.

<img width="854" height="169" alt="image" src="https://github.com/user-attachments/assets/610bfb8d-6d11-4a62-b3d8-bb93b1222580" />

An upcoming PR will also add this flag to `vercel logs`, `vercel env`, and `vercel redeploy`.

