### PR TITLE
Fix issue with experimental backends builder that didn't respect api functions output

### DIFF
--- a/.changeset/rude-dryers-stare.md
+++ b/.changeset/rude-dryers-stare.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix issue with experimental backends builder that didn't respect api functions output

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -723,7 +723,8 @@ async function doBuild(
             // not for static builders (which handle public/ directories)
             if (
               shouldUseExperimentalBackends(buildConfig.framework) &&
-              builderPkg.name !== '@vercel/static'
+              builderPkg.name !== '@vercel/static' &&
+              isBackendBuilder(build)
             ) {
               const experimentalBackendBuilder = await import(
                 '@vercel/backends'


### PR DESCRIPTION
The `api` function build results weren't being processed because the build config is the same for all of the builders, we needed to also look at `build.src` for this conditional.