### PR TITLE
Vc link prompt issues

### DIFF
--- a/.changeset/vc-link-prompt-fix.md
+++ b/.changeset/vc-link-prompt-fix.md
@@ -1,0 +1,11 @@
+---
+'vercel': patch
+---
+
+Fix `vc link --yes` prompting for project selection when multiple projects match the same directory.
+
+When using `vc link` with a repo.json that has multiple projects for the same directory (e.g., after running `vc link --repo`), the CLI would prompt for project selection even when `--yes` was provided. This fix:
+
+- Uses the `--project` flag to auto-select the matching project when multiple projects are found
+- Errors with a helpful message when `--yes` is provided but no `--project` flag and multiple projects match
+- Errors when `--project` is provided but doesn't match any available project

--- a/packages/cli/src/util/link/ensure-link.ts
+++ b/packages/cli/src/util/link/ensure-link.ts
@@ -30,7 +30,15 @@ export async function ensureLink(
 ): Promise<ProjectLinked | number> {
   let { link } = opts;
   if (!link) {
-    link = await getLinkedProject(client, cwd);
+    try {
+      link = await getLinkedProject(client, cwd, {
+        projectName: opts.projectName,
+        autoConfirm: opts.autoConfirm,
+      });
+    } catch (err) {
+      output.prettyError(err);
+      return 1;
+    }
     opts.link = link;
   }
 

--- a/packages/cli/test/unit/util/projects/link.test.ts
+++ b/packages/cli/test/unit/util/projects/link.test.ts
@@ -230,4 +230,75 @@ describe('getLinkedProject', () => {
     expect(link.project.id).toEqual('QmbKpqpiUqbcke');
     expect(link.repoRoot).toEqual(cwd);
   });
+
+  it('should auto-select project when --project flag matches', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'QmScb7GPQt6gsS',
+      name: 'monorepo-blog',
+    });
+
+    // When projectName is provided, it should auto-select without prompting
+    const link = await getLinkedProject(client, cwd, {
+      projectName: 'monorepo-blog',
+    });
+
+    if (link.status !== 'linked') {
+      throw new Error('Expected to be linked');
+    }
+    expect(link.org.id).toEqual('team_dummy');
+    expect(link.org.type).toEqual('team');
+    expect(link.project.id).toEqual('QmScb7GPQt6gsS');
+    expect(link.repoRoot).toEqual(cwd);
+  });
+
+  it('should error when --project flag does not match any project', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+
+    // When projectName is provided but doesn't match, it should error
+    let error: Error | undefined;
+    try {
+      await getLinkedProject(client, cwd, {
+        projectName: 'non-existent-project',
+      });
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain(
+      'Project "non-existent-project" not found'
+    );
+    expect(error?.message).toContain('monorepo-dashboard');
+    expect(error?.message).toContain('monorepo-marketing');
+    expect(error?.message).toContain('monorepo-blog');
+  });
+
+  it('should error when --yes flag is provided but multiple projects match', async () => {
+    const cwd = fixture('monorepo-link');
+
+    useUser();
+    useTeams('team_dummy');
+
+    // When autoConfirm is true but no projectName, it should error
+    let error: Error | undefined;
+    try {
+      await getLinkedProject(client, cwd, {
+        autoConfirm: true,
+      });
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('Multiple projects found');
+    expect(error?.message).toContain('Use --project to specify');
+  });
 });


### PR DESCRIPTION
Fix `vc link --yes` prompting for project selection when multiple projects match the same directory.

Previously, when a `repo.json` contained multiple projects associated with the same directory, running `vc link --yes` would still trigger an interactive prompt to select a project. This PR modifies the `getProjectLinkFromRepoLink` function to respect the `--project` flag for automatic selection and to throw an error if `--yes` is used without `--project` in such ambiguous scenarios.

---
[Slack Thread](https://vercel.slack.com/archives/C09MK639NMN/p1768394601393509?thread_ts=1768394601.393509&cid=C09MK639NMN)

<a href="https://cursor.com/background-agent?bcId=bc-961024b3-d80b-42b0-be9e-bc5fe3138184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-961024b3-d80b-42b0-be9e-bc5fe3138184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

