### PR TITLE
[cli] Add vc redirects upload command for bulk upload of redirects

### DIFF
--- a/.changeset/neat-candles-exist.md
+++ b/.changeset/neat-candles-exist.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add a vercel redirects upload command to bulk upload redirects from CSV or JSON files.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,8 +46,8 @@
     "@vercel/h3": "workspace:*",
     "@vercel/hono": "workspace:*",
     "@vercel/hydrogen": "workspace:*",
-    "@vercel/next": "workspace:*",
     "@vercel/nestjs": "workspace:*",
+    "@vercel/next": "workspace:*",
     "@vercel/node": "workspace:*",
     "@vercel/python": "workspace:*",
     "@vercel/redwood": "workspace:*",
@@ -57,6 +57,7 @@
     "@vercel/static-build": "workspace:*",
     "chokidar": "4.0.0",
     "esbuild": "0.27.0",
+    "form-data": "^4.0.0",
     "jose": "5.9.6"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/redirects/command.ts
+++ b/packages/cli/src/commands/redirects/command.ts
@@ -152,6 +152,49 @@ export const addSubcommand = {
   ],
 } as const;
 
+export const uploadSubcommand = {
+  name: 'upload',
+  aliases: ['import'],
+  description: 'Upload redirects from a CSV or JSON file',
+  arguments: [
+    {
+      name: 'file',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip confirmation prompt',
+    },
+    {
+      name: 'overwrite',
+      description: 'Replace all existing redirects',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Upload redirects from CSV file',
+      value: `${packageName} redirects upload redirects.csv`,
+    },
+    {
+      name: 'Upload redirects from JSON file',
+      value: `${packageName} redirects upload redirects.json`,
+    },
+    {
+      name: 'Upload and overwrite existing redirects',
+      value: `${packageName} redirects upload redirects.csv --overwrite`,
+    },
+    {
+      name: 'Upload without confirmation',
+      value: `${packageName} redirects upload redirects.csv --yes`,
+    },
+  ],
+} as const;
+
 export const removeSubcommand = {
   name: 'remove',
   aliases: ['rm'],
@@ -234,6 +277,7 @@ export const redirectsCommand = {
     listSubcommand,
     listVersionsSubcommand,
     addSubcommand,
+    uploadSubcommand,
     removeSubcommand,
     promoteSubcommand,
     restoreSubcommand,

--- a/packages/cli/src/commands/redirects/index.ts
+++ b/packages/cli/src/commands/redirects/index.ts
@@ -7,6 +7,7 @@ import { type Command, help } from '../help';
 import list from './list';
 import listVersions from './list-versions';
 import add from './add';
+import upload from './upload';
 import remove from './remove';
 import promote from './promote';
 import restore from './restore';
@@ -15,6 +16,7 @@ import {
   listSubcommand,
   listVersionsSubcommand,
   addSubcommand,
+  uploadSubcommand,
   removeSubcommand,
   promoteSubcommand,
   restoreSubcommand,
@@ -28,6 +30,7 @@ const COMMAND_CONFIG = {
   list: getCommandAliases(listSubcommand),
   'list-versions': getCommandAliases(listVersionsSubcommand),
   add: getCommandAliases(addSubcommand),
+  upload: getCommandAliases(uploadSubcommand),
   remove: getCommandAliases(removeSubcommand),
   promote: getCommandAliases(promoteSubcommand),
   restore: getCommandAliases(restoreSubcommand),
@@ -99,6 +102,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'upload':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('redirects', subcommandOriginal);
+        printHelp(uploadSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandUpload(subcommandOriginal);
+      return upload(client, args);
     case 'remove':
       if (needHelp) {
         telemetry.trackCliFlagHelp('redirects', subcommandOriginal);

--- a/packages/cli/src/commands/redirects/list.ts
+++ b/packages/cli/src/commands/redirects/list.ts
@@ -173,9 +173,9 @@ function formatRedirectsTable(
     destination: string;
     permanent?: boolean;
     statusCode?: number;
-    action?: '+' | '-';
+    action?: '+' | '-' | '~';
   }>,
-  actionSymbol?: '+' | '-'
+  actionSymbol?: '+' | '-' | '~'
 ) {
   const rows: string[][] = redirects.map(redirect => {
     const status = redirect.statusCode || (redirect.permanent ? 308 : 307);

--- a/packages/cli/src/commands/redirects/upload.ts
+++ b/packages/cli/src/commands/redirects/upload.ts
@@ -1,0 +1,308 @@
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+import chalk from 'chalk';
+import FormData from 'form-data';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { uploadSubcommand } from './command';
+import { parseSubcommandArgs, ensureProjectLink } from './shared';
+import stamp from '../../util/output/stamp';
+import getRedirectVersions from '../../util/redirects/get-redirect-versions';
+import updateRedirectVersion from '../../util/redirects/update-redirect-version';
+import getRedirects from '../../util/redirects/get-redirects';
+import formatTable from '../../util/format-table';
+import {
+  validateUploadFile,
+  validateRedirectsArray,
+  validateCSVStructure,
+  validateVersionName,
+} from './validate-redirects';
+
+interface UploadResult {
+  alias?: string;
+  version: {
+    id: string;
+    name?: string;
+    isStaging?: boolean;
+    isLive?: boolean;
+    redirectCount?: number;
+  };
+}
+
+/**
+ * Uploads bulk redirects from a CSV or JSON file to the current project.
+ */
+export default async function upload(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, uploadSubcommand);
+  if (typeof parsed === 'number') return parsed;
+
+  const link = await ensureProjectLink(client);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+
+  const { args, flags } = parsed;
+  const skipPrompts = flags['--yes'];
+  const overwrite = flags['--overwrite'] || false;
+
+  const filePath = args[0];
+
+  if (!filePath) {
+    output.error('File path is required. Use: vercel redirects upload <file>');
+    return 1;
+  }
+
+  const fileValidation = validateUploadFile(filePath);
+  if (!fileValidation.valid) {
+    output.error(fileValidation.error!);
+    return 1;
+  }
+
+  const { versions } = await getRedirectVersions(client, project.id, teamId);
+  const existingStagingVersion = versions.find(v => v.isStaging);
+
+  if (!skipPrompts) {
+    const fileName = basename(filePath);
+    const fileType = filePath.endsWith('.csv') ? 'CSV' : 'JSON';
+    const message = overwrite
+      ? `Upload ${fileType} file "${fileName}" and replace all existing redirects?`
+      : `Upload ${fileType} file "${fileName}"?`;
+
+    const confirmed = await client.input.confirm(message, true);
+    if (!confirmed) {
+      output.log('Upload cancelled');
+      return 0;
+    }
+  }
+
+  let versionName: string | undefined;
+  if (!skipPrompts) {
+    const provideName = await client.input.confirm(
+      'Do you want to provide a name for this version?',
+      false
+    );
+
+    if (provideName) {
+      versionName = await client.input.text({
+        message: 'Version name (max 256 characters):',
+        validate: val => {
+          if (val && val.length > 256) {
+            return 'Name must be 256 characters or less';
+          }
+          return true;
+        },
+      });
+      const { valid, error } = validateVersionName(versionName);
+      if (!valid) {
+        output.error(error!);
+        return 1;
+      }
+    }
+  }
+
+  const uploadStamp = stamp();
+  output.spinner('Uploading redirects');
+
+  try {
+    let result: UploadResult;
+    const url = '/v1/bulk-redirects';
+
+    if (filePath.endsWith('.csv')) {
+      const csvContent = readFileSync(filePath);
+      const fileName = basename(filePath);
+
+      const csvValidation = validateCSVStructure(csvContent.toString());
+      if (!csvValidation.valid) {
+        output.error(`Invalid CSV: ${csvValidation.error}`);
+        return 1;
+      }
+
+      const form = new FormData();
+      form.append('teamId', teamId || org.id);
+      form.append('projectId', project.id);
+      form.append('overwrite', String(overwrite));
+
+      if (versionName) {
+        form.append('name', versionName);
+      }
+
+      form.append('bulkRedirectsFile', csvContent, {
+        filename: fileName,
+        contentType: 'text/csv',
+      });
+
+      result = await client.fetch(url, {
+        method: 'PUT',
+        headers: form.getHeaders(),
+        body: form,
+      });
+    } else {
+      const content = readFileSync(filePath, 'utf8');
+      let redirects;
+
+      try {
+        redirects = JSON.parse(content);
+      } catch (err) {
+        output.error('Invalid JSON file format');
+        return 1;
+      }
+
+      const redirectsValidation = validateRedirectsArray(redirects);
+      if (!redirectsValidation.valid) {
+        output.error(redirectsValidation.error!);
+        return 1;
+      }
+
+      const body: Record<string, any> = {
+        projectId: project.id,
+        redirects,
+        overwrite,
+      };
+
+      if (teamId) {
+        body.teamId = teamId;
+      }
+
+      if (versionName) {
+        body.versionName = versionName;
+      }
+
+      result = await client.fetch(url, {
+        method: 'PUT',
+        body,
+      });
+    }
+
+    output.log(
+      `${chalk.cyan('✓')} Redirects uploaded ${chalk.gray(uploadStamp())}`
+    );
+
+    output.spinner('Fetching diff');
+
+    // Fetch the redirects with diff=only to show what was added
+    const { redirects } = await getRedirects(client, project.id, {
+      teamId,
+      versionId: result.version.id,
+      diff: 'only',
+    });
+
+    const redirectCount = redirects.length;
+    output.print(`\n  ${chalk.bold('Summary:')}\n`);
+    output.print(
+      `    Uploaded ${redirectCount} redirect${redirectCount === 1 ? '' : 's'}\n`
+    );
+
+    if (redirectCount > 0) {
+      const added = redirects.filter(r => r.action === '+');
+      const deleted = redirects.filter(r => r.action === '-');
+      const edited = redirects.filter(r => r.action === '~');
+
+      output.print(`\n  ${chalk.bold('Changes:')}\n`);
+
+      if (added.length > 0) {
+        output.print(`    ${chalk.green(`Added: ${added.length}`)}\n`);
+      }
+      if (deleted.length > 0) {
+        output.print(`    ${chalk.red(`Deleted: ${deleted.length}`)}\n`);
+      }
+      if (edited.length > 0) {
+        output.print(`    ${chalk.yellow(`Modified: ${edited.length}`)}\n`);
+      }
+
+      output.print(`\n  ${chalk.bold('Redirect changes:')}\n`);
+
+      const displayRedirects = redirects.slice(0, 100);
+      const rows: string[][] = displayRedirects.map(redirect => {
+        const status = redirect.statusCode || (redirect.permanent ? 308 : 307);
+        const action = redirect.action || '+';
+
+        let colorFn: (str: string) => string;
+        let actionSymbol: string;
+
+        switch (action) {
+          case '+':
+            colorFn = chalk.green;
+            actionSymbol = '+';
+            break;
+          case '-':
+            colorFn = chalk.red;
+            actionSymbol = '-';
+            break;
+          case '~':
+            colorFn = chalk.yellow;
+            actionSymbol = '~';
+            break;
+          default:
+            colorFn = (s: string) => s;
+            actionSymbol = ' ';
+        }
+
+        return [
+          colorFn(`${actionSymbol} ${redirect.source}`),
+          colorFn(redirect.destination),
+          colorFn(status.toString()),
+        ];
+      });
+
+      output.print(
+        formatTable(
+          ['Source', 'Destination', 'Status'],
+          ['l', 'l', 'l'],
+          [{ rows }]
+        )
+      );
+
+      if (redirectCount > 100) {
+        output.print(
+          `\n  ${chalk.gray(`... and ${redirectCount - 100} more redirect${redirectCount - 100 === 1 ? '' : 's'}`)}\n`
+        );
+      }
+    }
+
+    if (result.alias) {
+      const testUrl = `https://${result.alias}`;
+      output.print(
+        `\n  ${chalk.bold('Test your changes:')} ${chalk.cyan(testUrl)}\n`
+      );
+    }
+
+    const newVersionName = result.version.name || result.version.id;
+    output.print(
+      `  ${chalk.bold('New staging version:')} ${newVersionName}\n\n`
+    );
+
+    if (existingStagingVersion) {
+      output.warn(
+        `There are other staged changes. Please review all changes with ${chalk.cyan('vercel redirects list --staging')} before promoting to production.`
+      );
+    } else if (!skipPrompts) {
+      const shouldPromote = await client.input.confirm(
+        'This is the only staged change. Do you want to promote it to production now?',
+        false
+      );
+
+      if (shouldPromote) {
+        const promoteStamp = stamp();
+        output.spinner('Promoting to production');
+
+        await updateRedirectVersion(
+          client,
+          project.id,
+          result.version.id,
+          'promote',
+          teamId
+        );
+
+        output.log(
+          `${chalk.cyan('✓')} Version promoted to production ${chalk.gray(promoteStamp())}`
+        );
+      }
+    }
+
+    return 0;
+  } catch (error: any) {
+    output.error(`Failed to upload redirects: ${error.message}`);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/redirects/validate-redirects.ts
+++ b/packages/cli/src/commands/redirects/validate-redirects.ts
@@ -1,0 +1,164 @@
+import { statSync } from 'fs';
+
+interface ValidationOptions {
+  maxFileSize?: number;
+  allowedExtensions?: string[];
+}
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+const ALLOWED_EXTENSIONS = ['.csv', '.json'];
+const MAX_REDIRECTS = 1_000_000;
+const MAX_URL_LENGTH = 2048;
+const VALID_STATUS_CODES = [301, 302, 303, 307, 308];
+
+export function validateUploadFile(
+  filePath: string,
+  options: ValidationOptions = {}
+): ValidationResult {
+  const maxSize = options.maxFileSize ?? MAX_FILE_SIZE;
+  const allowedExts = options.allowedExtensions ?? ALLOWED_EXTENSIONS;
+
+  try {
+    const stats = statSync(filePath);
+
+    if (!stats.isFile()) {
+      return { valid: false, error: `Path "${filePath}" is not a file` };
+    }
+
+    if (stats.size > maxSize) {
+      const sizeMB = Math.round(maxSize / (1024 * 1024));
+      return { valid: false, error: `File must be below ${sizeMB}MB` };
+    }
+
+    const hasValidExtension = allowedExts.some(ext =>
+      filePath.toLowerCase().endsWith(ext)
+    );
+    if (!hasValidExtension) {
+      return {
+        valid: false,
+        error: `File must be a .csv or .json file`,
+      };
+    }
+
+    return { valid: true };
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return { valid: false, error: `File "${filePath}" not found` };
+    }
+    return { valid: false, error: `Error accessing file: ${err.message}` };
+  }
+}
+
+export function validateRedirect(redirect: {
+  source: string;
+  destination: string;
+  statusCode?: number;
+  permanent?: boolean;
+}): ValidationResult {
+  if (!redirect.source) {
+    return { valid: false, error: 'Redirect source is required' };
+  }
+
+  if (redirect.source.length > MAX_URL_LENGTH) {
+    return { valid: false, error: 'Source URL is too long' };
+  }
+
+  if (!redirect.destination) {
+    return { valid: false, error: 'Redirect destination is required' };
+  }
+
+  if (redirect.destination.length > MAX_URL_LENGTH) {
+    return { valid: false, error: 'Destination URL is too long' };
+  }
+
+  const isPath = redirect.destination.startsWith('/');
+  const isURL = /^https?:\/\//i.test(redirect.destination);
+  if (!isPath && !isURL) {
+    return {
+      valid: false,
+      error: 'Destination must be a path (/) or full URL (http://)',
+    };
+  }
+
+  if (redirect.statusCode) {
+    if (!VALID_STATUS_CODES.includes(redirect.statusCode)) {
+      return {
+        valid: false,
+        error: `Invalid status code. Must be one of: ${VALID_STATUS_CODES.join(', ')}`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+export function validateRedirectsArray(redirects: any[]): ValidationResult {
+  if (!Array.isArray(redirects)) {
+    return {
+      valid: false,
+      error: 'JSON file must contain an array of redirects',
+    };
+  }
+
+  if (redirects.length === 0) {
+    return { valid: false, error: 'No redirects provided' };
+  }
+
+  if (redirects.length > MAX_REDIRECTS) {
+    return {
+      valid: false,
+      error: `Too many redirects. Maximum allowed: ${MAX_REDIRECTS}`,
+    };
+  }
+
+  for (let i = 0; i < redirects.length; i++) {
+    const result = validateRedirect(redirects[i]);
+    if (!result.valid) {
+      return {
+        valid: false,
+        error: `Redirect ${i + 1}: ${result.error}`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+export function validateCSVStructure(content: string): ValidationResult {
+  const lines = content.trim().split('\n');
+
+  if (lines.length < 2) {
+    return {
+      valid: false,
+      error: 'CSV must have a header and at least one redirect',
+    };
+  }
+
+  const header = lines[0].toLowerCase();
+  const hasSource = header.includes('source');
+  const hasDestination = header.includes('destination');
+
+  if (!hasSource || !hasDestination) {
+    return {
+      valid: false,
+      error: 'CSV must have "source" and "destination" columns',
+    };
+  }
+
+  return { valid: true };
+}
+
+export function validateVersionName(name: string): ValidationResult {
+  if (!name) {
+    return { valid: false, error: 'Name is required' };
+  }
+  if (name.length > 256) {
+    return { valid: false, error: 'Name must be 256 characters or less' };
+  }
+  return { valid: true };
+}

--- a/packages/cli/src/commands/redirects/validate-redirects.ts
+++ b/packages/cli/src/commands/redirects/validate-redirects.ts
@@ -68,6 +68,10 @@ export function validateRedirect(redirect: {
     return { valid: false, error: 'Source URL is too long' };
   }
 
+  if (!redirect.source.startsWith('/')) {
+    return { valid: false, error: 'Source must be a relative path' };
+  }
+
   if (!redirect.destination) {
     return { valid: false, error: 'Redirect destination is required' };
   }
@@ -76,13 +80,10 @@ export function validateRedirect(redirect: {
     return { valid: false, error: 'Destination URL is too long' };
   }
 
-  const isPath = redirect.destination.startsWith('/');
-  const isURL = /^https?:\/\//i.test(redirect.destination);
-  if (!isPath && !isURL) {
-    return {
-      valid: false,
-      error: 'Destination must be a path (/) or full URL (http://)',
-    };
+  try {
+    new URL(redirect.destination, 'https://vercel.com');
+  } catch {
+    return { valid: false, error: 'Destination must be a valid URL' };
   }
 
   if (redirect.statusCode) {
@@ -97,7 +98,7 @@ export function validateRedirect(redirect: {
   return { valid: true };
 }
 
-export function validateRedirectsArray(redirects: any[]): ValidationResult {
+export function validateRedirectsArray(redirects: unknown): ValidationResult {
   if (!Array.isArray(redirects)) {
     return {
       valid: false,

--- a/packages/cli/src/util/redirects/get-redirects.ts
+++ b/packages/cli/src/util/redirects/get-redirects.ts
@@ -6,7 +6,7 @@ export interface Redirect {
   permanent?: boolean;
   statusCode?: number;
   caseSensitive?: boolean;
-  action?: '+' | '-';
+  action?: '+' | '-' | '~';
 }
 
 export interface RedirectsPagination {
@@ -26,7 +26,7 @@ export interface GetRedirectsOptions {
   page?: number;
   perPage?: number;
   versionId?: string;
-  diff?: boolean;
+  diff?: boolean | 'only';
 }
 
 export default async function getRedirects(
@@ -47,7 +47,7 @@ export default async function getRedirects(
   }
 
   if (diff) {
-    params.set('diff', 'true');
+    params.set('diff', diff === true ? 'true' : diff);
   } else {
     params.set('per_page', perPage.toString());
 

--- a/packages/cli/src/util/telemetry/commands/redirects/index.ts
+++ b/packages/cli/src/util/telemetry/commands/redirects/index.ts
@@ -27,6 +27,13 @@ export class RedirectsTelemetryClient
     });
   }
 
+  trackCliSubcommandUpload(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'upload',
+      value: actual,
+    });
+  }
+
   trackCliSubcommandRemove(actual: string) {
     this.trackCliSubcommand({
       subcommand: 'remove',

--- a/packages/cli/test/fixtures/unit/commands/redirects/sample.csv
+++ b/packages/cli/test/fixtures/unit/commands/redirects/sample.csv
@@ -1,0 +1,6 @@
+source,destination,statusCode,permanent
+/old-home,/,301,true
+/blog/old-post,/blog/new-post,301,true
+/api/v1/*,/api/v2/$1,308,true
+/temp-offer,https://example.com/offer,302,false
+/case-sensitive,/new-case,307,false

--- a/packages/cli/test/fixtures/unit/commands/redirects/sample.json
+++ b/packages/cli/test/fixtures/unit/commands/redirects/sample.json
@@ -1,0 +1,37 @@
+[
+  {
+    "source": "/old-home",
+    "destination": "/",
+    "statusCode": 301,
+    "caseSensitive": false,
+    "preserveQueryParams": false
+  },
+  {
+    "source": "/blog/old-post",
+    "destination": "/blog/new-post",
+    "statusCode": 301,
+    "caseSensitive": false,
+    "preserveQueryParams": true
+  },
+  {
+    "source": "/api/v1/*",
+    "destination": "/api/v2/$1",
+    "statusCode": 308,
+    "caseSensitive": true,
+    "preserveQueryParams": false
+  },
+  {
+    "source": "/temp-offer",
+    "destination": "https://example.com/offer",
+    "statusCode": 302,
+    "caseSensitive": false,
+    "preserveQueryParams": false
+  },
+  {
+    "source": "/case-sensitive",
+    "destination": "/new-case",
+    "statusCode": 307,
+    "caseSensitive": true,
+    "preserveQueryParams": false
+  }
+]

--- a/packages/cli/test/unit/commands/redirects/upload.test.ts
+++ b/packages/cli/test/unit/commands/redirects/upload.test.ts
@@ -1,0 +1,467 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import redirects from '../../../../src/commands/redirects';
+import { useUser } from '../../../mocks/user';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { join } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+
+describe('redirects upload', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    const { project } = useProject({
+      ...defaultProject,
+      id: 'redirects-test',
+      name: 'redirects-test',
+    });
+    client.scenario.get('/v9/projects/:projectNameOrId', (_req, res) => {
+      res.json(project);
+    });
+    const cwd = setupUnitFixture('commands/redirects');
+    client.cwd = cwd;
+
+    fixtureDir = join(cwd, 'fixtures');
+    mkdirSync(fixtureDir, { recursive: true });
+
+    client.scenario.get('/v1/bulk-redirects/versions', (_req, res) => {
+      res.json({ versions: [] });
+    });
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'redirects';
+      const subcommand = 'upload';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = redirects(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  describe('CSV upload', () => {
+    it('should upload redirects from CSV file', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination,statusCode
+/old-path,/new-path,301
+/another,/dest,302`;
+      writeFileSync(csvPath, csvContent);
+
+      client.scenario.put('/v1/bulk-redirects', (_req, res) => {
+        res.json({
+          alias: 'test-alias.vercel.app',
+          version: {
+            id: 'version-1',
+            name: 'Upload Version',
+          },
+          redirectsCount: 2,
+          count: 2,
+        });
+      });
+
+      client.scenario.get('/v1/bulk-redirects', (req, res) => {
+        const versionId = req.query.versionId;
+        const diff = req.query.diff;
+        if (versionId === 'version-1' && diff === 'only') {
+          res.json({
+            redirects: [
+              {
+                source: '/old-path',
+                destination: '/new-path',
+                statusCode: 301,
+                action: '+',
+              },
+              {
+                source: '/another',
+                destination: '/dest',
+                statusCode: 302,
+                action: '+',
+              },
+            ],
+          });
+        } else {
+          res.json({ redirects: [] });
+        }
+      });
+
+      client.setArgv('redirects', 'upload', csvPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Uploading redirects');
+      await expect(client.stderr).toOutput('Redirects uploaded');
+      await expect(client.stderr).toOutput('Uploaded 2 redirects');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should prompt for confirmation without --yes flag', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      mockPutRedirects({ redirectCount: 1 });
+
+      client.setArgv('redirects', 'upload', csvPath);
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Upload CSV file "test.csv"?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to provide a name for this version?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput('This is the only staged change');
+      client.stdin.write('n\n');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should handle upload cancellation', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      client.setArgv('redirects', 'upload', csvPath);
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Upload CSV file "test.csv"?');
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput('Upload cancelled');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should handle --overwrite flag', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      mockPutRedirects({ redirectCount: 1 });
+
+      client.setArgv('redirects', 'upload', csvPath, '--overwrite', '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Uploading redirects');
+      await expect(client.stderr).toOutput('Uploaded 1 redirect');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should prompt to promote if no existing staging version', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      mockPutRedirects({ redirectCount: 1 });
+
+      client.scenario.post('/v1/bulk-redirects/versions', (_req, res) => {
+        res.json({
+          version: {
+            id: 'version-1',
+            name: 'Upload Version',
+            isLive: true,
+          },
+        });
+      });
+
+      client.setArgv('redirects', 'upload', csvPath);
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Upload CSV file "test.csv"?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to provide a name for this version?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput('This is the only staged change');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Version promoted to production');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should warn about existing staging changes', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      client.scenario.get('/v1/bulk-redirects/versions', (_req, res) => {
+        res.json({
+          versions: [
+            {
+              id: 'existing-staging',
+              name: 'Existing Staging',
+              isStaging: true,
+              isLive: false,
+            },
+          ],
+        });
+      });
+
+      client.scenario.put('/v1/bulk-redirects', (_req, res) => {
+        res.json({
+          alias: 'test-alias.vercel.app',
+          version: {
+            id: 'version-2',
+            name: 'Upload Version',
+          },
+          redirectsCount: 1,
+          count: 1,
+        });
+      });
+
+      client.scenario.get('/v1/bulk-redirects', (req, res) => {
+        const versionId = req.query.versionId;
+        const diff = req.query.diff;
+        if (versionId === 'version-2' && diff === 'only') {
+          res.json({
+            redirects: [
+              {
+                source: '/path1',
+                destination: '/dest1',
+                statusCode: 301,
+                action: '+',
+              },
+            ],
+          });
+        } else {
+          res.json({ redirects: [] });
+        }
+      });
+
+      client.setArgv('redirects', 'upload', csvPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+  });
+
+  describe('JSON upload', () => {
+    it('should upload redirects from JSON file', async () => {
+      const jsonPath = join(fixtureDir, 'test.json');
+      const jsonContent = JSON.stringify([
+        { source: '/old', destination: '/new', statusCode: 301 },
+        { source: '/path', destination: '/dest', statusCode: 302 },
+      ]);
+      writeFileSync(jsonPath, jsonContent);
+
+      mockPutRedirects({ redirectCount: 2 });
+
+      client.setArgv('redirects', 'upload', jsonPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Uploading redirects');
+      await expect(client.stderr).toOutput('Uploaded 2 redirects');
+
+      await expect(exitCodePromise).resolves.toEqual(0);
+    });
+
+    it('should error on invalid JSON format', async () => {
+      const jsonPath = join(fixtureDir, 'invalid.json');
+      const jsonContent = `{ invalid json }`;
+      writeFileSync(jsonPath, jsonContent);
+
+      client.setArgv('redirects', 'upload', jsonPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Invalid JSON file format');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error if JSON is not an array', async () => {
+      const jsonPath = join(fixtureDir, 'object.json');
+      const jsonContent = JSON.stringify({
+        redirect: { source: '/old', destination: '/new' },
+      });
+      writeFileSync(jsonPath, jsonContent);
+
+      client.setArgv('redirects', 'upload', jsonPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'JSON file must contain an array of redirects'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+  });
+
+  describe('file validation', () => {
+    it('should error if file does not exist', async () => {
+      client.setArgv('redirects', 'upload', '/nonexistent.csv', '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('File "/nonexistent.csv" not found');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error if path is not a file', async () => {
+      client.setArgv('redirects', 'upload', fixtureDir, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        `Path "${fixtureDir}" is not a file`
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error on unsupported file extension', async () => {
+      const txtPath = join(fixtureDir, 'test.txt');
+      writeFileSync(txtPath, 'some content');
+
+      client.setArgv('redirects', 'upload', txtPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('File must be a .csv or .json file');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error if file exceeds size limit', async () => {
+      const largePath = join(fixtureDir, 'large.csv');
+      const largeContent = 'a'.repeat(51 * 1024 * 1024);
+      writeFileSync(largePath, largeContent);
+
+      client.setArgv('redirects', 'upload', largePath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('File must be below 50MB');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error if no file path provided', async () => {
+      client.setArgv('redirects', 'upload');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('File path is required');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+  });
+
+  describe('API error handling', () => {
+    it('should handle API error response', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      client.scenario.put('/v1/bulk-redirects', (_req, res) => {
+        res.status(400).json({
+          error: {
+            message: 'Invalid redirect configuration',
+          },
+        });
+      });
+
+      client.setArgv('redirects', 'upload', csvPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput('Invalid redirect configuration');
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should handle non-JSON error response', async () => {
+      const csvPath = join(fixtureDir, 'test.csv');
+      const csvContent = `source,destination
+/path1,/dest1`;
+      writeFileSync(csvPath, csvContent);
+
+      client.scenario.put('/v1/bulk-redirects', (_req, res) => {
+        res.status(500).end('Internal Server Error');
+      });
+
+      client.setArgv('redirects', 'upload', csvPath, '--yes');
+      const exitCodePromise = redirects(client);
+
+      await expect(client.stderr).toOutput(
+        'Failed to upload redirects: Response Error (500)'
+      );
+
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+  });
+
+  it('tracks subcommand invocation', async () => {
+    const csvPath = join(fixtureDir, 'test.csv');
+    const csvContent = `source,destination
+/old,/new`;
+    writeFileSync(csvPath, csvContent);
+
+    mockPutRedirects({ redirectCount: 1 });
+
+    client.setArgv('redirects', 'upload', csvPath, '--yes');
+    const exitCodePromise = redirects(client);
+
+    await expect(exitCodePromise).resolves.toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:upload',
+        value: 'upload',
+      },
+    ]);
+  });
+});
+
+function mockPutRedirects(options?: { redirectCount?: number }): void {
+  const count = options?.redirectCount ?? 1;
+  client.scenario.put('/v1/bulk-redirects', (_req, res) => {
+    res.json({
+      alias: 'test-alias.vercel.app',
+      version: {
+        id: 'version-1',
+        name: 'Upload Version',
+      },
+      redirectsCount: count,
+      count: count,
+    });
+  });
+
+  client.scenario.get('/v1/bulk-redirects', (req, res) => {
+    const versionId = req.query.versionId;
+    const diff = req.query.diff;
+    if (versionId === 'version-1' && diff === 'only') {
+      const redirects = [];
+      for (let i = 0; i < count; i++) {
+        redirects.push({
+          source: `/path${i}`,
+          destination: `/dest${i}`,
+          statusCode: 301,
+          action: '+',
+        });
+      }
+      res.json({ redirects });
+    } else {
+      res.json({ redirects: [] });
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       esbuild:
         specifier: 0.27.0
         version: 0.27.0
+      form-data:
+        specifier: ^4.0.0
+        version: 4.0.5
       jose:
         specifier: 5.9.6
         version: 5.9.6
@@ -9596,7 +9599,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
@@ -9643,7 +9646,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9690,7 +9693,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9737,7 +9740,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9813,7 +9816,7 @@ packages:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 5.1.8(@types/node@22.5.0)
+      vite: 5.1.8(@types/node@18.0.0)
     dev: true
 
   /@vitest/pretty-format@2.0.3:
@@ -10404,7 +10407,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -10754,7 +10756,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
 
   /call-bind@1.0.8:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
@@ -11145,7 +11146,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -11584,7 +11584,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -11747,7 +11746,6 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
@@ -11922,12 +11920,10 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-iterator-helpers@1.2.1:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
@@ -11963,7 +11959,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -11973,7 +11968,6 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    dev: true
 
   /es-shim-unscopables@1.1.0:
     resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
@@ -12461,7 +12455,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -12490,7 +12484,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.11.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12516,7 +12510,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.11.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12526,7 +12520,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12547,11 +12541,11 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12578,7 +12572,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12589,16 +12583,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13521,6 +13515,17 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: false
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -13621,7 +13626,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
@@ -13682,7 +13686,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
@@ -13711,7 +13714,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-stream@3.0.0:
     resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
@@ -13896,7 +13898,6 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /got@11.8.5:
     resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
@@ -13994,21 +13995,18 @@ packages:
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-    dev: true
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /hono@4.10.1:
     resolution: {integrity: sha512-rpGNOfacO4WEPClfkEt1yfl8cbu10uB1lNpiI33AKoiAHwOS8lV748JiLx4b5ozO/u4qLjIvfpFsPXdY5Qjkmg==}
@@ -15999,7 +15997,6 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}


### PR DESCRIPTION
This PR adds a `vc redirects upload` command to upload CSV or JSON files to Vercel. 

<img width="1063" height="400" alt="Screenshot 2025-12-11 at 10 33 05 AM" src="https://github.com/user-attachments/assets/95407814-be01-4784-99af-6f040bec5d08" />

The CLI will do some light sanity checks on the files in the client and then upload them to the server. If successful, it will then fetch the diff for the new redirects in that upload and display them to the user. Similar to the `add` command, it can then prompt the user to promote if it is the only set of staged redirects.