### PR TITLE
fix(oidc): Add `"workflow"` condition for mock export

### DIFF
--- a/.changeset/three-fans-walk.md
+++ b/.changeset/three-fans-walk.md
@@ -1,0 +1,5 @@
+---
+"@vercel/oidc": patch
+---
+
+fix(oidc): add `"workflow"` as export condition

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -12,6 +12,7 @@
     ".": {
       "browser": "./dist/index-browser.js",
       "react-native": "./dist/index-browser.js",
+      "workflow": "./dist/index-browser.js",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
Same as #14066, but for workflow

x-ref: https://vercel.slack.com/archives/C09125LC4AX/p1759978507470729?thread_ts=1759966155.894569&cid=C09125LC4AX