### PR TITLE
feat(cli): lazy initialize Sentry to improve startup performance

### DIFF
--- a/.changeset/wise-melons-happen.md
+++ b/.changeset/wise-melons-happen.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Defer sentry init until needed

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ import chalk from 'chalk';
 import epipebomb from 'epipebomb';
 import getLatestVersion from './util/get-latest-version';
 import { URL } from 'url';
-import * as Sentry from '@sentry/node';
+import { getSentry } from './util/get-sentry';
 import hp from './util/humanize-path';
 import { commands, commandNames } from './commands';
 import { handleCommandTypo } from './util/handle-command-typo';
@@ -61,7 +61,6 @@ import {
 } from './util/config/get-default';
 import * as ERRORS from './util/errors-ts';
 import { APIError } from './util/errors-ts';
-import { SENTRY_DSN } from './util/constants';
 import getUpdateCommand from './util/get-update-command';
 import { executeUpgrade } from './util/upgrade';
 import { getCommandName, getTitleName } from './util/pkg-name';
@@ -93,14 +92,6 @@ const GLOBAL_COMMANDS = new Set(['help']);
   This suppresses those errors.
 */
 epipebomb();
-
-// Configure the error reporting system
-Sentry.init({
-  dsn: SENTRY_DSN,
-  release: `vercel-cli@${pkg.version}`,
-  environment: 'stable',
-  autoSessionTracking: false,
-});
 
 let client: Client;
 
@@ -863,7 +854,7 @@ const main = async () => {
       }
       output.prettyError(err);
     } else {
-      await reportError(Sentry, client, err);
+      await reportError(getSentry(), client, err);
 
       // Otherwise it is an unexpected error and we should show the trace
       // and an unexpected error message
@@ -885,7 +876,7 @@ const handleRejection = async (err: any) => {
       await handleUnexpected(err);
     } else {
       output.error(`An unexpected rejection occurred\n  ${err}`);
-      await reportError(Sentry, client, err);
+      await reportError(getSentry(), client, err);
     }
   } else {
     output.error('An unexpected empty rejection occurred');
@@ -904,7 +895,7 @@ const handleUnexpected = async (err: Error) => {
   }
 
   output.error(`An unexpected error occurred!\n${err.stack}`);
-  await reportError(Sentry, client, err);
+  await reportError(getSentry(), client, err);
 
   process.exit(1);
 };

--- a/packages/cli/src/util/get-sentry.ts
+++ b/packages/cli/src/util/get-sentry.ts
@@ -1,0 +1,32 @@
+import type * as SentryType from '@sentry/node';
+
+let sentry: typeof SentryType | undefined;
+
+/**
+ * Lazily initializes and returns the Sentry SDK.
+ * Sentry is only initialized on the first call to this function,
+ * which improves CLI startup performance for the common case
+ * where no errors occur.
+ */
+export function getSentry(): typeof SentryType {
+  if (!sentry) {
+    // Dynamic require to avoid loading Sentry at startup
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require('@sentry/node') as typeof SentryType;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SENTRY_DSN } = require('./constants');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('./pkg').default;
+
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      release: `vercel-cli@${pkg.version}`,
+      environment: 'stable',
+      autoSessionTracking: false,
+    });
+
+    sentry = Sentry;
+  }
+
+  return sentry;
+}


### PR DESCRIPTION
## Summary
- Defer Sentry SDK initialization until an error is actually reported
- Improves CLI startup performance for the common case where no errors occur
- Sentry configuration is now co-located with initialization in a dedicated utility module

## Test plan
- Verify CLI starts without loading Sentry
- Confirm error reporting still works correctly when an error occurs
- Check that all three error reporting paths (`main`, `handleRejection`, `handleUnexpected`) correctly trigger Sentry initialization

🤖 Generated with Claude Code