### PR TITLE
Add experimental support for `.vercel/routes.json`

### DIFF
--- a/.changeset/kind-snakes-hide.md
+++ b/.changeset/kind-snakes-hide.md
@@ -1,0 +1,6 @@
+---
+'@vercel/routing-utils': patch
+'vercel': patch
+---
+
+Add experimental support for routes.json

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -733,6 +733,9 @@ async function doBuild(
                 // Convert routes from introspection format to Vercel routing format
                 const convertedRoutes = [];
                 for (const route of routesJson.routes) {
+                  if (typeof route.source !== 'string') {
+                    continue;
+                  }
                   const { src } = sourceToRegex(route.source);
                   const newRoute: Route = {
                     src,

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import dotenv from 'dotenv';
-import fs from 'fs-extra';
+import fs, { existsSync } from 'fs-extra';
 import minimatch from 'minimatch';
 import { join, normalize, relative, resolve, sep } from 'path';
 import semver from 'semver';
@@ -42,6 +42,7 @@ import {
   appendRoutesToPhase,
   getTransformedRoutes,
   mergeRoutes,
+  sourceToRegex,
   type MergeRoutesProps,
   type Route,
 } from '@vercel/routing-utils';
@@ -706,6 +707,56 @@ async function doBuild(
             message: `The Runtime "${build.use}" is using "${lambdaRuntime}", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.`,
             link: 'https://vercel.link/function-runtimes',
           });
+        }
+      }
+
+      // Experimental feature where users can provide a routes.json which will be mapped ot the
+      // single lambda function output, giving o11y to those routes.
+      const backendBuilders = [
+        '@vercel/express',
+        '@vercel/hono',
+        '@vercel/fastify',
+      ];
+      const isBackendBuilder = build.use && backendBuilders.includes(build.use);
+      if (process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON === '1') {
+        if ('output' in buildResult && buildResult.output && isBackendBuilder) {
+          const routesJsonPath = join(outputDir, '..', 'routes.json');
+          if (existsSync(routesJsonPath)) {
+            try {
+              const routesJson = await readJSONFile(routesJsonPath);
+              if (
+                routesJson &&
+                typeof routesJson === 'object' &&
+                'routes' in routesJson &&
+                Array.isArray(routesJson.routes)
+              ) {
+                // Convert routes from introspection format to Vercel routing format
+                const convertedRoutes = [];
+                for (const route of routesJson.routes) {
+                  const { src } = sourceToRegex(route.source);
+                  const newRoute: Route = {
+                    src,
+                    dest: route.source,
+                  };
+                  if (route.methods) {
+                    newRoute.methods = route.methods;
+                  }
+                  if (route.source === '/') {
+                    continue;
+                  }
+                  convertedRoutes.push(newRoute);
+                }
+                // Wrap routes with filesystem handler and catch-all
+                (buildResult as BuildResultV2Typical).routes = [
+                  { handle: 'filesystem' },
+                  ...convertedRoutes,
+                  { src: '/(.*)', dest: '/' },
+                ];
+              }
+            } catch (error) {
+              output.error(`Failed to read routes.json: ${error}`);
+            }
+          }
         }
       }
 

--- a/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "orgId": ".",
+  "projectId": ".",
+  "settings": {
+    "framework": null
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/.vercel/routes.json
+++ b/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/.vercel/routes.json
@@ -1,0 +1,13 @@
+{
+  "routes": [
+    {
+      "source": "/users/:id",
+      "methods": ["GET"]
+    },
+    {
+      "source": "/api/posts/:postId",
+      "methods": ["GET"]
+    }
+  ]
+}
+

--- a/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/index.js
+++ b/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/index.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('Hello World');
+});
+
+app.get('/users/:id', (req, res) => {
+  res.send(`User ${req.params.id}`);
+});
+
+app.get('/api/posts/:postId', (req, res) => {
+  res.send(`Post ${req.params.postId}`);
+});
+
+module.exports = app;
+

--- a/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/package.json
+++ b/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "express-with-routes-json",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}
+

--- a/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/vercel.json
+++ b/packages/cli/test/fixtures/unit/commands/build/express-with-routes-json/vercel.json
@@ -1,0 +1,9 @@
+{
+  "builds": [
+    {
+      "src": "index.js",
+      "use": "@vercel/express"
+    }
+  ]
+}
+

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1319,46 +1319,50 @@ describe.skipIf(flakey)('build', () => {
     expect(fs.existsSync(join(output, 'static', '.env'))).toBe(false);
   });
 
