### PR TITLE
[python] enhanced custom entrypoint detection in `pyproject.toml`

### DIFF
--- a/packages/python/src/entrypoint.ts
+++ b/packages/python/src/entrypoint.ts
@@ -135,23 +135,35 @@ export async function getPyprojectEntrypoint(
   if (!pyprojectData) return null;
 
   // If `pyproject.toml` has a [project.scripts] table and contains a script
-  // named "app", parse the value (format: "module:attr") to determine the
-  // module and map it to a file path.
+  // named "app", interpret the value as either:
+  //   - a direct file path, e.g. "main.py" or "api/my_server.py", or
+  //   - a classic entrypoint string, e.g. "package.module:app"
   const scripts = pyprojectData.project?.scripts as
     | Record<string, unknown>
     | undefined;
   const appScript = scripts?.app;
   if (typeof appScript !== 'string') return null;
 
-  // Expect values like "package.module:app". Extract the module portion.
-  const match = appScript.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
-  if (!match) return null;
-  const modulePath = match[1];
-  const relPath = modulePath.replace(/\./g, '/');
+  const raw = appScript.trim();
+  if (!raw) return null;
 
-  // Prefer an existing file match if present; otherwise fall back to "<module>.py".
   try {
     const fsFiles = await glob('**', workPath);
+
+    // First, support direct file paths such as "main.py" or "src/server.py".
+    if (raw.endsWith('.py')) {
+      // Normalize to the glob/FS key format (POSIX-style, no leading "./").
+      const candidate = raw.replace(/^\.\/+/, '').replace(/\\/g, '/');
+      if (fsFiles[candidate]) return candidate;
+    }
+
+    // Next, support classic "package.module:attr" style entrypoints.
+    const match = raw.match(/([A-Za-z_][\w.]*)\s*:\s*([A-Za-z_][\w]*)/);
+    if (!match) return null;
+    const modulePath = match[1];
+    const relPath = modulePath.replace(/\./g, '/');
+
+    // Prefer an existing file match if present; otherwise fall back to "<module>.py".
     const candidates = [`${relPath}.py`, `${relPath}/__init__.py`];
     for (const candidate of candidates) {
       if (fsFiles[candidate]) return candidate;

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -626,6 +626,78 @@ describe('pyproject.toml entrypoint detection', () => {
 
     if (fs.existsSync(workPath)) fs.removeSync(workPath);
   });
+
+  it('resolves FastAPI entrypoint from pyproject scripts using direct .py path', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-pyproject-fastapi-file-${Date.now()}`
+    );
+    fs.mkdirSync(path.join(workPath, 'backend', 'api'), { recursive: true });
+    makeMockPython('3.9');
+
+    const files = {
+      'pyproject.toml': new FileBlob({
+        data: '[project]\nname = "x"\nversion = "0.0.1"\n\n[project.scripts]\napp = "backend/api/server_main.py"\n',
+      }),
+      'backend/api/server_main.py': new FileBlob({
+        data: 'from fastapi import FastAPI\napp = FastAPI()\n',
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath,
+      files,
+      entrypoint: 'missing.py',
+      meta: { isDev: true },
+      config: { framework: 'fastapi' },
+      repoRootPath: workPath,
+    });
+
+    const handler = result.output.files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    const content = handler.data.toString();
+    expect(content.includes('backend/api/server_main.py')).toBe(true);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
+
+  it('resolves Flask entrypoint from pyproject scripts using direct .py path', async () => {
+    const workPath = path.join(
+      tmpdir(),
+      `python-pyproject-flask-file-${Date.now()}`
+    );
+    fs.mkdirSync(path.join(workPath, 'backend'), { recursive: true });
+    makeMockPython('3.9');
+
+    const files = {
+      'pyproject.toml': new FileBlob({
+        data: '[project]\nname = "x"\nversion = "0.0.1"\n\n[project.scripts]\napp = "backend/my_flask_app.py"\n',
+      }),
+      'backend/my_flask_app.py': new FileBlob({
+        data: 'from flask import Flask\napp = Flask(__name__)\n',
+      }),
+    } as Record<string, FileBlob>;
+
+    const result = await build({
+      workPath,
+      files,
+      entrypoint: 'missing.py',
+      meta: { isDev: true },
+      config: { framework: 'flask' },
+      repoRootPath: workPath,
+    });
+
+    const handler = result.output.files?.['vc__handler__python.py'];
+    if (!handler || !('data' in handler)) {
+      throw new Error('handler bootstrap not found');
+    }
+    const content = handler.data.toString();
+    expect(content.includes('backend/my_flask_app.py')).toBe(true);
+
+    if (fs.existsSync(workPath)) fs.removeSync(workPath);
+  });
 });
 
 describe('python version fallback logging', () => {


### PR DESCRIPTION
Also support filepaths in project app script in `pyproject.toml`.

e.g. 

```toml
[project.scripts]
app = "main.py"
```

Is now also be a valid entrypoint format as opposed to just `main:app`