### PR TITLE
Add fastify as a direct dependency

### DIFF
--- a/.changeset/honest-bugs-mate.md
+++ b/.changeset/honest-bugs-mate.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add fastify as a direct dependency

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@vercel/go": "3.2.3",
     "@vercel/backends": "workspace:*",
     "@vercel/express": "0.1.5",
+    "@vercel/fastify": "0.1.5",
     "@vercel/hono": "0.2.5",
     "@vercel/h3": "0.1.11",
     "@vercel/hydrogen": "1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@vercel/express':
         specifier: 0.1.5
         version: link:../express
+      '@vercel/fastify':
+        specifier: 0.1.5
+        version: link:../fastify
       '@vercel/fun':
         specifier: 1.1.6
         version: 1.1.6


### PR DESCRIPTION
This was missing from the depenencies, causing us to download it on-the-fly during builds