### PR TITLE
[build-utils] Allow Node.js v24 behind env var

### DIFF
--- a/.changeset/little-grapes-invent.md
+++ b/.changeset/little-grapes-invent.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Allow Node.js 24 behind env var feature flag

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -66,7 +66,7 @@ export const BUN_VERSIONS: BunVersion[] = [
 ];
 
 export function getNodeVersionByMajor(major: number): NodeVersion | undefined {
-  return NODE_VERSIONS.find(v => v.major === major);
+  return getOptions().find(v => v.major === major);
 }
 
 function getOptions(): NodeVersion[] {

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -70,6 +70,12 @@ export function getNodeVersionByMajor(major: number): NodeVersion | undefined {
 }
 
 function getOptions() {
+  if (process.env.VERCEL_ALLOW_NODEJS_24 === '1') {
+    return [
+      { major: 24, range: '24.x', runtime: 'nodejs24.x' },
+      ...NODE_VERSIONS,
+    ];
+  }
   return NODE_VERSIONS;
 }
 

--- a/packages/build-utils/src/fs/node-version.ts
+++ b/packages/build-utils/src/fs/node-version.ts
@@ -69,10 +69,14 @@ export function getNodeVersionByMajor(major: number): NodeVersion | undefined {
   return NODE_VERSIONS.find(v => v.major === major);
 }
 
-function getOptions() {
+function getOptions(): NodeVersion[] {
   if (process.env.VERCEL_ALLOW_NODEJS_24 === '1') {
     return [
-      { major: 24, range: '24.x', runtime: 'nodejs24.x' },
+      new NodeVersion({
+        major: 24,
+        range: '24.x',
+        runtime: 'nodejs24.x',
+      }),
       ...NODE_VERSIONS,
     ];
   }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -322,7 +322,7 @@ it('should throw for discontinued versions', async () => {
   }
 });
 
-it('should only allow nodejs22.x when env var is set', async () => {
+it('should only allow nodejs22.x', async () => {
   expect(getLatestNodeVersion()).toHaveProperty('major', 22);
   expect(await getSupportedNodeVersion('22.x')).toHaveProperty('major', 22);
   expect(await getSupportedNodeVersion('22')).toHaveProperty('major', 22);
@@ -330,7 +330,7 @@ it('should only allow nodejs22.x when env var is set', async () => {
   expect(await getSupportedNodeVersion('>=20')).toHaveProperty('major', 22);
 });
 
-it('should only allow nodejs22.x when env var is set', async () => {
+it('should only allow nodejs24.x when env var is set', async () => {
   try {
     expect(getLatestNodeVersion()).toHaveProperty('major', 22);
     await expect(getSupportedNodeVersion('24.x')).rejects.toThrow();

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -330,6 +330,23 @@ it('should only allow nodejs22.x when env var is set', async () => {
   expect(await getSupportedNodeVersion('>=20')).toHaveProperty('major', 22);
 });
 
+it('should only allow nodejs22.x when env var is set', async () => {
+  try {
+    expect(getLatestNodeVersion()).toHaveProperty('major', 22);
+    expect(getSupportedNodeVersion('24.x')).rejects.toThrow();
+
+    process.env.VERCEL_ALLOW_NODEJS_24 = '1';
+
+    expect(getLatestNodeVersion()).toHaveProperty('major', 24);
+    expect(await getSupportedNodeVersion('24.x')).toHaveProperty('major', 24);
+    expect(await getSupportedNodeVersion('24')).toHaveProperty('major', 24);
+    expect(await getSupportedNodeVersion('24.3.0')).toHaveProperty('major', 24);
+    expect(await getSupportedNodeVersion('>=24')).toHaveProperty('major', 24);
+  } finally {
+    delete process.env.VERCEL_ALLOW_NODEJS_24;
+  }
+});
+
 it('should warn for deprecated versions, soon to be discontinued', async () => {
   const realDateNow = Date.now;
   try {

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -322,7 +322,7 @@ it('should throw for discontinued versions', async () => {
   }
 });
 
-it('should only allow nodejs22.x', async () => {
+it('should allow nodejs22.x', async () => {
   expect(getLatestNodeVersion()).toHaveProperty('major', 22);
   expect(await getSupportedNodeVersion('22.x')).toHaveProperty('major', 22);
   expect(await getSupportedNodeVersion('22')).toHaveProperty('major', 22);

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -333,7 +333,7 @@ it('should only allow nodejs22.x when env var is set', async () => {
 it('should only allow nodejs22.x when env var is set', async () => {
   try {
     expect(getLatestNodeVersion()).toHaveProperty('major', 22);
-    expect(getSupportedNodeVersion('24.x')).rejects.toThrow();
+    await expect(getSupportedNodeVersion('24.x')).rejects.toThrow();
 
     process.env.VERCEL_ALLOW_NODEJS_24 = '1';
 


### PR DESCRIPTION
Similar to what we did for `22.x`: #12159

Tested at: https://runtime-version-jkfik663q.vercel.sh/node-24