### PR TITLE
Add changeset for TanStack Start release

### DIFF
--- a/.changeset/soft-swans-do.md
+++ b/.changeset/soft-swans-do.md
@@ -1,0 +1,6 @@
+---
+'vercel': minor
+'@vercel/client': minor
+---
+
+Add TanStack Start framework preset


### PR DESCRIPTION
For some reason, https://github.com/vercel/vercel/pull/14178 does not bump vercel and/or @vercel/client, and therefore did not make a new CLI release. This fixes that.