### PR TITLE
[cli] Add logsv2 command

### DIFF
--- a/.changeset/logsv2-command.md
+++ b/.changeset/logsv2-command.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add hidden `logsv2` command with request-logs API support

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -22,6 +22,7 @@ import { listCommand } from './list/command';
 import { loginCommand } from './login/command';
 import { logoutCommand } from './logout/command';
 import { logsCommand } from './logs/command';
+import { logsv2Command } from './logsv2/command';
 import { mcpCommand } from './mcp/command';
 import { microfrontendsCommand } from './microfrontends/command';
 import { openCommand } from './open/command';
@@ -67,6 +68,7 @@ const commandsStructs = [
   loginCommand,
   logoutCommand,
   logsCommand,
+  logsv2Command,
   mcpCommand,
   microfrontendsCommand,
   openCommand,

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -1,0 +1,115 @@
+import { packageName } from '../../util/pkg-name';
+
+export const logsv2Command = {
+  name: 'logsv2',
+  aliases: [],
+  description: 'Display request logs for a project using the new logs API.',
+  hidden: true,
+  arguments: [],
+  options: [
+    {
+      name: 'project',
+      shorthand: 'p',
+      type: String,
+      deprecated: false,
+      description: 'Project ID or name (defaults to linked project)',
+    },
+    {
+      name: 'deployment',
+      shorthand: 'd',
+      type: String,
+      deprecated: false,
+      description: 'Filter logs to a specific deployment ID or URL',
+    },
+    {
+      name: 'environment',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Filter by environment: production or preview',
+    },
+    {
+      name: 'level',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description: 'Filter by log level: error, warning, info, fatal',
+    },
+    {
+      name: 'status-code',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Filter by HTTP status code (e.g., 500, 4xx)',
+    },
+    {
+      name: 'source',
+      shorthand: null,
+      type: [String],
+      deprecated: false,
+      description:
+        'Filter by source: serverless, edge-function, edge-middleware, static',
+    },
+    {
+      name: 'since',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Start time (ISO format or relative: 1h, 30m)',
+    },
+    {
+      name: 'until',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'End time (ISO format or relative, default: now)',
+    },
+    {
+      name: 'limit',
+      shorthand: 'n',
+      type: Number,
+      deprecated: false,
+      description: 'Maximum number of results (default: 100)',
+    },
+    {
+      name: 'json',
+      shorthand: 'j',
+      type: Boolean,
+      deprecated: false,
+      description: 'Output logs as JSON Lines for piping to other tools',
+    },
+    {
+      name: 'search',
+      shorthand: 's',
+      type: String,
+      deprecated: false,
+      description: 'Full-text search query',
+    },
+  ],
+  examples: [
+    {
+      name: 'Display recent logs for the linked project',
+      value: `${packageName} logsv2`,
+    },
+    {
+      name: 'Display error logs from the last hour',
+      value: `${packageName} logsv2 --level error --since 1h`,
+    },
+    {
+      name: 'Display logs for a specific deployment',
+      value: `${packageName} logsv2 --deployment dpl_xxxxx`,
+    },
+    {
+      name: 'Filter logs by status code and output as JSON',
+      value: `${packageName} logsv2 --status-code 500 --json`,
+    },
+    {
+      name: 'Search logs and pipe to jq',
+      value: `${packageName} logsv2 --search "timeout" --json | jq '.message'`,
+    },
+    {
+      name: 'Display production logs only',
+      value: `${packageName} logsv2 --environment production`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -85,6 +85,13 @@ export const logsv2Command = {
       deprecated: false,
       description: 'Full-text search query',
     },
+    {
+      name: 'request-id',
+      shorthand: null,
+      type: String,
+      deprecated: false,
+      description: 'Filter by request ID',
+    },
   ],
   examples: [
     {
@@ -110,6 +117,10 @@ export const logsv2Command = {
     {
       name: 'Display production logs only',
       value: `${packageName} logsv2 --environment production`,
+    },
+    {
+      name: 'Display logs for a specific request',
+      value: `${packageName} logsv2 --request-id req_xxxxx`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -79,8 +79,8 @@ export const logsv2Command = {
       description: 'Output logs as JSON Lines for piping to other tools',
     },
     {
-      name: 'search',
-      shorthand: 's',
+      name: 'query',
+      shorthand: 'q',
       type: String,
       deprecated: false,
       description: 'Full-text search query',
@@ -112,7 +112,7 @@ export const logsv2Command = {
     },
     {
       name: 'Search logs and pipe to jq',
-      value: `${packageName} logsv2 --search "timeout" --json | jq '.message'`,
+      value: `${packageName} logsv2 --query "timeout" --json | jq '.message'`,
     },
     {
       name: 'Display production logs only',

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -97,6 +97,7 @@ export default async function logsv2(client: Client) {
   }
 
   let projectId: string;
+  let ownerId: string;
 
   if (projectOption) {
     output.spinner(`Fetching project "${projectOption}"`, 1000);
@@ -112,6 +113,7 @@ export default async function logsv2(client: Client) {
       return 1;
     }
     projectId = project.id;
+    ownerId = project.accountId;
   } else {
     const link = await getLinkedProject(client);
     if (link.status === 'error') {
@@ -127,6 +129,7 @@ export default async function logsv2(client: Client) {
     client.config.currentTeam =
       link.org.type === 'team' ? link.org.id : undefined;
     projectId = link.project.id;
+    ownerId = link.org.id;
   }
 
   let deploymentId: string | undefined;
@@ -187,6 +190,7 @@ export default async function logsv2(client: Client) {
   try {
     for await (const log of fetchAllRequestLogs(client, {
       projectId,
+      ownerId,
       deploymentId,
       environment: environmentOption,
       level: levels.length > 0 ? levels : undefined,

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -1,0 +1,304 @@
+import { isErrnoException } from '@vercel/error-utils';
+import chalk from 'chalk';
+import { format } from 'date-fns';
+import type Client from '../../util/client';
+import { printError } from '../../util/error';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import getScope from '../../util/get-scope';
+import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { ProjectNotFound } from '../../util/errors-ts';
+import {
+  fetchAllRequestLogs,
+  resolveDeploymentId,
+  type RequestLogEntry,
+} from '../../util/logs-v2';
+import { getCommandName } from '../../util/pkg-name';
+import { Logsv2TelemetryClient } from '../../util/telemetry/commands/logsv2';
+import { help } from '../help';
+import { logsv2Command } from './command';
+import output from '../../output-manager';
+
+const DATE_TIME_FORMAT = 'MMM dd HH:mm:ss.SS';
+
+function parseLevels(levels?: string | string[]): string[] {
+  if (!levels) return [];
+  if (typeof levels === 'string') return [levels];
+  return levels;
+}
+
+function parseSources(sources?: string | string[]): string[] {
+  if (!sources) return [];
+  if (typeof sources === 'string') return [sources];
+  return sources;
+}
+
+export default async function logsv2(client: Client) {
+  let parsedArguments;
+  const flagsSpecification = getFlagsSpecification(logsv2Command.options);
+
+  try {
+    parsedArguments = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const telemetry = new Logsv2TelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  if (parsedArguments.flags['--help']) {
+    telemetry.trackCliFlagHelp('logsv2');
+    output.print(help(logsv2Command, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  const projectOption = parsedArguments.flags['--project'];
+  const deploymentOption = parsedArguments.flags['--deployment'];
+  const environmentOption = parsedArguments.flags['--environment'];
+  const levelOption = parsedArguments.flags['--level'];
+  const statusCodeOption = parsedArguments.flags['--status-code'];
+  const sourceOption = parsedArguments.flags['--source'];
+  const sinceOption = parsedArguments.flags['--since'];
+  const untilOption = parsedArguments.flags['--until'];
+  const limitOption = parsedArguments.flags['--limit'];
+  const jsonOption = parsedArguments.flags['--json'];
+  const searchOption = parsedArguments.flags['--search'];
+
+  telemetry.trackCliOptionProject(projectOption);
+  telemetry.trackCliOptionDeployment(deploymentOption);
+  telemetry.trackCliOptionEnvironment(environmentOption);
+  telemetry.trackCliOptionLevel(levelOption);
+  telemetry.trackCliOptionStatusCode(statusCodeOption);
+  telemetry.trackCliOptionSource(sourceOption);
+  telemetry.trackCliOptionSince(sinceOption);
+  telemetry.trackCliOptionUntil(untilOption);
+  telemetry.trackCliOptionLimit(limitOption);
+  telemetry.trackCliFlagJson(jsonOption);
+  telemetry.trackCliOptionSearch(searchOption);
+
+  let contextName: string | null = null;
+
+  try {
+    ({ contextName } = await getScope(client));
+  } catch (err: unknown) {
+    if (
+      isErrnoException(err) &&
+      (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')
+    ) {
+      output.error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  let projectId: string;
+
+  if (projectOption) {
+    output.spinner(`Fetching project "${projectOption}"`, 1000);
+    const project = await getProjectByIdOrName(
+      client,
+      projectOption,
+      client.config.currentTeam
+    );
+    output.stopSpinner();
+
+    if (project instanceof ProjectNotFound) {
+      output.error(`Project not found: ${projectOption}`);
+      return 1;
+    }
+    projectId = project.id;
+  } else {
+    const link = await getLinkedProject(client);
+    if (link.status === 'error') {
+      return link.exitCode;
+    } else if (link.status === 'not_linked') {
+      output.error(
+        `Your codebase isn't linked to a project on Vercel. Run ${getCommandName(
+          'link'
+        )} to begin, or specify a project with ${chalk.bold('--project')}.`
+      );
+      return 1;
+    }
+    client.config.currentTeam =
+      link.org.type === 'team' ? link.org.id : undefined;
+    projectId = link.project.id;
+  }
+
+  let deploymentId: string | undefined;
+  if (deploymentOption) {
+    output.spinner(`Resolving deployment "${deploymentOption}"`, 1000);
+    deploymentId = await resolveDeploymentId(client, deploymentOption);
+    output.stopSpinner();
+  }
+
+  if (
+    environmentOption &&
+    !['production', 'preview'].includes(environmentOption)
+  ) {
+    output.error(
+      `Invalid environment: ${environmentOption}. Must be "production" or "preview".`
+    );
+    return 1;
+  }
+
+  const validLevels = ['error', 'warning', 'info', 'fatal'];
+  const levels = parseLevels(levelOption);
+  for (const level of levels) {
+    if (!validLevels.includes(level)) {
+      output.error(
+        `Invalid log level: ${level}. Must be one of: ${validLevels.join(', ')}.`
+      );
+      return 1;
+    }
+  }
+
+  const validSources = [
+    'serverless',
+    'edge-function',
+    'edge-middleware',
+    'static',
+  ];
+  const sources = parseSources(sourceOption);
+  for (const source of sources) {
+    if (!validSources.includes(source)) {
+      output.error(
+        `Invalid source: ${source}. Must be one of: ${validSources.join(', ')}.`
+      );
+      return 1;
+    }
+  }
+
+  const limit = limitOption ?? 100;
+
+  if (!jsonOption) {
+    output.print(
+      `Fetching logs for project ${chalk.bold(projectId)} in ${chalk.bold(contextName)}...\n\n`
+    );
+  }
+
+  output.spinner('Fetching logs...', 1000);
+
+  let count = 0;
+  try {
+    for await (const log of fetchAllRequestLogs(client, {
+      projectId,
+      deploymentId,
+      environment: environmentOption,
+      level: levels.length > 0 ? levels : undefined,
+      statusCode: statusCodeOption,
+      source: sources.length > 0 ? sources : undefined,
+      since: sinceOption,
+      until: untilOption,
+      limit,
+      search: searchOption,
+    })) {
+      output.stopSpinner();
+      if (jsonOption) {
+        client.stdout.write(JSON.stringify(log) + '\n');
+      } else {
+        prettyPrintLogEntry(log);
+      }
+      count++;
+    }
+  } catch (err) {
+    output.stopSpinner();
+    printError(err);
+    return 1;
+  }
+
+  output.stopSpinner();
+
+  if (!jsonOption) {
+    if (count === 0) {
+      output.print(
+        chalk.gray('No logs found matching the specified filters.\n')
+      );
+    } else {
+      output.print(chalk.gray(`\nDisplayed ${count} log entries.\n`));
+    }
+  }
+
+  return 0;
+}
+
+function prettyPrintLogEntry(log: RequestLogEntry) {
+  const date = format(log.timestamp, DATE_TIME_FORMAT);
+  const levelIcon = getLevelIcon(log.level);
+  const sourceIcon = getSourceIcon(log.source);
+  const status =
+    log.responseStatusCode <= 0
+      ? chalk.gray('---')
+      : getStatusColor(log.responseStatusCode);
+
+  const headerLine = `${chalk.dim(date)}  ${levelIcon}  ${chalk.bold(
+    log.requestMethod.padEnd(6)
+  )}  ${status}  ${chalk.dim(log.domain)}  ${sourceIcon}  ${log.requestPath}`;
+
+  output.print(`${headerLine}\n`);
+
+  if (log.message) {
+    const message = log.message.replace(/\n$/, '');
+    const truncatedIndicator = log.messageTruncated ? chalk.gray('…') : '';
+    output.print(
+      `${colorizeMessage(message, log.level)}${truncatedIndicator}\n\n`
+    );
+  } else {
+    output.print('\n');
+  }
+}
+
+function getLevelIcon(level: string): string {
+  switch (level) {
+    case 'fatal':
+    case 'error':
+      return '🚫';
+    case 'warning':
+      return '⚠️';
+    default:
+      return 'ℹ️';
+  }
+}
+
+function getSourceIcon(source: string): string {
+  switch (source) {
+    case 'edge-function':
+      return 'ന';
+    case 'edge-middleware':
+      return 'ɛ';
+    case 'serverless':
+      return 'ƒ';
+    default:
+      return ' ';
+  }
+}
+
+function getStatusColor(status: number): string {
+  const statusStr = String(status);
+  if (status >= 500) {
+    return chalk.red(statusStr);
+  } else if (status >= 400) {
+    return chalk.yellow(statusStr);
+  } else if (status >= 300) {
+    return chalk.cyan(statusStr);
+  } else if (status >= 200) {
+    return chalk.green(statusStr);
+  }
+  return chalk.gray(statusStr);
+}
+
+function colorizeMessage(message: string, level: string): string {
+  switch (level) {
+    case 'fatal':
+    case 'error':
+      return chalk.red(message);
+    case 'warning':
+      return chalk.yellow(message);
+    default:
+      return message;
+  }
+}

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -67,7 +67,7 @@ export default async function logsv2(client: Client) {
   const untilOption = parsedArguments.flags['--until'];
   const limitOption = parsedArguments.flags['--limit'];
   const jsonOption = parsedArguments.flags['--json'];
-  const searchOption = parsedArguments.flags['--search'];
+  const queryOption = parsedArguments.flags['--query'];
   const requestIdOption = parsedArguments.flags['--request-id'];
 
   telemetry.trackCliOptionProject(projectOption);
@@ -80,7 +80,7 @@ export default async function logsv2(client: Client) {
   telemetry.trackCliOptionUntil(untilOption);
   telemetry.trackCliOptionLimit(limitOption);
   telemetry.trackCliFlagJson(jsonOption);
-  telemetry.trackCliOptionSearch(searchOption);
+  telemetry.trackCliOptionQuery(queryOption);
   telemetry.trackCliOptionRequestId(requestIdOption);
 
   let contextName: string | null = null;
@@ -201,7 +201,7 @@ export default async function logsv2(client: Client) {
       since: sinceOption,
       until: untilOption,
       limit,
-      search: searchOption,
+      search: queryOption,
       requestId: requestIdOption,
     })) {
       output.stopSpinner();

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -68,6 +68,7 @@ export default async function logsv2(client: Client) {
   const limitOption = parsedArguments.flags['--limit'];
   const jsonOption = parsedArguments.flags['--json'];
   const searchOption = parsedArguments.flags['--search'];
+  const requestIdOption = parsedArguments.flags['--request-id'];
 
   telemetry.trackCliOptionProject(projectOption);
   telemetry.trackCliOptionDeployment(deploymentOption);
@@ -80,6 +81,7 @@ export default async function logsv2(client: Client) {
   telemetry.trackCliOptionLimit(limitOption);
   telemetry.trackCliFlagJson(jsonOption);
   telemetry.trackCliOptionSearch(searchOption);
+  telemetry.trackCliOptionRequestId(requestIdOption);
 
   let contextName: string | null = null;
 
@@ -200,6 +202,7 @@ export default async function logsv2(client: Client) {
       until: untilOption,
       limit,
       search: searchOption,
+      requestId: requestIdOption,
     })) {
       output.stopSpinner();
       if (jsonOption) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -734,6 +734,10 @@ const main = async () => {
           telemetry.trackCliCommandLogs(userSuppliedSubCommand);
           func = require('./commands/logs').default;
           break;
+        case 'logsv2':
+          telemetry.trackCliCommandLogsv2(userSuppliedSubCommand);
+          func = require('./commands/logsv2').default;
+          break;
         case 'mcp':
           func = require('./commands/mcp').default;
           break;

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -1,8 +1,6 @@
 import ms from 'ms';
 import type Client from './client';
 
-const DASHBOARD_API_BASE_URL = 'https://vercel.com';
-
 export interface RequestLogEntry {
   id: string;
   timestamp: number;
@@ -44,8 +42,6 @@ export interface FetchRequestLogsOptions {
   search?: string;
   requestId?: string;
   page?: number;
-  /** Base URL for the dashboard API (defaults to https://vercel.com, override for tests) */
-  baseUrl?: string;
 }
 
 function parseRelativeTime(input: string): number {
@@ -78,15 +74,7 @@ export async function fetchRequestLogs(
     search,
     requestId,
     page = 0,
-    baseUrl,
   } = options;
-
-  // Use client's apiUrl if it's localhost (test environment), otherwise use dashboard URL
-  const effectiveBaseUrl =
-    baseUrl ??
-    (client.apiUrl.startsWith('http://127.0.0.1')
-      ? client.apiUrl
-      : DASHBOARD_API_BASE_URL);
 
   const now = Date.now();
   const defaultStartDate = now - 24 * 60 * 60 * 1000; // 24 hours ago
@@ -131,7 +119,7 @@ export async function fetchRequestLogs(
     query.set('requestId', requestId);
   }
 
-  const url = `${effectiveBaseUrl}/api/logs/request-logs?${query.toString()}`;
+  const url = `/api/logs/request-logs?${query.toString()}`;
 
   const data = await client.fetch<{
     rows?: RequestLogEntry[];

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -119,7 +119,13 @@ export async function fetchRequestLogs(
     query.set('requestId', requestId);
   }
 
-  const url = `/api/logs/request-logs?${query.toString()}`;
+  // The request-logs API is on vercel.com, not api.vercel.com
+  // In tests, client.apiUrl points to the mock server, so use that
+  const baseUrl =
+    client.apiUrl === 'https://api.vercel.com'
+      ? 'https://vercel.com'
+      : client.apiUrl;
+  const url = `${baseUrl}/api/logs/request-logs?${query.toString()}`;
 
   const data = await client.fetch<{
     rows?: RequestLogEntry[];

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -169,31 +169,3 @@ export async function* fetchAllRequestLogs(
     page++;
   }
 }
-
-export async function resolveDeploymentId(
-  client: Client,
-  deploymentIdOrUrl: string
-): Promise<string> {
-  if (
-    deploymentIdOrUrl.startsWith('dpl_') ||
-    !deploymentIdOrUrl.includes('.')
-  ) {
-    return deploymentIdOrUrl;
-  }
-
-  try {
-    const url = new URL(
-      deploymentIdOrUrl.startsWith('http')
-        ? deploymentIdOrUrl
-        : `https://${deploymentIdOrUrl}`
-    );
-    const hostname = url.hostname;
-
-    const deployment = await client.fetch<{ id: string }>(
-      `/v13/deployments/get?url=${encodeURIComponent(hostname)}`
-    );
-    return deployment.id;
-  } catch {
-    return deploymentIdOrUrl;
-  }
-}

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -40,6 +40,7 @@ export interface FetchRequestLogsOptions {
   until?: string;
   limit?: number;
   search?: string;
+  requestId?: string;
   page?: number;
 }
 
@@ -71,6 +72,7 @@ export async function fetchRequestLogs(
     since,
     until,
     search,
+    requestId,
     page = 0,
   } = options;
 
@@ -111,6 +113,10 @@ export async function fetchRequestLogs(
 
   if (search) {
     query.set('search', search);
+  }
+
+  if (requestId) {
+    query.set('requestId', requestId);
   }
 
   const url = `/api/logs/request-logs?${query.toString()}`;

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -1,6 +1,8 @@
 import ms from 'ms';
 import type Client from './client';
 
+const DASHBOARD_API_BASE_URL = 'https://vercel.com';
+
 export interface RequestLogEntry {
   id: string;
   timestamp: number;
@@ -42,6 +44,8 @@ export interface FetchRequestLogsOptions {
   search?: string;
   requestId?: string;
   page?: number;
+  /** Base URL for the dashboard API (defaults to https://vercel.com, override for tests) */
+  baseUrl?: string;
 }
 
 function parseRelativeTime(input: string): number {
@@ -74,7 +78,15 @@ export async function fetchRequestLogs(
     search,
     requestId,
     page = 0,
+    baseUrl,
   } = options;
+
+  // Use client's apiUrl if it's localhost (test environment), otherwise use dashboard URL
+  const effectiveBaseUrl =
+    baseUrl ??
+    (client.apiUrl.startsWith('http://127.0.0.1')
+      ? client.apiUrl
+      : DASHBOARD_API_BASE_URL);
 
   const now = Date.now();
   const defaultStartDate = now - 24 * 60 * 60 * 1000; // 24 hours ago
@@ -119,7 +131,7 @@ export async function fetchRequestLogs(
     query.set('requestId', requestId);
   }
 
-  const url = `/api/logs/request-logs?${query.toString()}`;
+  const url = `${effectiveBaseUrl}/api/logs/request-logs?${query.toString()}`;
 
   const data = await client.fetch<{
     rows?: RequestLogEntry[];

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -1,0 +1,187 @@
+import ms from 'ms';
+import type Client from './client';
+
+export interface RequestLogEntry {
+  id: string;
+  timestamp: number;
+  deploymentId: string;
+  projectId: string;
+  level: 'error' | 'warning' | 'info' | 'fatal';
+  message: string;
+  source: 'serverless' | 'edge-function' | 'edge-middleware' | 'static';
+  domain: string;
+  requestMethod: string;
+  requestPath: string;
+  responseStatusCode: number;
+  environment: 'production' | 'preview';
+  branch?: string;
+  cache?: string;
+  traceId?: string;
+  messageTruncated?: boolean;
+}
+
+export interface RequestLogsResponse {
+  logs: RequestLogEntry[];
+  pagination?: {
+    next?: string;
+    hasMore?: boolean;
+  };
+}
+
+export interface FetchRequestLogsOptions {
+  projectId: string;
+  deploymentId?: string;
+  environment?: string;
+  level?: string[];
+  statusCode?: string;
+  source?: string[];
+  since?: string;
+  until?: string;
+  limit?: number;
+  search?: string;
+  cursor?: string;
+}
+
+function parseRelativeTime(input: string): number {
+  const now = Date.now();
+  const msValue = ms(input);
+  if (typeof msValue === 'number') {
+    return now - msValue;
+  }
+  const date = new Date(input);
+  if (!isNaN(date.getTime())) {
+    return date.getTime();
+  }
+  throw new Error(`Invalid time format: ${input}`);
+}
+
+function formatStatusCodeFilter(statusCode: string): string {
+  if (statusCode.endsWith('xx')) {
+    return statusCode;
+  }
+  return statusCode;
+}
+
+export async function fetchRequestLogs(
+  client: Client,
+  options: FetchRequestLogsOptions
+): Promise<RequestLogsResponse> {
+  const {
+    projectId,
+    deploymentId,
+    environment,
+    level,
+    statusCode,
+    source,
+    since,
+    until,
+    limit = 100,
+    search,
+    cursor,
+  } = options;
+
+  const query = new URLSearchParams();
+  query.set('projectId', projectId);
+  query.set('limit', String(limit));
+
+  if (deploymentId) {
+    query.set('deploymentId', deploymentId);
+  }
+
+  if (environment) {
+    query.set('environment', environment);
+  }
+
+  if (level && level.length > 0) {
+    for (const l of level) {
+      query.append('level', l);
+    }
+  }
+
+  if (statusCode) {
+    query.set('statusCode', formatStatusCodeFilter(statusCode));
+  }
+
+  if (source && source.length > 0) {
+    for (const s of source) {
+      query.append('source', s);
+    }
+  }
+
+  if (since) {
+    const sinceMs = parseRelativeTime(since);
+    query.set('since', String(sinceMs));
+  }
+
+  if (until) {
+    const untilMs = parseRelativeTime(until);
+    query.set('until', String(untilMs));
+  }
+
+  if (search) {
+    query.set('search', search);
+  }
+
+  if (cursor) {
+    query.set('cursor', cursor);
+  }
+
+  const url = `/api/logs/request-logs?${query.toString()}`;
+
+  return client.fetch<RequestLogsResponse>(url);
+}
+
+export async function* fetchAllRequestLogs(
+  client: Client,
+  options: FetchRequestLogsOptions
+): AsyncGenerator<RequestLogEntry> {
+  let cursor: string | undefined;
+  let remaining = options.limit ?? 100;
+
+  do {
+    const batchLimit = Math.min(remaining, 100);
+    const response = await fetchRequestLogs(client, {
+      ...options,
+      limit: batchLimit,
+      cursor,
+    });
+
+    for (const log of response.logs) {
+      yield log;
+      remaining--;
+      if (remaining <= 0) {
+        return;
+      }
+    }
+
+    cursor = response.pagination?.next;
+  } while (cursor && remaining > 0);
+}
+
+export async function resolveDeploymentId(
+  client: Client,
+  deploymentIdOrUrl: string
+): Promise<string> {
+  if (
+    deploymentIdOrUrl.startsWith('dpl_') ||
+    !deploymentIdOrUrl.includes('.')
+  ) {
+    return deploymentIdOrUrl;
+  }
+
+  try {
+    const url = new URL(
+      deploymentIdOrUrl.startsWith('http')
+        ? deploymentIdOrUrl
+        : `https://${deploymentIdOrUrl}`
+    );
+    const hostname = url.hostname;
+
+    const deployment = await client.fetch<{ id: string }>(
+      `/v13/deployments/get?url=${encodeURIComponent(hostname)}`
+    );
+    return deployment.id;
+  } catch {
+    return deploymentIdOrUrl;
+  }
+}

--- a/packages/cli/src/util/logs-v2.ts
+++ b/packages/cli/src/util/logs-v2.ts
@@ -107,9 +107,8 @@ export async function fetchRequestLogs(
 
   if (source && source.length > 0) {
     query.set('source', source.join(','));
-  } else {
-    query.set('source', 'serverless,edge-function,edge-middleware,static');
   }
+  // Don't set a default source filter - let the API return all sources
 
   if (search) {
     query.set('search', search);

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -117,4 +117,13 @@ export class Logsv2TelemetryClient
       });
     }
   }
+
+  trackCliOptionRequestId(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'request-id',
+        value: this.redactedValue,
+      });
+    }
+  }
 }

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -109,10 +109,10 @@ export class Logsv2TelemetryClient
     }
   }
 
-  trackCliOptionSearch(v: string | undefined) {
+  trackCliOptionQuery(v: string | undefined) {
     if (v) {
       this.trackCliOption({
-        option: 'search',
+        option: 'query',
         value: this.redactedValue,
       });
     }

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -1,0 +1,120 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { logsv2Command } from '../../../../commands/logsv2/command';
+
+export class Logsv2TelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof logsv2Command>
+{
+  trackCliOptionProject(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'project',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDeployment(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'deployment',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionEnvironment(v: string | undefined) {
+    if (v) {
+      const allowed = ['production', 'preview'].includes(v)
+        ? v
+        : this.redactedValue;
+      this.trackCliOption({
+        option: 'environment',
+        value: allowed,
+      });
+    }
+  }
+
+  trackCliOptionLevel(v: string[] | undefined) {
+    if (v && v.length > 0) {
+      const allowedLevels = ['error', 'warning', 'info', 'fatal'];
+      const sanitized = v.every(l => allowedLevels.includes(l))
+        ? v.join(',')
+        : this.redactedValue;
+      this.trackCliOption({
+        option: 'level',
+        value: sanitized,
+      });
+    }
+  }
+
+  trackCliOptionStatusCode(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'status-code',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSource(v: string[] | undefined) {
+    if (v && v.length > 0) {
+      const allowedSources = [
+        'serverless',
+        'edge-function',
+        'edge-middleware',
+        'static',
+      ];
+      const sanitized = v.every(s => allowedSources.includes(s))
+        ? v.join(',')
+        : this.redactedValue;
+      this.trackCliOption({
+        option: 'source',
+        value: sanitized,
+      });
+    }
+  }
+
+  trackCliOptionSince(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'since',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionUntil(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'until',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionLimit(v: number | undefined) {
+    if (typeof v === 'number') {
+      this.trackCliOption({
+        option: 'limit',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliFlagJson(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('json');
+    }
+  }
+
+  trackCliOptionSearch(v: string | undefined) {
+    if (v) {
+      this.trackCliOption({
+        option: 'search',
+        value: this.redactedValue,
+      });
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -194,6 +194,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandLogsv2(actual: string) {
+    this.trackCliCommand({
+      command: 'logsv2',
+      value: actual,
+    });
+  }
+
   trackCliCommandMicrofrontends(actual: string) {
     this.trackCliCommand({
       command: 'microfrontends',

--- a/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
+++ b/packages/cli/test/fixtures/unit/commands/git/connect/unlinked/.gitignore
@@ -1,2 +1,3 @@
 !.vercel
 .vercel
+.env*.local

--- a/packages/cli/test/fixtures/unit/commands/logsv2/linked-project/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/logsv2/linked-project/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "projectId": "prj_logsv2test",
+  "orgId": "team_dummy"
+}

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -37,6 +37,7 @@ describe('index', () => {
         ['login', 'login'],
         ['logout', 'logout'],
         ['logs', 'logs'],
+        ['logsv2', 'logsv2'],
         ['ls', 'list'],
         ['mcp', 'mcp'],
         ['mf', 'microfrontends'],

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -514,7 +514,7 @@ describe('logsv2', () => {
     });
   });
 
-  describe('--search option', () => {
+  describe('--query option', () => {
     beforeEach(() => {
       useUser();
       useTeams('team_dummy');
@@ -536,23 +536,23 @@ describe('logsv2', () => {
       });
 
       client.cwd = fixture('linked-project');
-      client.setArgv('logsv2', '--search', 'timeout');
+      client.setArgv('logsv2', '--query', 'timeout');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
       expect(receivedSearch).toEqual('timeout');
     });
 
-    it('should track telemetry for --search option', async () => {
+    it('should track telemetry for --query option', async () => {
       useRequestLogs([]);
 
       client.cwd = fixture('linked-project');
-      client.setArgv('logsv2', '--search', 'error');
+      client.setArgv('logsv2', '--query', 'error');
       await logsv2(client);
 
       expect(client.telemetryEventStore).toHaveTelemetryEvents([
         {
-          key: 'option:search',
+          key: 'option:query',
           value: '[REDACTED]',
         },
       ]);

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -1,0 +1,564 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import { defaultProject, useProject } from '../../../mocks/project';
+import logsv2 from '../../../../src/commands/logsv2';
+import { join } from 'path';
+import type { RequestLogEntry } from '../../../../src/util/logs-v2';
+
+const fixture = (name: string) =>
+  join(__dirname, '../../../fixtures/unit/commands/logsv2', name);
+
+function createMockLog(
+  overrides: Partial<RequestLogEntry> = {}
+): RequestLogEntry {
+  return {
+    id: 'log_123',
+    timestamp: Date.now(),
+    deploymentId: 'dpl_test123',
+    projectId: 'prj_logsv2test',
+    level: 'info',
+    message: 'Test log message',
+    source: 'serverless',
+    domain: 'test.vercel.app',
+    requestMethod: 'GET',
+    requestPath: '/api/test',
+    responseStatusCode: 200,
+    environment: 'production',
+    ...overrides,
+  };
+}
+
+function useRequestLogs(logs: RequestLogEntry[] = []) {
+  client.scenario.get('/api/logs/request-logs', (req, res) => {
+    res.json({
+      logs,
+      pagination: {
+        hasMore: false,
+      },
+    });
+  });
+}
+
+describe('logsv2', () => {
+  describe('--help', () => {
+    it('should display help and track telemetry', async () => {
+      client.setArgv('logsv2', '--help');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(2);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'logsv2',
+        },
+      ]);
+    });
+
+    it('should display help with examples', async () => {
+      client.setArgv('logsv2', '--help');
+      await logsv2(client);
+
+      const output = client.getFullOutput();
+      expect(output).toContain('Display request logs');
+      expect(output).toContain('--level');
+      expect(output).toContain('--environment');
+    });
+  });
+
+  describe('with linked project', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should fetch logs for linked project', async () => {
+      const mockLogs = [
+        createMockLog({ message: 'First log' }),
+        createMockLog({ message: 'Second log' }),
+      ];
+      useRequestLogs(mockLogs);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Fetching logs');
+    });
+
+    it('should output logs as JSON with --json flag', async () => {
+      const mockLogs = [createMockLog({ message: 'JSON log test' })];
+      useRequestLogs(mockLogs);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--json');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      await expect(client.stdout).toOutput('"message":"JSON log test"');
+    });
+
+    it('should track telemetry for --json flag', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--json');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:json',
+          value: 'TRUE',
+        },
+      ]);
+    });
+
+    it('should display "no logs found" when empty', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('No logs found');
+    });
+  });
+
+  describe('--project option', () => {
+    beforeEach(() => {
+      useUser();
+      useProject({
+        ...defaultProject,
+        id: 'prj_explicit',
+        name: 'explicit-project',
+      });
+    });
+
+    it('should fetch logs for specified project', async () => {
+      useRequestLogs([createMockLog()]);
+
+      client.setArgv('logsv2', '--project', 'explicit-project');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --project option', async () => {
+      useRequestLogs([]);
+
+      client.setArgv('logsv2', '--project', 'explicit-project');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:project',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should error when project not found', async () => {
+      client.scenario.get('/v9/projects/nonexistent', (_req, res) => {
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+
+      client.setArgv('logsv2', '--project', 'nonexistent');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Project not found');
+    });
+  });
+
+  describe('--level option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by error level', async () => {
+      const errorLog = createMockLog({
+        level: 'error',
+        message: 'Error occurred',
+      });
+      useRequestLogs([errorLog]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--level', 'error');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for valid --level values', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--level', 'error');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:level',
+          value: 'error',
+        },
+      ]);
+    });
+
+    it('should track telemetry for multiple --level values', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--level', 'error', '--level', 'warning');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:level',
+          value: 'error,warning',
+        },
+      ]);
+    });
+
+    it('should error on invalid level', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--level', 'invalid');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid log level: invalid');
+    });
+  });
+
+  describe('--environment option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by production environment', async () => {
+      useRequestLogs([createMockLog({ environment: 'production' })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--environment', 'production');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for production environment', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--environment', 'production');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:environment',
+          value: 'production',
+        },
+      ]);
+    });
+
+    it('should track telemetry for preview environment', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--environment', 'preview');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:environment',
+          value: 'preview',
+        },
+      ]);
+    });
+
+    it('should error on invalid environment', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--environment', 'staging');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid environment: staging');
+    });
+  });
+
+  describe('--source option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by serverless source', async () => {
+      useRequestLogs([createMockLog({ source: 'serverless' })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--source', 'serverless');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for valid --source values', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--source', 'edge-function');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:source',
+          value: 'edge-function',
+        },
+      ]);
+    });
+
+    it('should error on invalid source', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--source', 'invalid-source');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid source: invalid-source');
+    });
+  });
+
+  describe('--status-code option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by status code', async () => {
+      useRequestLogs([createMockLog({ responseStatusCode: 500 })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--status-code', '500');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --status-code option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--status-code', '500');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:status-code',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
+  describe('--since and --until options', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by time range', async () => {
+      useRequestLogs([createMockLog()]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--since', '1h');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --since option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--since', '1h');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:since',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+
+    it('should track telemetry for --until option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--until', '30m');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:until',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
+  describe('--limit option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should limit number of results', async () => {
+      useRequestLogs([createMockLog(), createMockLog()]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--limit', '10');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --limit option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--limit', '50');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:limit',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
+  describe('--search option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should search logs', async () => {
+      useRequestLogs([createMockLog({ message: 'timeout error occurred' })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--search', 'timeout');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --search option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--search', 'error');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:search',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
+  describe('--deployment option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by deployment ID', async () => {
+      useRequestLogs([createMockLog({ deploymentId: 'dpl_specific123' })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--deployment', 'dpl_specific123');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --deployment option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--deployment', 'dpl_abc123');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:deployment',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should error when not linked and no project specified', async () => {
+      useUser();
+
+      client.setArgv('logsv2');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput("isn't linked to a project");
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -188,17 +188,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by error level', async () => {
-      const errorLog = createMockLog({
-        level: 'error',
-        message: 'Error occurred',
+      let receivedLevel: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedLevel = req.query.level as string;
+        res.json({
+          rows: [createMockLog({ level: 'error', message: 'Error occurred' })],
+          hasMoreRows: false,
+        });
       });
-      useRequestLogs([errorLog]);
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--level', 'error');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedLevel).toEqual('error');
     });
 
     it('should track telemetry for valid --level values', async () => {
@@ -253,13 +257,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by production environment', async () => {
-      useRequestLogs([createMockLog({ environment: 'production' })]);
+      let receivedEnvironment: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedEnvironment = req.query.environment as string;
+        res.json({
+          rows: [createMockLog({ environment: 'production' })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--environment', 'production');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedEnvironment).toEqual('production');
     });
 
     it('should track telemetry for production environment', async () => {
@@ -314,13 +326,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by serverless source', async () => {
-      useRequestLogs([createMockLog({ source: 'serverless' })]);
+      let receivedSource: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedSource = req.query.source as string;
+        res.json({
+          rows: [createMockLog({ source: 'serverless' })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--source', 'serverless');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedSource).toEqual('serverless');
     });
 
     it('should track telemetry for valid --source values', async () => {
@@ -360,13 +380,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by status code', async () => {
-      useRequestLogs([createMockLog({ responseStatusCode: 500 })]);
+      let receivedStatusCode: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedStatusCode = req.query.statusCode as string;
+        res.json({
+          rows: [createMockLog({ responseStatusCode: 500 })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--status-code', '500');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedStatusCode).toEqual('500');
     });
 
     it('should track telemetry for --status-code option', async () => {
@@ -397,13 +425,25 @@ describe('logsv2', () => {
     });
 
     it('should filter by time range', async () => {
-      useRequestLogs([createMockLog()]);
+      let receivedStartDate: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedStartDate = req.query.startDate as string;
+        res.json({
+          rows: [createMockLog()],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--since', '1h');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      const startDateMs = parseInt(receivedStartDate!, 10);
+      const now = Date.now();
+      const oneHourAgo = now - 60 * 60 * 1000;
+      expect(startDateMs).toBeGreaterThan(oneHourAgo - 1000);
+      expect(startDateMs).toBeLessThan(oneHourAgo + 1000);
     });
 
     it('should track telemetry for --since option', async () => {
@@ -486,13 +526,21 @@ describe('logsv2', () => {
     });
 
     it('should search logs', async () => {
-      useRequestLogs([createMockLog({ message: 'timeout error occurred' })]);
+      let receivedSearch: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedSearch = req.query.search as string;
+        res.json({
+          rows: [createMockLog({ message: 'timeout error occurred' })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--search', 'timeout');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedSearch).toEqual('timeout');
     });
 
     it('should track telemetry for --search option', async () => {
@@ -523,13 +571,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by deployment ID', async () => {
-      useRequestLogs([createMockLog({ deploymentId: 'dpl_specific123' })]);
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: 'dpl_specific123' })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--deployment', 'dpl_specific123');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual('dpl_specific123');
     });
 
     it('should track telemetry for --deployment option', async () => {
@@ -560,13 +616,21 @@ describe('logsv2', () => {
     });
 
     it('should filter by request ID', async () => {
-      useRequestLogs([createMockLog({ id: 'req_specific123' })]);
+      let receivedRequestId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedRequestId = req.query.requestId as string;
+        res.json({
+          rows: [createMockLog({ id: 'req_specific123' })],
+          hasMoreRows: false,
+        });
+      });
 
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--request-id', 'req_specific123');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(0);
+      expect(receivedRequestId).toEqual('req_specific123');
     });
 
     it('should track telemetry for --request-id option', async () => {

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -31,12 +31,10 @@ function createMockLog(
 }
 
 function useRequestLogs(logs: RequestLogEntry[] = []) {
-  client.scenario.get('/api/logs/request-logs', (req, res) => {
+  client.scenario.get('/api/logs/request-logs', (_req, res) => {
     res.json({
-      logs,
-      pagination: {
-        hasMore: false,
-      },
+      rows: logs,
+      hasMoreRows: false,
     });
   });
 }

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -548,6 +548,43 @@ describe('logsv2', () => {
     });
   });
 
+  describe('--request-id option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should filter by request ID', async () => {
+      useRequestLogs([createMockLog({ id: 'req_specific123' })]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--request-id', 'req_specific123');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry for --request-id option', async () => {
+      useRequestLogs([]);
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--request-id', 'req_abc123');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'option:request-id',
+          value: '[REDACTED]',
+        },
+      ]);
+    });
+  });
+
   describe('error handling', () => {
     it('should error when not linked and no project specified', async () => {
       useUser();

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { client } from '../../mocks/client';
+import { useUser } from '../../mocks/user';
+import {
+  fetchRequestLogs,
+  fetchAllRequestLogs,
+  resolveDeploymentId,
+  type RequestLogEntry,
+} from '../../../src/util/logs-v2';
+
+function createMockLog(
+  overrides: Partial<RequestLogEntry> = {}
+): RequestLogEntry {
+  return {
+    id: 'log_123',
+    timestamp: Date.now(),
+    deploymentId: 'dpl_test123',
+    projectId: 'prj_test',
+    level: 'info',
+    message: 'Test log message',
+    source: 'serverless',
+    domain: 'test.vercel.app',
+    requestMethod: 'GET',
+    requestPath: '/api/test',
+    responseStatusCode: 200,
+    environment: 'production',
+    ...overrides,
+  };
+}
+
+describe('logs-v2 utility', () => {
+  beforeEach(() => {
+    useUser();
+  });
+
+  describe('fetchRequestLogs', () => {
+    it('should fetch logs with projectId', async () => {
+      const mockLogs = [createMockLog()];
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.projectId).toEqual('prj_test');
+        res.json({ logs: mockLogs, pagination: {} });
+      });
+
+      const result = await fetchRequestLogs(client, { projectId: 'prj_test' });
+
+      expect(result.logs).toHaveLength(1);
+      expect(result.logs[0].id).toEqual('log_123');
+    });
+
+    it('should include deploymentId in query when provided', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.deploymentId).toEqual('dpl_specific');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        deploymentId: 'dpl_specific',
+      });
+    });
+
+    it('should include environment filter in query', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.environment).toEqual('production');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        environment: 'production',
+      });
+    });
+
+    it('should include multiple level filters in query', async () => {
+      const receivedLevels: string[] = [];
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        if (Array.isArray(req.query.level)) {
+          receivedLevels.push(...req.query.level);
+        } else if (req.query.level) {
+          receivedLevels.push(req.query.level);
+        }
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        level: ['error', 'warning'],
+      });
+
+      expect(receivedLevels).toContain('error');
+      expect(receivedLevels).toContain('warning');
+    });
+
+    it('should include multiple source filters in query', async () => {
+      const receivedSources: string[] = [];
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        if (Array.isArray(req.query.source)) {
+          receivedSources.push(...req.query.source);
+        } else if (req.query.source) {
+          receivedSources.push(req.query.source);
+        }
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        source: ['serverless', 'edge-function'],
+      });
+
+      expect(receivedSources).toContain('serverless');
+      expect(receivedSources).toContain('edge-function');
+    });
+
+    it('should include statusCode filter in query', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.statusCode).toEqual('500');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        statusCode: '500',
+      });
+    });
+
+    it('should include search query in request', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.search).toEqual('timeout');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        search: 'timeout',
+      });
+    });
+
+    it('should include limit in query', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.limit).toEqual('50');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        limit: 50,
+      });
+    });
+
+    it('should default limit to 100', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.limit).toEqual('100');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, { projectId: 'prj_test' });
+    });
+
+    it('should include cursor for pagination', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.cursor).toEqual('cursor_abc123');
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        cursor: 'cursor_abc123',
+      });
+    });
+
+    it('should parse relative time for --since option', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        const sinceMs = parseInt(req.query.since as string, 10);
+        const now = Date.now();
+        const oneHourAgo = now - 60 * 60 * 1000;
+        expect(sinceMs).toBeGreaterThan(oneHourAgo - 1000);
+        expect(sinceMs).toBeLessThan(oneHourAgo + 1000);
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        since: '1h',
+      });
+    });
+
+    it('should parse ISO date for --since option', async () => {
+      const isoDate = '2024-01-15T10:00:00Z';
+      const expectedMs = new Date(isoDate).getTime();
+
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        const sinceMs = parseInt(req.query.since as string, 10);
+        expect(sinceMs).toEqual(expectedMs);
+        res.json({ logs: [], pagination: {} });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        since: isoDate,
+      });
+    });
+  });
+
+  describe('fetchAllRequestLogs', () => {
+    it('should yield all logs from single page', async () => {
+      const mockLogs = [
+        createMockLog({ id: 'log_1' }),
+        createMockLog({ id: 'log_2' }),
+      ];
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        res.json({ logs: mockLogs, pagination: { hasMore: false } });
+      });
+
+      const logs: RequestLogEntry[] = [];
+      for await (const log of fetchAllRequestLogs(client, {
+        projectId: 'prj_test',
+      })) {
+        logs.push(log);
+      }
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0].id).toEqual('log_1');
+      expect(logs[1].id).toEqual('log_2');
+    });
+
+    it('should paginate through multiple pages', async () => {
+      let requestCount = 0;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        requestCount++;
+        if (!req.query.cursor) {
+          res.json({
+            logs: [createMockLog({ id: 'log_page1' })],
+            pagination: { next: 'cursor_page2', hasMore: true },
+          });
+        } else if (req.query.cursor === 'cursor_page2') {
+          res.json({
+            logs: [createMockLog({ id: 'log_page2' })],
+            pagination: { hasMore: false },
+          });
+        }
+      });
+
+      const logs: RequestLogEntry[] = [];
+      for await (const log of fetchAllRequestLogs(client, {
+        projectId: 'prj_test',
+        limit: 200,
+      })) {
+        logs.push(log);
+      }
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0].id).toEqual('log_page1');
+      expect(logs[1].id).toEqual('log_page2');
+      expect(requestCount).toEqual(2);
+    });
+
+    it('should respect limit across pages', async () => {
+      let requestCount = 0;
+      client.scenario.get('/api/logs/request-logs', (_req, res) => {
+        requestCount++;
+        res.json({
+          logs: [
+            createMockLog({ id: `log_${requestCount}_1` }),
+            createMockLog({ id: `log_${requestCount}_2` }),
+          ],
+          pagination: { next: `cursor_${requestCount + 1}`, hasMore: true },
+        });
+      });
+
+      const logs: RequestLogEntry[] = [];
+      for await (const log of fetchAllRequestLogs(client, {
+        projectId: 'prj_test',
+        limit: 3,
+      })) {
+        logs.push(log);
+      }
+
+      expect(logs).toHaveLength(3);
+    });
+  });
+
+  describe('resolveDeploymentId', () => {
+    it('should return deployment ID as-is if it starts with dpl_', async () => {
+      const result = await resolveDeploymentId(client, 'dpl_abc123');
+      expect(result).toEqual('dpl_abc123');
+    });
+
+    it('should return ID as-is if it does not contain a dot', async () => {
+      const result = await resolveDeploymentId(client, 'abc123');
+      expect(result).toEqual('abc123');
+    });
+
+    it('should resolve URL to deployment ID', async () => {
+      client.scenario.get('/v13/deployments/get', (req, res) => {
+        expect(req.query.url).toEqual('my-app.vercel.app');
+        res.json({ id: 'dpl_resolved123' });
+      });
+
+      const result = await resolveDeploymentId(client, 'my-app.vercel.app');
+      expect(result).toEqual('dpl_resolved123');
+    });
+
+    it('should handle full URL with https', async () => {
+      client.scenario.get('/v13/deployments/get', (req, res) => {
+        expect(req.query.url).toEqual('my-app.vercel.app');
+        res.json({ id: 'dpl_fromhttps' });
+      });
+
+      const result = await resolveDeploymentId(
+        client,
+        'https://my-app.vercel.app'
+      );
+      expect(result).toEqual('dpl_fromhttps');
+    });
+
+    it('should return input on resolution failure', async () => {
+      client.scenario.get('/v13/deployments/get', (_req, res) => {
+        res.status(404).json({ error: { code: 'not_found' } });
+      });
+
+      const result = await resolveDeploymentId(client, 'unknown.vercel.app');
+      expect(result).toEqual('unknown.vercel.app');
+    });
+  });
+});

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -45,6 +45,7 @@ describe('logs-v2 utility', () => {
       const result = await fetchRequestLogs(client, {
         projectId: 'prj_test',
         ownerId: 'team_test',
+        baseUrl: client.apiUrl,
       });
 
       expect(result.logs).toHaveLength(1);
@@ -61,6 +62,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         deploymentId: 'dpl_specific',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -74,6 +76,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         environment: 'production',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -87,6 +90,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         level: ['error', 'warning'],
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -100,6 +104,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         source: ['serverless', 'edge-function'],
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -113,6 +118,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         statusCode: '500',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -126,6 +132,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         search: 'timeout',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -139,6 +146,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         requestId: 'req_abc123',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -156,6 +164,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         since: '1h',
+        baseUrl: client.apiUrl,
       });
     });
 
