### PR TITLE
Fix typescript dep

### DIFF
--- a/.changeset/nine-lizards-relax.md
+++ b/.changeset/nine-lizards-relax.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix typescript dependency

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -175,6 +175,7 @@
     "tmp-promise": "1.0.3",
     "tree-kill": "1.2.2",
     "ts-node": "10.9.1",
+    "typescript": "4.9.5",
     "utility-types": "2.1.0",
     "vite": "^5.1.6",
     "vitest": "^2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,7 +750,10 @@ importers:
         version: 1.2.2
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@5.7.3)
+        version: 10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@4.9.5)
+      typescript:
+        specifier: 4.9.5
+        version: 4.9.5
       utility-types:
         specifier: 2.1.0
         version: 2.1.0
@@ -1497,7 +1500,7 @@ importers:
         version: 12.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@5.7.3)
+        version: 10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@4.9.5)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -16809,7 +16812,7 @@ packages:
       code-block-writer: 10.1.1
     dev: false
 
-  /ts-node@10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@5.7.3):
+  /ts-node@10.9.1(@swc/core@1.2.218)(@types/node@18.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -16836,7 +16839,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.7.3
+      typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -17170,6 +17173,7 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}


### PR DESCRIPTION
https://github.com/vercel/vercel/pull/9858 removed `typescript` from the CLI package, I think that was an oversight at the time. Until now, it's been fine because the top-level package.json still has 4.9.5. However, recently some peer deps on typescript caused version 5.7.3 to be hoisted by pnpm, resulting in calls to `pnpm tsc -v` to use 4.9.5, resulting in [breaking types](https://github.com/vercel/vercel/actions/runs/17773681536/job/50515964558?pr=13943)