### PR TITLE
Ensure `ttl` check handles zero values correctly in InMemoryCache

### DIFF
--- a/.changeset/eleven-wombats-remain.md
+++ b/.changeset/eleven-wombats-remain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': patch
+---
+
+Replace truthy check in InMemoryCache.get() with a null check so that zero ttl values don't persist indefinitely.

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -13,7 +13,7 @@ export class InMemoryCache implements RuntimeCache {
   async get(key: string): Promise<unknown | null> {
     const entry = this.cache[key];
     if (entry) {
-      if (entry.ttl && entry.lastModified + entry.ttl * 1000 < Date.now()) {
+      if (entry.ttl != null && entry.lastModified + entry.ttl * 1000 < Date.now()) {
         // If the entry is expired, delete it and return null
         await this.delete(key);
         return null;

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -125,10 +125,21 @@ describe('getCache', () => {
     );
   });
 
-  test('should handle zero ttl correctly', async () => {
+  test('should not get entry with zero ttl', async () => {
     const cache = getCache();
     await cache.set('key', 'value', { ttl: 0 });
     const result = await cache.get('key');
+    expect(result).toBe(null);
+  });
+
+  test('should overwrite existing entry with zero ttl entry', async () => {
+    const cache = getCache();
+    await cache.set('key', 'initial-value');
+    let result = await cache.get('key');
+    expect(result).toBe('initial-value');
+
+    await cache.set('key', 'new-value', { ttl: 0 });
+    result = await cache.get('key');
     expect(result).toBe(null);
   });
 });

--- a/packages/functions/test/unit/cache/index.test.ts
+++ b/packages/functions/test/unit/cache/index.test.ts
@@ -8,8 +8,8 @@ import {
   vitest,
 } from 'vitest';
 
-import { getCache } from '../../../src/cache/index';
 import { InMemoryCache } from '../../../src/cache/in-memory-cache';
+import { getCache } from '../../../src/cache/index';
 import { getContext } from '../../../src/get-context';
 
 vitest.mock('../../../src/get-context', () => ({
@@ -123,5 +123,12 @@ describe('getCache', () => {
       `${namespace}$b876d32`,
       undefined
     );
+  });
+
+  test('should handle zero ttl correctly', async () => {
+    const cache = getCache();
+    await cache.set('key', 'value', { ttl: 0 });
+    const result = await cache.get('key');
+    expect(result).toBe(null);
   });
 });


### PR DESCRIPTION
Replaces the truthy check in `InMemoryCache.get()` with a null check, so that zero `ttl` values don't persist indefinitely.

This fixes the issue locally, but it is present in Vercel as well.