### PR TITLE
[go] fix go ci failing e2e tests

### DIFF
--- a/.changeset/tough-impalas-camp.md
+++ b/.changeset/tough-impalas-camp.md
@@ -1,0 +1,5 @@
+---
+"@vercel/go": patch
+---
+
+[go] fix ci failing e2e tests

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "node ../../utils/build-builder.mjs",
     "test": "jest --reporters=default --reporters=jest-junit --env node --verbose --runInBand --bail",
-    "test-e2e": "echo 'Go e2e tests temporarily disabled'",
+    "test-e2e": "pnpm test",
     "type-check": "tsc --noEmit"
   },
   "files": [

--- a/packages/go/test/fixtures/11-go-mod-shared/go.mod
+++ b/packages/go/test/fixtures/11-go-mod-shared/go.mod
@@ -1,3 +1,3 @@
 module with-shared
 
-go 1.13
+go 1.18

--- a/packages/go/test/fixtures/11-go-mod-shared/vercel.json
+++ b/packages/go/test/fixtures/11-go-mod-shared/vercel.json
@@ -4,7 +4,7 @@
   "probes": [
     {
       "path": "/api",
-      "mustContain": "version:go1.13.15:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "version:go1.18.10:RANDOMNESS_PLACEHOLDER"
     }
   ]
 }

--- a/packages/go/test/fixtures/16-custom-flag/go.mod
+++ b/packages/go/test/fixtures/16-custom-flag/go.mod
@@ -1,3 +1,3 @@
 module custom-flag
 
-go 1.14
+go 1.18

--- a/packages/go/test/fixtures/16-custom-flag/probes.json
+++ b/packages/go/test/fixtures/16-custom-flag/probes.json
@@ -2,7 +2,7 @@
   "probes": [
     {
       "path": "/",
-      "mustContain": "version:go1.14.15:first:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "version:go1.18.10:first:RANDOMNESS_PLACEHOLDER"
     }
   ]
 }

--- a/packages/go/test/fixtures/17-go-mod-api/api/go.mod
+++ b/packages/go/test/fixtures/17-go-mod-api/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vercel/does-not-exist
 
-go 1.13
+go 1.18
 
 require (
   github.com/dhruvbird/go-cowsay v0.0.0-20131019225157-6fd7bd0281c0 // indirect

--- a/packages/go/test/fixtures/17-go-mod-api/probes.json
+++ b/packages/go/test/fixtures/17-go-mod-api/probes.json
@@ -2,7 +2,7 @@
   "probes": [
     {
       "path": "/api/v1/routes/someroute",
-      "mustContain": "version:go1.13.15:Dependency:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "version:go1.18.10:Dependency:RANDOMNESS_PLACEHOLDER"
     }
   ]
 }

--- a/packages/go/test/fixtures/23-main-go/api/go.mod
+++ b/packages/go/test/fixtures/23-main-go/api/go.mod
@@ -1,5 +1,5 @@
 module github.com/vercel/does-not-exist
 
-go 1.13
+go 1.18
 
 require github.com/dhruvbird/go-cowsay v0.0.0-20131019225157-6fd7bd0281c0 // indirect

--- a/packages/go/test/fixtures/23-main-go/vercel.json
+++ b/packages/go/test/fixtures/23-main-go/vercel.json
@@ -3,7 +3,7 @@
   "probes": [
     {
       "path": "/api",
-      "mustContain": "version:go1.13.15:RANDOMNESS_PLACEHOLDER"
+      "mustContain": "version:go1.18.10:RANDOMNESS_PLACEHOLDER"
     }
   ]
 }

--- a/packages/go/test/fixtures/24-bad-handler/api/go.mod
+++ b/packages/go/test/fixtures/24-bad-handler/api/go.mod
@@ -1,3 +1,3 @@
 module handler
 
-go 1.13
+go 1.18


### PR DESCRIPTION
Fixes CI e2e fixture builds failing with the following error by upgrading the minimum go version in the fixtures from 1.13 -> 1.18 as [aws-lambda-go](https://github.com/aws/aws-lambda-go/blob/main/go.mod) relies on 1.18 and [vercel/go-bridge](https://github.com/vercel/go-bridge/blob/master/go/bridge/bridge.go) relies on aws-lambda-go
```
go: extracting gopkg.in/yaml.v3 v3.0.1
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: extracting gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
handler imports
	github.com/vercel/go-bridge/go/bridge imports
	github.com/aws/aws-lambda-go/lambda imports
	github.com/aws/aws-lambda-go/lambdacontext imports
	log/slog: malformed module path "log/slog": missing dot in first path element
failed to `go mod tidy`
Error: Command failed: go mod tidy
```