### PR TITLE
Use new domains apis in cli

### DIFF
--- a/.changeset/rude-eyes-roll.md
+++ b/.changeset/rude-eyes-roll.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update domains commands to use the new domains APIs

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -230,13 +230,6 @@ function handleSetupDomainError<T>(error: SetupDomainError | T): T | 1 {
     return 1;
   }
 
-  if (error instanceof ERRORS.DomainServiceNotAvailable) {
-    output.error(
-      'The domain purchase service is not available. Try again later.'
-    );
-    return 1;
-  }
-
   if (error instanceof ERRORS.UnexpectedDomainPurchaseError) {
     output.error('There was an unexpected error while purchasing the domain.');
     return 1;
@@ -272,6 +265,13 @@ function handleSetupDomainError<T>(error: SetupDomainError | T): T | 1 {
       `You can't purchase the domain you're aliasing to since your card was declined.`
     );
     output.print('  Please add a valid payment method and retry.\n');
+    return 1;
+  }
+
+  if (error instanceof ERRORS.TLDNotSupportedViaCLI) {
+    output.error(
+      `The TLD for domain name ${error.meta.domain} is not supported via the CLI. Use the REST API or the dashboard to purchase.`
+    );
     return 1;
   }
 

--- a/packages/cli/src/commands/domains/buy.ts
+++ b/packages/cli/src/commands/domains/buy.ts
@@ -60,18 +60,17 @@ export default async function buy(client: Client, argv: string[]) {
   }
 
   const availableStamp = stamp();
-  const [domainPrice, renewalPrice] = await Promise.all([
-    getDomainPrice(client, domainName),
-    getDomainPrice(client, domainName, 'renewal'),
-  ]);
+  const domainPrice = await getDomainPrice(client, domainName);
 
   if (domainPrice instanceof Error) {
     output.prettyError(domainPrice);
     return 1;
   }
 
