### PR TITLE
[CICD-DX] prefer first production alias

### DIFF
--- a/.changeset/twenty-badgers-prove.md
+++ b/.changeset/twenty-badgers-prove.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+prefer the first production alias for `vercel curl` when no deployment is provided

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -181,7 +181,15 @@ export async function getDeploymentUrlAndToken(
     return 1;
   }
 
-  const target = linkedProject.project.latestDeployments?.[0]?.url;
+  /** this is a url like `test-express-5.vercel.app` */
+  const preferredAlias = linkedProject.project.targets?.production?.alias?.[0];
+  /**
+   * this is a url like `test-express-5-yw3u1f2bj-uncurated-tests.vercel.app`
+   *
+   * we're using it as a fallback because as a deployment rolls out there can be a race on getting the `preferredAlias`
+   */
+  const backupAlias = linkedProject.project.latestDeployments?.[0]?.url;
+  const target = preferredAlias || backupAlias;
 
   let baseUrl: string;
 


### PR DESCRIPTION
We've encountered a use-case where when targeting rolling releases the prior behavior that picked a more specific deployment URL means that rolling releases would therefore be disabled.

This PR fixes that by defaulting to a URL (if one is not provided with `--deployment`) that supports that use-case.  In a way, this is also, perhaps, a more reasonable default in general.