### PR TITLE
feat(cli): update telemetry to track full URLs in curl/httpstat

### DIFF
--- a/packages/cli/src/commands/curl/deployment-url.ts
+++ b/packages/cli/src/commands/curl/deployment-url.ts
@@ -10,8 +10,8 @@ export async function getDeploymentUrlById(
   try {
     // Accept a full deployment URL directly
     if (
-      deploymentIdOrUrl.startsWith('http://') ||
-      deploymentIdOrUrl.startsWith('https://')
+      deploymentIdOrUrl.toLowerCase().startsWith('http://') ||
+      deploymentIdOrUrl.toLowerCase().startsWith('https://')
     ) {
       try {
         const url = new URL(deploymentIdOrUrl);

--- a/packages/cli/src/commands/curl/shared.ts
+++ b/packages/cli/src/commands/curl/shared.ts
@@ -92,7 +92,7 @@ export function setupCurlLikeCommand(
 
   // Check if path is a full URL
   const isFullUrl = Boolean(
-    path && (path.startsWith('http://') || path.startsWith('https://'))
+    path && (path.toLowerCase().startsWith('http://') || path.toLowerCase().startsWith('https://'))
   );
 
   // If not a full URL, require a path argument

--- a/packages/cli/src/util/bisect/normalize-url.ts
+++ b/packages/cli/src/util/bisect/normalize-url.ts
@@ -1,5 +1,5 @@
 function hasScheme(url: string): Boolean {
-  return url.startsWith('http://') || url.startsWith('https://');
+  return url.toLowerCase().startsWith('http://') || url.toLowerCase().startsWith('https://');
 }
 
 export function normalizeURL(url: string): string {

--- a/packages/cli/src/util/telemetry/commands/curl/index.ts
+++ b/packages/cli/src/util/telemetry/commands/curl/index.ts
@@ -8,8 +8,14 @@ export class CurlTelemetryClient
 {
   trackCliArgumentPath(path: string | undefined) {
     if (path) {
-      // Track whether path starts with / or not
-      const value = path.startsWith('/') ? 'slash' : 'no-slash';
+      // Track whether path is a full URL or relative path
+      const isFullUrl =
+        path.startsWith('http://') || path.startsWith('https://');
+      const value = isFullUrl
+        ? 'full-url'
+        : path.startsWith('/')
+          ? 'slash'
+          : 'no-slash';
       this.trackCliArgument({
         arg: 'path',
         value,

--- a/packages/cli/src/util/telemetry/commands/curl/index.ts
+++ b/packages/cli/src/util/telemetry/commands/curl/index.ts
@@ -10,7 +10,7 @@ export class CurlTelemetryClient
     if (path) {
       // Track whether path is a full URL or relative path
       const isFullUrl =
-        path.startsWith('http://') || path.startsWith('https://');
+        path.toLowerCase().startsWith('http://') || path.toLowerCase().startsWith('https://');
       const value = isFullUrl
         ? 'full-url'
         : path.startsWith('/')
@@ -27,8 +27,8 @@ export class CurlTelemetryClient
     if (deploymentId) {
       // Track whether value is a URL, or if dpl_ prefix was provided
       const value =
-        deploymentId.startsWith('http://') ||
-        deploymentId.startsWith('https://')
+        deploymentId.toLowerCase().startsWith('http://') ||
+        deploymentId.toLowerCase().startsWith('https://')
           ? 'url'
           : deploymentId.startsWith('dpl_')
             ? 'dpl_'

--- a/packages/cli/src/util/telemetry/commands/httpstat/index.ts
+++ b/packages/cli/src/util/telemetry/commands/httpstat/index.ts
@@ -10,7 +10,7 @@ export class HttpstatTelemetryClient
     if (path) {
       // Track whether path is a full URL or relative path
       const isFullUrl =
-        path.startsWith('http://') || path.startsWith('https://');
+        path.toLowerCase().startsWith('http://') || path.toLowerCase().startsWith('https://');
       const value = isFullUrl
         ? 'full-url'
         : path.startsWith('/')
@@ -27,8 +27,8 @@ export class HttpstatTelemetryClient
     if (deploymentId) {
       // Track whether value is a URL, or if dpl_ prefix was provided
       const value =
-        deploymentId.startsWith('http://') ||
-        deploymentId.startsWith('https://')
+        deploymentId.toLowerCase().startsWith('http://') ||
+        deploymentId.toLowerCase().startsWith('https://')
           ? 'url'
           : deploymentId.startsWith('dpl_')
             ? 'dpl_'

--- a/packages/cli/src/util/telemetry/commands/httpstat/index.ts
+++ b/packages/cli/src/util/telemetry/commands/httpstat/index.ts
@@ -8,8 +8,14 @@ export class HttpstatTelemetryClient
 {
   trackCliArgumentPath(path: string | undefined) {
     if (path) {
-      // Track whether path starts with / or not
-      const value = path.startsWith('/') ? 'slash' : 'no-slash';
+      // Track whether path is a full URL or relative path
+      const isFullUrl =
+        path.startsWith('http://') || path.startsWith('https://');
+      const value = isFullUrl
+        ? 'full-url'
+        : path.startsWith('/')
+          ? 'slash'
+          : 'no-slash';
       this.trackCliArgument({
         arg: 'path',
         value,


### PR DESCRIPTION
## Summary

This PR updates telemetry to track when users provide full URLs vs relative paths in `vc curl` and `vc httpstat` commands.

## Changes

- Update `trackCliArgumentPath` to detect full URLs
- Track `full-url` value when a full URL is provided
- Keep existing `slash` and `no-slash` values for relative paths
- Apply to both curl and httpstat telemetry clients

## Why This PR?

This will help us understand usage patterns and adoption of the new full URL feature. We can track how many users are using the faster full URL path vs the project-linked relative path.

## Testing

- TypeScript typecheck passes
- Linter passes

## Dependencies

Depends on PR #14557