### PR TITLE
[rust] Allow developers to develop Rust functions on Windows

### DIFF
--- a/crates/vercel_runtime/Cargo.toml
+++ b/crates/vercel_runtime/Cargo.toml
@@ -18,12 +18,14 @@ tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 tokio-stream = "0.1"
 lazy_static = "1.4"
-libc = "0.2"
 http-body = "1.0"
 tower = { version = "0.5", features = ["util"] }
 
 axum = { version = "0.8", optional = true }
 axum-streams = { version = "0.24", features = ["json", "text"], optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [features]
 default = []

--- a/crates/vercel_runtime/src/ipc_utils.rs
+++ b/crates/vercel_runtime/src/ipc_utils.rs
@@ -1,0 +1,124 @@
+#![cfg(unix)]
+
+use base64::prelude::*;
+use serde::Serialize;
+use std::collections::VecDeque;
+use std::io::prelude::*;
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::types::Error;
+
+pub static IPC_READY: AtomicBool = AtomicBool::new(false);
+static INIT_LOG_BUF_MAX_BYTES: usize = 1_000_000;
+
+lazy_static::lazy_static! {
+    pub static ref INIT_LOG_BUFFER: Arc<Mutex<(VecDeque<String>, usize)>> = {
+        register_exit_handler();
+        Arc::new(Mutex::new((VecDeque::new(), 0)))
+    };
+}
+
+// Register exit handler to flush buffered messages
+fn register_exit_handler() {
+    extern "C" fn exit_handler() {
+        flush_init_log_buf_to_stderr();
+    }
+    unsafe {
+        libc::atexit(exit_handler);
+    }
+}
+
+pub fn send_message<T: Serialize>(stream: &Arc<Mutex<UnixStream>>, message: T) -> Result<(), Error> {
+    let json_str = serde_json::to_string(&message)?;
+    let msg = format!("{json_str}\0");
+
+    let mut stream = stream.lock().map_err(|e| {
+        Box::new(std::io::Error::other(format!(
+            "Failed to acquire stream lock: {}",
+            e
+        ))) as Error
+    })?;
+
+    stream.write_all(msg.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+pub fn enqueue_or_send_message<T: Serialize>(
+    stream: &Option<Arc<Mutex<UnixStream>>>,
+    message: T,
+) -> Result<(), Error> {
+    if IPC_READY.load(Ordering::Relaxed)
+        && let Some(stream) = stream
+    {
+        return send_message(stream, message);
+    }
+
+    // Buffer the message if IPC is not ready
+    let json_str = serde_json::to_string(&message)?;
+    let msg_len = json_str.len();
+
+    if let Ok(mut buffer) = INIT_LOG_BUFFER.lock() {
+        if buffer.1 + msg_len <= INIT_LOG_BUF_MAX_BYTES {
+            buffer.0.push_back(json_str);
+            buffer.1 += msg_len;
+        } else {
+            // Fallback to stderr if buffer is full - decode base64
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json_str)
+                && let Some(payload) = parsed.get("payload")
+                && let Some(msg) = payload.get("message")
+                && let Some(msg_str) = msg.as_str()
+                && let Ok(decoded) = BASE64_STANDARD.decode(msg_str)
+                && let Ok(text) = String::from_utf8(decoded)
+            {
+                eprint!("{}", text);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn flush_init_log_buffer(stream: &Option<Arc<Mutex<UnixStream>>>) {
+    if let Some(stream) = stream {
+        if let Ok(mut buffer) = INIT_LOG_BUFFER.lock() {
+            while let Some(json_str) = buffer.0.pop_front() {
+                if let Ok(message) = serde_json::from_str::<serde_json::Value>(&json_str)
+                    && let Err(_e) = send_message(stream, message)
+                {
+                    // Failed to send buffered message
+                    break;
+                }
+            }
+            buffer.1 = 0; // Reset byte count
+        }
+    } else {
+        flush_init_log_buf_to_stderr();
+    }
+}
+
+pub fn flush_init_log_buf_to_stderr() {
+    if let Ok(mut buffer) = INIT_LOG_BUFFER.lock() {
+        let mut combined: Vec<String> = Vec::new();
+
+        while let Some(json_str) = buffer.0.pop_front() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json_str)
+                && let Some(payload) = parsed.get("payload")
+                && let Some(msg) = payload.get("message")
+                && let Some(msg_str) = msg.as_str()
+                && let Ok(decoded) = BASE64_STANDARD.decode(msg_str)
+                && let Ok(text) = String::from_utf8(decoded)
+            {
+                combined.push(text);
+            }
+        }
+
+        if !combined.is_empty() {
+            eprint!("{}", combined.join(""));
+        }
+
+        buffer.1 = 0;
+    }
+}

--- a/crates/vercel_runtime/src/lib.rs
+++ b/crates/vercel_runtime/src/lib.rs
@@ -9,34 +9,31 @@ use std::task::{Context, Poll};
 use tokio::net::TcpListener;
 use tower::Service;
 
+pub use hyper::Response;
+pub use types::{Error, ResponseBody};
+pub type Request = hyper::Request<hyper::body::Incoming>;
+
+#[cfg(feature = "axum")]
+pub mod axum;
+
+#[cfg(unix)]
+mod ipc;
+#[cfg(unix)]
+mod ipc_utils;
+mod types;
+
+use crate::types::IntoFunctionResponse;
+
 #[cfg(unix)]
 use {
+    crate::ipc::core::{EndMessage, StartMessage},
+    crate::ipc::log::{Level, LogMessage},
+    crate::ipc_utils::{IPC_READY, enqueue_or_send_message, flush_init_log_buffer, send_message},
     std::env,
     std::os::unix::net::UnixStream,
     std::sync::atomic::Ordering,
     std::sync::{Arc, Mutex},
 };
-
-pub use hyper::Response;
-pub use types::{Error, ResponseBody};
-pub type Request = hyper::Request<hyper::body::Incoming>;
-
-#[cfg(unix)]
-use {
-  crate::ipc::core::{EndMessage, StartMessage},
-  crate::ipc::log::{Level, LogMessage},
-  crate::ipc_utils::{
-      enqueue_or_send_message, flush_init_log_buffer, send_message, IPC_READY,
-  },
-};
-
-#[cfg(feature = "axum")]
-pub mod axum;
-
-mod types;
-
-use crate::types::IntoFunctionResponse;
-
 
 #[cfg(unix)]
 #[derive(Clone)]


### PR DESCRIPTION
Previously, the runtime failed to compile on Windows due to the `std::os::unix::net::UnixStream` referenced in the IPC module. However, it appears IPC is only utilized in Vercel's production environment and is unnecessary during local development. This patch resolves the issue by isolating IPC-related logic into conditional compilation specific to Unix systems.

@ecklf plz review this