### PR TITLE
chore: ignore js files from functions dir that fail lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -43,3 +43,6 @@ packages/remix/test/fixtures-*
 
 # gatsby-plugin-vercel-analytics
 packages/gatsby-plugin-vercel-analytics
+
+# functions
+packages/functions/**/*.js


### PR DESCRIPTION
pnpm build && pnpm lint fails because this package emits some js files
