### PR TITLE
[build-utils] feat: support `runtimeLanguage` in build-utils

### DIFF
--- a/.changeset/healthy-paws-brush.md
+++ b/.changeset/healthy-paws-brush.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Support `runtimeLanguage` in build-utils

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -111,8 +111,8 @@ export class Lambda {
   handler: string;
   runtime: string;
   /**
-   * When using a generic runtime such as "executable" or "provided" (custom runtimes) for compiled languages,
-   * this field can be used to specify the language of the runtime.
+   * When using a generic runtime such as "executable" or "provided" (custom runtimes),
+   * this field can be used to specify the language the executable was compiled with.
    */
   runtimeLanguage?: LambdaExecutableRuntimeLanguages;
   architecture: LambdaArchitecture;

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -188,6 +188,10 @@ export class Lambda {
       );
     }
 
+    if (runtimeLanguage !== undefined) {
+      assert(runtimeLanguage === 'rust', '"runtimeLanguage" must be "rust"');
+    }
+
     if (
       'experimentalAllowBundling' in opts &&
       opts.experimentalAllowBundling !== undefined

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -17,11 +17,13 @@ export type { TriggerEvent };
 
 export type LambdaOptions = LambdaOptionsWithFiles | LambdaOptionsWithZipBuffer;
 
+export type LambdaExecutableRuntimeLanguages = 'rust';
 export type LambdaArchitecture = 'x86_64' | 'arm64';
 
 export interface LambdaOptionsBase {
   handler: string;
   runtime: string;
+  runtimeLanguage?: LambdaExecutableRuntimeLanguages;
   architecture?: LambdaArchitecture;
   memory?: number;
   maxDuration?: number;
@@ -108,6 +110,11 @@ export class Lambda {
   files?: Files;
   handler: string;
   runtime: string;
+  /**
+   * When using a generic runtime such as "executable" or "provided" (custom runtimes) for compiled languages,
+   * this field can be used to specify the language of the runtime.
+   */
+  runtimeLanguage?: LambdaExecutableRuntimeLanguages;
   architecture: LambdaArchitecture;
   memory?: number;
   maxDuration?: number;
@@ -148,6 +155,7 @@ export class Lambda {
     const {
       handler,
       runtime,
+      runtimeLanguage,
       maxDuration,
       architecture,
       memory,
@@ -328,6 +336,7 @@ export class Lambda {
     this.files = 'files' in opts ? opts.files : undefined;
     this.handler = handler;
     this.runtime = runtime;
+    this.runtimeLanguage = runtimeLanguage;
     this.architecture = getDefaultLambdaArchitecture(architecture);
     this.memory = memory;
     this.maxDuration = maxDuration;

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -359,4 +359,68 @@ describe('Lambda', () => {
       });
     });
   });
+
+  describe('runtimeLanguage validation', () => {
+    it('should create Lambda with valid runtimeLanguage (rust)', () => {
+      const files: Files = {};
+      const lambda = new Lambda({
+        files,
+        handler: 'index.handler',
+        runtime: 'provided.al2',
+        runtimeLanguage: 'rust',
+      });
+
+      expect(lambda.runtimeLanguage).toBe('rust');
+    });
+
+    it('should create Lambda without runtimeLanguage', () => {
+      const files: Files = {};
+      const lambda = new Lambda({
+        files,
+        handler: 'index.handler',
+        runtime: 'nodejs22.x',
+      });
+
+      expect(lambda.runtimeLanguage).toBeUndefined();
+    });
+
+    it('should throw error for invalid runtimeLanguage (python)', () => {
+      const files: Files = {};
+      expect(
+        () =>
+          new Lambda({
+            files,
+            handler: 'index.handler',
+            runtime: 'provided.al2',
+            runtimeLanguage: 'python' as any,
+          })
+      ).toThrow('"runtimeLanguage" must be "rust"');
+    });
+
+    it('should throw error for invalid runtimeLanguage (number)', () => {
+      const files: Files = {};
+      expect(
+        () =>
+          new Lambda({
+            files,
+            handler: 'index.handler',
+            runtime: 'provided.al2',
+            runtimeLanguage: 123 as any,
+          })
+      ).toThrow('"runtimeLanguage" must be "rust"');
+    });
+
+    it('should throw error for invalid runtimeLanguage (empty string)', () => {
+      const files: Files = {};
+      expect(
+        () =>
+          new Lambda({
+            files,
+            handler: 'index.handler',
+            runtime: 'provided.al2',
+            runtimeLanguage: '' as any,
+          })
+      ).toThrow('"runtimeLanguage" must be "rust"');
+    });
+  });
 });


### PR DESCRIPTION
For compiled languages: this adds a field to build outputs that provides information on the language the binary was compiled with when using `executable` or `provided` runtimes. We will use this value to provide more detailed information in the dashboard.