### PR TITLE
Fix allowQuery logic for RDC navigations with fallback root params

### DIFF
--- a/.changeset/good-tigers-write.md
+++ b/.changeset/good-tigers-write.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix allowQuery logic for RDC navigations with fallback root params


### PR DESCRIPTION
## Why?

This fixes a bug in the experimental `rdcForNavigations` feature where the allowQuery logic for RSC and segment prerenders didn't correctly account for routes with fallback root params that generate non-empty shells. This caused inconsistent rendering behavior because the different prerender types weren't properly synchronized.

## What?

The fix consolidates the allowQuery logic by reusing `htmlAllowQuery` for both RSC and segment prerenders, ensuring they all reference the same postponed state and share the same render. This keeps the prerender types in sync and ensures consistent behavior.

## Changes

- Added clarifying comments explaining the postponed prerender logic
- Removed the `isAppClientParamParsingEnabled` conditional that was causing incorrect behavior
- Simplified fallback value creation logic by moving it outside the Prerender constructor calls
- Ensured RSC and segment prerenders use the same `htmlAllowQuery` logic