### PR TITLE
[build-utils] Add 'go' as a valid runtimeLanguage option

### DIFF
--- a/.changeset/build-utils-add-go-runtime-language.md
+++ b/.changeset/build-utils-add-go-runtime-language.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Add 'go' as a valid runtimeLanguage option for Lambda functions

--- a/packages/build-utils/src/lambda.ts
+++ b/packages/build-utils/src/lambda.ts
@@ -17,7 +17,7 @@ export type { TriggerEvent };
 
 export type LambdaOptions = LambdaOptionsWithFiles | LambdaOptionsWithZipBuffer;
 
-export type LambdaExecutableRuntimeLanguages = 'rust';
+export type LambdaExecutableRuntimeLanguages = 'rust' | 'go';
 export type LambdaArchitecture = 'x86_64' | 'arm64';
 
 export interface LambdaOptionsBase {
@@ -202,7 +202,10 @@ export class Lambda {
     }
 
     if (runtimeLanguage !== undefined) {
-      assert(runtimeLanguage === 'rust', '"runtimeLanguage" must be "rust"');
+      assert(
+        runtimeLanguage === 'rust' || runtimeLanguage === 'go',
+        '"runtimeLanguage" is invalid. Valid options: "rust", "go"'
+      );
     }
 
     if (

--- a/packages/build-utils/test/unit.lambda.test.ts
+++ b/packages/build-utils/test/unit.lambda.test.ts
@@ -373,6 +373,18 @@ describe('Lambda', () => {
       expect(lambda.runtimeLanguage).toBe('rust');
     });
 
+    it('should create Lambda with valid runtimeLanguage (go)', () => {
+      const files: Files = {};
+      const lambda = new Lambda({
+        files,
+        handler: 'index.handler',
+        runtime: 'provided.al2',
+        runtimeLanguage: 'go',
+      });
+
+      expect(lambda.runtimeLanguage).toBe('go');
+    });
+
     it('should create Lambda without runtimeLanguage', () => {
       const files: Files = {};
       const lambda = new Lambda({
@@ -394,7 +406,7 @@ describe('Lambda', () => {
             runtime: 'provided.al2',
             runtimeLanguage: 'python' as any,
           })
-      ).toThrow('"runtimeLanguage" must be "rust"');
+      ).toThrow('"runtimeLanguage" is invalid. Valid options: "rust", "go"');
     });
 
     it('should throw error for invalid runtimeLanguage (number)', () => {
@@ -407,7 +419,7 @@ describe('Lambda', () => {
             runtime: 'provided.al2',
             runtimeLanguage: 123 as any,
           })
-      ).toThrow('"runtimeLanguage" must be "rust"');
+      ).toThrow('"runtimeLanguage" is invalid. Valid options: "rust", "go"');
     });
 
     it('should throw error for invalid runtimeLanguage (empty string)', () => {
@@ -420,7 +432,7 @@ describe('Lambda', () => {
             runtime: 'provided.al2',
             runtimeLanguage: '' as any,
           })
-      ).toThrow('"runtimeLanguage" must be "rust"');
+      ).toThrow('"runtimeLanguage" is invalid. Valid options: "rust", "go"');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `'go'` to `LambdaExecutableRuntimeLanguages` type in `@vercel/build-utils`
- Updates Lambda validation to accept both `'rust'` and `'go'`

Follows the pattern established in #14347 for Rust.

**Note:** The Go builder update to use this new option will be done in a follow-up PR after this change is released.