### PR TITLE
fix(cli): don’t overshow settings override log

### DIFF
--- a/.changeset/fast-cats-sin.md
+++ b/.changeset/fast-cats-sin.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix bug that was over-showing the local settings override log

--- a/packages/cli/src/util/input/edit-project-settings.ts
+++ b/packages/cli/src/util/input/edit-project-settings.ts
@@ -40,8 +40,12 @@ export async function editProjectSettings(
     projectSettings
   );
 
+  const hasLocalConfigurationOverrides =
+    localConfigurationOverrides &&
+    Object.values(localConfigurationOverrides ?? {}).some(Boolean);
+
   // Start UX by displaying (and applying) overrides. They will be referenced throughout remainder of CLI.
-  if (localConfigurationOverrides) {
+  if (hasLocalConfigurationOverrides) {
     // Apply local overrides (from `vercel.json`)
     for (const setting of settingKeys) {
       const localConfigValue = localConfigurationOverrides[setting];


### PR DESCRIPTION
This log:
`Local settings detected in vercel.json:`

Was always showing, even without local settings overrides. This is because the object is always passed in which is truthy. We need to check the values. 

```
localConfigurationOverrides {
  buildCommand: undefined,
  devCommand: undefined,
  framework: undefined,
  commandForIgnoringBuildStep: undefined,
  installCommand: undefined,
  outputDirectory: undefined
}
```