### PR TITLE
[python] update fastapi example

### DIFF
--- a/.changeset/six-eggs-sit.md
+++ b/.changeset/six-eggs-sit.md
@@ -1,0 +1,5 @@
+---
+"examples": patch
+---
+
+[python] update fastapi example

--- a/examples/fastapi/.gitignore
+++ b/examples/fastapi/.gitignore
@@ -1,4 +1,4 @@
-.vercel
+.vercel/
 .venv/
 venv/
 __pycache__/

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -1,21 +1,12 @@
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse, HTMLResponse
-from fastapi.exceptions import HTTPException
+from fastapi.responses import HTMLResponse
+
 
 app = FastAPI(
     title="Vercel + FastAPI",
     description="Vercel + FastAPI",
     version="1.0.0",
 )
-
-
-app.mount("/public", StaticFiles(directory="public"), name="public")
-
-
-@app.get("/favicon.ico", include_in_schema=False)
-async def favicon():
-    return FileResponse("public/favicon.ico")
 
 
 @app.get("/api/data")


### PR DESCRIPTION
Updates FastAPI example to not use `app.mount(...)` since public dir is auto handled by static builder