### PR TITLE
Revert "[go] Reuse go mod cache and go cache on project rebuild."

### DIFF
--- a/.changeset/plenty-comics-repair.md
+++ b/.changeset/plenty-comics-repair.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Revert the inclusion of GOMODCACHE and GOCACHE env vars

--- a/README.md
+++ b/README.md
@@ -162,13 +162,10 @@ Sometimes you want to test changes to a Builder against an existing project, may
 
 1. Change directory to the desired Builder `cd ./packages/node`
 2. Run `pnpm build` to compile typescript and other build steps
-3. Run `npm pack` to create a tarball file. It is imporant to not use `pnpm pack` because it will not preserve the file permissions
-4. Move the resulting tarball to a directory
-5. Run `vercel <directory>` to upload the tarball file and get a URL. Remember to append `/<tarball name>` to then end of your URL
-6. Edit any existing `vercel.json` project and replace `use` with the URL
-7. Run `vercel` or `vercel dev` to deploy with the experimental Builder
-
-**Note:** You will need to turn off vercel authentication in settings -> deployment protection so the builder can be downloaded
+3. Run `npm pack` to create a tarball file
+4. Run `vercel *.tgz` to upload the tarball file and get a URL
+5. Edit any existing `vercel.json` project and replace `use` with the URL
+6. Run `vercel` or `vercel dev` to deploy with the experimental Builder
 
 ## Reference
 

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -18,7 +18,6 @@ import { tmpdir } from 'os';
 import yauzl from 'yauzl-promise';
 import XDGAppPaths from 'xdg-app-paths';
 import type { Env } from '@vercel/build-utils';
-import { getWriteableDirectory } from '@vercel/build-utils';
 
 const streamPipeline = promisify(pipeline);
 
@@ -279,51 +278,15 @@ export async function createGo({
   }
 
   const setGoEnv = async (goDir: string | null) => {
-    if (!goDir) {
-      env.GOROOT = undefined;
-      env.PATH = PATH;
-      return;
-    }
-
-    const isUnix = platform !== 'win32';
-
-    const setEnvPaths = (modCache: string, buildCache: string) => {
-      env.GOMODCACHE = modCache;
-      env.GOCACHE = buildCache;
-      debug(`Set GOMODCACHE to ${env.GOMODCACHE}`);
-      debug(`Set GOCACHE to ${env.GOCACHE}`);
-    };
-
-    if (isUnix && goDir === goGlobalCacheDir) {
-      // Using global cache → link it to goCacheDir
+    if (platform !== 'win32' && goDir === goGlobalCacheDir) {
       debug(`Symlinking ${goDir} -> ${goCacheDir}`);
       await remove(goCacheDir);
       await mkdirp(dirname(goCacheDir));
       await symlink(goDir, goCacheDir);
-
-      const modCache = join(goDir, 'pkg', 'mod');
-      const buildCache = join(goDir, 'go-build');
-      setEnvPaths(modCache, buildCache);
-
       goDir = goCacheDir;
-    } else if (isUnix && goDir === goCacheDir) {
-      // Using local cache → link temp writable directories
-      const tmpBase = await getWriteableDirectory();
-      const tmpModCache = join(tmpBase, 'pkg');
-      const tmpBuildCache = join(tmpBase, '.cache');
-
-      await Promise.all([
-        mkdirp(join(goDir, 'pkg', 'mod')),
-        mkdirp(join(goDir, '.cache', 'go-build')),
-        symlink(join(goCacheDir, 'pkg', 'mod'), tmpModCache),
-        symlink(join(goCacheDir, '.cache', 'go-build'), tmpBuildCache),
-      ]);
-
-      setEnvPaths(tmpModCache, tmpBuildCache);
     }
-
-    env.GOROOT = goDir;
-    env.PATH = `${join(goDir, 'bin')}${delimiter}${PATH}`;
+    env.GOROOT = goDir || undefined;
+    env.PATH = goDir ? `${join(goDir, 'bin')}${delimiter}${PATH}` : PATH;
   };
 
   // try each of these Go directories looking for the version we need


### PR DESCRIPTION
Reverts vercel/vercel#14484

This change ended up causing slower builds for a customer. I'm not able to reproduce it so reverting in the meantime.