### PR TITLE
feat(functions): Add `continent` to `geolocation()` return

### DIFF
--- a/.changeset/strong-chefs-battle.md
+++ b/.changeset/strong-chefs-battle.md
@@ -1,0 +1,5 @@
+---
+'@vercel/functions': minor
+---
+
+Add request continent to `geolocation()`

--- a/packages/functions/src/headers.ts
+++ b/packages/functions/src/headers.ts
@@ -7,6 +7,10 @@ export const CITY_HEADER_NAME = 'x-vercel-ip-city';
  */
 export const COUNTRY_HEADER_NAME = 'x-vercel-ip-country';
 /**
+ * Continent of the original client IP as calculated by Vercel Proxy.
+ */
+export const CONTINENT_HEADER_NAME = 'x-vercel-ip-continent';
+/**
  * Client IP as calculated by Vercel Proxy.
  */
 export const IP_HEADER_NAME = 'x-real-ip';
@@ -60,6 +64,9 @@ export interface Geo {
 
   /** The country that the request originated from. */
   country?: string;
+
+  /** The continent that the request originated from. */
+  continent?: string;
 
   /** The flag emoji for the country the request originated from. */
   flag?: string;
@@ -157,6 +164,7 @@ function getRegionFromRequestId(requestId?: string): string | undefined {
  * {
  *  "city": "New York",
  *  "country": "US",
+ *  "continent": "NA",
  *  "flag": "🇺🇸",
  *  "countryRegion": "NY",
  *  "region": "iad1",
@@ -182,6 +190,7 @@ export function geolocation(request: Request): Geo {
     // city name may be encoded to support multi-byte characters
     city: getHeaderWithDecode(request, CITY_HEADER_NAME),
     country: getHeader(request.headers, COUNTRY_HEADER_NAME),
+    continent: getHeader(request.headers, CONTINENT_HEADER_NAME),
     flag: getFlag(getHeader(request.headers, COUNTRY_HEADER_NAME)),
     countryRegion: getHeader(request.headers, REGION_HEADER_NAME),
     region: getRegionFromRequestId(

--- a/packages/functions/test/e2e/headers.test.ts
+++ b/packages/functions/test/e2e/headers.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest';
 import {
   CITY_HEADER_NAME,
   COUNTRY_HEADER_NAME,
+  CONTINENT_HEADER_NAME,
   geolocation,
   ipAddress,
   IP_HEADER_NAME,
@@ -30,6 +31,7 @@ test.each(['lambda', 'edge'])(
     expect(headers[LATITUDE_HEADER_NAME]).toBeDefined();
     expect(headers[LONGITUDE_HEADER_NAME]).toBeDefined();
     expect(headers[POSTAL_CODE_HEADER_NAME]).toBeDefined();
+    expect(headers[CONTINENT_HEADER_NAME]).toBeDefined();
   }
 );
 
@@ -57,6 +59,7 @@ test.each(['lambda', 'edge'])(
 
     expect(payload.city).toBeDefined();
     expect(payload.country).toBeDefined();
+    expect(payload.continent).toBeDefined();
     expect(payload.flag).toBeDefined();
     expect(payload.countryRegion).toBeDefined();
     expect(payload.region).toBeDefined();

--- a/packages/functions/test/unit/headers.test.ts
+++ b/packages/functions/test/unit/headers.test.ts
@@ -3,6 +3,7 @@ import { expect, test, describe } from 'vitest';
 import {
   CITY_HEADER_NAME,
   COUNTRY_HEADER_NAME,
+  CONTINENT_HEADER_NAME,
   Geo,
   geolocation,
   IP_HEADER_NAME,
@@ -30,6 +31,7 @@ describe('`geolocation`', () => {
       city: undefined,
       flag: undefined,
       country: undefined,
+      continent: undefined,
       countryRegion: undefined,
       latitude: undefined,
       longitude: undefined,
@@ -43,6 +45,7 @@ describe('`geolocation`', () => {
       headers: {
         [CITY_HEADER_NAME]: 'Tel Aviv',
         [COUNTRY_HEADER_NAME]: 'IL',
+        [CONTINENT_HEADER_NAME]: 'AS',
         [LATITUDE_HEADER_NAME]: '32.109333',
         [LONGITUDE_HEADER_NAME]: '34.855499',
         [REGION_HEADER_NAME]: 'TA', // https://en.wikipedia.org/wiki/ISO_3166-2:IL
@@ -54,6 +57,7 @@ describe('`geolocation`', () => {
       city: 'Tel Aviv',
       flag: '🇮🇱',
       country: 'IL',
+      continent: 'AS',
       latitude: '32.109333',
       longitude: '34.855499',
       region: 'fra1',
@@ -67,6 +71,7 @@ describe('`geolocation`', () => {
       headers: {
         [CITY_HEADER_NAME]: 'Tokyo',
         [COUNTRY_HEADER_NAME]: 'JP',
+        [CONTINENT_HEADER_NAME]: 'AS',
         [LATITUDE_HEADER_NAME]: '37.1233',
         [LONGITUDE_HEADER_NAME]: '30.733399',
         [REGION_HEADER_NAME]: '13',
@@ -78,6 +83,7 @@ describe('`geolocation`', () => {
       city: 'Tokyo',
       flag: '🇯🇵',
       country: 'JP',
+      continent: 'AS',
       latitude: '37.1233',
       longitude: '30.733399',
       region: 'hnd1',
@@ -91,6 +97,7 @@ describe('`geolocation`', () => {
       headers: {
         [CITY_HEADER_NAME]: 'Tokyo',
         [COUNTRY_HEADER_NAME]: 'JP',
+        [CONTINENT_HEADER_NAME]: 'AS',
         [LATITUDE_HEADER_NAME]: '37.1233',
         [LONGITUDE_HEADER_NAME]: '30.733399',
         [REGION_HEADER_NAME]: '13',
@@ -101,6 +108,7 @@ describe('`geolocation`', () => {
       city: 'Tokyo',
       flag: '🇯🇵',
       country: 'JP',
+      continent: 'AS',
       latitude: '37.1233',
       longitude: '30.733399',
       region: 'dev1',
@@ -114,6 +122,7 @@ describe('`geolocation`', () => {
       headers: {
         [CITY_HEADER_NAME]: 'Tokyo',
         [COUNTRY_HEADER_NAME]: 'AAA',
+        [CONTINENT_HEADER_NAME]: 'AS',
         [LATITUDE_HEADER_NAME]: '37.1233',
         [LONGITUDE_HEADER_NAME]: '30.733399',
         [REGION_HEADER_NAME]: '13',
@@ -124,6 +133,7 @@ describe('`geolocation`', () => {
       city: 'Tokyo',
       flag: undefined,
       country: 'AAA',
+      continent: 'AS',
       latitude: '37.1233',
       longitude: '30.733399',
       region: 'dev1',
@@ -138,6 +148,7 @@ describe('`geolocation`', () => {
         // São Paulo
         [CITY_HEADER_NAME]: 'S%C3%A3o%20Paulo',
         [COUNTRY_HEADER_NAME]: 'BR',
+        [CONTINENT_HEADER_NAME]: 'SA',
         [LATITUDE_HEADER_NAME]: '-23.6283',
         [LONGITUDE_HEADER_NAME]: '-46.6409',
         [REGION_HEADER_NAME]: 'SP',
@@ -149,6 +160,7 @@ describe('`geolocation`', () => {
       city: 'São Paulo',
       flag: '🇧🇷',
       country: 'BR',
+      continent: 'SA',
       latitude: '-23.6283',
       longitude: '-46.6409',
       region: 'gru1',


### PR DESCRIPTION
Updates `geolocation()` in the functions package to include the continent of the users request. This is from the vercel reference docs (https://vercel.com/docs/headers/request-headers#x-vercel-ip-continent).