### PR TITLE
[cli] remove vercel_ts_config_enabled feature flag

### DIFF
--- a/.changeset/three-deers-doubt.md
+++ b/.changeset/three-deers-doubt.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Remove vercel.ts feature flag

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -409,7 +409,7 @@ async function doBuild(
 
   const sourceConfigFile = await findSourceVercelConfigFile(workPath);
   let corepackShimDir: string | null | undefined;
-  if (sourceConfigFile && process.env.VERCEL_TS_CONFIG_ENABLED) {
+  if (sourceConfigFile) {
     corepackShimDir = await initCorepack({ repoRootPath: cwd });
 
     const installCommand = project.settings.installCommand;

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -108,18 +108,6 @@ export async function compileVercelConfig(
     throw new ConflictingConfigFiles([vercelJsonPath, nowJsonPath]);
   }
 
-  // Only check for vercel.{ext} if feature flag is enabled
-  if (!process.env.VERCEL_TS_CONFIG_ENABLED) {
-    return {
-      configPath: hasVercelJson
-        ? vercelJsonPath
-        : hasNowJson
-          ? nowJsonPath
-          : null,
-      wasCompiled: false,
-    };
-  }
-
   const vercelConfigPath = await findVercelConfigFile(workPath);
   const vercelDir = join(workPath, VERCEL_DIR);
   const compiledConfigPath = join(vercelDir, 'vercel.json');

--- a/packages/cli/src/util/config/files.ts
+++ b/packages/cli/src/util/config/files.ts
@@ -144,7 +144,6 @@ export function readLocalConfig(
 
   // If reading from .vercel/vercel.json (compiled config), detect the source file
   const isCompiledConfig =
-    process.env.VERCEL_TS_CONFIG_ENABLED &&
     basename(target) === 'vercel.json' &&
     basename(dirname(target)) === PROJECT_VERCEL_DIR;
 

--- a/packages/cli/src/util/config/local-path.ts
+++ b/packages/cli/src/util/config/local-path.ts
@@ -29,14 +29,12 @@ export default function getLocalPathConfig(prefix: string) {
     throw new ConflictingConfigFiles([vercelConfigPath, nowConfigPath]);
   }
 
-  // If feature flag is enabled, check for compiled vercel.ts first
-  if (process.env.VERCEL_TS_CONFIG_ENABLED) {
-    const compiledConfigPath = path.join(prefix, VERCEL_DIR, 'vercel.json');
-    const compiledConfigExists = existsSync(compiledConfigPath);
+  // Check for compiled vercel.ts first
+  const compiledConfigPath = path.join(prefix, VERCEL_DIR, 'vercel.json');
+  const compiledConfigExists = existsSync(compiledConfigPath);
 
-    if (compiledConfigExists) {
-      return compiledConfigPath;
-    }
+  if (compiledConfigExists) {
+    return compiledConfigPath;
   }
 
   if (nowConfigExists) {

--- a/packages/cli/src/util/config/read-config.ts
+++ b/packages/cli/src/util/config/read-config.ts
@@ -7,25 +7,14 @@ import { compileVercelConfig } from '../compile-vercel-config';
 export default async function readConfig(dir: string) {
   let pkgFilePath: string;
 
-  if (process.env.VERCEL_TS_CONFIG_ENABLED) {
-    try {
-      const compileResult = await compileVercelConfig(dir);
-      pkgFilePath = compileResult.configPath || getLocalConfigPath(dir);
-    } catch (err) {
-      if (err instanceof Error) {
-        return err as any;
-      }
-      throw err;
+  try {
+    const compileResult = await compileVercelConfig(dir);
+    pkgFilePath = compileResult.configPath || getLocalConfigPath(dir);
+  } catch (err) {
+    if (err instanceof Error) {
+      return err as any;
     }
-  } else {
-    try {
-      pkgFilePath = getLocalConfigPath(dir);
-    } catch (err) {
-      if (err instanceof Error) {
-        return err as any;
-      }
-      throw err;
-    }
+    throw err;
   }
 
   const result = await readJSONFile<VercelConfig>(pkgFilePath);

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -10,11 +10,9 @@ describe('compileVercelConfig', () => {
 
   beforeEach(() => {
     tmpDir = getNewTmpDir();
-    process.env.VERCEL_TS_CONFIG_ENABLED = '1';
   });
 
   afterEach(async () => {
-    delete process.env.VERCEL_TS_CONFIG_ENABLED;
     await remove(tmpDir);
   });
 
@@ -57,16 +55,6 @@ describe('compileVercelConfig', () => {
         },
       ],
     });
-  });
-
-  it('should ignore vercel.ts if feature flag is disabled', async () => {
-    delete process.env.VERCEL_TS_CONFIG_ENABLED;
-    const vercelTsPath = join(tmpDir, 'vercel.ts');
-    await writeFile(vercelTsPath, 'export default {}');
-
-    const result = await compileVercelConfig(tmpDir);
-    expect(result.wasCompiled).toBe(false);
-    expect(result.configPath).toBe(null);
   });
 
   it('should throw error if both vercel.ts and vercel.json exist', async () => {


### PR DESCRIPTION
Removes the `VERCEL_TS_CONFIG_ENABLED` from the various parts of the CLI it's currently in. To prepare for launch and to fix any issues within the build container.