### PR TITLE
[CICD-DX] Fix JSON formatting in env values to prevent double-escaping

### DIFF
--- a/.changeset/shy-ways-hunt.md
+++ b/.changeset/shy-ways-hunt.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Bugfix: handle json values with newlines when pulling environment variables

--- a/packages/cli/src/util/env/format-env-value.ts
+++ b/packages/cli/src/util/env/format-env-value.ts
@@ -1,17 +1,18 @@
 export function formatEnvValue(value: string | undefined): string {
   if (value == null) return '';
 
-  // JSON objects/arrays are self-delimiting, safe to leave unquoted
-  // Skip if value contains newlines (would span multiple lines in .env file)
-  if (!/[\r\n]/.test(value)) {
-    try {
-      const parsed = JSON.parse(value);
-      if (typeof parsed === 'object' && parsed !== null) {
-        return value;
-      }
-    } catch {
-      // Not valid JSON, continue with normal formatting
+  // Check if value is a valid JSON object/array
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === 'object' && parsed !== null) {
+      // JSON objects/arrays are self-delimiting, so we just need to
+      // escape newlines (to keep .env file line-based) without quoting
+      // or escaping inner quotes. This prevents double-escaping when
+      // bundlers inline values during build.
+      return value.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
     }
+  } catch {
+    // Not valid JSON, continue with normal formatting
   }
 
   const needsQuotes =

--- a/packages/cli/test/unit/util/env/format-env-value.test.ts
+++ b/packages/cli/test/unit/util/env/format-env-value.test.ts
@@ -75,9 +75,10 @@ describe('formatEnvValue', () => {
       expect(formatEnvValue('{}')).toBe('{}');
     });
 
-    it('still escapes JSON with literal newlines', () => {
+    it('escapes newlines in multiline JSON without quoting (self-delimiting)', () => {
       const json = '{\n  "key": "value"\n}';
-      expect(formatEnvValue(json)).toBe('"{\\n  \\"key\\": \\"value\\"\\n}"');
+      // JSON is self-delimiting, so just escape newlines without outer quotes
+      expect(formatEnvValue(json)).toBe('{\\n  "key": "value"\\n}');
     });
 
     it('does not treat JSON primitives as objects (string)', () => {
@@ -168,9 +169,10 @@ describe('formatEnvValue', () => {
       );
     });
 
-    it('handles multiline JSON', () => {
+    it('handles multiline JSON (escapes newlines but not quotes)', () => {
       const json = '{\n  "key": "value"\n}';
-      expect(formatEnvValue(json)).toBe('"{\\n  \\"key\\": \\"value\\"\\n}"');
+      // Inner quotes are NOT escaped to prevent bundlers from double-escaping during build inlining
+      expect(formatEnvValue(json)).toBe('"{\\n  "key": "value"\\n}"');
     });
 
     it('handles private key format (has spaces, so quoted)', () => {

--- a/packages/cli/test/unit/util/env/format-env-value.test.ts
+++ b/packages/cli/test/unit/util/env/format-env-value.test.ts
@@ -172,7 +172,7 @@ describe('formatEnvValue', () => {
     it('handles multiline JSON (escapes newlines but not quotes)', () => {
       const json = '{\n  "key": "value"\n}';
       // Inner quotes are NOT escaped to prevent bundlers from double-escaping during build inlining
-      expect(formatEnvValue(json)).toBe('"{\\n  "key": "value"\\n}"');
+      expect(formatEnvValue(json)).toBe('{\\n  "key": "value"\\n}');
     });
 
     it('handles private key format (has spaces, so quoted)', () => {


### PR DESCRIPTION
Update `formatEnvVariable` to handle JSON formatted witih newlines



fixes https://linear.app/vercel/issue/CICD-1725/parsing-json-env-vars-oror-00883392