### PR TITLE
feat(oidc): add conditional export for browsers

### DIFF
--- a/.changeset/real-jars-pretend.md
+++ b/.changeset/real-jars-pretend.md
@@ -1,0 +1,7 @@
+---
+'@vercel/oidc': patch
+---
+
+feat(oidc): add conditional export for browsers
+
+Introduces a browser export with mock methods that don't require access to a file system or environment variables. This makes `@vercel/oidc` usable for universal libraries that are run in both frontend and backend.

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": "./dist/index-browser.js",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     }

--- a/packages/oidc/src/index-browser.test.ts
+++ b/packages/oidc/src/index-browser.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'vitest';
+
+import * as DefaultImports from './index';
+import * as BrowserImports from './index-browser';
+
+describe('browser export', () => {
+  test('should match the default export', async () => {
+    expect(Object.keys(BrowserImports)).toStrictEqual(
+      Object.keys(DefaultImports)
+    );
+  });
+});

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -1,3 +1,5 @@
+export { getContext } from './get-context';
+
 export async function getVercelOidcToken(): Promise<string> {
   return '';
 }

--- a/packages/oidc/src/index-browser.ts
+++ b/packages/oidc/src/index-browser.ts
@@ -1,0 +1,7 @@
+export async function getVercelOidcToken(): Promise<string> {
+  return '';
+}
+
+export function getVercelOidcTokenSync(): string {
+  return '';
+}


### PR DESCRIPTION
This is just a base of discussion. It would make it easier for us to use `@vercel/oidc` in the AI SDK. And if we go down this path, we could also make conditional exports for Bun, Deno, and other run times in case they need different code for file system access, OS-specific APIs or environment variables.

If we want to go ahead with this PR, I'd like to merge https://github.com/vercel/vercel/pull/14004 first, then update this PR accordingly, so that the default and browser entry points don't diverge.

See also https://github.com/vercel/ai/pull/8975