### PR TITLE
Move e2e tests to Version Packages PRs only

### DIFF
--- a/.changeset/tough-experts-relate.md
+++ b/.changeset/tough-experts-relate.md
@@ -1,0 +1,4 @@
+---
+---
+
+Move e2e tests to Version Packages PRs only

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ matrix.runner }}
     name: ${{matrix.scriptName}} (${{matrix.packageName}}, ${{matrix.chunkNumber}}, ${{ matrix.runner }}, Node v${{ matrix.nodeVersion }})
-    if: ${{ needs.setup.outputs['tests'] != '[]' }}
+    if: ${{ needs.setup.result != 'skipped' && needs.setup.outputs['tests'] != '[]' }}
     needs:
       - setup
     strategy:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,196 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  VERCEL_TELEMETRY_DISABLED: '1'
+  TURBO_REMOTE_ONLY: 'true'
+  TURBO_TEAM: 'vercel'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check-trigger:
+    name: Check E2E Trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - id: check
+        run: |
+          # Run if run-e2e-tests label is present
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests') }}" = "true" ]; then
+            echo "E2E tests triggered by run-e2e-tests label"
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Run if Version Packages PR from vercel-release-bot
+          if [ "${{ github.event.pull_request.title }}" = "Version Packages" ]; then
+            if [ "${{ github.event.pull_request.user.login }}" = "vercel-release-bot" ]; then
+              echo "E2E tests triggered by Version Packages PR from vercel-release-bot"
+              echo "should-run=true" >> $GITHUB_OUTPUT
+            else
+              echo "::warning::Version Packages PR not authored by vercel-release-bot, skipping e2e tests"
+              echo "should-run=false" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+
+          echo "E2E tests not triggered (no matching conditions)"
+          echo "should-run=false" >> $GITHUB_OUTPUT
+
+  setup:
+    name: Find Changes
+    runs-on: ubuntu-latest
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should-run == 'true'
+    outputs:
+      tests: ${{ steps['set-tests'].outputs['tests'] }}
+      dplUrl: ${{ steps.waitForTarball.outputs.url }}
+      affectedPackages: ${{ steps['affected-packages'].outputs['packages'] }}
+      testStrategy: ${{ steps['affected-packages'].outputs['strategy'] }}
+      affectedCount: ${{ steps['affected-packages'].outputs['count'] }}
+      totalCount: ${{ steps['affected-packages'].outputs['total'] }}
+      allPackages: ${{ steps['affected-packages'].outputs['allPackages'] }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+      - run: pnpm install
+      - id: affected-packages
+        run: |
+          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
+
+          AFFECTED_OUTPUT=$(node utils/test-affected.js "${{ github.event.pull_request.base.sha }}" 2>&1)
+
+          PACKAGE_COUNT=$(echo "$AFFECTED_OUTPUT" | grep -o "Found [0-9]* affected packages" | grep -o "[0-9]*" | head -1 || echo "0")
+          TOTAL_COUNT=$(echo "$AFFECTED_OUTPUT" | grep -o "Total packages with tests: [0-9]*" | grep -o "[0-9]*" | head -1 || echo "0")
+
+          if echo "$AFFECTED_OUTPUT" | grep -q "config or workflow changes detected"; then
+            STRATEGY="all-e2e"
+          elif echo "$AFFECTED_OUTPUT" | grep -q "test-all result detected"; then
+            STRATEGY="test-all"
+          elif [ "$PACKAGE_COUNT" -gt "0" ]; then
+            STRATEGY="affected-only"
+          else
+            STRATEGY="no-tests"
+          fi
+
+          PACKAGES=$(echo "$AFFECTED_OUTPUT" | sed -n '/Affected packages that would be tested:/,/This would result in the following turbo filters:/p' | grep "  - " | sed 's/  - //' | tr '\n' ',' | sed 's/,$//')
+
+          ALL_PACKAGES=$(echo "$AFFECTED_OUTPUT" | grep "All packages with tests:" | sed 's/All packages with tests: //' | head -1 | xargs)
+
+          echo "PACKAGE_COUNT=$PACKAGE_COUNT"
+          echo "TOTAL_COUNT=$TOTAL_COUNT"
+          echo "STRATEGY=$STRATEGY"
+
+          echo "strategy=$STRATEGY" >> $GITHUB_OUTPUT
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+          echo "count=$PACKAGE_COUNT" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL_COUNT" >> $GITHUB_OUTPUT
+          echo "allPackages=$ALL_PACKAGES" >> $GITHUB_OUTPUT
+      - id: set-tests
+        run: |
+          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          export TEST_TYPE=e2e
+
+          TESTS_ARRAY=$(node utils/chunk-tests.js $SCRIPT_NAME)
+          echo "E2E tests to run:"
+          echo "$TESTS_ARRAY"
+          echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
+        env:
+          TEST_TYPE: e2e
+      - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
+        id: waitForTarball
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 360
+          check_interval: 5
+
+  test:
+    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    name: ${{matrix.scriptName}} (${{matrix.packageName}}, ${{matrix.chunkNumber}}, ${{ matrix.runner }}, Node v${{ matrix.nodeVersion }})
+    if: ${{ needs.setup.outputs['tests'] != '[]' }}
+    needs:
+      - setup
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs['tests']) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+
+      - name: install yarn@1.22.19
+        run: npm i -g yarn@1.22.19
+
+      - name: install pnpm@8.3.1
+        run: npm i -g pnpm@8.3.1
+
+      - run: pnpm install
+
+      - name: Build ${{matrix.packageName}} and all its dependencies
+        run: node utils/gen.js && node_modules/.bin/turbo run build --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}}...
+        env:
+          FORCE_COLOR: '1'
+      - name: Test ${{matrix.packageName}}
+        run: node utils/gen.js && node_modules/.bin/turbo run ${{matrix.testScript}} --summarize --cache-dir=".turbo" --log-order=stream --filter=${{matrix.packageName}} -- ${{ join(matrix.testPaths, ' ') }}
+        shell: bash
+        env:
+          JEST_JUNIT_OUTPUT_FILE: ${{github.workspace}}/.junit-reports/${{matrix.scriptName}}-${{matrix.packageName}}-${{matrix.chunkNumber}}-${{ matrix.runner }}.xml
+          VERCEL_CLI_VERSION: ${{ needs.setup.outputs.dplUrl }}/tarballs/vercel.tgz
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FORCE_COLOR: '1'
+      - name: 'Determine Turbo HIT or MISS'
+        if: ${{ !cancelled() }}
+        id: turbo-summary
+        shell: bash
+        run: |
+          TURBO_MISS_COUNT=`node utils/determine-turbo-hit-or-miss.js`
+          echo "MISS COUNT: $TURBO_MISS_COUNT"
+          echo "misses=$TURBO_MISS_COUNT" >> $GITHUB_OUTPUT
+      - name: 'Upload Test Report to Datadog'
+        if: ${{ steps['turbo-summary'].outputs.misses != '0' && !cancelled() }}
+        run: 'pnpm dlx @datadog/datadog-ci@4.2.2 junit upload --service vercel-cli .junit-reports'
+        env:
+          DATADOG_API_KEY: ${{secrets.DATADOG_API_KEY_CLI}}
+          DD_ENV: ci
+
+  summary:
+    name: Summary (e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - check-trigger
+      - test
+    steps:
+      - name: Check All
+        run: |-
+          for status in ${{ join(needs.*.result, ' ') }}
+          do
+            if [ "$status" != "success" ] && [ "$status" != "skipped" ]
+            then
+              echo "Some checks failed"
+              exit 1
+            fi
+          done

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -103,14 +103,12 @@ jobs:
           echo "allPackages=$ALL_PACKAGES" >> $GITHUB_OUTPUT
       - id: set-tests
         run: |
-          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          export TEST_TYPE=e2e
-
-          TESTS_ARRAY=$(node utils/chunk-tests.js $SCRIPT_NAME)
+          TESTS_ARRAY=$(node utils/chunk-tests.js)
           echo "E2E tests to run:"
           echo "$TESTS_ARRAY"
           echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
         env:
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: e2e
       - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
         id: waitForTarball

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Tests
 
 on:
   pull_request:
@@ -81,9 +81,11 @@ jobs:
           export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
 
           TESTS_ARRAY=$(node utils/chunk-tests.js $SCRIPT_NAME)
-          echo "Files to test:"
+          echo "Unit tests to run:"
           echo "$TESTS_ARRAY"
           echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
+        env:
+          TEST_TYPE: unit
       - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
         id: waitForTarball
         with:
@@ -121,7 +123,7 @@ jobs:
             const unaffectedPackages = allPackagesList.filter(pkg => !affectedSet.has(pkg));
             const unaffectedList = unaffectedPackages.map(p => `1. \`${p}\``).join('\n');
 
-            let message = '## 🧪 Test Strategy\n\n';
+            let message = '## 🧪 Unit Test Strategy\n\n';
             message += `**Comparing**: [\`${baseSha.substring(0, 7)}\`](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${baseSha}) → [\`${headSha.substring(0, 7)}\`](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${headSha}) ([view diff](https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${baseSha}...${headSha}))\n\n`;
 
             if (strategy === 'all-e2e') {
@@ -136,7 +138,7 @@ jobs:
               }
               message += '### Results\n\n';
               message += '- **Unit tests**: All affected packages will run unit tests\n';
-              message += '- **E2E tests**: All e2e tests will run\n';
+              message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: All affected packages will run type checks';
             } else if (strategy === 'affected-only') {
               message += '**Strategy**: Affected packages only\n\n';
@@ -150,14 +152,14 @@ jobs:
               }
               message += '### Results\n\n';
               message += '- **Unit tests**: Only affected packages will run unit tests\n';
