### PR TITLE
import backends lib async

### DIFF
--- a/.changeset/rich-buses-nail.md
+++ b/.changeset/rich-buses-nail.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Re-enable experimental backends support

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
     "vitest-run": "vitest --config ./vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
-    "test-e2e-node-20-22": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
+    "test-e2e-node-all-versions": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
     "test-dev": "pnpm test test/dev/",
     "coverage": "codecov",
     "build": "node scripts/build.mjs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --bail",
     "vitest-run": "vitest --config ./vitest.config.mts",
     "vitest-unit": "jest test/unit/ --listTests",
-    "test-e2e": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
+    "test-e2e-node-20-22": "rimraf test/fixtures/integration && pnpm test test/integration-1.test.ts test/integration-2.test.ts test/integration-3.test.ts",
     "test-dev": "pnpm test test/dev/",
     "coverage": "codecov",
     "build": "node scripts/build.mjs",

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -4,7 +4,6 @@ import fs, { existsSync } from 'fs-extra';
 import minimatch from 'minimatch';
 import { join, normalize, relative, resolve, sep } from 'path';
 import semver from 'semver';
-// import * as experimentalBackendBuilder from '@vercel/backends';
 
 import {
   download,
@@ -28,7 +27,7 @@ import {
   type FlagDefinitions,
   type Meta,
   type PackageJson,
-  // shouldUseExperimentalBackends,
+  shouldUseExperimentalBackends,
 } from '@vercel/build-utils';
 import type { VercelConfig } from '@vercel/client';
 import { fileNameSymbol } from '@vercel/client';
@@ -640,16 +639,18 @@ async function doBuild(
       let buildResult: BuildResultV2 | BuildResultV3;
       try {
         buildResult = await builderSpan.trace<BuildResultV2 | BuildResultV3>(
-          () => {
+          async () => {
             // Use experimental backends builder only for backend framework builders,
             // not for static builders (which handle public/ directories)
-            // hotfix: disable experimental backends for now
-            // if (
-            //   shouldUseExperimentalBackends(buildConfig.framework) &&
-            //   builderPkg.name !== '@vercel/static'
-            // ) {
-            //   return experimentalBackendBuilder.build(buildOptions);
-            // }
+            if (
+              shouldUseExperimentalBackends(buildConfig.framework) &&
+              builderPkg.name !== '@vercel/static'
+            ) {
+              const experimentalBackendBuilder = await import(
+                '@vercel/backends'
+              );
+              return experimentalBackendBuilder.build(buildOptions);
+            }
             return builder.build(buildOptions);
           }
         );

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,10 @@
       "dependsOn": ["build"],
       "outputLogs": "new-only"
     },
+    "test-e2e-node-all-versions": {
+      "dependsOn": ["build"],
+      "outputLogs": "new-only"
+    },
     "test-unit": {
       "dependsOn": ["build"],
       "outputLogs": "new-only"

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -49,6 +49,15 @@ const runnersMap = new Map([
       max: 7,
       testScript: 'test',
       runners: ['ubuntu-latest'],
+    },
+  ],
+  [
+    'test-e2e-node-20-22',
+    {
+      min: 1,
+      max: 7,
+      testScript: 'test',
+      runners: ['ubuntu-latest'],
       nodeVersions: ['20', '22'],
     },
   ],

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -52,7 +52,7 @@ const runnersMap = new Map([
     },
   ],
   [
-    'test-e2e-node-20-22',
+    'test-e2e-node-all-versions',
     {
       min: 1,
       max: 7,

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -44,7 +44,13 @@ const runnersMap = new Map([
   ],
   [
     'test-e2e',
-    { min: 1, max: 7, testScript: 'test', runners: ['ubuntu-latest'] },
+    {
+      min: 1,
+      max: 7,
+      testScript: 'test',
+      runners: ['ubuntu-latest'],
+      nodeVersions: ['20', '22'],
+    },
   ],
   [
     'test-next-local',


### PR DESCRIPTION
For node 20, this was failing due to require of ESM, moving to async import instead. Tested manually to make sure this didn't break as well.

This also updates e2e tests so that they run on node 20.