### PR TITLE
[cli][tests] Fix build tests polluting static fixture

### DIFF
--- a/.changeset/kind-plants-play.md
+++ b/.changeset/kind-plants-play.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix build tests polluting static fixture by adding cleanup for deploymentId validation tests.

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs-extra';
 import { join } from 'path';
 import { getWriteableDirectory } from '@vercel/build-utils';
@@ -1752,16 +1752,29 @@ describe.skipIf(flakey)('build', () => {
     });
   });
 
-  it('should reject deploymentId with dpl_ prefix in config.json', async () => {
-    const cwd = fixture('static');
-    const output = join(cwd, '.vercel/output');
+  describe('deploymentId validation', () => {
+    const staticFixture = fixture('static');
+    const generatedFiles = ['build.mjs', 'package.json', 'vercel.json'];
 
-    // Create a build script that creates config.json with invalid deploymentId
-    // This simulates a builder using Build Output API that creates an invalid config.json
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+    afterEach(async () => {
+      // Clean up generated files from the static fixture
+      await Promise.all(
+        generatedFiles.map(file =>
+          fs.remove(join(staticFixture, file)).catch(() => {})
+        )
+      );
+    });
+
+    it('should reject deploymentId with dpl_ prefix in config.json', async () => {
+      const cwd = fixture('static');
+      const output = join(cwd, '.vercel/output');
+
+      // Create a build script that creates config.json with invalid deploymentId
+      // This simulates a builder using Build Output API that creates an invalid config.json
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -1774,49 +1787,49 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    // Create package.json with build script
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    // Create vercel.json to use the build script
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      // Create package.json with build script
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      // Create vercel.json to use the build script
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      await expect(client.stderr).toOutput(
+        'cannot start with the "dpl_" prefix. Please choose a different deploymentId in your config'
+      );
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_DEPLOYMENT_ID',
+        message: expect.stringContaining('cannot start with the "dpl_" prefix'),
+      });
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(1);
+    it('should allow deploymentId without dpl_ prefix in config.json', async () => {
+      const cwd = fixture('static');
 
-    await expect(client.stderr).toOutput(
-      'cannot start with the "dpl_" prefix. Please choose a different deploymentId in your config'
-    );
-
-    const builds = await fs.readJSON(join(output, 'builds.json'));
-    expect(builds.error).toMatchObject({
-      code: 'INVALID_DEPLOYMENT_ID',
-      message: expect.stringContaining('cannot start with the "dpl_" prefix'),
-    });
-  });
-
-  it('should allow deploymentId without dpl_ prefix in config.json', async () => {
-    const cwd = fixture('static');
-
-    // Create a build script that creates config.json with valid deploymentId
-    // This simulates a builder using Build Output API that creates a valid config.json
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      // Create a build script that creates config.json with valid deploymentId
+      // This simulates a builder using Build Output API that creates a valid config.json
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -1829,38 +1842,38 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    // Create package.json with build script
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    // Create vercel.json to use the build script
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      // Create package.json with build script
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      // Create vercel.json to use the build script
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(0);
-  });
+    it('should reject deploymentId with invalid characters (spaces) in config.json', async () => {
+      const cwd = fixture('static');
+      const output = join(cwd, '.vercel/output');
 
-  it('should reject deploymentId with invalid characters (spaces) in config.json', async () => {
-    const cwd = fixture('static');
-    const output = join(cwd, '.vercel/output');
-
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -1873,46 +1886,46 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      await expect(client.stderr).toOutput(
+        'contains invalid characters. Only alphanumeric characters'
+      );
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_DEPLOYMENT_ID',
+        message: expect.stringContaining('contains invalid characters'),
+      });
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(1);
+    it('should reject deploymentId with invalid characters (question mark) in config.json', async () => {
+      const cwd = fixture('static');
+      const output = join(cwd, '.vercel/output');
 
-    await expect(client.stderr).toOutput(
-      'contains invalid characters. Only alphanumeric characters'
-    );
-
-    const builds = await fs.readJSON(join(output, 'builds.json'));
-    expect(builds.error).toMatchObject({
-      code: 'INVALID_DEPLOYMENT_ID',
-      message: expect.stringContaining('contains invalid characters'),
-    });
-  });
-
-  it('should reject deploymentId with invalid characters (question mark) in config.json', async () => {
-    const cwd = fixture('static');
-    const output = join(cwd, '.vercel/output');
-
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -1925,41 +1938,41 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_DEPLOYMENT_ID',
+        message: expect.stringContaining('contains invalid characters'),
+      });
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(1);
+    it('should allow deploymentId with valid characters (base62 + hyphen + underscore) in config.json', async () => {
+      const cwd = fixture('static');
 
-    const builds = await fs.readJSON(join(output, 'builds.json'));
-    expect(builds.error).toMatchObject({
-      code: 'INVALID_DEPLOYMENT_ID',
-      message: expect.stringContaining('contains invalid characters'),
-    });
-  });
-
-  it('should allow deploymentId with valid characters (base62 + hyphen + underscore) in config.json', async () => {
-    const cwd = fixture('static');
-
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -1972,37 +1985,37 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(0);
-  });
+    it('should reject deploymentId longer than 32 characters in config.json', async () => {
+      const cwd = fixture('static');
+      const output = join(cwd, '.vercel/output');
 
-  it('should reject deploymentId longer than 32 characters in config.json', async () => {
-    const cwd = fixture('static');
-    const output = join(cwd, '.vercel/output');
-
-    // Create a build script that creates config.json with deploymentId > 32 chars
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      // Create a build script that creates config.json with deploymentId > 32 chars
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -2015,48 +2028,48 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    // Create package.json with build script
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    // Create vercel.json to use the build script
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      // Create package.json with build script
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
+      });
+
+      // Create vercel.json to use the build script
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(1);
+
+      await expect(client.stderr).toOutput(
+        'must be 32 characters or less. Please choose a shorter deploymentId in your config'
+      );
+
+      const builds = await fs.readJSON(join(output, 'builds.json'));
+      expect(builds.error).toMatchObject({
+        code: 'INVALID_DEPLOYMENT_ID',
+        message: expect.stringContaining('must be 32 characters or less'),
+      });
     });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(1);
+    it('should allow deploymentId with exactly 32 characters in config.json', async () => {
+      const cwd = fixture('static');
 
-    await expect(client.stderr).toOutput(
-      'must be 32 characters or less. Please choose a shorter deploymentId in your config'
-    );
-
-    const builds = await fs.readJSON(join(output, 'builds.json'));
-    expect(builds.error).toMatchObject({
-      code: 'INVALID_DEPLOYMENT_ID',
-      message: expect.stringContaining('must be 32 characters or less'),
-    });
-  });
-
-  it('should allow deploymentId with exactly 32 characters in config.json', async () => {
-    const cwd = fixture('static');
-
-    // Create a build script that creates config.json with exactly 32 character deploymentId
-    const buildScript = join(cwd, 'build.mjs');
-    await fs.writeFile(
-      buildScript,
-      `import fs from 'fs';
+      // Create a build script that creates config.json with exactly 32 character deploymentId
+      const buildScript = join(cwd, 'build.mjs');
+      await fs.writeFile(
+        buildScript,
+        `import fs from 'fs';
 import { join } from 'path';
 
 const outputDir = join(process.cwd(), '.vercel', 'output');
@@ -2069,27 +2082,28 @@ fs.writeFileSync(
   }, null, 2)
 );
 `
-    );
+      );
 
-    // Create package.json with build script
-    await fs.writeJSON(join(cwd, 'package.json'), {
-      scripts: {
-        build: 'node build.mjs',
-      },
-    });
-
-    // Create vercel.json to use the build script
-    await fs.writeJSON(join(cwd, 'vercel.json'), {
-      builds: [
-        {
-          src: 'package.json',
-          use: '@vercel/static-build',
+      // Create package.json with build script
+      await fs.writeJSON(join(cwd, 'package.json'), {
+        scripts: {
+          build: 'node build.mjs',
         },
-      ],
-    });
+      });
 
-    client.cwd = cwd;
-    const exitCode = await build(client);
-    expect(exitCode).toEqual(0);
+      // Create vercel.json to use the build script
+      await fs.writeJSON(join(cwd, 'vercel.json'), {
+        builds: [
+          {
+            src: 'package.json',
+            use: '@vercel/static-build',
+          },
+        ],
+      });
+
+      client.cwd = cwd;
+      const exitCode = await build(client);
+      expect(exitCode).toEqual(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add cleanup for deploymentId validation tests that write temporary files (build.mjs, package.json, vercel.json) to the static fixture directory
- Without cleanup, these files persist and cause subsequent tests using the static fixture to fail due to changed build detection behavior

## Test plan
- [x] Run `pnpm --filter vercel exec vitest run test/unit/commands/build/index.test.ts`
- [x] Verify git status shows no new unstaged changes after tests complete