### PR TITLE
[go] Reuse go mod cache and go cache on project rebuild.

### DIFF
--- a/.changeset/popular-kings-learn.md
+++ b/.changeset/popular-kings-learn.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': minor
+---
+
+Use GOMODCACHE and GOCACHE to speed up rebuilding Go projects

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -460,12 +460,12 @@ exports.build = ({ files, workPath }) => {
 };
 ```
 
-### `getWritableDirectory()`
+### `getWriteableDirectory()`
 
-Signature: `getWritableDirectory(): String`
+Signature: `getWriteableDirectory(): String`
 
 ```typescript
-import { getWritableDirectory } from '@vercel/build-utils';
+import { getWriteableDirectory } from '@vercel/build-utils';
 ```
 
 In some occasions, you might want to write to a temporary directory.

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -460,12 +460,12 @@ exports.build = ({ files, workPath }) => {
 };
 ```
 
-### `getWriteableDirectory()`
+### `getWritableDirectory()`
 
-Signature: `getWriteableDirectory(): String`
+Signature: `getWritableDirectory(): String`
 
 ```typescript
-import { getWriteableDirectory } from '@vercel/build-utils';
+import { getWritableDirectory } from '@vercel/build-utils';
 ```
 
 In some occasions, you might want to write to a temporary directory.

--- a/README.md
+++ b/README.md
@@ -162,10 +162,13 @@ Sometimes you want to test changes to a Builder against an existing project, may
 
 1. Change directory to the desired Builder `cd ./packages/node`
 2. Run `pnpm build` to compile typescript and other build steps
-3. Run `npm pack` to create a tarball file
-4. Run `vercel *.tgz` to upload the tarball file and get a URL
-5. Edit any existing `vercel.json` project and replace `use` with the URL
-6. Run `vercel` or `vercel dev` to deploy with the experimental Builder
+3. Run `npm pack` to create a tarball file. It is imporant to not use `pnpm pack` because it will not preserve the file permissions
+4. Move the resulting tarball to a directory
+5. Run `vercel <directory>` to upload the tarball file and get a URL. Remember to append `/<tarball name>` to then end of your URL
+6. Edit any existing `vercel.json` project and replace `use` with the URL
+7. Run `vercel` or `vercel dev` to deploy with the experimental Builder
+
+**Note:** You will need to turn off vercel authentication in settings -> deployment protection so the builder can be downloaded
 
 ## Reference
 

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -279,23 +279,51 @@ export async function createGo({
   }
 
   const setGoEnv = async (goDir: string | null) => {
-    if (platform !== 'win32' && goDir === goGlobalCacheDir) {
+    if (!goDir) {
+      env.GOROOT = undefined;
+      env.PATH = PATH;
+      return;
+    }
+
+    const isUnix = platform !== 'win32';
+
+    const setEnvPaths = (modCache: string, buildCache: string) => {
+      env.GOMODCACHE = modCache;
+      env.GOCACHE = buildCache;
+      debug(`Set GOMODCACHE to ${env.GOMODCACHE}`);
+      debug(`Set GOCACHE to ${env.GOCACHE}`);
+    };
+
+    if (isUnix && goDir === goGlobalCacheDir) {
+      // Using global cache → link it to goCacheDir
       debug(`Symlinking ${goDir} -> ${goCacheDir}`);
       await remove(goCacheDir);
       await mkdirp(dirname(goCacheDir));
       await symlink(goDir, goCacheDir);
-      env.GOMODCACHE = join(goDir, 'pkg', 'mod');
+
+      const modCache = join(goDir, 'pkg', 'mod');
+      const buildCache = join(goDir, 'go-build');
+      setEnvPaths(modCache, buildCache);
+
       goDir = goCacheDir;
-    } else if (platform !== 'win32' && goDir === goCacheDir) {
-      const tmpGoModCacheBase = await getWriteableDirectory();
-      const tmpGoModCache = join(tmpGoModCacheBase, 'pkg');
-      await mkdirp(join(goDir, 'pkg', 'mod'));
-      await symlink(join(goCacheDir, 'pkg', 'mod'), tmpGoModCache);
-      env.GOMODCACHE = tmpGoModCache;
-      debug(`Set GOMODCACHE to ${env.GOMODCACHE}`);
+    } else if (isUnix && goDir === goCacheDir) {
+      // Using local cache → link temp writable directories
+      const tmpBase = await getWriteableDirectory();
+      const tmpModCache = join(tmpBase, 'pkg');
+      const tmpBuildCache = join(tmpBase, '.cache');
+
+      await Promise.all([
+        mkdirp(join(goDir, 'pkg', 'mod')),
+        mkdirp(join(goDir, '.cache', 'go-build')),
+        symlink(join(goCacheDir, 'pkg', 'mod'), tmpModCache),
+        symlink(join(goCacheDir, '.cache', 'go-build'), tmpBuildCache),
+      ]);
+
+      setEnvPaths(tmpModCache, tmpBuildCache);
     }
-    env.GOROOT = goDir || undefined;
-    env.PATH = goDir ? `${join(goDir, 'bin')}${delimiter}${PATH}` : PATH;
+
+    env.GOROOT = goDir;
+    env.PATH = `${join(goDir, 'bin')}${delimiter}${PATH}`;
   };
 
   // try each of these Go directories looking for the version we need

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -286,7 +286,7 @@ export async function createGo({
       await symlink(goDir, goCacheDir);
       env.GOMODCACHE = join(goDir, 'pkg', 'mod');
       goDir = goCacheDir;
-    } else if (goDir === goCacheDir) {
+    } else if (platform !== 'win32' && goDir === goCacheDir) {
       const tmpGoModCacheBase = await getWriteableDirectory();
       const tmpGoModCache = join(tmpGoModCacheBase, 'pkg');
       await mkdirp(join(goDir, 'pkg', 'mod'));


### PR DESCRIPTION
## Problem

It seems that each time I run `vercel` from my golang project it redownloads and recompiles all the modules needed to build my app, plus the wrapper's modules. This slows down deployments.

## Solution

This change refactors the `setGoEnv` function, which configures Go-related environment variables and symlinks for different build environments. It now ensures that Go’s module and build caches (`GOMODCACHE` and `GOCACHE`) are properly set up depending on whether the system is using a global cache or a writable local cache directory. 