### PR TITLE
Allow `vercel.json` function configuration on output function paths

### DIFF
--- a/.changeset/blue-dingos-grin.md
+++ b/.changeset/blue-dingos-grin.md
@@ -1,0 +1,5 @@
+---
+'@vercel/fs-detectors': minor
+---
+
+Remove "unused_function" check when collecting Builders list

--- a/.changeset/great-kids-perform.md
+++ b/.changeset/great-kids-perform.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Allow `vercel.json` function configuration on output function paths

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -411,6 +411,7 @@ async function writeBuildResultV3(args: {
  * If the filename does not have a file extension then one attempts to be inferred
  * from the extension of the `fsPath`.
  *
+ * @param outputDir The path of the `.vercel/output` directory
  * @param file The `File` instance to write
  * @param path The URL path where the `File` can be accessed from
  * @param overrides Record of override configuration when a File is renamed or has other metadata
@@ -473,7 +474,7 @@ async function writeStaticFile(
  * the filesystem at a different location with an identical configuration,
  * then create a symlink to the previous location instead of copying the files again.
  *
- * @param outputPath The path of the `.vercel/output` directory
+ * @param outputDir The path of the `.vercel/output` directory
  * @param dest The path of destination function's `.func` directory
  * @param fn The Lambda or EdgeFunction instance to create the symlink for
  * @param functionConfiguration The function configuration for this instance
@@ -510,7 +511,7 @@ async function writeFunctionSymlink(
 /**
  * Serializes the `EdgeFunction` instance to the file system.
  *
- * @param outputPath The path of the `.vercel/output` directory
+ * @param outputDir The path of the `.vercel/output` directory
  * @param edgeFunction The `EdgeFunction` instance
  * @param path The URL path where the `EdgeFunction` can be accessed from
  * @param functionConfiguration (optional) Extra configuration to apply to the function
@@ -578,7 +579,7 @@ async function writeEdgeFunction(
 /**
  * Writes the file references from the `Lambda` instance to the file system.
  *
- * @param outputPath The path of the `.vercel/output` directory
+ * @param outputDir The path of the `.vercel/output` directory
  * @param lambda The `Lambda` instance
  * @param path The URL path where the `Lambda` can be accessed from
  * @param functionConfiguration (optional) Extra configuration to apply to the function's `.vc-config.json` file

--- a/packages/cli/src/util/build/write-build-result.ts
+++ b/packages/cli/src/util/build/write-build-result.ts
@@ -9,6 +9,7 @@ import {
   resolve,
   posix,
 } from 'path';
+import deepEqual from 'fast-deep-equal';
 import {
   type Builder,
   type BuildResultV2,
@@ -54,6 +55,14 @@ interface FunctionConfiguration {
   maxDuration?: number;
   experimentalTriggers?: TriggerEvent[];
   supportsCancellation?: boolean;
+}
+
+/**
+ * Tracks a written function along with its configuration.
+ */
+interface ExistingFunctionEntry {
+  config: FunctionConfiguration | undefined;
+  path: string;
 }
 
 export async function writeBuildResult(args: {
@@ -176,18 +185,25 @@ async function writeBuildResultV2(args: {
     );
   }
 
-  const existingFunctions = new Map<Lambda | EdgeFunction, string>();
+  const existingFunctions = new Map<
+    Lambda | EdgeFunction,
+    ExistingFunctionEntry[]
+  >();
   const overrides: Record<string, PathOverride> = {};
 
   for (const [path, output] of Object.entries(buildResult.output)) {
     const normalizedPath = stripDuplicateSlashes(path);
     if (isLambda(output)) {
+      const functionConfiguration = await getLambdaOptionsFromFunction({
+        sourceFile: normalizedPath,
+        config: vercelConfig ?? undefined,
+      });
       await writeLambda(
         repoRootPath,
         outputDir,
         output,
         normalizedPath,
-        undefined,
+        functionConfiguration,
         existingFunctions,
         standalone
       );
@@ -260,11 +276,16 @@ async function writeBuildResultV2(args: {
         vercelConfig?.cleanUrls
       );
     } else if (isEdgeFunction(output)) {
+      const functionConfiguration = await getLambdaOptionsFromFunction({
+        sourceFile: normalizedPath,
+        config: vercelConfig ?? undefined,
+      });
       await writeEdgeFunction(
         repoRootPath,
         outputDir,
         output,
         normalizedPath,
+        functionConfiguration,
         existingFunctions,
         standalone
       );
@@ -374,6 +395,7 @@ async function writeBuildResultV3(args: {
       outputDir,
       output,
       path,
+      functionConfiguration,
       undefined,
       standalone
     );
@@ -448,27 +470,37 @@ async function writeStaticFile(
 
 /**
  * If the `fn` Lambda or Edge function has already been written to
- * the filesystem at a different location, then create a symlink
- * to the previous location instead of copying the files again.
+ * the filesystem at a different location with an identical configuration,
+ * then create a symlink to the previous location instead of copying the files again.
  *
  * @param outputPath The path of the `.vercel/output` directory
  * @param dest The path of destination function's `.func` directory
  * @param fn The Lambda or EdgeFunction instance to create the symlink for
+ * @param functionConfiguration The function configuration for this instance
  * @param existingFunctions Map of `Lambda`/`EdgeFunction` instances that have previously been written
  */
 async function writeFunctionSymlink(
   outputDir: string,
   dest: string,
   fn: Lambda | EdgeFunction,
-  existingFunctions: Map<Lambda | EdgeFunction, string>
+  functionConfiguration: FunctionConfiguration | undefined,
+  existingFunctions: Map<Lambda | EdgeFunction, ExistingFunctionEntry[]>
 ) {
-  const existingPath = existingFunctions.get(fn);
+  const entries = existingFunctions.get(fn);
 
   // Function has not been written to the filesystem, so bail
-  if (!existingPath) return false;
+  if (!entries) return false;
+
+  // Find an entry with a matching function configuration
+  const matchingEntry = entries.find(entry =>
+    deepEqual(entry.config, functionConfiguration)
+  );
+
+  // No matching configuration found, so bail
+  if (!matchingEntry) return false;
 
   const destDir = dirname(dest);
-  const targetDest = join(outputDir, 'functions', `${existingPath}.func`);
+  const targetDest = join(outputDir, 'functions', `${matchingEntry.path}.func`);
   const target = relative(destDir, targetDest);
   await fs.mkdirp(destDir);
   await fs.symlink(target, dest);
@@ -481,6 +513,7 @@ async function writeFunctionSymlink(
  * @param outputPath The path of the `.vercel/output` directory
  * @param edgeFunction The `EdgeFunction` instance
  * @param path The URL path where the `EdgeFunction` can be accessed from
+ * @param functionConfiguration (optional) Extra configuration to apply to the function
  * @param existingFunctions (optional) Map of `Lambda`/`EdgeFunction` instances that have previously been written
  */
 async function writeEdgeFunction(
@@ -488,7 +521,8 @@ async function writeEdgeFunction(
   outputDir: string,
   edgeFunction: EdgeFunction,
   path: string,
-  existingFunctions?: Map<Lambda | EdgeFunction, string>,
+  functionConfiguration?: FunctionConfiguration,
+  existingFunctions?: Map<Lambda | EdgeFunction, ExistingFunctionEntry[]>,
   standalone: boolean = false
 ) {
   const dest = join(outputDir, 'functions', `${path}.func`);
@@ -499,12 +533,15 @@ async function writeEdgeFunction(
         outputDir,
         dest,
         edgeFunction,
+        functionConfiguration,
         existingFunctions
       )
     ) {
       return;
     }
-    existingFunctions.set(edgeFunction, path);
+    const entries = existingFunctions.get(edgeFunction) ?? [];
+    entries.push({ config: functionConfiguration, path });
+    existingFunctions.set(edgeFunction, entries);
   }
 
   await fs.mkdirp(dest);
@@ -553,18 +590,26 @@ async function writeLambda(
   lambda: Lambda,
   path: string,
   functionConfiguration?: FunctionConfiguration,
-  existingFunctions?: Map<Lambda | EdgeFunction, string>,
+  existingFunctions?: Map<Lambda | EdgeFunction, ExistingFunctionEntry[]>,
   standalone: boolean = false
 ) {
   const dest = join(outputDir, 'functions', `${path}.func`);
 
   if (existingFunctions) {
     if (
-      await writeFunctionSymlink(outputDir, dest, lambda, existingFunctions)
+      await writeFunctionSymlink(
+        outputDir,
+        dest,
+        lambda,
+        functionConfiguration,
+        existingFunctions
+      )
     ) {
       return;
     }
-    existingFunctions.set(lambda, path);
+    const entries = existingFunctions.get(lambda) ?? [];
+    entries.push({ config: functionConfiguration, path });
+    existingFunctions.set(lambda, entries);
   }
 
   await fs.mkdirp(dest);

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -135,7 +135,7 @@ export async function detectBuilders(
   const sortedFiles = files.sort(sortFiles);
   const apiSortedFiles = files.sort(sortFilesBySegmentCount);
 
-  // Keep track of functions that are used
+  // Keep track of functions that are used by API builders
   const usedFunctions = new Set<string>();
 
   const addToUsedFunctions = (builder: Builder) => {
@@ -302,24 +302,6 @@ export async function detectBuilders(
         },
       };
     }
-  }
-
-  const unusedFunctionError = checkUnusedFunctions(
-    frontendBuilder,
-    usedFunctions,
-    options
-  );
-
-  if (unusedFunctionError) {
-    return {
-      builders: null,
-      errors: [unusedFunctionError],
-      warnings,
-      redirectRoutes: null,
-      defaultRoutes: null,
-      rewriteRoutes: null,
-      errorRoutes: null,
-    };
   }
 
   // Exclude the middleware builder for Next.js apps since @vercel/next
@@ -697,69 +679,6 @@ function validateFunctions({ functions = {} }: Options) {
           code: 'invalid_function_property',
           message: `The property \`excludeFiles\` must be a string.`,
         };
-      }
-    }
-  }
-
-  return null;
-}
-
-function checkUnusedFunctions(
-  frontendBuilder: Builder | null,
-  usedFunctions: Set<string>,
-  options: Options
-): ErrorResponse | null {
-  const unusedFunctions = new Set(
-    Object.keys(options.functions || {}).filter(key => !usedFunctions.has(key))
-  );
-
-  if (!unusedFunctions.size) {
-    return null;
-  }
-
-  // Next.js can use functions only for `src/pages` or `pages`
-  if (frontendBuilder && isOfficialRuntime('next', frontendBuilder.use)) {
-    for (const fnKey of unusedFunctions.values()) {
-      if (
-        fnKey.startsWith('pages/') ||
-        fnKey.startsWith('src/pages') ||
-        fnKey.startsWith('app/') ||
-        fnKey.startsWith('src/app/') ||
-        fnKey.startsWith('middleware') ||
-        fnKey.startsWith('src/middleware')
-      ) {
-        unusedFunctions.delete(fnKey);
-      } else {
-        return {
-          code: 'unused_function',
-          message: `The pattern "${fnKey}" defined in \`functions\` doesn't match any Serverless Functions.`,
-          action: 'Learn More',
-          link: 'https://vercel.link/unmatched-function-pattern',
-        };
-      }
-    }
-  }
-  if (
-    frontendBuilder &&
-    (isOfficialRuntime('express', frontendBuilder.use) ||
-      isOfficialRuntime('hono', frontendBuilder.use))
-  ) {
-    // Copied from builder entrypoint detection
-    const validFilenames = [
-      'app',
-      'index',
-      'server',
-      'src/app',
-      'src/index',
-      'src/server',
-    ];
-    const validExtensions = ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'];
-    const validEntrypoints = validFilenames.flatMap(filename =>
-      validExtensions.map(extension => `${filename}.${extension}`)
-    );
-    for (const fnKey of unusedFunctions.values()) {
-      if (validEntrypoints.includes(fnKey)) {
-        unusedFunctions.delete(fnKey);
       }
     }
   }

--- a/packages/fs-detectors/src/detect-builders.ts
+++ b/packages/fs-detectors/src/detect-builders.ts
@@ -764,17 +764,6 @@ function checkUnusedFunctions(
     }
   }
 
-  if (unusedFunctions.size) {
-    const [fnKey] = Array.from(unusedFunctions);
-
-    return {
-      code: 'unused_function',
-      message: `The pattern "${fnKey}" defined in \`functions\` doesn't match any Serverless Functions inside the \`api\` directory.`,
-      action: 'Learn More',
-      link: 'https://vercel.link/unmatched-function-pattern',
-    };
-  }
-
   return null;
 }
 

--- a/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
+++ b/packages/fs-detectors/test/unit.builds-and-routes-detector.test.ts
@@ -602,17 +602,6 @@ describe('Test `detectBuilders`', () => {
     expect(builders[0].use).toBe('vercel-php@0.1.0');
   });
 
-  it('use a custom runtime but without a source', async () => {
-    const functions = { 'api/user.php': { runtime: 'vercel-php@0.1.0' } };
-    const files = ['api/team.js'];
-    const { errors } = await invokeDetectBuilders(files, null, {
-      functions,
-    });
-
-    expect(errors.length).toBe(1);
-    expect(errors[0].code).toBe('unused_function');
-  });
-
   it('do not allow empty functions', async () => {
     const functions = { 'api/user.php': {} };
     const files = ['api/user.php'];
@@ -635,20 +624,6 @@ describe('Test `detectBuilders`', () => {
 
     expect(errors.length).toBe(1);
     expect(errors[0].code).toBe('invalid_function');
-  });
-
-  it('Do not allow functions that are not used by @vercel/next', async () => {
-    const pkg = {
-      scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' },
-    };
-    const functions = { 'test.js': { memory: 1024 } };
-    const files = ['pages/index.js', 'test.js'];
-
-    const { errors } = await invokeDetectBuilders(files, pkg, { functions });
-
-    expect(errors).toBeDefined();
-    expect(errors[0].code).toBe('unused_function');
   });
 
   it('Must include includeFiles config property', async () => {
@@ -873,26 +848,6 @@ describe('Test `detectBuilders`', () => {
     ]);
   });
 
-  it('Error for non-api functions', async () => {
-    const files = ['server/hello.ts', 'public/index.html'];
-    const functions = {
-      'server/**/*.ts': {
-        runtime: '@vercel/node@1.3.1',
-      },
-    };
-
-    const { errors } = await invokeDetectBuilders(files, null, { functions });
-
-    expect(errors).toEqual([
-      {
-        code: 'unused_function',
-        message: `The pattern "server/**/*.ts" defined in \`functions\` doesn't match any Serverless Functions inside the \`api\` directory.`,
-        action: 'Learn More',
-        link: 'https://vercel.link/unmatched-function-pattern',
-      },
-    ]);
-  });
-
   it('Works with fallback last', async () => {
     const files = ['api/simple.rs', 'api/complex.rs'];
     const functions = {
@@ -912,31 +867,6 @@ describe('Test `detectBuilders`', () => {
 
     // mostly asserting that this doesn't fail
     expect(builders).toHaveLength(2);
-  });
-
-  it('Errors with fallback first', async () => {
-    const files = ['api/simple.rs', 'api/complex.rs'];
-    const functions = {
-      'api/**/*.rs': {
-        runtime: 'ecklf-tmp-runtime-test@1.0.142',
-        maxDuration: 180,
-      },
-      'api/simple.rs': {
-        runtime: 'ecklf-tmp-runtime-test@1.0.142',
-        maxDuration: 120,
-      },
-    };
-
-    const { errors } = await invokeDetectBuilders(files, null, { functions });
-
-    expect(errors).toEqual([
-      {
-        code: 'unused_function',
-        message: `The pattern "api/simple.rs" defined in \`functions\` doesn't match any Serverless Functions inside the \`api\` directory.`,
-        action: 'Learn More',
-        link: 'https://vercel.link/unmatched-function-pattern',
-      },
-    ]);
   });
 
   it('All static if `buildCommand` is an empty string', async () => {
@@ -1966,18 +1896,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     expect(builders[0].use).toBe('vercel-php@0.1.0');
   });
 
-  it('use a custom runtime but without a source', async () => {
-    const functions = { 'api/user.php': { runtime: 'vercel-php@0.1.0' } };
-    const files = ['api/team.js'];
-    const { errors } = await invokeDetectBuilders(files, null, {
-      functions,
-      featHandleMiss,
-    });
-
-    expect(errors.length).toBe(1);
-    expect(errors[0].code).toBe('unused_function');
-  });
-
   it('do not allow empty functions', async () => {
     const functions = { 'api/user.php': {} };
     const files = ['api/user.php'];
@@ -2002,23 +1920,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
 
     expect(errors.length).toBe(1);
     expect(errors[0].code).toBe('invalid_function');
-  });
-
-  it('Do not allow functions that are not used by @vercel/next', async () => {
-    const pkg = {
-      scripts: { build: 'next build' },
-      dependencies: { next: '9.0.0' },
-    };
-    const functions = { 'test.js': { memory: 1024 } };
-    const files = ['pages/index.js', 'test.js'];
-
-    const { errors } = await invokeDetectBuilders(files, pkg, {
-      functions,
-      featHandleMiss,
-    });
-
-    expect(errors).toBeDefined();
-    expect(errors[0].code).toBe('unused_function');
   });
 
   it('Must include includeFiles config property', async () => {
@@ -2385,29 +2286,6 @@ describe('Test `detectBuilders` with `featHandleMiss=true`', () => {
     ]);
     expect(errorRoutes.length).toBe(1);
     expect((errorRoutes[0] as Source).status).toBe(404);
-  });
-
-  it('Error for non-api functions', async () => {
-    const files = ['server/hello.ts', 'public/index.html'];
-    const functions = {
-      'server/**/*.ts': {
-        runtime: '@vercel/node@1.3.1',
-      },
-    };
-
-    const { errors } = await invokeDetectBuilders(files, null, {
-      functions,
-      featHandleMiss,
-    });
-
-    expect(errors).toEqual([
-      {
-        code: 'unused_function',
-        message: `The pattern "server/**/*.ts" defined in \`functions\` doesn't match any Serverless Functions inside the \`api\` directory.`,
-        action: 'Learn More',
-        link: 'https://vercel.link/unmatched-function-pattern',
-      },
-    ]);
   });
 
   it('All static if `buildCommand` is an empty string', async () => {


### PR DESCRIPTION
Improve function deduplication by considering function configuration when creating symlinks.

### What changed?

- Enhanced the function deduplication logic to consider function configuration when determining if functions are identical
- Added tracking of function configuration alongside paths in the `existingFunctions` map
- Introduced a new `ExistingFunctionEntry` interface to store both config and path information
- Modified `writeFunctionSymlink` to only create symlinks when both the function and its configuration match
- Removed the warning for unused functions in the `checkUnusedFunctions` function
- Added function configuration retrieval for Lambda and Edge functions in the build result writing process

### How to test?

1. Create a project with multiple serverless functions that have identical code but different configurations
2. Run a build and verify that functions with different configurations are not deduplicated via symlinks
3. Verify that functions with identical code and configurations are still properly deduplicated

### Why make this change?

Previously, the system would deduplicate functions based solely on the function instance, creating symlinks even when functions had different configurations. This could lead to incorrect behavior since functions with different configurations (like memory size, timeout, etc.) should be treated as distinct entities even if their code is identical. This change ensures that only truly identical functions (same code and configuration) are deduplicated, maintaining the correct behavior for each function endpoint.