### PR TITLE
[build-utils] Optimize getNodeVersion by separating package.json lookup

### DIFF
--- a/.changeset/optimize-get-node-version.md
+++ b/.changeset/optimize-get-node-version.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Add `findPackageJson` function for optimized package.json lookup without lockfile scanning. This improves `getNodeVersion` performance by avoiding unnecessary lockfile parsing.

--- a/packages/build-utils/src/fs/run-user-scripts.ts
+++ b/packages/build-utils/src/fs/run-user-scripts.ts
@@ -38,11 +38,7 @@ const NO_OVERRIDE = {
 
 export type CliType = 'yarn' | 'npm' | 'pnpm' | 'bun' | 'vlt';
 
-export interface ScanParentDirsResult {
-  /**
-   * "yarn", "npm", or "pnpm" depending on the presence of lockfiles.
-   */
-  cliType: CliType;
+export interface FindPackageJsonResult {
   /**
    * The file path of found `package.json` file, or `undefined` if not found.
    */
@@ -52,6 +48,13 @@ export interface ScanParentDirsResult {
    * option is enabled.
    */
   packageJson?: PackageJson;
+}
+
+export interface ScanParentDirsResult extends FindPackageJsonResult {
+  /**
+   * "yarn", "npm", or "pnpm" depending on the presence of lockfiles.
+   */
+  cliType: CliType;
   /**
    * The file path of the lockfile (`yarn.lock`, `package-lock.json`, or `pnpm-lock.yaml`)
    * or `undefined` if not found.
@@ -316,7 +319,7 @@ export async function getNodeVersion(
     latestVersion.runtime = 'nodejs';
     return latestVersion;
   }
-  const { packageJson } = await scanParentDirs(destPath, true);
+  const { packageJson } = await findPackageJson(destPath, true);
   const configuredVersion = config.nodeVersion || fallbackVersion;
 
   const packageJsonVersion = packageJson?.engines?.node;
@@ -353,11 +356,16 @@ export async function getNodeVersion(
   return supportedNodeVersion;
 }
 
-export async function scanParentDirs(
+/**
+ * Traverses up directories to find and optionally read package.json.
+ * This is a lightweight alternative to `scanParentDirs` when only
+ * package.json information is needed (without lockfile detection).
+ */
+export async function findPackageJson(
   destPath: string,
   readPackageJson = false,
   base = '/'
-): Promise<ScanParentDirsResult> {
+): Promise<FindPackageJsonResult> {
   assert(path.isAbsolute(destPath));
 
   const pkgJsonPath = await walkParentDirs({
@@ -376,6 +384,25 @@ export async function scanParentDirs(
       );
     }
   }
+
+  return {
+    packageJsonPath: pkgJsonPath || undefined,
+    packageJson,
+  };
+}
+
+export async function scanParentDirs(
+  destPath: string,
+  readPackageJson = false,
+  base = '/'
+): Promise<ScanParentDirsResult> {
+  assert(path.isAbsolute(destPath));
+
+  const { packageJsonPath: pkgJsonPath, packageJson } = await findPackageJson(
+    destPath,
+    readPackageJson,
+    base
+  );
   const {
     paths: [
       yarnLockPath,

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -35,6 +35,7 @@ import {
   getNodeBinPath,
   getNodeBinPaths,
   scanParentDirs,
+  findPackageJson,
   traverseUpDirectories,
 } from './fs/run-user-scripts';
 import {
@@ -102,6 +103,7 @@ export {
   isDirectory,
   getLambdaOptionsFromFunction,
   scanParentDirs,
+  findPackageJson,
   getIgnoreFilter,
   cloneEnv,
   hardLinkDir,


### PR DESCRIPTION
## Summary

- Add `findPackageJson` function for lightweight package.json lookup without lockfile scanning
- Update `getNodeVersion` to use `findPackageJson` instead of `scanParentDirs`
- Improves performance by avoiding unnecessary lockfile parsing when only `package.json` is needed

## Problem

`getNodeVersion` was calling `scanParentDirs` internally, which scans and parses all possible lockfiles (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `vlt-lock.json`). However, `getNodeVersion` only needs `packageJson?.engines?.node` - it doesn't use any lockfile information.

## Solution

Created a new `findPackageJson` function that only traverses directories to find and optionally read `package.json`, without any lockfile scanning. Updated `getNodeVersion` to use this lightweight function.

## Performance Impact

**Before**: `getNodeVersion` triggered:
- `walkParentDirs` for `package.json` + `walkParentDirsMulti` for 6 lockfiles
- Reading and parsing up to 5 lockfiles  
- `readProjectRootInfo` traversal for turbo support

**After**: `getNodeVersion` triggers:
- Only `walkParentDirs` for `package.json`
- Only reading/parsing that single file

## Breaking Changes

None - all exports maintain the same function signatures.