### PR TITLE
[routing-utils] Undeprecate `routes`

### DIFF
--- a/.changeset/young-brooms-impress.md
+++ b/.changeset/young-brooms-impress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': minor
+---
+
+Undeprecate `routes`

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -350,7 +350,6 @@ const transformsSchema = {
  */
 export const routesSchema = {
   type: 'array',
-  deprecated: true,
   description:
     'A list of routes objects used to rewrite paths to point towards other internal or external paths',
   example: [{ dest: 'https://docs.example.com', src: '/docs' }],


### PR DESCRIPTION
`@vercel/config` makes heavy use of `routes` under the hood, and we've now seen a few instances of people needing to explicitly use `routes` when dynamically generating complex rewrites.

This property was deprecated some time ago, presumably because `redirects/rewrites` have similar functionality, but they are not equivalent. Given the increased usage of `routes`, I think we should no longer mark it deprecated.