### PR TITLE
CI: update `CODEOWNERS` for easier merging of "Version Packages" PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,7 @@
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 
 # Unrestricted Paths
+# These paths are updated by the changeset CLI for "Version Packages" pull requests
 .changeset/
+/packages/*/CHANGELOG.md
+/packages/*/package.json


### PR DESCRIPTION
Adds all paths that are updated by "Version Packages" PRs to the  unrestricted paths section in `CODEOWNERS`

Example: https://github.com/vercel/vercel/pull/14070/files

As discussed with @LukeSheard 