### PR TITLE
Add support for inlclude/exclude files config from vercel.json

### DIFF
--- a/.changeset/two-phones-promise.md
+++ b/.changeset/two-phones-promise.md
@@ -1,0 +1,6 @@
+---
+'@vercel/fs-detectors': patch
+'@vercel/node': patch
+---
+
+Add support for inlclude/exclude files config from vercel.json

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -721,6 +721,30 @@ function checkUnusedFunctions(
       }
     }
   }
+  if (
+    frontendBuilder &&
+    (isOfficialRuntime('express', frontendBuilder.use) ||
+      isOfficialRuntime('hono', frontendBuilder.use))
+  ) {
+    // Copied from builder entrypoint detection
+    const validFilenames = [
+      'app',
+      'index',
+      'server',
+      'src/app',
+      'src/index',
+      'src/server',
+    ];
+    const validExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
+    const validEntrypoints = validFilenames.flatMap(filename =>
+      validExtensions.map(extension => `${filename}.${extension}`)
+    );
+    for (const fnKey of unusedFunctions.values()) {
+      if (validEntrypoints.includes(fnKey)) {
+        unusedFunctions.delete(fnKey);
+      }
+    }
+  }
 
   if (unusedFunctions.size) {
     const [fnKey] = Array.from(unusedFunctions);

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -477,7 +477,22 @@ export const build = async ({
     );
   }
   if (entrypointCallback) {
-    entrypointPath = join(entrypointFsDirname, await entrypointCallback());
+    const entrypoint = await entrypointCallback();
+    entrypointPath = join(entrypointFsDirname, entrypoint);
+    const functionConfig = config.functions?.[entrypoint];
+    if (functionConfig) {
+      const normalizeArray = (value: any) =>
+        Array.isArray(value) ? value : value ? [value] : [];
+
+      config.includeFiles = [
+        ...normalizeArray(config.includeFiles),
+        ...normalizeArray(functionConfig.includeFiles),
+      ];
+      config.excludeFiles = [
+        ...normalizeArray(config.excludeFiles),
+        ...normalizeArray(functionConfig.excludeFiles),
+      ];
+    }
   }
 
   const isMiddleware = config.middleware === true;


### PR DESCRIPTION
This adds function config for exclude and include files settings, other function configs like region and max duration haven't actually been supported for the node builder so adding that next.
```
// vercel.json
{
  "functions": {
     "server.ts": { "includeFiles": "views/**/*" }
  }
}
```