### PR TITLE
[config] update to support respectOriginCacheControl

### DIFF
--- a/.changeset/wet-queens-brush.md
+++ b/.changeset/wet-queens-brush.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+update to support respectOriginCacheControl

--- a/packages/config/example/vercel.ts
+++ b/packages/config/example/vercel.ts
@@ -95,6 +95,13 @@ export const config: VercelConfig = {
     // Basic rewrite without transforms
     routes.rewrite('/app', 'https://backend.example.com/app'),
 
+    // External rewrite with caching disabled
+    // By default, external rewrites respect the origin's Cache-Control header
+    // Set respectOriginCacheControl: false to disable caching
+    routes.rewrite('/external/(.*)', 'https://external-api.example.com/$1', {
+      respectOriginCacheControl: false,
+    }),
+
     // Multiple transforms: headers and query parameters
     routes.rewrite(
       '/api/:version/(.*)',

--- a/packages/config/scripts/generate-types.ts
+++ b/packages/config/scripts/generate-types.ts
@@ -346,6 +346,7 @@ export interface Rewrite {
   destination: string;
   has?: Condition[];
   missing?: Condition[];
+  respectOriginCacheControl?: boolean;
 }
 
 /**

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -38,6 +38,41 @@ describe('Router', () => {
       });
     });
 
+    it('should add a rewrite rule with respectOriginCacheControl: false', () => {
+      const rewrite = router.rewrite(
+        '/external/(.*)',
+        'https://external-api.example.com/$1',
+        {
+          respectOriginCacheControl: false,
+        }
+      );
+      expect(rewrite).toEqual({
+        source: '/external/(.*)',
+        destination: 'https://external-api.example.com/$1',
+        respectOriginCacheControl: false,
+      });
+    });
+
+    it('should add a rewrite rule with respectOriginCacheControl: true', () => {
+      const rewrite = router.rewrite(
+        '/external/(.*)',
+        'https://external-api.example.com/$1',
+        {
+          respectOriginCacheControl: true,
+        }
+      );
+      expect(rewrite).toEqual({
+        source: '/external/(.*)',
+        destination: 'https://external-api.example.com/$1',
+        respectOriginCacheControl: true,
+      });
+    });
+
+    it('should not include respectOriginCacheControl when not specified', () => {
+      const rewrite = router.rewrite('/api/(.*)', '/legacy-api/$1');
+      expect(rewrite).not.toHaveProperty('respectOriginCacheControl');
+    });
+
     it('should return Rewrite type for simple rewrites', () => {
       const rewrite = router.rewrite('/api/(.*)', '/legacy-api/$1');
       expect(rewrite).toHaveProperty('source');
@@ -202,6 +237,25 @@ describe('Router', () => {
 
       expect(route.transforms[0].env).toEqual(['API_KEY']);
       expect(route.transforms[1].env).toEqual(['REGION']);
+    });
+
+    it('should include respectOriginCacheControl in route with transforms', () => {
+      const route = router.rewrite(
+        '/api/(.*)',
+        'https://backend.example.com/$1',
+        {
+          requestHeaders: {
+            authorization: deploymentEnv('API_KEY'),
+          },
+          respectOriginCacheControl: false,
+        }
+      );
+
+      expect(route).toMatchObject({
+        src: '/api/(.*)',
+        dest: 'https://backend.example.com/$1',
+        respectOriginCacheControl: false,
+      });
     });
 
     it('should not extract path params as env vars', () => {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -237,6 +237,7 @@ export interface Rewrite {
   destination: string;
   has?: Condition[];
   missing?: Condition[];
+  respectOriginCacheControl?: boolean;
 }
 
 /**


### PR DESCRIPTION
Support respectOriginCacheControl in the types and schemas within @vercel/config to disable external rewrite cache via `vercel.ts`