@@ -173,6 +182,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         since: isoDate,
+        baseUrl: client.apiUrl,
       });
     });
   });
@@ -191,6 +201,7 @@ describe('logs-v2 utility', () => {
       for await (const log of fetchAllRequestLogs(client, {
         projectId: 'prj_test',
         ownerId: 'team_test',
+        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }
@@ -223,6 +234,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         limit: 200,
+        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }
@@ -251,6 +263,7 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         limit: 3,
+        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -4,7 +4,6 @@ import { useUser } from '../../mocks/user';
 import {
   fetchRequestLogs,
   fetchAllRequestLogs,
-  resolveDeploymentId,
   type RequestLogEntry,
 } from '../../../src/util/logs-v2';
 
@@ -256,50 +255,6 @@ describe('logs-v2 utility', () => {
       }
 
       expect(logs).toHaveLength(3);
-    });
-  });
-
-  describe('resolveDeploymentId', () => {
-    it('should return deployment ID as-is if it starts with dpl_', async () => {
-      const result = await resolveDeploymentId(client, 'dpl_abc123');
-      expect(result).toEqual('dpl_abc123');
-    });
-
-    it('should return ID as-is if it does not contain a dot', async () => {
-      const result = await resolveDeploymentId(client, 'abc123');
-      expect(result).toEqual('abc123');
-    });
-
-    it('should resolve URL to deployment ID', async () => {
-      client.scenario.get('/v13/deployments/get', (req, res) => {
-        expect(req.query.url).toEqual('my-app.vercel.app');
-        res.json({ id: 'dpl_resolved123' });
-      });
-
-      const result = await resolveDeploymentId(client, 'my-app.vercel.app');
-      expect(result).toEqual('dpl_resolved123');
-    });
-
-    it('should handle full URL with https', async () => {
-      client.scenario.get('/v13/deployments/get', (req, res) => {
-        expect(req.query.url).toEqual('my-app.vercel.app');
-        res.json({ id: 'dpl_fromhttps' });
-      });
-
-      const result = await resolveDeploymentId(
-        client,
-        'https://my-app.vercel.app'
-      );
-      expect(result).toEqual('dpl_fromhttps');
-    });
-
-    it('should return input on resolution failure', async () => {
-      client.scenario.get('/v13/deployments/get', (_req, res) => {
-        res.status(404).json({ error: { code: 'not_found' } });
-      });
-
-      const result = await resolveDeploymentId(client, 'unknown.vercel.app');
-      expect(result).toEqual('unknown.vercel.app');
     });
   });
 });

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -45,7 +45,6 @@ describe('logs-v2 utility', () => {
       const result = await fetchRequestLogs(client, {
         projectId: 'prj_test',
         ownerId: 'team_test',
-        baseUrl: client.apiUrl,
       });
 
       expect(result.logs).toHaveLength(1);
@@ -62,7 +61,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         deploymentId: 'dpl_specific',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -76,7 +74,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         environment: 'production',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -90,7 +87,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         level: ['error', 'warning'],
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -104,7 +100,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         source: ['serverless', 'edge-function'],
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -118,7 +113,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         statusCode: '500',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -132,7 +126,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         search: 'timeout',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -146,7 +139,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         requestId: 'req_abc123',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -164,7 +156,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         since: '1h',
-        baseUrl: client.apiUrl,
       });
     });
 
