### PR TITLE
[go]Use deterministic tmpdir path for go cache dirs.

### DIFF
--- a/.changeset/quiet-spoons-clean.md
+++ b/.changeset/quiet-spoons-clean.md
@@ -1,0 +1,5 @@
+---
+'@vercel/go': patch
+---
+
+Use deterministic tmpdir when setting GOMODCACHE and GOCACHE dirs.


### PR DESCRIPTION
#14484 introduced support for `GOCACHE` and `GOMODCACHE`. This actually slowed down builds for customers because we compile a binary for every go handler separately and sequentially. Since the `getWriteableDirectory` function always returns a randomly named tmpdir, this meant we lost caching altogether.

The fix implemented here is to use a deterministic directory based on the `workPath`. I was able to reproduce the issue and test that this change greatly improved the compile time.