### PR TITLE
[CICD-DX] curl: add support for missing protocol in `--deployment`

### DIFF
--- a/.changeset/thirty-garlics-drop.md
+++ b/.changeset/thirty-garlics-drop.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+adds support for missing protocol when using the `--deployment` flag of `vercel curl`

--- a/packages/cli/src/commands/curl/deployment-url.ts
+++ b/packages/cli/src/commands/curl/deployment-url.ts
@@ -23,6 +23,10 @@ export async function getDeploymentUrlById(
       }
     }
 
+    if (deploymentIdOrUrl.includes('vercel.app')) {
+      return `https://${deploymentIdOrUrl}`;
+    }
+
     let fullDeploymentId = deploymentIdOrUrl;
     if (!fullDeploymentId.startsWith('dpl_')) {
       fullDeploymentId = `dpl_${deploymentIdOrUrl}`;

--- a/packages/cli/test/unit/commands/curl/index.test.ts
+++ b/packages/cli/test/unit/commands/curl/index.test.ts
@@ -605,6 +605,22 @@ describe('curl', () => {
 });
 
 describe('getDeploymentUrlById', () => {
+  it('should accept a bare vercel.app host and return https origin', async () => {
+    const mockClient = {
+      fetch: vi.fn().mockResolvedValue({
+        url: 'should-not-be-used.vercel.app',
+      }),
+    } as any;
+
+    const result = await getDeploymentUrlById(
+      mockClient,
+      'my-app-abc123.vercel.app'
+    );
+
+    expect(result).toBe('https://my-app-abc123.vercel.app');
+    expect(mockClient.fetch).not.toHaveBeenCalled();
+  });
+
   it('should add dpl_ prefix when missing', async () => {
     const mockClient = {
       fetch: vi.fn().mockResolvedValue({


### PR DESCRIPTION
while we did support an argument like `--deployment https://test-express-5.vercel.app` we also want to support that same thing without a protocol (as it appears in the Vercel dashboard), like `--deployment test-express-5.vercel.app`.

closes: FLOW-5382