### PR TITLE
[cli] create util to execute and set config path conditionally based on vercel.ts

### DIFF
--- a/.changeset/great-lizards-exercise.md
+++ b/.changeset/great-lizards-exercise.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+add config path compilation util

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@vercel/rust": "1.0.3",
     "@vercel/static-build": "2.8.12",
     "chokidar": "4.0.0",
+    "esbuild": "0.27.0",
     "jose": "5.9.6"
   },
   "devDependencies": {

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -61,8 +61,6 @@ export async function compileVercelConfig(
     };
   }
 
-  output.debug(`Compiling vercel.ts to ${compiledConfigPath}`);
-
   try {
     const { build } = await import('esbuild');
 

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -61,12 +61,12 @@ export async function compileVercelConfig(
     };
   }
 
+  const tempOutPath = join(vercelDir, 'vercel-temp.js');
+
   try {
     const { build } = await import('esbuild');
 
     await mkdir(vercelDir, { recursive: true });
-
-    const tempOutPath = join(vercelDir, 'vercel-temp.js');
 
     await build({
       entryPoints: [vercelTsPath],
@@ -91,12 +91,6 @@ export async function compileVercelConfig(
 
     output.debug(`Compiled vercel.ts -> ${compiledConfigPath}`);
 
-    try {
-      await unlink(tempOutPath);
-    } catch (err) {
-      output.debug(`Failed to cleanup temp file: ${err}`);
-    }
-
     return {
       configPath: compiledConfigPath,
       wasCompiled: true,
@@ -107,6 +101,14 @@ export async function compileVercelConfig(
       message: `Failed to compile vercel.ts: ${error.message}`,
       link: 'https://vercel.com/docs/projects/project-configuration',
     });
+  } finally {
+    try {
+      await unlink(tempOutPath);
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') {
+        output.debug(`Failed to cleanup temp file: ${err}`);
+      }
+    }
   }
 }
 

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -157,15 +157,24 @@ export async function compileVercelConfig(
         stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
       });
 
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error('Config loader timed out after 10 seconds'));
+      }, 10000);
+
       child.on('message', message => {
+        clearTimeout(timeout);
+        child.kill();
         resolve(message);
       });
 
       child.on('error', err => {
+        clearTimeout(timeout);
         reject(err);
       });
 
       child.on('exit', code => {
+        clearTimeout(timeout);
         if (code !== 0) {
           reject(new Error(`Config loader exited with code ${code}`));
         }

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -154,7 +154,6 @@ export async function compileVercelConfig(
     const config = await new Promise((resolve, reject) => {
       const child = fork(loaderPath, [tempOutPath], {
         stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-        env: process.env,
       });
 
       child.on('message', message => {

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -146,7 +146,7 @@ export async function compileVercelConfig(
 
     const loaderScript = `
       const configModule = await import(process.argv[2]);
-      const config = configModule.default || configModule.config || configModule;
+      const config = ('default' in configModule) ? configModule.default : (configModule.config || configModule);
       process.send(config);
     `;
     await writeFile(loaderPath, loaderScript, 'utf-8');

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -178,11 +178,16 @@ export async function compileVercelConfig(
 
 export async function getVercelConfigPath(workPath: string): Promise<string> {
   const vercelJsonPath = join(workPath, 'vercel.json');
+  const nowJsonPath = join(workPath, 'now.json');
   const compiledConfigPath = join(workPath, VERCEL_DIR, 'vercel.json');
 
   if (await fileExists(compiledConfigPath)) {
     return compiledConfigPath;
   }
 
-  return vercelJsonPath;
+  if (await fileExists(vercelJsonPath)) {
+    return vercelJsonPath;
+  }
+
+  return nowJsonPath;
 }

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -1,0 +1,124 @@
+import { existsSync } from 'fs';
+import { mkdir, writeFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import output from '../output-manager';
+import { NowBuildError } from '@vercel/build-utils';
+import { VERCEL_DIR } from './projects/link';
+import { ConflictingConfigFiles } from './errors-ts';
+
+export interface CompileConfigResult {
+  configPath: string | null;
+  wasCompiled: boolean;
+}
+
+export async function compileVercelConfig(
+  workPath: string
+): Promise<CompileConfigResult> {
+  const vercelJsonPath = join(workPath, 'vercel.json');
+  const nowJsonPath = join(workPath, 'now.json');
+  const hasVercelJson = existsSync(vercelJsonPath);
+  const hasNowJson = existsSync(nowJsonPath);
+
+  // Check for conflicting vercel.json and now.json
+  if (hasVercelJson && hasNowJson) {
+    throw new ConflictingConfigFiles([vercelJsonPath, nowJsonPath]);
+  }
+
+  // Only check for vercel.ts if feature flag is enabled
+  if (!process.env.VERCEL_TS_CONFIG_ENABLED) {
+    return {
+      configPath: hasVercelJson
+        ? vercelJsonPath
+        : hasNowJson
+          ? nowJsonPath
+          : null,
+      wasCompiled: false,
+    };
+  }
+
+  const vercelTsPath = join(workPath, 'vercel.ts');
+  const vercelDir = join(workPath, VERCEL_DIR);
+  const compiledConfigPath = join(vercelDir, 'vercel.json');
+
+  const hasVercelTs = existsSync(vercelTsPath);
+
+  if (hasVercelTs && hasVercelJson) {
+    throw new ConflictingConfigFiles(
+      [vercelTsPath, vercelJsonPath],
+      'Both vercel.ts and vercel.json exist in your project. Please use only one configuration method.',
+      'https://vercel.com/docs/projects/project-configuration'
+    );
+  }
+
+  if (!hasVercelTs) {
+    return {
+      configPath: hasVercelJson
+        ? vercelJsonPath
+        : hasNowJson
+          ? nowJsonPath
+          : null,
+      wasCompiled: false,
+    };
+  }
+
+  output.debug(`Compiling vercel.ts to ${compiledConfigPath}`);
+
+  try {
+    const { build } = await import('esbuild');
+
+    await mkdir(vercelDir, { recursive: true });
+
+    const tempOutPath = join(vercelDir, 'vercel-temp.js');
+
+    await build({
+      entryPoints: [vercelTsPath],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      outfile: tempOutPath,
+      packages: 'external',
+      target: 'node18',
+      sourcemap: 'inline',
+    });
+
+    delete require.cache[require.resolve(tempOutPath)];
+    const configModule = require(tempOutPath);
+    const config = configModule.default || configModule;
+
+    await writeFile(
+      compiledConfigPath,
+      JSON.stringify(config, null, 2),
+      'utf-8'
+    );
+
+    output.debug(`Compiled vercel.ts -> ${compiledConfigPath}`);
+
+    try {
+      await unlink(tempOutPath);
+    } catch (err) {
+      output.debug(`Failed to cleanup temp file: ${err}`);
+    }
+
+    return {
+      configPath: compiledConfigPath,
+      wasCompiled: true,
+    };
+  } catch (error: any) {
+    throw new NowBuildError({
+      code: 'vercel_ts_compilation_failed',
+      message: `Failed to compile vercel.ts: ${error.message}`,
+      link: 'https://vercel.com/docs/projects/project-configuration',
+    });
+  }
+}
+
+export function getVercelConfigPath(workPath: string): string {
+  const vercelJsonPath = join(workPath, 'vercel.json');
+  const compiledConfigPath = join(workPath, VERCEL_DIR, 'vercel.json');
+
+  if (existsSync(compiledConfigPath)) {
+    return compiledConfigPath;
+  }
+
+  return vercelJsonPath;
+}

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -10,6 +10,7 @@ import { ConflictingConfigFiles } from './errors-ts';
 export interface CompileConfigResult {
   configPath: string | null;
   wasCompiled: boolean;
+  sourceFile?: string;
 }
 
 const VERCEL_CONFIG_EXTENSIONS = ['ts', 'mts', 'js', 'mjs', 'cjs'] as const;
@@ -23,6 +24,21 @@ function findAllVercelConfigFiles(workPath: string): string[] {
     }
   }
   return foundFiles;
+}
+
+/**
+ * Finds the source vercel config file basename (e.g., 'vercel.ts', 'vercel.js')
+ * @param workPath - The directory to search in
+ * @returns The basename of the config file, or null if not found
+ */
+export function findSourceVercelConfigFile(workPath: string): string | null {
+  for (const ext of VERCEL_CONFIG_EXTENSIONS) {
+    const configPath = join(workPath, `vercel.${ext}`);
+    if (existsSync(configPath)) {
+      return basename(configPath);
+    }
+  }
+  return null;
 }
 
 function findVercelConfigFile(workPath: string): string | null {
@@ -131,6 +147,7 @@ export async function compileVercelConfig(
     return {
       configPath: compiledConfigPath,
       wasCompiled: true,
+      sourceFile: findSourceVercelConfigFile(workPath) ?? undefined,
     };
   } catch (error: any) {
     throw new NowBuildError({

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import { mkdir, writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
+import { config as dotenvConfig } from 'dotenv';
 import output from '../output-manager';
 import { NowBuildError } from '@vercel/build-utils';
 import { VERCEL_DIR } from './projects/link';
@@ -68,6 +69,9 @@ export async function compileVercelConfig(
       wasCompiled: false,
     };
   }
+
+  dotenvConfig({ path: join(workPath, '.env') });
+  dotenvConfig({ path: join(workPath, '.env.local') });
 
   const tempOutPath = join(vercelDir, 'vercel-temp.js');
 

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -42,6 +42,14 @@ export async function compileVercelConfig(
 
   const hasVercelTs = existsSync(vercelTsPath);
 
+  if (hasVercelTs && hasNowJson) {
+    throw new ConflictingConfigFiles(
+      [vercelTsPath, nowJsonPath],
+      'Both vercel.ts and now.json exist in your project. Please use only one configuration method.',
+      'https://vercel.com/docs/projects/project-configuration'
+    );
+  }
+
   if (hasVercelTs && hasVercelJson) {
     throw new ConflictingConfigFiles(
       [vercelTsPath, vercelJsonPath],

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -89,7 +89,7 @@ export async function compileVercelConfig(
 
     delete require.cache[require.resolve(tempOutPath)];
     const configModule = require(tempOutPath);
-    const config = configModule.default || configModule;
+    const config = configModule.default || configModule.config || configModule;
 
     await writeFile(
       compiledConfigPath,

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -145,8 +145,9 @@ export async function compileVercelConfig(
     });
 
     const loaderScript = `
-      const configModule = await import(process.argv[2]);
-      const config = ('default' in configModule) ? configModule.default : (configModule.config || configModule);
+      import { pathToFileURL } from 'url';
+      const configModule = await import(pathToFileURL(process.argv[2]).href);
+      const config = ('default' in configModule) ? configModule.default : ('config' in configModule) ? configModule.config : configModule;
       process.send(config);
     `;
     await writeFile(loaderPath, loaderScript, 'utf-8');

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -698,12 +698,13 @@ export class CantParseJSONFile extends NowError<
 export class ConflictingConfigFiles extends NowBuildError {
   files: string[];
 
-  constructor(files: string[]) {
+  constructor(files: string[], message?: string, link?: string) {
     super({
       code: 'CONFLICTING_CONFIG_FILES',
       message:
+        message ||
         'Cannot use both a `vercel.json` and `now.json` file. Please delete the `now.json` file.',
-      link: 'https://vercel.link/combining-old-and-new-config',
+      link: link || 'https://vercel.link/combining-old-and-new-config',
     });
     this.files = files;
   }

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { writeFile, remove } from 'fs-extra';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { compileVercelConfig } from '../../../src/util/compile-vercel-config';
 import { getNewTmpDir } from '../../helpers/get-tmp-dir';
 import { VERCEL_DIR } from '../../../src/util/projects/link';

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -79,4 +79,35 @@ describe('compileVercelConfig', () => {
       /Both vercel.ts and vercel.json exist/
     );
   });
+
+  it('should compile vercel.mjs to vercel.json', async () => {
+    const vercelMjsPath = join(tmpDir, 'vercel.mjs');
+    const vercelMjsContent = `
+      export default {
+        rewrites: [
+          {
+            source: '/api/:path*',
+            destination: '/backend/:path*'
+          }
+        ]
+      };
+    `;
+    await writeFile(vercelMjsPath, vercelMjsContent);
+
+    const result = await compileVercelConfig(tmpDir);
+
+    expect(result.wasCompiled).toBe(true);
+    expect(result.configPath).toBe(join(tmpDir, VERCEL_DIR, 'vercel.json'));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const compiledConfig = require(result.configPath!);
+    expect(compiledConfig).toEqual({
+      rewrites: [
+        {
+          source: '/api/:path*',
+          destination: '/backend/:path*',
+        },
+      ],
+    });
+  });
 });

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -1,0 +1,81 @@
+import { join } from 'path';
+import { writeFile, remove } from 'fs-extra';
+import { compileVercelConfig } from '../../../src/util/compile-vercel-config';
+import { getNewTmpDir } from '../../helpers/get-tmp-dir';
+import { VERCEL_DIR } from '../../../src/util/projects/link';
+
+describe('compileVercelConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = getNewTmpDir();
+    process.env.VERCEL_TS_CONFIG_ENABLED = '1';
+  });
+
+  afterEach(async () => {
+    delete process.env.VERCEL_TS_CONFIG_ENABLED;
+    await remove(tmpDir);
+  });
+
+  it('should compile vercel.ts to vercel.json', async () => {
+    const vercelTsPath = join(tmpDir, 'vercel.ts');
+    const vercelTsContent = `
+      export default {
+        headers: [
+          {
+            source: '/(.*)',
+            headers: [
+              {
+                key: 'X-Test',
+                value: 'true'
+              }
+            ]
+          }
+        ]
+      };
+    `;
+    await writeFile(vercelTsPath, vercelTsContent);
+
+    const result = await compileVercelConfig(tmpDir);
+
+    expect(result.wasCompiled).toBe(true);
+    expect(result.configPath).toBe(join(tmpDir, VERCEL_DIR, 'vercel.json'));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const compiledConfig = require(result.configPath!);
+    expect(compiledConfig).toEqual({
+      headers: [
+        {
+          source: '/(.*)',
+          headers: [
+            {
+              key: 'X-Test',
+              value: 'true',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should ignore vercel.ts if feature flag is disabled', async () => {
+    delete process.env.VERCEL_TS_CONFIG_ENABLED;
+    const vercelTsPath = join(tmpDir, 'vercel.ts');
+    await writeFile(vercelTsPath, 'export default {}');
+
+    const result = await compileVercelConfig(tmpDir);
+    expect(result.wasCompiled).toBe(false);
+    expect(result.configPath).toBe(null);
+  });
+
+  it('should throw error if both vercel.ts and vercel.json exist', async () => {
+    const vercelTsPath = join(tmpDir, 'vercel.ts');
+    const vercelJsonPath = join(tmpDir, 'vercel.json');
+    await writeFile(vercelTsPath, 'export default {}');
+    await writeFile(vercelJsonPath, '{}');
+
+    await expect(compileVercelConfig(tmpDir)).rejects.toThrow(
+      /Both vercel.ts and vercel.json exist/
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
       chokidar:
         specifier: 4.0.0
         version: 4.0.0
+      esbuild:
+        specifier: 0.27.0
+        version: 0.27.0
       jose:
         specifier: 5.9.6
         version: 5.9.6
@@ -4264,6 +4267,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.27.0:
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -4306,6 +4318,15 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.27.0:
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -4352,6 +4373,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.27.0:
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -4394,6 +4424,15 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.27.0:
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -4440,6 +4479,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.27.0:
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -4482,6 +4530,15 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.27.0:
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -4528,6 +4585,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.27.0:
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -4570,6 +4636,15 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.27.0:
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -4616,6 +4691,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.27.0:
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -4658,6 +4742,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.27.0:
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -4704,6 +4797,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.27.0:
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-loong64@0.18.20:
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -4746,6 +4848,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.27.0:
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -4792,6 +4903,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.27.0:
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-ppc64@0.18.20:
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -4834,6 +4954,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.27.0:
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -4880,6 +5009,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.27.0:
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-s390x@0.18.20:
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -4922,6 +5060,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.27.0:
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -4968,6 +5115,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.27.0:
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/netbsd-arm64@0.25.11:
     resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
     engines: {node: '>=18'}
@@ -4975,6 +5131,15 @@ packages:
     os: [netbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.27.0:
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.18.20:
@@ -5021,6 +5186,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.27.0:
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/openbsd-arm64@0.23.1:
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
@@ -5037,6 +5211,15 @@ packages:
     os: [openbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.27.0:
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -5083,6 +5266,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.27.0:
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/openharmony-arm64@0.25.11:
     resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
     engines: {node: '>=18'}
@@ -5090,6 +5282,15 @@ packages:
     os: [openharmony]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.27.0:
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.18.20:
@@ -5136,6 +5337,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.27.0:
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-arm64@0.18.20:
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -5178,6 +5388,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.27.0:
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.18.20:
@@ -5224,6 +5443,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.27.0:
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -5266,6 +5494,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.27.0:
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.7.0(eslint@8.24.0):
@@ -9359,7 +9596,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
@@ -9406,7 +9643,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9453,7 +9690,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9500,7 +9737,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9576,7 +9813,7 @@ packages:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 5.1.8(@types/node@22.5.0)
+      vite: 5.1.8(@types/node@18.0.0)
     dev: true
 
   /@vitest/pretty-format@2.0.3:
@@ -12130,6 +12367,40 @@ packages:
       '@esbuild/win32-x64': 0.25.11
     dev: true
 
+  /esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
+    dev: false
+
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -12190,7 +12461,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -12219,7 +12490,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.11.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12245,7 +12516,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.11.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12255,7 +12526,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12276,11 +12547,11 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12307,7 +12578,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12318,16 +12589,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Created a new util to conditionally check whether a `vercel.ts` configuration file exists, and if so return it as the config path. Existing logic to check between a `now.json` and a `vercel.json` is still available. 

This util executes the TypeScript configuration file and generates an intermediary `vercel.json` inside `VERCEL_DIR`.  It's protected by a feature flag, and will be protected similarly in the actual commands where it's used (`dev`, `build`, and `deploy`).