### PR TITLE
Include `.vercel/routes.json` during `vc deploy`

### DIFF
--- a/.changeset/gorgeous-rings-nail.md
+++ b/.changeset/gorgeous-rings-nail.md
@@ -1,0 +1,5 @@
+---
+'@vercel/client': patch
+---
+
+Include `.vercel/routes.json` during `vc deploy`


### PR DESCRIPTION
`vc deploy` auto-ignores `.vercel`, but we want it to include the `.vercel/routes.json` if it exists