### PR TITLE
[python] uv workspaces fix - don't throw on missing `uv.lock`

### DIFF
--- a/.changeset/many-feet-divide.md
+++ b/.changeset/many-feet-divide.md
@@ -1,0 +1,5 @@
+---
+"@vercel/python": patch
+---
+
+[python] uv workspaces fix don't throw on missing `uv.lock`

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -69,6 +69,7 @@ export async function downloadFilesInWorkPath({
 
 export const build: BuildV3 = async ({
   workPath,
+  repoRootPath,
   files: originalFiles,
   entrypoint,
   meta = {},
@@ -303,6 +304,7 @@ export const build: BuildV3 = async ({
       workPath,
       entryDirectory,
       fsFiles,
+      repoRootPath,
       pythonPath: pythonVersion.pythonPath,
       pipPath: pythonVersion.pipPath,
       uvPath,

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -86,8 +86,6 @@ export async function runUvSync({
   locked: boolean;
 }) {
   // Use copy mode so installed dependencies are real files in the venv.
-  // This avoids broken symlinks in the Lambda bundle when uv links packages from
-  // its global cache directory.
   const args = ['sync', '--active', '--no-dev', '--link-mode', 'copy'];
   if (locked) {
     args.push('--locked');

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import fs from 'fs';
 import os from 'os';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import which from 'which';
 import {
   FileFsRef,
@@ -10,6 +10,7 @@ import {
   debug,
   glob,
   readConfigFile,
+  traverseUpDirectories,
 } from '@vercel/build-utils';
 import { getVenvPythonBin, runUvCommand, findDir } from './utils';
 
@@ -84,7 +85,10 @@ export async function runUvSync({
   projectDir: string;
   locked: boolean;
 }) {
-  const args = ['sync', '--active', '--no-dev'];
+  // Use copy mode so installed dependencies are real files in the venv.
+  // This avoids broken symlinks in the Lambda bundle when uv links packages from
+  // its global cache directory.
+  const args = ['sync', '--active', '--no-dev', '--link-mode', 'copy'];
   if (locked) {
     args.push('--locked');
   }
@@ -269,6 +273,7 @@ interface EnsureUvProjectParams {
   workPath: string;
   entryDirectory: string;
   fsFiles: Record<string, any>;
+  repoRootPath?: string;
   pythonPath: string;
   pipPath: string;
   uvPath: string;
@@ -363,10 +368,31 @@ async function filterMissingRuntimeDependencies({
   });
 }
 
+function findUvLockUpwards(
+  startDir: string,
+  repoRootPath?: string
+): string | null {
+  // In uv workspaces, `uv.lock` is typically written at the workspace root, not
+  // necessarily next to the member project being synced. When Vercel builds from
+  // a subdirectory (rootDirectory), we still want to honor that workspace lock.
+  const start = resolve(startDir);
+  const base = repoRootPath ? resolve(repoRootPath) : undefined;
+
+  for (const dir of traverseUpDirectories({ start, base })) {
+    const lockPath = join(dir, 'uv.lock');
+    const pyprojectPath = join(dir, 'pyproject.toml');
+    if (fs.existsSync(lockPath) && fs.existsSync(pyprojectPath)) {
+      return lockPath;
+    }
+  }
+  return null;
+}
+
 export async function ensureUvProject({
   workPath,
   entryDirectory,
   fsFiles,
+  repoRootPath,
   pythonPath,
   pipPath,
   uvPath,
@@ -383,6 +409,7 @@ export async function ensureUvProject({
 
   let projectDir: string;
   let pyprojectPath: string;
+  let lockPath: string | null = null;
 
   if (manifestType === 'uv.lock') {
     if (!manifestPath) {
@@ -395,6 +422,7 @@ export async function ensureUvProject({
         `Expected "pyproject.toml" next to "uv.lock" in "${projectDir}"`
       );
     }
+    lockPath = manifestPath;
     console.log('Installing required dependencies from uv.lock...');
   } else if (manifestType === 'pyproject.toml') {
     if (!manifestPath) {
@@ -405,8 +433,14 @@ export async function ensureUvProject({
     projectDir = dirname(manifestPath);
     pyprojectPath = manifestPath;
     console.log('Installing required dependencies from pyproject.toml...');
-    const lockPath = join(projectDir, 'uv.lock');
-    if (!fs.existsSync(lockPath)) {
+
+    // If a workspace-root uv.lock exists (common in monorepos), use it as-is.
+    const workspaceLock = findUvLockUpwards(projectDir, repoRootPath);
+    if (workspaceLock) {
+      lockPath = workspaceLock;
+    } else {
+      // Otherwise, generate a lock. In uv workspaces, this may still write
+      // the lockfile at the workspace root, not necessarily in projectDir.
       await uvLock({ projectDir, uvPath });
     }
   } else if (manifestType === 'Pipfile.lock' || manifestType === 'Pipfile') {
@@ -493,14 +527,15 @@ export async function ensureUvProject({
     }
   }
 
-  const lockPath = join(projectDir, 'uv.lock');
-  if (!fs.existsSync(lockPath)) {
-    throw new Error(
-      `Expected "uv.lock" to exist in "${projectDir}" after preparing uv project`
-    );
-  }
+  // Re-resolve lockfile in case earlier operations (uv add/lock) wrote it at a
+  // workspace root directory rather than `projectDir`.
+  const resolvedLockPath =
+    lockPath && fs.existsSync(lockPath)
+      ? lockPath
+      : findUvLockUpwards(projectDir, repoRootPath) ||
+        join(projectDir, 'uv.lock');
 
-  return { projectDir, pyprojectPath, lockPath };
+  return { projectDir, pyprojectPath, lockPath: resolvedLockPath };
 }
 
 async function getGlobalScriptsDir(pythonPath: string): Promise<string | null> {


### PR DESCRIPTION
If you have a project with multiple `pyproject.toml` using uv workspaces and the `uv.lock` file is at the repo root instead of the app root, it currently throws the following error:
```
vc build
Vercel CLI 50.0.0
WARN! Build not running on Vercel. System environment variables will not be available.
Using Python 3.12 from pyproject.toml
Using uv at "/opt/homebrew/bin/uv"
Installing required dependencies from pyproject.toml...
Error: Expected "uv.lock" to exist in "/Users/ricardo/Documents/code/scratchpad/turbo-with-python-uv/apps/python-app2" after preparing uv project
```

This PR resolves the lockfile even if it is at the repo root or outside the project root