-              message += '- **E2E tests**: Only affected packages will run e2e tests\n';
+              message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: Only affected packages will run type checks';
             } else if (strategy === 'no-tests') {
               message += '**Strategy**: No tests needed\n\n';
               message += '✨ No packages affected - skipping tests\n\n';
               message += '### Results\n\n';
               message += '- **Unit tests**: None\n';
-              message += '- **E2E tests**: None\n';
+              message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: None';
             } else if (strategy === 'test-all') {
               message += '**Strategy**: Full test suite\n\n';
@@ -171,14 +173,14 @@ jobs:
               }
               message += '### Results\n\n';
               message += '- **Unit tests**: All packages will run unit tests\n';
-              message += '- **E2E tests**: All e2e tests will run\n';
+              message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: All packages will run type checks';
             } else {
               message += '**Strategy**: Unknown\n\n';
               message += `⚠️ Unknown strategy: ${strategy}\n\n`;
               message += '### Results\n\n';
               message += '- **Unit tests**: Unknown\n';
-              message += '- **E2E tests**: Unknown\n';
+              message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: Unknown';
             }
 
@@ -193,7 +195,7 @@ jobs:
 
             const existingComment = comments.find(comment =>
               comment.user.login === 'github-actions[bot]' &&
-              comment.body.includes('## 🧪 Test Strategy')
+              (comment.body.includes('## 🧪 Unit Test Strategy') || comment.body.includes('## 🧪 Test Strategy'))
             );
 
             if (existingComment) {
@@ -271,7 +273,7 @@ jobs:
           DD_ENV: ci
 
   summary:
-    name: Summary
+    name: Summary (unit)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
           DD_ENV: ci
 
   summary:
-    name: Summary (unit)
+    name: Summary
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,8 @@ jobs:
             message += `**Comparing**: [\`${baseSha.substring(0, 7)}\`](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${baseSha}) → [\`${headSha.substring(0, 7)}\`](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${headSha}) ([view diff](https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${baseSha}...${headSha}))\n\n`;
 
             if (strategy === 'all-e2e') {
-              message += '**Strategy**: Code changed outside of a package - running ALL tests\n\n';
-              message += '⚠️ All tests will run because global code changes could impact all packages.\n\n';
+              message += '**Strategy**: Code changed outside of a package - running all unit tests\n\n';
+              message += '⚠️ All unit tests will run because global code changes could impact all packages.\n\n';
               if (packages) {
                 const packageList = packages.split(',').map(p => `1. \`${p.trim()}\``).join('\n');
                 message += `<details>\n<summary>Affected packages - ${affectedCount} (${percentage}%)</summary>\n\n${packageList}\n\n</details>\n\n`;
@@ -162,8 +162,8 @@ jobs:
               message += '- **E2E tests**: Handled separately (Version Packages PRs or `run-e2e-tests` label)\n';
               message += '- **Type checks**: None';
             } else if (strategy === 'test-all') {
-              message += '**Strategy**: Full test suite\n\n';
-              message += '🔄 Running all tests (unable to determine affected packages)\n\n';
+              message += '**Strategy**: Full unit test suite\n\n';
+              message += '🔄 Running all unit tests (unable to determine affected packages)\n\n';
               if (packages) {
                 const packageList = packages.split(',').map(p => `1. \`${p.trim()}\``).join('\n');
                 message += `<details>\n<summary>Affected packages - ${affectedCount} (${percentage}%)</summary>\n\n${packageList}\n\n</details>\n\n`;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,12 @@ jobs:
           echo "allPackages=$ALL_PACKAGES" >> $GITHUB_OUTPUT
       - id: set-tests
         run: |
-          # Set base SHA for affected package detection
-          export TURBO_BASE_SHA="${{ github.event.pull_request.base.sha }}"
-
-          TESTS_ARRAY=$(node utils/chunk-tests.js $SCRIPT_NAME)
+          TESTS_ARRAY=$(node utils/chunk-tests.js)
           echo "Unit tests to run:"
           echo "$TESTS_ARRAY"
           echo "tests=$TESTS_ARRAY" >> $GITHUB_OUTPUT
         env:
+          TURBO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           TEST_TYPE: unit
       - uses: patrickedqvist/wait-for-vercel-preview@bfdff514ff78a669f2536e9f4dd4ef5813a704a2
         id: waitForTarball

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -92,6 +92,17 @@ const runnersMap = new Map([
   ],
 ]);
 
+// Test type categorization for filtering
+const UNIT_TEST_SCRIPTS = ['vitest-unit', 'vitest-unit-node-24', 'test-unit'];
+const E2E_TEST_SCRIPTS = [
+  'vitest-e2e',
+  'vitest-e2e-node-20',
+  'test-e2e',
+  'test-e2e-node-all-versions',
+  'test-next-local',
+  'test-dev',
+];
+
 const packageOptionsOverrides = {
   // 'some-package': { min: 1, max: 1 },
 };
@@ -114,8 +125,18 @@ function getRunnerOptions(scriptName, packageName) {
 }
 
 async function getChunkedTests() {
-  const scripts = [...runnersMap.keys()];
+  let scripts = [...runnersMap.keys()];
   const rootPath = path.resolve(__dirname, '..');
+
+  // Filter scripts based on TEST_TYPE environment variable
+  const testType = process.env.TEST_TYPE;
+  if (testType === 'unit') {
+    scripts = scripts.filter(s => UNIT_TEST_SCRIPTS.includes(s));
+    console.error('Filtering to unit tests only:', scripts.join(', '));
+  } else if (testType === 'e2e') {
+    scripts = scripts.filter(s => E2E_TEST_SCRIPTS.includes(s));
+    console.error('Filtering to e2e tests only:', scripts.join(', '));
+  }
 
   // Get affected packages based on git changes
   const baseSha = process.env.TURBO_BASE_SHA || process.env.GITHUB_BASE_REF;


### PR DESCRIPTION
Split test workflows to restrict e2e tests to Version Packages PRs (from vercel-release-bot) or PRs with the run-e2e-tests label. Unit tests continue running on all regular PRs with affected package detection. Added TEST_TYPE environment variable support to chunk-tests.js for flexible test filtering.

This reduces unnecessary e2e test runs on regular PRs while maintaining full testing for releases and explicitly triggered cases.