### PR TITLE
[config] Export Route type in types

### DIFF
--- a/.changeset/thin-tables-sparkle.md
+++ b/.changeset/thin-tables-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Export Route type

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -3,6 +3,8 @@
  * https://openapi.vercel.sh/vercel.json
  */
 
+import type { Route } from './router';
+
 export type Framework =
   | 'blitzjs'
   | 'nextjs'
@@ -254,9 +256,8 @@ export interface HeaderRule {
 /**
  * Union type for all router helper outputs
  * Can be simple schema objects (Redirect, Rewrite, HeaderRule) or Routes with transforms
- * Note: Route type is defined in router.ts (uses src/dest instead of source/destination)
  */
-export type RouteType = Redirect | Rewrite | HeaderRule | any; // Route is internal to router
+export type RouteType = Redirect | Rewrite | HeaderRule | Route;
 
 export interface WildcardDomain {
   domain: string;


### PR DESCRIPTION
The `Route` type was only surfaced internally in the router, but given that it follows the `routes` schema, we should really export it in the types.

Among other things, this will allow people to use [reference types](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) for type safety in vercel.ts instead of having to import the entire config package.