### PR TITLE
Add validation and error handling for --cwd flag

### DIFF
--- a/.changeset/moody-toys-judge.md
+++ b/.changeset/moody-toys-judge.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add validation and error handling for --cwd flag

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,6 +76,7 @@ import { checkTelemetryStatus } from './util/telemetry/check-status';
 import output from './output-manager';
 import { checkGuidanceStatus } from './util/guidance/check-status';
 import { determineAgent } from '@vercel/detect-agent';
+import { validateDirectoryExists } from './util/validate-paths';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -326,7 +327,12 @@ const main = async () => {
 
   // The `--cwd` flag is respected for all sub-commands
   if (parsedArgs.flags['--cwd']) {
-    client.cwd = parsedArgs.flags['--cwd'];
+    const cwdPath = parsedArgs.flags['--cwd'];
+    const cwdExists = await validateDirectoryExists(cwdPath);
+    if (!cwdExists) {
+      return 1;
+    }
+    client.cwd = cwdPath;
   }
   const { cwd } = client;
 

--- a/packages/cli/src/util/validate-paths.ts
+++ b/packages/cli/src/util/validate-paths.ts
@@ -13,6 +13,25 @@ export async function validateRootDirectory(
   path: string,
   errorSuffix = ''
 ) {
+  const suffix = errorSuffix ? ` ${errorSuffix}` : '';
+
+  if (!(await validateDirectoryExists(path, errorSuffix))) {
+    return false;
+  }
+
+  if (!path.startsWith(cwd)) {
+    output.error(
+      `The provided path ${chalk.cyan(
+        `"${toHumanPath(path)}"`
+      )} is outside of the project.${suffix}`
+    );
+    return false;
+  }
+
+  return true;
+}
+
+export async function validateDirectoryExists(path: string, errorSuffix = '') {
   const pathStat = await lstat(path).catch(() => null);
   const suffix = errorSuffix ? ` ${errorSuffix}` : '';
 
@@ -30,15 +49,6 @@ export async function validateRootDirectory(
       `The provided path ${chalk.cyan(
         `“${toHumanPath(path)}”`
       )} is a file, but expected a directory.${suffix}`
-    );
-    return false;
-  }
-
-  if (!path.startsWith(cwd)) {
-    output.error(
-      `The provided path ${chalk.cyan(
-        `“${toHumanPath(path)}”`
-      )} is outside of the project.${suffix}`
     );
     return false;
   }

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -194,6 +194,42 @@ test('default command should work with --cwd option', async () => {
   );
 });
 
+test('should error when --cwd points to non-existent directory', async () => {
+  const projectDir = await setupE2EFixture(
+    'deploy-default-with-conflicting-sub-directory'
+  );
+
+  const { exitCode, stdout, stderr } = await execCli(
+    binaryPath,
+    ['--cwd', 'non-existent-directory'],
+    {
+      cwd: projectDir,
+    }
+  );
+
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
+  expect(stderr).toContain('The provided path');
+  expect(stderr).toContain('does not exist');
+});
+
+test('should error when --cwd points to a file instead of directory', async () => {
+  const projectDir = await setupE2EFixture(
+    'deploy-default-with-conflicting-sub-directory'
+  );
+
+  const { exitCode, stdout, stderr } = await execCli(
+    binaryPath,
+    ['--cwd', 'list/README.md'],
+    {
+      cwd: projectDir,
+    }
+  );
+
+  expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
+  expect(stderr).toContain('The provided path');
+  expect(stderr).toContain('is a file, but expected a directory');
+});
+
 test('should allow deploying a directory that was built with a target environment of "preview" and `--prebuilt` is used without specifying a target', async () => {
   const projectDir = await setupE2EFixture(
     'deploy-default-with-prebuilt-preview'


### PR DESCRIPTION
This commit introduces proper validation when using the --cwd flag to ensure the provided path exists and is a directory. It adds helpful error messages for two common error cases:

1. When the path does not exist
2. When the path is a file instead of a directory

Additionally, integration tests have been added to verify these error messages are displayed correctly.

### Before
<img width="762" height="549" alt="Screenshot 2025-10-02 at 2 02 05 AM" src="https://github.com/user-attachments/assets/e362ea4f-a41a-4a81-a37a-2216f2469387" />

### After

<img width="802" height="549" alt="Screenshot 2025-10-02 at 2 23 09 AM" src="https://github.com/user-attachments/assets/c76ee483-134b-4a1f-8e6e-9ecee3bd8fd9" />