### PR TITLE
[@vercel/firewall] Add optional env var for path prefix to use with Firewall rate limit requests

### DIFF
--- a/.changeset/fast-llamas-protect.md
+++ b/.changeset/fast-llamas-protect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/firewall': patch
+---
+
+Allow users to set a path prefix to the Rate Limit request to support microfrontends.

--- a/packages/firewall/src/rate-limit.ts
+++ b/packages/firewall/src/rate-limit.ts
@@ -90,7 +90,14 @@ export async function checkRateLimit(
     }
   }
 
-  const url = `https://${firewallHost}/.well-known/vercel/rate-limit-api/${encodeURIComponent(rateLimitId)}`;
+  let pathPrefix =
+    process.env.PUBLIC_VERCEL_FIREWALL_PATH_PREFIX ||
+    process.env.NEXT_PUBLIC_VERCEL_FIREWALL_PATH_PREFIX ||
+    '';
+  if (pathPrefix && !pathPrefix.startsWith('/')) {
+    pathPrefix = `/${pathPrefix}`;
+  }
+  const url = `https://${firewallHost}${pathPrefix}/.well-known/vercel/rate-limit-api/${encodeURIComponent(rateLimitId)}`;
 
   fullRateLimitKey = `${fullRateLimitKey}-${await hashString(
     fullRateLimitKey +

--- a/packages/firewall/test/e2e/rate-limit.test.ts
+++ b/packages/firewall/test/e2e/rate-limit.test.ts
@@ -219,5 +219,22 @@ function testWithCheckRateLimit(checkRateLimit: typeof checkRateLimitDist) {
         })
       ).rejects.toThrow('`headers` or `request` options are required');
     });
+
+    test('Should use path prefix when set', async () => {
+      process.env.NEXT_PUBLIC_VERCEL_FIREWALL_PATH_PREFIX = 'test-prefix';
+      try {
+        const { rateLimited } = await checkRateLimit('test-rule1', {
+          firewallHostForDevelopment: HOST,
+          rateLimitKey: '123' + rand,
+        });
+        expect(rateLimited).toBe(false);
+        expect(fetchCalls).toHaveLength(1);
+        expect(fetchCalls[0].url).toBe(
+          `https://${HOST}/test-prefix/.well-known/vercel/rate-limit-api/test-rule1`
+        );
+      } finally {
+        delete process.env.NEXT_PUBLIC_VERCEL_FIREWALL_PATH_PREFIX;
+      }
+    });
   };
 }

--- a/packages/firewall/test/e2e/rate-limit.test.ts
+++ b/packages/firewall/test/e2e/rate-limit.test.ts
@@ -221,11 +221,15 @@ function testWithCheckRateLimit(checkRateLimit: typeof checkRateLimitDist) {
     });
 
     test('Should use path prefix when set', async () => {
-      process.env.NEXT_PUBLIC_VERCEL_FIREWALL_PATH_PREFIX = 'test-prefix';
       try {
+        process.env.NEXT_PUBLIC_VERCEL_FIREWALL_PATH_PREFIX = 'test-prefix';
         const { rateLimited } = await checkRateLimit('test-rule1', {
           firewallHostForDevelopment: HOST,
           rateLimitKey: '123' + rand,
+          headers: {
+            'x-real-ip': '192.168.10.2' + rand,
+            host: HOST,
+          },
         });
         expect(rateLimited).toBe(false);
         expect(fetchCalls).toHaveLength(1);


### PR DESCRIPTION
In order to support microfrontends or applications using rewrites, this PR adds the ability for users to set an optional path prefix to the Firewall Rate Limit request endpoint. The path prefix would be used to route to the correct microfrontend, and the child microfrontend would then need to remove the path prefix via a rewrite. The `@vercel/microfrontends` package will automatically apply this logic so users don't need to think about it.