### PR TITLE
[draft] services queues (python)

### DIFF
--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -25,7 +25,7 @@ const servicesSchema = {
     additionalProperties: false,
     required: ['type', 'entry'],
     properties: {
-      type: { enum: ['web', 'cron'] },
+      type: { enum: ['web', 'cron', 'worker'] },
       entry: { type: 'string', minLength: 1, maxLength: 512 },
       prefix: { type: 'string', minLength: 1, maxLength: 256 },
       framework: { type: 'string', minLength: 1, maxLength: 128 },
@@ -46,6 +46,8 @@ const servicesSchema = {
         maxLength: 256,
       },
       handler: { type: 'string', minLength: 1, maxLength: 128 },
+      topic: { type: 'string', minLength: 1, maxLength: 256 },
+      consumer: { type: 'string', minLength: 1, maxLength: 128 },
       installCommand: { type: 'string', minLength: 1, maxLength: 256 },
       buildCommand: { type: 'string', minLength: 1, maxLength: 256 },
     },

--- a/packages/cli/test/unit/util/services.test.ts
+++ b/packages/cli/test/unit/util/services.test.ts
@@ -115,6 +115,35 @@ describe('services utilities', () => {
     ]);
   });
 
+  it('creates worker builds and internal routes for worker services', async () => {
+    const cwd = await createFixture({
+      'workers/worker.py': 'print("worker")\n',
+    });
+
+    const { builds, rewriteRoutes } = await servicesToBuildsAndRoutes(
+      [
+        {
+          type: 'worker',
+          entry: 'workers/worker.py',
+          topic: 'default',
+        },
+      ] as any,
+      cwd
+    );
+
+    expect(builds).toHaveLength(1);
+    expect(builds[0].src).toBe('workers/worker.py');
+    expect(builds[0].use).toBe('@vercel/python');
+
+    expect(rewriteRoutes).toEqual([
+      {
+        src: '^/_vc/workers/workers/worker/worker$',
+        dest: '/workers/worker.py',
+        check: true,
+      },
+    ]);
+  });
+
   it('requires schedule for cron services during validation', () => {
     const error = validateServices({
       services: [{ type: 'cron', entry: 'crons/daily.py' }],

--- a/packages/python/test/fixtures/44-services-crons/vercel.json
+++ b/packages/python/test/fixtures/44-services-crons/vercel.json
@@ -1,3 +1,14 @@
 {
-  "version": 2
+  "version": 2,
+  "services": [
+    {
+      "type": "web",
+      "entry": "web/main.py"
+    },
+    {
+      "type": "cron",
+      "entry": "workers/scheduler.py",
+      "schedule": "* * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
Adds support for worker services
For python, also allows queue workers to be defined by an entry as opposed to 'experimentalTriggers'.
When a worker service specifies an entry, it gets wrapped as an app and exposed as an internal url, e.g `/_vc/workers/my_worker/listen`

Also pairs with new `vercel-workers` PyPI package:
* https://github.com/vercel/vqs-py/tree/main/src/vercel/workers
* https://pypi.org/project/vercel-workers/

`workers/worker.py`
```python
from vercel.workers import MessageMetadata, subscribe

@subscribe(topic="default")
def listen(message, metadata: MessageMetadata):
    print("worker received:", message, metadata)
```

`vercel.json`
```json
{
  "version": 2,
  "services": [
    {
      "type": "web",
      "entry": "web/main.py"
    },
    {
      "type": "worker",
      "entry": "workers/worker.py",
      "topic": "default",
      "consumer": "billing"
    }
  ]
}
```