### PR TITLE
[config] Undeprecate routes

### DIFF
--- a/.changeset/shiny-gifts-nail.md
+++ b/.changeset/shiny-gifts-nail.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': minor
+---
+
+Undeprecate `routes`

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -327,9 +327,13 @@ export interface Transform {
  */
 export interface Route {
   /** Pattern to match request paths using path-to-regexp syntax */
-  src: string;
+  src?: string;
+  /** Alias for `src`. A pattern that matches each incoming pathname (excluding querystring). */
+  source?: string;
   /** Optional destination for rewrite/redirect */
   dest?: string;
+  /** Alias for `dest`. An absolute pathname to an existing resource or an external URL. */
+  destination?: string;
   /** Array of HTTP methods to match. If not provided, matches all methods */
   methods?: string[];
   /** Array of transforms to apply */
@@ -342,6 +346,8 @@ export interface Route {
   redirect?: boolean;
   /** Status code for the response */
   status?: number;
+  /** Alias for `status`. An optional integer to override the status code of the response. */
+  statusCode?: number;
   /** Headers to set (alternative to using transforms) */
   headers?: Record<string, string>;
   /** Environment variables referenced in dest or transforms */
@@ -1098,11 +1104,15 @@ export class Router {
    *    });
    */
   public route(config: Route): this {
-    this.validateSourcePattern(config.src);
+    const src = config.src ?? config.source;
+    if (!src) {
+      throw new Error('Route must define either `src` or `source`.');
+    }
+    this.validateSourcePattern(src);
 
     // Auto-extract env vars from each transform if not already specified
     if (config.transforms) {
-      const pathParams = this.extractPathParams(config.src);
+      const pathParams = this.extractPathParams(src);
       for (const transform of config.transforms) {
         if (!transform.env && transform.args) {
           const envVars = extractEnvVars(transform.args, pathParams);

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -345,7 +345,6 @@ export interface VercelConfig {
   rewrites?: RouteType[];
   /**
    * A list of routes objects used to rewrite paths to point towards other internal or external paths
-   * @deprecated
    */
   routes?: RouteType[];
   /**


### PR DESCRIPTION
Follow-up to https://github.com/vercel/vercel/pull/14520 which removes the `@deprecated` tag from the `routes` property in `@vercel/config`.

<!-- VADE_RISK_START -->
> [!NOTE]
> Low Risk Change
>
> This PR removes the @deprecated tag from routes and adds optional alias properties (source, destination, statusCode) to the Route interface with proper validation ensuring either src or source must be defined.
> 
> - Removes @deprecated JSDoc tag from `routes` property in VercelConfig
> - Adds alias properties (source, destination, statusCode) to Route interface
> - Changes `src` from required to optional with validation requiring either `src` or `source`
>
> <sup>Risk assessment for [commit 17de9dc](https://github.com/vercel/vercel/commit/17de9dc9cf967094253bf929ac87e2f0fbfce1ec).</sup>
<!-- VADE_RISK_END -->