### PR TITLE
allow installing products in one command

### DIFF
--- a/.changeset/violet-pets-compare.md
+++ b/.changeset/violet-pets-compare.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add support for installing marketplace products directly and listing available products

--- a/packages/cli/src/commands/install/command.ts
+++ b/packages/cli/src/commands/install/command.ts
@@ -18,5 +18,9 @@ export const installCommand: Command = {
       name: 'Install an integration from the marketplace',
       value: `${packageName} install acme`,
     },
+    {
+      name: 'Install a specific product from an integration',
+      value: `${packageName} install acme/cache`,
+    },
   ],
 };

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -20,6 +20,13 @@ export const addSubcommand = {
         `${packageName} integration add acme`,
       ],
     },
+    {
+      name: 'Install a specific product from an integration',
+      value: [
+        `${packageName} integration add <integration>/<product>`,
+        `${packageName} integration add acme/cache`,
+      ],
+    },
   ],
 } as const;
 

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -153,6 +153,28 @@ export const removeSubcommand = {
   ],
 } as const;
 
+export const productsSubcommand = {
+  name: 'products',
+  aliases: [],
+  description: 'Lists available products for a marketplace integration',
+  arguments: [
+    {
+      name: 'integration',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'List products for an integration',
+      value: [
+        `${packageName} integration products <integration>`,
+        `${packageName} integration products aws`,
+      ],
+    },
+  ],
+} as const;
+
 export const integrationCommand = {
   name: 'integration',
   aliases: [],
@@ -163,6 +185,7 @@ export const integrationCommand = {
     addSubcommand,
     listSubcommand,
     openSubcommand,
+    productsSubcommand,
     removeSubcommand,
   ],
   examples: [],

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -122,6 +122,7 @@ export default async function main(client: Client) {
         printHelp(productsSubcommand);
         return 2;
       }
+      telemetry.trackCliSubcommandProducts(subcommandOriginal);
       return products(client, subArgs);
     }
     default: {

--- a/packages/cli/src/commands/integration/index.ts
+++ b/packages/cli/src/commands/integration/index.ts
@@ -15,10 +15,12 @@ import {
   integrationCommand,
   listSubcommand,
   openSubcommand,
+  productsSubcommand,
   removeSubcommand,
 } from './command';
 import { list } from './list';
 import { openIntegration } from './open-integration';
+import { products } from './products';
 import { remove } from './remove-integration';
 
 const COMMAND_CONFIG = {
@@ -26,6 +28,7 @@ const COMMAND_CONFIG = {
   open: getCommandAliases(openSubcommand),
   list: getCommandAliases(listSubcommand),
   balance: getCommandAliases(balanceSubcommand),
+  products: getCommandAliases(productsSubcommand),
   remove: getCommandAliases(removeSubcommand),
 };
 
@@ -112,6 +115,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandRemove(subcommandOriginal);
       return remove(client);
+    }
+    case 'products': {
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('integration', subcommandOriginal);
+        printHelp(productsSubcommand);
+        return 2;
+      }
+      return products(client, subArgs);
     }
     default: {
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/integration/products.ts
+++ b/packages/cli/src/commands/integration/products.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { fetchIntegration } from '../../util/integration/fetch-integration';
+import table from '../../util/output/table';
+
+export async function products(client: Client, args: string[]) {
+  if (args.length > 1) {
+    output.error(
+      'Cannot list products for more than one integration at a time'
+    );
+    return 1;
+  }
+
+  const integrationSlug = args[0];
+
+  if (!integrationSlug) {
+    output.error('You must pass an integration slug');
+    return 1;
+  }
+
+  let integration;
+  try {
+    output.spinner('Fetching integration...', 500);
+    integration = await fetchIntegration(client, integrationSlug);
+  } catch (error) {
+    output.error(
+      `Failed to get integration "${integrationSlug}": ${(error as Error).message}`
+    );
+    return 1;
+  } finally {
+    output.stopSpinner();
+  }
+
+  if (!integration.products?.length) {
+    output.log(`Integration "${integrationSlug}" has no products available.`);
+    return 0;
+  }
+
+  output.log(
+    `Products for ${chalk.bold(integration.name)}:\n${table(
+      [
+        ['Slug', 'Name', 'Description'].map(header =>
+          chalk.bold(chalk.cyan(header))
+        ),
+        ...integration.products.map(product => [
+          chalk.bold(product.slug),
+          product.name,
+          chalk.gray(product.shortDescription || '–'),
+        ]),
+      ],
+      { hsep: 4 }
+    )}`
+  );
+
+  output.log(
+    `\nTo install a product, run: ${chalk.cyan(`vercel integration add ${integrationSlug}/<product-slug>`)}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/util/telemetry/commands/integration/index.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/index.ts
@@ -40,4 +40,11 @@ export class IntegrationTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandProducts(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'products',
+      value: actual,
+    });
+  }
 }


### PR DESCRIPTION
allows users to reference product directly in the install command, saving a step if the integration is already installed

## installing new product on existing integration
<img width="992" height="409" alt="Screenshot 2026-01-18 at 9 18 28 PM" src="https://github.com/user-attachments/assets/ba484e62-a1cc-483d-9fd3-bf9e87151fcc" />

## installing new integration + product
(same as before)
<img width="1001" height="78" alt="Screenshot 2026-01-18 at 9 22 40 PM" src="https://github.com/user-attachments/assets/204a9e82-4673-43af-8602-90dc42a6074e" />

## getting product names (slugs actually) for an integration
<img width="1021" height="151" alt="Screenshot 2026-01-18 at 9 34 50 PM" src="https://github.com/user-attachments/assets/7439d302-f315-4021-a63d-ba7260f49b41" />


## considerations
* requires the user to know the name of the integration they want to install in the first place. Opening up the list of integrations on the marketplace/adding search is a TODO.
* command is listed under the `vc integrations` which is described as "managing your existing integrations" but this will return products for **any** integration slug you pass in, not just the ones you have installed (not a blocker imo and is kinda nice)
