### PR TITLE
[functions] fix: move BuildCache timeout cleanup to prevent hanging on JSON parsing

### DIFF
--- a/.changeset/polite-sheep-repair.md
+++ b/.changeset/polite-sheep-repair.md
@@ -1,0 +1,9 @@
+---
+'@vercel/functions': patch
+---
+
+Fix BuildCache timeout handling to prevent hanging during response parsing
+
+Moves `clearTimeout()` calls to occur immediately after fetch completion rather than after `response.json()` parsing. This prevents indefinite hangs when JSON parsing is slow or fails, which was causing 60-second build timeouts in static generation.
+
+The timeout now properly covers the network request phase, while allowing JSON parsing to complete without being constrained by the abort signal (which doesn't affect JSON parsing anyway).

--- a/packages/functions/src/cache/build-client.ts
+++ b/packages/functions/src/cache/build-client.ts
@@ -38,9 +38,9 @@ export class BuildCache {
         method: 'GET',
         signal: controller.signal,
       });
+      clearTimeout(timeoutId);
 
       if (res.status === 404) {
-        clearTimeout(timeoutId);
         return null;
       }
       if (res.status === 200) {
@@ -49,14 +49,10 @@ export class BuildCache {
         ) as PkgCacheState | null;
         if (cacheState !== PkgCacheState.Fresh) {
           res.body?.cancel?.();
-          clearTimeout(timeoutId);
           return null;
         }
-        const result = (await res.json()) as unknown;
-        clearTimeout(timeoutId);
-        return result;
+        return (await res.json()) as unknown;
       } else {
-        clearTimeout(timeoutId);
         throw new Error(`Failed to get cache: ${res.statusText}`);
       }
     } catch (error: any) {


### PR DESCRIPTION
### TL;DR

Fix BuildCache timeout handling to prevent build hangs during response parsing.

### What changed?

Moved `clearTimeout()` calls to occur immediately after fetch completion rather than after `response.json()` parsing in the BuildCache class. This ensures that timeouts are properly cleared as soon as the network request completes, regardless of how long JSON parsing takes.

### How to test?

1. Test scenarios where JSON parsing might be slow or fail
2. Verify that requests no longer hang indefinitely during static generation
3. Confirm that network requests still respect the timeout while JSON parsing is allowed to complete

### Why make this change?

The previous implementation was causing 60-second build timeouts during static generation because the timeout wasn't being cleared until after JSON parsing completed. Since the abort signal doesn't affect JSON parsing anyway, this change allows the timeout to properly cover just the network request phase while letting JSON parsing complete without constraints. This prevents indefinite hangs when parsing is slow or fails.