### PR TITLE
Patch OIDC data dir permissions

### DIFF
--- a/.changeset/young-suits-visit.md
+++ b/.changeset/young-suits-visit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Fix directory permissions so that files can be created under the OIDC data directory in linux

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -97,7 +97,7 @@ export function saveToken(token: VercelTokenResponse, projectId: string): void {
     }
     const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
     const tokenJson = JSON.stringify(token);
-    fs.mkdirSync(path.dirname(tokenPath), { mode: 0o660, recursive: true }); // read/write perms for owner only
+    fs.mkdirSync(path.dirname(tokenPath), { mode: 0o770, recursive: true }); // read/write/exec perms for owner/group only, x required for dir ops
     fs.writeFileSync(tokenPath, tokenJson);
     fs.chmodSync(tokenPath, 0o660); // read/write perms for owner only
     return;


### PR DESCRIPTION
previously was 0o660 which didn't allow directory operations in linux