### PR TITLE
fix(cli): handle triggering re-auth with legacy token + flags

### DIFF
--- a/.changeset/dry-mangos-glow.md
+++ b/.changeset/dry-mangos-glow.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+fix(cli): handle triggering re-auth with legacy token + flags
+
+If CLI was using a legacy token (ie. was signed in on a version previous to `48.0.0`) and not having a SAML authorization for a team resource, certain commands failed to initiate the SAML re-authentication flow. This change ensures that the user is prompted to log in again in such cases.

--- a/.changeset/dry-mangos-glow.md
+++ b/.changeset/dry-mangos-glow.md
@@ -4,4 +4,4 @@
 
 fix(cli): handle triggering re-auth with legacy token + flags
 
-If CLI was using a legacy token (ie. was signed in on a version previous to `48.0.0`) and not having a SAML authorization for a team resource, certain commands failed to initiate the SAML re-authentication flow. This change ensures that the user is prompted to log in again in such cases.
+If the CLI was using a legacy token (ie, was signed in on a version previous to 48.0.0) and did not have a SAML authorization for a team resource, commands with flags unknown to vc login failed to initiate the SAML re-authentication flow as we were parsing all arguments. This change ensures that the user is prompted to log in again in such cases.

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -11,11 +11,13 @@ import { login as future } from './future';
 
 export default async function login(
   client: Client,
-  /**
-   * In addition to `vercel login`, this command is also called inline in some cases, to trigger
-   * re-authentication flows. In those cases, we don't want to parse the args.
-   */
-  shouldParseArgs = false
+  options: {
+    /**
+     * In addition to `vercel login`, this command is also called inline in some cases, to trigger
+     * re-authentication flows. In those cases, we don't want to parse the args.
+     */
+    shouldParseArgs: boolean;
+  }
 ): Promise<number> {
   let parsedArgs = null;
 
@@ -29,7 +31,7 @@ export default async function login(
 
   // Parse CLI args
   try {
-    if (shouldParseArgs) {
+    if (options.shouldParseArgs) {
       parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
     }
   } catch (error) {
@@ -48,7 +50,7 @@ export default async function login(
     return 2;
   }
 
-  if (shouldParseArgs && parsedArgs) {
+  if (options.shouldParseArgs && parsedArgs) {
     const obsoleteFlags = Object.keys(parsedArgs.flags).filter(flag => {
       const flagKey = flag.replace('--', '');
       const option = loginCommand.options.find(o => o.name === flagKey);

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -11,8 +11,11 @@ import { login as future } from './future';
 
 export default async function login(
   client: Client,
-  /** Lets skip obsolete option warnings unless called via `vercel login`. */
-  shouldWarnObsoleteOptions = false
+  /**
+   * In addition to `vercel login`, this command is also called inline in some cases, to trigger
+   * re-authentication flows. In those cases, we don't want to parse the args.
+   */
+  shouldParseArgs = false
 ): Promise<number> {
   let parsedArgs = null;
 
@@ -26,24 +29,26 @@ export default async function login(
 
   // Parse CLI args
   try {
-    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+    if (shouldParseArgs) {
+      parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+    }
   } catch (error) {
     printError(error);
     return 1;
   }
 
-  if (parsedArgs.flags['--help']) {
+  if (parsedArgs?.flags['--help']) {
     telemetry.trackCliFlagHelp('login');
     output.print(help(loginCommand, { columns: client.stderr.columns }));
     return 0;
   }
 
-  if (parsedArgs.flags['--token']) {
+  if (parsedArgs?.flags['--token']) {
     output.error('`--token` may not be used with the "login" command');
     return 2;
   }
 
-  if (shouldWarnObsoleteOptions) {
+  if (shouldParseArgs && parsedArgs) {
     const obsoleteFlags = Object.keys(parsedArgs.flags).filter(flag => {
       const flagKey = flag.replace('--', '');
       const option = loginCommand.options.find(o => o.name === flagKey);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -401,7 +401,7 @@ const main = async () => {
     if (isTTY) {
       output.log(`No existing credentials found. Please log in:`);
       try {
-        const result = await login(client);
+        const result = await login(client, { shouldParseArgs: false });
         // The login function failed, so it returned an exit code
         if (result !== 0) return result;
       } catch (error) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -401,7 +401,7 @@ const main = async () => {
     if (isTTY) {
       output.log(`No existing credentials found. Please log in:`);
       try {
-        const result = await login(client, { shouldParseArgs: true });
+        const result = await login(client, { shouldParseArgs: false });
         // The login function failed, so it returned an exit code
         if (result !== 0) return result;
       } catch (error) {
@@ -692,7 +692,8 @@ const main = async () => {
           break;
         case 'login':
           telemetry.trackCliCommandLogin(userSuppliedSubCommand);
-          func = (c: Client) => require('./commands/login').default(c, true);
+          func = (c: Client) =>
+            require('./commands/login').default(c, { shouldParseArgs: true });
           break;
         case 'logout':
           telemetry.trackCliCommandLogout(userSuppliedSubCommand);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -401,7 +401,7 @@ const main = async () => {
     if (isTTY) {
       output.log(`No existing credentials found. Please log in:`);
       try {
-        const result = await login(client, { shouldParseArgs: false });
+        const result = await login(client, { shouldParseArgs: true });
         // The login function failed, so it returned an exit code
         if (result !== 0) return result;
       } catch (error) {

--- a/packages/cli/src/util/login/prompt.ts
+++ b/packages/cli/src/util/login/prompt.ts
@@ -19,7 +19,7 @@ export default async function prompt(
     return await doSamlLogin(client, slug, ssoUserId);
   }
 
-  return await login(client);
+  return await login(client, { shouldParseArgs: false });
 }
 
 async function readInput(client: Client, message: string): Promise<string> {

--- a/packages/cli/src/util/login/saml.ts
+++ b/packages/cli/src/util/login/saml.ts
@@ -12,7 +12,7 @@ export default async function doSamlLogin(
 ) {
   if (!client.authConfig.refreshToken) {
     output.log('Token is outdated, please log in again.');
-    const exitCode = await login(client);
+    const exitCode = await login(client, { shouldParseArgs: false });
     if (exitCode !== 0) return exitCode;
   }
 

--- a/packages/cli/src/util/login/saml.ts
+++ b/packages/cli/src/util/login/saml.ts
@@ -12,7 +12,7 @@ export default async function doSamlLogin(
 ) {
   if (!client.authConfig.refreshToken) {
     output.log('Token is outdated, please log in again.');
-    const exitCode = await login(await client);
+    const exitCode = await login(client);
     if (exitCode !== 0) return exitCode;
   }
 

--- a/packages/cli/test/unit/commands/login/future.test.ts
+++ b/packages/cli/test/unit/commands/login/future.test.ts
@@ -76,7 +76,7 @@ describe('login', () => {
     expect(teamBefore).toBeUndefined();
     const tokenBefore = client.authConfig.token;
 
-    const exitCodePromise = login(client);
+    const exitCodePromise = login(client, { shouldParseArgs: true });
     expect(await exitCodePromise, 'exit code for "login"').toBe(0);
     await expect(client.stderr).toOutput('Congratulations!');
 

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -11,7 +11,7 @@ describe('login', () => {
       const command = 'login';
 
       client.setArgv(command, '--help');
-      const exitCodePromise = login(client, true);
+      const exitCodePromise = login(client, { shouldParseArgs: true });
       await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -25,7 +25,7 @@ describe('login', () => {
 
   it('should not allow the `--token` flag', async () => {
     client.setArgv('login', '--token', 'foo');
-    const exitCodePromise = login(client, true);
+    const exitCodePromise = login(client, { shouldParseArgs: true });
     await expect(client.stderr).toOutput(
       'Error: `--token` may not be used with the "login" command\n'
     );

--- a/packages/cli/test/unit/commands/login/index.test.ts
+++ b/packages/cli/test/unit/commands/login/index.test.ts
@@ -11,7 +11,7 @@ describe('login', () => {
       const command = 'login';
 
       client.setArgv(command, '--help');
-      const exitCodePromise = login(client);
+      const exitCodePromise = login(client, true);
       await expect(exitCodePromise).resolves.toEqual(0);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
@@ -25,7 +25,7 @@ describe('login', () => {
 
   it('should not allow the `--token` flag', async () => {
     client.setArgv('login', '--token', 'foo');
-    const exitCodePromise = login(client);
+    const exitCodePromise = login(client, true);
     await expect(client.stderr).toOutput(
       'Error: `--token` may not be used with the "login" command\n'
     );


### PR DESCRIPTION
If the CLI was using a legacy token (ie, was signed in on a version previous to `48.0.0`) and did not have a SAML authorization for a team resource, commands with flags unknown to `vc login` failed to initiate the SAML re-authentication flow as we were parsing all arguments. This change ensures that the user is prompted to log in again in such cases.