### PR TITLE
Disable network blocking logic during introspection while it's opt-in

### DIFF
--- a/.changeset/fast-bottles-study.md
+++ b/.changeset/fast-bottles-study.md
@@ -1,0 +1,5 @@
+---
+'@vercel/introspection': patch
+---
+
+Disable network blocking logic during introspection while it's opt-in

--- a/packages/introspection/src/loaders/cjs.ts
+++ b/packages/introspection/src/loaders/cjs.ts
@@ -1,7 +1,8 @@
 import Module from 'module';
 import { handle as handleHono } from '../hono.js';
 import { handle as handleExpress } from '../express.js';
-import './block-network.js';
+// Disabling network blocking logic while introspection is opt-in
+// import './block-network.js';
 
 const originalRequire = Module.prototype.require;
 

--- a/packages/introspection/src/loaders/esm.ts
+++ b/packages/introspection/src/loaders/esm.ts
@@ -1,4 +1,5 @@
 import { register } from 'node:module';
-import './block-network.js';
+// Disabling network blocking logic while introspection is opt-in
+// import './block-network.js';
 
 register(new URL('./hooks.mjs', import.meta.url), import.meta.url);


### PR DESCRIPTION
The network stub logic for introspection is an experimental feature, it's pretty restrictive and results in us not getting introspection data when doing pretty basic things. Disabling for now while introspection is opt-in via `VERCEL_EXPERIMENTAL_BACKENDS=1`.