### PR TITLE
[build-utils] Add CI environment variable overrides for node version and package manager

### DIFF
--- a/.changeset/ci-override-node-version-package-manager.md
+++ b/.changeset/ci-override-node-version-package-manager.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': minor
+---
+
+Add CI environment variable overrides for node version and package manager detection. When `VERCEL_CI_CLI_TYPE` and/or `VERCEL_CI_NODE_VERSION` are set, the CLI will skip filesystem scanning for package manager and node version detection, using the provided values instead.

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -37,6 +37,8 @@ import {
   scanParentDirs,
   findPackageJson,
   traverseUpDirectories,
+  getOverriddenScanParentDirsResult,
+  getOverriddenNodeVersion,
 } from './fs/run-user-scripts';
 import {
   getLatestNodeVersion,
@@ -109,6 +111,8 @@ export {
   hardLinkDir,
   traverseUpDirectories,
   validateNpmrc,
+  getOverriddenScanParentDirsResult,
+  getOverriddenNodeVersion,
 };
 
 export { EdgeFunction } from './edge-function';

--- a/packages/build-utils/test/unit.ci-overrides.test.ts
+++ b/packages/build-utils/test/unit.ci-overrides.test.ts
@@ -1,0 +1,171 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getOverriddenScanParentDirsResult,
+  getOverriddenNodeVersion,
+} from '../src/fs/run-user-scripts';
+
+describe('Test CI Override Functions', () => {
+  // Store original env vars to restore after each test
+  const originalEnv: Record<string, string | undefined> = {};
+  const envVarsToClean = [
+    'VERCEL_CI_CLI_TYPE',
+    'VERCEL_CI_LOCKFILE_VERSION',
+    'VERCEL_CI_PACKAGE_MANAGER',
+    'VERCEL_CI_TURBO_SUPPORTS_COREPACK',
+    'VERCEL_CI_NODE_VERSION',
+  ];
+
+  beforeEach(() => {
+    // Save original values
+    for (const key of envVarsToClean) {
+      originalEnv[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    // Restore original values
+    for (const key of envVarsToClean) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+  });
+
+  describe('getOverriddenScanParentDirsResult()', () => {
+    test('returns undefined when VERCEL_CI_CLI_TYPE is not set', () => {
+      delete process.env.VERCEL_CI_CLI_TYPE;
+      expect(getOverriddenScanParentDirsResult()).toBeUndefined();
+    });
+
+    test('returns undefined for invalid cliType', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'invalid';
+      expect(getOverriddenScanParentDirsResult()).toBeUndefined();
+    });
+
+    test.each(['npm', 'yarn', 'pnpm', 'bun', 'vlt'] as const)(
+      'returns result with cliType=%s',
+      cliType => {
+        process.env.VERCEL_CI_CLI_TYPE = cliType;
+        const result = getOverriddenScanParentDirsResult();
+        expect(result).toBeDefined();
+        expect(result?.cliType).toBe(cliType);
+        expect(result?.packageJsonPath).toBeUndefined();
+        expect(result?.packageJson).toBeUndefined();
+        expect(result?.lockfilePath).toBeUndefined();
+      }
+    );
+
+    test('parses lockfileVersion correctly', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_LOCKFILE_VERSION = '9';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.lockfileVersion).toBe(9);
+    });
+
+    test('handles lockfileVersion of 0 correctly', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'bun';
+      process.env.VERCEL_CI_LOCKFILE_VERSION = '0';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.lockfileVersion).toBe(0);
+    });
+
+    test('handles decimal lockfileVersion correctly', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_LOCKFILE_VERSION = '5.4';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.lockfileVersion).toBe(5.4);
+    });
+
+    test('includes packageJsonPackageManager when set', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_PACKAGE_MANAGER = 'pnpm@9.0.0';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.packageJsonPackageManager).toBe('pnpm@9.0.0');
+    });
+
+    test('sets turboSupportsCorepackHome to true when VERCEL_CI_TURBO_SUPPORTS_COREPACK is "1"', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_TURBO_SUPPORTS_COREPACK = '1';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.turboSupportsCorepackHome).toBe(true);
+    });
+
+    test('sets turboSupportsCorepackHome to false when VERCEL_CI_TURBO_SUPPORTS_COREPACK is "0"', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_TURBO_SUPPORTS_COREPACK = '0';
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.turboSupportsCorepackHome).toBe(false);
+    });
+
+    test('sets turboSupportsCorepackHome to undefined when VERCEL_CI_TURBO_SUPPORTS_COREPACK is not set', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      delete process.env.VERCEL_CI_TURBO_SUPPORTS_COREPACK;
+      const result = getOverriddenScanParentDirsResult();
+      expect(result?.turboSupportsCorepackHome).toBeUndefined();
+    });
+
+    test('returns complete result with all env vars set', () => {
+      process.env.VERCEL_CI_CLI_TYPE = 'pnpm';
+      process.env.VERCEL_CI_LOCKFILE_VERSION = '9';
+      process.env.VERCEL_CI_PACKAGE_MANAGER = 'pnpm@9.5.0';
+      process.env.VERCEL_CI_TURBO_SUPPORTS_COREPACK = '1';
+
+      const result = getOverriddenScanParentDirsResult();
+      expect(result).toEqual({
+        cliType: 'pnpm',
+        lockfileVersion: 9,
+        packageJsonPackageManager: 'pnpm@9.5.0',
+        turboSupportsCorepackHome: true,
+        packageJsonPath: undefined,
+        packageJson: undefined,
+        lockfilePath: undefined,
+      });
+    });
+  });
+
+  describe('getOverriddenNodeVersion()', () => {
+    test('returns undefined when VERCEL_CI_NODE_VERSION is not set', () => {
+      delete process.env.VERCEL_CI_NODE_VERSION;
+      expect(getOverriddenNodeVersion()).toBeUndefined();
+    });
+
+    test('returns undefined for invalid (non-numeric) value', () => {
+      process.env.VERCEL_CI_NODE_VERSION = 'invalid';
+      expect(getOverriddenNodeVersion()).toBeUndefined();
+    });
+
+    test('returns undefined for empty string', () => {
+      process.env.VERCEL_CI_NODE_VERSION = '';
+      expect(getOverriddenNodeVersion()).toBeUndefined();
+    });
+
+    test.each([18, 20, 22, 24])('returns NodeVersion for major=%d', major => {
+      process.env.VERCEL_CI_NODE_VERSION = String(major);
+      const result = getOverriddenNodeVersion();
+      expect(result).toBeDefined();
+      expect(result?.major).toBe(major);
+      expect(result?.range).toBe(`${major}.x`);
+      expect(result?.runtime).toBe(`nodejs${major}.x`);
+    });
+
+    test('constructs NodeVersion for unknown major version', () => {
+      process.env.VERCEL_CI_NODE_VERSION = '99';
+      const result = getOverriddenNodeVersion();
+      expect(result).toBeDefined();
+      expect(result?.major).toBe(99);
+      expect(result?.range).toBe('99.x');
+      expect(result?.runtime).toBe('nodejs99.x');
+    });
+
+    test('handles version "0" correctly (edge case)', () => {
+      process.env.VERCEL_CI_NODE_VERSION = '0';
+      const result = getOverriddenNodeVersion();
+      // Version 0 is not in the known list, so it should construct one
+      expect(result).toBeDefined();
+      expect(result?.major).toBe(0);
+      expect(result?.range).toBe('0.x');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add support for CI to pass pre-computed node version and package manager information via environment variables
- When these environment variables are set, the CLI skips filesystem scanning for package manager and node version detection
- This optimization reduces redundant file system operations when CI has already determined these values

## Environment Variables

| Variable | Type | Description | Example |
|----------|------|-------------|---------|
| `VERCEL_CI_NODE_VERSION` | `string` | Node.js major version | `"22"` |
| `VERCEL_CI_CLI_TYPE` | `string` | Package manager type | `"pnpm"`, `"npm"`, `"yarn"`, `"bun"`, `"vlt"` |
| `VERCEL_CI_LOCKFILE_VERSION` | `string` | Lockfile version | `"9"` |
| `VERCEL_CI_PACKAGE_MANAGER` | `string` | package.json packageManager value | `"pnpm@9.5.0"` |
| `VERCEL_CI_TURBO_SUPPORTS_COREPACK` | `string` | Turbo corepack support | `"1"` or `"0"` |

## Usage Example

```typescript
const argv = [vercelBin, 'build', '--output', outputDir];

await spawnAsync(process.execPath, argv, {
  cwd,
  env: {
    ...existingEnv,
    // CI override env vars - skip filesystem scanning in CLI
    VERCEL_CI_NODE_VERSION: String(nodeVersion.major),
    VERCEL_CI_CLI_TYPE: detectedCliType,
    VERCEL_CI_LOCKFILE_VERSION: lockfileVersion !== undefined ? String(lockfileVersion) : undefined,
    VERCEL_CI_PACKAGE_MANAGER: packageJsonPackageManager,
    VERCEL_CI_TURBO_SUPPORTS_COREPACK: turboSupportsCorepackHome ? '1' : '0',
  },
});
```

## Test Plan

- Added 24 unit tests covering the new override functions
- All existing unit tests pass (250 tests)