### PR TITLE
Fix token expiry check

### DIFF
--- a/.changeset/fast-needles-kick.md
+++ b/.changeset/fast-needles-kick.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+Fix OIDC token expiry check

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -144,8 +144,6 @@ export function getTokenPayload(token: string): TokenPayload {
   return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
 }
 
-const TIME_15_MINUTES_IN_MS = 15 * 60 * 1000;
-
 export function isExpired(token: TokenPayload): boolean {
-  return token.exp * 1000 < Date.now() + TIME_15_MINUTES_IN_MS;
+  return token.exp * 1000 < Date.now();
 }


### PR DESCRIPTION
We currently check if an OIDC token is within 15 minutes of expiration which creates a race condition when using the new OIDC client in production. If a token expires at T100, we may check at T90 if it is expired and return true. This causes a refresh which then fails as there is no local token.

Fix logic to not check with a delta. Clients of this should not be caching a token, even for the duration of a function, so checking exact expiry vs now is correct.