### PR TITLE
[cli] add new commands `vercel cache invalidate --srcimg`

### DIFF
--- a/.changeset/fuzzy-files-joke.md
+++ b/.changeset/fuzzy-files-joke.md
@@ -1,0 +1,5 @@
+---
+"vercel": minor
+---
+
+[cli] add new commands `vercel cache invalidate --srcimg`

--- a/packages/cli/src/commands/cache/command.ts
+++ b/packages/cli/src/commands/cache/command.ts
@@ -48,6 +48,14 @@ export const invalidateSubcommand = {
       argument: 'TAGS',
       deprecated: false,
     },
+    {
+      name: 'srcimg',
+      description: 'Source Image to invalidate',
+      shorthand: null,
+      type: String,
+      argument: 'SRCIMG',
+      deprecated: false,
+    },
   ],
   examples: [
     {
@@ -57,6 +65,10 @@ export const invalidateSubcommand = {
     {
       name: 'Invalidate all cached content associated with any one of multiple tags',
       value: `${packageName} cache invalidate --tag foo,bar,baz`,
+    },
+    {
+      name: 'Invalidate all cached content associated with a source image',
+      value: `${packageName} cache invalidate --srcimg /api/avatar/1`,
     },
   ],
 } as const;
@@ -77,6 +89,14 @@ export const dangerouslyDeleteSubcommand = {
       deprecated: false,
     },
     {
+      name: 'srcimg',
+      description: 'Source Image to delete',
+      shorthand: null,
+      type: String,
+      argument: 'SRCIMG',
+      deprecated: false,
+    },
+    {
       name: 'revalidation-deadline-seconds',
       description: 'Revalidation deadline in seconds',
       shorthand: null,
@@ -93,6 +113,14 @@ export const dangerouslyDeleteSubcommand = {
     {
       name: 'Dangerously delete all cached content associated with a tag if not accessed in the next hour',
       value: `${packageName} cache dangerously-delete --tag foo --revalidation-deadline-seconds 3600`,
+    },
+    {
+      name: 'Dangerously delete all cached content associated with a source image',
+      value: `${packageName} cache dangerously-delete --srcimg /api/avatar/1`,
+    },
+    {
+      name: 'Dangerously delete all cached content associated with a source image if not accessed in the next hour',
+      value: `${packageName} cache dangerously-delete --srcimg /api/avatar/1 --revalidation-deadline-seconds 3600`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -48,20 +48,41 @@ export default async function dangerouslyDelete(
   client.config.currentTeam = org.type === 'team' ? org.id : undefined;
   const yes = Boolean(parsedArgs.flags['--yes']);
   const tag = parsedArgs.flags['--tag'];
+  const srcimg = parsedArgs.flags['--srcimg'];
+  const revalidate = parsedArgs.flags['--revalidation-deadline-seconds'];
   telemetry.trackCliFlagYes(yes);
   telemetry.trackCliOptionTag(tag);
+  telemetry.trackCliOptionSrcimg(srcimg);
+  telemetry.trackCliOptionRevalidationDeadlineSeconds(revalidate);
 
-  if (!tag) {
-    output.error(`The --tag option is required`);
+  if (tag && srcimg) {
+    output.error(`Cannot use both --tag and --srcimg options`);
     return 1;
   }
 
-  const revalidate = parsedArgs.flags['--revalidation-deadline-seconds'];
-  telemetry.trackCliOptionRevalidationDeadlineSeconds(revalidate);
+  let itemName = '';
+  let itemValue = '';
+  let flag = '';
+  let postUrl = '';
+  let postBody = {};
+  if (tag) {
+    itemName = plural('tag', tag.split(',').length, false);
+    itemValue = tag;
+    flag = '--tag';
+    postUrl = '/v1/edge-cache/dangerously-delete-by-tags';
+    postBody = { tags: tag };
+  } else if (srcimg) {
+    itemName = 'source image';
+    itemValue = srcimg;
+    flag = '--srcimg';
+    postUrl = '/v1/edge-cache/dangerously-delete-by-src-images';
+    postBody = { srcImages: [srcimg] };
+  } else {
+    output.error(`The --tag or --srcimg option is required`);
+    return 1;
+  }
 
-  const tagsDesc = plural('tag', tag.split(',').length, false);
-  const msg = `You are about to dangerously delete all cached content associated with ${tagsDesc} ${tag} for project ${project.name}`;
-  const query = new URLSearchParams({ projectIdOrName: project.id }).toString();
+  const msg = `You are about to dangerously delete all cached content associated with ${itemName} ${itemValue} for project ${project.name}`;
 
   if (!yes) {
     if (!process.stdin.isTTY) {
@@ -70,7 +91,7 @@ export default async function dangerouslyDelete(
           ? ` --revalidation-deadline-seconds ${revalidate}`
           : '';
       output.print(
-        `${msg}. To continue, run ${getCommandName(`cache dangerously-delete --tag ${tag}${optional} --yes`)}.`
+        `${msg}. To continue, run ${getCommandName(`cache dangerously-delete ${flag} ${itemValue}${optional} --yes`)}.`
       );
       return 1;
     }
@@ -81,20 +102,15 @@ export default async function dangerouslyDelete(
     }
   }
 
-  await client.fetch(`/v1/edge-cache/dangerously-delete-by-tags?${query}`, {
+  await client.fetch(`${postUrl}?projectIdOrName=${project.id}`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      tags: tag,
-      revalidationDeadlineSeconds: revalidate,
-    }),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(postBody),
   });
 
   output.print(
     prependEmoji(
-      `Successfully deleted all cached content associated with ${tagsDesc} ${tag}`,
+      `Successfully deleted all cached content associated with ${itemName} ${itemValue}`,
       emoji('success')
     ) + `\n`
   );

--- a/packages/cli/src/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/commands/cache/dangerously-delete.ts
@@ -70,13 +70,13 @@ export default async function dangerouslyDelete(
     itemValue = tag;
     flag = '--tag';
     postUrl = '/v1/edge-cache/dangerously-delete-by-tags';
-    postBody = { tags: tag };
+    postBody = { tags: tag, revalidationDeadlineSeconds: revalidate };
   } else if (srcimg) {
     itemName = 'source image';
     itemValue = srcimg;
     flag = '--srcimg';
     postUrl = '/v1/edge-cache/dangerously-delete-by-src-images';
-    postBody = { srcImages: [srcimg] };
+    postBody = { srcImages: [srcimg], revalidationDeadlineSeconds: revalidate };
   } else {
     output.error(`The --tag or --srcimg option is required`);
     return 1;

--- a/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/dangerously-delete.ts
@@ -21,6 +21,15 @@ export class CacheDangerouslyDeleteTelemetryClient
     }
   }
 
+  trackCliOptionSrcimg(srcimg: string | undefined) {
+    if (srcimg) {
+      this.trackCliOption({
+        option: 'srcimg',
+        value: srcimg,
+      });
+    }
+  }
+
   trackCliOptionRevalidationDeadlineSeconds(seconds: number | undefined) {
     if (seconds) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/cache/invalidate.ts
+++ b/packages/cli/src/util/telemetry/commands/cache/invalidate.ts
@@ -20,4 +20,13 @@ export class CacheInvalidateTelemetryClient
       });
     }
   }
+
+  trackCliOptionSrcimg(srcimg: string | undefined) {
+    if (srcimg) {
+      this.trackCliOption({
+        option: 'srcimg',
+        value: srcimg,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -46,7 +46,9 @@ describe('cache dangerously-delete', () => {
     client.setArgv('cache', 'dangerously-delete', '--yes');
     const exitCode = await cache(client);
     expect(exitCode).toEqual(1);
-    await expect(client.stderr).toOutput('The --tag option is required');
+    await expect(client.stderr).toOutput(
+      'The --tag or --srcimg option is required'
+    );
   });
 
   it('should succeed with --tag', async () => {
@@ -85,7 +87,7 @@ describe('cache dangerously-delete', () => {
     );
   });
 
-  it('should ask for confirmation if the --yes option is omitted', async () => {
+  it('should ask for confirmation when --tag is missing --yes', async () => {
     client.setArgv('cache', 'dangerously-delete', '--tag=foo');
     const exitCode = await cache(client);
     expect(exitCode).toEqual(1);
@@ -94,7 +96,7 @@ describe('cache dangerously-delete', () => {
     );
   });
 
-  it('should ask for confirmation and if no --yes and pass through the --revalidation-deadline-seconds', async () => {
+  it('should ask for confirmation when --tag and --revalidation-deadline-seconds is missing --yes', async () => {
     client.setArgv(
       'cache',
       'dangerously-delete',
@@ -105,6 +107,52 @@ describe('cache dangerously-delete', () => {
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput(
       `You are about to dangerously delete all cached content associated with tag foo for project ${projectId}. To continue, run \`vercel cache dangerously-delete --tag foo --revalidation-deadline-seconds 60 --yes\`.`
+    );
+  });
+
+  it('should succeed with --srcimg', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-src-images`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          srcImages: ['/api/avatar/1'],
+        });
+        res.end();
+      }
+    );
+    client.setArgv(
+      'cache',
+      'dangerously-delete',
+      '--srcimg=/api/avatar/1',
+      '--yes'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully deleted all cached content associated with source image /api/avatar/1'
+    );
+  });
+
+  it('should ask for confirmation when --srcimg is missing --yes', async () => {
+    client.setArgv('cache', 'dangerously-delete', '--srcimg=/api/avatar/1');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      `You are about to dangerously delete all cached content associated with source image /api/avatar/1 for project ${projectId}. To continue, run \`vercel cache dangerously-delete --srcimg /api/avatar/1 --yes\`.`
+    );
+  });
+
+  it('should ask for confirmation when --srcimg and --revalidation-deadline-seconds is missing --yes', async () => {
+    client.setArgv(
+      'cache',
+      'dangerously-delete',
+      '--srcimg=/api/avatar/1',
+      '--revalidation-deadline-seconds=60'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      `You are about to dangerously delete all cached content associated with source image /api/avatar/1 for project ${projectId}. To continue, run \`vercel cache dangerously-delete --srcimg /api/avatar/1 --revalidation-deadline-seconds 60 --yes\`.`
     );
   });
 });

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -205,4 +205,18 @@ describe('cache dangerously-delete', () => {
       `You are about to dangerously delete all cached content associated with source image /api/avatar/1 for project ${projectId}. To continue, run \`vercel cache dangerously-delete --srcimg /api/avatar/1 --revalidation-deadline-seconds 60 --yes\`.`
     );
   });
+
+  it('should error when both --tag and --srcimg are provided', async () => {
+    client.setArgv(
+      'cache',
+      'dangerously-delete',
+      '--tag=foo',
+      '--srcimg=/api/avatar/1'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Cannot use both --tag and --srcimg options'
+    );
+  });
 });

--- a/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
+++ b/packages/cli/test/unit/commands/cache/dangerously-delete.test.ts
@@ -87,6 +87,31 @@ describe('cache dangerously-delete', () => {
     );
   });
 
+  it('should succeed with --tag and --revalidation-deadline-seconds', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-tags`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          tags: 'foo',
+          revalidationDeadlineSeconds: 60,
+        });
+        res.end();
+      }
+    );
+    client.setArgv(
+      'cache',
+      'dangerously-delete',
+      '--tag=foo',
+      '--revalidation-deadline-seconds=60',
+      '--yes'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully deleted all cached content associated with tag foo'
+    );
+  });
+
   it('should ask for confirmation when --tag is missing --yes', async () => {
     client.setArgv('cache', 'dangerously-delete', '--tag=foo');
     const exitCode = await cache(client);
@@ -124,6 +149,31 @@ describe('cache dangerously-delete', () => {
       'cache',
       'dangerously-delete',
       '--srcimg=/api/avatar/1',
+      '--yes'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully deleted all cached content associated with source image /api/avatar/1'
+    );
+  });
+
+  it('should succeed with --srcimg and --revalidation-deadline-seconds', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/dangerously-delete-by-src-images`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          srcImages: ['/api/avatar/1'],
+          revalidationDeadlineSeconds: 60,
+        });
+        res.end();
+      }
+    );
+    client.setArgv(
+      'cache',
+      'dangerously-delete',
+      '--srcimg=/api/avatar/1',
+      '--revalidation-deadline-seconds=60',
       '--yes'
     );
     const exitCode = await cache(client);

--- a/packages/cli/test/unit/commands/cache/invalidate.test.ts
+++ b/packages/cli/test/unit/commands/cache/invalidate.test.ts
@@ -113,4 +113,18 @@ describe('cache invalidate', () => {
       `You are about to invalidate all cached content associated with source image /api/avatar/1 for project ${projectId}. To continue, run \`vercel cache invalidate --srcimg /api/avatar/1 --yes\`.`
     );
   });
+
+  it('should error when both --tag and --srcimg are provided', async () => {
+    client.setArgv(
+      'cache',
+      'invalidate',
+      '--tag=foo',
+      '--srcimg=/api/avatar/1'
+    );
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Cannot use both --tag and --srcimg options'
+    );
+  });
 });

