### PR TITLE
[CICD-DX] Don't prompt to `env pull` on newly created projects

### DIFF
--- a/.changeset/old-emus-stare.md
+++ b/.changeset/old-emus-stare.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Don't prompt to env pull when linking to a newly created project

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -245,7 +245,8 @@ export default async function setupAndLink(
       project.name,
       org.slug,
       successEmoji,
-      autoConfirm
+      autoConfirm,
+      false // don't prompt to pull env for newly created projects
     );
 
     await connectGitRepository(client, path, project, autoConfirm, org);

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -304,7 +304,8 @@ export async function linkFolderToProject(
   projectName: string,
   orgSlug: string,
   successEmoji: EmojiLabel = 'link',
-  autoConfirm: boolean = false
+  autoConfirm: boolean = false,
+  shouldPullEnv: boolean = true
 ) {
   // if the project is already linked, we skip linking
   if (await hasProjectLink(client, projectLink, path)) {
@@ -345,6 +346,10 @@ export async function linkFolderToProject(
       emoji(successEmoji)
     ) + '\n'
   );
+
+  if (!shouldPullEnv) {
+    return;
+  }
 
   const pullEnvConfirmed =
     autoConfirm ||

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -330,9 +330,6 @@ test('should prefill "project name" prompt with now.json `name`', async () => {
 
   await waitForPrompt(now, /Linked to/);
 
-  await waitForPrompt(now, 'Would you like to pull environment variables now?');
-  now.stdin?.write('n\n');
-
   const output = await now;
   expect(output.exitCode, formatOutput(output)).toBe(0);
 
@@ -1132,9 +1129,6 @@ test('[vc link] should show project prompts but not framework when `builds` defi
 
   await waitForPrompt(vc, 'Linked to');
 
-  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
-  vc.stdin?.write('n\n');
-
   const output = await vc;
 
   // Ensure the exit code is right
@@ -1327,8 +1321,6 @@ test.skip('vercel.json configuration overrides in a new project prompt user and 
   vc.stdin?.write('\x1b[B'); // Down Arrow
   vc.stdin?.write('\n');
   await waitForPrompt(vc, 'Linked to');
-  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
-  vc.stdin?.write('n\n');
   const deployment = await vc;
   expect(deployment.exitCode, formatOutput(deployment)).toBe(0);
   // assert the command were executed

--- a/packages/cli/test/integration-2.test.ts
+++ b/packages/cli/test/integration-2.test.ts
@@ -113,12 +113,6 @@ async function setupProject(
   }
 
   await waitForPrompt(process, 'Linked to');
-
-  await waitForPrompt(
-    process,
-    'Would you like to pull environment variables now?'
-  );
-  process.stdin?.write('n\n');
 }
 
 beforeAll(async () => {

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -38,7 +38,7 @@ afterAll(async () => {
   }
 });
 
-test('[vc link] should prompt for env pull and handle acceptance', async () => {
+test('[vc link] should skip env pull prompt when creating new project', async () => {
   const dir = await setupE2EFixture('project-link-gitignore');
   const projectName = `link-env-pull-${Math.random().toString(36).split('.')[1]}`;
 
@@ -61,7 +61,7 @@ test('[vc link] should prompt for env pull and handle acceptance', async () => {
   await waitForPrompt(vc, 'Link to existing project?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
+  await waitForPrompt(vc, `What's your project's name? (${projectName})`);
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'In which directory is your code located?');
@@ -75,9 +75,6 @@ test('[vc link] should prompt for env pull and handle acceptance', async () => {
 
   await waitForPrompt(vc, /Linked to/);
 
-  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
-  vc.stdin?.write('y\n');
-
   const { exitCode, stdout, stderr } = await vc;
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);
 
@@ -86,7 +83,7 @@ test('[vc link] should prompt for env pull and handle acceptance', async () => {
   );
 });
 
-test('[vc link] should handle env pull prompt decline', async () => {
+test('[vc link] should not create .env.local when linking new project', async () => {
   const dir = await setupE2EFixture('project-link-gitignore');
   const projectName = `link-env-decline-${Math.random().toString(36).split('.')[1]}`;
 
@@ -109,7 +106,7 @@ test('[vc link] should handle env pull prompt decline', async () => {
   await waitForPrompt(vc, 'Link to existing project?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
+  await waitForPrompt(vc, `What's your project's name? (${projectName})`);
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'In which directory is your code located?');
@@ -122,9 +119,6 @@ test('[vc link] should handle env pull prompt decline', async () => {
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, /Linked to/);
-
-  await waitForPrompt(vc, 'Would you like to pull environment variables now?');
-  vc.stdin?.write('n\n');
 
   const { exitCode, stdout, stderr } = await vc;
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(0);

--- a/packages/cli/test/integration-link-env-pull.test.ts
+++ b/packages/cli/test/integration-link-env-pull.test.ts
@@ -61,7 +61,7 @@ test('[vc link] should skip env pull prompt when creating new project', async ()
   await waitForPrompt(vc, 'Link to existing project?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, `What's your project's name? (${projectName})`);
+  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'In which directory is your code located?');
@@ -106,7 +106,7 @@ test('[vc link] should not create .env.local when linking new project', async ()
   await waitForPrompt(vc, 'Link to existing project?');
   vc.stdin?.write('no\n');
 
-  await waitForPrompt(vc, `What's your project's name? (${projectName})`);
+  await waitForPrompt(vc, `What’s your project’s name? (${projectName})`);
   vc.stdin?.write('\n');
 
   await waitForPrompt(vc, 'In which directory is your code located?');

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -1298,11 +1298,6 @@ describe('deploy', () => {
         );
         client.stdin.write('\n');
 
-        await expect(client.stderr).toOutput(
-          'Would you like to pull environment variables now?'
-        );
-        client.stdin.write('n\n');
-
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);
       });
@@ -1342,11 +1337,6 @@ describe('deploy', () => {
           'Do you want to change additional project settings?'
         );
         client.stdin.write('\n');
-
-        await expect(client.stderr).toOutput(
-          'Would you like to pull environment variables now?'
-        );
-        client.stdin.write('n\n');
 
         const exitCode = await exitCodePromise;
         expect(exitCode).toEqual(0);

--- a/packages/cli/test/unit/commands/link/index.test.ts
+++ b/packages/cli/test/unit/commands/link/index.test.ts
@@ -643,11 +643,6 @@ describe('link', () => {
       `Linked to ${user.username}/awesome-app (created .vercel and added it to .gitignore)`
     );
 
-    await expect(client.stderr).toOutput(
-      'Would you like to pull environment variables now?'
-    );
-    client.stdin.write('n\n');
-
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "link"').toEqual(0);
   });


### PR DESCRIPTION
Newly created projects won't have environment variables. In these cases, we can streamline the process and avoid prompting the user to pull environment variables

fixes https://linear.app/vercel/issue/CIFEAT-469/dont-pull-environment-variables-on-vc-link-if-user-just-created-the