### PR TITLE
OIDC error refinement

### DIFF
--- a/.changeset/young-stingrays-design.md
+++ b/.changeset/young-stingrays-design.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+improve error messages for package consumers

--- a/packages/oidc/docs/README.md
+++ b/packages/oidc/docs/README.md
@@ -101,4 +101,4 @@ The OIDC token.
 
 #### Defined in
 
-[get-vercel-oidc-token.ts:81](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token.ts#L81)
+[get-vercel-oidc-token.ts:85](https://github.com/vercel/vercel/blob/main/packages/oidc/src/get-vercel-oidc-token.ts#L85)

--- a/packages/oidc/src/get-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.test.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from 'crypto';
+import { describe, beforeEach, afterEach, test, vi, expect } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+vi.mock('./token-io');
+vi.mock('./get-context', () => ({
+  getContext: () => ({ headers: {} }),
+}));
+
+import { findRootDir, getUserDataDir } from './token-io';
+import { getVercelOidcToken } from './get-vercel-oidc-token';
+import * as tokenUtil from './token-util';
+
+describe('getVercelOidcToken - Error Scenarios', () => {
+  let rootDir: string;
+  let userDataDir: string;
+  let cliDataDir: string;
+  let tokenDataDir: string;
+
+  const projectId = 'test-project-id';
+  const teamId = 'test-team-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    process.env.VERCEL_OIDC_TOKEN = undefined;
+    const random = `test-${randomUUID()}`;
+
+    rootDir = path.join(os.tmpdir(), random);
+
+    userDataDir = path.join(rootDir, 'data');
+    cliDataDir = path.join(userDataDir, 'com.vercel.cli');
+    tokenDataDir = path.join(userDataDir, 'com.vercel.token');
+
+    fs.mkdirSync(cliDataDir, { recursive: true });
+    fs.mkdirSync(tokenDataDir, { recursive: true });
+    fs.mkdirSync(path.join(rootDir, '.vercel'), {
+      recursive: true,
+    });
+
+    vi.spyOn(process, 'cwd').mockReturnValue(rootDir);
+    vi.mocked(findRootDir).mockReturnValue(rootDir);
+    vi.mocked(getUserDataDir).mockReturnValue(userDataDir);
+  });
+
+  afterEach(() => {
+    // Clean up test directories
+    if (fs.existsSync(rootDir)) {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  test('should throw helpful error when CLI auth file is missing', async () => {
+    // Setup: Create project.json but no auth.json
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Don't create auth.json file
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Failed to refresh OIDC token: Log in to Vercel CLI and link your project with `vc link`/
+    );
+  });
+
+  test('should throw helpful error when project.json is missing', async () => {
+    // Setup: Create auth.json but no project.json
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test-auth-token' })
+    );
+
+    // Don't create project.json
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /project\.json not found, have you linked your project with `vc link\?`/
+    );
+  });
+
+  test('should throw helpful error when root directory cannot be found', async () => {
+    // Setup: Mock findRootDir to return null
+    vi.mocked(findRootDir).mockReturnValue(null);
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Unable to find project root directory\. Have you linked your project with `vc link\?`/
+    );
+  });
+
+  test('should throw helpful error when user data directory cannot be found', async () => {
+    // Setup: Create project.json
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Mock getUserDataDir to return null (simulates missing data dir)
+    vi.mocked(getUserDataDir).mockReturnValue(null);
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Unable to find user data directory\. Please reach out to Vercel support\./
+    );
+  });
+
+  test('should throw helpful error when API returns non-200', async () => {
+    // Setup: Create both auth.json and project.json
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test-auth-token' })
+    );
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Mock the API call to return error
+    vi.spyOn(tokenUtil, 'getVercelOidcToken').mockRejectedValue(
+      new Error('Failed to refresh OIDC token: Unauthorized')
+    );
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Failed to refresh OIDC token: Unauthorized/
+    );
+  });
+
+  test('should throw helpful error when token response is malformed', async () => {
+    // Setup: Create both auth.json and project.json
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test-auth-token' })
+    );
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Mock the API call to return malformed response
+    vi.spyOn(tokenUtil, 'getVercelOidcToken').mockRejectedValue(
+      new TypeError(
+        'Vercel OIDC token is malformed. Expected a string-valued token property. Please run `vc env pull` and try again'
+      )
+    );
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Vercel OIDC token is malformed\. Expected a string-valued token property\. Please run `vc env pull` and try again/
+    );
+  });
+
+  test('should throw helpful error when token has invalid format', async () => {
+    // Setup: Set an invalid token format (not JWT)
+    process.env.VERCEL_OIDC_TOKEN = 'not-a-valid-jwt-token';
+
+    // Mock getTokenPayload to throw error for invalid format
+    vi.spyOn(tokenUtil, 'getTokenPayload').mockImplementation(() => {
+      throw new Error('Invalid token. Please run `vc env pull` and try again');
+    });
+
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Invalid token\. Please run `vc env pull` and try again/
+    );
+  });
+
+  test('should throw error when token expiry check fails', async () => {
+    // Setup: Invalid token format in env (will fail when checking expiry)
+    process.env.VERCEL_OIDC_TOKEN = 'not-a-jwt-token';
+
+    // When getTokenPayload is called, it will throw an error for invalid format
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      /Invalid token\. Please run `vc env pull` and try again/
+    );
+  });
+
+  test('should throw error when no token is available initially', async () => {
+    // Setup: No token in env (initial sync will fail)
+    process.env.VERCEL_OIDC_TOKEN = undefined;
+
+    // When there's no token, it should fail when trying to check if it's expired
+    await expect(getVercelOidcToken()).rejects.toThrow(/Invalid token/);
+  });
+
+  test('should propagate filesystem errors when saving token fails', async () => {
+    // Setup: Create auth.json and project.json
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test-auth-token' })
+    );
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Mock successful API call
+    vi.spyOn(tokenUtil, 'getVercelOidcToken').mockResolvedValue({
+      token: 'new-valid-token',
+    });
+
+    // Mock getTokenPayload to show expired token initially
+    vi.spyOn(tokenUtil, 'getTokenPayload').mockReturnValue({
+      sub: 'test-sub',
+      name: 'test-name',
+      exp: Date.now() / 1000 - 1000, // Expired
+    });
+
+    // Mock saveToken to throw a filesystem error
+    vi.spyOn(tokenUtil, 'saveToken').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    // Create expired token to trigger refresh
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    await expect(getVercelOidcToken()).rejects.toThrow(/EACCES|permission/i);
+  });
+
+  test('should succeed when valid token exists in env', async () => {
+    // Setup: Create valid token
+    const validToken = createValidToken();
+    process.env.VERCEL_OIDC_TOKEN = validToken;
+
+    // Mock getTokenPayload to return valid expiry
+    vi.spyOn(tokenUtil, 'getTokenPayload').mockReturnValue({
+      sub: 'test-sub',
+      name: 'test-name',
+      exp: Date.now() / 1000 + 43200, // 12 hours from now
+    });
+
+    const token = await getVercelOidcToken();
+    expect(token).toBe(validToken);
+  });
+
+  test('should refresh when token is expired but all configs are valid', async () => {
+    // Setup: Create all required files
+    fs.writeFileSync(
+      path.join(cliDataDir, 'auth.json'),
+      JSON.stringify({ token: 'test-auth-token' })
+    );
+    fs.writeFileSync(
+      path.join(rootDir, '.vercel', 'project.json'),
+      JSON.stringify({ projectId, orgId: teamId })
+    );
+
+    // Mock successful API call
+    const newToken = createValidToken('new-token');
+    vi.spyOn(tokenUtil, 'getVercelOidcToken').mockResolvedValue({
+      token: newToken,
+    });
+
+    // Mock getTokenPayload for both expired and new token
+    vi.spyOn(tokenUtil, 'getTokenPayload')
+      .mockReturnValueOnce({
+        sub: 'test-sub',
+        name: 'test-name',
+        exp: Date.now() / 1000 - 1000, // Expired 1000 seconds ago
+      })
+      .mockReturnValue({
+        sub: 'test-sub',
+        name: 'test-name',
+        exp: Date.now() / 1000 + 43200, // 12 hours from now
+      });
+
+    // Create expired token
+    const expiredToken = createExpiredToken();
+    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+
+    const token = await getVercelOidcToken();
+    expect(token).toBe(newToken);
+  });
+});
+
+// Helper functions
+function createExpiredToken(): string {
+  // Create a JWT-like token structure with expired timestamp
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'RS256', typ: 'JWT' })
+  ).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: 'test-sub',
+      exp: 1, // Jan 1, 1970 - clearly expired
+      iat: 1,
+    })
+  ).toString('base64url');
+  return `${header}.${payload}.fake_signature`;
+}
+
+function createValidToken(value = 'valid-token'): string {
+  // Create a JWT-like token structure with valid timestamp
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'RS256', typ: 'JWT' })
+  ).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: 'test-sub',
+      exp: Math.floor(Date.now() / 1000) + 43200, // 12 hours from now
+      iat: Math.floor(Date.now() / 1000),
+    })
+  ).toString('base64url');
+  return `${header}.${payload}.fake_signature_${value}`;
+}

