### PR TITLE
fix(oidc): remove `ms` dependency

### DIFF
--- a/.changeset/thirty-dolphins-teach.md
+++ b/.changeset/thirty-dolphins-teach.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+fix(oidc): remove `ms` dependency

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -45,9 +45,5 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@types/ms": "2.1.0",
-    "ms": "2.1.3"
   }
 }

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { VercelOidcTokenError } from './token-error';
 import { findRootDir, getUserDataDir } from './token-io';
-import ms from 'ms';
 
 export function getVercelDataDir(): string | null {
   const vercelFolder = 'com.vercel.cli';
@@ -145,7 +144,8 @@ export function getTokenPayload(token: string): TokenPayload {
   return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
 }
 
+const TIME_15_MINUTES_IN_MS = 15 * 60 * 1000;
+
 export function isExpired(token: TokenPayload): boolean {
-  const timeout = ms('15m');
-  return token.exp * 1000 < Date.now() + timeout;
+  return token.exp * 1000 < Date.now() + TIME_15_MINUTES_IN_MS;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1628,13 +1628,6 @@ importers:
         version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@16.18.11)
 
   packages/oidc:
-    dependencies:
-      '@types/ms':
-        specifier: 2.1.0
-        version: 2.1.0
-      ms:
-        specifier: 2.1.3
-        version: 2.1.3
     devDependencies:
       tinyspawn:
         specifier: 1.3.1
@@ -7064,10 +7057,6 @@ packages:
   /@types/ms@0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
-
-  /@types/ms@2.1.0:
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-    dev: false
 
   /@types/multistream@2.1.1:
     resolution: {integrity: sha512-PqavtNFnMyXRZS5vuW16wMOKeJUCD5PIGHdNBHzF5Urjncsij90hRQ82Wcy9+uSdnmrR2Gfao6xoJVq1wAWzbA==}


### PR DESCRIPTION
It is only used in one line. It will help `ai` to adopt `@vercel/oidc` as we try to limit our dependency tree to a minimum
