### PR TITLE
[build-utils] Restore chunk size of prebuilt archive back to 100MB

### DIFF
--- a/.changeset/lovely-mirrors-help.md
+++ b/.changeset/lovely-mirrors-help.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Revert the prebuilt archive split from 20MB back to 100MB

--- a/packages/build-utils/src/fs/stream-to-buffer.ts
+++ b/packages/build-utils/src/fs/stream-to-buffer.ts
@@ -31,7 +31,7 @@ const MB = 1024 * 1024;
 
 export async function streamToBufferChunks(
   stream: NodeJS.ReadableStream,
-  chunkSize: number = 20 * MB
+  chunkSize: number = 100 * MB
 ): Promise<Buffer[]> {
   const chunks: Buffer[] = [];
   let currentChunk: Buffer[] = [];

--- a/packages/build-utils/test/unit.stream-to-buffer.test.ts
+++ b/packages/build-utils/test/unit.stream-to-buffer.test.ts
@@ -5,22 +5,22 @@ import { Readable } from 'stream';
 const MB = 1024 * 1024;
 
 describe('streamToBufferChunks', () => {
-  it("returns 1 buffer when the total volume doesn't exceed 20mb", async () => {
-    const stream = Readable.from(Buffer.from('a'.repeat(20 * MB)));
+  it("returns 1 buffer when the total volume doesn't exceed 100mb", async () => {
+    const stream = Readable.from(Buffer.from('a'.repeat(10 * MB)));
 
     const buffers = await streamToBufferChunks(stream);
 
     expect(buffers.length).toBe(1);
-    expect(buffers[0].length).toBe(20 * MB);
+    expect(buffers[0].length).toBe(10 * MB);
   });
   it('returns multiple buffers when when the mbLimit is exceeded', async () => {
-    const stream = Readable.from(Buffer.from('a'.repeat(50 * MB)));
+    const stream = Readable.from(Buffer.from('a'.repeat(250 * MB)));
 
     const buffers = await streamToBufferChunks(stream);
 
     expect(buffers.length).toBe(3);
-    expect(buffers[0].length).toBe(20 * MB);
-    expect(buffers[1].length).toBe(20 * MB);
-    expect(buffers[2].length).toBe(10 * MB);
+    expect(buffers[0].length).toBe(100 * MB);
+    expect(buffers[1].length).toBe(100 * MB);
+    expect(buffers[2].length).toBe(50 * MB);
   });
 });


### PR DESCRIPTION
### Summary

Revert of #14046.
Restore chunk size of prebuilt archive back to 100MB.

### Context

We have resolved an incident with the network setup, so small chunks are not required anymore for successful uploads.