### PR TITLE
[python] fix python version detection in `pyproject.toml`

### DIFF
--- a/.changeset/angry-spiders-learn.md
+++ b/.changeset/angry-spiders-learn.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+make python version range detection in requires-python in pyproject.toml more robust

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -241,17 +241,12 @@ export const build: BuildV3 = async ({
     } catch (err) {
       debug('Failed to parse pyproject.toml', err);
     }
-    const VERSION_REGEX = /\b\d+\.\d+\b/;
-    const exact = requiresPython?.trim().match(VERSION_REGEX)?.[0];
-    if (exact) {
-      declaredPythonVersion = { version: exact, source: 'pyproject.toml' };
-      debug(
-        `Found Python version ${exact} in pyproject.toml (requires-python: "${requiresPython}")`
-      );
-    } else if (requiresPython) {
-      debug(
-        `Could not parse Python version from pyproject.toml requires-python: "${requiresPython}"`
-      );
+    if (typeof requiresPython === 'string' && requiresPython.trim()) {
+      declaredPythonVersion = {
+        version: requiresPython.trim(),
+        source: 'pyproject.toml',
+      };
+      debug(`Found requires-python "${requiresPython}" in pyproject.toml`);
     }
   } else if (pipfileLockDir) {
     let lock: {

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -62,6 +62,44 @@ it('should ignore minor version in vercel dev', () => {
   expect(warningMessages).toStrictEqual([]);
 });
 
+describe('requires-python range parsing', () => {
+  it('selects latest installed within range ">=3.10,<3.12"', () => {
+    makeMockPython('3.10');
+    makeMockPython('3.11');
+    const result = getSupportedPythonVersion({
+      declaredPythonVersion: {
+        version: '>=3.10,<3.12',
+        source: 'pyproject.toml',
+      },
+    });
+    expect(result).toHaveProperty('runtime', 'python3.11');
+  });
+
+  it('selects highest allowed when upper bound inclusive (>=3.10,<=3.12)', () => {
+    makeMockPython('3.11');
+    makeMockPython('3.12');
+    const result = getSupportedPythonVersion({
+      declaredPythonVersion: {
+        version: '>=3.10,<=3.12',
+        source: 'pyproject.toml',
+      },
+    });
+    expect(result).toHaveProperty('runtime', 'python3.12');
+  });
+
+  it('respects compatible release "~=3.10" (>=3.10,<3.11)', () => {
+    makeMockPython('3.10');
+    makeMockPython('3.11');
+    const result = getSupportedPythonVersion({
+      declaredPythonVersion: {
+        version: '~=3.10',
+        source: 'pyproject.toml',
+      },
+    });
+    expect(result).toHaveProperty('runtime', 'python3.10');
+  });
+});
+
 it('should select latest supported installed version when no Piplock detected', () => {
   makeMockPython('3.10');
   const result = getSupportedPythonVersion({

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -681,7 +681,7 @@ describe('python version fallback logging', () => {
     });
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Using Python 3.11 from pyproject.toml')
+      expect.stringContaining('Using Python 3.12 from pyproject.toml')
     );
   });
 });

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -21,6 +21,9 @@ beforeEach(() => {
   console.warn = m => {
     warningMessages.push(m);
   };
+  // Isolate PATH so discovery relies only on mocked binaries
+  fs.mkdirSync(tmpPythonDir, { recursive: true });
+  process.env.PATH = tmpPythonDir;
 });
 
 afterEach(() => {
@@ -163,7 +166,7 @@ it('should warn for deprecated versions, soon to be discontinued', () => {
 function makeMockPython(version: string) {
   fs.mkdirSync(tmpPythonDir, { recursive: true });
   const isWin = process.platform === 'win32';
-  const posixScript = '#!/usr/bin/env sh\n# mock binary\nexit 0\n';
+  const posixScript = '#!/bin/sh\n# mock binary\nexit 0\n';
   const winScript = '@echo off\r\nrem mock binary\r\nexit /b 0\r\n';
 
   for (const name of ['python', 'pip']) {
@@ -173,6 +176,14 @@ function makeMockPython(version: string) {
     );
     fs.writeFileSync(bin, isWin ? winScript : posixScript, 'utf8');
     if (!isWin) fs.chmodSync(bin, 0o755);
+
+    // Also provide unversioned "python3"/"pip3" shims for dev mode
+    const major = version.split('.')[0];
+    if (major === '3') {
+      const shim = path.join(tmpPythonDir, `${name}3${isWin ? '.cmd' : ''}`);
+      fs.writeFileSync(shim, isWin ? winScript : posixScript, 'utf8');
+      if (!isWin) fs.chmodSync(shim, 0o755);
+    }
   }
 
   const uvBin = path.join(tmpPythonDir, `uv${isWin ? '.cmd' : ''}`);

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -681,7 +681,7 @@ describe('python version fallback logging', () => {
     });
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Using Python 3.12 from pyproject.toml')
+      expect.stringContaining('Using Python 3.11 from pyproject.toml')
     );
   });
 });


### PR DESCRIPTION
Properly supports ranges in `requires-python` in `pyproject.toml`

e.g:
```toml
requires-python = ">=3.10,<=3.12"
```
Selects python 3.12 (latest supported & installed version that matches constraints)