### PR TITLE
fix(next): treat interception routes with dynamic params as dynamic

### DIFF
--- a/.changeset/sharp-birds-lucky-foxes.md
+++ b/.changeset/sharp-birds-lucky-foxes.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix dynamic interception routes not being recognized during prerendering when cache components is enabled

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1276,6 +1276,7 @@ export const build: BuildV2 = async buildOptions => {
       entryDirectory,
       htmlContentType,
       prerenderManifest,
+      nextVersion,
       routesManifest
     );
     hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
@@ -1856,7 +1857,7 @@ export const build: BuildV2 = async buildOptions => {
             path.relative(workPath, pages[page].fsPath)
           );
           const pathname = page.replace(/\.js$/, '');
-          const routeIsDynamic = isDynamicRoute(pathname);
+          const routeIsDynamic = isDynamicRoute(pathname, nextVersion);
           routeIsApi = isApiPage(pageFileName);
 
           if (routeIsDynamic) {
@@ -1969,7 +1970,7 @@ export const build: BuildV2 = async buildOptions => {
 
           const pathname = page.replace(/\.js$/, '');
 
-          if (isDynamicRoute(pathname)) {
+          if (isDynamicRoute(pathname, nextVersion)) {
             dynamicPages.push(normalizePage(pathname));
           }
 
@@ -2311,6 +2312,7 @@ export const build: BuildV2 = async buildOptions => {
       isAppClientSegmentCacheEnabled: false,
       isAppClientParamParsingEnabled: false,
       appPathnameFilesMap: getAppRouterPathnameFilesMap(files),
+      nextVersion,
     });
 
     await Promise.all(

--- a/packages/next/src/is-dynamic-route.ts
+++ b/packages/next/src/is-dynamic-route.ts
@@ -170,13 +170,18 @@ function extractInterceptionRouteInformation(
 // eslint-disable-next-line no-useless-escape
 const TEST_DYNAMIC_ROUTE = /\/\[[^\/]+?\](?=\/|$)/;
 
-export function isDynamicRoute(route: string, nextVersion: string): boolean {
+export function isDynamicRoute(
+  route: string,
+  nextVersion: string | null
+): boolean {
   // If the Next.js version is greater than or equal to 16.0.0, and the route is
   // an interception route, we need to extract the intercepted route. This is
   // gated on the version to ensure that we don't break existing behaviors for
   // older versions.
+  const coerced = nextVersion ? semver.coerce(nextVersion) : null;
   if (
-    semver.gte(semver.coerce(nextVersion)!, '16.0.0', {
+    coerced &&
+    semver.gte(coerced, '16.0.0', {
       loose: true,
       includePrerelease: true,
     }) &&

--- a/packages/next/src/is-dynamic-route.ts
+++ b/packages/next/src/is-dynamic-route.ts
@@ -175,7 +175,13 @@ export function isDynamicRoute(route: string, nextVersion: string): boolean {
   // an interception route, we need to extract the intercepted route. This is
   // gated on the version to ensure that we don't break existing behaviors for
   // older versions.
-  if (semver.gte(nextVersion, '16.0.0') && isInterceptionRouteAppPath(route)) {
+  if (
+    semver.gte(semver.coerce(nextVersion)!, '16.0.0', {
+      loose: true,
+      includePrerelease: true,
+    }) &&
+    isInterceptionRouteAppPath(route)
+  ) {
     route = extractInterceptionRouteInformation(route).interceptedRoute;
   }
 

--- a/packages/next/src/is-dynamic-route.ts
+++ b/packages/next/src/is-dynamic-route.ts
@@ -1,0 +1,183 @@
+import semver from 'semver';
+
+/**
+ * For a given page path, this function ensures that there is a leading slash.
+ * If there is not a leading slash, one is added, otherwise it is noop.
+ */
+export function ensureLeadingSlash(path: string) {
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function isGroupSegment(segment: string) {
+  return segment[0] === '(' && segment.endsWith(')');
+}
+
+/**
+ * Normalizes an app route so it represents the actual request path. Essentially
+ * performing the following transformations:
+ *
+ * - `/(dashboard)/user/[id]/page` to `/user/[id]`
+ * - `/(dashboard)/account/page` to `/account`
+ * - `/user/[id]/page` to `/user/[id]`
+ * - `/account/page` to `/account`
+ * - `/page` to `/`
+ * - `/(dashboard)/user/[id]/route` to `/user/[id]`
+ * - `/(dashboard)/account/route` to `/account`
+ * - `/user/[id]/route` to `/user/[id]`
+ * - `/account/route` to `/account`
+ * - `/route` to `/`
+ * - `/` to `/`
+ *
+ * @param route the app route to normalize
+ * @returns the normalized pathname
+ */
+function normalizeAppPath(route: string) {
+  return ensureLeadingSlash(
+    route.split('/').reduce((pathname, segment, index, segments) => {
+      // Empty segments are ignored.
+      if (!segment) {
+        return pathname;
+      }
+
+      // Groups are ignored.
+      if (isGroupSegment(segment)) {
+        return pathname;
+      }
+
+      // Parallel segments are ignored.
+      if (segment[0] === '@') {
+        return pathname;
+      }
+
+      // The last segment (if it's a leaf) should be ignored.
+      if (
+        (segment === 'page' || segment === 'route') &&
+        index === segments.length - 1
+      ) {
+        return pathname;
+      }
+
+      return `${pathname}/${segment}`;
+    }, '')
+  );
+}
+
+// order matters here, the first match will be used
+const INTERCEPTION_ROUTE_MARKERS = [
+  '(..)(..)',
+  '(.)',
+  '(..)',
+  '(...)',
+] as const;
+
+function isInterceptionRouteAppPath(path: string): boolean {
+  // TODO-APP: add more serious validation
+  return path
+    .split('/')
+    .some(segment =>
+      INTERCEPTION_ROUTE_MARKERS.some(m => segment.startsWith(m))
+    );
+}
+
+type InterceptionRouteInformation = {
+  /**
+   * The intercepting route. This is the route that is being intercepted or the
+   * route that the user was coming from. This is matched by the Next-Url
+   * header.
+   */
+  interceptingRoute: string;
+
+  /**
+   * The intercepted route. This is the route that is being intercepted or the
+   * route that the user is going to. This is matched by the request pathname.
+   */
+  interceptedRoute: string;
+};
+
+function extractInterceptionRouteInformation(
+  path: string
+): InterceptionRouteInformation {
+  let interceptingRoute: string | undefined;
+  let marker: (typeof INTERCEPTION_ROUTE_MARKERS)[number] | undefined;
+  let interceptedRoute: string | undefined;
+
+  for (const segment of path.split('/')) {
+    marker = INTERCEPTION_ROUTE_MARKERS.find(m => segment.startsWith(m));
+    if (marker) {
+      [interceptingRoute, interceptedRoute] = path.split(marker, 2);
+      break;
+    }
+  }
+
+  if (!interceptingRoute || !marker || !interceptedRoute) {
+    throw new Error(
+      `Invalid interception route: ${path}. Must be in the format /<intercepting route>/(..|...|..)(..)/<intercepted route>`
+    );
+  }
+
+  interceptingRoute = normalizeAppPath(interceptingRoute); // normalize the path, e.g. /(blog)/feed -> /feed
+
+  switch (marker) {
+    case '(.)':
+      // (.) indicates that we should match with sibling routes, so we just need to append the intercepted route to the intercepting route
+      if (interceptingRoute === '/') {
+        interceptedRoute = `/${interceptedRoute}`;
+      } else {
+        interceptedRoute = interceptingRoute + '/' + interceptedRoute;
+      }
+      break;
+    case '(..)':
+      // (..) indicates that we should match at one level up, so we need to remove the last segment of the intercepting route
+      if (interceptingRoute === '/') {
+        throw new Error(
+          `Invalid interception route: ${path}. Cannot use (..) marker at the root level, use (.) instead.`
+        );
+      }
+      interceptedRoute = interceptingRoute
+        .split('/')
+        .slice(0, -1)
+        .concat(interceptedRoute)
+        .join('/');
+      break;
+    case '(...)':
+      // (...) will match the route segment in the root directory, so we need to use the root directory to prepend the intercepted route
+      interceptedRoute = '/' + interceptedRoute;
+      break;
+    case '(..)(..)': {
+      // (..)(..) indicates that we should match at two levels up, so we need to remove the last two segments of the intercepting route
+
+      const splitInterceptingRoute = interceptingRoute.split('/');
+      if (splitInterceptingRoute.length <= 2) {
+        throw new Error(
+          `Invalid interception route: ${path}. Cannot use (..)(..) marker at the root level or one level up.`
+        );
+      }
+
+      interceptedRoute = splitInterceptingRoute
+        .slice(0, -2)
+        .concat(interceptedRoute)
+        .join('/');
+      break;
+    }
+    default:
+      throw new Error('Invariant: unexpected marker');
+  }
+
+  return { interceptingRoute, interceptedRoute };
+}
+
+// Identify /[param]/ in route string
+// eslint-disable-next-line no-useless-escape
+const TEST_DYNAMIC_ROUTE = /\/\[[^\/]+?\](?=\/|$)/;
+
+export function isDynamicRoute(route: string, nextVersion: string): boolean {
+  // If the Next.js version is greater than or equal to 16.0.0, and the route is
+  // an interception route, we need to extract the intercepted route. This is
+  // gated on the version to ensure that we don't break existing behaviors for
+  // older versions.
+  if (semver.gte(nextVersion, '16.0.0') && isInterceptionRouteAppPath(route)) {
+    route = extractInterceptionRouteInformation(route).interceptedRoute;
+  }
+
+  return TEST_DYNAMIC_ROUTE.test(ensureLeadingSlash(route));
+}

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -687,7 +687,7 @@ export async function serverBuild({
       }
       const normalizedPathname = normalizePage(pathname);
 
-      if (isDynamicRoute(normalizedPathname)) {
+      if (isDynamicRoute(normalizedPathname, nextVersion)) {
         dynamicPages.push(normalizedPathname);
       }
 
@@ -1259,7 +1259,10 @@ export async function serverBuild({
             }
             case 'server/pages-manifest.json': {
               for (const key of Object.keys(manifestData)) {
-                if (isDynamicRoute(key) && !normalizedPages.has(key)) {
+                if (
+                  isDynamicRoute(key, nextVersion) &&
+                  !normalizedPages.has(key)
+                ) {
                   delete manifestData[key];
                 }
               }
@@ -1272,7 +1275,7 @@ export async function serverBuild({
                   key.replace(/(^|\/)(page|route)$/, '');
 
                 if (
-                  isDynamicRoute(normalizedKey) &&
+                  isDynamicRoute(normalizedKey, nextVersion) &&
                   !normalizedPages.has(normalizedKey)
                 ) {
                   delete manifestData[key];
@@ -1625,6 +1628,7 @@ export async function serverBuild({
     isAppClientSegmentCacheEnabled,
     isAppClientParamParsingEnabled,
     appPathnameFilesMap: getAppRouterPathnameFilesMap(files),
+    nextVersion,
   });
 
   await Promise.all(
@@ -1664,7 +1668,7 @@ export async function serverBuild({
       // they are in the prerender manifest since a dynamic
       // route can have some prerendered paths and the rest SSR
       inversedAppPathManifest[route] &&
-      isDynamicRoute(route)
+      isDynamicRoute(route, nextVersion)
     ) {
       return;
     }
@@ -2599,7 +2603,10 @@ export async function serverBuild({
             // filter to only static data routes as dynamic routes will be handled
             // below
             const { pathname } = new URL(route.dest || '/', 'http://n');
-            return !isDynamicRoute(pathname.replace(/(\\)?\.json$/, ''));
+            return !isDynamicRoute(
+              pathname.replace(/(\\)?\.json$/, ''),
+              nextVersion
+            );
           })
         : []),
 

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2883,7 +2883,11 @@ export const onPrerenderRoute =
           allowQuery = Object.values(routeKeys);
         }
       } else {
-        const isDynamic = isDynamicRoute(pageKey);
+        // We added the `!!route` check because the isDynamicRoute does not
+        // currently support intercepting routes, but if it exists in the
+        // `dynamicRoutes` part of the routes manifest, then we know that it's
+        // dynamic!
+        const isDynamic = !!route || isDynamicRoute(pageKey);
 
         if (routeKeys) {
           // if we have routeKeys in the routes-manifest we use those

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2858,7 +2858,11 @@ export const onPrerenderRoute =
         (r): r is RoutesManifestRoute =>
           r.page === pageKey && !('isMiddleware' in r)
       ) as RoutesManifestRoute | undefined;
-      const isDynamic = isDynamicRoute(routeKey);
+      // We added the `!!route` check because the isDynamicRoute does not
+      // currently support intercepting routes, but if it exists in the
+      // `dynamicRoutes` part of the routes manifest, then we know that it's
+      // dynamic!
+      const isDynamic = !!route || isDynamicRoute(routeKey);
       const routeKeys = route?.routeKeys;
 
       // by default allowQuery should be undefined and only set when

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2858,11 +2858,12 @@ export const onPrerenderRoute =
         (r): r is RoutesManifestRoute =>
           r.page === pageKey && !('isMiddleware' in r)
       ) as RoutesManifestRoute | undefined;
-      // We added the `!!route` check because the isDynamicRoute does not
-      // currently support intercepting routes, but if it exists in the
-      // `dynamicRoutes` part of the routes manifest, then we know that it's
-      // dynamic!
-      const isDynamic = !!route || isDynamicRoute(routeKey);
+      const isRouteKeyDynamic =
+        routesManifest?.dynamicRoutes.some(
+          (r): r is RoutesManifestRoute =>
+            r.page === routeKey && !('isMiddleware' in r)
+        ) ?? false;
+      const isDynamic = isRouteKeyDynamic || isDynamicRoute(routeKey);
       const routeKeys = route?.routeKeys;
 
       // by default allowQuery should be undefined and only set when
@@ -2887,7 +2888,7 @@ export const onPrerenderRoute =
         // currently support intercepting routes, but if it exists in the
         // `dynamicRoutes` part of the routes manifest, then we know that it's
         // dynamic!
-        const isDynamic = !!route || isDynamicRoute(pageKey);
+        const isDynamic = isRouteKeyDynamic || isDynamicRoute(pageKey);
 
         if (routeKeys) {
           // if we have routeKeys in the routes-manifest we use those


### PR DESCRIPTION
## What

Fixes an issue where interception routes with dynamic path parameters were not being recognized as dynamic routes during prerendering.

## Why

When cache components is enabled, interception routes with dynamic parameters (like `/foo/(..)bar/[id]`) were being treated as static routes. This caused incorrect payloads to be served because the prerender logic wasn't handling them as dynamic routes that need special payload generation.

The root cause is that `isDynamicRoute()` doesn't currently support the interception route syntax (e.g., `(..)`, `(...)`, `(.)`).

## How

Patched the `isDynamicRoute` to handle interception routes the same way that Next.js does from Next.js 16 onwards.

NAR-482