### PR TITLE
[functions] add timeout for cache requests in runtime cache build client to fail faster on gateway timeouts

### DIFF
--- a/.changeset/pink-ways-attend.md
+++ b/.changeset/pink-ways-attend.md
@@ -2,7 +2,8 @@
 '@vercel/functions': patch
 ---
 
-Add configurable timeout to BuildCache to fail faster on gateway timeouts
+Add configurable timeout to RuntimeCache with sensible default to fail faster on gateway timeouts
 
-The BuildCache client now includes a configurable timeout (default 500ms) for all fetch requests to prevent indefinite hangs on 502/504 gateway timeouts. The timeout can be configured via the `RUNTIME_CACHE_TIMEOUT`
-environment variable or passed directly to the BuildCache constructor. When a timeout occurs, the request is aborted and the error is logged via the onError callback.
+The RuntimeCache client now includes a configurable timeout (default 500ms) for all fetch requests to prevent indefinite hangs on 502/504 gateway timeouts. 
+The timeout can be configured at build time via the `RUNTIME_CACHE_TIMEOUT` environment variable. When a timeout occurs, the request is aborted and the
+error is logged via the onError callback.

--- a/.changeset/pink-ways-attend.md
+++ b/.changeset/pink-ways-attend.md
@@ -1,0 +1,8 @@
+---
+'@vercel/functions': patch
+---
+
+Add configurable timeout to BuildCache to fail faster on gateway timeouts
+
+The BuildCache client now includes a configurable timeout (default 500ms) for all fetch requests to prevent indefinite hangs on 502/504 gateway timeouts. The timeout can be configured via the `RUNTIME_CACHE_TIMEOUT`
+environment variable or passed directly to the BuildCache constructor. When a timeout occurs, the request is aborted and the error is logged via the onError callback.

--- a/packages/functions/src/cache/build-client.ts
+++ b/packages/functions/src/cache/build-client.ts
@@ -61,6 +61,7 @@ export class BuildCache {
         const timeoutError = new Error(
           `Cache request timed out after ${this.timeout}ms`
         );
+        timeoutError.stack = error.stack;
         this.onError?.(timeoutError);
       } else {
         this.onError?.(error);
@@ -111,6 +112,7 @@ export class BuildCache {
         const timeoutError = new Error(
           `Cache request timed out after ${this.timeout}ms`
         );
+        timeoutError.stack = error.stack;
         this.onError?.(timeoutError);
       } else {
         this.onError?.(error);
@@ -138,6 +140,7 @@ export class BuildCache {
         const timeoutError = new Error(
           `Cache request timed out after ${this.timeout}ms`
         );
+        timeoutError.stack = error.stack;
         this.onError?.(timeoutError);
       } else {
         this.onError?.(error);
@@ -168,6 +171,7 @@ export class BuildCache {
         const timeoutError = new Error(
           `Cache request timed out after ${this.timeout}ms`
         );
+        timeoutError.stack = error.stack;
         this.onError?.(timeoutError);
       } else {
         this.onError?.(error);

--- a/packages/functions/src/cache/build-client.ts
+++ b/packages/functions/src/cache/build-client.ts
@@ -38,9 +38,9 @@ export class BuildCache {
         method: 'GET',
         signal: controller.signal,
       });
-      clearTimeout(timeoutId);
 
       if (res.status === 404) {
+        clearTimeout(timeoutId);
         return null;
       }
       if (res.status === 200) {
@@ -49,10 +49,14 @@ export class BuildCache {
         ) as PkgCacheState | null;
         if (cacheState !== PkgCacheState.Fresh) {
           res.body?.cancel?.();
+          clearTimeout(timeoutId);
           return null;
         }
-        return (await res.json()) as unknown;
+        const result = (await res.json()) as unknown;
+        clearTimeout(timeoutId);
+        return result;
       } else {
+        clearTimeout(timeoutId);
         throw new Error(`Failed to get cache: ${res.statusText}`);
       }
     } catch (error: any) {

--- a/packages/functions/src/cache/build-client.ts
+++ b/packages/functions/src/cache/build-client.ts
@@ -57,7 +57,14 @@ export class BuildCache {
       }
     } catch (error: any) {
       clearTimeout(timeoutId);
-      this.onError?.(error);
+      if (error.name === 'AbortError') {
+        const timeoutError = new Error(
+          `Cache request timed out after ${this.timeout}ms`
+        );
+        this.onError?.(timeoutError);
+      } else {
+        this.onError?.(error);
+      }
       return null;
     }
   };
@@ -100,7 +107,14 @@ export class BuildCache {
       }
     } catch (error: any) {
       clearTimeout(timeoutId);
-      this.onError?.(error);
+      if (error.name === 'AbortError') {
+        const timeoutError = new Error(
+          `Cache request timed out after ${this.timeout}ms`
+        );
+        this.onError?.(timeoutError);
+      } else {
+        this.onError?.(error);
+      }
     }
   };
 
