### PR TITLE
[experimental-services] Add "services" as experimental framework preset

### DIFF
--- a/.changeset/moody-months-tease.md
+++ b/.changeset/moody-months-tease.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[experimental-services] Add "services" as experimental framework preset

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4147,6 +4147,7 @@ export const frameworks = [
         value: 'N/A',
       },
     },
+    getOutputDirName: async () => 'public',
   },
   {
     name: 'Other',

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4121,6 +4121,34 @@ export const frameworks = [
     ],
   },
   {
+    name: 'Services',
+    slug: 'services',
+    experimental: true,
+    logo: 'https://api-frameworks.vercel.sh/framework-logos/other.svg',
+    tagline:
+      'Multiple services deployed as serverless functions within your project.',
+    description:
+      'Multiple services deployed as serverless functions within your project.',
+    website: 'https://vercel.com',
+    detectors: {},
+    settings: {
+      installCommand: {
+        placeholder: 'None',
+      },
+      buildCommand: {
+        placeholder: 'None',
+        value: null,
+      },
+      devCommand: {
+        placeholder: 'None',
+        value: null,
+      },
+      outputDirectory: {
+        value: 'N/A',
+      },
+    },
+  },
+  {
     name: 'Other',
     slug: null,
     logo: 'https://api-frameworks.vercel.sh/framework-logos/other.svg',


### PR DESCRIPTION
Adds "services" as gated experimental framework preset