### PR TITLE
Include account info in requests

### DIFF
--- a/.changeset/pretty-spiders-tease.md
+++ b/.changeset/pretty-spiders-tease.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Include account info in curl requests

--- a/packages/cli/src/commands/curl/bypass-token.ts
+++ b/packages/cli/src/commands/curl/bypass-token.ts
@@ -22,24 +22,17 @@ async function createDeploymentProtectionToken(
     );
   }
 
-  const query = new URLSearchParams();
-  if (orgId) {
-    query.set('teamId', orgId);
-  }
-
   try {
     const response = await client.fetch<{
       protectionBypass: ProjectProtectionBypass;
-    }>(
-      `/v1/projects/${projectId}/protection-bypass${query.toString() ? `?${query}` : ''}`,
-      {
-        method: 'PATCH',
-        body: '{}',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    }>(`/v1/projects/${projectId}/protection-bypass`, {
+      method: 'PATCH',
+      body: '{}',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      accountId: orgId,
+    });
     const { protectionBypass } = response;
 
     output.log(

--- a/packages/cli/src/commands/curl/deployment-url.ts
+++ b/packages/cli/src/commands/curl/deployment-url.ts
@@ -4,7 +4,8 @@ import type { Deployment } from '@vercel-internals/types';
 
 export async function getDeploymentUrlById(
   client: Client,
-  deploymentId: string
+  deploymentId: string,
+  accountId?: string
 ): Promise<string | null> {
   try {
     let fullDeploymentId = deploymentId;
@@ -13,7 +14,8 @@ export async function getDeploymentUrlById(
     }
 
     const deployment = await client.fetch<Deployment>(
-      `/v13/deployments/${fullDeploymentId}`
+      `/v13/deployments/${fullDeploymentId}`,
+      { accountId }
     );
 
     if (!deployment || !deployment.url) {

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -123,9 +123,10 @@ export async function getDeploymentUrlAndToken(
   const { deploymentFlag, protectionBypassFlag } = options;
 
   let link;
+  let scope;
 
   try {
-    await getScope(client);
+    scope = await getScope(client);
   } catch (err: unknown) {
     if (
       isErrnoException(err) &&
@@ -173,7 +174,13 @@ export async function getDeploymentUrlAndToken(
   let baseUrl: string;
 
   if (deploymentFlag) {
-    const deploymentUrl = await getDeploymentUrlById(client, deploymentFlag);
+    // Get the accountId from the scope (team or user)
+    const accountId = scope.team?.id || scope.user.id;
+    const deploymentUrl = await getDeploymentUrlById(
+      client,
+      deploymentFlag,
+      accountId
+    );
     if (!deploymentUrl) {
       output.error(`No deployment found for ID "${deploymentFlag}"`);
       return 1;

--- a/packages/cli/test/unit/commands/curl/index.test.ts
+++ b/packages/cli/test/unit/commands/curl/index.test.ts
@@ -6,6 +6,8 @@ import { useUser } from '../../../mocks/user';
 import { useProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 
+const MOCK_ACCOUNT_ID = 'team_test123';
+
 let spawnMock: ReturnType<typeof vi.fn>;
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
@@ -565,10 +567,15 @@ describe('getDeploymentUrlById', () => {
       }),
     } as any;
 
-    await getDeploymentUrlById(mockClient, 'ERiL45NJvP8ghWxgbvCM447bmxwV');
+    await getDeploymentUrlById(
+      mockClient,
+      'ERiL45NJvP8ghWxgbvCM447bmxwV',
+      MOCK_ACCOUNT_ID
+    );
 
     expect(mockClient.fetch).toHaveBeenCalledWith(
-      '/v13/deployments/dpl_ERiL45NJvP8ghWxgbvCM447bmxwV'
+      '/v13/deployments/dpl_ERiL45NJvP8ghWxgbvCM447bmxwV',
+      { accountId: MOCK_ACCOUNT_ID }
     );
   });
 
@@ -579,10 +586,15 @@ describe('getDeploymentUrlById', () => {
       }),
     } as any;
 
-    await getDeploymentUrlById(mockClient, 'dpl_ERiL45NJvP8ghWxgbvCM447bmxwV');
+    await getDeploymentUrlById(
+      mockClient,
+      'dpl_ERiL45NJvP8ghWxgbvCM447bmxwV',
+      MOCK_ACCOUNT_ID
+    );
 
     expect(mockClient.fetch).toHaveBeenCalledWith(
-      '/v13/deployments/dpl_ERiL45NJvP8ghWxgbvCM447bmxwV'
+      '/v13/deployments/dpl_ERiL45NJvP8ghWxgbvCM447bmxwV',
+      { accountId: MOCK_ACCOUNT_ID }
     );
   });
 
@@ -593,7 +605,8 @@ describe('getDeploymentUrlById', () => {
 
     const result = await getDeploymentUrlById(
       mockClient,
-      'ERiL45NJvP8ghWxgbvCM447bmxwV'
+      'ERiL45NJvP8ghWxgbvCM447bmxwV',
+      MOCK_ACCOUNT_ID
     );
 
     expect(result).toBeNull();
@@ -606,11 +619,16 @@ describe('getDeploymentUrlById', () => {
       }),
     } as any;
 
-    const result = await getDeploymentUrlById(mockClient, 'XYZ789ABC123');
+    const result = await getDeploymentUrlById(
+      mockClient,
+      'XYZ789ABC123',
+      MOCK_ACCOUNT_ID
+    );
 
     expect(result).toBe('https://my-app-xyz789.vercel.app');
     expect(mockClient.fetch).toHaveBeenCalledWith(
-      '/v13/deployments/dpl_XYZ789ABC123'
+      '/v13/deployments/dpl_XYZ789ABC123',
+      { accountId: MOCK_ACCOUNT_ID }
     );
   });
 });


### PR DESCRIPTION
When issuing a request while logged into a team that doesn't own the given project, this would fail to issue a bypass token