### PR TITLE
[cli] Fix vc deploy to show full build logs on build error

### DIFF
--- a/.changeset/few-cougars-worry.md
+++ b/.changeset/few-cougars-worry.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix build errored deployments to always show full build logs

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -22,7 +22,6 @@ import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
 import getPrebuiltJson from '../../util/deploy/get-prebuilt-json';
-import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
 import { isValidArchive } from '../../util/deploy/validate-archive-format';
 import purchaseDomainIfAvailable from '../../util/domains/purchase-domain-if-available';
 import { emoji, prependEmoji } from '../../util/emoji';
@@ -70,7 +69,6 @@ import output from '../../output-manager';
 import { ensureLink } from '../../util/link/ensure-link';
 import { UploadErrorMissingArchive } from '../../util/deploy/process-deployment';
 import { displayBuildLogsUntilFinalError } from '../../util/logs';
-import { determineAgent } from '@vercel/detect-agent';
 
 export default async (client: Client): Promise<number> => {
   const telemetryClient = new DeployTelemetryClient({

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -22,6 +22,7 @@ import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
 import getPrebuiltJson from '../../util/deploy/get-prebuilt-json';
+import { printDeploymentStatus } from '../../util/deploy/print-deployment-status';
 import { isValidArchive } from '../../util/deploy/validate-archive-format';
 import purchaseDomainIfAvailable from '../../util/domains/purchase-domain-if-available';
 import { emoji, prependEmoji } from '../../util/emoji';
@@ -706,6 +707,8 @@ export default async (client: Client): Promise<number> => {
     printError(err);
     return 1;
   }
+
+  return printDeploymentStatus(deployment, deployStamp, noWait);
 };
 
 function handleCreateDeployError(error: Error, localConfig: VercelConfig) {

--- a/packages/cli/src/util/logs.ts
+++ b/packages/cli/src/util/logs.ts
@@ -35,6 +35,30 @@ export function displayBuildLogs(
   return { promise, abortController };
 }
 
+export async function displayBuildLogsUntilFinalError(
+  client: Client,
+  deployment: Deployment,
+  error: string
+) {
+  const abortController = new AbortController();
+  return printEvents(
+    client,
+    deployment.id,
+    {
+      mode: 'logs',
+      onEvent: (event: BuildLog) => {
+        printBuildLog(event, output.print);
+        if (event.level === 'error' && event.text?.includes(error)) {
+          abortController.abort();
+        }
+      },
+      quiet: false,
+      findOpts: { direction: 'forward', follow: true },
+    },
+    abortController
+  );
+}
+
 export interface DisplayRuntimeLogsOptions {
   projectId?: string;
   deploymentId: string;


### PR DESCRIPTION
This fixes a bug where sometimes the `vc deploy` with build errors do not return the full logs: https://linear.app/vercel/issue/FLOW-3934/vercel-deploy-builds-logs-do-not-contain-full-build-logs

We receive the build error before the logs are ready to grab. Ideally, we'd want some general way to know when logs are done, but in this case we know what the last log line will be, so we can watch the logs until we see that.