### PR TITLE
[python] flush startup logs atexit

### DIFF
--- a/.changeset/clean-hornets-buy.md
+++ b/.changeset/clean-hornets-buy.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+[python] flush startup logs atexit

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -201,7 +201,7 @@ def enqueue_or_send_message(msg: dict):
 
 def flush_init_log_buf_to_stderr():
     global _init_log_buf, _init_log_buf_bytes
-    with contextlib.suppress(Exception):
+    try:
         combined: list[str] = []
         for m in _init_log_buf:
             payload = m.get("payload", {})
@@ -213,6 +213,9 @@ def flush_init_log_buf_to_stderr():
                 combined.append(decoded)
         if combined:
             _stderr("".join(combined))
+    except Exception:
+        pass
+    finally:
         _init_log_buf.clear()
         _init_log_buf_bytes = 0
 

--- a/packages/python/vc_init.py
+++ b/packages/python/vc_init.py
@@ -19,6 +19,7 @@ import builtins
 from typing import Callable, Literal, TextIO
 import contextvars
 import contextlib
+import atexit
 
 
 _here = os.path.dirname(__file__)
@@ -196,6 +197,27 @@ def enqueue_or_send_message(msg: dict):
             payload = msg.get("payload", {})
             decoded = base64.b64decode(payload.get("message", "")).decode(errors="ignore")
             _original_stderr.write(decoded + "\n")
+
+
+def flush_init_log_buf_to_stderr():
+    global _init_log_buf, _init_log_buf_bytes
+    with contextlib.suppress(Exception):
+        combined: list[str] = []
+        for m in _init_log_buf:
+            payload = m.get("payload", {})
+            msg = payload.get("message")
+            if not msg:
+                continue
+            with contextlib.suppress(Exception):
+                decoded = base64.b64decode(msg).decode(errors="ignore")
+                combined.append(decoded)
+        if combined:
+            _stderr("".join(combined))
+        _init_log_buf.clear()
+        _init_log_buf_bytes = 0
+
+
+atexit.register(flush_init_log_buf_to_stderr)
 
 
 if 'VERCEL_IPC_PATH' in os.environ:


### PR DESCRIPTION
Flushes any logs still in the buffer at exit, this prevents any edge cases where the code exits but logs haven't flushed so they get dropped.

**ex:**
```python
# main.py
print("Starting app…")     # this would previously get dropped
raise Exception("startup error")
```