### PR TITLE
[client] Add retry logic to deployment status polling

### DIFF
--- a/.changeset/chatty-pianos-sit.md
+++ b/.changeset/chatty-pianos-sit.md
@@ -1,0 +1,5 @@
+---
+'@vercel/client': patch
+---
+
+checkDeploymentStatus now retries up to 3 times on HTTP 429 or 5xx

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -38,7 +38,9 @@ export function parseRetryAfterMs(response: any): number | null {
     let retryAfterMs = Number(header) * 1000;
     if (Number.isNaN(retryAfterMs)) {
       let retryAfterDateMs = Date.parse(header);
-      if (!Number.isNaN(retryAfterDateMs)) {
+      if (Number.isNaN(retryAfterDateMs)) {
+        retryAfterMs = RETRY_DELAY_DEFAULT_MS;
+      } else {
         retryAfterMs = retryAfterDateMs - Date.now();
       }
     }

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import sleep from 'sleep-promise';
+import type { Deployment, VercelClientOptions } from '../src/types';
+import { checkDeploymentStatus } from '../src/check-deployment-status';
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual('../src/utils');
+  return {
+    ...actual,
+    fetch: mockFetch,
+  };
+});
+
+vi.mock('sleep-promise', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+function mockDeployment(): Deployment {
+  return {
+    id: 'dpl_123',
+    name: 'test-deployment',
+    url: 'test.vercel.app',
+    readyState: 'QUEUED',
+  } as Deployment;
+}
+
+function mockClientOptions(): VercelClientOptions {
+  return {
+    token: 'test-token',
+    path: '/test/path',
+  };
+}
+
+function mockResponse(
+  status: number,
+  body: any = {},
+  headers: Record<string, string> = {}
+) {
+  return {
+    status,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe('checkDeploymentStatus()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('retry logic', () => {
+    it('should retry on HTTP 429 with Retry-After header', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponse(429, {}, { 'retry-after': '6' }))
+        .mockResolvedValueOnce(mockResponse(429, {}, { 'retry-after': '7' }))
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            ...mockDeployment(),
+            readyState: 'READY',
+          })
+        );
+
+      const iterator = checkDeploymentStatus(
+        mockDeployment(),
+        mockClientOptions()
+      );
+      const result = await iterator.next();
+
+      expect(result.value).toEqual({
+        type: 'ready',
+        payload: expect.objectContaining({ readyState: 'READY' }),
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(sleep).toHaveBeenCalledWith(6_000);
+      expect(sleep).toHaveBeenCalledWith(7_000);
+    });
+
+    it('should retry up to 3 times on consecutive failures', async () => {
+      mockFetch.mockResolvedValue(mockResponse(500, { error: 'mock error' }));
+
+      const iterator = checkDeploymentStatus(
+        mockDeployment(),
+        mockClientOptions()
+      );
+      const result = await iterator.next();
+
+      expect(result.value).toEqual({
+        type: 'error',
+        payload: 'mock error',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
This is an attempt to fix https://vercel.slack.com/archives/C09MK639NMN/p1764806810028989?thread_ts=1761256638.364529&cid=C09MK639NMN

We do a lot of deployments in parallel in the Next.js CI, and hit the rate limit very often:
https://github.com/vercel/next.js/actions/workflows/test_e2e_deploy_release.yml

This is a simple GET request (safe to retry), and the API returns an HTTP 429 in this case, so we should just use the `Retry-After` header. I also added a check for HTTP 5xx errors.

I used claude to help write some unit tests, though I cleaned up and simplified what claude generated.

The rate limit for this endpoint is pretty high (500/min), but I tested this manually by removing the normal `getPollingDelay` sleep at the end of the generator loop, and by adding a bunch of artificial parallel fetches to the code.