### PR TITLE
fix(next): ensure segment route suffixes are captured correctly in dynamic routes

### DIFF
--- a/.changeset/neat-tigers-vanish.md
+++ b/.changeset/neat-tigers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix segment route suffix capture in dynamic routes to ensure .segments/.+\.segment\.rsc routes are properly rewritten

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -592,14 +592,15 @@ export async function getDynamicRoutes({
             routes.push({
               src: route.src.replace(
                 new RegExp(escapeStringRegexp('(?:/)?$')),
+                // Now than the upstream issues has been resolved, we can safely
+                // add the suffix back, this resolves a bug related to segment
+                // rewrites not capturing the correct suffix values when
+                // enabled.
                 shouldSkipSuffixes
-                  ? '\\.rsc(?:/)?$'
+                  ? '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
                   : '(?<rscSuffix>\\.rsc|\\.prefetch\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
               ),
-              dest: route.dest?.replace(
-                /($|\?)/,
-                shouldSkipSuffixes ? '.rsc$1' : '$rscSuffix$1'
-              ),
+              dest: route.dest?.replace(/($|\?)/, '$rscSuffix$1'),
               check: true,
               override: true,
             });


### PR DESCRIPTION
## What?

Fixes a bug where segment routes with `.segments/.+\.segment\.rsc` suffixes were not being properly captured in dynamic route rewrites.

## Why?

Previously, the regex pattern for capturing RSC suffixes in dynamic routes only handled regular `.rsc` and `.prefetch.rsc` patterns. Segment-specific routes (`.segments/.+\.segment\.rsc`) were not being captured, causing incorrect rewrite destinations and routing issues.

## How?

Updated the regex pattern in `packages/next/src/utils.ts` to include segment-specific suffixes in the `rscSuffix` capture group:

- When `shouldSkipSuffixes` is true: `(?<rscSuffix>\.rsc|\.segments/.+\.segment\.rsc)`
- When `shouldSkipSuffixes` is false: `(?<rscSuffix>\.rsc|\.prefetch\.rsc|\.segments/.+\.segment\.rsc)`

The destination replacement continues to use `$rscSuffix$1` to properly substitute the captured suffix.

[NAR-398](https://linear.app/vercel/issue/NAR-398)