### PR TITLE
[next] add pages router config json path for workflow

### DIFF
--- a/.changeset/fair-cougars-divide.md
+++ b/.changeset/fair-cougars-divide.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix experimentalTriggers not applying to Pages Router workflow routes

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1970,10 +1970,17 @@ export async function getPageLambdaGroups({
         ),
         pageExtensions,
       });
+      // For App Router, source file is like `step/route.js` so config is at `../config.json`
+      // For Pages Router, source file is like `step.js` so config is at `./config.json`
+      const isAppRouterRoute =
+        sourceFile.endsWith('/route.js') || sourceFile.endsWith('/route.ts');
+      const configRelativePath = isAppRouterRoute
+        ? '../config.json'
+        : './config.json';
       const config = JSON.parse(
         await fs
           .readFile(
-            path.join(entryPath, path.dirname(sourceFile), '../config.json'),
+            path.join(entryPath, path.dirname(sourceFile), configRelativePath),
             'utf8'
           )
           .catch(() => '{}')


### PR DESCRIPTION
Adds the correct path resolution for Pages Router config path needed for workflow routes on Vercel