### PR TITLE
[OIDC] Refresh the CLI Auth Token When Refreshing OIDC

### DIFF
--- a/.changeset/swift-rules-pull.md
+++ b/.changeset/swift-rules-pull.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': minor
+---
+
+Allow vercel/oidc to refresh the vercel CLI auth token when running locally

--- a/packages/oidc/src/auth-config.ts
+++ b/packages/oidc/src/auth-config.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getVercelDataDir } from './token-util';
+
+/**
+ * Auth configuration stored in ~/.../com.vercel.cli/auth.json
+ */
+export interface AuthConfig {
+  /** An `access_token` obtained using the OAuth Device Authorization flow. */
+  token?: string;
+  /** A `refresh_token` obtained using the OAuth Device Authorization flow. */
+  refreshToken?: string;
+  /**
+   * The absolute time (seconds) when the token expires.
+   * Used to optimistically check if the token is still valid.
+   */
+  expiresAt?: number;
+  /** Whether to skip writing this config to disk. */
+  skipWrite?: boolean;
+}
+
+/**
+ * Get the path to the auth config file
+ */
+function getAuthConfigPath(): string {
+  const dataDir = getVercelDataDir();
+  if (!dataDir) {
+    throw new Error(
+      `Unable to find Vercel CLI data directory. Your platform: ${process.platform}. Supported: darwin, linux, win32.`
+    );
+  }
+  return path.join(dataDir, 'auth.json');
+}
+
+/**
+ * Read the auth config from disk
+ * Returns null if the file doesn't exist or cannot be read
+ */
+export function readAuthConfig(): AuthConfig | null {
+  try {
+    const authPath = getAuthConfigPath();
+    if (!fs.existsSync(authPath)) {
+      return null;
+    }
+    const content = fs.readFileSync(authPath, 'utf8');
+    if (!content) {
+      return null;
+    }
+    return JSON.parse(content) as AuthConfig;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Write the auth config to disk with proper permissions
+ */
+export function writeAuthConfig(config: AuthConfig): void {
+  const authPath = getAuthConfigPath();
+  const authDir = path.dirname(authPath);
+
+  // Ensure directory exists with proper permissions
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { mode: 0o770, recursive: true });
+  }
+
+  // Write file with restrictive permissions (owner read/write only)
+  fs.writeFileSync(authPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+/**
+ * Check if an access token is valid (not expired)
+ * Copied from packages/cli/src/util/client.ts:72-81
+ */
+export function isValidAccessToken(authConfig: AuthConfig): boolean {
+  if (!authConfig.token) return false;
+
+  // When `--token` is passed to a command, `expiresAt` will be missing.
+  // We assume the token is valid in this case and handle errors further down.
+  if (typeof authConfig.expiresAt !== 'number') return true;
+
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  return authConfig.expiresAt >= nowInSeconds;
+}

--- a/packages/oidc/src/oauth.ts
+++ b/packages/oidc/src/oauth.ts
@@ -1,0 +1,102 @@
+import { hostname, platform, arch } from 'os';
+
+const VERCEL_ISSUER = 'https://vercel.com';
+const VERCEL_CLI_CLIENT_ID = 'cl_HYyOPBNtFMfHhaUn9L4QPfTZz6TP47bp';
+
+// Simplified user agent for OIDC package
+const userAgent = `@vercel/oidc node-${process.version} ${platform()} (${arch()}) ${hostname()}`;
+
+export interface TokenSet {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/**
+ * Cached authorization server metadata
+ */
+let _tokenEndpoint: string | null = null;
+
+/**
+ * Get the token endpoint from Vercel's OAuth discovery endpoint
+ */
+async function getTokenEndpoint(): Promise<string> {
+  if (_tokenEndpoint) {
+    return _tokenEndpoint;
+  }
+
+  const discoveryUrl = `${VERCEL_ISSUER}/.well-known/openid-configuration`;
+  const response = await fetch(discoveryUrl, {
+    headers: { 'user-agent': userAgent },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to discover OAuth endpoints');
+  }
+
+  const metadata = await response.json();
+  if (!metadata || typeof metadata.token_endpoint !== 'string') {
+    throw new Error('Invalid OAuth discovery response');
+  }
+
+  const endpoint = metadata.token_endpoint;
+  _tokenEndpoint = endpoint;
+  return endpoint;
+}
+
+/**
+ * Refresh an OAuth access token using a refresh token
+ */
+export async function refreshTokenRequest(options: {
+  refresh_token: string;
+}): Promise<Response> {
+  const tokenEndpoint = await getTokenEndpoint();
+
+  return await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'user-agent': userAgent,
+    },
+    body: new URLSearchParams({
+      client_id: VERCEL_CLI_CLIENT_ID,
+      grant_type: 'refresh_token',
+      ...options,
+    }),
+  });
+}
+
+/**
+ * Process the token response and extract the token set
+ */
+export async function processTokenResponse(
+  response: Response
+): Promise<[Error] | [null, TokenSet]> {
+  const json = await response.json();
+
+  if (!response.ok) {
+    const errorMsg =
+      typeof json === 'object' && json && 'error' in json
+        ? String(json.error)
+        : 'Token refresh failed';
+    return [new Error(errorMsg)];
+  }
+
+  // Validate response structure
+  if (typeof json !== 'object' || json === null) {
+    return [new Error('Invalid token response')];
+  }
+  if (typeof json.access_token !== 'string') {
+    return [new Error('Missing access_token in response')];
+  }
+  if (json.token_type !== 'Bearer') {
+    return [new Error('Invalid token_type in response')];
+  }
+  if (typeof json.expires_in !== 'number') {
+    return [new Error('Missing expires_in in response')];
+  }
+
+  return [null, json as TokenSet];
+}

--- a/packages/oidc/src/token-util.test.ts
+++ b/packages/oidc/src/token-util.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getVercelCliToken } from './token-util';
+import * as authConfig from './auth-config';
+import * as oauth from './oauth';
+
+vi.mock('fs');
+vi.mock('./token-io', () => ({
+  getUserDataDir: vi.fn(() => '/mock/user/data'),
+  findRootDir: vi.fn(() => '/mock/root'),
+}));
+
+describe('getVercelCliToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return token if valid and not expired', async () => {
+    const validToken = {
+      token: 'valid-access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600, // expires in 1 hour
+    };
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(validToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBe('valid-access-token');
+    expect(authConfig.writeAuthConfig).not.toHaveBeenCalled();
+  });
+
+  it('should return null if auth config does not exist', async () => {
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(null);
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBeNull();
+  });
+
+  it('should refresh token if expired and refresh token exists', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'valid-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
+    };
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'new-refresh-token',
+      }),
+    } as Response;
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockResolvedValue(mockResponse);
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBe('new-access-token');
+    expect(oauth.refreshTokenRequest).toHaveBeenCalledWith({
+      refresh_token: 'valid-refresh-token',
+    });
+    expect(authConfig.writeAuthConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresAt: expect.any(Number),
+      })
+    );
+  });
+
+  it('should clear auth and return null if token expired and no refresh token', async () => {
+    const expiredTokenNoRefresh = {
+      token: 'expired-access-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(
+      expiredTokenNoRefresh
+    );
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBeNull();
+    expect(authConfig.writeAuthConfig).toHaveBeenCalledWith({});
+  });
+
+  it('should clear auth if refresh fails with OAuth error', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'invalid-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    const mockErrorResponse = {
+      ok: false,
+      json: async () => ({
+        error: 'invalid_grant',
+        error_description: 'Refresh token expired',
+      }),
+    } as Response;
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockResolvedValue(mockErrorResponse);
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBeNull();
+    expect(authConfig.writeAuthConfig).toHaveBeenCalledWith({});
+  });
+
+  it('should clear auth if refresh fails with network error', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'valid-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockRejectedValue(
+      new Error('Network error')
+    );
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBeNull();
+    expect(authConfig.writeAuthConfig).toHaveBeenCalledWith({});
+  });
+
+  it('should treat token as valid if expiresAt is missing (--token case)', async () => {
+    const tokenWithoutExpiry = {
+      token: 'cli-provided-token',
+    };
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(tokenWithoutExpiry);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+
+    const token = await getVercelCliToken();
+
+    expect(token).toBe('cli-provided-token');
+    expect(authConfig.writeAuthConfig).not.toHaveBeenCalled();
+  });
+
+  it('should preserve new refresh token if provided in response', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'new-refresh-token',
+      }),
+    } as Response;
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockResolvedValue(mockResponse);
+
+    await getVercelCliToken();
+
+    expect(authConfig.writeAuthConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refreshToken: 'new-refresh-token',
+      })
+    );
+  });
+
+  it('should not overwrite refresh token if not provided in response', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'existing-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        // No refresh_token in response
+      }),
+    } as Response;
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockResolvedValue(mockResponse);
+
+    await getVercelCliToken();
+
+    const writeCall = vi.mocked(authConfig.writeAuthConfig).mock.calls[0][0];
+    expect(writeCall).not.toHaveProperty('refreshToken');
+  });
+
+  it('should calculate expiresAt correctly from expires_in', async () => {
+    const expiredToken = {
+      token: 'expired-access-token',
+      refreshToken: 'valid-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 3600,
+    };
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 7200, // 2 hours
+      }),
+    } as Response;
+
+    vi.spyOn(authConfig, 'readAuthConfig').mockReturnValue(expiredToken);
+    vi.spyOn(authConfig, 'writeAuthConfig').mockImplementation(() => {});
+    vi.spyOn(oauth, 'refreshTokenRequest').mockResolvedValue(mockResponse);
+
+    const beforeCall = Math.floor(Date.now() / 1000);
+    await getVercelCliToken();
+    const afterCall = Math.floor(Date.now() / 1000);
+
+    const writeCall = vi.mocked(authConfig.writeAuthConfig).mock.calls[0][0];
+    expect(writeCall.expiresAt).toBeGreaterThanOrEqual(beforeCall + 7200);
+    expect(writeCall.expiresAt).toBeLessThanOrEqual(afterCall + 7200);
+  });
+});

