### PR TITLE
[rust] use tower based approach, add axum utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "vercel_runtime"
-version = "2.0.0-alpha.4"
+version = "2.0.0"
 dependencies = [
  "axum",
  "axum-streams",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "axum"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-streams"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169daa5072f0d89815e9ab6d32d9e20dc3f58c7c624d083df0d857cec6f0df64"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "serde",
+ "serde_json",
+ "tokio-stream",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,12 +129,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -74,6 +167,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -93,10 +214,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -263,10 +390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -409,6 +554,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +617,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "system-configuration"
@@ -524,6 +698,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +731,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -562,9 +759,12 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "vercel_runtime"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
+ "axum",
+ "axum-streams",
  "base64",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -574,6 +774,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "axum-streams"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169daa5072f0d89815e9ab6d32d9e20dc3f58c7c624d083df0d857cec6f0df64"
+checksum = "49debcb7f7400a7f2c96d590795c12372f4db7ad0f518d5a02286d8c8b8c691d"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vercel_runtime"
-version = "2.0.0-alpha.4"
+version = "2.0.0"
 edition = "2024"
 description = "Vercel Runtime for Rust"
 license = "Apache-2.0"

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -23,7 +23,7 @@ http-body = "1.0"
 tower = { version = "0.5", features = ["util"] }
 
 axum = { version = "0.8", optional = true }
-axum-streams = { version = "0.22", features = ["json", "text"], optional = true }
+axum-streams = { version = "0.24", features = ["json", "text"], optional = true }
 
 [features]
 default = []

--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vercel_runtime"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 edition = "2024"
 description = "Vercel Runtime for Rust"
 license = "Apache-2.0"
@@ -19,3 +19,12 @@ http-body-util = "0.1"
 tokio-stream = "0.1"
 lazy_static = "1.4"
 libc = "0.2"
+http-body = "1.0"
+tower = { version = "0.5", features = ["util"] }
+
+axum = { version = "0.8", optional = true }
+axum-streams = { version = "0.22", features = ["json", "text"], optional = true }
+
+[features]
+default = []
+axum = ["dep:axum", "dep:axum-streams"]

--- a/crates/vercel_runtime/src/axum.rs
+++ b/crates/vercel_runtime/src/axum.rs
@@ -1,0 +1,247 @@
+#![cfg(feature = "axum")]
+
+use axum::response::Response;
+use axum::{body::Body, response::IntoResponse};
+use http_body_util::BodyExt;
+use hyper::body::{Bytes, Frame};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::{AppState, Error, Request, ResponseBody};
+
+/// Utility functions for handling streaming responses
+pub struct StreamingUtils;
+
+impl StreamingUtils {
+    /// Determines if a response should be treated as streaming based on headers
+    pub fn is_streaming_response(headers: &axum::http::HeaderMap) -> bool {
+        headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|ct| ct.contains("text/event-stream") || ct.contains("application/json"))
+            .unwrap_or(false)
+    }
+
+    /// Creates a stream body from an axum Body for streaming responses
+    pub async fn create_stream_body(body: Body) -> Result<ResponseBody, Error> {
+        // Create a channel to manually pump the body frames
+        let (tx, rx) = mpsc::channel::<Result<Frame<Bytes>, Error>>(10);
+
+        tokio::spawn(async move {
+            let mut body = body;
+            while let Some(frame) = body.frame().await {
+                match frame {
+                    Ok(f) => {
+                        if tx.send(Ok(f)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(Box::new(e) as Error)).await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        let stream = ReceiverStream::new(rx);
+        let stream_body = http_body_util::StreamBody::new(stream);
+        Ok(stream_body.into())
+    }
+
+    /// Process an Axum response, converting body based on whether it's streaming
+    pub async fn process_response(
+        response: Response<Body>,
+    ) -> Result<Response<ResponseBody>, Error> {
+        let (parts, body) = response.into_parts();
+
+        // Check if this is a streaming response based on headers
+        let is_streaming = Self::is_streaming_response(&parts.headers);
+
+        if is_streaming {
+            // For streaming responses, we need to manually build the stream body
+            let stream_body = Self::create_stream_body(body).await?;
+            Ok(Response::from_parts(parts, stream_body))
+        } else {
+            // For non-streaming responses, convert to bytes as before
+            let bytes = axum::body::to_bytes(body, usize::MAX)
+                .await
+                .map_err(|e| Box::new(e) as Error)?;
+            Ok(Response::from_parts(parts, bytes.into()))
+        }
+    }
+}
+
+// Keep the original layer implementation but with a simpler approach
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// A Tower layer that automatically handles streaming responses.
+///
+/// This layer checks if a response is a streaming response based on content-type headers
+/// and automatically converts the body to the appropriate format for streaming or non-streaming responses.
+#[derive(Clone)]
+pub struct StreamingLayer;
+
+impl StreamingLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for StreamingLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for StreamingLayer {
+    type Service = StreamingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        StreamingService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct StreamingService<S> {
+    inner: S,
+}
+
+impl<S> Service<axum::http::Request<Body>> for StreamingService<S>
+where
+    S: Service<axum::http::Request<Body>, Response = Response<Body>, Error = Infallible>
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<ResponseBody>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<Body>) -> Self::Future {
+        let future = self.inner.call(req);
+
+        Box::pin(async move {
+            let response = future.await?;
+            // Use the utility function to process the response
+            match StreamingUtils::process_response(response).await {
+                Ok(processed_response) => Ok(processed_response),
+                Err(_) => {
+                    // Fallback to empty body on error
+                    let empty_body = "".into();
+                    let fallback_response =
+                        Response::builder().status(500).body(empty_body).unwrap();
+                    Ok(fallback_response)
+                }
+            }
+        })
+    }
+}
+
+/// A Tower layer that converts Vercel requests/responses to work with Axum
+#[derive(Clone)]
+pub struct VercelLayer;
+
+impl VercelLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for VercelLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for VercelLayer {
+    type Service = VercelService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        VercelService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct VercelService<S> {
+    inner: S,
+}
+
+impl<S> Service<(AppState, Request)> for VercelService<S>
+where
+    S: Service<
+            axum::http::Request<axum::body::Body>,
+            Response = axum::response::Response<axum::body::Body>,
+            Error = std::convert::Infallible,
+        > + Send
+        + Clone
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = hyper::Response<ResponseBody>;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(_)) => Poll::Ready(Err("Service error".into())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, (_state, req): (AppState, Request)) -> Self::Future {
+        let mut service = self.inner.clone();
+
+        Box::pin(async move {
+            let (parts, body) = req.into_parts();
+            let body_bytes = http_body_util::BodyExt::collect(body)
+                .await
+                .map_err(|e| Box::new(e) as Error)?
+                .to_bytes();
+            let axum_body = axum::body::Body::from(body_bytes);
+            let axum_req = axum::http::Request::from_parts(parts, axum_body);
+
+            match tower::ServiceExt::ready(&mut service).await {
+                Ok(ready_service) => match tower::Service::call(ready_service, axum_req).await {
+                    Ok(axum_response) => StreamingUtils::process_response(axum_response).await,
+                    Err(_) => Ok(hyper::Response::builder()
+                        .status(500)
+                        .body("Internal Server Error".into())
+                        .unwrap()),
+                },
+                Err(_) => Ok(hyper::Response::builder()
+                    .status(500)
+                    .body("Service Not Ready".into())
+                    .unwrap()),
+            }
+        })
+    }
+}
+
+pub fn stream_response<F>(generator: F) -> impl IntoResponse
+where
+    F: FnOnce(mpsc::Sender<Result<Bytes, std::io::Error>>) + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(10);
+
+    tokio::spawn(async move {
+        generator(tx);
+    });
+
+    let stream = ReceiverStream::new(rx);
+
+    axum::response::Response::builder()
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .body(axum::body::Body::from_stream(stream))
+        .unwrap()
+}

--- a/crates/vercel_runtime/src/axum/mod.rs
+++ b/crates/vercel_runtime/src/axum/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "axum")]
-
 use axum::response::Response;
 use axum::{body::Body, response::IntoResponse};
 use http_body_util::BodyExt;
