### PR TITLE
Node options path quoting

### DIFF
--- a/.changeset/quiet-paths-quote.md
+++ b/.changeset/quiet-paths-quote.md
@@ -1,0 +1,5 @@
+---
+'@vercel/node': patch
+---
+
+Quote paths with spaces in NODE_OPTIONS to fix an issue where `vercel dev` was unable to find cjs or esm loaders in case those were in paths whose folders contained spaces.

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -85,14 +85,14 @@ export async function forkDevServer(options: {
 
     if (options.maybeTranspile) {
       if (options.isTypeScript) {
-        nodeOptions = `--require ${cjsLoader} --loader ${esmLoader} ${
+        nodeOptions = `--require "${cjsLoader}" --loader "${esmLoader}" ${
           nodeOptions || ''
         }`;
       } else {
         if (options.isEsm) {
           // no transform needed because Node.js supports ESM natively
         } else {
-          nodeOptions = `--require ${cjsLoader} ${nodeOptions || ''}`;
+          nodeOptions = `--require "${cjsLoader}" ${nodeOptions || ''}`;
         }
       }
     }

--- a/packages/node/src/fork-dev-server.ts
+++ b/packages/node/src/fork-dev-server.ts
@@ -85,14 +85,18 @@ export async function forkDevServer(options: {
 
     if (options.maybeTranspile) {
       if (options.isTypeScript) {
-        nodeOptions = `--require "${cjsLoader}" --loader "${esmLoader}" ${
+        // Normalize paths to use forward slashes for cross-platform compatibility
+        const normalizedCjsLoader = cjsLoader.replace(/\\/g, '/');
+        nodeOptions = `--require "${normalizedCjsLoader}" --loader "${esmLoader}" ${
           nodeOptions || ''
         }`;
       } else {
         if (options.isEsm) {
           // no transform needed because Node.js supports ESM natively
         } else {
-          nodeOptions = `--require "${cjsLoader}" ${nodeOptions || ''}`;
+          // Normalize paths to use forward slashes for cross-platform compatibility
+          const normalizedCjsLoader = cjsLoader.replace(/\\/g, '/');
+          nodeOptions = `--require "${normalizedCjsLoader}" ${nodeOptions || ''}`;
         }
       }
     }

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -617,9 +617,11 @@ test('forkDevServer should quote paths with spaces in NODE_OPTIONS', async () =>
   });
 
   try {
-    // The child process should start successfully even with spaces in the path
-    // If the paths weren't quoted, Node would fail to start
-    expect(child.pid).toBeDefined();
+    // The server should start successfully even with spaces in the path
+    // If the paths weren't quoted, Node would fail with "Cannot find module"
+    const result = await readMessage(child);
+    expect(result.state).toBe('message');
+    expect(result.value.port).toBeGreaterThan(0);
   } finally {
     child.kill(9);
   }

--- a/packages/node/test/unit/dev.test.ts
+++ b/packages/node/test/unit/dev.test.ts
@@ -617,12 +617,6 @@ test('forkDevServer should quote paths with spaces in NODE_OPTIONS', async () =>
   });
 
   try {
-    // Check that NODE_OPTIONS has properly quoted paths
-    const env = (child as any).spawnargs || [];
-    const nodeOptions = child.spawnfile?.includes('node')
-      ? process.env.NODE_OPTIONS
-      : (child as any)?.env?.NODE_OPTIONS;
-
     // The child process should start successfully even with spaces in the path
     // If the paths weren't quoted, Node would fail to start
     expect(child.pid).toBeDefined();


### PR DESCRIPTION
Adds quotes to `NODE_OPTIONS` paths in dev server forking and a new test to fix "Cannot find module" errors with paths containing spaces.

---
[Slack Thread](https://vercel.slack.com/archives/C08SV1UERN2/p1767902611125079?thread_ts=1767902611.125079&cid=C08SV1UERN2)

<a href="https://cursor.com/background-agent?bcId=bc-d8f8a8d5-e234-4b06-967b-90066ed6087b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8f8a8d5-e234-4b06-967b-90066ed6087b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

