### PR TITLE
Fix allowQuery logic for RDC navigations with fallback root params Redux

### DIFF
--- a/.changeset/clever-starfishes-compare.md
+++ b/.changeset/clever-starfishes-compare.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix allowQuery logic for RDC navigations with fallback root params

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3104,15 +3104,22 @@ export const onPrerenderRoute =
             )}`;
           }
 
-          // We follow the same logic as the HTML allowQuery as it's already
-          // going to vary based on if there's a static shell generated or if
-          // there's fallback root params. If there are fallback root params,
-          // and we can serve a fallback, then we should follow the same logic
-          // for the dynamic RSC routes.
-          const rdcRSCAllowQuery = htmlAllowQuery;
+          // If client param parsing is enabled, we follow the same logic as the
+          // HTML allowQuery as it's already going to vary based on if there's a
+          // static shell generated or if there's fallback root params. If there
+          // are fallback root params, and we can serve a fallback, then we
+          // should follow the same logic for the dynamic RSC routes.
+          //
+          // If client param parsing is not enabled, we have to use the
+          // allowQuery because the RSC payloads will contain dynamic segment
+          // values.
+          const rdcRSCAllowQuery = isAppClientParamParsingEnabled
+            ? htmlAllowQuery
+            : allowQuery;
 
           // Use the fallback value for the RSC route if the route doesn't
-          // vary based on the route parameters.
+          // vary based on the route parameters and there's an actual postponed
+          // state to fallback to.
           let fallback: FileBlob | null = null;
           if (
             rdcRSCAllowQuery &&
@@ -3183,12 +3190,19 @@ export const onPrerenderRoute =
               routeFileNoExt + prefetchSegmentDirSuffix
             );
 
-            // We follow the same logic as the HTML allowQuery as it's already
-            // going to vary based on if there's a static shell generated or if
-            // there's fallback root params. If there are fallback root params,
-            // and we can serve a fallback, then we should follow the same logic
-            // for the segment prerenders.
-            const segmentAllowQuery = htmlAllowQuery;
+            // If client param parsing is enabled, we follow the same logic as
+            // the HTML allowQuery as it's already going to vary based on if
+            // there's a static shell generated or if there's fallback root
+            // params. If there are fallback root params, and we can serve a
+            // fallback, then we should follow the same logic for the segment
+            // prerenders.
+            //
+            // If client param parsing is not enabled, we have to use the
+            // allowQuery because the segment payloads will contain dynamic
+            // segment values.
+            const segmentAllowQuery = isAppClientParamParsingEnabled
+              ? htmlAllowQuery
+              : allowQuery;
 
             for (const segmentPath of meta.segmentPaths) {
               const outputSegmentPath =


### PR DESCRIPTION
## Why?

This is a reland of #14040 with a fix for cache poisoning when client param parsing is disabled.

The original PR had a bug: it always used `htmlAllowQuery` for RSC and segment prerenders, but when client param parsing is disabled, RSC payloads contain dynamic segment values. Using `htmlAllowQuery` (which could be `[]`) in this case caused cache poisoning because the cache didn't vary on the dynamic segments.

This fixes the experimental `rdcForNavigations` feature where the allowQuery logic for RSC and segment prerenders didn't correctly account for routes with fallback root params that generate non-empty shells.

## What?

The fix consolidates the allowQuery logic by:
- When client param parsing IS enabled: use `htmlAllowQuery` for RSC and segment prerenders (same as original PR)
- When client param parsing is NOT enabled: use `allowQuery` to ensure RSC payloads properly vary on dynamic segments

This ensures all prerender types reference the same postponed state and share the same render while preventing cache poisoning.

## Changes from original PR #14040

- Added conditional logic based on `isAppClientParamParsingEnabled` to choose between `htmlAllowQuery` and `allowQuery`
- Added check to only create pre-render content type when `postponedState` exists
- Added check to only create fallback when there's an actual postponed state
- Moved fallback value creation logic outside the Prerender constructor calls for clarity
