### PR TITLE
Revert change to module resolution which slowed down Typescript builds

### DIFF
--- a/.changeset/two-peaches-report.md
+++ b/.changeset/two-peaches-report.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Revert change to module resolution which slowed down Typescript builds for functions

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -271,17 +271,21 @@ export function register(opts: Options = {}): Register {
       getCompilationSettings: () => config.options,
       getDefaultLibFileName: () => ts.getDefaultLibFilePath(config.options),
       getCustomTransformers: () => transformers,
-      resolveModuleNames: (moduleNames: string[], containingFile: string) => {
-        return moduleNames.map(moduleName => {
-          const result = ts.resolveModuleName(
-            moduleName,
-            containingFile,
-            config.options,
-            ts.sys
-          );
-          return result.resolvedModule;
-        });
-      },
+      // This hurts performance, but for Express, type checking will fail to find @types/express without it
+      // so keeping it on for now for Express/Hono projects
+      resolveModuleNames: process.env.EXPERIMENTAL_NODE_TYPESCRIPT_ERRORS
+        ? (moduleNames: string[], containingFile: string) => {
+            return moduleNames.map(moduleName => {
+              const result = ts.resolveModuleName(
+                moduleName,
+                containingFile,
+                config.options,
+                ts.sys
+              );
+              return result.resolvedModule;
+            });
+          }
+        : undefined,
     };
 
     const registry = ts.createDocumentRegistry(


### PR DESCRIPTION
This [fix](https://github.com/vercel/vercel/pull/13828/files#diff-338bc2d6d432ebe72a264aaabed3c64b72522426aed88a0e16d243132ec669b4R274) was done because our TS build process isn't resolving `@types/express`, and presumably others. However, it results in a much slower build process for some apps. I think this has been that way for years, but working to verify that. The reason this wouldn't have been an issue is because we don't fail the build for TS errors for `api/` functions, so wasn't really a big deal if it showed up in the build logs but the build succeeded. However we started to fail builds for Express and Hono type failures, so this addition is necessary.

For now, I've used the same env flag we set from Express/Hono builders which tell the TS process to fail on errors so we continue to check types properly on those apps, while falling back to the old behavior for `api/` functions. The longer term fix will be either to make the `resolveModuleNames` more performant or perhaps update this whole module to just use the normal compiler API. It's not clear to me why this is using a TS service host in the first place. Alternatively, we are looking into alternative builders like `rolldown` or `esbuild`.