### PR TITLE
feat: add oidc token command to get token

### DIFF
--- a/.changeset/moody-plants-press.md
+++ b/.changeset/moody-plants-press.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add oidc token command for retrieving your OIDC token

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -24,6 +24,7 @@ import { logoutCommand } from './logout/command';
 import { logsCommand } from './logs/command';
 import { mcpCommand } from './mcp/command';
 import { microfrontendsCommand } from './microfrontends/command';
+import { oidcCommand } from './oidc/command';
 import { openCommand } from './open/command';
 import { projectCommand } from './project/command';
 import { promoteCommand } from './promote/command';
@@ -68,6 +69,7 @@ const commandsStructs = [
   logsCommand,
   mcpCommand,
   microfrontendsCommand,
+  oidcCommand,
   openCommand,
   projectCommand,
   promoteCommand,

--- a/packages/cli/src/commands/oidc/command.ts
+++ b/packages/cli/src/commands/oidc/command.ts
@@ -1,0 +1,53 @@
+import { packageName } from '../../util/pkg-name';
+
+export const tokenSubcommand = {
+  name: 'token',
+  aliases: [],
+  description: 'Get the OIDC token for a Vercel project',
+  arguments: [],
+  options: [
+    {
+      name: 'json',
+      description: 'Output as JSON with expiration time',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'project',
+      description: 'Project name or ID (defaults to linked project)',
+      shorthand: 'p',
+      argument: 'NAME_OR_ID',
+      type: String,
+      deprecated: false,
+    },
+  ],
+  examples: [
+    {
+      name: 'Get OIDC token for the linked project',
+      value: `${packageName} oidc token`,
+    },
+    {
+      name: 'Get OIDC token for a specific project',
+      value: `${packageName} oidc token --project my-app`,
+    },
+    {
+      name: 'Get OIDC token as JSON (includes expiration)',
+      value: `${packageName} oidc token --json`,
+    },
+    {
+      name: 'Use with environment variable',
+      value: `export VERCEL_OIDC_TOKEN=$(${packageName} oidc token)`,
+    },
+  ],
+} as const;
+
+export const oidcCommand = {
+  name: 'oidc',
+  aliases: [],
+  description: 'Manage OIDC tokens for Vercel projects',
+  arguments: [],
+  subcommands: [tokenSubcommand],
+  options: [],
+  examples: [],
+} as const;

--- a/packages/cli/src/commands/oidc/index.ts
+++ b/packages/cli/src/commands/oidc/index.ts
@@ -1,0 +1,70 @@
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import getInvalidSubcommand from '../../util/get-invalid-subcommand';
+import getSubcommand from '../../util/get-subcommand';
+import { printError } from '../../util/error';
+import { type Command, help } from '../help';
+import token from './token';
+import { oidcCommand, tokenSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { OidcTelemetryClient } from '../../util/telemetry/commands/oidc';
+import { getCommandAliases } from '..';
+
+const COMMAND_CONFIG = {
+  token: getCommandAliases(tokenSubcommand),
+};
+
+export default async function main(client: Client) {
+  const telemetry = new OidcTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(oidcCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification, {
+      permissive: true,
+    });
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const subArgs = parsedArgs.args.slice(1);
+  const { subcommand, args, subcommandOriginal } = getSubcommand(
+    subArgs,
+    COMMAND_CONFIG
+  );
+
+  const needHelp = parsedArgs.flags['--help'];
+
+  if (!subcommand && needHelp) {
+    telemetry.trackCliFlagHelp('oidc', subcommand);
+    output.print(help(oidcCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  function printHelp(command: Command) {
+    output.print(
+      help(command, { parent: oidcCommand, columns: client.stderr.columns })
+    );
+  }
+
+  switch (subcommand) {
+    case 'token':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('oidc', subcommandOriginal);
+        printHelp(tokenSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandToken(subcommandOriginal);
+      return token(client, args);
+    default:
+      output.error(getInvalidSubcommand(COMMAND_CONFIG));
+      output.print(help(oidcCommand, { columns: client.stderr.columns }));
+      return 2;
+  }
+}

--- a/packages/cli/src/commands/oidc/token.ts
+++ b/packages/cli/src/commands/oidc/token.ts
@@ -53,7 +53,7 @@ export default async function token(
   const projectFlag = opts['--project'];
 
   telemetryClient.trackCliFlagJson(jsonOutput);
-  telemetryClient.trackCliFlagProject(projectFlag);
+  telemetryClient.trackCliOptionProject(projectFlag);
 
   let projectId: string;
   let teamId: string | undefined;

--- a/packages/cli/src/commands/oidc/token.ts
+++ b/packages/cli/src/commands/oidc/token.ts
@@ -1,0 +1,131 @@
+import { decodeJwt } from 'jose';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import { getLinkedProject } from '../../util/projects/link';
+import getProjectByNameOrId from '../../util/projects/get-project-by-id-or-name';
+import { isAPIError, ProjectNotFound } from '../../util/errors-ts';
+import { tokenSubcommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import output from '../../output-manager';
+import { OidcTokenTelemetryClient } from '../../util/telemetry/commands/oidc/token';
+import { getCommandName } from '../../util/pkg-name';
+
+interface OidcTokenResponse {
+  token: string;
+}
+
+async function getOidcToken(
+  client: Client,
+  projectId: string,
+  teamId?: string
+): Promise<OidcTokenResponse> {
+  const params = new URLSearchParams({ source: 'vercel-cli:oidc:token' });
+  if (teamId) {
+    params.set('teamId', teamId);
+  }
+
+  const url = `/v1/projects/${encodeURIComponent(projectId)}/token?${params}`;
+  return client.fetch<OidcTokenResponse>(url, { method: 'POST' });
+}
+
+export default async function token(
+  client: Client,
+  argv: string[]
+): Promise<number> {
+  const telemetryClient = new OidcTokenTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(tokenSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { flags: opts } = parsedArgs;
+  const jsonOutput = opts['--json'];
+  const projectFlag = opts['--project'];
+
+  telemetryClient.trackCliFlagJson(jsonOutput);
+  telemetryClient.trackCliFlagProject(projectFlag);
+
+  let projectId: string;
+  let teamId: string | undefined;
+
+  // Resolve project from --project flag or linked project
+  if (projectFlag) {
+    // Use --project flag
+    const project = await getProjectByNameOrId(client, projectFlag);
+    if (project instanceof ProjectNotFound) {
+      output.error(`Project not found: ${projectFlag}`);
+      return 1;
+    }
+    projectId = project.id;
+    teamId = project.accountId;
+  } else {
+    // Fall back to linked project
+    const link = await getLinkedProject(client);
+    if (link.status === 'error') {
+      return link.exitCode;
+    }
+    if (link.status === 'not_linked') {
+      output.error(
+        `No project linked. Use --project flag or run ${getCommandName('link')} first.`
+      );
+      return 1;
+    }
+    projectId = link.project.id;
+    teamId = link.org.type === 'team' ? link.org.id : undefined;
+  }
+
+  // Fetch the OIDC token
+  let response: OidcTokenResponse;
+  try {
+    response = await getOidcToken(client, projectId, teamId);
+  } catch (err) {
+    if (isAPIError(err)) {
+      if (err.status === 403) {
+        output.error(
+          'OIDC is not enabled for this project. Enable it in your project settings.'
+        );
+        return 1;
+      }
+      output.error(`Failed to get OIDC token: ${err.message}`);
+      return 1;
+    }
+    throw err;
+  }
+
+  const { token: oidcToken } = response;
+
+  // Output the token
+  if (jsonOutput) {
+    // Decode JWT to get expiration
+    let expiresAt: string | undefined;
+    try {
+      const { exp } = decodeJwt(oidcToken);
+      if (exp !== undefined) {
+        expiresAt = new Date(exp * 1000).toISOString();
+      }
+    } catch {
+      // Token might not be a valid JWT, continue without expiration
+    }
+
+    const result = {
+      token: oidcToken,
+      ...(expiresAt && { expiresAt }),
+    };
+    client.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    // Plain output for piping
+    client.stdout.write(oidcToken + '\n');
+  }
+
+  return 0;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -711,6 +711,10 @@ const main = async () => {
           telemetry.trackCliCommandMicrofrontends(userSuppliedSubCommand);
           func = require('./commands/microfrontends').default;
           break;
+        case 'oidc':
+          telemetry.trackCliCommandOidc(userSuppliedSubCommand);
+          func = require('./commands/oidc').default;
+          break;
         case 'open':
           telemetry.trackCliCommandOpen(userSuppliedSubCommand);
           func = require('./commands/open').default;

--- a/packages/cli/src/util/telemetry/commands/oidc/index.ts
+++ b/packages/cli/src/util/telemetry/commands/oidc/index.ts
@@ -1,0 +1,15 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { oidcCommand } from '../../../../commands/oidc/command';
+
+export class OidcTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof oidcCommand>
+{
+  trackCliSubcommandToken(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'token',
+      value: actual,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/oidc/token.ts
+++ b/packages/cli/src/util/telemetry/commands/oidc/token.ts
@@ -12,9 +12,12 @@ export class OidcTokenTelemetryClient
     }
   }
 
-  trackCliFlagProject(project: string | undefined) {
+  trackCliOptionProject(project: string | undefined) {
     if (project) {
-      this.trackCliFlag('project');
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
     }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/oidc/token.ts
+++ b/packages/cli/src/util/telemetry/commands/oidc/token.ts
@@ -1,0 +1,20 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { tokenSubcommand } from '../../../../commands/oidc/command';
+
+export class OidcTokenTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof tokenSubcommand>
+{
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+
+  trackCliFlagProject(project: string | undefined) {
+    if (project) {
+      this.trackCliFlag('project');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -201,6 +201,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandOidc(actual: string) {
+    this.trackCliCommand({
+      command: 'oidc',
+      value: actual,
+    });
+  }
+
   trackCliCommandOpen(actual: string) {
     this.trackCliCommand({
       command: 'open',

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -41,6 +41,7 @@ describe('index', () => {
         ['mcp', 'mcp'],
         ['mf', 'microfrontends'],
         ['microfrontends', 'microfrontends'],
+        ['oidc', 'oidc'],
         ['open', 'open'],
         ['project', 'project'],
         ['projects', 'project'],


### PR DESCRIPTION
Command that returns the OIDC token to stdout. This is helpful to use the OIDC token to log in to services like Claude Code using AI Gateway.

Example using Claude Code where you set the apiKeyHelper to point to a team/project:
```json
{
  "apiKeyHelper": "vercel oidc token --scope <teamId> --project <projectId>"
}
```
Combined with `ANTHROPIC_BASE_URL="https://ai-gateway.vercel.sh"` and you no longer need to manually download an API key.
