### PR TITLE
Error message enhancement

### DIFF
--- a/.changeset/many-numbers-wash.md
+++ b/.changeset/many-numbers-wash.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Improve error message when deploying a non-existent path that could be mistaken for an unknown subcommand. The error now clarifies that both the path doesn't exist and the argument is not a known command.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -140,6 +140,8 @@ export default async (client: Client): Promise<number> => {
 
   // #region Path validation
   let paths;
+  // Keep track of the original argument for better error messages
+  const originalArg = parsedArguments.args[0];
   if (parsedArguments.args.length > 0) {
     // If path is relative: resolve
     // if path is absolute: clear up strange `/` etc
@@ -150,7 +152,7 @@ export default async (client: Client): Promise<number> => {
   }
 
   // check paths
-  const pathValidation = await validatePaths(client, paths);
+  const pathValidation = await validatePaths(client, paths, originalArg);
 
   if (!pathValidation.valid) {
     return pathValidation.exitCode;

--- a/packages/cli/test/integration-3.test.ts
+++ b/packages/cli/test/integration-3.test.ts
@@ -535,9 +535,9 @@ test('create a production deployment', async () => {
 });
 
 test('try to deploy non-existing path', async () => {
-  const goal = `Error: Could not find “${humanizePath(
+  const goal = `Error: The specified path "${humanizePath(
     path.join(process.cwd(), session)
-  )}”`;
+  )}" does not exist and "${session}" is not a known command.`;
 
   const { stderr, stdout, exitCode } = await execCli(binaryPath, [
     session,
@@ -545,7 +545,7 @@ test('try to deploy non-existing path', async () => {
   ]);
 
   expect(exitCode, formatOutput({ stdout, stderr })).toBe(1);
-  expect(stderr.trim().endsWith(goal), `should end with "${goal}"`).toBe(true);
+  expect(stderr.includes(goal), `should include "${goal}"`).toBe(true);
 });
 
 test('try to deploy with non-existing team', async () => {
@@ -740,10 +740,10 @@ test('vercel hasOwnProperty not a valid subcommand', async () => {
 
   expect(output.exitCode, formatOutput(output)).toBe(1);
   expect(
-    output.stderr.endsWith(
-      `Error: Could not find “${humanizePath(
+    output.stderr.includes(
+      `Error: The specified path "${humanizePath(
         path.join(process.cwd(), 'hasOwnProperty')
-      )}”`
+      )}" does not exist and "hasOwnProperty" is not a known command.`
     )
   ).toEqual(true);
 });

--- a/packages/cli/test/unit/commands/deploy/index.test.ts
+++ b/packages/cli/test/unit/commands/deploy/index.test.ts
@@ -65,9 +65,9 @@ describe('deploy', () => {
     client.setArgv('deploy', badName);
     const exitCodePromise = deploy(client);
     await expect(client.stderr).toOutput(
-      `Error: Could not find “${humanizePath(
+      `Error: The specified path "${humanizePath(
         join(client.cwd, 'does-not-exist')
-      )}”\n`
+      )}" does not exist and "does-not-exist" is not a known command.`
     );
     const exitCode = await exitCodePromise;
     expect(exitCode, 'exit code for "deploy"').toEqual(1);


### PR DESCRIPTION
Improve the error message when a user provides a non-existent path that could be mistaken for an unknown subcommand.

---
[Slack Thread](https://vercel.slack.com/archives/C09MK639NMN/p1767987812585889?thread_ts=1767987812.585889&cid=C09MK639NMN)

<a href="https://cursor.com/background-agent?bcId=bc-518b4c22-cf5b-4f27-aaec-e6905b774de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-518b4c22-cf5b-4f27-aaec-e6905b774de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

