### PR TITLE
[cli] Add guidance mode for deploy and env commands

### DIFF
--- a/.changeset/swift-buttons-occur.md
+++ b/.changeset/swift-buttons-occur.md
@@ -2,4 +2,4 @@
 "vercel": minor
 ---
 
-Add guidance flag for deploy command
+Add guidance flag for deploy and env commands

--- a/.changeset/swift-buttons-occur.md
+++ b/.changeset/swift-buttons-occur.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+Add guidance flag for deploy command

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -119,6 +119,13 @@ export const deployCommand = {
       description: 'Print the build logs',
     },
     {
+      name: 'guidance',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Receive command suggestions once deployment is complete',
+    },
+    {
       name: 'no-logs',
       shorthand: null,
       type: Boolean,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -105,6 +105,7 @@ export default async (client: Client): Promise<number> => {
     telemetryClient.trackCliFlagPublic(parsedArguments.flags['--public']);
     telemetryClient.trackCliFlagLogs(parsedArguments.flags['--logs']);
     telemetryClient.trackCliFlagNoLogs(parsedArguments.flags['--no-logs']);
+    telemetryClient.trackCliFlagGuidance(parsedArguments.flags['--guidance']);
     telemetryClient.trackCliFlagForce(parsedArguments.flags['--force']);
     telemetryClient.trackCliFlagWithCache(
       parsedArguments.flags['--with-cache']

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -711,7 +711,12 @@ export default async (client: Client): Promise<number> => {
     return 1;
   }
 
-  return printDeploymentStatus(deployment, deployStamp, noWait);
+  return printDeploymentStatus(
+    deployment,
+    deployStamp,
+    noWait,
+    parsedArguments.flags['--guidance'] ?? false
+  );
 };
 
 function handleCreateDeployError(error: Error, localConfig: VercelConfig) {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -70,6 +70,7 @@ import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
 import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 import { displayBuildLogs } from '../../util/logs';
+import { determineAgent } from '@vercel/detect-agent';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({
@@ -711,12 +712,9 @@ export default async (client: Client): Promise<number> => {
     return 1;
   }
 
-  return printDeploymentStatus(
-    deployment,
-    deployStamp,
-    noWait,
-    parsedArguments.flags['--guidance'] ?? false
-  );
+  const guidanceMode =
+    parsedArguments.flags['--guidance'] ?? (await determineAgent()) !== false;
+  return printDeploymentStatus(deployment, deployStamp, noWait, guidanceMode);
 };
 
 function handleCreateDeployError(error: Error, localConfig: VercelConfig) {

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -21,6 +21,8 @@ import { getFlagsSpecification } from '../../util/get-flags-specification';
 import { printError } from '../../util/error';
 import { addSubcommand } from './command';
 import { getLinkedProject } from '../../util/projects/link';
+import { determineAgent } from '@vercel/detect-agent';
+import { suggestNextCommands } from '../../util/suggest-next-commands';
 
 export default async function add(client: Client, argv: string[]) {
   let parsedArgs;
@@ -48,6 +50,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
+  telemetryClient.trackCliFlagGuidance(opts['--guidance']);
 
   if (args.length > 3) {
     output.error(
@@ -201,6 +204,13 @@ export default async function add(client: Client, argv: string[]) {
       emoji('success')
     )}\n`
   );
+
+  const guidanceMode =
+    parsedArgs.flags['--guidance'] ?? (await determineAgent()) !== false;
+
+  if (guidanceMode) {
+    suggestNextCommands([getCommandName(`env ls`), getCommandName(`env pull`)]);
+  }
 
   return 0;
 }

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -18,7 +18,15 @@ export const listSubcommand = {
       required: false,
     },
   ],
-  options: [],
+  options: [
+    {
+      name: 'guidance',
+      description: 'Receive command suggestions once command is complete',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+  ],
   examples: [],
 } as const;
 
@@ -48,6 +56,13 @@ export const addSubcommand = {
       ...forceOption,
       description: 'Force overwrites when a command would normally fail',
       shorthand: null,
+    },
+    {
+      name: 'guidance',
+      description: 'Receive command suggestions once command is complete',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
     },
   ],
   examples: [

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -99,7 +99,11 @@ export default async function ls(client: Client, argv: string[]) {
   const guidanceMode =
     parsedArgs.flags['--guidance'] ?? (await determineAgent()) !== false;
   if (guidanceMode) {
-    suggestNextCommands([getCommandName(`env ls`), getCommandName(`env pull`)]);
+    suggestNextCommands([
+      getCommandName(`env add`),
+      getCommandName('env rm'),
+      getCommandName(`env pull`),
+    ]);
   }
 
   return 0;

--- a/packages/cli/src/commands/env/ls.ts
+++ b/packages/cli/src/commands/env/ls.ts
@@ -40,7 +40,7 @@ export default async function ls(client: Client, argv: string[]) {
     printError(err);
     return 1;
   }
-  const { args } = parsedArgs;
+  const { args, flags } = parsedArgs;
 
   if (args.length > 2) {
     output.error(
@@ -51,10 +51,10 @@ export default async function ls(client: Client, argv: string[]) {
     return 1;
   }
 
-  const [envTarget, envGitBranch, guidance] = args;
+  const [envTarget, envGitBranch] = args;
   telemetryClient.trackCliArgumentEnvironment(envTarget);
   telemetryClient.trackCliArgumentGitBranch(envGitBranch);
-  telemetryClient.trackCliFlagGuidance(Boolean(guidance));
+  telemetryClient.trackCliFlagGuidance(flags['--guidance']);
 
   const link = await getLinkedProject(client);
   if (link.status === 'error') {

--- a/packages/cli/src/commands/redeploy/index.ts
+++ b/packages/cli/src/commands/redeploy/index.ts
@@ -251,7 +251,7 @@ export default async function redeploy(client: Client): Promise<number> {
       }
     }
 
-    return printDeploymentStatus(deployment, deployStamp, noWait);
+    return printDeploymentStatus(deployment, deployStamp, noWait, false);
   } catch (err: unknown) {
     output.prettyError(err);
     if (isErrnoException(err) && err.code === 'ERR_INVALID_TEAM') {

--- a/packages/cli/src/util/deploy/print-deployment-status.ts
+++ b/packages/cli/src/util/deploy/print-deployment-status.ts
@@ -6,6 +6,7 @@ import linkStyle from '../output/link';
 import { prependEmoji, emoji } from '../../util/emoji';
 import output from '../../output-manager';
 import { getCommandName } from '../pkg-name';
+import { suggestNextCommands } from '../suggest-next-commands';
 
 /**
  * Prints (to `output`) warnings and errors, if any.
@@ -101,16 +102,4 @@ export async function printDeploymentStatus(
   }
 
   return 0;
-}
-
-function suggestNextCommands(commands: string[]) {
-  output.print(
-    chalk.dim(
-      [
-        `Common next commands:`,
-        ...commands.map(command => `- ${command}`),
-      ].join('\n')
-    )
-  );
-  output.print('\n');
 }

--- a/packages/cli/src/util/deploy/print-deployment-status.ts
+++ b/packages/cli/src/util/deploy/print-deployment-status.ts
@@ -5,6 +5,7 @@ import { isDeploying } from '../../util/deploy/is-deploying';
 import linkStyle from '../output/link';
 import { prependEmoji, emoji } from '../../util/emoji';
 import output from '../../output-manager';
+import { getCommandName } from '../pkg-name';
 
 /**
  * Prints (to `output`) warnings and errors, if any.
@@ -15,6 +16,8 @@ export async function printDeploymentStatus(
     aliasError,
     indications,
     aliasWarning,
+    url,
+    target,
   }: {
     readyState: Deployment['readyState'];
     alias: string[];
@@ -30,7 +33,8 @@ export async function printDeploymentStatus(
     };
   },
   deployStamp: () => string,
-  noWait: boolean
+  noWait: boolean,
+  guidanceMode: boolean
 ): Promise<number> {
   indications = indications || [];
 
@@ -85,5 +89,28 @@ export async function printDeploymentStatus(
     output.print(message + link);
   }
 
+  if (guidanceMode) {
+    output.print('\n');
+    suggestNextCommands(
+      [
+        getCommandName(`inspect ${url} --logs`),
+        getCommandName(`redeploy ${url}`),
+        target !== 'production' ? getCommandName(`deploy --prod`) : false,
+      ].filter(Boolean) as string[]
+    );
+  }
+
   return 0;
+}
+
+function suggestNextCommands(commands: string[]) {
+  output.print(
+    chalk.dim(
+      [
+        `Common next commands:`,
+        ...commands.map(command => `- ${command}`),
+      ].join('\n')
+    )
+  );
+  output.print('\n');
 }

--- a/packages/cli/src/util/suggest-next-commands.ts
+++ b/packages/cli/src/util/suggest-next-commands.ts
@@ -1,0 +1,14 @@
+import output from '../output-manager';
+import chalk from 'chalk';
+
+export function suggestNextCommands(commands: string[]) {
+  output.print(
+    chalk.dim(
+      [
+        `Common next commands:`,
+        ...commands.map(command => `- ${command}`),
+      ].join('\n')
+    )
+  );
+  output.print('\n');
+}

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -99,6 +99,11 @@ export class DeployTelemetryClient
       this.trackCliFlag('no-logs');
     }
   }
+  trackCliFlagGuidance(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('guidance');
+    }
+  }
   trackCliFlagNoClipboard(flag: boolean | undefined) {
     if (flag) {
       this.trackCliFlag('no-clipboard');

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -50,4 +50,10 @@ export class EnvAddTelemetryClient
       this.trackCliFlag('force');
     }
   }
+
+  trackCliFlagGuidance(guidance: boolean | undefined) {
+    if (guidance) {
+      this.trackCliFlag('guidance');
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/env/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/env/ls.ts
@@ -29,4 +29,10 @@ export class EnvLsTelemetryClient
       });
     }
   }
+
+  trackCliFlagGuidance(guidance: boolean | undefined) {
+    if (guidance) {
+      this.trackCliFlag('guidance');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1796,6 +1796,7 @@ exports[`help command > env help output snapshots > env add help output snapshot
   Options:
 
    --force      Force overwrites when a command would normally fail                                                      
+   --guidance   Receive command suggestions once command is complete                                                     
    --sensitive  Add a sensitive Environment Variable                                                                     
 
 
@@ -2002,9 +2003,14 @@ exports[`help command > env help output snapshots > env help column width 120 1`
 
 exports[`help command > env help output snapshots > env list help output snapshots > env list help column width 120 1`] = `
 "
-  ▲ vercel env list [environment] [git-branch]
+  ▲ vercel env list [environment] [git-branch] [options]
 
   List all Environment Variables for a Project                                                                          
+
+  Options:
+
+   --guidance  Receive command suggestions once command is complete                                                      
+
 
   Global Options:
 

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -753,6 +753,13 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 nothing 
                                 has     
                                 changed 
+       --guidance               Receive 
+                                command 
+                                suggest…
+                                once    
+                                deploym…
+                                is      
+                                complete
   -l,  --logs                   Print   
                                 the     
                                 build   
@@ -921,6 +928,8 @@ exports[`help command > deploy help output snapshots > deploy help column width 
                                 (e.g. \`-e KEY1=value1 -e KEY2=value2\`)          
   -f,  --force                  Force a new deployment even if nothing has      
                                 changed                                         
+       --guidance               Receive command suggestions once deployment is  
+                                complete                                        
   -l,  --logs                   Print the build logs                            
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m   
                                 KEY1=value1 -m KEY2=value2\`)                    
@@ -993,6 +1002,7 @@ exports[`help command > deploy help output snapshots > deploy help column width 
   -b,  --build-env <KEY=VALUE>  Specify environment variables during build-time (e.g. \`-b KEY1=value1 -b KEY2=value2\`)  
   -e,  --env <KEY=VALUE>        Specify environment variables during run-time (e.g. \`-e KEY1=value1 -e KEY2=value2\`)    
   -f,  --force                  Force a new deployment even if nothing has changed                                      
+       --guidance               Receive command suggestions once deployment is complete                                 
   -l,  --logs                   Print the build logs                                                                    
   -m,  --meta <KEY=VALUE>       Specify metadata for the deployment (e.g. \`-m KEY1=value1 -m KEY2=value2\`)              
        --no-wait                Don't wait for the deployment to finish                                                 

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1109,6 +1109,16 @@ describe('deploy', () => {
         { key: 'flag:logs', value: 'TRUE' },
       ]);
     });
+    it('--guidance', async () => {
+      client.cwd = setupUnitFixture('commands/deploy/static');
+      client.setArgv('deploy', '--guidance');
+      const exitCode = await deploy(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'flag:guidance', value: 'TRUE' },
+      ]);
+    });
     it('--name', async () => {
       client.cwd = setupUnitFixture('commands/deploy/static');
       client.setArgv('deploy', '--name', 'okok');

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -53,6 +53,24 @@ describe('env add', () => {
     });
   });
 
+  describe('--guidance', () => {
+    it('tracks telemetry', async () => {
+      const command = 'env';
+      const subcommand = 'ls';
+
+      client.setArgv(command, subcommand, '--guidance');
+      const exitCodePromise = env(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:guidance',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
   describe('[name]', () => {
     describe('--sensitive', () => {
       it('tracks flag', async () => {

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -56,7 +56,7 @@ describe('env add', () => {
   describe('--guidance', () => {
     it('tracks telemetry', async () => {
       const command = 'env';
-      const subcommand = 'ls';
+      const subcommand = 'add';
 
       client.setArgv(command, subcommand, '--guidance');
       const exitCodePromise = env(client);

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -64,9 +64,10 @@ describe('env add', () => {
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          key: 'flag:guidance',
-          value: `${command}:${subcommand}`,
+          key: `subcommand:add`,
+          value: 'add',
         },
+        { key: 'flag:guidance', value: `TRUE` },
       ]);
     });
   });

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -53,25 +53,6 @@ describe('env add', () => {
     });
   });
 
-  describe('--guidance', () => {
-    it('tracks telemetry', async () => {
-      const command = 'env';
-      const subcommand = 'add';
-
-      client.setArgv(command, subcommand, '--guidance');
-      const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(0);
-
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        {
-          key: `subcommand:add`,
-          value: 'add',
-        },
-        { key: 'flag:guidance', value: `TRUE` },
-      ]);
-    });
-  });
-
   describe('[name]', () => {
     describe('--sensitive', () => {
       it('tracks flag', async () => {
@@ -148,6 +129,51 @@ describe('env add', () => {
           },
           {
             key: `flag:force`,
+            value: 'TRUE',
+          },
+        ]);
+      });
+    });
+
+    describe('--guidance', () => {
+      it('tracks telemetry', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'FORCE_FLAG',
+          'preview',
+          'branchName',
+          '--force',
+          '--guidance'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: `subcommand:add`,
+            value: 'add',
+          },
+          {
+            key: `argument:name`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:environment`,
+            value: 'preview',
+          },
+          {
+            key: `argument:git-branch`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `flag:force`,
+            value: 'TRUE',
+          },
+          {
+            key: `flag:guidance`,
             value: 'TRUE',
           },
         ]);

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -60,7 +60,7 @@ describe('env add', () => {
 
       client.setArgv(command, subcommand, '--guidance');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -62,6 +62,24 @@ describe('env ls', () => {
     });
   });
 
+  describe('--guidance', () => {
+    it('tracks telemetry', async () => {
+      const command = 'env';
+      const subcommand = 'ls';
+
+      client.setArgv(command, subcommand, '--guidance');
+      const exitCodePromise = env(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:guidance',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
   describe('[environment]', () => {
     it('tracks `environment` argument', async () => {
       client.setArgv('env', 'ls', 'production');

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -73,9 +73,10 @@ describe('env ls', () => {
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          key: 'flag:guidance',
-          value: `${command}:${subcommand}`,
+          key: 'subcommand:ls',
+          value: 'ls',
         },
+        { key: 'flag:guidance', value: 'TRUE' },
       ]);
     });
   });

--- a/packages/cli/test/unit/commands/env/ls.test.ts
+++ b/packages/cli/test/unit/commands/env/ls.test.ts
@@ -69,7 +69,7 @@ describe('env ls', () => {
 
       client.setArgv(command, subcommand, '--guidance');
       const exitCodePromise = env(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
+      await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {


### PR DESCRIPTION
Follow up to https://github.com/vercel/vercel/pull/13896 that also adds `--guidance` to `vercel env add` and `vercel env ls`.