### PR TITLE
Add @vercel/ai-sdk as code owner for oidc package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /examples/nextjs                         @vercel/ci-cd @ijjk @ztanner @huozhi
 /packages/node                           @vercel/ci-cd @Kikobeats
 /packages/related-projects               @vercel/ci-cd @Kikobeats @mknichel
-/packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management
+/packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 
 # Unrestricted Paths


### PR DESCRIPTION
This requires the team to be granted write access to `vercel/vercel`

~~Alternatively we can just add myself as user. But team is preferable~~

**Update:** team access was granted