### PR TITLE
[cli] add new commands `vercel cache invalidate --tag`

### DIFF
--- a/.changeset/fast-pillows-type.md
+++ b/.changeset/fast-pillows-type.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add new commands `vercel cache invalidate --tag` and `vercel cache dangerously-delete --tag`

--- a/packages/cli/src/commands/cache/command.ts
+++ b/packages/cli/src/commands/cache/command.ts
@@ -36,7 +36,7 @@ export const purgeSubcommand = {
 export const invalidateSubcommand = {
   name: 'invalidate',
   aliases: [],
-  description: 'Invalidate cache by tags',
+  description: 'Invalidate all cached content by tag',
   arguments: [],
   options: [
     yesOption,
@@ -51,11 +51,11 @@ export const invalidateSubcommand = {
   ],
   examples: [
     {
-      name: 'Invalidate cache by a single tag',
+      name: 'Invalidate all cached content associated with a tag',
       value: `${packageName} cache invalidate --tag foo`,
     },
     {
-      name: 'Invalidate cache by multiple tags',
+      name: 'Invalidate all cached content associated with any one of multiple tags',
       value: `${packageName} cache invalidate --tag foo,bar,baz`,
     },
   ],
@@ -64,7 +64,7 @@ export const invalidateSubcommand = {
 export const dangerouslyDeleteSubcommand = {
   name: 'dangerously-delete',
   aliases: [],
-  description: 'Dangerously delete cache by tags',
+  description: 'Dangerously delete all cached content by tag',
   arguments: [],
   options: [
     yesOption,
@@ -87,11 +87,11 @@ export const dangerouslyDeleteSubcommand = {
   ],
   examples: [
     {
-      name: 'Dangerously delete cache by tag',
+      name: 'Dangerously delete all cached content associated with a tag',
       value: `${packageName} cache dangerously-delete --tag foo`,
     },
     {
-      name: 'Dangerously delete cache by tag with deadline of 1 hour',
+      name: 'Dangerously delete all cached content associated with a tag if not accessed in the next hour',
       value: `${packageName} cache dangerously-delete --tag foo --revalidation-deadline-seconds 3600`,
     },
   ],

--- a/packages/cli/src/commands/cache/command.ts
+++ b/packages/cli/src/commands/cache/command.ts
@@ -33,12 +33,80 @@ export const purgeSubcommand = {
   ],
 } as const;
 
+export const invalidateSubcommand = {
+  name: 'invalidate',
+  aliases: [],
+  description: 'Invalidate cache by tags',
+  arguments: [],
+  options: [
+    yesOption,
+    {
+      name: 'tag',
+      description: 'Tags to invalidate (comma-separated)',
+      shorthand: null,
+      type: String,
+      argument: 'TAGS',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Invalidate cache by a single tag',
+      value: `${packageName} cache invalidate --tag foo`,
+    },
+    {
+      name: 'Invalidate cache by multiple tags',
+      value: `${packageName} cache invalidate --tag foo,bar,baz`,
+    },
+  ],
+} as const;
+
+export const dangerouslyDeleteSubcommand = {
+  name: 'dangerously-delete',
+  aliases: [],
+  description: 'Dangerously delete cache by tags',
+  arguments: [],
+  options: [
+    yesOption,
+    {
+      name: 'tag',
+      description: 'Tags to delete (comma-separated)',
+      shorthand: null,
+      type: String,
+      argument: 'TAGS',
+      deprecated: false,
+    },
+    {
+      name: 'revalidation-deadline-seconds',
+      description: 'Revalidation deadline in seconds',
+      shorthand: null,
+      type: Number,
+      argument: 'REVALIDATION-DEADLINE-SECONDS',
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Dangerously delete cache by tag',
+      value: `${packageName} cache dangerously-delete --tag foo`,
+    },
+    {
+      name: 'Dangerously delete cache by tag with deadline of 1 hour',
+      value: `${packageName} cache dangerously-delete --tag foo --revalidation-deadline-seconds 3600`,
+    },
+  ],
+} as const;
+
 export const cacheCommand = {
   name: 'cache',
   aliases: [],
   description: 'Manage cache for a Project',
   arguments: [],
-  subcommands: [purgeSubcommand],
+  subcommands: [
+    purgeSubcommand,
+    invalidateSubcommand,
+    dangerouslyDeleteSubcommand,
+  ],
   options: [],
   examples: [],
 } as const;

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -1,0 +1,100 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { dangerouslyDeleteSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { emoji, prependEmoji } from '../../util/emoji';
+import { CacheDangerouslyDeleteTelemetryClient } from '../../util/telemetry/commands/cache/dangerously-delete';
+
+export default async function dangerouslyDelete(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new CacheDangerouslyDeleteTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    dangerouslyDeleteSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const link = await getLinkedProject(client);
+
+  if (link.status === 'not_linked') {
+    output.error(
+      'No project linked. Run `vercel link` to link a project to this directory.'
+    );
+    return 1;
+  }
+
+  if (link.status === 'error') {
+    return link.exitCode;
+  }
+
+  const { project, org } = link;
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+  const yes = Boolean(parsedArgs.flags['--yes']);
+  telemetry.trackCliFlagYes(yes);
+
+  const tag = parsedArgs.flags['--tag'];
+  telemetry.trackCliOptionTag(tag);
+  if (!tag) {
+    output.error(`Invalid cache tag "${tag}".}`);
+    return 1;
+  }
+
+  const revalidate = parsedArgs.flags['--revalidation-deadline-seconds'];
+  telemetry.trackCliOptionRevalidationDeadlineSeconds(revalidate);
+
+  const msg = `You are about to dangerously delete tag ${tag} for project ${project.name}`;
+  const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
+
+  if (!yes) {
+    if (!process.stdin.isTTY) {
+      const optional =
+        typeof revalidate !== 'undefined'
+          ? ` --revalidation-deadline-seconds ${revalidate}`
+          : '';
+      output.print(
+        `${msg}. To continue, run ${getCommandName(`cache dangerously-delete --tag ${tag}${optional} --yes`)}.`
+      );
+      return 1;
+    }
+    const confirmed = await client.input.confirm(`${msg}. Continue?`, true);
+    if (!confirmed) {
+      output.print(`Canceled.\n`);
+      return 0;
+    }
+  }
+
+  await client.fetch(`/v1/edge-cache/dangerously-delete-by-tags?${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      tags: tag
+        .split(',')
+        .map(str => str.trim())
+        .filter(Boolean),
+      revalidateationDeadlineSeconds: revalidate,
+    }),
+  });
+
+  output.print(
+    prependEmoji(`Successfully deleted tag ${tag}`, emoji('success')) + `\n`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -58,7 +58,7 @@ export default async function dangerouslyDelete(
   const revalidate = parsedArgs.flags['--revalidation-deadline-seconds'];
   telemetry.trackCliOptionRevalidationDeadlineSeconds(revalidate);
 
-  const msg = `You are about to dangerously delete tag ${tag} for project ${project.name}`;
+  const msg = `You are about to dangerously delete all cached content associated with tag ${tag} for project ${project.name}`;
   const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
 
   if (!yes) {

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -8,6 +8,7 @@ import { getCommandName } from '../../util/pkg-name';
 import { getLinkedProject } from '../../util/projects/link';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { CacheDangerouslyDeleteTelemetryClient } from '../../util/telemetry/commands/cache/dangerously-delete';
+import plural from 'pluralize';
 
 export default async function dangerouslyDelete(
   client: Client,
@@ -58,7 +59,8 @@ export default async function dangerouslyDelete(
   const revalidate = parsedArgs.flags['--revalidation-deadline-seconds'];
   telemetry.trackCliOptionRevalidationDeadlineSeconds(revalidate);
 
-  const msg = `You are about to dangerously delete all cached content associated with tag ${tag} for project ${project.name}`;
+  const tagsDesc = plural('tag', tag.split(',').length, false);
+  const msg = `You are about to dangerously delete all cached content associated with ${tagsDesc} ${tag} for project ${project.name}`;
   const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
 
   if (!yes) {
@@ -85,16 +87,16 @@ export default async function dangerouslyDelete(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      tags: tag
-        .split(',')
-        .map(str => str.trim())
-        .filter(Boolean),
+      tags: tag,
       revalidationDeadlineSeconds: revalidate,
     }),
   });
 
   output.print(
-    prependEmoji(`Successfully deleted tag ${tag}`, emoji('success')) + `\n`
+    prependEmoji(
+      `Successfully deleted all cached content associated with ${tagsDesc} ${tag}`,
+      emoji('success')
+    ) + `\n`
   );
   return 0;
 }

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -46,12 +46,12 @@ export default async function dangerouslyDelete(
   const { project, org } = link;
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
   const yes = Boolean(parsedArgs.flags['--yes']);
-  telemetry.trackCliFlagYes(yes);
-
   const tag = parsedArgs.flags['--tag'];
+  telemetry.trackCliFlagYes(yes);
   telemetry.trackCliOptionTag(tag);
+
   if (!tag) {
-    output.error(`Invalid cache tag "${tag}".}`);
+    output.error(`The --tag option is required`);
     return 1;
   }
 

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -89,7 +89,7 @@ export default async function dangerouslyDelete(
         .split(',')
         .map(str => str.trim())
         .filter(Boolean),
-      revalidateationDeadlineSeconds: revalidate,
+      revalidationDeadlineSeconds: revalidate,
     }),
   });
 

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -5,7 +5,14 @@ import getSubcommand from '../../util/get-subcommand';
 import { printError } from '../../util/error';
 import { type Command, help } from '../help';
 import purge from './purge';
-import { cacheCommand, purgeSubcommand } from './command';
+import invalidate from './invalidate';
+import dangerouslyDelete from './dangerously-delete';
+import {
+  cacheCommand,
+  purgeSubcommand,
+  invalidateSubcommand,
+  dangerouslyDeleteSubcommand,
+} from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
 import { getCommandAliases } from '..';
@@ -13,6 +20,8 @@ import { CacheTelemetryClient } from '../../util/telemetry/commands/cache';
 
 const COMMAND_CONFIG = {
   purge: getCommandAliases(purgeSubcommand),
+  invalidate: getCommandAliases(invalidateSubcommand),
+  'dangerously-delete': getCommandAliases(dangerouslyDeleteSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -62,6 +71,20 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandPurge(subcommandOriginal);
       return purge(client, args);
+    case 'invalidate':
+      if (needHelp) {
+        printHelp(invalidateSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandInvalidate(subcommandOriginal);
+      return invalidate(client, args);
+    case 'dangerously-delete':
+      if (needHelp) {
+        printHelp(dangerouslyDeleteSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandDangerouslyDelete(subcommandOriginal);
+      return dangerouslyDelete(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(cacheCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/cache/invalidate.ts
+++ b/packages/cli/src/commands/cache/invalidate.ts
@@ -1,0 +1,92 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { invalidateSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { getCommandName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { emoji, prependEmoji } from '../../util/emoji';
+import { CacheInvalidateTelemetryClient } from '../../util/telemetry/commands/cache/invalidate';
+
+export default async function invalidate(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetry = new CacheInvalidateTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(
+    invalidateSubcommand.options
+  );
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const link = await getLinkedProject(client);
+
+  if (link.status === 'not_linked') {
+    output.error(
+      'No project linked. Run `vercel link` to link a project to this directory.'
+    );
+    return 1;
+  }
+
+  if (link.status === 'error') {
+    return link.exitCode;
+  }
+
+  const { project, org } = link;
+  client.config.currentTeam = org.type === 'team' ? org.id : undefined;
+  const yes = Boolean(parsedArgs.flags['--yes']);
+  telemetry.trackCliFlagYes(yes);
+
+  const tag = parsedArgs.flags['--tag'];
+  telemetry.trackCliOptionTag(tag);
+  if (!tag) {
+    output.error(`Invalid cache tag "${tag}".}`);
+    return 1;
+  }
+
+  const msg = `You are about to invalidate tag ${tag} for project ${project.name}`;
+  const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
+
+  if (!yes) {
+    if (!process.stdin.isTTY) {
+      output.print(
+        `${msg}. To continue, run ${getCommandName(`cache invalidate --tag ${tag} --yes`)}.`
+      );
+      return 1;
+    }
+    const confirmed = await client.input.confirm(`${msg}. Continue?`, true);
+    if (!confirmed) {
+      output.print(`Canceled.\n`);
+      return 0;
+    }
+  }
+
+  await client.fetch(`/v1/edge-cache/invalidate-by-tags?${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      tags: tag
+        .split(',')
+        .map(str => str.trim())
+        .filter(Boolean),
+    }),
+  });
+
+  output.print(
+    prependEmoji(`Successfully invalidated tag ${tag}`, emoji('success')) + `\n`
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/cache/invalidate.ts
+++ b/packages/cli/src/commands/cache/invalidate.ts
@@ -55,7 +55,7 @@ export default async function invalidate(
     return 1;
   }
 
-  const msg = `You are about to invalidate tag ${tag} for project ${project.name}`;
+  const msg = `You are about to invalidate all cached content associated with tag ${tag} for project ${project.name}`;
   const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
 
   if (!yes) {

--- a/packages/cli/src/commands/cache/invalidate.ts
+++ b/packages/cli/src/commands/cache/invalidate.ts
@@ -46,12 +46,12 @@ export default async function invalidate(
   const { project, org } = link;
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
   const yes = Boolean(parsedArgs.flags['--yes']);
-  telemetry.trackCliFlagYes(yes);
-
   const tag = parsedArgs.flags['--tag'];
+  telemetry.trackCliFlagYes(yes);
   telemetry.trackCliOptionTag(tag);
+
   if (!tag) {
-    output.error(`Invalid cache tag "${tag}".}`);
+    output.error(`The --tag option is required`);
     return 1;
   }
 

--- a/packages/cli/src/commands/cache/invalidate.ts
+++ b/packages/cli/src/commands/cache/invalidate.ts
@@ -8,6 +8,7 @@ import { getCommandName } from '../../util/pkg-name';
 import { getLinkedProject } from '../../util/projects/link';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { CacheInvalidateTelemetryClient } from '../../util/telemetry/commands/cache/invalidate';
+import plural from 'pluralize';
 
 export default async function invalidate(
   client: Client,
@@ -55,7 +56,8 @@ export default async function invalidate(
     return 1;
   }
 
-  const msg = `You are about to invalidate all cached content associated with tag ${tag} for project ${project.name}`;
+  const tagsDesc = plural('tag', tag.split(',').length, false);
+  const msg = `You are about to invalidate all cached content associated with ${tagsDesc} ${tag} for project ${project.name}`;
   const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
 
   if (!yes) {
@@ -78,15 +80,15 @@ export default async function invalidate(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      tags: tag
-        .split(',')
-        .map(str => str.trim())
-        .filter(Boolean),
+      tags: tag,
     }),
   });
 
   output.print(
-    prependEmoji(`Successfully invalidated tag ${tag}`, emoji('success')) + `\n`
+    prependEmoji(
+      `Successfully invalidated all cached content associated with ${tagsDesc} ${tag}`,
+      emoji('success')
+    ) + `\n`
   );
   return 0;
 }

--- a/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
@@ -1,0 +1,32 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { dangerouslyDeleteSubcommand } from '../../../../commands/cache/command';
+
+export class CacheDangerouslyDeleteTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof dangerouslyDeleteSubcommand>
+{
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionTag(tag: string | undefined) {
+    if (tag) {
+      this.trackCliOption({
+        option: 'tag',
+        value: tag,
+      });
+    }
+  }
+
+  trackCliOptionRevalidationDeadlineSeconds(seconds: number | undefined) {
+    if (seconds) {
+      this.trackCliOption({
+        option: 'revalidation-deadline-seconds',
+        value: seconds,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
@@ -25,7 +25,7 @@ export class CacheDangerouslyDeleteTelemetryClient
     if (seconds) {
       this.trackCliOption({
         option: 'revalidation-deadline-seconds',
-        value: seconds,
+        value: seconds?.toString(),
       });
     }
   }

--- a/packages/cli/src/util/telemetry/commands/cache/index.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/index.ts
@@ -12,4 +12,18 @@ export class CacheTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandInvalidate(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'invalidate',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDangerouslyDelete(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'dangerously-delete',
+      value: actual,
+    });
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/cache/invalidate.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/invalidate.ts
@@ -1,0 +1,23 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { invalidateSubcommand } from '../../../../commands/cache/command';
+
+export class CacheInvalidateTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof invalidateSubcommand>
+{
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliOptionTag(tag: string | undefined) {
+    if (tag) {
+      this.trackCliOption({
+        option: 'tag',
+        value: tag,
+      });
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import cache from '../../../../src/commands/cache';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeam } from '../../../mocks/team';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import { basename, join } from 'path';
+import { outputFile } from 'fs-extra';
+
+describe('cache dangerously-delete', () => {
+  beforeEach(async () => {
+    useUser();
+    useTeam('team_dummy');
+    const cwd = setupTmpDir();
+    client.cwd = cwd;
+    useProject({
+      ...defaultProject,
+      id: basename(cwd),
+      name: basename(cwd),
+    });
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ projectId: basename(cwd), orgId: 'team_dummy' })
+    );
+  });
+
+  it('should error when project is not linked', async () => {
+    client.setArgv('cache', 'dangerously-delete');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+  });
+
+  it('should error without --tag', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-tags`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          tags: ['foo'],
+        });
+        res.end();
+      }
+    );
+    client.setArgv('cache', 'dangerously-delete', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('The --tag option is required');
+  });
+
+  it('should succeed with --tag', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-tags`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          tags: ['foo'],
+        });
+        res.end();
+      }
+    );
+    client.setArgv('cache', 'dangerously-delete', '--tag=foo', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Successfully deleted tag foo');
+  });
+
+  it('should succeed with multiple tags', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-tags`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          tags: ['foo', 'bar', 'baz'],
+        });
+        res.end();
+      }
+    );
+    client.setArgv('cache', 'dangerously-delete', '--tag=foo,bar,baz', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully deleted tag foo,bar,baz'
+    );
+  });
+});

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -38,7 +38,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: ['foo'],
+          tags: 'foo',
         });
         res.end();
       }
@@ -54,7 +54,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: ['foo'],
+          tags: 'foo',
         });
         res.end();
       }
@@ -62,7 +62,9 @@ describe('cache dangerously-delete', () => {
     client.setArgv('cache', 'dangerously-delete', '--tag=foo', '--yes');
     const exitCode = await cache(client);
     expect(exitCode).toEqual(0);
-    await expect(client.stderr).toOutput('Successfully deleted tag foo');
+    await expect(client.stderr).toOutput(
+      'Successfully deleted all cached content associated with tag foo'
+    );
   });
 
   it('should succeed with multiple tags', async () => {
@@ -70,7 +72,7 @@ describe('cache dangerously-delete', () => {
       `/v1/edge-cache/dangerously-delete-by-tags`,
       (req, res) => {
         expect(req.body).toEqual({
-          tags: ['foo', 'bar', 'baz'],
+          tags: 'foo,bar,baz',
         });
         res.end();
       }
@@ -79,7 +81,7 @@ describe('cache dangerously-delete', () => {
     const exitCode = await cache(client);
     expect(exitCode).toEqual(0);
     await expect(client.stderr).toOutput(
-      'Successfully deleted tag foo,bar,baz'
+      'Successfully deleted all cached content associated with tags foo,bar,baz'
     );
   });
 

--- a/packages/cli/test/unit/commands/cache/invalidate.test.ts
+++ b/packages/cli/test/unit/commands/cache/invalidate.test.ts
@@ -71,4 +71,13 @@ describe('cache invalidate', () => {
       'Successfully invalidated tag foo,bar,baz'
     );
   });
+
+  it('should ask for confirmation if the --yes option is omitted', async () => {
+    client.setArgv('cache', 'invalidate', '--tag=foo');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'You are about to invalidate all cached content associated with tag foo for project 4. To continue, run `vercel cache invalidate --tag foo --yes`.'
+    );
+  });
 });

--- a/packages/cli/test/unit/commands/cache/invalidate.test.ts
+++ b/packages/cli/test/unit/commands/cache/invalidate.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import cache from '../../../../src/commands/cache';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeam } from '../../../mocks/team';
+import { setupTmpDir } from '../../../helpers/setup-unit-fixture';
+import { basename, join } from 'path';
+import { outputFile } from 'fs-extra';
+
+describe('cache invalidate', () => {
+  beforeEach(async () => {
+    useUser();
+    useTeam('team_dummy');
+    const cwd = setupTmpDir();
+    client.cwd = cwd;
+    useProject({
+      ...defaultProject,
+      id: basename(cwd),
+      name: basename(cwd),
+    });
+    await outputFile(
+      join(cwd, '.vercel', 'project.json'),
+      JSON.stringify({ projectId: basename(cwd), orgId: 'team_dummy' })
+    );
+  });
+
+  it('should error when project is not linked', async () => {
+    client.setArgv('cache', 'invalidate');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+  });
+
+  it('should error without --tag', async () => {
+    client.scenario.post(`/v1/edge-cache/invalidate-by-tags`, (req, res) => {
+      expect(req.body).toEqual({
+        tags: ['foo'],
+      });
+      res.end();
+    });
+    client.setArgv('cache', 'invalidate', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('The --tag option is required');
+  });
+
+  it('should succeed with --tag', async () => {
+    client.scenario.post(`/v1/edge-cache/invalidate-by-tags`, (req, res) => {
+      expect(req.body).toEqual({
+        tags: ['foo'],
+      });
+      res.end();
+    });
+    client.setArgv('cache', 'invalidate', '--tag=foo', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Successfully invalidated tag foo');
+  });
+
+  it('should succeed with multiple tags', async () => {
+    client.scenario.post(`/v1/edge-cache/invalidate-by-tags`, (req, res) => {
+      expect(req.body).toEqual({
+        tags: ['foo', 'bar', 'baz'],
+      });
+      res.end();
+    });
+    client.setArgv('cache', 'invalidate', '--tag=foo,bar,baz', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully invalidated tag foo,bar,baz'
+    );
+  });
+});


### PR DESCRIPTION
This PR adds two new commands:

- `vercel cache invalidate --tag foo`
- `vercel cache dangerously-delete --tag foo --revalidation-deadline-seconds 604800`

Closes https://github.com/vercel/vercel/pull/13848