### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Docusaurus framework

### DIFF
--- a/.changeset/docusaurus-cache-pattern.md
+++ b/.changeset/docusaurus-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": minor
+---
+
+Add cachePattern for Docusaurus framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -466,6 +466,7 @@ export const frameworks = [
 
       return base;
     },
+    cachePattern: '.docusaurus/**',
     defaultRoutes: [
       {
         src: '^/[^./]+\\.[0-9a-f]{8}\\.(css|js)$',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,11 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure Docusaurus has cachePattern defined', () => {
+    const docusaurus = frameworkList.find(f => f.slug === 'docusaurus-2');
+    expect(docusaurus?.cachePattern).toBe('.docusaurus/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `.docusaurus/**` to Docusaurus framework configuration to cache generated resources directory, improving build performance.