### PR TITLE
[python] flask framework detection bugfix

### DIFF
--- a/.changeset/polite-toes-flash.md
+++ b/.changeset/polite-toes-flash.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[python] make flask framework detection case insensitive

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2124,15 +2124,15 @@ export const frameworks = [
       some: [
         {
           path: 'requirements.txt',
-          matchContent: 'flask',
+          matchContent: '[Ff]lask',
         },
         {
           path: 'pyproject.toml',
-          matchContent: 'flask',
+          matchContent: '[Ff]lask',
         },
         {
           path: 'Pipfile',
-          matchContent: 'flask',
+          matchContent: '[Ff]lask',
         },
       ],
     },


### PR DESCRIPTION
Makes flask detection case insensitive, `Flask` and `flask` are both recognized now (pypi is case insensitive but official pypi page lists it as `Flask`)