### PR TITLE
Make Nitro supersede Vite in detection

### DIFF
--- a/.changeset/large-rockets-bathe.md
+++ b/.changeset/large-rockets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@vercel/frameworks': patch
+---
+
+Make Nitro supersede Vite in detection

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2374,6 +2374,7 @@ export const frameworks = [
     detectors: {
       some: [{ matchPackage: 'nitropack' }, { matchPackage: 'nitro' }],
     },
+    supersedes: ['vite'],
     settings: {
       installCommand: {
         placeholder:


### PR DESCRIPTION
Nitro + Vite apps currently get detected as Vite, but they should be Nitro.