### PR TITLE
Update CLI typo error message to clarify directory or subcommand

### DIFF
--- a/.changeset/metal-poets-notice.md
+++ b/.changeset/metal-poets-notice.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update missing command error message

--- a/packages/cli/src/util/handle-command-typo.ts
+++ b/packages/cli/src/util/handle-command-typo.ts
@@ -29,7 +29,7 @@ export function handleCommandTypo({
   const suggestion = didYouMean(command, availableCommands, threshold);
   if (suggestion) {
     output.error(
-      `${command} is not a valid target directory or subcommand. Did you mean ${param(suggestion)}?`
+      `${param(command)} is not a valid target directory or subcommand. Did you mean ${param(suggestion)}?`
     );
     return true;
   }

--- a/packages/cli/src/util/handle-command-typo.ts
+++ b/packages/cli/src/util/handle-command-typo.ts
@@ -29,7 +29,7 @@ export function handleCommandTypo({
   const suggestion = didYouMean(command, availableCommands, threshold);
   if (suggestion) {
     output.error(
-      `The ${param(command)} subcommand does not exist. Did you mean ${param(suggestion)}?`
+      `${command} is not a valid target directory or subcommand. Did you mean ${param(suggestion)}?`
     );
     return true;
   }


### PR DESCRIPTION
Updated the error message when a user provides an invalid subcommand or target directory. The message now clearly indicates that the input is not a valid target directory or subcommand, which better reflects the CLI's dual-purpose behavior where users can run `vc [directory]` to deploy or `vc [subcommand]` for other operations.

🤖 Generated with Claude Code