@@ -182,7 +173,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         since: isoDate,
-        baseUrl: client.apiUrl,
       });
     });
   });
@@ -201,7 +191,6 @@ describe('logs-v2 utility', () => {
       for await (const log of fetchAllRequestLogs(client, {
         projectId: 'prj_test',
         ownerId: 'team_test',
-        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }
@@ -234,7 +223,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         limit: 200,
-        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }
@@ -263,7 +251,6 @@ describe('logs-v2 utility', () => {
         projectId: 'prj_test',
         ownerId: 'team_test',
         limit: 3,
-        baseUrl: client.apiUrl,
       })) {
         logs.push(log);
       }

--- a/packages/cli/test/unit/util/logs-v2.test.ts
+++ b/packages/cli/test/unit/util/logs-v2.test.ts
@@ -129,6 +129,19 @@ describe('logs-v2 utility', () => {
       });
     });
 
+    it('should include requestId filter in query', async () => {
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        expect(req.query.requestId).toEqual('req_abc123');
+        res.json({ rows: [], hasMoreRows: false });
+      });
+
+      await fetchRequestLogs(client, {
+        projectId: 'prj_test',
+        ownerId: 'team_test',
+        requestId: 'req_abc123',
+      });
+    });
+
     it('should parse relative time for --since option', async () => {
       client.scenario.get('/api/logs/request-logs', (req, res) => {
         const startDateMs = parseInt(req.query.startDate as string, 10);


### PR DESCRIPTION
## Summary

Adds a new hidden `vercel logsv2` command that uses the newer `/api/logs/request-logs` endpoint (same as the Vercel dashboard). This provides project-scoped log querying with extensive filtering options, designed to eventually replace the existing `logs` command.

## New Features

- **Project-scoped logs**: Query logs across all deployments in a project (vs deployment-only in v1)
- **Rich filtering**: Level, source, status code, environment, time range, request ID, and full-text search
- **Agent-native output**: JSON Lines format for easy piping to `jq` and automation tools
- **Historical data**: Query past logs with `--since`/`--until` (vs real-time only in v1)

## New Options

| Option | Type | Description |
|--------|------|-------------|
| `--project, -p` | string | Project ID or name (defaults to linked project) |
| `--deployment, -d` | string | Filter to specific deployment ID or URL |
| `--environment` | string | `production` or `preview` |
| `--level` | string[] | `error`, `warning`, `info`, `fatal` (repeatable) |
| `--status-code` | string | HTTP status code filter (e.g., `500`, `4xx`) |
| `--source` | string[] | `serverless`, `edge-function`, `edge-middleware`, `static` |
| `--since` | string | Start time (ISO date or relative: `1h`, `30m`, `2d`) |
| `--until` | string | End time (default: now) |
| `--limit, -n` | number | Maximum results (default: 100) |
| `--json, -j` | boolean | Output as JSON Lines for piping |
| `--query, -q` | string | Full-text search query |
| `--request-id` | string | Filter by request ID |

## Agent-Native Design

The command follows CLI best practices for automation:

- **JSON Lines output** (`--json`): Each log entry is a separate JSON object on its own line
- **stdout/stderr separation**: Log data to stdout, status messages to stderr
- **Clear exit codes**: 0 = success, 1 = error, 2 = help displayed
- **TTY detection**: Pretty output for terminals, plain for pipes
- **NO_COLOR support**: Respects color preferences

## Usage Examples

```bash
# View recent errors for linked project
vercel logsv2 --level error --since 1h

# Search logs with JSON output for jq processing
vercel logsv2 --json --query "timeout" | jq '.statusCode'

# Filter by deployment and status code
vercel logsv2 --deployment dpl_abc123 --status-code 500

# Production errors in the last day
vercel logsv2 --environment production --level error --since 1d

# Filter by specific request ID
vercel logsv2 --request-id req_xxxxx
```

## Comparison: logs vs logsv2

| Feature | `logs` (v1) | `logsv2` (new) |
|---------|-------------|----------------|
| Scope | Single deployment | Project-wide (+ optional deployment filter) |
| Data access | Real-time streaming | Historical via pagination |
| Filtering | None (use jq) | level, source, status, environment, request ID, search |
| Time range | "now" only | `--since` / `--until` |
| API | `/v1/.../runtime-logs` (streaming) | `/api/logs/request-logs` (REST) |
| Timeout | 5 minutes auto-abort | None |

## Breaking Changes

None - this is a new hidden command. The existing `logs` command is unchanged.

## Rollout Strategy

1. **Phase 1 (this PR)**: Hidden `vercel logsv2` command for testing
2. **Phase 2**: Feature flag to redirect `vercel logs` → `logsv2`
3. **Phase 3**: Promote to default, deprecate v1

## Test Plan

- [x] Unit tests for `logs-v2.ts` utility (18 tests)
- [x] Unit tests for `logsv2` command (34 tests)
- [x] Manual testing with linked project
- [x] Manual testing with `--project` flag
- [x] Verify JSON output pipes correctly to `jq`
- [ ] Test all filter combinations
