### PR TITLE
[next]: fix clobbering of dynamic route data

### DIFF
--- a/.changeset/sour-poems-develop.md
+++ b/.changeset/sour-poems-develop.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+fix route info from being overwritten in dynamic routes

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -597,6 +597,7 @@ export async function getDynamicRoutes({
                 !prefetchDataRoute);
 
             routes.push({
+              ...route,
               src: route.src.replace(
                 new RegExp(escapeStringRegexp('(?:/)?$')),
                 // Now than the upstream issues has been resolved, we can safely

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/package.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "next": "15.6.0-canary.60",
+    "next": "canary",
     "react": "latest",
     "react-dom": "latest"
   }

--- a/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
+++ b/packages/next/test/fixtures/00-app-dir-no-ppr/vercel.json
@@ -123,6 +123,15 @@
       "mustContain": "nested app router catch-all"
     },
     {
+      "path": "/nested/blog-fallback-false/non-existent",
+      "status": 200,
+      "mustContain": ":",
+      "headers": {
+        "rsc": 1,
+        "next-router-prefetch": 1
+      }
+    },
+    {
       "path": "/dynamic-index/hello/index",
       "status": 200,
       "mustContain": "dynamic-index"


### PR DESCRIPTION
`00-app-dir-no-ppr` in newer versions of Next.js was catching a logic bug in the builder that omitted important details on the `route` when reconstructing it. I removed the failing assertion in https://github.com/vercel/vercel/pull/14465 just so we can get tests running again.

In this case, when client segment cache is enabled, RSC requests to `fallback: false` pages like `/nested/blog-fallback-false/non-existent` in the test app match the dummy RSC output (`{}`) rather than the correct RSC route instead of falling through to the app router catch-all. 

I unpinned `00-app-dir-no-ppr` since there's no reason for this test app to be pinned to an older version of Next.js. 