### PR TITLE
feat(cli): validate CRON_SECRET for invalid HTTP header characters during build

### DIFF
--- a/.changeset/cron-secret-validation.md
+++ b/.changeset/cron-secret-validation.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+[cli] Add validation for CRON_SECRET environment variable during build to detect invalid HTTP header characters

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -85,6 +85,7 @@ import {
 import readJSONFile from '../../util/read-json-file';
 import { BuildTelemetryClient } from '../../util/telemetry/commands/build';
 import { validateConfig } from '../../util/validate-config';
+import { validateCronSecret } from '../../util/validate-cron-secret';
 import {
   compileVercelConfig,
   findSourceVercelConfigFile,
@@ -485,6 +486,14 @@ async function doBuild(
 
   if (validateError) {
     throw validateError;
+  }
+
+  // Validate CRON_SECRET if crons are defined
+  if (localConfig.crons && localConfig.crons.length > 0) {
+    const cronSecretError = validateCronSecret(process.env.CRON_SECRET);
+    if (cronSecretError) {
+      throw cronSecretError;
+    }
   }
 
   if (localConfig.customErrorPage) {

--- a/packages/cli/src/util/validate-cron-secret.ts
+++ b/packages/cli/src/util/validate-cron-secret.ts
@@ -27,7 +27,7 @@ export function validateCronSecret(
       code: 'INVALID_CRON_SECRET',
       message:
         'The `CRON_SECRET` environment variable contains leading or trailing whitespace, which is not allowed in HTTP header values.',
-      link: 'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs',
+      link: 'https://vercel.link/securing-cron-jobs',
       action: 'Learn More',
     });
   }
@@ -71,7 +71,7 @@ export function validateCronSecret(
     return new NowBuildError({
       code: 'INVALID_CRON_SECRET',
       message: `The \`CRON_SECRET\` environment variable contains characters that are not valid in HTTP headers: ${descriptions.join(', ')}${moreText}. Only visible ASCII characters (letters, digits, symbols), spaces, and tabs are allowed.`,
-      link: 'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs',
+      link: 'https://vercel.link/securing-cron-jobs',
       action: 'Learn More',
     });
   }

--- a/packages/cli/src/util/validate-cron-secret.ts
+++ b/packages/cli/src/util/validate-cron-secret.ts
@@ -1,0 +1,80 @@
+import { NowBuildError } from '@vercel/build-utils';
+
+/**
+ * Validates that the CRON_SECRET environment variable contains only characters
+ * that are valid in HTTP header values.
+ *
+ * According to RFC 7230, HTTP header field values may only contain:
+ * - Visible ASCII characters (0x21-0x7E)
+ * - Space (0x20) and horizontal tab (0x09) - but not at the start or end
+ *
+ * CRON_SECRET is sent as an Authorization header when Vercel invokes cron jobs,
+ * so it must contain only valid HTTP header characters.
+ *
+ * @param cronSecret - The value of the CRON_SECRET environment variable
+ * @returns NowBuildError if invalid, null if valid or not set
+ */
+export function validateCronSecret(
+  cronSecret: string | undefined
+): NowBuildError | null {
+  if (!cronSecret) {
+    return null;
+  }
+
+  // Check for leading or trailing whitespace
+  if (cronSecret !== cronSecret.trim()) {
+    return new NowBuildError({
+      code: 'INVALID_CRON_SECRET',
+      message:
+        'The `CRON_SECRET` environment variable contains leading or trailing whitespace, which is not allowed in HTTP header values.',
+      link: 'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs',
+      action: 'Learn More',
+    });
+  }
+
+  // Find any invalid characters
+  const invalidChars: Array<{ char: string; index: number; code: number }> = [];
+
+  for (let i = 0; i < cronSecret.length; i++) {
+    const code = cronSecret.charCodeAt(i);
+    // Valid characters are:
+    // - Horizontal tab (0x09)
+    // - Space (0x20)
+    // - Visible ASCII characters (0x21-0x7E)
+    const isValidChar =
+      code === 0x09 || // HTAB
+      (code >= 0x20 && code <= 0x7e); // Space through tilde (visible ASCII)
+
+    if (!isValidChar) {
+      invalidChars.push({
+        char: cronSecret[i],
+        index: i,
+        code,
+      });
+    }
+  }
+
+  if (invalidChars.length > 0) {
+    const descriptions = invalidChars.slice(0, 3).map(({ code, index }) => {
+      if (code < 0x20) {
+        return `control character (0x${code.toString(16).padStart(2, '0')}) at position ${index}`;
+      } else if (code === 0x7f) {
+        return `DEL character at position ${index}`;
+      } else {
+        return `non-ASCII character (0x${code.toString(16).padStart(2, '0')}) at position ${index}`;
+      }
+    });
+
+    const moreCount = invalidChars.length - 3;
+    const moreText = moreCount > 0 ? `, and ${moreCount} more` : '';
+
+    return new NowBuildError({
+      code: 'INVALID_CRON_SECRET',
+      message: `The \`CRON_SECRET\` environment variable contains characters that are not valid in HTTP headers: ${descriptions.join(', ')}${moreText}. Only visible ASCII characters (letters, digits, symbols), spaces, and tabs are allowed.`,
+      link: 'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs',
+      action: 'Learn More',
+    });
+  }
+
+  return null;
+}

--- a/packages/cli/test/unit/util/validate-cron-secret.test.ts
+++ b/packages/cli/test/unit/util/validate-cron-secret.test.ts
@@ -190,7 +190,7 @@ describe('validateCronSecret', () => {
       const error = validateCronSecret('my\x00Secret');
       expect(error).not.toBeNull();
       expect(error!.link).toBe(
-        'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs'
+        'https://vercel.link/securing-cron-jobs'
       );
     });
 

--- a/packages/cli/test/unit/util/validate-cron-secret.test.ts
+++ b/packages/cli/test/unit/util/validate-cron-secret.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { validateCronSecret } from '../../../src/util/validate-cron-secret';
 
 describe('validateCronSecret', () => {
@@ -189,9 +190,7 @@ describe('validateCronSecret', () => {
     it('should include the documentation link', () => {
       const error = validateCronSecret('my\x00Secret');
       expect(error).not.toBeNull();
-      expect(error!.link).toBe(
-        'https://vercel.link/securing-cron-jobs'
-      );
+      expect(error!.link).toBe('https://vercel.link/securing-cron-jobs');
     });
 
     it('should include the Learn More action', () => {

--- a/packages/cli/test/unit/util/validate-cron-secret.test.ts
+++ b/packages/cli/test/unit/util/validate-cron-secret.test.ts
@@ -1,0 +1,203 @@
+import { validateCronSecret } from '../../../src/util/validate-cron-secret';
+
+describe('validateCronSecret', () => {
+  describe('valid CRON_SECRET values', () => {
+    it('should return null for undefined CRON_SECRET', () => {
+      const error = validateCronSecret(undefined);
+      expect(error).toBeNull();
+    });
+
+    it('should return null for empty string CRON_SECRET', () => {
+      const error = validateCronSecret('');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for valid alphanumeric secret', () => {
+      const error = validateCronSecret('mySecretToken123');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for valid secret with special characters', () => {
+      const error = validateCronSecret('Bearer my-secret_token.123!@#$%^&*()');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for valid secret with spaces in the middle', () => {
+      const error = validateCronSecret('Bearer token123');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for valid secret with tab in the middle', () => {
+      const error = validateCronSecret('Bearer\ttoken123');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for a 16-character random string', () => {
+      const error = validateCronSecret('aB3dEf6hIj9kLmN0');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for all printable ASCII characters', () => {
+      // All visible ASCII characters (0x21-0x7E)
+      const visibleAscii = Array.from({ length: 94 }, (_, i) =>
+        String.fromCharCode(0x21 + i)
+      ).join('');
+      const error = validateCronSecret(visibleAscii);
+      expect(error).toBeNull();
+    });
+  });
+
+  describe('invalid CRON_SECRET values - whitespace issues', () => {
+    it('should return error for secret with leading space', () => {
+      const error = validateCronSecret(' mySecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('leading or trailing whitespace');
+    });
+
+    it('should return error for secret with trailing space', () => {
+      const error = validateCronSecret('mySecret ');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('leading or trailing whitespace');
+    });
+
+    it('should return error for secret with leading tab', () => {
+      const error = validateCronSecret('\tmySecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('leading or trailing whitespace');
+    });
+
+    it('should return error for secret with trailing tab', () => {
+      const error = validateCronSecret('mySecret\t');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('leading or trailing whitespace');
+    });
+
+    it('should return error for secret with leading newline', () => {
+      const error = validateCronSecret('\nmySecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+    });
+
+    it('should return error for secret with trailing newline', () => {
+      const error = validateCronSecret('mySecret\n');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+    });
+  });
+
+  describe('invalid CRON_SECRET values - control characters', () => {
+    it('should return error for secret with null character', () => {
+      const error = validateCronSecret('my\x00Secret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('control character');
+      expect(error!.message).toContain('0x00');
+    });
+
+    it('should return error for secret with bell character', () => {
+      const error = validateCronSecret('my\x07Secret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('control character');
+    });
+
+    it('should return error for secret with carriage return', () => {
+      const error = validateCronSecret('my\rSecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('control character');
+    });
+
+    it('should return error for secret with newline in the middle', () => {
+      const error = validateCronSecret('my\nSecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('control character');
+    });
+
+    it('should return error for secret with DEL character', () => {
+      const error = validateCronSecret('my\x7FSecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('DEL character');
+    });
+
+    it('should return error for secret with escape character', () => {
+      const error = validateCronSecret('my\x1BSecret');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('control character');
+    });
+  });
+
+  describe('invalid CRON_SECRET values - non-ASCII characters', () => {
+    it('should return error for secret with non-ASCII character (é)', () => {
+      const error = validateCronSecret('mySecrét');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('non-ASCII character');
+    });
+
+    it('should return error for secret with emoji', () => {
+      const error = validateCronSecret('mySecret🔐');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('non-ASCII character');
+    });
+
+    it('should return error for secret with Chinese character', () => {
+      const error = validateCronSecret('mySecret密钥');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('non-ASCII character');
+    });
+
+    it('should return error for secret with high ASCII character', () => {
+      const error = validateCronSecret('mySecret\x80');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('non-ASCII character');
+    });
+
+    it('should return error for secret with Latin-1 supplement character (©)', () => {
+      const error = validateCronSecret('mySecret©');
+      expect(error).not.toBeNull();
+      expect(error!.code).toBe('INVALID_CRON_SECRET');
+      expect(error!.message).toContain('non-ASCII character');
+    });
+  });
+
+  describe('error message formatting', () => {
+    it('should list multiple invalid characters', () => {
+      const error = validateCronSecret('a\x00b\x01c\x02d');
+      expect(error).not.toBeNull();
+      expect(error!.message).toContain('position 1');
+      expect(error!.message).toContain('position 3');
+      expect(error!.message).toContain('position 5');
+    });
+
+    it('should truncate when more than 3 invalid characters', () => {
+      const error = validateCronSecret('a\x00b\x01c\x02d\x03e\x04f');
+      expect(error).not.toBeNull();
+      expect(error!.message).toContain('and 2 more');
+    });
+
+    it('should include the documentation link', () => {
+      const error = validateCronSecret('my\x00Secret');
+      expect(error).not.toBeNull();
+      expect(error!.link).toBe(
+        'https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs'
+      );
+    });
+
+    it('should include the Learn More action', () => {
+      const error = validateCronSecret('my\x00Secret');
+      expect(error).not.toBeNull();
+      expect(error!.action).toBe('Learn More');
+    });
+  });
+});


### PR DESCRIPTION
Add validation to detect and fail the build when CRON_SECRET contains characters that are not valid in HTTP headers. CRON_SECRET is sent as an Authorization header when Vercel invokes cron jobs.

Invalid characters include:
- Control characters (0x00-0x1F except tab, and DEL 0x7F)
- Non-ASCII characters (> 0x7E)
- Leading/trailing whitespace

This helps users catch configuration issues early during build time rather than having cron job invocations fail at runtime.

<img width="1261" height="516" alt="image" src="https://github.com/user-attachments/assets/60522e4a-b89b-4159-a970-125338a8eaf9" />
