### PR TITLE
[CICD-DX] Fix project naming with `vc link --repo`

### DIFF
--- a/.changeset/rich-jobs-chew.md
+++ b/.changeset/rich-jobs-chew.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix project naming with vc link --repo

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -237,8 +237,7 @@ export async function ensureRepoLink(
               frameworks.map((framework, i) => {
                 const name = slugify(
                   [
-                    basename(rootPath),
-                    basename(rootDirectory),
+                    basename(rootDirectory) || basename(rootPath),
                     i > 0 ? framework.slug : '',
                   ]
                     .filter(Boolean)

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -276,9 +276,6 @@ export async function ensureRepoLink(
         ...selection,
         framework: selection.framework.slug,
       }));
-      if (selection.rootDirectory) {
-        (project as any).rootDirectory = selection.rootDirectory;
-      }
       await connectGitProvider(
         client,
         project.id,

--- a/packages/cli/src/util/link/repo.ts
+++ b/packages/cli/src/util/link/repo.ts
@@ -276,6 +276,9 @@ export async function ensureRepoLink(
         ...selection,
         framework: selection.framework.slug,
       }));
+      if (selection.rootDirectory) {
+        (project as any).rootDirectory = selection.rootDirectory;
+      }
       await connectGitProvider(
         client,
         project.id,

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -178,10 +178,7 @@ export function useUnknownProject() {
     }
     if (
       (type === 'github' || type === 'gitlab' || type === 'bitbucket') &&
-      (repo === 'user/repo' ||
-        repo === 'user2/repo2' ||
-        repo === 'user3/repo3' ||
-        repo === 'user/repo4')
+      (repo === 'user/repo' || repo === 'user2/repo2' || repo === 'user3/repo3')
     ) {
       project.link = {
         type,
@@ -374,10 +371,7 @@ export function useProject(
     const { type, repo, org } = req.body;
     if (
       (type === 'github' || type === 'gitlab' || type === 'bitbucket') &&
-      (repo === 'user/repo' ||
-        repo === 'user2/repo2' ||
-        repo === 'user3/repo3' ||
-        repo === 'user/repo4')
+      (repo === 'user/repo' || repo === 'user2/repo2' || repo === 'user3/repo3')
     ) {
       project.link = {
         type,

--- a/packages/cli/test/mocks/project.ts
+++ b/packages/cli/test/mocks/project.ts
@@ -146,33 +146,42 @@ export const defaultProject: Project = {
  * to allow `useProject` responses to still happen.
  */
 export function useUnknownProject() {
-  let project: Project;
+  const projects = new Map<string, Project>();
   client.scenario.get(`/:version/projects/:projectNameOrId`, (req, res) => {
-    if (
-      project?.id === req.params.projectNameOrId ||
-      project?.name === req.params.projectNameOrId
-    ) {
+    const project = Array.from(projects.values()).find(
+      p =>
+        p.id === req.params.projectNameOrId ||
+        p.name === req.params.projectNameOrId
+    );
+    if (project) {
       return res.json(project);
     }
     res.status(404).send();
   });
   client.scenario.post(`/:version/projects`, (req, res) => {
-    project = {
+    const project = {
       ...defaultProject,
       ...req.body,
       id: req.body.name,
     };
+    projects.set(project.id, project);
     res.json(project);
   });
   client.scenario.post(`/v9/projects/:projectNameOrId/link`, (req, res) => {
     const { type, repo, org } = req.body;
     const projName = req.params.projectNameOrId;
-    if (projName !== project.name && projName !== project.id) {
+    const project = Array.from(projects.values()).find(
+      p => p.name === projName || p.id === projName
+    );
+    if (!project) {
       return res.status(404).send('Invalid Project name or ID');
     }
     if (
       (type === 'github' || type === 'gitlab' || type === 'bitbucket') &&
-      (repo === 'user/repo' || repo === 'user2/repo2')
+      (repo === 'user/repo' ||
+        repo === 'user2/repo2' ||
+        repo === 'user3/repo3' ||
+        repo === 'user/repo4')
     ) {
       project.link = {
         type,
@@ -204,8 +213,17 @@ export function useUnknownProject() {
     }
   });
   client.scenario.patch(`/:version/projects/:projectNameOrId`, (req, res) => {
-    Object.assign(project, req.body);
-    res.json(project);
+    const project = Array.from(projects.values()).find(
+      p =>
+        p.name === req.params.projectNameOrId ||
+        p.id === req.params.projectNameOrId
+    );
+    if (project) {
+      Object.assign(project, req.body);
+      res.json(project);
+    } else {
+      res.status(404).send();
+    }
   });
 }
 
@@ -356,7 +374,10 @@ export function useProject(
     const { type, repo, org } = req.body;
     if (
       (type === 'github' || type === 'gitlab' || type === 'bitbucket') &&
-      (repo === 'user/repo' || repo === 'user2/repo2' || repo === 'user3/repo3')
+      (repo === 'user/repo' ||
+        repo === 'user2/repo2' ||
+        repo === 'user3/repo3' ||
+        repo === 'user/repo4')
     ) {
       project.link = {
         type,

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -194,7 +194,7 @@ describe('link', () => {
       const cwd = setupTmpDir();
 
       await mkdirp(join(cwd, '.git'));
-      const repoUrl = 'https://github.com/user/repo4.git';
+      const repoUrl = 'https://github.com/user/repo.git';
       await writeFile(
         join(cwd, '.git/config'),
         `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -111,7 +111,7 @@ describe('link', () => {
       });
     });
 
-    it('should create new Project with Git connection linked', async () => {
+    it('should create new Project at repo root using repo folder name', async () => {
       const user = useUser();
       const cwd = setupTmpDir();
 
@@ -183,9 +183,123 @@ describe('link', () => {
         throw project;
       }
       expect(project.name).toEqual(repoJson.projects[0].name);
+      expect(project.name).toEqual(basename(cwd));
       expect(project.framework).toEqual('nextjs');
       expect(project.link?.repo).toEqual('user/repo');
       expect(project.link?.type).toEqual('github');
+    });
+
+    it('should create projects using subdirectory names for monorepo workspaces', async () => {
+      const user = useUser();
+      const cwd = setupTmpDir();
+
+      await mkdirp(join(cwd, '.git'));
+      const repoUrl = 'https://github.com/user/my-monorepo.git';
+      await writeFile(
+        join(cwd, '.git/config'),
+        `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
+      );
+
+      await writeJSON(join(cwd, 'package.json'), {
+        name: 'my-monorepo',
+        private: true,
+        workspaces: ['packages/frontend', 'packages/api'],
+      });
+
+      await mkdirp(join(cwd, 'packages/frontend'));
+      await writeJSON(join(cwd, 'packages/frontend/package.json'), {
+        name: 'frontend',
+        dependencies: {
+          next: 'latest',
+        },
+      });
+
+      await mkdirp(join(cwd, 'packages/api'));
+      await writeJSON(join(cwd, 'packages/api/package.json'), {
+        name: 'api',
+        dependencies: {
+          remix: 'latest',
+        },
+      });
+
+      useTeams('team_dummy');
+      useUnknownProject();
+      client.scenario.get(`/v9/projects`, (_req, res) => {
+        res.json({
+          projects: [],
+          pagination: { count: 0, next: null, prev: null },
+        });
+      });
+
+      client.cwd = cwd;
+      client.setArgv('--repo');
+      const exitCodePromise = link(client);
+
+      await expect(client.stderr).toOutput(
+        'The `--repo` flag is in alpha, please report issues'
+      );
+
+      await expect(client.stderr).toOutput('Link Git repository at ');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Which scope should contain your Project(s)?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(`Fetching Projects for ${repoUrl}`);
+      await expect(client.stderr).toOutput(`No Projects are linked`);
+      await expect(client.stderr).toOutput(
+        `Detected 2 new Projects that may be created.`
+      );
+      await expect(client.stderr).toOutput(`Which Projects should be created?`);
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        `Linked to 2 Projects under ${user.username} (created .vercel and added it to .gitignore)`
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+
+      const repoJson = await readJSON(join(cwd, '.vercel/repo.json'));
+      expect(repoJson.orgId).toEqual(user.id);
+      expect(repoJson.remoteName).toEqual('origin');
+      expect(repoJson.projects).toHaveLength(2);
+
+      const frontendProject = repoJson.projects.find(
+        (p: any) => p.directory === 'packages/frontend'
+      );
+      const apiProject = repoJson.projects.find(
+        (p: any) => p.directory === 'packages/api'
+      );
+
+      expect(frontendProject).toBeDefined();
+      expect(frontendProject.name).toBeTruthy();
+      expect(frontendProject.directory).toEqual('packages/frontend');
+
+      expect(apiProject).toBeDefined();
+      expect(apiProject.name).toBeTruthy();
+      expect(apiProject.directory).toEqual('packages/api');
+
+      const frontendProjectDetails = await getProjectByNameOrId(
+        client,
+        frontendProject.id
+      );
+      const apiProjectDetails = await getProjectByNameOrId(
+        client,
+        apiProject.id
+      );
+
+      if (
+        frontendProjectDetails instanceof ProjectNotFound ||
+        apiProjectDetails instanceof ProjectNotFound
+      ) {
+        throw new Error('Projects not found');
+      }
+
+      expect(frontendProjectDetails.framework).toEqual('nextjs');
+      expect(apiProjectDetails.framework).toEqual('remix');
     });
 
     it('should gracefully report error when creating new Project fails', async () => {

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -194,7 +194,7 @@ describe('link', () => {
       const cwd = setupTmpDir();
 
       await mkdirp(join(cwd, '.git'));
-      const repoUrl = 'https://github.com/user/my-monorepo.git';
+      const repoUrl = 'https://github.com/user/repo4.git';
       await writeFile(
         join(cwd, '.git/config'),
         `[remote "origin"]\n\turl = ${repoUrl}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`
@@ -218,7 +218,7 @@ describe('link', () => {
       await writeJSON(join(cwd, 'packages/api/package.json'), {
         name: 'api',
         dependencies: {
-          remix: 'latest',
+          '@remix-run/dev': 'latest',
         },
       });
 

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -268,19 +268,12 @@ describe('link', () => {
       expect(repoJson.projects).toHaveLength(2);
 
       const frontendProject = repoJson.projects.find(
-        (p: any) => p.directory === 'packages/frontend'
+        (p: any) => p.name === 'frontend'
       );
-      const apiProject = repoJson.projects.find(
-        (p: any) => p.directory === 'packages/api'
-      );
+      const apiProject = repoJson.projects.find((p: any) => p.name === 'api');
 
       expect(frontendProject).toBeDefined();
-      expect(frontendProject.name).toBeTruthy();
-      expect(frontendProject.directory).toEqual('packages/frontend');
-
       expect(apiProject).toBeDefined();
-      expect(apiProject.name).toBeTruthy();
-      expect(apiProject.directory).toEqual('packages/api');
 
       const frontendProjectDetails = await getProjectByNameOrId(
         client,


### PR DESCRIPTION
# Fix Project Naming in Monorepo Workspaces

This PR fixes an issue with project naming when linking repositories to Vercel. Previously, when linking a monorepo with workspaces, the project names would include both the repository name and the workspace directory name, creating redundancy.

The changes:

1. Modified the project naming logic to use only the workspace directory name when available, falling back to the repository name when needed
2. Added a comprehensive test for monorepo workspaces to verify that projects are created with the correct names based on subdirectory names
3. Updated an existing test to verify that project names match the repository folder name

This ensures that projects in monorepos have cleaner, more intuitive names that match their workspace directory structure.

[CleanShot 2025-11-21 at 12.59.29.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1729eec1-c966-4ddb-b175-5e87c456bc41.mp4" />](https://app.graphite.com/user-attachments/video/1729eec1-c966-4ddb-b175-5e87c456bc41.mp4)



fixes https://linear.app/vercel/issue/FLOW-4854/vc-link-repo-adds-the-repos-name-as-a-prefix-which-creates-a-different