### PR TITLE
fix(python): Avoid uploading pycache

### DIFF
--- a/.changeset/tidy-lobsters-repair.md
+++ b/.changeset/tidy-lobsters-repair.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+fix(python): Avoid uploading pycache

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -201,6 +201,9 @@ export const build: BuildV3 = async ({
     '**/node_modules/**',
     '**/.next/**',
     '**/.nuxt/**',
+    '**/.venv/**',
+    '**/venv/**',
+    '**/__pycache__/**',
   ];
 
   const globOptions: GlobOptions = {

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -69,6 +69,7 @@ async function pipInstall(pipPath: string, workPath: string, args: string[]) {
   const cmdArgs = [
     'install',
     '--disable-pip-version-check',
+    '--no-compile',
     '--target',
     target,
     ...args,


### PR DESCRIPTION
__pycache__ directories should not be uploaded. This alone significantly decreases the size of heavy dependencies: pandas ~67MB -> 34MB , numpy ~34 -> 21MB, django ~30 -> 23MB, transformers ~105 -> 55MB

**Testing:**
Django app imports transformers, pandas, numpy, django (deploys successfully)
https://test-python-heavy-deps-aniepebl4-ricardogonzalez-7180s-projects.vercel.app/start/

**Prev:** max lambda size error