### PR TITLE
[cli] Adjust `vc blob --help` wording for the `store` subcommand

### DIFF
--- a/.changeset/cold-eagles-jam.md
+++ b/.changeset/cold-eagles-jam.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Adjust `vc blob --help` wording for the `store` subcommand

--- a/packages/cli/src/commands/blob/command.ts
+++ b/packages/cli/src/commands/blob/command.ts
@@ -232,7 +232,7 @@ export const getStoreSubcommand = {
 export const storeSubcommand = {
   name: 'store',
   aliases: [],
-  description: 'Interact with Blob stores',
+  description: 'Manage or create a Blob store',
   arguments: [],
   subcommands: [addStoreSubcommand, removeStoreSubcommand, getStoreSubcommand],
   options: [],


### PR DESCRIPTION
Update CLI description for blob stores to "Manage or create a Blob store" to improve discoverability of the `vc blob store add` command.

---
[Slack Thread](https://vercel.slack.com/archives/C07MTGF3RNU/p1768438382822389?thread_ts=1768438382.822389&cid=C07MTGF3RNU)

<a href="https://cursor.com/background-agent?bcId=bc-3c0a9554-7c2a-4550-a271-e263d0f75695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c0a9554-7c2a-4550-a271-e263d0f75695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

