### PR TITLE
[next-builder] Don't explicitly exit(1) the process on error bubbling  to the root of the handler

### DIFF
--- a/.changeset/shy-olives-wonder.md
+++ b/.changeset/shy-olives-wonder.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': minor
+---
+
+Let global error handlers handle errors that next.js passes up to the function runtime rather than directly exiting the process

--- a/packages/next/src/middleware-launcher.ts
+++ b/packages/next/src/middleware-launcher.ts
@@ -34,44 +34,36 @@ const middlewareModule = require('__NEXT_MIDDLEWARE_PATH__');
 // Returns a wrapped handler that runs with "@next/request-context"
 // and will crash the lambda if an error isn't caught.
 const serve = async (request: Request): Promise<Response> => {
-  try {
-    const context = getVercelRequestContext();
-    return await withNextRequestContext(
-      { waitUntil: context.waitUntil },
-      async () => {
-        // we need to await as it could use top-level await
-        let middlewareHandler = await middlewareModule;
-        middlewareHandler = middlewareHandler.default || middlewareHandler;
+  const context = getVercelRequestContext();
+  return await withNextRequestContext(
+    { waitUntil: context.waitUntil },
+    async () => {
+      // we need to await as it could use top-level await
+      let middlewareHandler = await middlewareModule;
+      middlewareHandler = middlewareHandler.default || middlewareHandler;
 
-        const result = await middlewareHandler({
-          request: {
-            url: request.url,
-            method: request.method,
-            headers: toPlainHeaders(request.headers),
-            nextConfig: conf,
-            page: '/middleware',
-            body:
-              request.method !== 'GET' && request.method !== 'HEAD'
-                ? request.body
-                : undefined,
-            waitUntil: context.waitUntil,
-          },
-        });
+      const result = await middlewareHandler({
+        request: {
+          url: request.url,
+          method: request.method,
+          headers: toPlainHeaders(request.headers),
+          nextConfig: conf,
+          page: '/middleware',
+          body:
+            request.method !== 'GET' && request.method !== 'HEAD'
+              ? request.body
+              : undefined,
+          waitUntil: context.waitUntil,
+        },
+      });
 
-        if (result.waitUntil && context.waitUntil) {
-          context.waitUntil(result.waitUntil);
-        }
-
-        return result.response;
+      if (result.waitUntil && context.waitUntil) {
+        context.waitUntil(result.waitUntil);
       }
-    );
-  } catch (err) {
-    console.error(err);
-    // crash the lambda immediately to clean up any bad module state,
-    // this was previously handled in ___vc_bridge on an unhandled rejection
-    // but we can do this quicker by triggering here
-    process.exit(1);
-  }
+
+      return result.response;
+    }
+  );
 };
 
 // The default handler method should be exported as a function on the module.

--- a/packages/next/src/server-launcher.ts
+++ b/packages/next/src/server-launcher.ts
@@ -42,22 +42,11 @@ const nextServer = new NextServer({
 // and will crash the lambda if an error isn't caught.
 const serve =
   (handler: any) => async (req: IncomingMessage, res: ServerResponse) => {
-    try {
-      const vercelContext = getVercelRequestContext();
-      await withNextRequestContext(
-        { waitUntil: vercelContext.waitUntil },
-        () => {
-          // @preserve entryDirectory handler
-          return handler(req, res);
-        }
-      );
-    } catch (err) {
-      console.error(err);
-      // crash the lambda immediately to clean up any bad module state,
-      // this was previously handled in ___vc_bridge on an unhandled rejection
-      // but we can do this quicker by triggering here
-      process.exit(1);
-    }
+    const vercelContext = getVercelRequestContext();
+    await withNextRequestContext({ waitUntil: vercelContext.waitUntil }, () => {
+      // @preserve entryDirectory handler
+      return handler(req, res);
+    });
   };
 
 // The default handler method should be exported as a function on the module.


### PR DESCRIPTION

Instead let things bubble to the proper global error handling facilities (which e.g. in the case of Fluid keep the process alive until other requests finished).

In practice, it is unexpected that errors bubble up to this stage, but it can happen in true exceptions or when next.js has a bug (which is how we found this).