### PR TITLE
[CICD-DX] Add password masking for environment variable input

### DIFF
--- a/.changeset/witty-kangaroos-allow.md
+++ b/.changeset/witty-kangaroos-allow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Prompts if environment vairables should be sensitive. Masks value when inputting new environment variable.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "@inquirer/confirm": "3.1.2",
     "@inquirer/expand": "2.1.2",
     "@inquirer/input": "2.1.2",
+    "@inquirer/password": "2.1.2",
     "@inquirer/select": "2.2.2",
     "@next/env": "11.1.2",
     "@sentry/node": "7.120.1",

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -143,8 +143,12 @@ export default async function add(client: Client, argv: string[]) {
   if (stdInput) {
     envValue = stdInput;
   } else {
-    envValue = await client.input.text({
+    output.log(
+      `🔐 Your value will be encrypted. Use --sensitive to keep it hidden after creation.`
+    );
+    envValue = await client.input.password({
       message: `What's the value of ${envName}?`,
+      mask: true,
     });
   }
 

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -138,14 +138,23 @@ export default async function add(client: Client, argv: string[]) {
     return 1;
   }
 
+  let type: 'encrypted' | 'sensitive' = opts['--sensitive']
+    ? 'sensitive'
+    : 'encrypted';
   let envValue: string;
 
   if (stdInput) {
     envValue = stdInput;
   } else {
-    output.log(
-      `🔐 Your value will be encrypted. Use --sensitive to keep it hidden after creation.`
-    );
+    if (type === 'encrypted') {
+      const isSensitive = await client.input.confirm(
+        `Your value will be encrypted. Mark as sensitive?`,
+        false
+      );
+      if (isSensitive) {
+        type = 'sensitive';
+      }
+    }
     envValue = await client.input.password({
       message: `What's the value of ${envName}?`,
       mask: true,
@@ -174,7 +183,6 @@ export default async function add(client: Client, argv: string[]) {
     });
   }
 
-  const type = opts['--sensitive'] ? 'sensitive' : 'encrypted';
   const upsert = opts['--force'] ? 'true' : '';
 
   const addStamp = stamp();

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -3,6 +3,7 @@ import checkbox from '@inquirer/checkbox';
 import confirm from '@inquirer/confirm';
 import expand from '@inquirer/expand';
 import input from '@inquirer/input';
+import password from '@inquirer/password';
 import select from '@inquirer/select';
 import { EventEmitter } from 'events';
 import { URL } from 'url';
@@ -122,6 +123,11 @@ export default class Client extends EventEmitter implements Stdio {
     this.input = {
       text: (opts: Parameters<typeof input>[0]) =>
         input({ theme, ...opts }, { input: this.stdin, output: this.stderr }),
+      password: (opts: Parameters<typeof password>[0]) =>
+        password(
+          { theme, ...opts },
+          { input: this.stdin, output: this.stderr }
+        ),
       checkbox: <T>(opts: Parameters<typeof checkbox<T>>[0]) =>
         checkbox<T>(
           { theme, ...opts },

--- a/packages/cli/test/integration-1.test.ts
+++ b/packages/cli/test/integration-1.test.ts
@@ -502,6 +502,8 @@ test('deploy `api-env` fixture and test `vercel env` command', async () => {
 
     await waitForPrompt(vc, "What's the name of the variable?");
     vc.stdin?.write(`${promptEnvVar}\n`);
+    await waitForPrompt(vc, 'Mark as sensitive?');
+    vc.stdin?.write('n\n');
     await waitForPrompt(
       vc,
       chunk =>

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -594,6 +594,8 @@ test('override an existing env var', async () => {
     options
   );
 
+  await waitForPrompt(addEnvCommand, /Mark as sensitive\?/);
+  addEnvCommand.stdin?.write('n\n');
   await waitForPrompt(addEnvCommand, /What's the value of [^?]+\?/);
   addEnvCommand.stdin?.write('test\n');
 
@@ -611,6 +613,8 @@ test('override an existing env var', async () => {
     options
   );
 
+  await waitForPrompt(overrideEnvCommand, /Mark as sensitive\?/);
+  overrideEnvCommand.stdin?.write('n\n');
   await waitForPrompt(overrideEnvCommand, /What's the value of [^?]+\?/);
   overrideEnvCommand.stdin?.write('test\n');
 

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -106,6 +106,8 @@ describe('env add', () => {
           '--force'
         );
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
@@ -147,6 +149,8 @@ describe('env add', () => {
           '--guidance'
         );
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput("What's the value of FORCE_FLAG?");
         client.stdin.write('testvalue\n');
         await expect(exitCodePromise).resolves.toBe(0);
@@ -184,6 +188,8 @@ describe('env add', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');
         const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
         await expect(client.stderr).toOutput(
           "What's the value of environment-variable?"
         );
@@ -216,6 +222,8 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput('Mark as sensitive?');
+          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of REDIS_CONNECTION_STRING?"
           );
@@ -236,6 +244,8 @@ describe('env add', () => {
             'branchName'
           );
           const exitCodePromise = env(client);
+          await expect(client.stderr).toOutput('Mark as sensitive?');
+          client.stdin.write('n\n');
           await expect(client.stderr).toOutput(
             "What's the value of TELEMETRY_EVENTS?"
           );

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -319,6 +319,8 @@ describe('env pull', () => {
       client.setArgv('env', 'add', 'NEW_VAR');
       const addPromise = env(client);
 
+      await expect(client.stderr).toOutput('Mark as sensitive?');
+      client.stdin.write('n\n');
       await expect(client.stderr).toOutput("What's the value of NEW_VAR?");
       client.stdin.write('testvalue\n');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       '@inquirer/input':
         specifier: 2.1.2
         version: 2.1.2
+      '@inquirer/password':
+        specifier: 2.1.2
+        version: 2.1.2
       '@inquirer/select':
         specifier: 2.2.2
         version: 2.2.2
@@ -5448,6 +5451,15 @@ packages:
     dependencies:
       '@inquirer/core': 7.1.3
       '@inquirer/type': 1.5.5
+    dev: true
+
+  /@inquirer/password@2.1.2:
+    resolution: {integrity: sha512-PSdF3PgYdNPLAwlIWiLyyXowZP2sNufQSTegNxnKoE/Ki5TwWphgphAGubd6X12hQAFaBrswqGpDjkwA/DOAig==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 7.1.3
+      '@inquirer/type': 1.5.5
+      ansi-escapes: 4.3.2
     dev: true
 
   /@inquirer/select@2.2.2:


### PR DESCRIPTION
Adds password masking for environment variable input, as well as an option to mark the variable as sensitive.

note: opting to use password input rather than allowing a user to view the input, then masking afterwards. Masking afterwards becomes challenging with patterns such as clearLines if the user's terminal width is short. Password input becomes more predictable and safer here.

nit: This command will continue to prompt/ask if the variable is sensitive even if the team settings dictate that all values will be sensitive.

## Example output:

![CleanShot 2025-11-20 at 18.19.00@2x.png](https://app.graphite.com/user-attachments/assets/e046226d-bfa3-484e-8d55-13e0df3c3d05.png)

## Example output w/ `--sensitive`:

![CleanShot 2025-11-20 at 18.18.06@2x.png](https://app.graphite.com/user-attachments/assets/b90efdd1-7170-4903-8740-2cc6c51c32ae.png)



fixes [FLOW-5327: Communicate default encryption for env variables + blur sensitive data after command is sent​](https://linear.app/vercel/issue/FLOW-5327/communicate-default-encryption-for-env-variables-blur-sensitive-data)