### PR TITLE
Skip introspection on routes that fail path-to-regex conversion

### DIFF
--- a/.changeset/good-pigs-buy.md
+++ b/.changeset/good-pigs-buy.md
@@ -1,0 +1,5 @@
+---
+'@vercel/introspection': patch
+---
+
+Fix issue where middleware with splat arg causes all introspection to fail for Hono apps

--- a/packages/introspection/src/express.ts
+++ b/packages/introspection/src/express.ts
@@ -1,6 +1,7 @@
 import type { Express } from 'express';
 import { pathToRegexp } from 'path-to-regexp';
 import { setupCloseHandlers } from './util.js';
+import { debug } from '@vercel/build-utils';
 
 let app: Express | null = null;
 
@@ -71,17 +72,23 @@ const extractRoutes = () => {
           m.push(method.toUpperCase());
         }
       }
-      const { regexp } = pathToRegexp(route.route.path);
+      try {
+        const { regexp } = pathToRegexp(route.route.path);
 
-      if (route.route.path === '/') {
-        continue;
+        if (route.route.path === '/') {
+          continue;
+        }
+
+        routes.push({
+          src: regexp.source,
+          dest: route.route.path,
+          methods: m,
+        });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'Unknown error';
+        debug(`Error extracting routes for ${route.route.path}: ${message}`);
+        //
       }
-
-      routes.push({
-        src: regexp.source,
-        dest: route.route.path,
-        methods: m,
-      });
     }
   }
   return { routes, additionalFolders, additionalDeps };

--- a/packages/introspection/src/hono.ts
+++ b/packages/introspection/src/hono.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
 import { pathToRegexp } from 'path-to-regexp';
 import { setupCloseHandlers } from './util.js';
+import { debug } from '@vercel/build-utils';
 
 const apps: Hono[] = [];
 
@@ -34,17 +35,23 @@ function extractRoutes() {
   for (const route of app.routes) {
     const routePath = route.path;
     const method = route.method.toUpperCase();
-    const { regexp } = pathToRegexp(routePath);
+    try {
+      const { regexp } = pathToRegexp(routePath);
 
-    if (routePath === '/') {
-      continue;
+      if (routePath === '/') {
+        continue;
+      }
+
+      routes.push({
+        src: regexp.source,
+        dest: routePath,
+        methods: [method],
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error';
+      debug(`Error extracting routes for ${routePath}: ${message}`);
+      //
     }
-
-    routes.push({
-      src: regexp.source,
-      dest: routePath,
-      methods: [method],
-    });
   }
   return routes;
 }


### PR DESCRIPTION
We use `path-to-regex` to convert Hono routes to a regular expression. They don't map 1:1 and in the case of a `/*` route, a failure on the conversion caused all o11y to fail.

The proper fix here will be to map hono routes to their appropriate regex logic, which isn't an API they've exposed, as far as I can tell.