### PR TITLE
[config] Merge computed Rewrite/Redirect types to Route if they are mixed with Route

### DIFF
--- a/packages/config/src/cli.test.ts
+++ b/packages/config/src/cli.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeConfig } from './cli';
+
+describe('normalizeConfig', () => {
+  it('should normalize rewrites array when it contains mixed Rewrite and Route formats', () => {
+    const config = {
+      rewrites: [
+        { source: '/simple', destination: '/dest' },
+        { src: '/complex', dest: '/dest', transforms: [] },
+      ],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.rewrites).toBeUndefined();
+    expect(result.routes).toEqual([
+      { src: '/simple', dest: '/dest' },
+      { src: '/complex', dest: '/dest', transforms: [] },
+    ]);
+  });
+
+  it('should leave pure Rewrite arrays unchanged', () => {
+    const config = {
+      rewrites: [
+        { source: '/a', destination: '/b' },
+        { source: '/c', destination: '/d' },
+      ],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.rewrites).toEqual(config.rewrites);
+    expect(result.routes).toBeUndefined();
+  });
+
+  it('should move pure Route arrays from rewrites to routes', () => {
+    const config = {
+      rewrites: [
+        { src: '/a', dest: '/b' },
+        { src: '/c', dest: '/d' },
+      ],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.rewrites).toBeUndefined();
+    expect(result.routes).toEqual([
+      { src: '/a', dest: '/b' },
+      { src: '/c', dest: '/d' },
+    ]);
+  });
+
+  it('should preserve has/missing/respectOriginCacheControl when converting rewrites', () => {
+    const config = {
+      rewrites: [
+        {
+          source: '/api/(.*)',
+          destination: '/backend/$1',
+          has: [{ type: 'header', key: 'X-Custom' }],
+          missing: [{ type: 'cookie', key: 'auth' }],
+          respectOriginCacheControl: false,
+        },
+        { src: '/other', dest: '/dest' },
+      ],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.routes).toEqual([
+      {
+        src: '/api/(.*)',
+        dest: '/backend/$1',
+        has: [{ type: 'header', key: 'X-Custom' }],
+        missing: [{ type: 'cookie', key: 'auth' }],
+        respectOriginCacheControl: false,
+      },
+      { src: '/other', dest: '/dest' },
+    ]);
+  });
+
+  it('should normalize redirects array when it contains mixed Redirect and Route formats', () => {
+    const config = {
+      redirects: [
+        { source: '/old', destination: '/new', permanent: true },
+        { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+      ],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.redirects).toBeUndefined();
+    expect(result.routes).toEqual([
+      { src: '/old', dest: '/new', redirect: true, status: 308 },
+      { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+    ]);
+  });
+
+  it('should not merge when routes and rewrites both exist explicitly', () => {
+    const config = {
+      routes: [{ src: '/a', dest: '/b' }],
+      rewrites: [{ source: '/c', destination: '/d' }],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.routes).toEqual([{ src: '/a', dest: '/b' }]);
+    expect(result.rewrites).toEqual([{ source: '/c', destination: '/d' }]);
+  });
+
+  it('should handle empty config', () => {
+    expect(normalizeConfig({})).toEqual({});
+  });
+
+  it('should handle empty arrays', () => {
+    const config = { rewrites: [], redirects: [] };
+    const result = normalizeConfig(config);
+
+    expect(result.rewrites).toEqual([]);
+    expect(result.redirects).toEqual([]);
+  });
+
+  it('should preserve other config fields during normalization', () => {
+    const config = {
+      framework: 'nextjs',
+      buildCommand: 'npm run build',
+      rewrites: [{ src: '/a', dest: '/b' }],
+    };
+
+    const result = normalizeConfig(config);
+
+    expect(result.framework).toBe('nextjs');
+    expect(result.buildCommand).toBe('npm run build');
+    expect(result.routes).toEqual([{ src: '/a', dest: '/b' }]);
+  });
+});

--- a/packages/config/src/cli.ts
+++ b/packages/config/src/cli.ts
@@ -140,11 +140,11 @@ async function configureRouter() {
     }
   }
 
+  // Merge: export const declarations take precedence over default export
   const config = {
     ...routerConfig,
     ...exportedConstants,
   };
-
   return normalizeConfig(config);
 }
 


### PR DESCRIPTION
@pbzona was testing vercel.ts and ran into a DX issue where computed rewrites with transforms correctly get turned into the Route type, but if one of them doesn’t have transforms it stays Rewrite, and you can’t mix both. See [Slack thread](https://vercel.slack.com/archives/C09SG01P39C/p1766440463591849) for a code snippet.

Technically this is expected behavior and these types are generated correctly, but it’s a DX issue because this is presumably a common use case that will burn people unnecessarily.

This PR:
- converts all rewrites to routes if they’re computed
- does not if routes and redirects/rewrites are both explicitly present (so it will still throw a schema validation error)

This should be fine because it’s following expected behavior for this pattern. But if we merge this we should add it to the docs too.
