### PR TITLE
Ensure `vc dev` uses project-level ts when available

### DIFF
--- a/.changeset/proud-dogs-sip.md
+++ b/.changeset/proud-dogs-sip.md
@@ -1,0 +1,5 @@
+---
+"@vercel/node": patch
+---
+
+Ensure `vc dev` uses project-level ts when available


### PR DESCRIPTION
During `vc build` the `node` builder uses a fairly outdated Typescript version (4.9.5) when there's no other Typescript version found. However, for `vc dev`, we were still using the old one even if project has it's own version installed. This copies over the logic to try the project-level one first during `vc dev`.

Fixes [this](https://community.vercel.com/t/vc-dev-fails-with-zod-v4-type-definitions-works-with-zod-v3/18331/2), at least partially. We will be updating the Typescript version used by the node builder, but at least you're not stuck doing module patches until then.