### PR TITLE
[python-analysis] Convert to vitest

### DIFF
--- a/.changeset/neat-ears-march.md
+++ b/.changeset/neat-ears-march.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python-analysis': minor
+---
+
+use vitest instead of jest for testing

--- a/packages/python-analysis/jest.config.js
+++ b/packages/python-analysis/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/packages/python-analysis/package.json
+++ b/packages/python-analysis/package.json
@@ -19,8 +19,8 @@
     "build": "node ../../utils/build.mjs",
     "generate:schemas": "ts-to-zod --all",
     "prebuild": "pnpm generate:schemas",
-    "test": "jest --reporters=default --reporters=jest-junit --coverage --env node --verbose",
-    "test-unit": "pnpm test test/*.test.ts",
+    "vitest-run": "vitest -c ../../vitest.config.mts",
+    "vitest-unit": "glob --absolute 'test/*.test.ts'",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -34,10 +34,9 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/jest": "27.4.1",
     "@types/js-yaml": "4.0.9",
     "@types/node": "20.11.0",
-    "jest-junit": "16.0.0",
-    "ts-to-zod": "^3"
+    "ts-to-zod": "^3",
+    "vitest": "2.1.4"
   }
 }

--- a/packages/python-analysis/test/package.test.ts
+++ b/packages/python-analysis/test/package.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { describe, it, expect } from 'vitest';
 import {
   discoverPythonPackage,
   PythonAnalysisError,

--- a/packages/python-analysis/test/pipfile-parser.test.ts
+++ b/packages/python-analysis/test/pipfile-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   convertPipfileToPyprojectToml,
   convertPipfileLockToPyprojectToml,

--- a/packages/python-analysis/test/python-selector.test.ts
+++ b/packages/python-analysis/test/python-selector.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   selectPython,
   pythonVersionToString,

--- a/packages/python-analysis/test/requirements-txt-parser.test.ts
+++ b/packages/python-analysis/test/requirements-txt-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   parseRequirementsFile,
   convertRequirementsToPyprojectToml,

--- a/packages/python-analysis/test/uv-python-version-parser.test.ts
+++ b/packages/python-analysis/test/uv-python-version-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   parseUvPythonRequest,
   parsePythonVersionFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2126,21 +2126,18 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
-      '@types/jest':
-        specifier: 27.4.1
-        version: 27.4.1
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
       '@types/node':
         specifier: 20.11.0
         version: 20.11.0
-      jest-junit:
-        specifier: 16.0.0
-        version: 16.0.0
       ts-to-zod:
         specifier: ^3
         version: 3.15.0(@types/node@20.11.0)
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@edge-runtime/vm@3.2.0)(@types/node@20.11.0)
 
   packages/react-router:
     dependencies:


### PR DESCRIPTION
@vercel/python-analysis now uses vitest instead of jest for testing
