### PR TITLE
docs(cli): update curl/httpstat command descriptions and examples

### DIFF
--- a/packages/cli/src/commands/curl/command.ts
+++ b/packages/cli/src/commands/curl/command.ts
@@ -4,7 +4,7 @@ export const curlCommand = {
   name: 'curl',
   aliases: [],
   description:
-    'Execute curl with automatic deployment URL and protection bypass.',
+    'Execute curl with automatic deployment URL and protection bypass. Works with full URLs or relative paths.',
   arguments: [
     {
       name: 'path',
@@ -32,12 +32,20 @@ export const curlCommand = {
   ],
   examples: [
     {
-      name: 'Make a GET request to an API endpoint',
+      name: 'Use a full URL directly (fast, no project linking required)',
+      value: `${packageName} curl https://example.com/api/hello`,
+    },
+    {
+      name: 'Make a GET request to an API endpoint (relative path)',
       value: `${packageName} curl /api/hello`,
     },
     {
       name: 'Make a POST request with data',
       value: `${packageName} curl /api/users -- --request POST --data '{"name": "John"}'`,
+    },
+    {
+      name: 'Use full URL with curl flags',
+      value: `${packageName} curl https://api.example.com/data -- --header "Content-Type: application/json" --request POST`,
     },
     {
       name: 'Target a specific deployment by ID',

--- a/packages/cli/src/commands/httpstat/command.ts
+++ b/packages/cli/src/commands/httpstat/command.ts
@@ -4,7 +4,7 @@ export const httpstatCommand = {
   name: 'httpstat',
   aliases: [],
   description:
-    'Execute httpstat with automatic deployment URL and protection bypass to visualize HTTP timing statistics.',
+    'Execute httpstat with automatic deployment URL and protection bypass to visualize HTTP timing statistics. Works with full URLs or relative paths.',
   arguments: [
     {
       name: 'path',
@@ -32,12 +32,20 @@ export const httpstatCommand = {
   ],
   examples: [
     {
+      name: 'Use a full URL directly (fast, no project linking required)',
+      value: `${packageName} httpstat https://example.com/api/hello`,
+    },
+    {
       name: 'Visualize timing for a GET request to an API endpoint',
       value: `${packageName} httpstat /api/hello`,
     },
     {
       name: 'Make a POST request with data and see timing details',
       value: `${packageName} httpstat /api/users -- -X POST -d '{"name": "John"}'`,
+    },
+    {
+      name: 'Use full URL with httpstat flags',
+      value: `${packageName} httpstat https://api.example.com/data -- -X POST -H "Content-Type: application/json"`,
     },
     {
       name: 'Target a specific deployment by ID',


### PR DESCRIPTION
## Summary

This PR updates the command descriptions and examples to prominently feature full URL support as the primary use case.

## Changes

- Add note about full URL support in command descriptions
- Add full URL examples as the first example for both `curl` and `httpstat` commands
- Show full URL usage with flags
- Keep existing relative path examples for backward compatibility

## Why This PR?

Makes it clear to users that these commands work instantly with full URLs without requiring project linking. Full URLs are now the first example shown, making the ergonomic improvement obvious.

## Testing

- TypeScript typecheck passes
- Linter passes
- Examples verified manually

## Dependencies

Depends on PR #14556