### PR TITLE
[cli] Add telemetry for CLI misuse tracking

### DIFF
--- a/packages/cli/src/util/telemetry-context.ts
+++ b/packages/cli/src/util/telemetry-context.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'node:crypto';
+import type { TelemetryEventStore } from './telemetry';
+
+interface TelemetryContext {
+  command: string;
+  store: TelemetryEventStore;
+}
+
+let currentContext: TelemetryContext | null = null;
+
+export function setTelemetryContext(
+  command: string,
+  store: TelemetryEventStore
+) {
+  currentContext = { command, store };
+}
+
+export function clearTelemetryContext() {
+  currentContext = null;
+}
+
+export function trackArgumentError(error: string) {
+  if (currentContext) {
+    currentContext.store.add({
+      id: randomUUID(),
+      eventTime: Date.now(),
+      key: `error:argument_error:${currentContext.command}`,
+      value: error,
+    });
+  }
+}

--- a/packages/cli/src/util/telemetry/index.ts
+++ b/packages/cli/src/util/telemetry/index.ts
@@ -201,6 +201,23 @@ export class TelemetryClient {
       value: subcommand ? `${command}:${subcommand}` : command,
     });
   }
+
+  protected trackCliInvalidCommand(command: string) {
+    this.track({
+      key: 'error:invalid_command',
+      value: command,
+    });
+  }
+
+  protected trackCliArgumentError(eventData: {
+    command: string;
+    error: string;
+  }) {
+    this.track({
+      key: `error:argument_error:${eventData.command}`,
+      value: eventData.error,
+    });
+  }
 }
 
 export class TelemetryEventStore {

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -387,4 +387,12 @@ export class RootTelemetryClient extends TelemetryClient {
       this.trackCliFlag('no-color');
     }
   }
+
+  trackInvalidCommand(command: string) {
+    this.trackCliInvalidCommand(command);
+  }
+
+  trackArgumentError(command: string, error: string) {
+    this.trackCliArgumentError({ command, error });
+  }
 }


### PR DESCRIPTION
## Summary

- Track invalid commands (e.g., `vercel delpoy`, `vercel logs`) to identify typos and expected-but-missing features
- Track argument parsing errors (e.g., `vercel deploy --invalid-flag`) to understand user expectations

This helps optimize the CLI for both human and agentic use by revealing what users expect but don't find.

## Events

| Event | Example | Trigger |
|-------|---------|---------|
| `error:invalid_command` | `delpoy` | `vercel delpoy` |
| `error:argument_error:deploy` | `Unknown option: --force` | `vercel deploy --force` |

## Implementation

Uses a lightweight telemetry context set in `index.ts` before command execution, allowing `parseArguments` to automatically track errors without modifying individual commands.

## Test plan

- [ ] Run `vercel foobar` → should track `error:invalid_command`
- [ ] Run `vercel deploy --xyz` → should track `error:argument_error:deploy`
- [ ] Verify `VERCEL_TELEMETRY_DISABLED=1` prevents tracking

🤖 Generated with [Claude Code](https://claude.ai/code)