### PR TITLE
fix(cli): remove content-encoding header in extension proxy

### DIFF
--- a/.changeset/shaggy-hairs-provide.md
+++ b/.changeset/shaggy-hairs-provide.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove `content-encoding` response header for CLI extensions proxy

--- a/packages/cli/src/util/extension/exec.ts
+++ b/packages/cli/src/util/extension/exec.ts
@@ -77,6 +77,7 @@ export async function execExtension(
       },
     });
     exitCode = result.exitCode;
+    debug(`extension command exited with code ${exitCode}`);
   } catch (err: unknown) {
     error(
       `Vercel CLI extension ${JSON.stringify(extensionCommand)} failed:\n${errorToString(err)}`

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -25,7 +25,15 @@ export function createProxy(client: Client): Server {
         json: false,
       });
       res.statusCode = fetchRes.status;
-      mergeIntoServerResponse(toOutgoingHeaders(fetchRes.headers), res);
+
+      const outgoingHeaders = toOutgoingHeaders(fetchRes.headers);
+
+      // Remove content-encoding header because fetch() automatically decompresses
+      // the response body but retains the header, which would cause the downstream
+      // client to attempt decompression on an already-decompressed stream
+      delete outgoingHeaders['content-encoding'];
+
+      mergeIntoServerResponse(outgoingHeaders, res);
       fetchRes.body.pipe(res);
     } catch (err: unknown) {
       output.prettyError(err);

--- a/packages/cli/src/util/extension/proxy.ts
+++ b/packages/cli/src/util/extension/proxy.ts
@@ -32,6 +32,7 @@ export function createProxy(client: Client): Server {
       // the response body but retains the header, which would cause the downstream
       // client to attempt decompression on an already-decompressed stream
       delete outgoingHeaders['content-encoding'];
+      delete outgoingHeaders['content-length'];
 
       mergeIntoServerResponse(outgoingHeaders, res);
       fetchRes.body.pipe(res);


### PR DESCRIPTION
The `fetch()` API automatically decompresses gzipped response bodies but
retains the `content-encoding` header. This caused downstream clients to
attempt decompression again on an already-decompressed stream.

Now properly delete the `content-encoding` header to prevent double
decompression.