### PR TITLE
[cli-auth] Add publish config so cli-auth publishes successfuly

### DIFF
--- a/.changeset/light-emus-press.md
+++ b/.changeset/light-emus-press.md
@@ -1,0 +1,5 @@
+---
+'@vercel/cli-auth': patch
+---
+
+Add publish config to fix release

--- a/packages/cli-auth/package.json
+++ b/packages/cli-auth/package.json
@@ -3,6 +3,9 @@
   "description": "Used by Vercel's CLIs to handle authentication",
   "version": "0.0.1",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "*.js",
     "*.js.map",


### PR DESCRIPTION
[The last CLI release failed](https://github.com/vercel/vercel/actions/runs/18416256421/job/52480516883) because cli-auth package was missing this publish config.