### PR TITLE
[CODEOWNERS] Assign packages/python and python/* to @vercel/team-python

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 /packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
+/packages/python                         @vercel/team-python
+/python                                  @vercel/team-python
+/.github/workflows/*python*.yml          @vercel/team-python
 
 # Unrestricted Paths
 # These paths are updated by the changeset CLI for "Version Packages" pull requests

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # Restricted Paths
 *                                        @vercel/ci-cd
 /.github/workflows                       @vercel/ci-cd @ijjk
-/packages/fs-detectors                   @vercel/ci-cd @agadzik @chloetedder
+/packages/fs-detectors                   @vercel/ci-cd @vercel/team-python @agadzik @chloetedder
 /packages/next                           @vercel/ci-cd @timneutkens @ijjk @ztanner @huozhi
 /packages/routing-utils                  @vercel/ci-cd @ijjk
 /packages/static-build                   @vercel/ci-cd
@@ -19,9 +19,9 @@
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 /packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
-/packages/python*                        @vercel/team-python
-/python                                  @vercel/team-python
-/.github/workflows/*python*.yml          @vercel/team-python
+/packages/python*                        @vercel/ci-cd @vercel/team-python
+/python                                  @vercel/ci-cd @vercel/team-python
+/.github/workflows/*python*.yml          @vercel/ci-cd @vercel/team-python
 
 # Unrestricted Paths
 # These paths are updated by the changeset CLI for "Version Packages" pull requests

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 /packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
-/packages/python                         @vercel/team-python
+/packages/python*                        @vercel/team-python
 /python                                  @vercel/team-python
 /.github/workflows/*python*.yml          @vercel/team-python
 


### PR DESCRIPTION
Assign Python-related code to the newly realized Python team.
