### PR TITLE
[ruby] Use bundler environment variables instead of flags.

### DIFF
--- a/.changeset/hip-months-search.md
+++ b/.changeset/hip-months-search.md
@@ -1,0 +1,5 @@
+---
+'@vercel/ruby': patch
+---
+
+Replace bundle install flags with environment variables.

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
-    "test": "echo 'Temporarily skipping ruby tests'",
+    "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --runInBand --bail",
     "test-e2e": "pnpm test",
     "type-check": "tsc --noEmit"
   },

--- a/packages/ruby/src/index.ts
+++ b/packages/ruby/src/index.ts
@@ -138,20 +138,15 @@ async function bundleInstall(
     BUNDLE_SILENCE_ROOT_WARNING: '1',
     BUNDLE_APP_CONFIG: bundleAppConfig,
     BUNDLE_JOBS: '4',
+    BUNDLE_DEPLOYMENT: 'true',
+    BUNDLE_PATH: bundleDir,
+    BUNDLE_FROZEN: 'true',
   });
 
-  debug('running "bundle install --deployment --frozen"');
+  debug('running "bundle install"');
   const installRes = await execa(
     bundlePath,
-    [
-      'install',
-      '--deployment',
-      '--frozen',
-      '--gemfile',
-      gemfilePath,
-      '--path',
-      bundleDir,
-    ],
+    ['install', '--gemfile', gemfilePath],
     {
       stdio: 'pipe',
       env: bundlerEnv,


### PR DESCRIPTION
## Problem

Bundler made breaking changes to their CLI in a recent update.

> In particular, the --clean, --deployment, --frozen, --no-prune, --path, --shebang, --system, --without, and --with options to bundle install.

This causes ruby builds to fail since we use some of these flags when performing a bundle install.

## Solution

Add the flags to the existing bundle environment variable list.

> This magic has been removed from Bundler 4, and you now explicitly need to configure it, either through environment variables, application configuration, or machine configuration. 