### PR TITLE
feat(cli): inject NEXT_PUBLIC_VERCEL_ENV during build

### DIFF
--- a/.changeset/environment-vars-build.md
+++ b/.changeset/environment-vars-build.md
@@ -4,7 +4,7 @@
 
 Inject NEXT_PUBLIC_VERCEL_ENV and NEXT_PUBLIC_VERCEL_TARGET_ENV during `vercel build` and `vercel deploy --prebuilt`.
 
-When using `vercel build` locally followed by `vercel deploy --prebuilt`, the CLI now automatically injects `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` environment variables based on the deployment target:
+When using `vercel build` locally followed by `vercel deploy --prebuilt`, the CLI now automatically injects `VERCEL_ENV`, `VERCEL_TARGET_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` environment variables based on the deployment target:
 
 - With `--prod` flag → `production`
 - With `--target production` → `production`  

--- a/.changeset/environment-vars-build.md
+++ b/.changeset/environment-vars-build.md
@@ -1,0 +1,14 @@
+---
+'vercel': patch
+---
+
+Inject NEXT_PUBLIC_VERCEL_ENV and NEXT_PUBLIC_VERCEL_TARGET_ENV during `vercel build` and `vercel deploy --prebuilt`.
+
+When using `vercel build` locally followed by `vercel deploy --prebuilt`, the CLI now automatically injects `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` environment variables based on the deployment target:
+
+- With `--prod` flag → `production`
+- With `--target production` → `production`  
+- With `--target preview` → `preview`
+- Default (no flags) → `preview`
+
+This allows the build output to know what environment it's targeting, making the local build environment match Vercel's infrastructure.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -348,6 +348,19 @@ export default async function main(client: Client): Promise<number> {
     process.env.VERCEL = '1';
     process.env.NOW_BUILDER = '1';
 
+    // Inject VERCEL_ENV and related environment variables based on target
+    // This makes the local build environment match Vercel's infrastructure
+    envToUnset.add('VERCEL_ENV');
+    process.env.VERCEL_ENV = target;
+
+    // Inject NEXT_PUBLIC_VERCEL_ENV for Next.js client-side code
+    envToUnset.add('NEXT_PUBLIC_VERCEL_ENV');
+    process.env.NEXT_PUBLIC_VERCEL_ENV = target;
+
+    // Inject NEXT_PUBLIC_VERCEL_TARGET_ENV (same as VERCEL_ENV for local builds)
+    envToUnset.add('NEXT_PUBLIC_VERCEL_TARGET_ENV');
+    process.env.NEXT_PUBLIC_VERCEL_TARGET_ENV = target;
+
     try {
       await rootSpan
         .child('vc.doBuild')

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -353,6 +353,9 @@ export default async function main(client: Client): Promise<number> {
     envToUnset.add('VERCEL_ENV');
     process.env.VERCEL_ENV = target;
 
+    envToUnset.add('VERCEL_TARGET_ENV');
+    process.env.VERCEL_TARGET_ENV = target;
+
     // Inject NEXT_PUBLIC_VERCEL_ENV for Next.js client-side code
     envToUnset.add('NEXT_PUBLIC_VERCEL_ENV');
     process.env.NEXT_PUBLIC_VERCEL_ENV = target;

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -871,6 +871,47 @@ describe.skipIf(flakey)('build', () => {
     expect(Object.keys(env).includes('VERCEL_ANALYTICS_ID')).toEqual(true);
   });
 
+  it('should set `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` environment variables with default target', async () => {
+    const cwd = fixture('vercel-analytics-id');
+    const output = join(cwd, '.vercel/output');
+    client.cwd = cwd;
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(env.VERCEL_ENV).toEqual('preview');
+    expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('preview');
+    expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('preview');
+  });
+
+  it('should set `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` to "production" with --prod flag', async () => {
+    const cwd = fixture('vercel-analytics-id');
+    const output = join(cwd, '.vercel/output');
+    client.cwd = cwd;
+    client.setArgv('build', '--prod');
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(env.VERCEL_ENV).toEqual('production');
+    expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('production');
+    expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('production');
+  });
+
+  it('should set `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` to "production" with --target production flag', async () => {
+    const cwd = fixture('vercel-analytics-id');
+    const output = join(cwd, '.vercel/output');
+    client.cwd = cwd;
+    client.setArgv('build', '--target', 'production');
+    const exitCode = await build(client);
+    expect(exitCode).toEqual(0);
+
+    const env = await fs.readJSON(join(output, 'static', 'env.json'));
+    expect(env.VERCEL_ENV).toEqual('production');
+    expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('production');
+    expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('production');
+  });
+
   describe.each([
     {
       fixtureName: 'with-valid-vercel-otel',

--- a/packages/cli/test/unit/commands/build/index.test.ts
+++ b/packages/cli/test/unit/commands/build/index.test.ts
@@ -880,6 +880,7 @@ describe.skipIf(flakey)('build', () => {
 
     const env = await fs.readJSON(join(output, 'static', 'env.json'));
     expect(env.VERCEL_ENV).toEqual('preview');
+    expect(env.VERCEL_TARGET_ENV).toEqual('preview');
     expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('preview');
     expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('preview');
   });
@@ -894,6 +895,7 @@ describe.skipIf(flakey)('build', () => {
 
     const env = await fs.readJSON(join(output, 'static', 'env.json'));
     expect(env.VERCEL_ENV).toEqual('production');
+    expect(env.VERCEL_TARGET_ENV).toEqual('production');
     expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('production');
     expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('production');
   });
@@ -908,6 +910,7 @@ describe.skipIf(flakey)('build', () => {
 
     const env = await fs.readJSON(join(output, 'static', 'env.json'));
     expect(env.VERCEL_ENV).toEqual('production');
+    expect(env.VERCEL_TARGET_ENV).toEqual('production');
     expect(env.NEXT_PUBLIC_VERCEL_ENV).toEqual('production');
     expect(env.NEXT_PUBLIC_VERCEL_TARGET_ENV).toEqual('production');
   });


### PR DESCRIPTION
Fixes #14666

## Summary
Injects `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_TARGET_ENV` environment variables during `vercel build` based on deployment target flags.

## Changes
- Modified `packages/cli/src/commands/build/index.ts` to inject environment variables before build execution
- Added unit tests to verify variables are set correctly with different flags
- Created changeset for release documentation

## Behavior
- `vercel build --prod` → sets variables to `'production'`
- `vercel build --target production` → sets variables to `'production'`
- `vercel build --target preview` → sets variables to `'preview'`
- `vercel build` (no flags) → defaults to `'preview'`

## Test Plan
- [x] Added 3 unit tests covering default, --prod, and --target flags
- [x] Code passes Prettier formatting
- [x] Code passes ESLint checks
- [x] Pre-commit hooks passed