### PR TITLE
Improve handling of 429 error codes in the Vercel CLI

### DIFF
--- a/.changeset/popular-cougars-heal.md
+++ b/.changeset/popular-cougars-heal.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve handling of 429 error codes and Retry-After headers

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -755,7 +755,7 @@ function handleCreateDeployError(error: Error, localConfig: VercelConfig) {
   if (error instanceof TooManyRequests) {
     output.error(
       `Too many requests detected for ${error.meta.api} API. Try again in ${ms(
-        error.meta.retryAfter * 1000,
+        error.meta.retryAfterMs,
         {
           long: true,
         }

--- a/packages/cli/src/util/certs/handle-cert-error.ts
+++ b/packages/cli/src/util/certs/handle-cert-error.ts
@@ -17,7 +17,7 @@ export default function handleCertError<T>(
   if (error instanceof ERRORS.TooManyRequests) {
     output.error(
       `Too many requests detected for ${error.meta.api} API. Try again in ${ms(
-        error.meta.retryAfter * 1000,
+        error.meta.retryAfterMs,
         {
           long: true,
         }

--- a/packages/cli/src/util/certs/map-cert-error.ts
+++ b/packages/cli/src/util/certs/map-cert-error.ts
@@ -4,7 +4,7 @@ export default function mapCertError(error: ERRORS.APIError, cns?: string[]) {
   const errorCode: string = error.code;
   if (errorCode === 'too_many_requests') {
     const retryAfter =
-      typeof error.retryAfter === 'number' ? error.retryAfter : 0;
+      typeof error.retryAfterMs === 'number' ? error.retryAfterMs : 0;
     return new ERRORS.TooManyRequests('certificates', retryAfter);
   }
   if (errorCode === 'not_found') {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -299,6 +299,10 @@ export default class Client extends EventEmitter implements Stdio {
             // there's no sense in retrying
             return bail(normalizeError(reauthError));
           }
+        } else if (typeof error.retryAfterMs === 'number') {
+          // Respect the Retry-After header and then try again below.
+          // This covers 429 responses which would otherwise bail out
+          sleep(error.retryAfterMs);
         } else if (res.status >= 400 && res.status < 500) {
           // Any other 4xx should bail without retrying
           return bail(error);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -302,7 +302,7 @@ export default class Client extends EventEmitter implements Stdio {
         } else if (typeof error.retryAfterMs === 'number') {
           // Respect the Retry-After header and then try again below.
           // This covers 429 responses which would otherwise bail out
-          sleep(error.retryAfterMs);
+          await sleep(error.retryAfterMs);
         } else if (res.status >= 400 && res.status < 500) {
           // Any other 4xx should bail without retrying
           return bail(error);

--- a/packages/cli/src/util/error.ts
+++ b/packages/cli/src/util/error.ts
@@ -2,6 +2,7 @@ import type { Response } from 'node-fetch';
 import errorOutput from './output/error';
 import bytes from 'bytes';
 import type { APIError } from './errors-ts';
+import { parseRetryAfterHeaderAsMillis } from './errors-ts';
 import { getCommandName } from './pkg-name';
 import output from '../output-manager';
 
@@ -10,7 +11,7 @@ export const error = errorOutput;
 export interface ResponseError extends Error {
   status: number;
   serverMessage: string;
-  retryAfter?: number;
+  retryAfterMs?: number;
   [key: string]: any;
 }
 
@@ -54,12 +55,10 @@ export async function responseError(
     }
   }
 
-  if (res.status === 429) {
-    const retryAfter = res.headers.get('Retry-After');
-
-    if (retryAfter) {
-      err.retryAfter = Number.parseInt(retryAfter, 10);
-    }
+  if (res.status === 429 || res.status === 503) {
+    err.retryAfterMs = parseRetryAfterHeaderAsMillis(
+      res.headers.get('Retry-After')
+    );
   }
 
   return err;

--- a/packages/cli/src/util/error.ts
+++ b/packages/cli/src/util/error.ts
@@ -56,9 +56,11 @@ export async function responseError(
   }
 
   if (res.status === 429 || res.status === 503) {
-    err.retryAfterMs = parseRetryAfterHeaderAsMillis(
+    const parsed = parseRetryAfterHeaderAsMillis(
       res.headers.get('Retry-After')
     );
+    // If the retry-after header is missing or malfomed set to 0.  This ensures users will attempt a retry even in these cases.
+    err.retryAfterMs = parsed ?? (res.status === 429 ? 0 : undefined);
   }
 
   return err;

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -38,9 +38,11 @@ export class APIError extends Error {
 
     // HTTP 429 (Too Many Requests) or 503 (Service Unavailable) both are spec'd to serve retry-after headers
     if (response.status === 429 || response.status === 503) {
-      this.retryAfterMs = parseRetryAfterHeaderAsMillis(
+      const parsed = parseRetryAfterHeaderAsMillis(
         response.headers.get('Retry-After')
       );
+      // If the retry-after header is missing or malfomed set to 0.  This ensures users will attempt a retry even in these cases.
+      this.retryAfterMs = parsed ?? (res.status === 429 ? 0 : undefined);
     }
   }
 }

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -57,11 +57,11 @@ export function parseRetryAfterHeaderAsMillis(
     if (Number.isNaN(retryAfterMs)) {
       return undefined;
     } else {
-      // If the date is in the past (clock skew? latency?) just retry immediately
-      retryAfterMs = Math.max(retryAfterMs - Date.now(), 0);
+      retryAfterMs = retryAfterMs - Date.now();
     }
   }
-  return retryAfterMs;
+  // If the date is in the past (clock skew? latency?) just retry immediately
+  return Math.max(retryAfterMs, 0);
 }
 
 export function isAPIError(v: unknown): v is APIError {

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -57,7 +57,8 @@ export function parseRetryAfterHeaderAsMillis(
     if (Number.isNaN(retryAfterMs)) {
       return undefined;
     } else {
-      retryAfterMs = retryAfterMs - Date.now();
+      // If the date is in the past (clock skew? latency?) just retry immediately
+      retryAfterMs = Math.max(retryAfterMs - Date.now(), 0);
     }
   }
   return retryAfterMs;

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -506,12 +506,12 @@ export class CertOrderNotFound extends NowError<
  */
 export class TooManyRequests extends NowError<
   'TOO_MANY_REQUESTS',
-  { api: string; retryAfter: number }
+  { api: string; retryAfterMs: number }
 > {
-  constructor(api: string, retryAfter: number) {
+  constructor(api: string, retryAfterMs: number) {
     super({
       code: 'TOO_MANY_REQUESTS',
-      meta: { api, retryAfter },
+      meta: { api, retryAfterMs },
       message: `Rate limited. Too many requests to the same endpoint.`,
     });
   }

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -42,7 +42,7 @@ export class APIError extends Error {
         response.headers.get('Retry-After')
       );
       // If the retry-after header is missing or malfomed set to 0.  This ensures users will attempt a retry even in these cases.
-      this.retryAfterMs = parsed ?? (res.status === 429 ? 0 : undefined);
+      this.retryAfterMs = parsed ?? (response.status === 429 ? 0 : undefined);
     }
   }
 }

--- a/packages/cli/src/util/errors-ts.ts
+++ b/packages/cli/src/util/errors-ts.ts
@@ -18,7 +18,7 @@ export class APIError extends Error {
   link?: string;
   slug?: string;
   action?: string;
-  retryAfter: number | null | 'never';
+  retryAfterMs?: number | 'never';
   [key: string]: any;
 
   constructor(message: string, response: Response, body?: object) {
@@ -26,7 +26,6 @@ export class APIError extends Error {
     this.message = `${message} (${response.status})`;
     this.status = response.status;
     this.serverMessage = message;
-    this.retryAfter = null;
 
     if (body) {
       for (const field of Object.keys(body)) {
@@ -37,13 +36,31 @@ export class APIError extends Error {
       }
     }
 
-    if (response.status === 429) {
-      const retryAfter = response.headers.get('Retry-After');
-      if (retryAfter) {
-        this.retryAfter = parseInt(retryAfter, 10);
-      }
+    // HTTP 429 (Too Many Requests) or 503 (Service Unavailable) both are spec'd to serve retry-after headers
+    if (response.status === 429 || response.status === 503) {
+      this.retryAfterMs = parseRetryAfterHeaderAsMillis(
+        response.headers.get('Retry-After')
+      );
     }
   }
+}
+
+export function parseRetryAfterHeaderAsMillis(
+  header: string | null
+): number | undefined {
+  if (!header) return undefined;
+  // The header might be a literal number of seconds or a formatted date
+  // The date format is spec'd and date.parse should handle it.
+  let retryAfterMs = Number(header) * 1000;
+  if (Number.isNaN(retryAfterMs)) {
+    retryAfterMs = Date.parse(header);
+    if (Number.isNaN(retryAfterMs)) {
+      return undefined;
+    } else {
+      retryAfterMs = retryAfterMs - Date.now();
+    }
+  }
+  return retryAfterMs;
 }
 
 export function isAPIError(v: unknown): v is APIError {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -306,7 +306,7 @@ export default class Now {
       } else {
         const error = await responseError(res, 'Failed to remove deployment');
         // Always respect Retry-After headers and retry
-        if (error.retryAfterMs) {
+        if (typeof error.retryAfterMs === 'number') {
           await sleep(error.retryAfterMs);
           throw error;
         }

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -405,7 +405,7 @@ export default class Now {
       }
       const err = await responseError(res);
       // Always respect Retry-After headers and retry
-      if (err.retryAfterMs) {
+      if (typeof err.retryAfterMs === 'number') {
         await sleep(err.retryAfterMs);
         throw err;
       }

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -406,7 +406,7 @@ export default class Now {
       const err = await responseError(res);
       // Always respect Retry-After headers and retry
       if (err.retryAfterMs) {
-        sleep(err.retryAfterMs);
+        await sleep(err.retryAfterMs);
         throw err;
       }
       if (res.status >= 400 && res.status < 500) {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -307,7 +307,7 @@ export default class Now {
         const error = await responseError(res, 'Failed to remove deployment');
         // Always respect Retry-After headers and retry
         if (error.retryAfterMs) {
-          sleep(error.retryAfterMs);
+          await sleep(error.retryAfterMs);
           throw error;
         }
         if (res.status > 200 && res.status < 500) {

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -17,6 +17,7 @@ import type Client from './client';
 import { type FetchOptions, isJSONObject } from './client';
 import type { ArchiveFormat, Dictionary } from '@vercel/client';
 import output from '../output-manager';
+import sleep from './sleep';
 
 export interface NowOptions {
   client: Client;
@@ -210,10 +211,10 @@ export default class Now {
   async handleDeploymentError(error: any, { env }: any) {
     if (error.status === 429) {
       if (error.code === 'builds_rate_limited') {
-        const err = Object.create(APIError.prototype);
+        const err: APIError = Object.create(APIError.prototype);
         err.message = error.message;
         err.status = error.status;
-        err.retryAfter = 'never';
+        err.retryAfterMs = 'never';
         err.code = error.code;
         return err;
       }
@@ -229,10 +230,10 @@ export default class Now {
         msg += 'Please slow down.';
       }
 
-      const err = Object.create(APIError.prototype);
+      const err: APIError = Object.create(APIError.prototype);
       err.message = msg;
       err.status = error.status;
-      err.retryAfter = 'never';
+      err.retryAfterMs = 'never';
 
       return err;
     }
@@ -302,12 +303,20 @@ export default class Now {
 
       if (res.status === 200) {
         // What we want
-      } else if (res.status > 200 && res.status < 500) {
-        // If something is wrong with our request, we don't retry
-        return bail(await responseError(res, 'Failed to remove deployment'));
       } else {
-        // If something is wrong with the server, we retry
-        throw await responseError(res, 'Failed to remove deployment');
+        const error = await responseError(res, 'Failed to remove deployment');
+        // Always respect Retry-After headers and retry
+        if (error.retryAfterMs) {
+          sleep(error.retryAfterMs);
+          throw error;
+        }
+        if (res.status > 200 && res.status < 500) {
+          // If something is wrong with our request, we don't retry
+          return bail(error);
+        } else {
+          // If something is wrong with the server, we retry
+          throw error;
+        }
       }
     });
 
@@ -395,6 +404,11 @@ export default class Now {
           : res;
       }
       const err = await responseError(res);
+      // Always respect Retry-After headers and retry
+      if (err.retryAfterMs) {
+        sleep(err.retryAfterMs);
+        throw err;
+      }
       if (res.status >= 400 && res.status < 500) {
         return bail(err);
       }

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -190,7 +190,8 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    expect(formatted.retryAfterMs).toEqual(undefined);
+    // We default to 0 in this case
+    expect(formatted.retryAfterMs).toEqual(0);
   });
 });
 

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -175,7 +175,7 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    expect(formatted.retryAfterMs).toEqual(20);
+    expect(formatted.retryAfterMs).toEqual(2000);
   });
 
   it('should parse 429 response error without retry header', async () => {

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -175,7 +175,7 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    expect(formatted.retryAfterMs).toEqual(2000);
+    expect(formatted.retryAfterMs).toEqual(20000);
   });
 
   it('should parse 429 response error without retry header', async () => {

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -175,7 +175,7 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    expect(formatted.retryAfter).toEqual(20);
+    expect(formatted.retryAfterMs).toEqual(20);
   });
 
   it('should parse 429 response error without retry header', async () => {
@@ -190,7 +190,7 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    expect(formatted.retryAfter).toEqual(undefined);
+    expect(formatted.retryAfterMs).toEqual(undefined);
   });
 });
 

--- a/packages/cli/test/unit/util/error.test.ts
+++ b/packages/cli/test/unit/util/error.test.ts
@@ -190,7 +190,7 @@ describe('responseError()', () => {
     const res = await fetch(url);
     const formatted = await responseError(res);
     expect(formatted.message).toEqual('You were rate limited (429)');
-    // We default to 0 in this case
+    // We default to 0 in this case so callers still know to retry
     expect(formatted.retryAfterMs).toEqual(0);
   });
 });

--- a/packages/cli/test/unit/util/errors-ts.test.ts
+++ b/packages/cli/test/unit/util/errors-ts.test.ts
@@ -1,0 +1,30 @@
+import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { parseRetryAfterHeaderAsMillis } from '../../../src/util/errors-ts';
+
+describe('APIError Retry-After parsing', () => {
+  const mockDateString = 'Tue, 29 Oct 2024 16:56:32 GMT';
+  beforeEach(() => {
+    // Enable fake timers and set the system time
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse(mockDateString) - 7_000);
+  });
+
+  afterEach(() => {
+    // Restore the real system time and clear the fake timers
+    vi.useRealTimers();
+  });
+  it('edge cases', () => {
+    expect(parseRetryAfterHeaderAsMillis(null)).toBe(undefined);
+    expect(parseRetryAfterHeaderAsMillis('')).toBe(undefined);
+    expect(parseRetryAfterHeaderAsMillis('hello')).toBe(undefined);
+  });
+  it('number cases', () => {
+    expect(parseRetryAfterHeaderAsMillis('1')).toBe(1000);
+    expect(parseRetryAfterHeaderAsMillis('1.1')).toBe(1100);
+    expect(parseRetryAfterHeaderAsMillis('1.1abc')).toBe(undefined);
+  });
+
+  it('dates', () => {
+    expect(parseRetryAfterHeaderAsMillis(mockDateString)).toBe(7_000);
+  });
+});

--- a/packages/cli/test/unit/util/errors-ts.test.ts
+++ b/packages/cli/test/unit/util/errors-ts.test.ts
@@ -26,5 +26,7 @@ describe('APIError Retry-After parsing', () => {
 
   it('dates', () => {
     expect(parseRetryAfterHeaderAsMillis(mockDateString)).toBe(7_000);
+    const past = new Date(Date.parse(mockDateString) - 14_000).toISOString();
+    expect(parseRetryAfterHeaderAsMillis(past)).toBe(0);
   });
 });


### PR DESCRIPTION
* Handle `date` formatted `Retry-After` headers, this is similar to #14407 but on the CLI side
    * it is unfortunate to have two copies of parsing logic, but there isn't a clear place to share the logic and it is pretty simple
* Change the 'retry' loop logic in client.ts and `util/index.ts` to always respect and retry when there is a `Retry-After` header or the error code is 429.  Currently they always abort on 400 errors
* rename the `retryAfter` properties to `retryAfterMs` to be clearer

This should improve the CLIs ability to recover from temporary rate limit conditions.  This is important for the Next.js CI system where we generate a lot of deployments as part of release validation:  e.g. https://github.com/vercel/next.js/actions/runs/20041033845/job/57474897550