### PR TITLE
[rust] re-publish @vercel/rust due to failed run

### DIFF
--- a/.changeset/real-dolphins-grab.md
+++ b/.changeset/real-dolphins-grab.md
@@ -1,0 +1,5 @@
+---
+'@vercel/rust': patch
+---
+
+Re-publish due to failed run


### PR DESCRIPTION
The last run failed as we are publishing a new package. This is bumping a patch version to trigger a new release