### PR TITLE
Switch `Lambda` to `NodejsLambda`

### DIFF
--- a/.changeset/three-ants-eat.md
+++ b/.changeset/three-ants-eat.md
@@ -1,0 +1,5 @@
+---
+'@vercel/express': patch
+---
+
+Use NodejsLambda instead of Lambda

--- a/packages/express/src/experimental/build.ts
+++ b/packages/express/src/experimental/build.ts
@@ -1,5 +1,5 @@
 export const version = 2;
-import { BuildV2, Lambda } from '@vercel/build-utils';
+import { BuildV2, NodejsLambda } from '@vercel/build-utils';
 import { downloadInstallAndBundle, maybeExecBuildCommand } from './utils';
 import { rolldown } from './rolldown';
 import { entrypointCallback } from './find-entrypoint';
@@ -17,12 +17,18 @@ export const build: BuildV2 = async args => {
 
   const { routes } = await introspectApp(args, rolldownResult);
 
-  const lambda = new Lambda({
+  const lambda = new NodejsLambda({
     runtime: downloadResult.nodeVersion.runtime,
     ...rolldownResult,
+    shouldAddHelpers: false,
+    shouldAddSourcemapSupport: true,
+    framework: {
+      slug: 'express',
+    },
+    awsLambdaHandler: '',
   });
 
-  const output: Record<string, Lambda> = { index: lambda };
+  const output: Record<string, NodejsLambda> = { index: lambda };
   for (const route of routes) {
     if (route.dest) {
       if (route.dest === '/') {


### PR DESCRIPTION
The output from this experimental build isn't being handled properly in the build container. When this code is deployed with `vc deploy --prebuilt` things are working properly. 

This PR makes the output more similar to what the node builder produces, although I don't actually see where the issue is yet.