### PR TITLE
Add error status header for _error rendering

### DIFF
--- a/.changeset/perfect-bobcats-join.md
+++ b/.changeset/perfect-bobcats-join.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Add error status header for \_error rendering

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -2799,6 +2799,9 @@ export async function serverBuild({
               dest: path.posix.join('/', entryDirectory, '/$nextLocale/404'),
               status: 404,
               caseSensitive: true,
+              headers: {
+                'x-next-error-status': '404',
+              },
             },
             {
               src: path.posix.join('/', entryDirectory, '.*'),
@@ -2808,6 +2811,9 @@ export async function serverBuild({
                 `/${i18n.defaultLocale}/404`
               ),
               status: 404,
+              headers: {
+                'x-next-error-status': '404',
+              },
             },
           ]
         : [
@@ -2834,6 +2840,9 @@ export async function serverBuild({
                     : '/_error'
               ),
               status: 404,
+              headers: {
+                'x-next-error-status': '404',
+              },
             },
           ]),
 
@@ -2851,6 +2860,9 @@ export async function serverBuild({
               dest: path.posix.join('/', entryDirectory, '/$nextLocale/500'),
               status: 500,
               caseSensitive: true,
+              headers: {
+                'x-next-error-status': '500',
+              },
             },
             {
               src: path.posix.join('/', entryDirectory, '.*'),
@@ -2860,6 +2872,9 @@ export async function serverBuild({
                 `/${i18n.defaultLocale}/500`
               ),
               status: 500,
+              headers: {
+                'x-next-error-status': '500',
+              },
             },
           ]
         : [
@@ -2882,6 +2897,9 @@ export async function serverBuild({
                   : '/_error'
               ),
               status: 500,
+              headers: {
+                'x-next-error-status': '500',
+              },
             },
           ]),
     ],

--- a/packages/next/test/integration/integration-1.test.js
+++ b/packages/next/test/integration/integration-1.test.js
@@ -451,7 +451,9 @@ it('Should build the 404-getstaticprops-i18n example', async () => {
 
   const handleErrorIdx = (routes || []).findIndex(r => r.handle === 'error');
   expect(routes[handleErrorIdx + 1].dest).toBe('/$nextLocale/404');
-  expect(routes[handleErrorIdx + 1].headers).toBe(undefined);
+  expect(routes[handleErrorIdx + 1].headers).toEqual({
+    'x-next-error-status': '404',
+  });
 });
 
 it('Should build the gip-gsp-404 example', async () => {
@@ -462,7 +464,9 @@ it('Should build the gip-gsp-404 example', async () => {
 
   const handleErrorIdx = (routes || []).findIndex(r => r.handle === 'error');
   expect(routes[handleErrorIdx + 1].dest).toBe('/404');
-  expect(routes[handleErrorIdx + 1].headers).toBe(undefined);
+  expect(routes[handleErrorIdx + 1].headers).toEqual({
+    'x-next-error-status': '404',
+  });
   expect(output['404']).toBeDefined();
   expect(output['404'].type).toBe('Prerender');
   expect(output['_next/data/testing-build-id/404.json']).toBeDefined();


### PR DESCRIPTION
This adds an `x-next-error-status` header when we render `_error` dynamically at runtime to signal what status we are rendering for since legacy `_error` is rendered in an isolate function invoke after the original function crashes so it loses the context of if an error occurred or if it's a 404. 

Closes: NEXT-4797