### PR TITLE
[examples] remove unused `tsx` from hono example

### DIFF
--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -6,7 +6,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
-    "tsx": "^4.7.1",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/vercel/vercel/pull/13622/files#r2337737996

This removes the `tsx` dependency from the Hono example since its unused.