### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Sveltekit framework

### DIFF
--- a/.changeset/sveltekit-cache-pattern.md
+++ b/.changeset/sveltekit-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": minor
+---
+
+Add cachePattern for SvelteKit framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -1127,6 +1127,7 @@ export const frameworks = [
       },
     },
     getOutputDirName: async () => 'public',
+    cachePattern: '.svelte-kit/**',
   },
   {
     name: 'SvelteKit',
@@ -1166,6 +1167,7 @@ export const frameworks = [
       },
     },
     getOutputDirName: async () => 'public',
+    cachePattern: '.svelte-kit/**',
   },
   {
     name: 'Ionic React',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,13 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure SvelteKit has cachePattern defined', () => {
+    const sveltekit = frameworkList.find(f => f.slug === 'sveltekit');
+    const sveltekitV1 = frameworkList.find(f => f.slug === 'sveltekit-1');
+    expect(sveltekit?.cachePattern).toBe('.svelte-kit/**');
+    expect(sveltekitV1?.cachePattern).toBe('.svelte-kit/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `.svelte-kit/**` to Sveltekit framework configuration to cache generated resources directory, improving build performance.