-  if (renewalPrice instanceof Error) {
-    output.prettyError(renewalPrice);
+  const { years, purchasePrice, renewalPrice } = domainPrice;
+
+  if (purchasePrice === null || renewalPrice === null) {
+    output.error('Domain price not found');
     return 1;
   }
 
@@ -84,7 +83,6 @@ export default async function buy(client: Client, argv: string[]) {
     return 1;
   }
 
-  const { period, price } = domainPrice;
   output.log(
     `The domain ${param(domainName)} is ${chalk.underline(
       'available'
@@ -97,8 +95,8 @@ export default async function buy(client: Client, argv: string[]) {
   } else {
     if (
       !(await client.input.confirm(
-        `Buy now for ${chalk.bold(`$${price}`)} (${`${period}yr${
-          period > 1 ? 's' : ''
+        `Buy now for ${chalk.bold(`$${purchasePrice}`)} (${`${years}yr${
+          years > 1 ? 's' : ''
         }`})?`,
         false
       ))
@@ -107,10 +105,10 @@ export default async function buy(client: Client, argv: string[]) {
     }
 
     autoRenew = await client.input.confirm(
-      renewalPrice.period === 1
-        ? `Auto renew yearly for ${chalk.bold(`$${price}`)}?`
-        : `Auto renew every ${renewalPrice.period} years for ${chalk.bold(
-            `$${price}`
+      years === 1
+        ? `Auto renew yearly for ${chalk.bold(`$${renewalPrice}`)}?`
+        : `Auto renew every ${years} years for ${chalk.bold(
+            `$${renewalPrice}`
           )}?`,
       true
     );
@@ -121,7 +119,13 @@ export default async function buy(client: Client, argv: string[]) {
   output.spinner('Purchasing');
 
   try {
-    buyResult = await purchaseDomain(client, domainName, price, autoRenew);
+    buyResult = await purchaseDomain(
+      client,
+      domainName,
+      purchasePrice,
+      years,
+      autoRenew
+    );
   } catch (err: unknown) {
     output.error(
       'An unexpected error occurred while purchasing your domain. Please try again later.'
@@ -132,16 +136,16 @@ export default async function buy(client: Client, argv: string[]) {
 
   output.stopSpinner();
 
-  if (buyResult instanceof ERRORS.SourceNotFound) {
+  if (buyResult instanceof ERRORS.UnsupportedTLD) {
     output.error(
-      `Could not purchase domain. Please add a payment method using the dashboard.`
+      `The TLD for domain name ${buyResult.meta.domain} is not supported.`
     );
     return 1;
   }
 
-  if (buyResult instanceof ERRORS.UnsupportedTLD) {
+  if (buyResult instanceof ERRORS.TLDNotSupportedViaCLI) {
     output.error(
-      `The TLD for domain name ${buyResult.meta.domain} is not supported.`
+      `Purchased for the TLD for domain name ${buyResult.meta.domain} are not supported via the CLI. Use the REST API or the dashboard to purchase.`
     );
     return 1;
   }
@@ -156,13 +160,6 @@ export default async function buy(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (buyResult instanceof ERRORS.DomainServiceNotAvailable) {
-    output.error(
-      `The domain purchase service is not available. Please try again later.`
-    );
-    return 1;
-  }
-
   if (buyResult instanceof ERRORS.UnexpectedDomainPurchaseError) {
     output.error(`An unexpected error happened while performing the purchase.`);
     return 1;
@@ -173,33 +170,12 @@ export default async function buy(client: Client, argv: string[]) {
     return 1;
   }
 
-  if (buyResult.pending) {
-    output.success(
-      `Domain ${param(domainName)} order was submitted ${purchaseStamp()}`
-    );
-    output.note(
-      `Your domain is processing and will be available once the order is completed.`
-    );
-    output.print(
-      `  An email will be sent upon completion for you to start using your new domain.\n`
-    );
-  } else {
-    output.success(`Domain ${param(domainName)} purchased ${purchaseStamp()}`);
-    if (!buyResult.verified) {
-      output.note(
-        `Your domain is not fully configured yet so it may appear as not verified.`
-      );
-      output.print(
-        `  It might take a few minutes, but you will get an email as soon as it is ready.\n`
-      );
-    } else {
-      output.note(
-        `You may now use your domain as an alias to your deployments. Run ${getCommandName(
-          `alias --help`
-        )}`
-      );
-    }
-  }
+  output.success(`Domain ${param(domainName)} purchased ${purchaseStamp()}`);
+  output.note(
+    `You may now use your domain as an alias to your deployments. Run ${getCommandName(
+      `alias --help`
+    )}`
+  );
 
   return 0;
 }

--- a/packages/cli/src/commands/domains/inspect.ts
+++ b/packages/cli/src/commands/domains/inspect.ts
@@ -201,8 +201,8 @@ async function fetchInformation({
 }) {
   const [domain, renewalPrice] = await Promise.all([
     getDomainByName(client, contextName, domainName, { ignoreWait: true }),
-    getDomainPrice(client, domainName, 'renewal')
-      .then(res => (res instanceof Error ? null : res.price))
+    getDomainPrice(client, domainName)
+      .then(res => (res instanceof Error ? null : res.renewalPrice))
       .catch(() => null),
   ]);
 

--- a/packages/cli/src/util/domains/get-domain-price.ts
+++ b/packages/cli/src/util/domains/get-domain-price.ts
@@ -1,23 +1,19 @@
-import { stringify } from 'querystring';
 import { isAPIError, UnsupportedTLD } from '../errors-ts';
 import type Client from '../client';
 
 type Response = {
-  price: number;
-  period: number;
+  purchasePrice: number | null;
+  renewalPrice: number | null;
+  transferPrice: number | null;
+  years: number;
 };
 
-export default async function getDomainPrice(
-  client: Client,
-  name: string,
-  type?: 'new' | 'renewal'
-) {
+export default async function getDomainPrice(client: Client, name: string) {
   try {
-    const querystr = type ? stringify({ name, type }) : stringify({ name });
-    return await client.fetch<Response>(`/v3/domains/price?${querystr}`);
+    return await client.fetch<Response>(`/v1/registrar/domains/${name}/price`);
   } catch (err: unknown) {
     if (isAPIError(err)) {
-      if (err.code === 'unsupported_tld') {
+      if (err.code === 'tld_not_supported') {
         return new UnsupportedTLD(name);
       }
 

--- a/packages/cli/src/util/domains/get-domain-status.ts
+++ b/packages/cli/src/util/domains/get-domain-status.ts
@@ -1,8 +1,7 @@
-import qs from 'querystring';
 import type Client from '../client';
 
 export default async function getDomainStatus(client: Client, domain: string) {
   return client.fetch<{ available: boolean }>(
-    `/v3/domains/status?${qs.stringify({ name: domain })}`
+    `/v1/registrar/domains/${encodeURIComponent(domain)}/availability`
   );
 }

--- a/packages/cli/src/util/domains/get-order.ts
+++ b/packages/cli/src/util/domains/get-order.ts
@@ -1,0 +1,63 @@
+import { isAPIError } from '../errors-ts';
+import type Client from '../client';
+import sleep from '../sleep';
+import getScope from '../get-scope';
+
+type Response = {
+  orderId: string;
+  domains: {
+    domainName: string;
+    status: 'pending' | 'completed' | 'failed' | 'refunded' | 'refund-failed';
+  }[];
+  status: 'draft' | 'purchasing' | 'completed' | 'failed';
+  error?: {
+    code: 'payment_failed' | 'unexpected_error';
+  };
+};
+
+export default async function getOrder(client: Client, orderId: string) {
+  const { team } = await getScope(client);
+  const teamParam = team ? `?teamId=${team.slug}` : '';
+
+  try {
+    return await client.fetch<Response>(
+      `/v1/registrar/orders/${orderId}${teamParam}`
+    );
+  } catch (err: unknown) {
+    if (isAPIError(err)) {
+      if (err.code === 'not_found') {
+        return null;
+      }
+
+      if (err.status < 500) {
+        return err;
+      }
+    }
+
+    throw err;
+  }
+}
+
+export const pollForOrder = async (
+  client: Client,
+  orderId: string,
+  timeoutMs: number = 10000
+) => {
+  const intervalMs = 500;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    const order = await getOrder(client, orderId);
+
+    if (
+      order !== null &&
+      (order.status === 'completed' || order.status === 'failed')
+    ) {
+      return order;
+    }
+
+    await sleep(intervalMs);
+  }
+
+  return null;
+};

--- a/packages/cli/src/util/domains/transfer-in-domain.ts
+++ b/packages/cli/src/util/domains/transfer-in-domain.ts
@@ -1,41 +1,77 @@
 import * as ERRORS from '../errors-ts';
 import type Client from '../client';
-import type { Domain } from '@vercel-internals/types';
+import getScope from '../get-scope';
+import { pollForOrder } from './get-order';
 
-type Response = {
-  domain: Domain;
+type TransferInResponse = {
+  orderId: string;
 };
 
 export default async function transferInDomain(
   client: Client,
   name: string,
   authCode: string,
-  expectedPrice: number
+  expectedPrice: number,
+  years: number
 ) {
+  const { team } = await getScope(client);
+  const teamParam = team ? `?teamId=${team.slug}` : '';
+
   try {
-    return await client.fetch<Response>(`/v4/domains`, {
-      body: { method: 'transfer-in', name, authCode, expectedPrice },
-      method: 'POST',
-    });
+    const { orderId } = await client.fetch<TransferInResponse>(
+      `/v1/registrar/domains/${name}/transfer${teamParam}`,
+      {
+        body: {
+          authCode,
+          autoRenew: true,
+          years,
+          expectedPrice,
+          contactInformation: {
+            firstName: 'Vercel',
+            lastName: 'Whois',
+            email: 'domains@registrar.vercel.com',
+            phone: '+14153985463',
+            address1: '100 First Street, Suite 2400',
+            city: 'San Fransisco',
+            state: 'CA',
+            zip: '94105',
+            country: 'US',
+            companyName: 'Vercel Inc.',
+          },
+        },
+        method: 'POST',
+      }
+    );
+
+    const order = await pollForOrder(client, orderId);
+
+    if (order === null) {
+      // Timed out, something went wrong
+      return new ERRORS.UnexpectedDomainTransferError(name);
+    }
+
+    if (order.status === 'completed') {
+      const domain = order.domains.find(domain => domain.domainName === name);
+      if (domain?.status === 'completed') {
+        return { ok: true };
+      }
+    }
+
+    if (order.error?.code === 'payment_failed') {
+      return new ERRORS.DomainPaymentError();
+    }
+
+    return new ERRORS.UnexpectedDomainTransferError(name);
   } catch (err: unknown) {
     if (ERRORS.isAPIError(err)) {
       if (err.code === 'invalid_name') {
         return new ERRORS.InvalidDomain(name);
       }
-      if (err.code === 'domain_already_exists') {
+      if (err.code === 'tld_not_supported') {
+        return new ERRORS.UnsupportedTLD(name);
+      }
+      if (err.code === 'domain_not_available') {
         return new ERRORS.DomainNotAvailable(name);
-      }
-      if (err.code === 'not_transferable') {
-        return new ERRORS.DomainNotTransferable(name);
-      }
-      if (err.code === 'invalid_auth_code') {
-        return new ERRORS.InvalidTransferAuthCode(name, authCode);
-      }
-      if (err.code === 'source_not_found') {
-        return new ERRORS.SourceNotFound();
-      }
-      if (err.code === 'registration_failed') {
-        return new ERRORS.DomainRegistrationFailed(name, err.message);
       }
     }
     throw err;

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -321,6 +321,22 @@ export class UnsupportedTLD extends NowError<
 }
 
 /**
+ * Returned when a given TLD can not be purchased via the CLI.
+ */
+export class TLDNotSupportedViaCLI extends NowError<
+  'UNSUPPORTED_TLD_VIA_CLI',
+  { domain: string }
+> {
+  constructor(domain: string) {
+    super({
+      code: 'UNSUPPORTED_TLD_VIA_CLI',
+      meta: { domain },
+      message: `Purchased for the TLD for domain name ${domain} are not supported via the CLI. Use the REST API or the dashboard to purchase.`,
+    });
+  }
+}
+
+/**
  * Returned when the user tries to purchase a domain but the API returns
  * an error telling that it is not available.
  */
@@ -333,23 +349,6 @@ export class DomainNotAvailable extends NowError<
       code: 'DOMAIN_NOT_AVAILABLE',
       meta: { domain },
       message: `The domain ${domain} is not available to be purchased.`,
-    });
-  }
-}
-
-/**
- * Returned when the domain purchase service is not available for reasons
- * that are out of our control.
- */
-export class DomainServiceNotAvailable extends NowError<
-  'DOMAIN_SERVICE_NOT_AVAILABLE',
-  { domain: string }
-> {
-  constructor(domain: string) {
-    super({
-      code: 'DOMAIN_SERVICE_NOT_AVAILABLE',
-      meta: { domain },
-      message: `The domain purchase is unavailable, try again later.`,
     });
   }
 }
@@ -383,6 +382,22 @@ export class UnexpectedDomainPurchaseError extends NowError<
       code: 'UNEXPECTED_DOMAIN_PURCHASE_ERROR',
       meta: { domain },
       message: `An unexpected error happened while purchasing.`,
+    });
+  }
+}
+
+/**
+ * Returned when there is an expected error during the domain transfer.
+ */
+export class UnexpectedDomainTransferError extends NowError<
+  'UNEXPECTED_DOMAIN_TRANSFER_ERROR',
+  { domain: string }
+> {
+  constructor(domain: string) {
+    super({
+      code: 'UNEXPECTED_DOMAIN_TRANSFER_ERROR',
+      meta: { domain },
+      message: `An unexpected error happened while transferring.`,
     });
   }
 }

--- a/packages/cli/test/unit/commands/domains/buy.test.ts
+++ b/packages/cli/test/unit/commands/domains/buy.test.ts
@@ -51,17 +51,25 @@ describe('domains buy', () => {
   describe('[name]', () => {
     it('should track redacted domain name positional argument', async () => {
       useUser();
-      client.scenario.get('/v3/domains/price', (req, res) => {
-        return res.json({
-          price: 100,
-          period: 1,
-        });
-      });
-      client.scenario.get('/v3/domains/status', (req, res) => {
-        return res.json({
-          available: true,
-        });
-      });
+      client.scenario.get(
+        '/v1/registrar/domains/example.com/price',
+        (req, res) => {
+          return res.json({
+            purchasePrice: 100,
+            renewalPrice: 100,
+            transferPrice: null,
+            years: 1,
+          });
+        }
+      );
+      client.scenario.get(
+        '/v1/registrar/domains/example.com/availability',
+        (req, res) => {
+          return res.json({
+            available: true,
+          });
+        }
+      );
 
       client.setArgv('domains', 'buy', 'example.com');
       const exitCodePromise = domains(client);


### PR DESCRIPTION
### TL;DR

Updated domain purchasing and transfer flows to use the new Registrar API endpoints.

### What changed?

- Refactored `getDomainPrice` to use the new `/v1/registrar/domains/{name}/price` endpoint
- Updated the domain purchase flow to use the new `/v1/registrar/domains/{name}/buy` endpoint
- Implemented order polling to track domain purchase status
- Updated domain transfer-in to use the new `/v1/registrar/domains/{name}/transfer` endpoint
- Simplified error handling for domain operations
- Removed obsolete error types and added new ones where needed
- Updated CLI output messages to match the new API responses

### How to test?

1. Try purchasing a domain with `vercel domains buy example.com`
2. Try transferring a domain with `vercel domains transfer-in example.com`
3. Inspect a domain with `vercel domains inspect example.com`

### Why make this change?

This change migrates the CLI to use the new Registrar API endpoints, which provide a more consistent and reliable way to purchase and manage domains. The new API offers better error handling and a more streamlined purchase flow, improving the overall user experience when buying or transferring domains.