### PR TITLE
docs: add missing-build-script error documentation

### DIFF
--- a/errors/missing-build-script.md
+++ b/errors/missing-build-script.md
@@ -1,0 +1,46 @@
+# Missing Build Script
+
+#### Why This Error Occurred
+
+Your project's `package.json` file is missing a `build` script in the `scripts` property. Vercel requires this script to know how to build your application for production deployment.
+
+When running `vercel dev`, the CLI validates that your project is properly configured for deployment, which includes having a build script defined.
+
+#### Possible Ways to Fix It
+
+Add a `build` script to the `scripts` property in your `package.json` file. The exact command depends on your framework:
+
+**For Next.js:**
+```json
+{
+  "scripts": {
+    "build": "next build"
+  }
+}
+```
+
+**For React (Create React App):**
+```json
+{
+  "scripts": {
+    "build": "react-scripts build"
+  }
+}
+```
+
+**For Vite:**
+```json
+{
+  "scripts": {
+    "build": "vite build"
+  }
+}
+```
+
+**For other frameworks:**
+Refer to your framework's documentation for the appropriate build command.
+
+#### Additional Resources
+
+- [Vercel Build Configuration](https://vercel.com/docs/deployments/configure-a-build)
+- [Project Configuration](https://vercel.com/docs/projects/project-configuration)


### PR DESCRIPTION
## Description

Fixes #14406

This PR adds the missing documentation for the `missing-build-script` error that is referenced by the Vercel CLI when a project's `package.json` is missing a build script.

## What was the issue?

When running `vercel dev` on a project without a build script, the CLI shows this error:

```
Error: Your `package.json` file is missing a `build` property inside the `scripts` property.
Learn More: https://vercel.link/missing-build-script
```

However, the link `https://vercel.link/missing-build-script` was pointing to a generic errors page that didn't contain relevant information about this specific error, resulting in a poor developer experience.

## What does this PR do?

This PR creates the `errors/missing-build-script.md` documentation file that:

- Explains why the error occurred
- Provides clear solutions for common frameworks (Next.js, React/CRA, Vite)
- Includes example `package.json` configurations
- Links to additional Vercel documentation resources

## Testing

- Created the documentation file following the same format as other error docs in the `/errors` directory
- Verified the file has no syntax errors
- Confirmed this matches the pattern used by other error documentation files

## Type of change

- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Follows the existing documentation format
- [x] Provides clear and actionable solutions
- [x] References the issue it fixes
