### PR TITLE
Add changesets that should have been included

### DIFF
--- a/.changeset/real-toes-hang.md
+++ b/.changeset/real-toes-hang.md
@@ -1,0 +1,6 @@
+---
+'@vercel/introspection': patch
+'@vercel/cervel': patch
+---
+
+Add support for 'main' entrypoint and search in `dist` for app entrypoint if a build script is provided

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -128,7 +128,6 @@ async function getChunkedTests() {
     affectedPackages = result.packages;
   } else if (result.result === 'test-none') {
     console.error('Testing strategy: no tests (no packages affected)');
-    console.log('[]');
     return [];
   }
 


### PR DESCRIPTION
[This PR](https://github.com/vercel/vercel/issues/14469) omitted a couple of changesets that resulted in more recent code not being bundled in to the latest release

Also fixes a failure mode encountered when a PR only had changsets in the diff