### PR TITLE
[CICD-DX] Include the branch name in output for `vc pull`

### DIFF
--- a/.changeset/modern-geckos-report.md
+++ b/.changeset/modern-geckos-report.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve messaging for vc pull

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -162,11 +162,17 @@ export async function envPullCommandLogic(
 
   const projectSlugLink = formatProject(link.org.slug, link.project.name);
 
-  output.log(
-    `Downloading \`${chalk.cyan(
-      environment
-    )}\` Environment Variables for ${projectSlugLink}`
-  );
+  const downloadMessage = gitBranch
+    ? `Downloading \`${chalk.cyan(
+        environment
+      )}\` Environment Variables for ${projectSlugLink} and branch ${chalk.cyan(
+        gitBranch
+      )}`
+    : `Downloading \`${chalk.cyan(
+        environment
+      )}\` Environment Variables for ${projectSlugLink}`;
+
+  output.log(downloadMessage);
 
   const pullStamp = stamp();
   output.spinner('Downloading');

--- a/packages/cli/src/commands/env/pull.ts
+++ b/packages/cli/src/commands/env/pull.ts
@@ -165,7 +165,7 @@ export async function envPullCommandLogic(
   const downloadMessage = gitBranch
     ? `Downloading \`${chalk.cyan(
         environment
-      )}\` Environment Variables for ${projectSlugLink} and branch ${chalk.cyan(
+      )}\` Environment Variables for ${projectSlugLink} and any overrides for branch ${chalk.cyan(
         gitBranch
       )}`
     : `Downloading \`${chalk.cyan(

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -118,11 +118,10 @@ describe('env pull', () => {
       'feat/awesome-thing'
     );
     const exitCodePromise = env(client);
+    // Full output: "Downloading `preview` Environment Variables for jqkgv/vercel-env-pull and any overrides for branch feat/awesome-thing"
+    // Note: Can't match the full string due to hyperlink ANSI codes around the org/project slug
     await expect(client.stderr).toOutput(
-      'Downloading `preview` Environment Variables for'
-    );
-    await expect(client.stderr).toOutput(
-      'and any overrides for branch feat/awesome-thing'
+      'vercel-env-pull and any overrides for branch feat/awesome-thing'
     );
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -121,7 +121,9 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `preview` Environment Variables for'
     );
-    await expect(client.stderr).toOutput('and branch feat/awesome-thing');
+    await expect(client.stderr).toOutput(
+      'and any overrides for branch feat/awesome-thing'
+    );
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'
     );

--- a/packages/cli/test/unit/commands/env/pull.test.ts
+++ b/packages/cli/test/unit/commands/env/pull.test.ts
@@ -121,6 +121,7 @@ describe('env pull', () => {
     await expect(client.stderr).toOutput(
       'Downloading `preview` Environment Variables for'
     );
+    await expect(client.stderr).toOutput('and branch feat/awesome-thing');
     await expect(client.stderr).toOutput(
       'Created .env.local file and added it to .gitignore'
     );


### PR DESCRIPTION
Include the branch name in output for `vc pull`. 

Improves messaging when using `vc pull` with a specified preview environment, as well as a branch to indicate that variables will be pulled for the environment AND the branch provided.

`vc pull --environment=preview --git-branch=this-is-a-branch`

fixes https://linear.app/vercel/issue/FLOW-1003/improve-message-on-vercel-pull-environment=preview-when-git-branch