### PR TITLE
Add experimental support for standalone mode for builds

### DIFF
--- a/.changeset/real-socks-marry.md
+++ b/.changeset/real-socks-marry.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add support for --experimentalStandalone build flag

--- a/.changeset/real-socks-marry.md
+++ b/.changeset/real-socks-marry.md
@@ -2,4 +2,4 @@
 "vercel": patch
 ---
 
-Add support for --experimentalStandalone build flag
+Add support for VERCEL_EXPERIMENTAL_STANDALONE_BUILD build env

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -35,6 +35,14 @@ export const buildCommand = {
       description:
         'Skip the confirmation prompt about pulling environment variables and project settings when not found locally',
     },
+    {
+      name: 'standalone',
+      description:
+        'Create a standalone build with all dependencies inlined into function output folders',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
   ],
   examples: [
     {

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -35,14 +35,15 @@ export const buildCommand = {
       description:
         'Skip the confirmation prompt about pulling environment variables and project settings when not found locally',
     },
-    {
-      name: 'experimentalStandalone',
-      description:
-        'Create a standalone build with all dependencies inlined into function output folders',
-      shorthand: null,
-      type: Boolean,
-      deprecated: false,
-    },
+    // FIXME: standalone:replace env var with flag
+    // {
+    //   name: 'experimentalStandalone',
+    //   description:
+    //     'Create a standalone build with all dependencies inlined into function output folders',
+    //   shorthand: null,
+    //   type: Boolean,
+    //   deprecated: false,
+    // },
   ],
   examples: [
     {

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -36,7 +36,7 @@ export const buildCommand = {
         'Skip the confirmation prompt about pulling environment variables and project settings when not found locally',
     },
     {
-      name: 'standalone',
+      name: 'experimentalStandalone',
       description:
         'Create a standalone build with all dependencies inlined into function output folders',
       shorthand: null,

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -171,6 +171,9 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliOptionTarget(parsedArgs.flags['--target']);
     telemetryClient.trackCliFlagProd(parsedArgs.flags['--prod']);
     telemetryClient.trackCliFlagYes(parsedArgs.flags['--yes']);
+    telemetryClient.trackCliFlagStandalone(
+      (parsedArgs.flags as any)['--standalone']
+    );
   } catch (error) {
     printError(error);
     return 1;
@@ -190,6 +193,7 @@ export default async function main(client: Client): Promise<number> {
     }) || 'preview';
 
   const yes = Boolean(parsedArgs.flags['--yes']);
+  const standalone = Boolean((parsedArgs.flags as any)['--standalone']);
 
   try {
     await validateNpmrc(cwd);
@@ -323,7 +327,7 @@ export default async function main(client: Client): Promise<number> {
       await rootSpan
         .child('vc.doBuild')
         .trace(span =>
-          doBuild(client, project, buildsJson, cwd, outputDir, span)
+          doBuild(client, project, buildsJson, cwd, outputDir, span, standalone)
         );
     } finally {
       await rootSpan.stop();
@@ -375,7 +379,8 @@ async function doBuild(
   buildsJson: BuildsManifest,
   cwd: string,
   outputDir: string,
-  span: Span
+  span: Span,
+  standalone: boolean = false
 ): Promise<void> {
   const { localConfigPath } = client;
 
@@ -695,7 +700,8 @@ async function doBuild(
               build,
               builder,
               builderPkg,
-              localConfig
+              localConfig,
+              standalone
             )
           )
           .then(

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -172,7 +172,7 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliFlagProd(parsedArgs.flags['--prod']);
     telemetryClient.trackCliFlagYes(parsedArgs.flags['--yes']);
     telemetryClient.trackCliFlagStandalone(
-      (parsedArgs.flags as any)['--standalone']
+      (parsedArgs.flags as any)['--experimentalStandalone']
     );
   } catch (error) {
     printError(error);
@@ -193,7 +193,9 @@ export default async function main(client: Client): Promise<number> {
     }) || 'preview';
 
   const yes = Boolean(parsedArgs.flags['--yes']);
-  const standalone = Boolean((parsedArgs.flags as any)['--standalone']);
+  const standalone = Boolean(
+    (parsedArgs.flags as any)['--experimentalStandalone']
+  );
 
   try {
     await validateNpmrc(cwd);

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -171,9 +171,9 @@ export default async function main(client: Client): Promise<number> {
     telemetryClient.trackCliOptionTarget(parsedArgs.flags['--target']);
     telemetryClient.trackCliFlagProd(parsedArgs.flags['--prod']);
     telemetryClient.trackCliFlagYes(parsedArgs.flags['--yes']);
-    telemetryClient.trackCliFlagStandalone(
-      (parsedArgs.flags as any)['--experimentalStandalone']
-    );
+    // telemetryClient.trackCliFlagStandalone(
+    //   (parsedArgs.flags as any)['--experimentalStandalone']
+    // );
   } catch (error) {
     printError(error);
     return 1;
@@ -193,9 +193,11 @@ export default async function main(client: Client): Promise<number> {
     }) || 'preview';
 
   const yes = Boolean(parsedArgs.flags['--yes']);
-  const standalone = Boolean(
-    (parsedArgs.flags as any)['--experimentalStandalone']
-  );
+  // FIXME: standalone:replace env var with flag
+  // const standalone = Boolean(
+  //   (parsedArgs.flags as any)['--experimentalStandalone']
+  // );
+  const standalone = process.env.VERCEL_EXPERIMENTAL_STANDALONE_BUILD === '1';
 
   try {
     await validateNpmrc(cwd);

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -27,7 +27,6 @@ import {
   type BuildResultBuildOutput,
   getLambdaOptionsFromFunction,
   normalizePath,
-  FileBlob,
   type TriggerEvent,
 } from '@vercel/build-utils';
 import pipe from 'promisepipe';
@@ -633,23 +632,11 @@ export async function filesWithoutFsRefs(
   let filePathMap: Record<string, string> | undefined;
   const out: Files = {};
   for (const [path, file] of Object.entries(files)) {
-    if (file.type === 'FileFsRef') {
-      if (standalone) {
-        const stat = await fs.stat(file.fsPath);
-        if (stat.isFile()) {
-          const fileContent = await fs.readFile(file.fsPath);
-          out[path] = new FileBlob({
-            data: fileContent,
-            mode: file.mode,
-            contentType: file.contentType,
-          });
-        }
-      } else {
-        if (!filePathMap) filePathMap = {};
-        filePathMap[normalizePath(path)] = normalizePath(
-          relative(repoRootPath, file.fsPath)
-        );
-      }
+    if (file.type === 'FileFsRef' && !standalone) {
+      if (!filePathMap) filePathMap = {};
+      filePathMap[normalizePath(path)] = normalizePath(
+        relative(repoRootPath, file.fsPath)
+      );
     } else {
       out[path] = file;
     }

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -483,7 +483,7 @@ async function writeLambda(
   let filePathMap: Record<string, string> | undefined;
   if (lambda.files) {
     // `files` is defined
-    const f = await filesWithoutFsRefs(lambda.files, repoRootPath, standalone);
+    const f = filesWithoutFsRefs(lambda.files, repoRootPath, standalone);
     filePathMap = f.filePathMap;
     ops.push(download(f.files, dest));
   } else if (lambda.zipBuffer) {
@@ -628,7 +628,7 @@ export function filesWithoutFsRefs(
   files: Files,
   repoRootPath: string,
   standalone: boolean = false
-): Promise<{ files: Files; filePathMap?: Record<string, string> }> {
+): { files: Files; filePathMap?: Record<string, string> } {
   let filePathMap: Record<string, string> | undefined;
   const out: Files = {};
   for (const [path, file] of Object.entries(files)) {

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -425,7 +425,7 @@ async function writeEdgeFunction(
 
   await fs.mkdirp(dest);
   const ops: Promise<any>[] = [];
-  const { files, filePathMap } = await filesWithoutFsRefs(
+  const { files, filePathMap } = filesWithoutFsRefs(
     edgeFunction.files,
     repoRootPath,
     standalone
@@ -624,7 +624,7 @@ export async function* findDirs(
  * and returns them in a JSON serializable map of repo root
  * relative paths to Lambda destination paths.
  */
-export async function filesWithoutFsRefs(
+export function filesWithoutFsRefs(
   files: Files,
   repoRootPath: string,
   standalone: boolean = false

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -27,6 +27,7 @@ import {
   type BuildResultBuildOutput,
   getLambdaOptionsFromFunction,
   normalizePath,
+  FileBlob,
   type TriggerEvent,
 } from '@vercel/build-utils';
 import pipe from 'promisepipe';
@@ -637,7 +638,6 @@ export async function filesWithoutFsRefs(
         const stat = await fs.stat(file.fsPath);
         if (stat.isFile()) {
           const fileContent = await fs.readFile(file.fsPath);
-          const { FileBlob } = await import('@vercel/build-utils');
           out[path] = new FileBlob({
             data: fileContent,
             mode: file.mode,

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -641,35 +641,28 @@ export async function* findDirs(
 export function filesWithoutFsRefs(
   files: Files,
   repoRootPath: string,
-  sharedDest: string,
-  standalone: boolean = false
+  sharedDest?: string,
+  standalone?: boolean
 ): { files: Files; filePathMap?: Record<string, string>; shared?: Files } {
   let filePathMap: Record<string, string> | undefined;
   const out: Files = {};
   const shared: Files = {};
-  if (standalone) {
-    for (const [path, file] of Object.entries(files)) {
-      if (file.type === 'FileFsRef') {
-        if (!filePathMap) filePathMap = {};
+  for (const [path, file] of Object.entries(files)) {
+    if (file.type === 'FileFsRef') {
+      if (!filePathMap) filePathMap = {};
+      if (standalone && sharedDest) {
         shared[path] = file;
         filePathMap[normalizePath(join(sharedDest, path))] = normalizePath(
           relative(repoRootPath, join(sharedDest, file.fsPath))
         );
       } else {
-        out[path] = file;
+        filePathMap[normalizePath(path)] = normalizePath(
+          relative(repoRootPath, file.fsPath)
+        );
       }
-    }
-    return { files: out, filePathMap, shared };
-  }
-  for (const [path, file] of Object.entries(files)) {
-    if (file.type === 'FileFsRef') {
-      if (!filePathMap) filePathMap = {};
-      filePathMap[normalizePath(path)] = normalizePath(
-        relative(repoRootPath, file.fsPath)
-      );
     } else {
       out[path] = file;
     }
   }
-  return { files: out, filePathMap };
+  return { files: out, filePathMap, shared };
 }

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -634,8 +634,6 @@ export async function filesWithoutFsRefs(
   for (const [path, file] of Object.entries(files)) {
     if (file.type === 'FileFsRef') {
       if (standalone) {
-        // Convert FileFsRef to FileBlob by reading the file content
-        // First check if it's actually a file, not a directory
         const stat = await fs.stat(file.fsPath);
         if (stat.isFile()) {
           const fileContent = await fs.readFile(file.fsPath);
@@ -645,11 +643,6 @@ export async function filesWithoutFsRefs(
             mode: file.mode,
             contentType: file.contentType,
           });
-          // Don't add to filePathMap since the file is now inlined
-        } else {
-          // If it's a directory, keep it as FileFsRef
-          // Don't add to filePathMap since directories can't be inlined
-          // and we don't want to reference external directories in standalone mode
         }
       } else {
         if (!filePathMap) filePathMap = {};

--- a/packages/cli/src/util/telemetry/commands/build/index.ts
+++ b/packages/cli/src/util/telemetry/commands/build/index.ts
@@ -35,4 +35,10 @@ export class BuildTelemetryClient
       this.trackCliFlag('yes');
     }
   }
+
+  trackCliFlagStandalone(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('standalone');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1530,11 +1530,11 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
-  describe('--standalone flag', () => {
-    it('should track telemetry for --standalone flag', async () => {
+  describe('--experimentalStandalone flag', () => {
+    it('should track telemetry for --experimentalStandalone flag', async () => {
       const command = 'build';
 
-      client.setArgv(command, '--standalone', '--help');
+      client.setArgv(command, '--experimentalStandalone', '--help');
       const exitCodePromise = build(client);
       await expect(exitCodePromise).resolves.toEqual(2);
 
@@ -1550,11 +1550,11 @@ describe.skipIf(flakey)('build', () => {
       ]);
     });
 
-    it('should convert FileFsRef to FileBlob when --standalone is used', async () => {
+    it('should convert FileFsRef to FileBlob when --experimentalStandalone is used', async () => {
       const cwd = fixture('node');
       const output = join(cwd, '.vercel/output');
       client.cwd = cwd;
-      client.setArgv('build', '--standalone');
+      client.setArgv('build', '--experimentalStandalone');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
@@ -1590,11 +1590,11 @@ describe.skipIf(flakey)('build', () => {
       }
     });
 
-    it('should work with static builds and --standalone flag', async () => {
+    it('should work with static builds and --experimentalStandalone flag', async () => {
       const cwd = fixture('static');
       const output = join(cwd, '.vercel/output');
       client.cwd = cwd;
-      client.setArgv('build', '--standalone');
+      client.setArgv('build', '--experimentalStandalone');
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1529,4 +1529,92 @@ describe.skipIf(flakey)('build', () => {
       expect(Object.keys(env).includes('VERCEL_ANALYTICS_ID')).toEqual(true);
     });
   });
+
+  describe('--standalone flag', () => {
+    it('should track telemetry for --standalone flag', async () => {
+      const command = 'build';
+
+      client.setArgv(command, '--standalone', '--help');
+      const exitCodePromise = build(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:standalone',
+          value: 'TRUE',
+        },
+        {
+          key: 'flag:help',
+          value: command,
+        },
+      ]);
+    });
+
+    it('should convert FileFsRef to FileBlob when --standalone is used', async () => {
+      const cwd = fixture('node');
+      const output = join(cwd, '.vercel/output');
+      client.cwd = cwd;
+      client.setArgv('build', '--standalone');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      // Check that functions were created
+      const functions = await fs.readdir(join(output, 'functions/api'));
+      expect(functions.sort()).toEqual([
+        'es6.func',
+        'index.func',
+        'mjs.func',
+        'typescript.func',
+      ]);
+
+      // Check that vc-config.json files exist and don't have filePathMap after standalone processing
+      for (const funcDir of functions) {
+        const vcConfigPath = join(
+          output,
+          'functions/api',
+          funcDir,
+          '.vc-config.json'
+        );
+        const vcConfig = await fs.readJSON(vcConfigPath);
+
+        // After standalone processing, filePathMap should be null (no file references)
+        expect(vcConfig.filePathMap).toBeUndefined();
+
+        // Check that the function files are present in the function directory
+        const funcFiles = await fs.readdir(
+          join(output, 'functions/api', funcDir)
+        );
+        expect(funcFiles).toContain('.vc-config.json');
+        // The actual function files should be inlined as FileBlob, so we should see more than just the config
+        expect(funcFiles.length).toBeGreaterThan(1);
+      }
+    });
+
+    it('should work with static builds and --standalone flag', async () => {
+      const cwd = fixture('static');
+      const output = join(cwd, '.vercel/output');
+      client.cwd = cwd;
+      client.setArgv('build', '--standalone');
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      // Static builds should work normally with standalone flag
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds).toMatchObject({
+        target: 'preview',
+        builds: [
+          {
+            require: '@vercel/static',
+            apiVersion: 2,
+            src: '**',
+            use: '@vercel/static',
+          },
+        ],
+      });
+
+      // "static" directory contains static files
+      const files = await fs.readdir(join(output, 'static'));
+      expect(files.sort()).toEqual(['index.html']);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1530,31 +1530,12 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
-  describe('--experimentalStandalone flag', () => {
-    it('should track telemetry for --experimentalStandalone flag', async () => {
-      const command = 'build';
-
-      client.setArgv(command, '--experimentalStandalone', '--help');
-      const exitCodePromise = build(client);
-      await expect(exitCodePromise).resolves.toEqual(2);
-
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        {
-          key: 'flag:standalone',
-          value: 'TRUE',
-        },
-        {
-          key: 'flag:help',
-          value: command,
-        },
-      ]);
-    });
-
-    it('should convert FileFsRef to FileBlob when --experimentalStandalone is used', async () => {
+  describe('VERCEL_EXPERIMENTAL_STANDALONE_BUILD env', () => {
+    it('should convert FileFsRef to FileBlob when VERCEL_EXPERIMENTAL_STANDALONE_BUILD is used', async () => {
       const cwd = fixture('node');
       const output = join(cwd, '.vercel/output');
       client.cwd = cwd;
-      client.setArgv('build', '--experimentalStandalone');
+      process.env.VERCEL_EXPERIMENTAL_STANDALONE_BUILD = '1';
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 
@@ -1590,11 +1571,11 @@ describe.skipIf(flakey)('build', () => {
       }
     });
 
-    it('should work with static builds and --experimentalStandalone flag', async () => {
+    it('should work with static builds and VERCEL_EXPERIMENTAL_STANDALONE_BUILD env', async () => {
       const cwd = fixture('static');
       const output = join(cwd, '.vercel/output');
       client.cwd = cwd;
-      client.setArgv('build', '--experimentalStandalone');
+      process.env.VERCEL_EXPERIMENTAL_STANDALONE_BUILD = '1';
       const exitCode = await build(client);
       expect(exitCode).toEqual(0);
 

--- a/packages/cli/test/unit/util/build/write-build-result.test.ts
+++ b/packages/cli/test/unit/util/build/write-build-result.test.ts
@@ -13,7 +13,10 @@ describe('filesWithoutFsRefs()', () => {
       ...(await glob('**', repoRootPath)),
       'blob-file.txt': new FileBlob({ data: 'blob file' }),
     };
-    const { files, filePathMap = {} } = filesWithoutFsRefs(input, repoRootPath);
+    const { files, filePathMap = {} } = await filesWithoutFsRefs(
+      input,
+      repoRootPath
+    );
 
     // Only the "blob-file.txt" file should be in the `files` object
     expect(Object.keys(files)).toHaveLength(1);


### PR DESCRIPTION
`VERCEL_EXPERIMENTAL_STANDALONE_BUILD` will put file references in `.vercel/output/shared`. This is an experimental feature that should address issues raised [here](https://github.com/vercel/vercel/issues/11097) where separate CI/CD actions that use the `.vercel` folder as an artifact from one container that runs `vc build` to another that runs `vc deploy --prebuilt` will work.

Test with `VERCEL_EXPERIMENTAL_STANDALONE_BUILD=1 vc build` 