### PR TITLE
Support root main as entry point for nestjs

### DIFF
--- a/.changeset/fair-poets-play.md
+++ b/.changeset/fair-poets-play.md
@@ -1,0 +1,6 @@
+---
+'@vercel/frameworks': minor
+'@vercel/nestjs': minor
+---
+
+Add root main as entrypoint for NestJS

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -3080,6 +3080,36 @@ export const frameworks = [
             '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
         },
         {
+          path: 'main.js',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'main.cjs',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'main.mjs',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'main.ts',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'main.cts',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
+          path: 'main.mts',
+          matchContent:
+            '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',
+        },
+        {
           path: 'app.js',
           matchContent:
             '(?:from|require|import)\\s*(?:\\(\\s*)?["\']@nestjs/core["\']\\s*(?:\\))?',

--- a/packages/nestjs/src/build.ts
+++ b/packages/nestjs/src/build.ts
@@ -7,13 +7,14 @@ export const { build, entrypointCallback, findEntrypoint, require_ } =
     'nestjs',
     /(?:from|require|import)\s*(?:\(\s*)?["']@nestjs\/core["']\s*(?:\))?/g,
     [
-      'src/main', // default, so most common
-      'app',
-      'index',
-      'server',
+      'src/main',
       'src/app',
       'src/index',
       'src/server',
+      'main',
+      'app',
+      'index',
+      'server',
     ],
     ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'],
     nodeBuild


### PR DESCRIPTION
Adds root `main.{js,cjs,mjs,ts,cts,mts}` as another potential entrypoint for NestJS projects.