### PR TITLE
[@vercel/routing-utils] Support header values up to 32kb in length

### DIFF
--- a/.changeset/lovely-fireants-join.md
+++ b/.changeset/lovely-fireants-join.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+Allow header values of up to 32kb in length in routes.

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -366,7 +366,7 @@ export const routesSchema = {
             patternProperties: {
               '^.{1,256}$': {
                 type: 'string',
-                maxLength: 4096,
+                maxLength: 32768,
               },
             },
           },
@@ -575,7 +575,7 @@ export const headersSchema = {
             },
             value: {
               type: 'string',
-              maxLength: 4096,
+              maxLength: 32768,
             },
           },
         },


### PR DESCRIPTION
Vercel's CDN supports header values up to 32kb in length, but the routes validation (from `vercel.json`, `next.config.js`, etc.) was being limited to just 4kb. This PR allows header values up to 32kb in length.