### PR TITLE
[python] allowing /api folder entrypoints for FastAPI + Flask

### DIFF
--- a/.changeset/red-forks-help.md
+++ b/.changeset/red-forks-help.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+"@vercel/frameworks": patch
+"@vercel/python": patch
+---
+
+[python] allowing /api folder entrypoints for FastAPI + Flask

--- a/.changeset/red-forks-help.md
+++ b/.changeset/red-forks-help.md
@@ -1,7 +1,5 @@
 ---
-"vercel": patch
-"@vercel/frameworks": patch
-"@vercel/python": patch
+"@vercel/python": major
 ---
 
 [python] allowing /api folder entrypoints for FastAPI + Flask

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -437,8 +437,8 @@ export async function getBuildMatches(
       const candidateDirs = ['', 'src', 'app', 'api'];
       const candidateNames = ['app', 'index', 'server', 'main'];
       const candidates: string[] = [];
-      for (const dir of candidateDirs) {
-        for (const name of candidateNames) {
+      for (const name of candidateNames) {
+        for (const dir of candidateDirs) {
           candidates.push(dir ? `${dir}/${name}.py` : `${name}.py`);
         }
       }

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -434,7 +434,7 @@ export async function getBuildMatches(
       buildConfig.config?.framework === 'flask'
     ) {
       // Mirror @vercel/python's entrypoint candidates
-      const candidateDirs = ['', 'src', 'app'];
+      const candidateDirs = ['', 'src', 'app', 'api'];
       const candidateNames = ['app', 'index', 'server', 'main'];
       const candidates: string[] = [];
       for (const dir of candidateDirs) {

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2030,6 +2030,7 @@ export const frameworks = [
       'FastAPI framework, high performance, easy to learn, fast to code, ready for production',
     website: 'https://fastapi.tiangolo.com',
     useRuntime: { src: 'index.py', use: '@vercel/python' },
+    ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [
         {
@@ -2081,6 +2082,7 @@ export const frameworks = [
     description: 'A Flask app, ready for production',
     website: 'https://flask.palletsprojects.com',
     useRuntime: { src: 'index.py', use: '@vercel/python' },
+    ignoreRuntimes: ['@vercel/python'],
     detectors: {
       some: [
         {

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -4,7 +4,7 @@ import type { FileFsRef } from '@vercel/build-utils';
 import { glob, debug } from '@vercel/build-utils';
 
 export const FASTAPI_ENTRYPOINT_FILENAMES = ['app', 'index', 'server', 'main'];
-export const FASTAPI_ENTRYPOINT_DIRS = ['', 'src', 'app', 'api', 'backend'];
+export const FASTAPI_ENTRYPOINT_DIRS = ['', 'src', 'app', 'api'];
 export const FASTAPI_CONTENT_REGEX =
   /(from\s+fastapi\s+import\s+FastAPI|import\s+fastapi|FastAPI\s*\()/;
 

--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -4,7 +4,7 @@ import type { FileFsRef } from '@vercel/build-utils';
 import { glob, debug } from '@vercel/build-utils';
 
 export const FASTAPI_ENTRYPOINT_FILENAMES = ['app', 'index', 'server', 'main'];
-export const FASTAPI_ENTRYPOINT_DIRS = ['', 'src', 'app'];
+export const FASTAPI_ENTRYPOINT_DIRS = ['', 'src', 'app', 'api', 'backend'];
 export const FASTAPI_CONTENT_REGEX =
   /(from\s+fastapi\s+import\s+FastAPI|import\s+fastapi|FastAPI\s*\()/;
 
@@ -30,7 +30,7 @@ export function isFastapiEntrypoint(
 
 // Flask zero-config detection
 export const FLASK_ENTRYPOINT_FILENAMES = ['app', 'index', 'server', 'main'];
-export const FLASK_ENTRYPOINT_DIRS = ['', 'src', 'app'];
+export const FLASK_ENTRYPOINT_DIRS = ['', 'src', 'app', 'api'];
 export const FLASK_CONTENT_REGEX =
   /(from\s+flask\s+import\s+Flask|import\s+flask|Flask\s*\()/;
 


### PR DESCRIPTION
This PR adds support for entrypoints inside the /api folder for FastAPI/Flask apps.
It adds `ignoreRuntimes: ['@vercel/python'],` because otherwise the API builder routes will overshadow the framework routes and 404 when they shouldn't