### PR TITLE
[ruby] add env var

### DIFF
--- a/.changeset/plenty-beans-cross.md
+++ b/.changeset/plenty-beans-cross.md
@@ -1,0 +1,5 @@
+---
+"@vercel/ruby": patch
+---
+
+[ruby] set `ENV['RACK_ENV'] ||= 'production'`

--- a/packages/ruby/vc_init.rb
+++ b/packages/ruby/vc_init.rb
@@ -7,6 +7,7 @@ require 'json'
 $entrypoint = '__VC_HANDLER_FILENAME'
 
 ENV['RAILS_ENV'] ||= 'production'
+ENV['RACK_ENV'] ||= 'production'
 ENV['RAILS_LOG_TO_STDOUT'] ||= '1'
 
 def rack_handler(httpMethod, path, body, headers)


### PR DESCRIPTION
set `ENV['RACK_ENV'] ||= 'production'` to avoid `Host not permitted` errors on frameworks like Sinatra