### PR TITLE
[domains] collect contact information for domain purchases

### DIFF
--- a/.changeset/angry-kiwis-eat.md
+++ b/.changeset/angry-kiwis-eat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Collect contact information when purchasing domains

--- a/packages/cli/src/util/domains/collect-contact-information.ts
+++ b/packages/cli/src/util/domains/collect-contact-information.ts
@@ -1,0 +1,98 @@
+import type Client from '../client';
+import output from '../../output-manager';
+
+export type ContactInformation = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  address1: string;
+  city: string;
+  state: string;
+  zip: string;
+  country: string;
+  companyName?: string;
+};
+
+export default async function collectContactInformation(
+  client: Client
+): Promise<ContactInformation> {
+  output.log('');
+  output.log('Please provide contact information for domain registration:');
+
+  const firstName = await client.input.text({
+    message: 'First name:',
+    validate: (val: string) => val.length > 0 || 'First name is required',
+  });
+
+  const lastName = await client.input.text({
+    message: 'Last name:',
+    validate: (val: string) => val.length > 0 || 'Last name is required',
+  });
+
+  const email = await client.input.text({
+    message: 'Email:',
+    validate: (val: string) => {
+      if (val.length === 0) return 'Email is required';
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val))
+        return 'Invalid email format';
+      return true;
+    },
+  });
+
+  const phone = await client.input.text({
+    message: 'Phone (include country code, e.g., +15551234567):',
+    validate: (val: string) => {
+      if (val.length === 0) return 'Phone is required';
+      if (!/^\+\d{10,15}$/.test(val))
+        return 'Phone must start with + and contain 10-15 digits';
+      return true;
+    },
+  });
+
+  const address1 = await client.input.text({
+    message: 'Address:',
+    validate: (val: string) => val.length > 0 || 'Address is required',
+  });
+
+  const city = await client.input.text({
+    message: 'City:',
+    validate: (val: string) => val.length > 0 || 'City is required',
+  });
+
+  const state = await client.input.text({
+    message: 'State/Province:',
+    validate: (val: string) => val.length > 0 || 'State/Province is required',
+  });
+
+  const zip = await client.input.text({
+    message: 'Postal/ZIP code:',
+    validate: (val: string) => val.length > 0 || 'Postal/ZIP code is required',
+  });
+
+  const country = await client.input.text({
+    message: 'Country code (2 letters, e.g., US):',
+    validate: (val: string) => {
+      if (val.length === 0) return 'Country code is required';
+      if (!/^[A-Z]{2}$/i.test(val)) return 'Country code must be 2 letters';
+      return true;
+    },
+  });
+
+  const companyName = await client.input.text({
+    message: 'Company name (optional):',
+  });
+
+  return {
+    firstName,
+    lastName,
+    email,
+    phone,
+    address1,
+    city,
+    state,
+    zip,
+    country: country.toUpperCase(),
+    companyName: companyName || undefined,
+  };
+}

--- a/packages/cli/src/util/domains/purchase-domain-if-available.ts
+++ b/packages/cli/src/util/domains/purchase-domain-if-available.ts
@@ -10,6 +10,7 @@ import stamp from '../output/stamp';
 import * as ERRORS from '../errors-ts';
 import output from '../../output-manager';
 import param from '../output/param';
+import collectContactInformation from './collect-contact-information';
 
 const isTTY = process.stdout.isTTY;
 
@@ -72,7 +73,18 @@ export default async function purchaseDomainIfAvailable(
     }
 
     output.print(eraseLines(1));
-    const result = await purchaseDomain(client, domain, purchasePrice, years);
+
+    // Collect contact information
+    const contactInformation = await collectContactInformation(client);
+
+    const result = await purchaseDomain(
+      client,
+      domain,
+      purchasePrice,
+      years,
+      true,
+      contactInformation
+    );
     if (result instanceof Error) {
       return result;
     }

--- a/packages/cli/src/util/domains/purchase-domain.ts
+++ b/packages/cli/src/util/domains/purchase-domain.ts
@@ -3,6 +3,7 @@ import type Client from '../client';
 import { pollForOrder } from './get-order';
 import { getDomain } from './get-domain';
 import getScope from '../get-scope';
+import type { ContactInformation } from './collect-contact-information';
 
 type OrderResponse = {
   orderId: string;
@@ -13,7 +14,8 @@ export default async function purchaseDomain(
   name: string,
   expectedPrice: number,
   years: number,
-  autoRenew: boolean = true
+  autoRenew: boolean = true,
+  contactInformation: ContactInformation
 ) {
   const { team, contextName } = await getScope(client);
   const teamParam = team ? `?teamId=${team.slug}` : '';
@@ -26,18 +28,7 @@ export default async function purchaseDomain(
           expectedPrice,
           autoRenew,
           years,
-          contactInformation: {
-            firstName: 'Vercel',
-            lastName: 'Whois',
-            email: 'domains@registrar.vercel.com',
-            phone: '+14153985463',
-            address1: '100 First Street, Suite 2400',
-            city: 'San Fransisco',
-            state: 'CA',
-            zip: '94105',
-            country: 'US',
-            companyName: 'Vercel Inc.',
-          },
+          contactInformation,
         },
         method: 'POST',
       }


### PR DESCRIPTION
### TL;DR

Added contact information collection for domain purchases in the CLI.

### What changed?

- Created a new utility function `collectContactInformation` that prompts users for their contact details when purchasing a domain
- Modified the domain purchase flow to collect and submit this contact information
- Added validation for each contact field (name, email, phone, address, etc.)
- Disabled domain purchases in CI mode since contact information is now required
- Updated the domain purchase API call to include the collected contact information

### How to test?

1. Run `vercel domains buy example.com` to purchase a domain
2. Verify that you're prompted to enter contact information
3. Complete the contact information form with valid data
4. Confirm that the domain purchase completes successfully