--- a/packages/oidc/src/get-vercel-oidc-token.test.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.test.ts
@@ -47,24 +47,18 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   afterEach(() => {
-    // Clean up test directories
     if (fs.existsSync(rootDir)) {
       fs.rmSync(rootDir, { recursive: true, force: true });
     }
   });
 
   test('should throw helpful error when CLI auth file is missing', async () => {
-    // Setup: Create project.json but no auth.json
     fs.writeFileSync(
       path.join(rootDir, '.vercel', 'project.json'),
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Don't create auth.json file
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Failed to refresh OIDC token: Log in to Vercel CLI and link your project with `vc link`/
@@ -72,17 +66,12 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when project.json is missing', async () => {
-    // Setup: Create auth.json but no project.json
     fs.writeFileSync(
       path.join(cliDataDir, 'auth.json'),
       JSON.stringify({ token: 'test-auth-token' })
     );
 
-    // Don't create project.json
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /project\.json not found, have you linked your project with `vc link\?`/
@@ -90,12 +79,8 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when root directory cannot be found', async () => {
-    // Setup: Mock findRootDir to return null
     vi.mocked(findRootDir).mockReturnValue(null);
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Unable to find project root directory\. Have you linked your project with `vc link\?`/
@@ -103,18 +88,13 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when user data directory cannot be found', async () => {
-    // Setup: Create project.json
     fs.writeFileSync(
       path.join(rootDir, '.vercel', 'project.json'),
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Mock getUserDataDir to return null (simulates missing data dir)
     vi.mocked(getUserDataDir).mockReturnValue(null);
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Unable to find user data directory\. Please reach out to Vercel support\./
@@ -122,7 +102,6 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when API returns non-200', async () => {
-    // Setup: Create both auth.json and project.json
     fs.writeFileSync(
       path.join(cliDataDir, 'auth.json'),
       JSON.stringify({ token: 'test-auth-token' })
@@ -132,14 +111,10 @@ describe('getVercelOidcToken - Error Scenarios', () => {
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Mock the API call to return error
     vi.spyOn(tokenUtil, 'getVercelOidcToken').mockRejectedValue(
       new Error('Failed to refresh OIDC token: Unauthorized')
     );
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Failed to refresh OIDC token: Unauthorized/
@@ -147,7 +122,6 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when token response is malformed', async () => {
-    // Setup: Create both auth.json and project.json
     fs.writeFileSync(
       path.join(cliDataDir, 'auth.json'),
       JSON.stringify({ token: 'test-auth-token' })
@@ -157,16 +131,12 @@ describe('getVercelOidcToken - Error Scenarios', () => {
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Mock the API call to return malformed response
     vi.spyOn(tokenUtil, 'getVercelOidcToken').mockRejectedValue(
       new TypeError(
         'Vercel OIDC token is malformed. Expected a string-valued token property. Please run `vc env pull` and try again'
       )
     );
-
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Vercel OIDC token is malformed\. Expected a string-valued token property\. Please run `vc env pull` and try again/
@@ -174,10 +144,8 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw helpful error when token has invalid format', async () => {
-    // Setup: Set an invalid token format (not JWT)
     process.env.VERCEL_OIDC_TOKEN = 'not-a-valid-jwt-token';
 
-    // Mock getTokenPayload to throw error for invalid format
     vi.spyOn(tokenUtil, 'getTokenPayload').mockImplementation(() => {
       throw new Error('Invalid token. Please run `vc env pull` and try again');
     });
@@ -188,25 +156,21 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should throw error when token expiry check fails', async () => {
-    // Setup: Invalid token format in env (will fail when checking expiry)
     process.env.VERCEL_OIDC_TOKEN = 'not-a-jwt-token';
 
-    // When getTokenPayload is called, it will throw an error for invalid format
     await expect(getVercelOidcToken()).rejects.toThrow(
       /Invalid token\. Please run `vc env pull` and try again/
     );
   });
 
-  test('should throw error when no token is available initially', async () => {
-    // Setup: No token in env (initial sync will fail)
+  test('should fail when no token exists and no CLI credentials available', async () => {
+    // No token in env, no auth.json, no project.json - completely unconfigured
     process.env.VERCEL_OIDC_TOKEN = undefined;
 
-    // When there's no token, it should fail when trying to check if it's expired
     await expect(getVercelOidcToken()).rejects.toThrow(/Invalid token/);
   });
 
   test('should propagate filesystem errors when saving token fails', async () => {
-    // Setup: Create auth.json and project.json
     fs.writeFileSync(
       path.join(cliDataDir, 'auth.json'),
       JSON.stringify({ token: 'test-auth-token' })
@@ -216,40 +180,31 @@ describe('getVercelOidcToken - Error Scenarios', () => {
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Mock successful API call
     vi.spyOn(tokenUtil, 'getVercelOidcToken').mockResolvedValue({
       token: 'new-valid-token',
     });
-
-    // Mock getTokenPayload to show expired token initially
     vi.spyOn(tokenUtil, 'getTokenPayload').mockReturnValue({
       sub: 'test-sub',
       name: 'test-name',
-      exp: Date.now() / 1000 - 1000, // Expired
+      exp: Date.now() / 1000 - 1000,
     });
-
-    // Mock saveToken to throw a filesystem error
     vi.spyOn(tokenUtil, 'saveToken').mockImplementation(() => {
       throw new Error('EACCES: permission denied');
     });
 
-    // Create expired token to trigger refresh
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     await expect(getVercelOidcToken()).rejects.toThrow(/EACCES|permission/i);
   });
 
   test('should succeed when valid token exists in env', async () => {
-    // Setup: Create valid token
     const validToken = createValidToken();
     process.env.VERCEL_OIDC_TOKEN = validToken;
 
-    // Mock getTokenPayload to return valid expiry
     vi.spyOn(tokenUtil, 'getTokenPayload').mockReturnValue({
       sub: 'test-sub',
       name: 'test-name',
-      exp: Date.now() / 1000 + 43200, // 12 hours from now
+      exp: Date.now() / 1000 + 43200,
     });
 
     const token = await getVercelOidcToken();
@@ -257,7 +212,6 @@ describe('getVercelOidcToken - Error Scenarios', () => {
   });
 
   test('should refresh when token is expired but all configs are valid', async () => {
-    // Setup: Create all required files
     fs.writeFileSync(
       path.join(cliDataDir, 'auth.json'),
       JSON.stringify({ token: 'test-auth-token' })
@@ -267,44 +221,37 @@ describe('getVercelOidcToken - Error Scenarios', () => {
       JSON.stringify({ projectId, orgId: teamId })
     );
 
-    // Mock successful API call
     const newToken = createValidToken('new-token');
     vi.spyOn(tokenUtil, 'getVercelOidcToken').mockResolvedValue({
       token: newToken,
     });
-
-    // Mock getTokenPayload for both expired and new token
     vi.spyOn(tokenUtil, 'getTokenPayload')
       .mockReturnValueOnce({
         sub: 'test-sub',
         name: 'test-name',
-        exp: Date.now() / 1000 - 1000, // Expired 1000 seconds ago
+        exp: Date.now() / 1000 - 1000,
       })
       .mockReturnValue({
         sub: 'test-sub',
         name: 'test-name',
-        exp: Date.now() / 1000 + 43200, // 12 hours from now
+        exp: Date.now() / 1000 + 43200,
       });
 
-    // Create expired token
-    const expiredToken = createExpiredToken();
-    process.env.VERCEL_OIDC_TOKEN = expiredToken;
+    process.env.VERCEL_OIDC_TOKEN = createExpiredToken();
 
     const token = await getVercelOidcToken();
     expect(token).toBe(newToken);
   });
 });
 
-// Helper functions
 function createExpiredToken(): string {
-  // Create a JWT-like token structure with expired timestamp
   const header = Buffer.from(
     JSON.stringify({ alg: 'RS256', typ: 'JWT' })
   ).toString('base64url');
   const payload = Buffer.from(
     JSON.stringify({
       sub: 'test-sub',
-      exp: 1, // Jan 1, 1970 - clearly expired
+      exp: 1,
       iat: 1,
     })
   ).toString('base64url');
@@ -312,14 +259,13 @@ function createExpiredToken(): string {
 }
 
 function createValidToken(value = 'valid-token'): string {
-  // Create a JWT-like token structure with valid timestamp
   const header = Buffer.from(
     JSON.stringify({ alg: 'RS256', typ: 'JWT' })
   ).toString('base64url');
   const payload = Buffer.from(
     JSON.stringify({
       sub: 'test-sub',
-      exp: Math.floor(Date.now() / 1000) + 43200, // 12 hours from now
+      exp: Math.floor(Date.now() / 1000) + 43200,
       iat: Math.floor(Date.now() / 1000),
     })
   ).toString('base64url');

--- a/packages/oidc/src/get-vercel-oidc-token.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.ts
@@ -49,10 +49,11 @@ export async function getVercelOidcToken(): Promise<string> {
       token = getVercelOidcTokenSync();
     }
   } catch (error) {
-    if (err?.message && error instanceof Error) {
-      error.message = `${err.message}\n${error.message}`;
+    let message = err instanceof Error ? err.message : '';
+    if (error instanceof Error) {
+      message = `${message}\n${error.message}`;
     }
-    throw new VercelOidcTokenError(`Failed to refresh OIDC token`, error);
+    throw new VercelOidcTokenError(message);
   }
   return token;
 }

--- a/packages/oidc/src/get-vercel-oidc-token.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.ts
@@ -53,7 +53,10 @@ export async function getVercelOidcToken(): Promise<string> {
     if (error instanceof Error) {
       message = `${message}\n${error.message}`;
     }
-    throw new VercelOidcTokenError(message);
+    if (message) {
+      throw new VercelOidcTokenError(message);
+    }
+    throw error;
   }
   return token;
 }

--- a/packages/oidc/src/token-io.ts
+++ b/packages/oidc/src/token-io.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import { VercelOidcTokenError } from './token-error';
 
-export function findRootDir(): string {
+export function findRootDir(): string | null {
   try {
     let dir = process.cwd();
     while (dir !== path.dirname(dir)) {
@@ -18,7 +18,7 @@ export function findRootDir(): string {
       'Token refresh only supported in node server environments'
     );
   }
-  throw new VercelOidcTokenError('Unable to find root directory');
+  return null;
 }
 
 export function getUserDataDir(): string | null {

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -15,7 +15,9 @@ export function getVercelDataDir(): string | null {
 export function getVercelCliToken(): string | null {
   const dataDir = getVercelDataDir();
   if (!dataDir) {
-    return null;
+    throw new VercelOidcTokenError(
+      'Unable to find Vercel CLI data directory. Please reach out to Vercel support.'
+    );
   }
   const tokenPath = path.join(dataDir, 'auth.json');
   if (!fs.existsSync(tokenPath)) {
@@ -37,91 +39,89 @@ export async function getVercelOidcToken(
   projectId: string,
   teamId?: string
 ): Promise<VercelTokenResponse | null> {
-  try {
-    const url = `https://api.vercel.com/v1/projects/${projectId}/token?source=vercel-oidc-refresh${teamId ? `&teamId=${teamId}` : ''}`;
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
-    });
-    if (!res.ok) {
-      throw new VercelOidcTokenError(
-        `Failed to refresh OIDC token: ${res.statusText}`
-      );
-    }
-    const tokenRes = await res.json();
-    assertVercelOidcTokenResponse(tokenRes);
-    return tokenRes;
-  } catch (e) {
-    throw new VercelOidcTokenError(`Failed to refresh OIDC token`, e);
+  const url = `https://api.vercel.com/v1/projects/${projectId}/token?source=vercel-oidc-refresh${teamId ? `&teamId=${teamId}` : ''}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+  if (!res.ok) {
+    throw new VercelOidcTokenError(
+      `Failed to refresh OIDC token: ${res.statusText}`
+    );
   }
+  const tokenRes = await res.json();
+  assertVercelOidcTokenResponse(tokenRes);
+  return tokenRes;
 }
 
 export function assertVercelOidcTokenResponse(
   res: unknown
 ): asserts res is VercelTokenResponse {
   if (!res || typeof res !== 'object') {
-    throw new TypeError('Expected an object');
+    throw new TypeError(
+      'Vercel OIDC token is malformed. Expected an object. Please run `vc env pull` and try again'
+    );
   }
   if (!('token' in res) || typeof res.token !== 'string') {
-    throw new TypeError('Expected a string-valued token property');
+    throw new TypeError(
+      'Vercel OIDC token is malformed. Expected a string-valued token property. Please run `vc env pull` and try again'
+    );
   }
 }
 
 export function findProjectInfo(): { projectId: string; teamId: string } {
   const dir = findRootDir();
   if (!dir) {
-    throw new VercelOidcTokenError('Unable to find root directory');
+    throw new VercelOidcTokenError(
+      'Unable to find project root directory. Have you linked your project with `vc link?`'
+    );
   }
-  try {
-    const prjPath = path.join(dir, '.vercel', 'project.json');
-    if (!fs.existsSync(prjPath)) {
-      throw new VercelOidcTokenError('project.json not found');
-    }
-    const prj = JSON.parse(fs.readFileSync(prjPath, 'utf8'));
-    if (typeof prj.projectId !== 'string' && typeof prj.orgId !== 'string') {
-      throw new TypeError('Expected a string-valued projectId property');
-    }
-    return { projectId: prj.projectId, teamId: prj.orgId };
-  } catch (e) {
-    throw new VercelOidcTokenError(`Unable to find project ID`, e);
+  const prjPath = path.join(dir, '.vercel', 'project.json');
+  if (!fs.existsSync(prjPath)) {
+    throw new VercelOidcTokenError(
+      'project.json not found, have you linked your project with `vc link?`'
+    );
   }
+  const prj = JSON.parse(fs.readFileSync(prjPath, 'utf8'));
+  if (typeof prj.projectId !== 'string' && typeof prj.orgId !== 'string') {
+    throw new TypeError(
+      'Expected a string-valued projectId property. Try running `vc link` to re-link your project.'
+    );
+  }
+  return { projectId: prj.projectId, teamId: prj.orgId };
 }
 
 export function saveToken(token: VercelTokenResponse, projectId: string): void {
-  try {
-    const dir = getUserDataDir();
-    if (!dir) {
-      throw new VercelOidcTokenError('Unable to find user data directory');
-    }
-    const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
-    const tokenJson = JSON.stringify(token);
-    fs.mkdirSync(path.dirname(tokenPath), { mode: 0o770, recursive: true }); // read/write/exec perms for owner/group only, x required for dir ops
-    fs.writeFileSync(tokenPath, tokenJson);
-    fs.chmodSync(tokenPath, 0o660); // read/write perms for owner only
-    return;
-  } catch (e) {
-    throw new VercelOidcTokenError(`Failed to save token`, e);
+  const dir = getUserDataDir();
+  if (!dir) {
+    throw new VercelOidcTokenError(
+      'Unable to find user data directory. Please reach out to Vercel support.'
+    );
   }
+  const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
+  const tokenJson = JSON.stringify(token);
+  fs.mkdirSync(path.dirname(tokenPath), { mode: 0o770, recursive: true }); // read/write/exec perms for owner/group only, x required for dir ops
+  fs.writeFileSync(tokenPath, tokenJson);
+  fs.chmodSync(tokenPath, 0o660); // read/write perms for owner only
+  return;
 }
 
 export function loadToken(projectId: string): VercelTokenResponse | null {
-  try {
-    const dir = getUserDataDir();
-    if (!dir) {
-      return null;
-    }
-    const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
-    if (!fs.existsSync(tokenPath)) {
-      return null;
-    }
-    const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
-    assertVercelOidcTokenResponse(token);
-    return token;
-  } catch (e) {
-    throw new VercelOidcTokenError(`Failed to load token`, e);
+  const dir = getUserDataDir();
+  if (!dir) {
+    throw new VercelOidcTokenError(
+      'Unable to find user data directory. Please reach out to Vercel support.'
+    );
   }
+  const tokenPath = path.join(dir, 'com.vercel.token', `${projectId}.json`);
+  if (!fs.existsSync(tokenPath)) {
+    return null;
+  }
+  const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
+  assertVercelOidcTokenResponse(token);
+  return token;
 }
 
 interface TokenPayload {
@@ -133,7 +133,9 @@ interface TokenPayload {
 export function getTokenPayload(token: string): TokenPayload {
   const tokenParts = token.split('.');
   if (tokenParts.length !== 3) {
-    throw new VercelOidcTokenError('Invalid token');
+    throw new VercelOidcTokenError(
+      'Invalid token. Please run `vc env pull` and try again'
+    );
   }
 
   const base64 = tokenParts[1].replace(/-/g, '+').replace(/_/g, '/');

--- a/packages/oidc/src/token.ts
+++ b/packages/oidc/src/token.ts
@@ -17,12 +17,12 @@ export async function refreshToken(): Promise<void> {
     const authToken = getVercelCliToken();
     if (!authToken) {
       throw new VercelOidcTokenError(
-        'Failed to refresh OIDC token: login to vercel cli'
+        'Failed to refresh OIDC token: Log in to Vercel CLI and link your project with `vc link`'
       );
     }
     if (!projectId) {
       throw new VercelOidcTokenError(
-        'Failed to refresh OIDC token: project id not found'
+        'Failed to refresh OIDC token: Try re-linking your project with `vc link`'
       );
     }
     maybeToken = await getVercelOidcToken(authToken, projectId, teamId);


### PR DESCRIPTION
Previously I attempted to handle error messages as if TS was golang, stacking context between layers. This approach led to poor end user messaging for actionable errors. 