### PR TITLE
[python]: don't cache python dependencies yet

### DIFF
--- a/.changeset/fluffy-ears-burn.md
+++ b/.changeset/fluffy-ears-burn.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+[python]: move python packages vendor dir out of /cache

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -244,7 +244,6 @@ export const build: BuildV3 = async ({
   const vendorBaseDir = join(
     workPath,
     '.vercel',
-    'cache',
     'python',
     `py${pythonVersion.version}`,
     entryDirectory


### PR DESCRIPTION
Need to add cache invalidation on requirements/Pipfile changes before we can cache the dependencies vendor dir. Moving base vendor dir out of .vercel/cache