### PR TITLE
[next] fix trailing slash handling for segment prefetch 

### DIFF
--- a/.changeset/quiet-hairs-collect.md
+++ b/.changeset/quiet-hairs-collect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+fix trailing slash handling for next build

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2279,7 +2279,11 @@ export async function serverBuild({
             prefetchSegmentSuffix
               ? [
                   {
-                    src: path.posix.join('/', entryDirectory, '/(?<path>.+)$'),
+                    src: path.posix.join(
+                      '/',
+                      entryDirectory,
+                      '/(?<path>.+?)(?:/)?$'
+                    ),
                     dest: path.posix.join(
                       '/',
                       entryDirectory,
@@ -2306,7 +2310,7 @@ export async function serverBuild({
                     override: true,
                   },
                   {
-                    src: path.posix.join('^/', entryDirectory, '$'),
+                    src: path.posix.join('^/', entryDirectory, '/?$'),
                     dest: path.posix.join(
                       '/',
                       entryDirectory,

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/about/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/about/page.jsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>about page</div>;
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/layout.jsx
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/page.jsx
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/app/page.jsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <div>
+      <p>index page</p>
+      <Link href="/about/">Go to about</Link>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/index.test.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/index.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+const ctx = {};
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    const info = await deployAndTest(__dirname);
+    Object.assign(ctx, info);
+  });
+});

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/next.config.js
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  trailingSlash: true,
+};

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/package.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-trailing-slash-segment-prefetch/vercel.json
@@ -1,0 +1,62 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "index page"
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "headers": {
+        "rsc": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/?_rsc=1r34m",
+      "status": 200,
+      "headers": {
+        "rsc": "1",
+        "next-router-prefetch": "1",
+        "next-router-segment-prefetch": "/_tree"
+      },
+      "responseHeaders": {
+        "x-matched-path": "/index.segments/_tree.segment.rsc"
+      }
+    },
+    {
+      "path": "/about/",
+      "status": 200,
+      "mustContain": "about page"
+    },
+    {
+      "path": "/about/",
+      "status": 200,
+      "headers": {
+        "rsc": "1"
+      },
+      "mustContain": ":{",
+      "mustNotContain": "<html"
+    },
+    {
+      "path": "/about/?_rsc=1r34m",
+      "status": 200,
+      "headers": {
+        "rsc": "1",
+        "next-router-prefetch": "1",
+        "next-router-segment-prefetch": "/_tree"
+      },
+      "responseHeaders": {
+        "x-matched-path": "/about.segments/_tree.segment.rsc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Fix

This PR adds the trailing slash handling to the segments prefetch requests. When trailing slash is enabled, the segment prefretch is failing as 404 because the slash is not matched in the regexes like other routes.


Closes NXT-118