### PR TITLE
[cli] bun ensure stderr output is string

### DIFF
--- a/.changeset/wild-falcons-run.md
+++ b/.changeset/wild-falcons-run.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+ensure bun dev server stderr outputs string not buffer

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -71,7 +71,7 @@ export async function forkDevServer(options: {
         console.log(output);
       }
     });
-    child.stderr?.on('data', console.error);
+    child.stderr?.on('data', data => console.error(data.toString()));
   } else {
     let nodeOptions = process.env.NODE_OPTIONS || '';
 

--- a/packages/node/test/dev-fixtures/bun-stderr.js
+++ b/packages/node/test/dev-fixtures/bun-stderr.js
@@ -1,0 +1,7 @@
+const STDERR_TEST_MESSAGE = 'STDERR_TEST_MESSAGE_12345';
+
+export function GET() {
+  // Write to stderr during request handling
+  console.error(STDERR_TEST_MESSAGE);
+  return new Response('OK');
+}


### PR DESCRIPTION
- Fix Bun runtime dev server stderr outputting raw `Buffer` instead of string
- Add regression test for Bun stderr handling

Fixes [#14186](https://github.com/vercel/vercel/issues/14186)