### PR TITLE
[cli] Adding Vercel CLI support for custom error pages

### DIFF
--- a/.changeset/brave-planets-glow.md
+++ b/.changeset/brave-planets-glow.md
@@ -1,0 +1,7 @@
+---
+'@vercel/client': patch
+'vercel': patch
+---
+
+Add support for `customErrorPage` configuration in `vercel.json` to customize pages for platform errors.
+

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -440,6 +440,26 @@ async function doBuild(
     throw validateError;
   }
 
+  if (localConfig.customErrorPage) {
+    const errorPages =
+      typeof localConfig.customErrorPage === 'string'
+        ? [localConfig.customErrorPage]
+        : Object.values(localConfig.customErrorPage);
+
+    for (const page of errorPages) {
+      if (page) {
+        const src = join(workPath, page);
+        if (!existsSync(src)) {
+          throw new NowBuildError({
+            code: 'CUSTOM_ERROR_PAGE_NOT_FOUND',
+            message: `The custom error page "${page}" was not found in "${workPath}".`,
+            link: 'https://vercel.com/docs/projects/project-configuration#custom-error-page',
+          });
+        }
+      }
+    }
+  }
+
   const projectSettings = {
     ...project.settings,
     ...pickOverrides(localConfig),

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -571,6 +571,21 @@ export default class DevServer {
 
     await this.validateVercelConfig(vercelConfig);
 
+    if (vercelConfig.customErrorPage) {
+      const errorPages =
+        typeof vercelConfig.customErrorPage === 'string'
+          ? [vercelConfig.customErrorPage]
+          : Object.values(vercelConfig.customErrorPage);
+
+      for (const page of errorPages) {
+        if (page && !fs.existsSync(join(this.cwd, page))) {
+          output.warn(
+            `The custom error page "${page}" was not found in "${this.cwd}". This will cause deployment to fail on Vercel.`
+          );
+        }
+      }
+    }
+
     this.projectSettings = {
       ...this.originalProjectSettings,
       ...pickOverrides(vercelConfig),

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -155,6 +155,26 @@ const cronsSchema = {
   },
 };
 
+const customErrorPageSchema = {
+  oneOf: [
+    { type: 'string', minLength: 1 },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        default5xx: {
+          type: 'string',
+          minLength: 1,
+        },
+        default4xx: {
+          type: 'string',
+          minLength: 1,
+        },
+      },
+    },
+  ],
+};
+
 const vercelConfigSchema = {
   type: 'object',
   // These are not all possibilities because `vc dev`
@@ -171,6 +191,7 @@ const vercelConfigSchema = {
     functions: functionsSchema,
     images: imagesSchema,
     crons: cronsSchema,
+    customErrorPage: customErrorPageSchema,
     bunVersion: { type: 'string' },
   },
 };

--- a/packages/cli/src/util/validate-config.ts
+++ b/packages/cli/src/util/validate-config.ts
@@ -161,6 +161,7 @@ const customErrorPageSchema = {
     {
       type: 'object',
       additionalProperties: false,
+      minProperties: 1,
       properties: {
         default5xx: {
           type: 'string',

--- a/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
@@ -1,3 +1,2 @@
 !.vercel
 .vercel
-.env*.local

--- a/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
@@ -1,2 +1,3 @@
 !.vercel
 .vercel
+.env*.local

--- a/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
+++ b/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
@@ -52,4 +52,12 @@ describe('validateConfig with customErrorPage', () => {
     // This usually matches the object schema and complains about additional properties
     expect(error?.message).toBeTruthy();
   });
+
+  it('should error with empty object customErrorPage', () => {
+    const config = {
+      customErrorPage: {},
+    };
+    const error = validateConfig(config);
+    expect(error).not.toBeNull();
+  });
 });

--- a/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
+++ b/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { validateConfig } from '../../../../src/util/validate-config';
+
+describe('validateConfig with customErrorPage', () => {
+  it('should not error with string customErrorPage', () => {
+    const config = {
+      customErrorPage: '_errors/error.html',
+    };
+    const error = validateConfig(config);
+    expect(error).toBeNull();
+  });
+
+  it('should not error with object customErrorPage', () => {
+    const config = {
+      customErrorPage: {
+        default5xx: '_errors/general-error.html',
+        default4xx: '_errors/not-found.html',
+      },
+    };
+    const error = validateConfig(config);
+    expect(error).toBeNull();
+  });
+
+  it('should not error with partial object customErrorPage', () => {
+    const config = {
+      customErrorPage: {
+        default5xx: '_errors/general-error.html',
+      },
+    };
+    const error = validateConfig(config);
+    expect(error).toBeNull();
+  });
+
+  it('should error with invalid type for customErrorPage', () => {
+    const config = {
+      // @ts-ignore
+      customErrorPage: 123,
+    };
+    const error = validateConfig(config);
+    expect(error).not.toBeNull();
+  });
+
+  it('should error with invalid properties in object customErrorPage', () => {
+    const config = {
+      customErrorPage: {
+        // @ts-ignore
+        foo: 'bar',
+      },
+    };
+    const error = validateConfig(config);
+    expect(error).not.toBeNull();
+    // This usually matches the object schema and complains about additional properties
+    expect(error?.message).toBeTruthy();
+  });
+});

--- a/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
+++ b/packages/cli/test/unit/util/dev/validate-custom-error-page.test.ts
@@ -33,9 +33,8 @@ describe('validateConfig with customErrorPage', () => {
 
   it('should error with invalid type for customErrorPage', () => {
     const config = {
-      // @ts-ignore
       customErrorPage: 123,
-    };
+    } as any;
     const error = validateConfig(config);
     expect(error).not.toBeNull();
   });
@@ -43,10 +42,9 @@ describe('validateConfig with customErrorPage', () => {
   it('should error with invalid properties in object customErrorPage', () => {
     const config = {
       customErrorPage: {
-        // @ts-ignore
         foo: 'bar',
       },
-    };
+    } as any;
     const error = validateConfig(config);
     expect(error).not.toBeNull();
     // This usually matches the object schema and complains about additional properties

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -164,6 +164,12 @@ export interface VercelConfig {
   images?: Images;
   crons?: Cron[];
   bunVersion?: string;
+  customErrorPage?:
+    | string
+    | {
+        default5xx?: string;
+        default4xx?: string;
+      };
 }
 
 export interface GitMetadata {
@@ -202,4 +208,10 @@ export interface DeploymentOptions {
   gitMetadata?: GitMetadata;
   autoAssignCustomDomains?: boolean;
   customEnvironmentSlugOrId?: string;
+  customErrorPage?:
+    | string
+    | {
+        default5xx?: string;
+        default4xx?: string;
+      };
 }


### PR DESCRIPTION
This PR adds CLI support for an upcoming feature on Vercel to customize pages for platform errors (e.g., 5xx errors from function timeouts).

Users can configure custom error pages in vercel.json:
```
{
  "customErrorPage": "_errors/error.html"
}
```
Or with separate pages for different error types:

```
{
  "customErrorPage": {
    "default5xx": "_errors/server-error.html",
    "default4xx": "_errors/not-found.html"
  }
}
```
