### PR TITLE
feat(frameworks): add cachePattern to support Build cache for Parcel framework

### DIFF
--- a/.changeset/parcel-cache-pattern.md
+++ b/.changeset/parcel-cache-pattern.md
@@ -1,0 +1,6 @@
+---
+"@vercel/frameworks": minor
+---
+
+Add cachePattern for Parcel framework to improve build performance
+

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -2043,6 +2043,7 @@ export const frameworks = [
     },
     dependency: 'parcel',
     getOutputDirName: async () => 'dist',
+    cachePattern: '.parcel-cache/**',
     defaultRoutes: [
       {
         src: '^/[^./]+\\.[0-9a-f]{8}\\.(css|js|png|jpg|webp|avif|svg)$',

--- a/packages/frameworks/test/frameworks.unit.test.ts
+++ b/packages/frameworks/test/frameworks.unit.test.ts
@@ -321,6 +321,11 @@ describe('frameworks', () => {
         })
     );
   });
+
+  it('ensure Parcel has cachePattern defined', () => {
+    const parcel = frameworkList.find(f => f.slug === 'parcel');
+    expect(parcel?.cachePattern).toBe('.parcel-cache/**');
+  });
 });
 
 function getValidator() {


### PR DESCRIPTION
Add cachePattern `.parcel-cache/**'` to Hugo framework configuration to cache generated resources directory, improving build performance.