### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Hugo framework

### DIFF
--- a/.changeset/hugo-cache-pattern.md
+++ b/.changeset/hugo-cache-pattern.md
@@ -1,5 +1,5 @@
 ---
-"@vercel/frameworks": patch
+"@vercel/frameworks": minor
 ---
 
 Add cachePattern for Hugo framework to improve build performance

--- a/.changeset/hugo-cache-pattern.md
+++ b/.changeset/hugo-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": patch
+---
+
+Add cachePattern for Hugo framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1673,6 +1673,7 @@ export const frameworks = [
 
       return (config && config.publishDir) || 'public';
     },
+    cachePattern: 'resources/_gen/**',
     defaultVersion: '0.58.2', // Must match the build image
   },
   {

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,11 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure Hugo has cachePattern defined', () => {
+    const hugo = frameworkList.find(f => f.slug === 'hugo');
+    expect(hugo?.cachePattern).toBe('resources/_gen/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `resources/_gen/**` to Hugo framework configuration to cache generated resources directory, improving build performance.

Docs: https://gohugo.io/configuration/caches/#article