### PR TITLE
[cli] remove early compilation in get-config for vercel.ts projects

### DIFF
--- a/.changeset/nice-coats-approve.md
+++ b/.changeset/nice-coats-approve.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Run install command earlier for vercel.ts

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -12,8 +12,6 @@ import {
   getInstalledPackageVersion,
   normalizePath,
   NowBuildError,
-  runNpmInstall,
-  runCustomInstallCommand,
   type Reporter,
   Span,
   type TraceEvent,
@@ -84,10 +82,7 @@ import {
 import readJSONFile from '../../util/read-json-file';
 import { BuildTelemetryClient } from '../../util/telemetry/commands/build';
 import { validateConfig } from '../../util/validate-config';
-import {
-  compileVercelConfig,
-  findSourceVercelConfigFile,
-} from '../../util/compile-vercel-config';
+import { compileVercelConfig } from '../../util/compile-vercel-config';
 import { help } from '../help';
 import { pullCommandLogic } from '../pull';
 import { buildCommand } from './command';
@@ -407,36 +402,6 @@ async function doBuild(
 
   const workPath = join(cwd, project.settings.rootDirectory || '.');
 
-  const sourceConfigFile = await findSourceVercelConfigFile(workPath);
-  let corepackShimDir: string | null | undefined;
-  if (sourceConfigFile && process.env.VERCEL_TS_CONFIG_ENABLED) {
-    corepackShimDir = await initCorepack({ repoRootPath: cwd });
-
-    const installCommand = project.settings.installCommand;
-    if (typeof installCommand === 'string') {
-      if (installCommand.trim()) {
-        output.log(`Running install command before config compilation...`);
-        await runCustomInstallCommand({
-          destPath: workPath,
-          installCommand,
-          spawnOpts: { env: process.env },
-          projectCreatedAt: project.settings.createdAt,
-        });
-      } else {
-        output.debug('Skipping empty install command');
-      }
-    } else {
-      output.log(`Installing dependencies before config compilation...`);
-      await runNpmInstall(
-        workPath,
-        [],
-        { env: process.env },
-        undefined,
-        project.settings.createdAt
-      );
-    }
-  }
-
   const compileResult = await compileVercelConfig(workPath);
 
   const vercelConfigPath =
@@ -636,10 +601,7 @@ async function doBuild(
   const buildResults: Map<Builder, BuildResult | BuildOutputConfig> = new Map();
   const overrides: PathOverride[] = [];
   const repoRootPath = cwd;
-  // Only initialize corepack if not already done during early install
-  if (!corepackShimDir) {
-    corepackShimDir = await initCorepack({ repoRootPath });
-  }
+  const corepackShimDir = await initCorepack({ repoRootPath });
   const diagnostics: Files = {};
 
   for (const build of sortedBuilders) {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -12,6 +12,8 @@ import {
   getInstalledPackageVersion,
   normalizePath,
   NowBuildError,
+  runNpmInstall,
+  runCustomInstallCommand,
   type Reporter,
   Span,
   type TraceEvent,
@@ -82,7 +84,10 @@ import {
 import readJSONFile from '../../util/read-json-file';
 import { BuildTelemetryClient } from '../../util/telemetry/commands/build';
 import { validateConfig } from '../../util/validate-config';
-import { compileVercelConfig } from '../../util/compile-vercel-config';
+import {
+  compileVercelConfig,
+  findSourceVercelConfigFile,
+} from '../../util/compile-vercel-config';
 import { help } from '../help';
 import { pullCommandLogic } from '../pull';
 import { buildCommand } from './command';
@@ -402,6 +407,36 @@ async function doBuild(
 
   const workPath = join(cwd, project.settings.rootDirectory || '.');
 
+  const sourceConfigFile = await findSourceVercelConfigFile(workPath);
+  let corepackShimDir: string | null | undefined;
+  if (sourceConfigFile) {
+    corepackShimDir = await initCorepack({ repoRootPath: cwd });
+
+    const installCommand = project.settings.installCommand;
+    if (typeof installCommand === 'string') {
+      if (installCommand.trim()) {
+        output.log(`Running install command before config compilation...`);
+        await runCustomInstallCommand({
+          destPath: workPath,
+          installCommand,
+          spawnOpts: { env: process.env },
+          projectCreatedAt: project.settings.createdAt,
+        });
+      } else {
+        output.debug('Skipping empty install command');
+      }
+    } else {
+      output.log(`Installing dependencies before config compilation...`);
+      await runNpmInstall(
+        workPath,
+        [],
+        { env: process.env },
+        undefined,
+        project.settings.createdAt
+      );
+    }
+  }
+
   const compileResult = await compileVercelConfig(workPath);
 
   const vercelConfigPath =
@@ -601,7 +636,10 @@ async function doBuild(
   const buildResults: Map<Builder, BuildResult | BuildOutputConfig> = new Map();
   const overrides: PathOverride[] = [];
   const repoRootPath = cwd;
-  const corepackShimDir = await initCorepack({ repoRootPath });
+  // Only initialize corepack if not already done during early install
+  if (!corepackShimDir) {
+    corepackShimDir = await initCorepack({ repoRootPath });
+  }
   const diagnostics: Files = {};
 
   for (const build of sortedBuilders) {

--- a/packages/cli/src/util/get-config.ts
+++ b/packages/cli/src/util/get-config.ts
@@ -3,6 +3,7 @@ import { fileNameSymbol } from '@vercel/client';
 import {
   CantParseJSONFile,
   CantFindConfig,
+  ConflictingConfigFiles,
   WorkingDirectoryDoesNotExist,
 } from './errors-ts';
 import humanizePath from './humanize-path';
@@ -10,12 +11,6 @@ import readJSONFile from './read-json-file';
 import type { VercelConfig } from './dev/types';
 import { isErrnoException } from '@vercel/error-utils';
 import output from '../output-manager';
-import {
-  compileVercelConfig,
-  findSourceVercelConfigFile,
-} from './compile-vercel-config';
-import { runNpmInstall } from '@vercel/build-utils';
-import { initCorepack } from './build/corepack';
 
 let config: VercelConfig;
 
@@ -60,40 +55,32 @@ export default async function getConfig(
   const vercelFilePath = path.resolve(localPath, 'vercel.json');
   const nowFilePath = path.resolve(localPath, 'now.json');
 
-  // Then try with `vercel.ts`, `vercel.json` or `now.json` in the same directory
-  const sourceConfigFile = await findSourceVercelConfigFile(localPath);
-  if (sourceConfigFile) {
-    await initCorepack({ repoRootPath: localPath });
-    output.log(`Installing dependencies before config compilation...`);
-    await runNpmInstall(localPath, [], { env: process.env });
+  // Try with `vercel.json` or `now.json` in the same directory
+  // Note: vercel.ts compilation is handled by the build command
+  const [vercelConfig, nowConfig] = await Promise.all([
+    readJSONFile<VercelConfig>(vercelFilePath),
+    readJSONFile<VercelConfig>(nowFilePath),
+  ]);
+  if (vercelConfig instanceof CantParseJSONFile) {
+    return vercelConfig;
   }
-
-  let compileResult;
-  try {
-    compileResult = await compileVercelConfig(localPath);
-  } catch (err) {
-    if (err instanceof Error) {
-      return err;
-    }
-    throw err;
+  if (nowConfig instanceof CantParseJSONFile) {
+    return nowConfig;
   }
-
-  if (compileResult.configPath) {
-    const localConfig = await readJSONFile<VercelConfig>(
-      compileResult.configPath
-    );
-    if (localConfig instanceof CantParseJSONFile) {
-      return localConfig;
-    }
-    if (localConfig !== null) {
-      const fileName = path.basename(compileResult.configPath);
-      output.debug(`Found config in file "${compileResult.configPath}"`);
-      config = localConfig;
-      config[fileNameSymbol] = compileResult.wasCompiled
-        ? compileResult.sourceFile || 'vercel.ts'
-        : fileName;
-      return config;
-    }
+  if (vercelConfig && nowConfig) {
+    return new ConflictingConfigFiles([vercelFilePath, nowFilePath]);
+  }
+  if (vercelConfig !== null) {
+    output.debug(`Found config in file "${vercelFilePath}"`);
+    config = vercelConfig;
+    config[fileNameSymbol] = 'vercel.json';
+    return config;
+  }
+  if (nowConfig !== null) {
+    output.debug(`Found config in file "${nowFilePath}"`);
+    config = nowConfig;
+    config[fileNameSymbol] = 'now.json';
+    return config;
   }
 
   // If we couldn't find the config anywhere return error

--- a/packages/cli/src/util/get-config.ts
+++ b/packages/cli/src/util/get-config.ts
@@ -56,7 +56,6 @@ export default async function getConfig(
   const nowFilePath = path.resolve(localPath, 'now.json');
 
   // Try with `vercel.json` or `now.json` in the same directory
-  // Note: vercel.ts compilation is handled by the build command
   const [vercelConfig, nowConfig] = await Promise.all([
     readJSONFile<VercelConfig>(vercelFilePath),
     readJSONFile<VercelConfig>(nowFilePath),


### PR DESCRIPTION
- the reason we were compiling the vercel config in the first place was because we were reading vercel.json in that place (cli entrypoint)
- the only property extracted by this JSON parse–turned–TypeScript compilation was to extract the scope property, which is a pre-vc link behavior, not even in the schema anymore. super legacy
- so we can just skip it
- we now remove compilation at that step (get-config)
- verified non-monorepos work