### PR TITLE
fix(oidc): export ES Module code from "import", "workflow", "react-native", and "browser" condition

### DIFF
--- a/.changeset/sweet-pears-glow.md
+++ b/.changeset/sweet-pears-glow.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+fix(oidc): export ES Module code from "import", "workflow", "react-native", and "browser" condition

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -10,10 +10,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/index-browser.js",
-      "react-native": "./dist/index-browser.js",
-      "workflow": "./dist/index-browser.js",
-      "import": "./dist/index.js",
+      "browser": "./dist/index-browser.mjs",
+      "react-native": "./dist/index-browser.mjs",
+      "workflow": "./dist/index-browser.mjs",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
@@ -42,7 +42,7 @@
     "pretest": "pnpm run build:code",
     "test": "vitest",
     "build": "pnpm run build:code && pnpm run build:docs",
-    "build:code": "node ../../utils/build.mjs",
+    "build:code": "node ../../utils/build.mjs --esm",
     "build:docs": "typedoc && prettier --write docs/**/*.md docs/*.md"
   },
   "license": "Apache-2.0",

--- a/packages/oidc/src/index-browser.test.ts
+++ b/packages/oidc/src/index-browser.test.ts
@@ -5,8 +5,8 @@ import * as BrowserImports from './index-browser';
 
 describe('browser export', () => {
   test('should match the default export', async () => {
-    expect(Object.keys(BrowserImports)).toStrictEqual(
-      Object.keys(DefaultImports)
+    expect(Object.keys(BrowserImports).sort()).toStrictEqual(
+      Object.keys(DefaultImports).sort()
     );
   });
 });

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -56,6 +56,22 @@ export async function esbuild(
     sourcemap: tsconfig.options.sourceMap,
     ...opts,
   });
+
+  const shouldBuildEsm = process.argv[2] === '--esm';
+
+  if (shouldBuildEsm) {
+    // Build ESM version with .mjs extension
+    await build({
+      entryPoints,
+      format: 'esm',
+      outdir,
+      platform: 'node',
+      target: ts.ScriptTarget[tsconfig.options.target],
+      sourcemap: tsconfig.options.sourceMap,
+      ...opts,
+      outExtension: { '.js': '.mjs' },
+    });
+  }
 }
 
 export async function tsc() {


### PR DESCRIPTION
- **docs: changeset**
- **test: make existing test more resilient**
- **build: support `--esm` flag for build script**
- **pkg: update exports and add `--esm` flag to export**
