### PR TITLE
[python] surface tracebacks on error logs

### DIFF
--- a/.changeset/four-guests-marry.md
+++ b/.changeset/four-guests-marry.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+[python] surface tracebacks on error logs

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -9,6 +9,7 @@ import inspect
 import asyncio
 import http
 import time
+import traceback
 from importlib import util
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import socket
@@ -50,6 +51,21 @@ def setup_logging(send_message: Callable[[dict], None], storage: contextvars.Con
                 message = record.getMessage()
             except Exception:
                 message = repr(getattr(record, "msg", ""))
+
+            with contextlib.suppress(Exception):
+                if record.exc_info:
+                    # logging allows exc_info=True or a (type, value, tb) tuple
+                    exc_info = record.exc_info
+                    if exc_info is True:
+                        exc_info = sys.exc_info()
+                    if isinstance(exc_info, tuple):
+                        tb = ''.join(traceback.format_exception(*exc_info))
+                        if tb:
+                            # Ensure separation from the original message
+                            if message:
+                                message = f"{message}\n{tb}"
+                            else:
+                                message = tb
 
             if record.levelno >= logging.CRITICAL:
                 level = "fatal"

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -61,7 +61,6 @@ def setup_logging(send_message: Callable[[dict], None], storage: contextvars.Con
                     if isinstance(exc_info, tuple):
                         tb = ''.join(traceback.format_exception(*exc_info))
                         if tb:
-                            # Ensure separation from the original message
                             if message:
                                 message = f"{message}\n{tb}"
                             else:


### PR DESCRIPTION
Surface tracebacks on error logs when:
* Using `logger.exception()` - automatically includes traceback
* Using `logger.error("msg", exc_info=True)` - explicitly includes traceback
* Using `logger.warning("msg", exc_info=sys.exc_info())` - passing exception tuple

**now**

<img width="1055" height="326" alt="Screenshot 2025-11-01 at 5 53 10 PM" src="https://github.com/user-attachments/assets/b20e1d66-2e9a-464b-bb85-63b970997014" />

**prev**

<img width="1054" height="78" alt="Screenshot 2025-11-01 at 5 53 40 PM" src="https://github.com/user-attachments/assets/e8494e08-c02c-4bfb-858a-87cfe342a03f" />
