### PR TITLE
feat(detect-agent): add TRAE detection support

### DIFF
--- a/.changeset/trae-detection-support.md
+++ b/.changeset/trae-detection-support.md
@@ -1,0 +1,5 @@
+---
+'@vercel/detect-agent': minor
+---
+
+Add TRAE detection support via TRAE_AI_SHELL_ID environment variable

--- a/packages/detect-agent/README.md
+++ b/packages/detect-agent/README.md
@@ -31,6 +31,7 @@ This package can detect the following AI agents and development environments:
 - **Devin** (Cognition Labs)
 - **Gemini CLI** (Google)
 - **Codex** (OpenAI)
+- **TRAE** (trae.ai)
 - **Replit** (online IDE)
 
 ## The AI_AGENT Standard

--- a/packages/detect-agent/src/index.ts
+++ b/packages/detect-agent/src/index.ts
@@ -10,6 +10,7 @@ const DEVIN = 'devin' as const;
 const REPLIT = 'replit' as const;
 const GEMINI = 'gemini' as const;
 const CODEX = 'codex' as const;
+const TRAE = 'trae' as const;
 
 export type KnownAgentNames =
   | typeof CURSOR
@@ -18,7 +19,8 @@ export type KnownAgentNames =
   | typeof DEVIN
   | typeof REPLIT
   | typeof GEMINI
-  | typeof CODEX;
+  | typeof CODEX
+  | typeof TRAE;
 
 export interface KnownAgentDetails {
   name: KnownAgentNames;
@@ -42,6 +44,7 @@ export const KNOWN_AGENTS = {
   REPLIT,
   GEMINI,
   CODEX,
+  TRAE,
 } as const;
 
 export async function determineAgent(): Promise<AgentResult> {
@@ -73,6 +76,10 @@ export async function determineAgent(): Promise<AgentResult> {
 
   if (process.env.CLAUDECODE || process.env.CLAUDE_CODE) {
     return { isAgent: true, agent: { name: CLAUDE } };
+  }
+
+  if (process.env.TRAE_AI_SHELL_ID) {
+    return { isAgent: true, agent: { name: TRAE } };
   }
 
   if (process.env.REPL_ID) {

--- a/packages/detect-agent/test/unit/determine-agent.test.ts
+++ b/packages/detect-agent/test/unit/determine-agent.test.ts
@@ -14,6 +14,7 @@ describe('determineAgent', () => {
     vi.stubEnv('CODEX_SANDBOX', '');
     vi.stubEnv('CLAUDECODE', '');
     vi.stubEnv('CLAUDE_CODE', '');
+    vi.stubEnv('TRAE_AI_SHELL_ID', '');
     vi.stubEnv('REPL_ID', '');
   });
 
@@ -174,6 +175,29 @@ describe('determineAgent', () => {
     });
   });
 
+  describe('trae detection', () => {
+    describe('TRAE_AI_SHELL_ID not set', () => {
+      it('returns no agent', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({ isAgent: false });
+      });
+    });
+
+    describe('TRAE_AI_SHELL_ID set', () => {
+      beforeEach(() => {
+        vi.stubEnv('TRAE_AI_SHELL_ID', '2');
+      });
+
+      it('detects trae', async () => {
+        const result = await determineAgent();
+        expect(result).toEqual({
+          isAgent: true,
+          agent: { name: KNOWN_AGENTS.TRAE },
+        });
+      });
+    });
+  });
+
   describe('devin detection', () => {
     describe('/opt/.devin does not exist', () => {
       it('returns no agent', async () => {
@@ -232,6 +256,7 @@ describe('determineAgent', () => {
       vi.stubEnv('GEMINI_CLI', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('CLAUDE_CODE', '1');
+      vi.stubEnv('TRAE_AI_SHELL_ID', '1');
       vi.stubEnv('REPL_ID', '1');
       mockFs({
         '/opt/.devin': mockFs.directory({
@@ -252,6 +277,7 @@ describe('determineAgent', () => {
       vi.stubEnv('GEMINI_CLI', '1');
       vi.stubEnv('CODEX_SANDBOX', 'seatbelt');
       vi.stubEnv('CLAUDE_CODE', '1');
+      vi.stubEnv('TRAE_AI_SHELL_ID', '1');
       vi.stubEnv('REPL_ID', '1');
       mockFs({
         '/opt/.devin': mockFs.directory({


### PR DESCRIPTION
Adds support for detecting TRAE.AI via the TRAE_AI_SHELL_ID environment variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)