### PR TITLE
[next]: prevents duplicated require statements for the same wasm file

### DIFF
--- a/packages/next/src/edge-function-source/get-edge-function-source.ts
+++ b/packages/next/src/edge-function-source/get-edge-function-source.ts
@@ -67,7 +67,12 @@ export async function getNextjsEdgeFunctionSource(
 
 function getWasmImportStatements(wasm: { name: string }[] = []) {
   return wasm
-    .filter(({ name }) => name.startsWith('wasm_'))
+    .filter(
+      ({ name }, index, self) =>
+        name.startsWith('wasm_') &&
+        // Prevents duplicated require statements for the same wasm file.
+        self.findIndex(t => t.name === name) === index
+    )
     .map(({ name }) => {
       const pathname = `/wasm/${name}.wasm`;
       return `const ${name} = require(${JSON.stringify(pathname)});`;


### PR DESCRIPTION
fixes https://github.com/kane50613/takumi/issues/332

## Description

When a wasm module is imported with `?module` query, the build generates duplicate entries with the same `name` but different `filePath`, resulting in duplicate wasm import declaration after `vercel build`.

## Steps

```ts
// route.ts
// @ts-expect-error
import module from "../../../node_modules/@takumi-rs/wasm/pkg/takumi_wasm_bg.wasm?module";
```

After `next build`, this is what resulted in `.next/server/middleware-manifest.json` **with the same wasm `name` but points to different `filePath`**.

```json
{
  "wasm": [
    {
      "name": "wasm_247a844fe6294404",
      "filePath": "server/edge/assets/takumi_wasm_bg.4dbd1754.wasm"
    },
    {
      "name": "wasm_247a844fe6294404",
      "filePath": "server/edge/chunks/node_modules_@takumi-rs_wasm_pkg_takumi_wasm_bg_23ace1ce.wasm"
    }
  ]
}
```

After `vercel build`

```js
// .vercel/output/functions/api/foo.func/index.js

  const wasm_247a844fe6294404 = require("/wasm/wasm_247a844fe6294404.wasm");
const wasm_247a844fe6294404 = require("/wasm/wasm_247a844fe6294404.wasm");
  globalThis._ENTRIES = {};
  ```
  
  ---
I'm not exactly sure does this fixes the root cause or not, but still dedup has to be implemented on code-gen side as well.