### PR TITLE
[frameworks] Detect nitro when nitro package exists

### DIFF
--- a/.changeset/tall-monkeys-bathe.md
+++ b/.changeset/tall-monkeys-bathe.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': minor
+---
+
+Update nitro framework detection to detect nitro package

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2333,7 +2333,7 @@ export const frameworks = [
       'Nitro lets you create web servers that run on multiple platforms.',
     website: 'https://nitro.build/',
     detectors: {
-      every: [{ matchPackage: 'nitropack' }],
+      some: [{ matchPackage: 'nitropack' }, { matchPackage: 'nitro' }],
     },
     settings: {
       installCommand: {
@@ -2351,7 +2351,7 @@ export const frameworks = [
         value: 'dist',
       },
     },
-    dependency: 'nitropack',
+    dependency: 'nitro',
     getOutputDirName: async () => 'public',
   },
   {

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2351,7 +2351,6 @@ export const frameworks = [
         value: 'dist',
       },
     },
-    dependency: 'nitro',
     getOutputDirName: async () => 'public',
   },
   {


### PR DESCRIPTION
Nitro is switching from `nitropack (v2)` to `nitro (v3)`: https://v3.nitro.build/docs/quick-start#create-a-nitro-project

This updates Nitro framework detection to detect the `nitro` package.