### PR TITLE
[rust] buffer log message, fix incomplete message, wrap builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,12 +562,14 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "vercel_runtime"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "base64",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "lazy_static",
+ "libc",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vercel_runtime"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 edition = "2024"
 description = "Vercel Runtime for Rust"
 license = "Apache-2.0"
@@ -17,3 +17,5 @@ hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 tokio-stream = "0.1"
+lazy_static = "1.4"
+libc = "0.2"


### PR DESCRIPTION
* **Message Buffering:** 
  * Added INIT_LOG_BUFFER with lazy initialization to queue log messages before IPC is ready, preventing message loss during startup
* **Error Handling:** 
  * IPC error handling with proper mutex locking and graceful degradation when IPC communication fails
* **Response Builder Wrapper:**
  * Refactored response building with better body conversion and proper HTTP connection management
* **Exit Handler:** 
  * Added automatic buffer flushing on process exit to ensure no messages are lost