### PR TITLE
[cli] ~Always compile vercel.ts routing rules to `routes` format

### DIFF
--- a/.changeset/rude-rocks-cheat.md
+++ b/.changeset/rude-rocks-cheat.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix Vercel config routes compilation

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -465,7 +465,7 @@ describe('compileVercelConfig', () => {
     await remove(tmpDir);
   });
 
-  it('should compile vercel.ts to vercel.json and convert headers to routes', async () => {
+  it('should compile vercel.ts to vercel.json', async () => {
     const vercelTsPath = join(tmpDir, 'vercel.ts');
     const vercelTsContent = `
       export default {
@@ -514,7 +514,7 @@ describe('compileVercelConfig', () => {
     );
   });
 
-  it('should compile vercel.mjs to vercel.json and convert rewrites to routes', async () => {
+  it('should compile vercel.mjs to vercel.json', async () => {
     const vercelMjsPath = join(tmpDir, 'vercel.mjs');
     const vercelMjsContent = `
       export default {

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -66,8 +66,8 @@ describe('normalizeConfig', () => {
         {
           source: '/api/(.*)',
           destination: '/backend/$1',
-          has: [{ type: 'header', key: 'X-Custom' }],
-          missing: [{ type: 'cookie', key: 'auth' }],
+          has: [{ type: 'header' as const, key: 'X-Custom' }],
+          missing: [{ type: 'cookie' as const, key: 'auth' }],
           respectOriginCacheControl: false,
         },
         { src: '/other', dest: '/dest' },
@@ -128,7 +128,7 @@ describe('normalizeConfig', () => {
     const config = {
       redirects: [
         { source: '/old', destination: '/new', permanent: true },
-        { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+        { src: '/complex', dest: '/dest', status: 308 },
       ],
     };
 
@@ -136,8 +136,8 @@ describe('normalizeConfig', () => {
 
     expect(result.redirects).toBeUndefined();
     expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
-      { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+      { src: '/old', dest: '/new', status: 308 },
+      { src: '/complex', dest: '/dest', status: 308 },
     ]);
   });
 
@@ -190,8 +190,8 @@ describe('normalizeConfig', () => {
     const result = normalizeConfig(config);
 
     expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
-      { src: '/temp', dest: '/other', redirect: true, status: 307 },
+      { src: '/old', dest: '/new', status: 308 },
+      { src: '/temp', dest: '/other', status: 307 },
     ]);
   });
 
@@ -214,7 +214,6 @@ describe('normalizeConfig', () => {
       {
         src: '/redirect-me',
         dest: '/new-location',
-        redirect: true,
         status: 307,
       },
     ]);
@@ -234,7 +233,7 @@ describe('normalizeConfig', () => {
     const config = {
       routes: [
         { src: '/a', dest: '/b' },
-        { src: '/c', dest: '/d', redirect: true, status: 308 },
+        { src: '/c', dest: '/d', status: 308 },
       ],
     };
 
@@ -242,7 +241,7 @@ describe('normalizeConfig', () => {
 
     expect(result.routes).toEqual([
       { src: '/a', dest: '/b' },
-      { src: '/c', dest: '/d', redirect: true, status: 308 },
+      { src: '/c', dest: '/d', status: 308 },
     ]);
   });
 
@@ -253,8 +252,8 @@ describe('normalizeConfig', () => {
           source: '/protected',
           destination: '/login',
           permanent: false,
-          has: [{ type: 'cookie', key: 'auth' }],
-          missing: [{ type: 'header', key: 'X-Admin' }],
+          has: [{ type: 'cookie' as const, key: 'auth' }],
+          missing: [{ type: 'header' as const, key: 'X-Admin' }],
         },
       ],
     };
@@ -265,7 +264,6 @@ describe('normalizeConfig', () => {
       {
         src: '/protected',
         dest: '/login',
-        redirect: true,
         status: 307,
         has: [{ type: 'cookie', key: 'auth' }],
         missing: [{ type: 'header', key: 'X-Admin' }],
@@ -280,9 +278,7 @@ describe('normalizeConfig', () => {
 
     const result = normalizeConfig(config);
 
-    expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 301 },
-    ]);
+    expect(result.routes).toEqual([{ src: '/old', dest: '/new', status: 301 }]);
   });
 
   it('should convert pure Redirect arrays to routes format', () => {
@@ -297,8 +293,8 @@ describe('normalizeConfig', () => {
 
     expect(result.redirects).toBeUndefined();
     expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
-      { src: '/temp', dest: '/other', redirect: true, status: 307 },
+      { src: '/old', dest: '/new', status: 308 },
+      { src: '/temp', dest: '/other', status: 307 },
     ]);
   });
 
@@ -317,8 +313,8 @@ describe('normalizeConfig', () => {
     expect(result.redirects).toBeUndefined();
     expect(result.routes).toEqual([
       { src: '/api/(.*)', dest: '/backend/$1' },
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
-      { src: '/temp', dest: '/other', redirect: true, status: 307 },
+      { src: '/old', dest: '/new', status: 308 },
+      { src: '/temp', dest: '/other', status: 307 },
     ]);
   });
 
@@ -330,8 +326,8 @@ describe('normalizeConfig', () => {
           dest: '/backend/$1',
           transforms: [
             {
-              type: 'request.headers',
-              op: 'set',
+              type: 'request.headers' as const,
+              op: 'set' as const,
               target: { key: 'x-custom' },
               args: 'value',
             },
@@ -358,7 +354,7 @@ describe('normalizeConfig', () => {
           },
         ],
       },
-      { src: '/old', dest: '/new', redirect: true, status: 307 },
+      { src: '/old', dest: '/new', status: 307 },
     ]);
   });
 
@@ -395,8 +391,8 @@ describe('normalizeConfig', () => {
         {
           source: '/api/(.*)',
           headers: [{ key: 'X-Custom', value: 'value' }],
-          has: [{ type: 'header', key: 'Authorization' }],
-          missing: [{ type: 'cookie', key: 'bypass' }],
+          has: [{ type: 'header' as const, key: 'Authorization' }],
+          missing: [{ type: 'cookie' as const, key: 'bypass' }],
         },
       ],
     };
@@ -435,7 +431,7 @@ describe('normalizeConfig', () => {
     expect(result.headers).toBeUndefined();
     expect(result.routes).toEqual([
       { src: '/api/(.*)', dest: '/backend/$1' },
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
+      { src: '/old', dest: '/new', status: 308 },
       {
         src: '/static/(.*)',
         headers: { 'Cache-Control': 'public, max-age=31536000' },


### PR DESCRIPTION
# Problem

A few weeks ago I shipped https://github.com/vercel/vercel/pull/14518 to fix a DX issue for `vercel.ts` where configs contianing rewrites and redirects that were being compiled to the `routes` format (because they e.g. contain transforms) in the intermediary vercel.json would return a schema validation error. So for example, this would fail:

```ts
export const config: VercelConfig = {
  rewrites: [
    routes.rewrite('/api/(.*)', 'https://backend.api.example.com/$1'),
    routes.rewrite('/(.*)', 'https://api.example.com/$1', {
      requestHeaders: {
        authorization: `Bearer token`,
      },
    })
  ]
}
```

The user is writing `routes.rewrite`, so these make sense to put in `rewrites`. But the rewrite with the header transform gets compiled to the `routes` format because transforms only exist on `routes`. So it generates a mixed array.

This particular issue is now fixed by https://github.com/vercel/vercel/pull/14518. But I think that solution is too narrow. For example, take this Vercel config:

```ts
export const config: VercelConfig = {
  routes: [
    routes.rewrite('/test-header', 'https://httpbin.org/headers', {
      requestHeaders: {
        authorization: `Bearer token`,
      },
    }),
    routes.redirect('/test-build', 'https://httpbin.org/headers'),
  ]
};
```

This looks like it should work, but it actually still generates a mixed array: `redirect` is a standard redirect in the `redirect` format, so it compiles to the `redirect` format (`source`, `destination`). But the rewrite, as https://github.com/vercel/vercel/pull/14518 added, compiles to the `routes` format (`src`, `dest`). So even though it's in routes, `redirect` doesn't get transformed to the `routes` format, and the build fails with this error:

```
Error: Invalid vercel.ts - `routes[1]` should NOT have additional property `source`. Did you mean `src`?
```

Ok, let's try a workaround:

```ts
export const config: VercelConfig = {
  rewrites: [
    routes.rewrite('/test-env', 'https://httpbin.org/headers', {
      requestHeaders: {
        authorization: `Bearer ${deploymentEnv('API_TOKEN')}`,
      },
    }),
  ],
  redirects: [
    routes.redirect('/test-build', 'https://httpbin.org/headers'),
  ]
};
```

Oops, this still doesn't work because, again as https://github.com/vercel/vercel/pull/14518 added, the first rewrite gets compiled to `routes` and is actually put inside `routes` in the intermediary vercel.json, but the redirect stays in the `redirects` format. And the build fails with this error:

```
Error: If `rewrites`, `redirects`, `headers`, `cleanUrls` or `trailingSlash` are used, then `routes` cannot be present.
```

So https://github.com/vercel/vercel/pull/14518 solved one instance of this DX issue, but not most of them.

# Solution

We should just always compile everything to `routes`. That way we never have to think about all the cases in which someone writes something that secretly gets compiled to routes and then accidentally generates a mixed array.

This PR compiles `rewrites`, `redirects`, and `headers` to the `routes` format, and places it under `routes` in the generated vercel.json. It also adds some types (previously there were too many `any`s). Vercel configs generated via `vercel.ts` after this PR will not contain `rewrites`, `redirects`, or `headers` properties.

If the user explicitly adds `routes` and tries to mix them, it still fails the schema validation. Example:

```ts
// ❌ this fails!
export const config: VercelConfig = {
  routes: [
    routes.rewrite('/test-header', 'https://httpbin.org/headers', {
      requestHeaders: {
        authorization: `Bearer token`,
      },
    }),
  ],
  redirects: [
    routes.redirect('/test-build', 'https://httpbin.org/headers')
  ]
};
```

But the other examples from above and the examples from https://github.com/vercel/vercel/pull/14518 still work.

This is what we should have done in the first place. The compilation step is supposed to be an implementation detail, but it was generating intermediary configs that differed from the syntax of `vercel.ts` configs. This PR brings it back to an implementation detail and makes the `vercel.ts` syntax generate the output that people actually expect.