-  it('should apply routes from `.vercel/routes.json` when VERCEL_EXPERIMENTAL_ROUTES_JSON is enabled', async () => {
-    const cwd = fixture('express-with-routes-json');
-    const output = join(cwd, '.vercel/output');
+  // Skip on Windows because route parameters with colons (e.g., `:id`) are used as filesystem paths
+  it.skipIf(process.platform === 'win32')(
+    'should apply routes from `.vercel/routes.json` when VERCEL_EXPERIMENTAL_ROUTES_JSON is enabled',
+    async () => {
+      const cwd = fixture('express-with-routes-json');
+      const output = join(cwd, '.vercel/output');
 
-    try {
-      process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON = '1';
-      client.cwd = cwd;
-      const exitCode = await build(client);
-      expect(exitCode).toEqual(0);
+      try {
+        process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON = '1';
+        client.cwd = cwd;
+        const exitCode = await build(client);
+        expect(exitCode).toEqual(0);
 
-      // `config.json` should include routes from `.vercel/routes.json`
-      const config = await fs.readJSON(join(output, 'config.json'));
-      expect(config).toMatchObject({
-        version: 3,
-        routes: [
-          { handle: 'filesystem' },
-          {
-            src: expect.stringMatching(/^\^.*users.*\$$/),
-            dest: '/users/:id',
-            methods: ['GET'],
-          },
-          {
-            src: expect.stringMatching(/^\^.*api.*posts.*\$$/),
-            dest: '/api/posts/:postId',
-            methods: ['GET'],
-          },
-          {
-            src: '/(.*)',
-            dest: '/',
-          },
-        ],
-      });
+        // `config.json` should include routes from `.vercel/routes.json`
+        const config = await fs.readJSON(join(output, 'config.json'));
+        expect(config).toMatchObject({
+          version: 3,
+          routes: [
+            { handle: 'filesystem' },
+            {
+              src: expect.stringMatching(/^\^.*users.*\$$/),
+              dest: '/users/:id',
+              methods: ['GET'],
+            },
+            {
+              src: expect.stringMatching(/^\^.*api.*posts.*\$$/),
+              dest: '/api/posts/:postId',
+              methods: ['GET'],
+            },
+            {
+              src: '/(.*)',
+              dest: '/',
+            },
+          ],
+        });
 
-      // "functions" directory should have the express function
-      const functions = await fs.readdir(join(output, 'functions'));
-      expect(functions).toContain('index.func');
-    } finally {
-      delete process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON;
+        // "functions" directory should have the express function
+        const functions = await fs.readdir(join(output, 'functions'));
+        expect(functions).toContain('index.func');
+      } finally {
+        delete process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON;
+      }
     }
-  });
+  );
 
   it('should build with `repo.json` link', async () => {
     const cwd = fixture('../../monorepo-link');

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1319,6 +1319,47 @@ describe.skipIf(flakey)('build', () => {
     expect(fs.existsSync(join(output, 'static', '.env'))).toBe(false);
   });
 
+  it('should apply routes from `.vercel/routes.json` when VERCEL_EXPERIMENTAL_ROUTES_JSON is enabled', async () => {
+    const cwd = fixture('express-with-routes-json');
+    const output = join(cwd, '.vercel/output');
+
+    try {
+      process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON = '1';
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+
+      // `config.json` should include routes from `.vercel/routes.json`
+      const config = await fs.readJSON(join(output, 'config.json'));
+      expect(config).toMatchObject({
+        version: 3,
+        routes: [
+          { handle: 'filesystem' },
+          {
+            src: expect.stringMatching(/^\^.*users.*\$$/),
+            dest: '/users/:id',
+            methods: ['GET'],
+          },
+          {
+            src: expect.stringMatching(/^\^.*api.*posts.*\$$/),
+            dest: '/api/posts/:postId',
+            methods: ['GET'],
+          },
+          {
+            src: '/(.*)',
+            dest: '/',
+          },
+        ],
+      });
+
+      // "functions" directory should have the express function
+      const functions = await fs.readdir(join(output, 'functions'));
+      expect(functions).toContain('index.func');
+    } finally {
+      delete process.env.VERCEL_EXPERIMENTAL_ROUTES_JSON;
+    }
+  });
+
   it('should build with `repo.json` link', async () => {
     const cwd = fixture('../../monorepo-link');
 

--- a/packages/routing-utils/src/index.ts
+++ b/packages/routing-utils/src/index.ts
@@ -20,7 +20,7 @@ import {
 export { appendRoutesToPhase } from './append';
 export { mergeRoutes } from './merge';
 export * from './schemas';
-export { getCleanUrls } from './superstatic';
+export { getCleanUrls, sourceToRegex } from './superstatic';
 export * from './types';
 
 const VALID_HANDLE_VALUES = [


### PR DESCRIPTION
Running `vc build` with `VERCEL_EXPERIMENTAL_ROUTES_JSON` and a `.vercel/routes.json` with o11y routes will map to the build output

```
{
  "routes": [
    {
      "source": "/users/:id",
      "methods": ["GET"]
    },
    {
      "source": "/api/posts/:postId",
      "methods": ["GET"]
    }
  ]
}
```