### PR TITLE
Update project settings when monorepo manager is detected

### DIFF
--- a/.changeset/happy-donuts-move.md
+++ b/.changeset/happy-donuts-move.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Enable automatic monorepo project settings overrides

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -439,7 +439,6 @@ async function doBuild(
   };
 
   if (
-    process.env.VERCEL_BUILD_MONOREPO_SUPPORT === '1' &&
     pkg?.scripts?.['vercel-build'] === undefined &&
     projectSettings.rootDirectory !== null &&
     projectSettings.rootDirectory !== '.'


### PR DESCRIPTION
This has been feature flagged for a long time, I'm not sure of the history but this is something we would benefit from adding. 

Right now, if you set up a turbo project and you have a `build` script in your app that depends on other workspaces running their `build` scripts, you need to go into your project and setup an alternate `build` command in your project settings.

```sh
projectSettings {
  createdAt: 1763141837283,
  framework: 'hono',
  devCommand: null,
  installCommand: null,
  buildCommand: null,
  outputDirectory: null,
  rootDirectory: 'apps/api',
  directoryListing: false,
  nodeVersion: '22.x'
}
```
```sh
> Detected Turbo. Adjusting default settings...
projectSettings {
  createdAt: 1763141837283,
  framework: 'hono',
  devCommand: null,
  installCommand: 'pnpm install',
  buildCommand: 'turbo run build',
  outputDirectory: null,
  rootDirectory: 'apps/api',
  directoryListing: false,
  nodeVersion: '22.x',
  commandForIgnoringBuildStep: 'npx turbo-ignore'
}
```