### PR TITLE
[CICD-DX] Improve deployment logs with condensed view and better status messages

### DIFF
--- a/.changeset/real-seahorses-live.md
+++ b/.changeset/real-seahorses-live.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Shows more descriptive log message while building

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -471,7 +471,7 @@ export default async (client: Client): Promise<number> => {
   const deployStamp = stamp();
   let deployment = null;
   const noWait = !!parsedArguments.flags['--no-wait'];
-  const withLogs = parsedArguments.flags['--logs'] ? true : false;
+  const withFullLogs = parsedArguments.flags['--logs'] ? true : false;
 
   const localConfigurationOverrides = pickOverrides(localConfig);
 
@@ -514,7 +514,7 @@ export default async (client: Client): Promise<number> => {
       target,
       skipAutoDetectionConfirmation: autoConfirm,
       noWait,
-      withLogs,
+      withFullLogs,
       autoAssignCustomDomains,
     };
 
@@ -670,7 +670,7 @@ export default async (client: Client): Promise<number> => {
     }
 
     if (err instanceof BuildError) {
-      if (withLogs === false) {
+      if (withFullLogs === false) {
         try {
           if (now.url) {
             const failedDeployment = await getDeployment(

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -50,7 +50,7 @@ export interface CreateOptions {
   projectSettings?: any;
   skipAutoDetectionConfirmation?: boolean;
   noWait?: boolean;
-  withLogs?: boolean;
+  withFullLogs?: boolean;
   autoAssignCustomDomains?: boolean;
 }
 
@@ -125,7 +125,7 @@ export default class Now {
       projectSettings,
       skipAutoDetectionConfirmation,
       noWait,
-      withLogs,
+      withFullLogs,
       autoAssignCustomDomains,
     }: CreateOptions,
     org: Org,
@@ -174,7 +174,7 @@ export default class Now {
       vercelOutputDir,
       rootDirectory,
       noWait,
-      withLogs,
+      withFullLogs,
     });
 
     if (deployment && deployment.warnings) {

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -824,7 +824,7 @@ test('deploys with only vercel.json and README.md', async () => {
   // assert timing order of showing URLs vs status updates
   // Preview URL appears twice: once with loading emoji, then again with success emoji
   expect(stripAnsi(stderr)).toMatch(
-    /Inspect.*\nPreview.*\nQueued.*\nBuilding.*\nPreview.*\nCompleting/
+    /Inspect.*\nPreview.*\n(Queued|Building).*[\s\S]*Completing/
   );
 
   const { host } = new URL(stdout);

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1096,7 +1096,7 @@ describe('deploy', () => {
         ...Object.values({
           ...baseCreateDeployArgs,
           createArgs: expect.objectContaining({
-            withLogs: true,
+            withFullLogs: true,
           }),
         })
       );

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -772,38 +772,6 @@ describe('deploy', () => {
       expect(output).toContain('Completing');
       expect(exitCode).toEqual(0);
     });
-
-    it('should not print and follow build logs while deploying with --no-logs', async () => {
-      let exitCode: number | undefined;
-      const runCommand = async () => {
-        const repoRoot = setupUnitFixture('commands/deploy/node');
-        client.cwd = repoRoot;
-        client.setArgv('deploy', '--no-logs');
-        exitCode = await deploy(client);
-      };
-
-      const slowlyDeploy = async () => {
-        await sleep(500);
-        deployment.readyState = 'READY';
-        deployment.aliasAssigned = true;
-      };
-
-      await Promise.all<void>([runCommand(), slowlyDeploy()]);
-
-      const output = client.getFullOutput();
-
-      expect(output).not.toContain(outputLine1);
-      expect(output).not.toContain(outputLine2);
-      expect(output).not.toContain(outputLine3);
-
-      expect(exitCode).toEqual(0);
-      expect(client.telemetryEventStore).toHaveTelemetryEvents([
-        {
-          key: 'flag:no-logs',
-          value: 'TRUE',
-        },
-      ]);
-    });
   });
 
   describe('calls createDeploy with the appropriate arguments', () => {


### PR DESCRIPTION
# Improve deployment logs display in CLI

- Shows the latest log message when building
- Renames `withLogs` to `withFullLogs`
- Light refactoring of parseLogLine implementation

[CleanShot 2025-11-18 at 15.29.59.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/da771587-7f15-4d7a-82df-7a4073b4b19e.mp4" />](https://app.graphite.com/user-attachments/video/da771587-7f15-4d7a-82df-7a4073b4b19e.mp4)

fixes https://linear.app/vercel/issue/FLOW-4673/show-condensed-logs-in-the-cli-on-deploy