### PR TITLE
Support running integration tests against a custom build-container.

### DIFF
--- a/test/lib/deployment/now-deploy.js
+++ b/test/lib/deployment/now-deploy.js
@@ -36,7 +36,22 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
     VERCEL_DEBUG,
     VERCEL_CLI_VERSION,
     VERCEL_FORCE_PYTHON_STREAMING,
+    VERCEL_FORCE_BUILD_IN_HIVE,
+    VERCEL_BUILD_CONTAINER_VERSION,
   } = process.env;
+
+  // Warn if using custom build container configuration
+  if (VERCEL_FORCE_BUILD_IN_HIVE || VERCEL_BUILD_CONTAINER_VERSION) {
+    logWithinTest('⚠️ Running tests against a custom build container');
+    if (VERCEL_FORCE_BUILD_IN_HIVE) {
+      logWithinTest(`VERCEL_FORCE_BUILD_IN_HIVE=${VERCEL_FORCE_BUILD_IN_HIVE}`);
+    }
+    if (VERCEL_BUILD_CONTAINER_VERSION) {
+      logWithinTest(
+        `VERCEL_BUILD_CONTAINER_VERSION=${VERCEL_BUILD_CONTAINER_VERSION}`
+      );
+    }
+  }
   const nowJson = JSON.parse(
     bodies['vercel.json'] || bodies['now.json'] || '{}'
   );
@@ -63,6 +78,8 @@ async function nowDeploy(projectName, bodies, randomness, uploadNowJson, opts) {
         VERCEL_DEBUG,
         VERCEL_CLI_VERSION,
         VERCEL_FORCE_PYTHON_STREAMING,
+        VERCEL_FORCE_BUILD_IN_HIVE,
+        VERCEL_BUILD_CONTAINER_VERSION,
         NEXT_TELEMETRY_DISABLED: '1',
       },
     },


### PR DESCRIPTION
This change allows us to run an existing integration test against a build container built from a pull request

```console
export VERCEL_FORCE_BUILD_IN_HIVE="..."
export VERCEL_BUILD_CONTAINER_VERSION="..."
pnpm test --filter=@vercel/python -- --testNamePattern="..."
```