### PR TITLE
feat(oidc): export `getContext()` method

### DIFF
--- a/.changeset/odd-clouds-attack.md
+++ b/.changeset/odd-clouds-attack.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+feat(oidc): export `getContext()` method

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -4,10 +4,25 @@
 
 ### Functions
 
+- [getContext](README.md#getcontext)
 - [getVercelOidcToken](README.md#getverceloidctoken)
 - [getVercelOidcTokenSync](README.md#getverceloidctokensync)
 
 ## Functions
+
+### getContext
+
+▸ **getContext**(): `Context`
+
+#### Returns
+
+`Context`
+
+#### Defined in
+
+[get-context.ts:7](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-context.ts#L7)
+
+---
 
 ### getVercelOidcToken
 

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -2,3 +2,4 @@ export {
   getVercelOidcToken,
   getVercelOidcTokenSync,
 } from './get-vercel-oidc-token';
+export { getContext } from './get-context';


### PR DESCRIPTION
We use the method in `@ai-sdk/gateway` to retrive the `x-vercel-id` header

```ts
getContext().headers?.['x-vercel-id'];
```

exporting `getContext()` would further unblock us from using `@vercel/oidc` as dependency in `@ai-sdk/gateway`, see https://github.com/vercel/ai/pull/8975