### PR TITLE
Unskip node framework tests

### DIFF
--- a/.changeset/gold-bottles-raise.md
+++ b/.changeset/gold-bottles-raise.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Add h3 example

--- a/examples/__tests__/integration/h3.test.ts
+++ b/examples/__tests__/integration/h3.test.ts
@@ -1,0 +1,4 @@
+import { deployExample } from '../test-utils';
+it('[examples] should deploy h3', async () => {
+  await deployExample('h3');
+});

--- a/examples/h3/package-lock.json
+++ b/examples/h3/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "01-basic",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "01-basic",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/examples/h3/package.json
+++ b/examples/h3/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "01-basic",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/h3/package.json
+++ b/examples/h3/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "h3": "2.0.0-beta.4"
+  },
   "author": "",
   "license": "ISC",
   "description": ""

--- a/examples/h3/server.js
+++ b/examples/h3/server.js
@@ -1,0 +1,7 @@
+import { H3 } from "h3";
+
+const app = new H3();
+
+app.get("/", () => "Hello World!");
+
+export default app

--- a/examples/h3/server.js
+++ b/examples/h3/server.js
@@ -2,6 +2,6 @@ import { H3 } from "h3";
 
 const app = new H3();
 
-app.get("/", () => "Hello World!");
+app.get("/", () => "Hello from H3!");
 
 export default app

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -217,9 +217,6 @@ async function getDeployment(host: string) {
 describe('frameworks', () => {
   const skipExamples = [
     'dojo',
-    'hono', // FIXME: hono-framework once builder lands in builder container because integration tests will fail if there's an example with no tests
-    'express', // FIXME: express-framework once builder lands in builder container because integration tests will fail if there's an example with no tests
-    'h3', // FIXME: h3-framework once builder lands in builder container because integration tests will fail if there's an example with no tests
     'saber',
     'gridsome',
     'sanity-v3',


### PR DESCRIPTION
We were skipping framework tests for hono, express, and h3 because the builders were not in the builder container, but now they are.

This adds an h3 example and reenables these tests.