### PR TITLE
Allow python runtimes to be automatically downloaded for now.

### DIFF
--- a/.changeset/witty-brooms-attend.md
+++ b/.changeset/witty-brooms-attend.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Re-enable automatic python installs at build time.

--- a/packages/python/src/utils.ts
+++ b/packages/python/src/utils.ts
@@ -6,6 +6,8 @@ import execa from 'execa';
 
 const isWin = process.platform === 'win32';
 
+export const UV_PYTHON_DOWNLOADS_MODE = 'automatic';
+
 export const isInVirtualEnv = (): string | undefined => {
   return process.env.VIRTUAL_ENV;
 };
@@ -47,9 +49,7 @@ export function getProtectedUvEnv(
 ): NodeJS.ProcessEnv {
   return {
     ...baseEnv,
-    // Prevent uv from downloading Python interpreters at build time.
-    // The build environment must use the pre-installed system Python.
-    UV_PYTHON_DOWNLOADS: 'never',
+    UV_PYTHON_DOWNLOADS: UV_PYTHON_DOWNLOADS_MODE,
   };
 }
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -3,7 +3,12 @@ import {
   DEFAULT_PYTHON_VERSION,
 } from '../src/version';
 import { build } from '../src/index';
-import { getProtectedUvEnv, createVenvEnv, getVenvBinDir } from '../src/utils';
+import {
+  getProtectedUvEnv,
+  createVenvEnv,
+  getVenvBinDir,
+  UV_PYTHON_DOWNLOADS_MODE,
+} from '../src/utils';
 import fs from 'fs-extra';
 import path from 'path';
 import { tmpdir } from 'os';
@@ -1256,33 +1261,33 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
   });
 
   describe('getProtectedUvEnv', () => {
-    it('sets UV_PYTHON_DOWNLOADS to "never" by default', () => {
+    it('sets UV_PYTHON_DOWNLOADS to the configured mode by default', () => {
       const env = getProtectedUvEnv({});
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
     it('overrides UV_PYTHON_DOWNLOADS when user tries to set it to "auto"', () => {
       const userEnv = { UV_PYTHON_DOWNLOADS: 'auto' };
       const env = getProtectedUvEnv(userEnv);
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
     it('overrides UV_PYTHON_DOWNLOADS when user tries to unset it (undefined)', () => {
       const userEnv = { UV_PYTHON_DOWNLOADS: undefined };
       const env = getProtectedUvEnv(userEnv);
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
     it('overrides UV_PYTHON_DOWNLOADS when user tries to set empty string', () => {
       const userEnv = { UV_PYTHON_DOWNLOADS: '' };
       const env = getProtectedUvEnv(userEnv);
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
     it('overrides UV_PYTHON_DOWNLOADS from process.env', () => {
       process.env.UV_PYTHON_DOWNLOADS = 'foobar';
       const env = getProtectedUvEnv();
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
 
     it('preserves other environment variables from baseEnv', () => {
@@ -1293,7 +1298,7 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       const env = getProtectedUvEnv(userEnv);
 
       expect(env.HOME).toBe('/home/user');
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
   });
 
@@ -1307,7 +1312,7 @@ describe('UV_PYTHON_DOWNLOADS environment variable protection', () => {
       expect(env.VIRTUAL_ENV).toBe(venvPath);
       expect(env.PATH).toContain(getVenvBinDir(venvPath));
       expect(env.PATH).toContain('/usr/bin');
-      expect(env.UV_PYTHON_DOWNLOADS).toBe('never');
+      expect(env.UV_PYTHON_DOWNLOADS).toBe(UV_PYTHON_DOWNLOADS_MODE);
     });
   });
 });


### PR DESCRIPTION
Re-enabled automatic python downloads at build time to not break customers who pin to a specific version of 3.12