@@ -72,7 +70,6 @@ impl StreamingUtils {
     }
 }
 
-// Keep the original layer implementation but with a simpler approach
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/vercel_runtime/src/ipc/core.rs
+++ b/crates/vercel_runtime/src/ipc/core.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RequestContext {
+    #[serde(rename = "invocationId")]
+    pub invocation_id: String,
+    #[serde(rename = "requestId")]
+    pub request_id: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StartMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub payload: StartPayload,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StartPayload {
+    #[serde(rename = "initDuration")]
+    pub init_duration: u64,
+    #[serde(rename = "httpPort")]
+    pub http_port: u16,
+}
+
+impl StartMessage {
+    pub fn new(init_duration: u64, http_port: u16) -> Self {
+        Self {
+            message_type: "server-started".to_string(),
+            payload: StartPayload {
+                init_duration,
+                http_port,
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EndMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub payload: EndPayload,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EndPayload {
+    pub context: RequestContext,
+    pub error: Option<serde_json::Value>,
+}
+
+impl EndMessage {
+    pub fn new(invocation_id: String, request_id: u64, error: Option<serde_json::Value>) -> Self {
+        Self {
+            message_type: "end".to_string(),
+            payload: EndPayload {
+                context: RequestContext {
+                    invocation_id,
+                    request_id,
+                },
+                error,
+            },
+        }
+    }
+}

--- a/crates/vercel_runtime/src/ipc/log.rs
+++ b/crates/vercel_runtime/src/ipc/log.rs
@@ -1,0 +1,101 @@
+#![allow(dead_code)]
+use crate::ipc::core::RequestContext;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum Stream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum LogType {
+    Stream { stream: Stream },
+    Level { level: Level },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LogPayload {
+    pub context: RequestContext,
+    pub message: String,
+    #[serde(flatten)]
+    pub log_type: LogType,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LogMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub payload: LogPayload,
+}
+
+impl LogMessage {
+    pub fn stream(invocation_id: String, request_id: u64, message: String, stream: Stream) -> Self {
+        Self {
+            message_type: "log".to_string(),
+            payload: LogPayload {
+                context: RequestContext {
+                    invocation_id,
+                    request_id,
+                },
+                message,
+                log_type: LogType::Stream { stream },
+            },
+        }
+    }
+
+    pub fn level(invocation_id: String, request_id: u64, message: String, level: Level) -> Self {
+        Self {
+            message_type: "log".to_string(),
+            payload: LogPayload {
+                context: RequestContext {
+                    invocation_id,
+                    request_id,
+                },
+                message,
+                log_type: LogType::Level { level },
+            },
+        }
+    }
+
+    pub fn encode_message(message: &str) -> String {
+        use base64::Engine;
+        use base64::engine::general_purpose::STANDARD as BASE64_ENCODER;
+        BASE64_ENCODER.encode(message)
+    }
+
+    pub fn with_stream(
+        invocation_id: String,
+        request_id: u64,
+        message: &str,
+        stream: Stream,
+    ) -> Self {
+        Self::stream(
+            invocation_id,
+            request_id,
+            Self::encode_message(message),
+            stream,
+        )
+    }
+
+    pub fn with_level(invocation_id: String, request_id: u64, message: &str, level: Level) -> Self {
+        Self::level(
+            invocation_id,
+            request_id,
+            Self::encode_message(message),
+            level,
+        )
+    }
+}

--- a/crates/vercel_runtime/src/ipc/metric.rs
+++ b/crates/vercel_runtime/src/ipc/metric.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+use crate::ipc::core::RequestContext;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MetricMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub payload: MetricPayload,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MetricPayload {
+    pub context: RequestContext,
+    #[serde(rename = "type")]
+    pub metric_type: Option<String>,
+    #[serde(rename = "payload")]
+    pub metric_payload: Option<serde_json::Value>,
+}
+
+impl MetricMessage {
+    pub fn new(
+        invocation_id: String,
+        request_id: u64,
+        metric_type: Option<String>,
+        metric_payload: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            message_type: "metric".to_string(),
+            payload: MetricPayload {
+                context: RequestContext {
+                    invocation_id,
+                    request_id,
+                },
+                metric_type,
+                metric_payload,
+            },
+        }
+    }
+}

--- a/crates/vercel_runtime/src/ipc/mod.rs
+++ b/crates/vercel_runtime/src/ipc/mod.rs
@@ -1,0 +1,3 @@
+pub mod core;
+pub mod log;
+pub mod metric;

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -192,10 +192,7 @@ impl AppState {
     }
 }
 
-pub fn send_message<T: Serialize>(
-    stream: &Arc<Mutex<UnixStream>>,
-    message: T,
-) -> Result<(), Error> {
+fn send_message<T: Serialize>(stream: &Arc<Mutex<UnixStream>>, message: T) -> Result<(), Error> {
     let json_str = serde_json::to_string(&message)?;
     let msg = format!("{json_str}\0");
 
@@ -211,7 +208,7 @@ pub fn send_message<T: Serialize>(
     Ok(())
 }
 
-pub fn enqueue_or_send_message<T: Serialize>(
+fn enqueue_or_send_message<T: Serialize>(
     stream: &Option<Arc<Mutex<UnixStream>>>,
     message: T,
 ) -> Result<(), Error> {
@@ -246,7 +243,7 @@ pub fn enqueue_or_send_message<T: Serialize>(
     Ok(())
 }
 
-pub fn flush_init_log_buffer(stream: &Option<Arc<Mutex<UnixStream>>>) {
+fn flush_init_log_buffer(stream: &Option<Arc<Mutex<UnixStream>>>) {
     if let Some(stream) = stream {
         if let Ok(mut buffer) = INIT_LOG_BUFFER.lock() {
             while let Some(json_str) = buffer.0.pop_front() {
@@ -264,7 +261,7 @@ pub fn flush_init_log_buffer(stream: &Option<Arc<Mutex<UnixStream>>>) {
     }
 }
 
-pub fn flush_init_log_buf_to_stderr() {
+fn flush_init_log_buf_to_stderr() {
     if let Ok(mut buffer) = INIT_LOG_BUFFER.lock() {
         let mut combined: Vec<String> = Vec::new();
 
@@ -297,7 +294,7 @@ where
     ServiceFn { f }
 }
 
-/// A Tower service wrapper around a function  
+/// A Tower service wrapper around a function
 #[derive(Clone)]
 pub struct ServiceFn<F> {
     f: F,


### PR DESCRIPTION
Adds support / utils for axum response streaming.
Uses tower-based service-fn support to make it similar to the current AWS api / easier to integrate with Axum via service layer.