### PR TITLE
[cli] compile config path in vercel dev, build, deploy

### DIFF
--- a/.changeset/unlucky-rivers-tease.md
+++ b/.changeset/unlucky-rivers-tease.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+support for alternative vercel config files in test

--- a/.changeset/unlucky-rivers-tease.md
+++ b/.changeset/unlucky-rivers-tease.md
@@ -2,4 +2,4 @@
 'vercel': patch
 ---
 
-support for alternative vercel config files in test
+support for alternative vercel config files in build, dev, and deploy commands

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -82,6 +82,7 @@ import {
 import readJSONFile from '../../util/read-json-file';
 import { BuildTelemetryClient } from '../../util/telemetry/commands/build';
 import { validateConfig } from '../../util/validate-config';
+import { compileVercelConfig } from '../../util/compile-vercel-config';
 import { help } from '../help';
 import { pullCommandLogic } from '../pull';
 import { buildCommand } from './command';
@@ -401,11 +402,16 @@ async function doBuild(
 
   const workPath = join(cwd, project.settings.rootDirectory || '.');
 
+  const compileResult = await compileVercelConfig(workPath);
+
+  const vercelConfigPath =
+    localConfigPath ||
+    compileResult.configPath ||
+    join(workPath, 'vercel.json');
+
   const [pkg, vercelConfig, nowConfig, hasInstrumentation] = await Promise.all([
     readJSONFile<PackageJson>(join(workPath, 'package.json')),
-    readJSONFile<VercelConfig>(
-      localConfigPath || join(workPath, 'vercel.json')
-    ),
+    readJSONFile<VercelConfig>(vercelConfigPath),
     readJSONFile<VercelConfig>(join(workPath, 'now.json')),
     detectInstrumentation(new LocalFileSystemDetector(workPath)),
   ]);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -18,6 +18,7 @@ import { join, resolve } from 'path';
 import Now, { type CreateOptions } from '../../util';
 import type Client from '../../util/client';
 import { readLocalConfig } from '../../util/config/files';
+import { compileVercelConfig } from '../../util/compile-vercel-config';
 import { createGitMeta } from '../../util/create-git-meta';
 import createDeploy from '../../util/deploy/create-deploy';
 import { getDeploymentChecks } from '../../util/deploy/get-deployment-checks';
@@ -156,6 +157,10 @@ export default async (client: Client): Promise<number> => {
   // #endregion
 
   // #region Config loading
+
+  // Compile vercel.ts to .vercel/vercel.json if it exists
+  await compileVercelConfig(paths[0]);
+
   let localConfig = client.localConfig || readLocalConfig(paths[0]);
 
   if (localConfig) {
@@ -351,7 +356,9 @@ export default async (client: Client): Promise<number> => {
   // If Root Directory is used we'll try to read the config
   // from there instead and use it if it exists.
   if (rootDirectory) {
-    const rootDirectoryConfig = readLocalConfig(join(cwd, rootDirectory));
+    const rootDirectoryPath = join(cwd, rootDirectory);
+    await compileVercelConfig(rootDirectoryPath);
+    const rootDirectoryConfig = readLocalConfig(rootDirectoryPath);
 
     if (rootDirectoryConfig) {
       debug(`Read local config from root directory (${rootDirectory})`);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -33,6 +33,7 @@ import {
   AliasDomainConfigured,
   BuildError,
   BuildsRateLimited,
+  ConflictingConfigFiles,
   ConflictingFilePath,
   ConflictingPathSegment,
   DeploymentNotFound,
@@ -670,7 +671,8 @@ export default async (client: Client): Promise<number> => {
       err instanceof AliasDomainConfigured ||
       err instanceof MissingBuildScript ||
       err instanceof ConflictingFilePath ||
-      err instanceof ConflictingPathSegment
+      err instanceof ConflictingPathSegment ||
+      err instanceof ConflictingConfigFiles
     ) {
       handleCreateDeployError(err, localConfig);
       return 1;
@@ -783,7 +785,8 @@ function handleCreateDeployError(error: Error, localConfig: VercelConfig) {
     error instanceof AliasDomainConfigured ||
     error instanceof MissingBuildScript ||
     error instanceof ConflictingFilePath ||
-    error instanceof ConflictingPathSegment
+    error instanceof ConflictingPathSegment ||
+    error instanceof ConflictingConfigFiles
   ) {
     output.error(error.message);
     return 1;

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -91,6 +91,11 @@ export default async function main(client: Client) {
 
   const vercelConfig = await readConfig(dir);
 
+  if (vercelConfig instanceof Error) {
+    output.prettyError(vercelConfig);
+    return 1;
+  }
+
   const hasBuilds =
     vercelConfig &&
     'builds' in vercelConfig &&

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -112,6 +112,14 @@ export async function compileVercelConfig(
   }
 
   if (!vercelConfigPath) {
+    if (existsSync(compiledConfigPath)) {
+      return {
+        configPath: compiledConfigPath,
+        wasCompiled: true,
+        sourceFile: findSourceVercelConfigFile(workPath) ?? undefined,
+      };
+    }
+
     return {
       configPath: hasVercelJson
         ? vercelJsonPath

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -112,20 +112,30 @@ export async function compileVercelConfig(
   }
 
   if (!vercelConfigPath) {
-    if (existsSync(compiledConfigPath)) {
+    if (hasVercelJson) {
+      return {
+        configPath: vercelJsonPath,
+        wasCompiled: false,
+      };
+    }
+
+    if (hasNowJson) {
+      return {
+        configPath: nowJsonPath,
+        wasCompiled: false,
+      };
+    }
+
+    if (await fileExists(compiledConfigPath)) {
       return {
         configPath: compiledConfigPath,
         wasCompiled: true,
-        sourceFile: findSourceVercelConfigFile(workPath) ?? undefined,
+        sourceFile: (await findSourceVercelConfigFile(workPath)) ?? undefined,
       };
     }
 
     return {
-      configPath: hasVercelJson
-        ? vercelJsonPath
-        : hasNowJson
-          ? nowJsonPath
-          : null,
+      configPath: null,
       wasCompiled: false,
     };
   }

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -239,12 +239,16 @@ export async function getVercelConfigPath(workPath: string): Promise<string> {
   const nowJsonPath = join(workPath, 'now.json');
   const compiledConfigPath = join(workPath, VERCEL_DIR, 'vercel.json');
 
-  if (await fileExists(compiledConfigPath)) {
-    return compiledConfigPath;
-  }
-
   if (await fileExists(vercelJsonPath)) {
     return vercelJsonPath;
+  }
+
+  if (await fileExists(nowJsonPath)) {
+    return nowJsonPath;
+  }
+
+  if (await fileExists(compiledConfigPath)) {
+    return compiledConfigPath;
   }
 
   return nowJsonPath;

--- a/packages/cli/src/util/config/read-config.ts
+++ b/packages/cli/src/util/config/read-config.ts
@@ -18,7 +18,14 @@ export default async function readConfig(dir: string) {
       throw err;
     }
   } else {
-    pkgFilePath = getLocalConfigPath(dir);
+    try {
+      pkgFilePath = getLocalConfigPath(dir);
+    } catch (err) {
+      if (err instanceof Error) {
+        return err as any;
+      }
+      throw err;
+    }
   }
 
   const result = await readJSONFile<VercelConfig>(pkgFilePath);

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -555,7 +555,11 @@ export default class DevServer {
   }
 
   async _getVercelConfig(): Promise<VercelConfig> {
-    const configPath = getVercelConfigPath(this.cwd);
+    const { compileVercelConfig } = await import('../compile-vercel-config');
+    const compileResult = await compileVercelConfig(this.cwd);
+
+    const configPath =
+      compileResult.configPath || getVercelConfigPath(this.cwd);
 
     const [
       pkg = null,

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -556,10 +556,23 @@ export default class DevServer {
 
   async _getVercelConfig(): Promise<VercelConfig> {
     const { compileVercelConfig } = await import('../compile-vercel-config');
-    const compileResult = await compileVercelConfig(this.cwd);
+    const { parseArguments } = await import('../../util/get-args');
 
-    const configPath =
-      compileResult.configPath || getVercelConfigPath(this.cwd);
+    const parsedArgs = parseArguments(
+      process.argv.slice(2),
+      {},
+      { permissive: true }
+    );
+    const hasLocalConfigFlag = !!parsedArgs.flags['--local-config'];
+
+    let configPath: string;
+
+    if (hasLocalConfigFlag) {
+      configPath = getVercelConfigPath(this.cwd);
+    } else {
+      const compileResult = await compileVercelConfig(this.cwd);
+      configPath = compileResult.configPath || getVercelConfigPath(this.cwd);
+    }
 
     const [
       pkg = null,

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -556,23 +556,8 @@ export default class DevServer {
 
   async _getVercelConfig(): Promise<VercelConfig> {
     const { compileVercelConfig } = await import('../compile-vercel-config');
-    const { parseArguments } = await import('../../util/get-args');
-
-    const parsedArgs = parseArguments(
-      process.argv.slice(2),
-      {},
-      { permissive: true }
-    );
-    const hasLocalConfigFlag = !!parsedArgs.flags['--local-config'];
-
-    let configPath: string;
-
-    if (hasLocalConfigFlag) {
-      configPath = getVercelConfigPath(this.cwd);
-    } else {
-      const compileResult = await compileVercelConfig(this.cwd);
-      configPath = compileResult.configPath || getVercelConfigPath(this.cwd);
-    }
+    await compileVercelConfig(this.cwd);
+    const configPath = getVercelConfigPath(this.cwd);
 
     const [
       pkg = null,


### PR DESCRIPTION
Add support for `vercel.ts` in vercel build, dev, and deploy commands by adding a step during checking for config path to compile the config path, which is a util from a PR earlier on the stack. This way, the right config file is found and used.