### PR TITLE
Next.js: Upload .next/trace-turbopack and .next/trace-build when it exists

### DIFF
--- a/.changeset/kind-tools-decide.md
+++ b/.changeset/kind-tools-decide.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add diagnostics for .next/trace-turbopack and .next/trace-build

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -2914,9 +2914,19 @@ export const diagnostics: Diagnostics = async ({
       'trace',
       path.join(basePath, diagnosticsEntrypoint, outputDirectory)
     )),
+    // Collect `.next/trace-build` file
+    ...(await glob(
+      'trace-build',
+      path.join(basePath, diagnosticsEntrypoint, outputDirectory)
+    )),
     // Collect `.next/turbopack` file
     ...(await glob(
       'turbopack',
+      path.join(basePath, diagnosticsEntrypoint, outputDirectory)
+    )),
+    // Collect `.next/trace-turbopack` file
+    ...(await glob(
+      'trace-turbopack',
       path.join(basePath, diagnosticsEntrypoint, outputDirectory)
     )),
   };


### PR DESCRIPTION
## What?

Implements uploading of `.next/trace-turbopack` (for digging into traces from Turbopack) and `.next/trace-build` (new file with high level overview: https://github.com/vercel/next.js/pull/83949)