### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Astro framework

### DIFF
--- a/.changeset/astro-cache-pattern.md
+++ b/.changeset/astro-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": minor
+---
+
+Add cachePattern for Astro framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -329,6 +329,7 @@ export const frameworks = [
     },
     dependency: 'astro',
     getOutputDirName: async () => 'dist',
+    cachePattern: '.astro/**',
     defaultRoutes: [
       {
         src: '^/assets/(.*)$',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,11 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure Astro has cachePattern defined', () => {
+    const astro = frameworkList.find(f => f.slug === 'astro');
+    expect(astro?.cachePattern).toBe('.astro/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `.astro/**` to Astro framework configuration to cache generated resources directory, improving build performance.