### PR TITLE
[next] reduce max function size threshold for Bun

### DIFF
--- a/.changeset/proud-pianos-cough.md
+++ b/.changeset/proud-pianos-cough.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': minor
+---
+
+Update functions size threshold when using Bun as a runtime

--- a/packages/next/src/constants.ts
+++ b/packages/next/src/constants.ts
@@ -7,7 +7,16 @@ export const MIB = 1024 * KIB;
  */
 export const EDGE_FUNCTION_SIZE_LIMIT = 4 * MIB;
 
+/**
+ * The maximum size of an uncompressed function.
+ */
 export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE = 250 * MIB;
+
+/**
+ * The maximum size of an uncompressed function using Bun. It's 100 MiB smaller
+ * than the default limit due to Bun's binary size.
+ */
+export const DEFAULT_MAX_UNCOMPRESSED_LAMBDA_SIZE_BUN = 150 * MIB;
 
 // we need to leave wiggle room as other files are added
 // post build so we don't want to completely pack the function

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1781,6 +1781,7 @@ export const build: BuildV2 = async buildOptions => {
         // like builds
         internalPages: [],
         experimentalPPRRoutes: undefined,
+        nodeVersion,
       });
 
       const initialApiLambdaGroups = await getPageLambdaGroups({
@@ -1796,6 +1797,7 @@ export const build: BuildV2 = async buildOptions => {
         initialPseudoLayerUncompressed: 0,
         internalPages: [],
         experimentalPPRRoutes: undefined,
+        nodeVersion,
       });
 
       for (const group of initialApiLambdaGroups) {
@@ -1827,7 +1829,8 @@ export const build: BuildV2 = async buildOptions => {
       ];
       await detectLambdaLimitExceeding(
         combinedInitialLambdaGroups,
-        compressedPages
+        compressedPages,
+        nodeVersion.runtime
       );
 
       let apiLambdaGroupIndex = 0;

--- a/packages/next/test/unit/utils.test.ts
+++ b/packages/next/test/unit/utils.test.ts
@@ -8,6 +8,7 @@ import {
   getNextConfig,
   getServerlessPages,
   normalizePrefetches,
+  getMaxUncompressedLambdaSize,
 } from '../../src/utils';
 import { FileFsRef, FileRef } from '@vercel/build-utils';
 import { genDir } from '../utils';
@@ -440,4 +441,30 @@ describe('normalizePrefetches', () => {
       'foo/bar/baz.prefetch.rsc',
     ]);
   });
+});
+
+describe('getMaxUncompressedLambdaSize', () => {
+  it.each(['bun1.x', 'bun2.x'])('should return 150 MiB for %s', runtime => {
+    const size = getMaxUncompressedLambdaSize(runtime);
+    expect(size).toBe(150 * 1024 * 1024);
+  });
+
+  it.each(['provided.al2023', 'nodejs22.x'])(
+    'should return 250 MiB for %s runtime',
+    runtime => {
+      const size = getMaxUncompressedLambdaSize(runtime);
+      expect(size).toBe(250 * 1024 * 1024);
+    }
+  );
+
+  it.each(['bun1.x', 'provided.al2023', 'nodejs22.x'])(
+    'should use override for %s',
+    runtime => {
+      const override = 100 * 1024 * 1024;
+      process.env.MAX_UNCOMPRESSED_LAMBDA_SIZE = override.toString();
+      const size = getMaxUncompressedLambdaSize(runtime);
+      expect(size).toBe(override);
+      delete process.env.MAX_UNCOMPRESSED_LAMBDA_SIZE;
+    }
+  );
 });


### PR DESCRIPTION
By default, we allow 250 MiB for the max uncompressed functions size. However, due to our current architecture and Bun's binary size, the effective limit when using the Bun runtime is around ~150 MiB (since Bun's binary is ~100 MiB)

This can cause issues when bundling routes together, as we won't split as agressively functions into different bundles: https://x.com/pavelsvitek_/status/1983618523235844098

This PR replaces `MAX_UNCOMPRESSED_LAMBDA_SIZE` (mapping to 250 MiB unless overriden) by a new `getMaxUncompressedLambdaSize` function, that returns 150 MiB for Bun and 250 MiB otherwise. This is used both to log a warning and control how many functions are bundled together