### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Angular framework

### DIFF
--- a/.changeset/angular-cache-pattern.md
+++ b/.changeset/angular-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": minor
+---
+
+Add cachePattern for Angular framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -972,6 +972,7 @@ export const frameworks = [
       }
       return base;
     },
+    cachePattern: '.angular/**',
     defaultRoutes: [
       {
         handle: 'filesystem',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,11 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure Angular has cachePattern defined', () => {
+    const angular = frameworkList.find(f => f.slug === 'angular');
+    expect(angular?.cachePattern).toBe('.angular/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `cachePattern: '.angular/**'` to Angular framework configuration to cache generated resources directory, improving build performance.