### PR TITLE
[rust] fix default architecture, support arm64 cross compilation

### DIFF
--- a/.changeset/stupid-eggs-march.md
+++ b/.changeset/stupid-eggs-march.md
@@ -1,0 +1,5 @@
+---
+'@vercel/rust': patch
+---
+
+Fix default architecture, support cross compile to arm64


### PR DESCRIPTION
Fixes an issue where the default architecture would be `arm64`, we should default to `x86_64` and do an `arm64` compilation in case it's explicitly defined in build outputs.