### PR TITLE
[client]: Set `prebuilt=1` as a query string argument when prebuilt

### DIFF
--- a/.changeset/wild-ties-repair.md
+++ b/.changeset/wild-ties-repair.md
@@ -1,0 +1,5 @@
+---
+'@vercel/client': major
+---
+
+Set prebuilt in the client options when sending requests to api-deployments

--- a/packages/client/src/utils/query-string.ts
+++ b/packages/client/src/utils/query-string.ts
@@ -22,5 +22,9 @@ export function generateQueryString(
     options.set('skipAutoDetectionConfirmation', '1');
   }
 
+  if (clientOptions.prebuilt) {
+    options.set('prebuilt', '1');
+  }
+
   return Array.from(options.entries()).length ? `?${options.toString()}` : '';
 }


### PR DESCRIPTION
# Overview

Use new `prebuilt` argument to the create-deployment endpoint to signify to api-deployments that we have a prebuilt deployment which doesn't need to run the full user build flow.
