### PR TITLE
feat(cli): detect full URLs in curl/httpstat commands

### DIFF
--- a/packages/cli/src/commands/curl/index.ts
+++ b/packages/cli/src/commands/curl/index.ts
@@ -20,7 +20,10 @@ export default async function curl(client: Client): Promise<number> {
     return setup;
   }
 
-  const { path, deploymentFlag, protectionBypassFlag, toolFlags } = setup;
+  const { path, isFullUrl, deploymentFlag, protectionBypassFlag, toolFlags } =
+    setup;
+  // isFullUrl will be used in a follow-up PR
+  void isFullUrl;
 
   const result = await getDeploymentUrlAndToken(client, 'curl', path, {
     deploymentFlag,

--- a/packages/cli/src/commands/httpstat/index.ts
+++ b/packages/cli/src/commands/httpstat/index.ts
@@ -20,7 +20,10 @@ export default async function httpstat(client: Client): Promise<number> {
     return setup;
   }
 
-  const { path, deploymentFlag, protectionBypassFlag, toolFlags } = setup;
+  const { path, isFullUrl, deploymentFlag, protectionBypassFlag, toolFlags } =
+    setup;
+  // isFullUrl will be used in a follow-up PR
+  void isFullUrl;
 
   const result = await getDeploymentUrlAndToken(client, 'httpstat', path, {
     deploymentFlag,


### PR DESCRIPTION
## Summary

This PR adds detection logic to identify when a full URL is provided as the path argument in `vc curl` and `vc httpstat` commands.

## Changes

- Add `isFullUrl` boolean flag to `CommandSetupResult` interface
- Detect full URLs (http:// or https://) in `setupCurlLikeCommand`
- Update validation to allow full URLs as path arguments
- Update callers to destructure the new field (not yet used)

## Why This PR?

This is the first step in making these commands more ergonomic. The detection is added but not yet used - that will be implemented in follow-up PRs to keep changes small and reviewable.

## Testing

- TypeScript typecheck passes
- Linter passes
- No functional changes yet (detection only)