--- a/packages/oidc/src/token.test.ts
+++ b/packages/oidc/src/token.test.ts
@@ -51,7 +51,7 @@ describe('refreshToken', () => {
     vi.mocked(findRootDir).mockReturnValue(rootDir);
     vi.mocked(getUserDataDir).mockReturnValue(userDataDir);
 
-    vi.spyOn(tokenUtil, 'getVercelCliToken').mockReturnValue('test');
+    vi.spyOn(tokenUtil, 'getVercelCliToken').mockResolvedValue('test');
     vi.spyOn(tokenUtil, 'getVercelOidcToken').mockResolvedValue({
       token: 'test-token',
     });

--- a/packages/oidc/src/token.ts
+++ b/packages/oidc/src/token.ts
@@ -14,7 +14,7 @@ export async function refreshToken(): Promise<void> {
   let maybeToken = loadToken(projectId);
 
   if (!maybeToken || isExpired(getTokenPayload(maybeToken.token))) {
-    const authToken = getVercelCliToken();
+    const authToken = await getVercelCliToken();
     if (!authToken) {
       throw new VercelOidcTokenError(
         'Failed to refresh OIDC token: Log in to Vercel CLI and link your project with `vc link`'


### PR DESCRIPTION
this PR solves a bug where it was possible to accidentally use an expired CLI auth token when refreshing the OIDC token locally