### PR TITLE
[routing-utils] Add `respectOriginCacheControl` to routes schema

### DIFF
--- a/.changeset/stupid-wombats-tan.md
+++ b/.changeset/stupid-wombats-tan.md
@@ -1,0 +1,5 @@
+---
+'@vercel/routing-utils': patch
+---
+
+Add respectOriginCacheControl to routes schema

--- a/packages/routing-utils/src/schemas.ts
+++ b/packages/routing-utils/src/schemas.ts
@@ -473,6 +473,11 @@ export const routesSchema = {
               maxLength: 256,
             },
           },
+          respectOriginCacheControl: {
+            description:
+              'When set to true (default), external rewrites will respect the Cache-Control header from the origin. When false, caching is disabled for this rewrite.',
+            type: 'boolean',
+          },
         },
       },
       {

--- a/packages/routing-utils/src/types.ts
+++ b/packages/routing-utils/src/types.ts
@@ -98,6 +98,7 @@ export type RouteWithSrc = {
    * A middleware index in the `middleware` key under the build result
    */
   middleware?: number;
+  respectOriginCacheControl?: boolean;
 };
 
 export type RouteWithHandle = {


### PR DESCRIPTION
https://github.com/vercel/vercel/pull/14506 Added `respectOriginCacheControl` to the rewrites schema. https://github.com/vercel/vercel/pull/14518 copies this property over to `routes` when merging. This causes a schema validation error that will break the upcoming release. These two PRs didn't know about each other which is why this wasn't caught.

Although `routes` is deprecated, it is actively used for transforms in vercel.ts. So this new property needs to be on the routes schema in addition to the rewrites schema.