### PR TITLE
[cli] bugfix: Fix spinner stop function call in deployment process

### DIFF
--- a/.changeset/young-phones-help.md
+++ b/.changeset/young-phones-help.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Bugfix: stop streaming logs after successful deploy

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -275,7 +275,7 @@ export default async function processDeployment({
 
       if (event.type === 'ready' && rollingRelease) {
         output.spinner('Releasing...', 0);
-        output.stopSpinner();
+        stopSpinner();
         return event.payload;
       }
 


### PR DESCRIPTION
Bugfix: correctly aborts log streaming when a deployment finishes



fixes https://linear.app/vercel/issue/CICD-1611/vercel-cli-48105-fails-preview-deployment-with-code-141