### PR TITLE
[python-runtime] Fix standalone python-runtime, enable via a feature flag

### DIFF
--- a/.changeset/healthy-timers-smoke.md
+++ b/.changeset/healthy-timers-smoke.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': minor
+---
+
+enable standalone python-runtime behind a feature flag

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -90,4 +90,4 @@ jobs:
             python/vercel-runtime/tests/release_smoke_test.py
 
       - name: Publish
-        run: uv publish
+        run: uv publish --directory python/vercel-runtime/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,2 @@
-[project]
-name = "vercel-monorepo"
-version = "0.0.0"
-requires-python = ">= 3.12"
-classifiers = [
-  "Private :: Do Not Upload"
-]
-
 [tool.uv.workspace]
 members = ["python/vercel-runtime"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,8 @@ requires-python = ">=3.12"
 
 [manifest]
 members = [
-    "vercel-monorepo",
     "vercel-runtime",
 ]
-
-[[package]]
-name = "vercel-monorepo"
-version = "0.0.0"
-source = { virtual = "." }
 
 [[package]]
 name = "vercel-runtime"


### PR DESCRIPTION
Use `VERCEL_RUNTIME_PYTHON_ENABLED` to opt-into the use of the
standalone `vercel-runtime` package.

Use `VERCEL_RUNTIME_PYTHON` to override the `vercel-runtime` dependency
spec (can be used to point it to an e.g a git repo branch or a local
directory).
