### PR TITLE
Exit early in `vc bisect` if good and bad URLs are the same

### DIFF
--- a/.changeset/gentle-cups-itch.md
+++ b/.changeset/gentle-cups-itch.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Exit early in `vc bisect` if good and bad URLs are the same

--- a/packages/cli/src/commands/bisect/index.ts
+++ b/packages/cli/src/commands/bisect/index.ts
@@ -172,6 +172,11 @@ export default async function bisect(client: Client): Promise<number> {
     return 1;
   }
 
+  if (badDeployment.url === goodDeployment.url) {
+    output.error(`Good and Bad deployments must be different`);
+    return 1;
+  }
+
   if (badDeployment.createdAt < goodDeployment.createdAt) {
     output.error(`Good deployment must be older than the Bad deployment`);
     return 1;

--- a/packages/cli/test/unit/commands/bisect/index.test.ts
+++ b/packages/cli/test/unit/commands/bisect/index.test.ts
@@ -416,4 +416,27 @@ describe('bisect', () => {
 
     await expect(bisectPromise).resolves.toEqual(0);
   });
+
+  describe('validation errors', () => {
+    it('should error when good and bad deployments are the same', async () => {
+      const { deployment1 } = setupBisectState();
+
+      client.setArgv(
+        'bisect',
+        '--good',
+        `https://${deployment1.url}`,
+        '--bad',
+        `https://${deployment1.url}`,
+        '--path',
+        '/docs'
+      );
+      const bisectPromise = bisect(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Good and Bad deployments must be different'
+      );
+
+      await expect(bisectPromise).resolves.toEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
### TL;DR

Added validation to prevent `vc bisect` from running when good and bad URLs are identical.

### What changed?

- Added an early exit condition in the `bisect` command that checks if the good and bad deployment URLs are the same
- Added a corresponding error message: "Good and Bad deployments must be different"
- Created a new test case to verify this validation works correctly

### How to test?

Run the `vc bisect` command with the same URL for both `--good` and `--bad` parameters:
```
vc bisect --good https://example.vercel.app --bad https://example.vercel.app --path /docs
```
The command should exit with an error message and return code 1.

### Why make this change?

Running a bisect operation when both the good and bad deployments are the same doesn't make sense and would waste resources. This validation prevents users from accidentally running an invalid bisect operation.