### PR TITLE
[draft] validating e2e tests rerun

### DIFF
--- a/packages/cli/test/dev/integration-1.test.ts
+++ b/packages/cli/test/dev/integration-1.test.ts
@@ -591,6 +591,7 @@ test('[vercel dev] should support directory listing', async () => {
     let body = await res.text();
     expect(res.status).toEqual(200);
     expect(body).toContain('Index of');
+    expect(body).toContain('Index of');
 
     // Get a file
     res = await fetch(`http://localhost:${port}/file.txt`);


### PR DESCRIPTION
Fixed a test for directory listing in Vercel dev mode by adding a duplicate assertion. The test now checks twice that the response body contains the text "Index of", which appears to be a redundant verification.