### PR TITLE
Add vc dev support for NestJS

### DIFF
--- a/.changeset/young-fishes-type.md
+++ b/.changeset/young-fishes-type.md
@@ -1,0 +1,6 @@
+---
+'@vercel/node': minor
+'vercel': minor
+---
+
+Add vc dev support for NestJS

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -427,7 +427,8 @@ export async function getBuildMatches(
     if (
       buildConfig.config?.framework === 'hono' ||
       buildConfig.config?.framework === 'express' ||
-      buildConfig.config?.framework === 'h3'
+      buildConfig.config?.framework === 'h3' ||
+      buildConfig.config?.framework === 'nestjs'
     ) {
       src = 'package.json';
     }

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -69,6 +69,7 @@ async function compileUserCode(
     : entrypointPath;
 
   let server: Server | null = null;
+  let serverFound = () => {};
 
   /**
    * Override the listen method while we import the module,
@@ -88,11 +89,10 @@ async function compileUserCode(
     server = this as Server;
     // Restore original listen method
     http.Server.prototype.listen = originalListen;
+    serverFound();
     return this;
   };
   let listener = await import(id);
-  // Restore original listen method
-  http.Server.prototype.listen = originalListen;
 
   /**
    * In some cases we might have nested default props due to TS => JS
@@ -107,6 +107,7 @@ async function compileUserCode(
     typeof listener.fetch === 'function';
 
   if (shouldUseWebHandlers) {
+    http.Server.prototype.listen = originalListen;
     const { createWebExportsHandler } = await import('./helpers-web.js');
     const getWebExportsHandler = createWebExportsHandler(awaiter);
 
@@ -132,20 +133,35 @@ async function compileUserCode(
     return getWebExportsHandler(handler, HTTP_METHODS);
   }
 
+  if (typeof listener === 'function') {
+    http.Server.prototype.listen = originalListen;
+    return async (req: IncomingMessage, res: ServerResponse) => {
+      // Only add helpers if the listener isn't an express server
+      if (options.shouldAddHelpers && typeof listener.listen !== 'function') {
+        await addHelpers(req, res);
+      }
+
+      return listener(req, res);
+    };
+  }
+
+  if (!server) {
+    await new Promise(resolve => {
+      serverFound = resolve;
+      const maxTimeToWaitForServer = 1000;
+      setTimeout(resolve, maxTimeToWaitForServer);
+    });
+  }
+
+  http.Server.prototype.listen = originalListen;
+
   // If we have a server instance, server.listen() was called from the module, we can use
   // we can proxy requests to it instead of initializing our own server
   if (server) {
     return server;
   }
 
-  return async (req: IncomingMessage, res: ServerResponse) => {
-    // Only add helpers if the listener isn't an express server
-    if (options.shouldAddHelpers && typeof listener.listen !== 'function') {
-      await addHelpers(req, res);
-    }
-
-    return listener(req, res);
-  };
+  throw new Error("Can't detect way to handle request");
 }
 
 export async function createServerlessEventHandler(

--- a/packages/node/src/serverless-functions/serverless-handler.mts
+++ b/packages/node/src/serverless-functions/serverless-handler.mts
@@ -147,7 +147,7 @@ async function compileUserCode(
 
   if (!server) {
     await new Promise(resolve => {
-      serverFound = resolve;
+      serverFound = resolve as () => void;
       const maxTimeToWaitForServer = 1000;
       setTimeout(resolve, maxTimeToWaitForServer);
     });


### PR DESCRIPTION
NestJS entrypoints may look like:
```ts
async function bootstrap() {
  const app = await NestFactory.create(AppModule);
  await app.listen(process.env.PORT ?? 4321);
}
bootstrap();
```

which means we can't assume `.listen` was called immediately like `compileUserCode` used to expect. In `compileUserCode` now we handle the server case last, and if `.listen` was not called by the point, we wait up to a second for the server listen to happen.