--- a/packages/cli/test/unit/commands/cache/invalidate.test.ts
+++ b/packages/cli/test/unit/commands/cache/invalidate.test.ts
@@ -43,7 +43,9 @@ describe('cache invalidate', () => {
     client.setArgv('cache', 'invalidate', '--yes');
     const exitCode = await cache(client);
     expect(exitCode).toEqual(1);
-    await expect(client.stderr).toOutput('The --tag option is required');
+    await expect(client.stderr).toOutput(
+      'The --tag or --srcimg option is required'
+    );
   });
 
   it('should succeed with --tag', async () => {
@@ -76,12 +78,39 @@ describe('cache invalidate', () => {
     );
   });
 
-  it('should ask for confirmation if the --yes option is omitted', async () => {
+  it('should ask for confirmation when --tag is missing --yes', async () => {
     client.setArgv('cache', 'invalidate', '--tag=foo');
     const exitCode = await cache(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput(
       `You are about to invalidate all cached content associated with tag foo for project ${projectId}. To continue, run \`vercel cache invalidate --tag foo --yes\`.`
+    );
+  });
+
+  it('should succeed with --srcimg', async () => {
+    client.scenario.post(
+      `/v1/edge-cache/invalidate-by-src-images`,
+      (req, res) => {
+        expect(req.body).toEqual({
+          srcImages: ['/api/avatar/1'],
+        });
+        res.end();
+      }
+    );
+    client.setArgv('cache', 'invalidate', '--srcimg=/api/avatar/1', '--yes');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput(
+      'Successfully invalidated all cached content associated with source image /api/avatar/1'
+    );
+  });
+
+  it('should ask for confirmation when --srcimg is missing --yes', async () => {
+    client.setArgv('cache', 'invalidate', '--srcimg=/api/avatar/1');
+    const exitCode = await cache(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput(
+      `You are about to invalidate all cached content associated with source image /api/avatar/1 for project ${projectId}. To continue, run \`vercel cache invalidate --srcimg /api/avatar/1 --yes\`.`
     );
   });
 });


### PR DESCRIPTION
This PR adds two new commands:

- `vercel cache invalidate --srcimg /api/avatar/1`
- `vercel cache dangerously-delete --srcimg /api/avatar/1 --revalidation-deadline-seconds 604800`