### PR TITLE
[functions] update link to docs

### DIFF
--- a/.changeset/dry-tips-compare.md
+++ b/.changeset/dry-tips-compare.md
@@ -1,0 +1,5 @@
+---
+"@vercel/functions": patch
+---
+
+[functions] update link to docs

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -2,4 +2,4 @@
 
 Runtime functions to be used with your Vercel Functions.
 
-Please [follow the documentation](https://vercel.com/docs/functions/vercel-functions-package) for examples and usage.
+Please [follow the documentation](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package) for examples and usage.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vercel/functions",
   "description": "Runtime functions to be used with your Vercel Functions",
-  "homepage": "https://vercel.com",
+  "homepage": "https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package",
   "files": [
     "**/*.js",
     "**/*.d.ts",


### PR DESCRIPTION
The readme link was redirecting so we can change it to link to the redirected page.

Also the [npm package](https://www.npmjs.com/package/@vercel/functions) should also link to the relevant docs.