### PR TITLE
[next]: fix missing postpone header

### DIFF
--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3196,6 +3196,9 @@ export const onPrerenderRoute =
               'cache-control':
                 'private, no-store, no-cache, max-age=0, must-revalidate',
               vary: rscVaryHeader,
+              ...(didPostpone && rscDidPostponeHeader && !isFallback
+                ? { [rscDidPostponeHeader]: '1' }
+                : {}),
             },
           });
         }


### PR DESCRIPTION
When RDC for RSCs was enabled via #13459, the logic to set the `x-nextjs-postponed` was not applied to the prerenders that were created. As a result, when issuing a runtime prefetch, the client router would not realize that it needed to trigger a dynamic request to retrieve the missing dynamic data. 

This applies the same logic that exists when creating the other data route prerenders [here](https://github.com/vercel/vercel/blob/00c960f0c187650152580f14ab17770cec46dfc2/packages/next/src/utils.ts#L3113-L3115).