### PR TITLE
Update codeowners for config package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/related-projects               @vercel/ci-cd @Kikobeats @mknichel
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
-/packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10
+/packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
 
 # Unrestricted Paths
 # These paths are updated by the changeset CLI for "Version Packages" pull requests

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/related-projects               @vercel/ci-cd @Kikobeats @mknichel
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
-/packages/config                         @vercel/edge-ingress @vercel/edge-content @vercel/edge-security @pranavkarthik10
+/packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10
 
 # Unrestricted Paths
 # These paths are updated by the changeset CLI for "Version Packages" pull requests


### PR DESCRIPTION
Code owners for the config package have a few problems:

- Missing cicd (all others have it)
- Includes edge-content and edge-security

This PR updates the code owners to remove the extra teams, re-add cicd, and add myself specifically.

As a follow-up, we will need someone to add the `@vercel/edge-ingress` team as a collaborator on `vercel/vercel` so that that team can be recognized by GitHub.