@@ -120,7 +134,14 @@ export class BuildCache {
       }
     } catch (error: any) {
       clearTimeout(timeoutId);
-      this.onError?.(error);
+      if (error.name === 'AbortError') {
+        const timeoutError = new Error(
+          `Cache request timed out after ${this.timeout}ms`
+        );
+        this.onError?.(timeoutError);
+      } else {
+        this.onError?.(error);
+      }
     }
   };
 
@@ -143,7 +164,14 @@ export class BuildCache {
       }
     } catch (error: any) {
       clearTimeout(timeoutId);
-      this.onError?.(error);
+      if (error.name === 'AbortError') {
+        const timeoutError = new Error(
+          `Cache request timed out after ${this.timeout}ms`
+        );
+        this.onError?.(timeoutError);
+      } else {
+        this.onError?.(error);
+      }
     }
   };
 }

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -135,7 +135,7 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
         if (debug) {
           console.error(error);
         } else {
-          console.error(error.message);
+          console.error(new Error(error.message));
         }
       },
       timeout,

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -125,10 +125,14 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
       console.error('Failed to parse RUNTIME_CACHE_HEADERS:', e);
       return inMemoryCacheInstance;
     }
+    const timeout = process.env.RUNTIME_CACHE_TIMEOUT
+      ? parseInt(process.env.RUNTIME_CACHE_TIMEOUT, 10)
+      : 500;
     buildCacheInstance = new BuildCache({
       endpoint: RUNTIME_CACHE_ENDPOINT,
       headers: parsedHeaders,
       onError: (error: Error) => console.error(error),
+      timeout,
     });
   }
 

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -131,7 +131,13 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
     buildCacheInstance = new BuildCache({
       endpoint: RUNTIME_CACHE_ENDPOINT,
       headers: parsedHeaders,
-      onError: (error: Error) => console.error(error),
+      onError: (error: Error) => {
+        if (debug) {
+          console.error(error);
+        } else {
+          console.error(error.message);
+        }
+      },
       timeout,
     });
   }

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -125,9 +125,17 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
       console.error('Failed to parse RUNTIME_CACHE_HEADERS:', e);
       return inMemoryCacheInstance;
     }
-    const timeout = process.env.RUNTIME_CACHE_TIMEOUT
-      ? parseInt(process.env.RUNTIME_CACHE_TIMEOUT, 10)
-      : 500;
+    let timeout = 500;
+    if (process.env.RUNTIME_CACHE_TIMEOUT) {
+      const parsed = parseInt(process.env.RUNTIME_CACHE_TIMEOUT, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        timeout = parsed;
+      } else {
+        console.warn(
+          `Invalid RUNTIME_CACHE_TIMEOUT value: "${process.env.RUNTIME_CACHE_TIMEOUT}". Using default: ${timeout}ms`
+        );
+      }
+    }
     buildCacheInstance = new BuildCache({
       endpoint: RUNTIME_CACHE_ENDPOINT,
       headers: parsedHeaders,

--- a/packages/functions/src/cache/index.ts
+++ b/packages/functions/src/cache/index.ts
@@ -131,13 +131,7 @@ function getCacheImplementation(debug?: boolean): RuntimeCache {
     buildCacheInstance = new BuildCache({
       endpoint: RUNTIME_CACHE_ENDPOINT,
       headers: parsedHeaders,
-      onError: (error: Error) => {
-        if (debug) {
-          console.error(error);
-        } else {
-          console.error(new Error(error.message));
-        }
-      },
+      onError: (error: Error) => console.error(error),
       timeout,
     });
   }


### PR DESCRIPTION
### TL;DR

Added configurable timeout to RuntimeCache to prevent indefinite hangs on gateway timeouts.

### What changed?

- Added a configurable timeout parameter to the RuntimeCache client (default: 500ms)
- Implemented AbortController and timeout logic for all fetch requests
- Added proper cleanup of timeout handlers
- Made timeout configurable via `RUNTIME_CACHE_TIMEOUT` environment variable or directly through the constructor

### How to test?

1. Set the `RUNTIME_CACHE_TIMEOUT` environment variable to a custom value (in milliseconds)
2. Alternatively, pass a custom timeout value directly to the BuildCache constructor
3. Verify that requests to the cache are aborted after the specified timeout period
4. Check that timeout errors are properly logged via the onError callback

### Why make this change?

The RuntimeCache client was previously vulnerable to indefinite hangs when encountering 502/504 gateway timeouts. This change ensures that requests fail fast with a proper error message rather than hanging indefinitely, improving the reliability and responsiveness of the system when the cache service is experiencing issues.

### Example

When timeout is reached an error like this will be logged in the build

```
Error: Cache request timed out after 500ms
    at async g.set (.next/server/app/api/e2e-test/route.js:6:2824)
    at async (.next/server/app/api/e2e-test/route.js:1:798)
    at async f (.next/server/app/api/e2e-test/route.js:1:1865)
    at async (.next/server/app/api/e2e-test/route.js:1:658)
    at async describe (.next/server/app/api/e2e-test/route.js:5:8)
    at async b (.next/server/app/api/e2e-test/route.js:1:345)
```

When this occurs, get() will return null (miss) and other calls will fail but not throw an error