### PR TITLE
[cli] Add non-interactive mode for adding redirects and fix a few other small issues

### DIFF
--- a/.changeset/short-hairs-deny.md
+++ b/.changeset/short-hairs-deny.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add options to vercel redirects commands to specify status code, case sensitivity, and preserving query params when adding redirects. Rename --staged flag to --staging and show diffs when listing redirects for the staging version.

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -132,7 +132,7 @@ export default async function add(client: Client, argv: string[]) {
   let versionName: string | undefined;
   if (flags['--name']) {
     versionName = flags['--name'];
-    if (versionName.length > 256) {
+    if (versionName && versionName.length > 256) {
       output.error('Name must be 256 characters or less');
       return 1;
     }

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -24,79 +24,137 @@ export default async function add(client: Client, argv: string[]) {
   const { versions } = await getRedirectVersions(client, project.id, teamId);
   const existingStagingVersion = versions.find(v => v.isStaging);
 
-  output.log('Add a new redirect\n');
+  const { args, flags } = parsed;
 
-  const source = await client.input.text({
-    message: 'What is the source URL?',
-    validate: val => {
-      if (!val) {
-        return 'Source URL cannot be empty';
-      }
-      if (!isValidUrl(val)) {
-        return 'Must be a relative path (starting with /) or an absolute URL';
-      }
-      return true;
-    },
-  });
-
-  const destination = await client.input.text({
-    message: 'What is the destination URL?',
-    validate: val => {
-      if (!val) {
-        return 'Destination URL cannot be empty';
-      }
-      if (!isValidUrl(val)) {
-        return 'Must be a relative path (starting with /) or an absolute URL';
-      }
-      return true;
-    },
-  });
-
-  const statusCode = await client.input.select({
-    message: 'Select the status code:',
-    choices: [
-      {
-        name: '301 - Moved Permanently (cached by browsers)',
-        value: 301,
-      },
-      {
-        name: '302 - Found (temporary redirect, not cached)',
-        value: 302,
-      },
-      {
-        name: '307 - Temporary Redirect (preserves request method)',
-        value: 307,
-      },
-      {
-        name: '308 - Permanent Redirect (preserves request method)',
-        value: 308,
-      },
-    ],
-  });
-
-  const caseSensitive = await client.input.confirm(
-    'Should the redirect be case sensitive?',
-    false
-  );
-
-  const provideName = await client.input.confirm(
-    'Do you want to provide a name for this version?',
-    false
-  );
-
-  let versionName: string | undefined;
-  if (provideName) {
-    versionName = await client.input.text({
-      message: 'Version name (max 256 characters):',
+  let source: string;
+  if (args[0]) {
+    source = args[0];
+    if (!isValidUrl(source)) {
+      output.error(
+        'Source must be a relative path (starting with /) or an absolute URL'
+      );
+      return 1;
+    }
+  } else {
+    output.log('Add a new redirect\n');
+    source = await client.input.text({
+      message: 'What is the source URL?',
       validate: val => {
-        if (val && val.length > 256) {
-          return 'Name must be 256 characters or less';
+        if (!val) {
+          return 'Source URL cannot be empty';
+        }
+        if (!isValidUrl(val)) {
+          return 'Must be a relative path (starting with /) or an absolute URL';
         }
         return true;
       },
     });
-    if (!versionName) {
-      versionName = undefined;
+  }
+
+  let destination: string;
+  if (args[1]) {
+    destination = args[1];
+    if (!isValidUrl(destination)) {
+      output.error(
+        'Destination must be a relative path (starting with /) or an absolute URL'
+      );
+      return 1;
+    }
+  } else {
+    if (!args[0]) {
+      output.log('Add a new redirect\n');
+    }
+    destination = await client.input.text({
+      message: 'What is the destination URL?',
+      validate: val => {
+        if (!val) {
+          return 'Destination URL cannot be empty';
+        }
+        if (!isValidUrl(val)) {
+          return 'Must be a relative path (starting with /) or an absolute URL';
+        }
+        return true;
+      },
+    });
+  }
+
+  let statusCode: number;
+  if (flags['--status']) {
+    statusCode = flags['--status'];
+    if (![301, 302, 307, 308].includes(statusCode)) {
+      output.error('Status code must be 301, 302, 307, or 308');
+      return 1;
+    }
+  } else {
+    statusCode = await client.input.select({
+      message: 'Select the status code:',
+      choices: [
+        {
+          name: '307 - Temporary Redirect (preserves request method)',
+          value: 307,
+        },
+        {
+          name: '308 - Permanent Redirect (preserves request method)',
+          value: 308,
+        },
+        {
+          name: '301 - Moved Permanently (cached by browsers)',
+          value: 301,
+        },
+        {
+          name: '302 - Found (temporary redirect, not cached)',
+          value: 302,
+        },
+      ],
+    });
+  }
+
+  let caseSensitive: boolean;
+  if (flags['--case-sensitive'] !== undefined) {
+    caseSensitive = flags['--case-sensitive'];
+  } else {
+    caseSensitive = await client.input.confirm(
+      'Should the redirect be case sensitive?',
+      false
+    );
+  }
+
+  let preserveQueryParams: boolean;
+  if (flags['--preserve-query-params'] !== undefined) {
+    preserveQueryParams = flags['--preserve-query-params'];
+  } else {
+    preserveQueryParams = await client.input.confirm(
+      'Should query parameters be preserved?',
+      false
+    );
+  }
+
+  let versionName: string | undefined;
+  if (flags['--name']) {
+    versionName = flags['--name'];
+    if (versionName.length > 256) {
+      output.error('Name must be 256 characters or less');
+      return 1;
+    }
+  } else {
+    const provideName = await client.input.confirm(
+      'Do you want to provide a name for this version?',
+      false
+    );
+
+    if (provideName) {
+      versionName = await client.input.text({
+        message: 'Version name (max 256 characters):',
+        validate: val => {
+          if (val && val.length > 256) {
+            return 'Name must be 256 characters or less';
+          }
+          return true;
+        },
+      });
+      if (!versionName) {
+        versionName = undefined;
+      }
     }
   }
 
@@ -112,6 +170,7 @@ export default async function add(client: Client, argv: string[]) {
         destination,
         statusCode,
         caseSensitive,
+        preserveQueryParams,
       },
     ],
     teamId,
@@ -124,6 +183,9 @@ export default async function add(client: Client, argv: string[]) {
   output.print(`    ${chalk.cyan(source)} → ${chalk.cyan(destination)}\n`);
   output.print(`    Status: ${statusCode}\n`);
   output.print(`    Case sensitive: ${caseSensitive ? 'Yes' : 'No'}\n`);
+  output.print(
+    `    Preserve query params: ${preserveQueryParams ? 'Yes' : 'No'}\n`
+  );
 
   if (alias) {
     const testUrl = source.startsWith('/')
@@ -161,7 +223,7 @@ export default async function add(client: Client, argv: string[]) {
     }
   } else {
     output.warn(
-      `There are other staged changes. Please review all changes with ${chalk.cyan('vercel redirects list --staged')} before promoting to production.`
+      `There are other staged changes. Please review all changes with ${chalk.cyan('vercel redirects list --staging')} before promoting to production.`
     );
   }
 

--- a/packages/cli/src/commands/redirects/add.ts
+++ b/packages/cli/src/commands/redirects/add.ts
@@ -25,6 +25,7 @@ export default async function add(client: Client, argv: string[]) {
   const existingStagingVersion = versions.find(v => v.isStaging);
 
   const { args, flags } = parsed;
+  const skipPrompts = flags['--yes'];
 
   let source: string;
   if (args[0]) {
@@ -36,6 +37,12 @@ export default async function add(client: Client, argv: string[]) {
       return 1;
     }
   } else {
+    if (skipPrompts) {
+      output.error(
+        'Source and destination are required when using --yes. Use: vercel redirects add <source> <destination> --yes'
+      );
+      return 1;
+    }
     output.log('Add a new redirect\n');
     source = await client.input.text({
       message: 'What is the source URL?',
@@ -61,6 +68,12 @@ export default async function add(client: Client, argv: string[]) {
       return 1;
     }
   } else {
+    if (skipPrompts) {
+      output.error(
+        'Source and destination are required when using --yes. Use: vercel redirects add <source> <destination> --yes'
+      );
+      return 1;
+    }
     if (!args[0]) {
       output.log('Add a new redirect\n');
     }
@@ -85,6 +98,8 @@ export default async function add(client: Client, argv: string[]) {
       output.error('Status code must be 301, 302, 307, or 308');
       return 1;
     }
+  } else if (skipPrompts) {
+    statusCode = 307;
   } else {
     statusCode = await client.input.select({
       message: 'Select the status code:',
@@ -112,6 +127,8 @@ export default async function add(client: Client, argv: string[]) {
   let caseSensitive: boolean;
   if (flags['--case-sensitive'] !== undefined) {
     caseSensitive = flags['--case-sensitive'];
+  } else if (skipPrompts) {
+    caseSensitive = false;
   } else {
     caseSensitive = await client.input.confirm(
       'Should the redirect be case sensitive?',
@@ -122,6 +139,8 @@ export default async function add(client: Client, argv: string[]) {
   let preserveQueryParams: boolean;
   if (flags['--preserve-query-params'] !== undefined) {
     preserveQueryParams = flags['--preserve-query-params'];
+  } else if (skipPrompts) {
+    preserveQueryParams = false;
   } else {
     preserveQueryParams = await client.input.confirm(
       'Should query parameters be preserved?',
@@ -136,6 +155,8 @@ export default async function add(client: Client, argv: string[]) {
       output.error('Name must be 256 characters or less');
       return 1;
     }
+  } else if (skipPrompts) {
+    versionName = undefined;
   } else {
     const provideName = await client.input.confirm(
       'Do you want to provide a name for this version?',

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -33,7 +33,7 @@ export const listSubcommand = {
       deprecated: false,
     },
     {
-      name: 'staged',
+      name: 'staging',
       description: 'List redirects from the staging version',
       shorthand: null,
       type: Boolean,
@@ -89,18 +89,57 @@ export const addSubcommand = {
   arguments: [
     {
       name: 'source',
-      required: true,
+      required: false,
     },
     {
       name: 'destination',
-      required: true,
+      required: false,
     },
   ],
-  options: [],
+  options: [
+    {
+      name: 'status',
+      description: 'HTTP status code (301, 302, 307, or 308)',
+      shorthand: null,
+      type: Number,
+      argument: 'CODE',
+      deprecated: false,
+    },
+    {
+      name: 'case-sensitive',
+      description: 'Make the redirect case sensitive',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'preserve-query-params',
+      description: 'Preserve query parameters when redirecting',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'name',
+      description: 'Version name for this redirect (max 256 characters)',
+      shorthand: null,
+      type: String,
+      argument: 'NAME',
+      deprecated: false,
+    },
+  ],
   examples: [
     {
-      name: 'Add a new redirect',
+      name: 'Add a new redirect interactively',
+      value: `${packageName} redirects add`,
+    },
+    {
+      name: 'Add a new redirect with arguments',
       value: `${packageName} redirects add /old-path /new-path`,
+    },
+    {
+      name: 'Add a redirect with all options',
+      value: `${packageName} redirects add /old-path /new-path --status 301 --case-sensitive --preserve-query-params --name "My redirect"`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -127,6 +127,10 @@ export const addSubcommand = {
       argument: 'NAME',
       deprecated: false,
     },
+    {
+      ...yesOption,
+      description: 'Skip prompts and use default values',
+    },
   ],
   examples: [
     {
@@ -140,6 +144,10 @@ export const addSubcommand = {
     {
       name: 'Add a redirect with all options',
       value: `${packageName} redirects add /old-path /new-path --status 301 --case-sensitive --preserve-query-params --name "My redirect"`,
+    },
+    {
+      name: 'Add a redirect non-interactively',
+      value: `${packageName} redirects add /old-path /new-path --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/redirects/remove.ts
+++ b/packages/cli/src/commands/redirects/remove.ts
@@ -121,7 +121,7 @@ export default async function remove(client: Client, argv: string[]) {
     }
   } else {
     output.warn(
-      `There are other staged changes. Review them with ${chalk.cyan('vercel redirects list --staged')} before promoting to production.`
+      `There are other staged changes. Review them with ${chalk.cyan('vercel redirects list --staging')} before promoting to production.`
     );
   }
 

--- a/packages/cli/src/commands/redirects/shared.ts
+++ b/packages/cli/src/commands/redirects/shared.ts
@@ -76,9 +76,13 @@ export async function confirmAction(
 }
 
 export function isValidUrl(url: string): boolean {
-  try {
-    new URL(url, 'https://vercel.com');
+  if (url.startsWith('/')) {
     return true;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
   } catch {
     return false;
   }

--- a/packages/cli/src/util/redirects/put-redirects.ts
+++ b/packages/cli/src/util/redirects/put-redirects.ts
@@ -6,6 +6,7 @@ export interface RedirectInput {
   destination: string;
   statusCode: number;
   caseSensitive: boolean;
+  preserveQueryParams?: boolean;
 }
 
 type Response = {

--- a/packages/cli/test/unit/commands/redirects/add.test.ts
+++ b/packages/cli/test/unit/commands/redirects/add.test.ts
@@ -41,7 +41,7 @@ describe('redirects add', () => {
   });
 
   describe('interactive mode', () => {
-    it('should add a redirect with status 301', async () => {
+    it('should add a redirect with status 307', async () => {
       mockGetVersions();
       mockPutRedirects();
       mockPromoteVersion();
@@ -64,6 +64,11 @@ describe('redirects add', () => {
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
         'Do you want to provide a name for this version?'
       );
       client.stdin.write('n\n');
@@ -71,7 +76,7 @@ describe('redirects add', () => {
       await expect(client.stderr).toOutput('Adding redirect');
       await expect(client.stderr).toOutput('Redirect added');
       await expect(client.stderr).toOutput('/old-path → /new-path');
-      await expect(client.stderr).toOutput('Status: 301');
+      await expect(client.stderr).toOutput('Status: 307');
       await expect(client.stderr).toOutput('promote it to production');
       client.stdin.write('y\n');
 
@@ -96,6 +101,11 @@ describe('redirects add', () => {
 
       await expect(client.stderr).toOutput(
         'Should the redirect be case sensitive?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
       );
       client.stdin.write('\n');
 
@@ -133,6 +143,11 @@ describe('redirects add', () => {
 
       await expect(client.stderr).toOutput(
         'Should the redirect be case sensitive?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
       );
       client.stdin.write('\n');
 
@@ -175,6 +190,11 @@ describe('redirects add', () => {
       client.stdin.write('\n');
 
       await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
         'Do you want to provide a name for this version?'
       );
       client.stdin.write('n\n');
@@ -208,6 +228,11 @@ describe('redirects add', () => {
     client.stdin.write('\n');
 
     await expect(client.stderr).toOutput(
+      'Should query parameters be preserved?'
+    );
+    client.stdin.write('\n');
+
+    await expect(client.stderr).toOutput(
       'Do you want to provide a name for this version?'
     );
     client.stdin.write('n\n');
@@ -223,6 +248,164 @@ describe('redirects add', () => {
         value: 'add',
       },
     ]);
+  });
+
+  describe('non-interactive mode', () => {
+    it('should add a redirect with positional arguments', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv('redirects', 'add', '/old-path', '/new-path');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Select the status code:');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Should the redirect be case sensitive?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
+      );
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to provide a name for this version?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput('Redirect added');
+      await expect(client.stderr).toOutput('/old-path → /new-path');
+      await expect(client.stderr).toOutput('Status: 307');
+
+      await expect(client.stderr).toOutput('promote it to production');
+      client.stdin.write('n\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should add a redirect with all flags', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv(
+        'redirects',
+        'add',
+        '/old',
+        '/new',
+        '--status',
+        '302',
+        '--case-sensitive',
+        '--preserve-query-params',
+        '--name',
+        'Test Version'
+      );
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Redirect added');
+      await expect(client.stderr).toOutput('/old → /new');
+      await expect(client.stderr).toOutput('Status: 302');
+      await expect(client.stderr).toOutput('Case sensitive: Yes');
+      await expect(client.stderr).toOutput('Preserve query params: Yes');
+
+      await expect(client.stderr).toOutput('promote it to production');
+      client.stdin.write('n\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should add a redirect with minimal flags', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv('redirects', 'add', '/source', '/dest', '--status', '308');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Should the redirect be case sensitive?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Should query parameters be preserved?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to provide a name for this version?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput('Redirect added');
+      await expect(client.stderr).toOutput('/source → /dest');
+      await expect(client.stderr).toOutput('Status: 308');
+      await expect(client.stderr).toOutput('Case sensitive: Yes');
+      await expect(client.stderr).toOutput('Preserve query params: No');
+
+      await expect(client.stderr).toOutput('promote it to production');
+      client.stdin.write('n\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should error on invalid status code', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv('redirects', 'add', '/old', '/new', '--status', '404');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Status code must be 301, 302, 307, or 308'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error on invalid source URL', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv('redirects', 'add', 'invalid-path', '/new');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Source must be a relative path (starting with /) or an absolute URL'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error on invalid destination URL', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      client.setArgv('redirects', 'add', '/old', 'invalid-path');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Destination must be a relative path (starting with /) or an absolute URL'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error on version name that is too long', async () => {
+      mockGetVersions();
+      mockPutRedirects();
+
+      const longName = 'a'.repeat(257);
+      client.setArgv('redirects', 'add', '/old', '/new', '--name', longName);
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Name must be 256 characters or less'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
   });
 });
 


### PR DESCRIPTION
This PR primarily adds the ability to specify options to `vc redirects add` for status code, case sensitivity, and preserving query params so it doesn't need to be interactive. 

It also applies two other small changes:

- Changes `--staged` to `--staging`
- Shows you the diff of the redirects compared to prod when you use `ls --staging`

<img width="479" height="172" alt="Screenshot 2025-12-08 at 11 37 35 AM" src="https://github.com/user-attachments/assets/db28491c-08ba-4b45-8c1b-2af6120a81da" />
