### PR TITLE
[python-runtime] Integrate with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,9 @@
     "api",
     "examples",
     "@vercel-internals/*"
-  ]
+  ],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.changeset/large-cooks-lie.md
+++ b/.changeset/large-cooks-lie.md
@@ -1,0 +1,5 @@
+---
+'vercel-runtime': minor
+---
+
+integrate python/vercel-runtime with changesets

--- a/.changeset/large-cooks-lie.md
+++ b/.changeset/large-cooks-lie.md
@@ -1,5 +1,5 @@
 ---
-'vercel-runtime': minor
+'@vercel/python-runtime': minor
 ---
 
 integrate python/vercel-runtime with changesets

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'python/vercel-runtime/**'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force publish even if version has not changed'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   check-version:
@@ -26,10 +32,10 @@ jobs:
           CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]+' python/vercel-runtime/pyproject.toml)
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-          # For workflow_dispatch, always consider version as changed
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # For workflow_dispatch with force=true, skip version check
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
             echo "version_changed=true" >> $GITHUB_OUTPUT
-            echo "Manual trigger - proceeding with publish"
+            echo "Force publish requested - proceeding with publish"
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,26 @@ jobs:
             const script = require('./utils/trigger-update-workflow.js')
             await script({ github, context })
 
+      - name: Trigger Python Runtime Release (if vercel-runtime changed)
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          script: |
+            const publishedPackages = JSON.parse('${{ steps.changesets.outputs.publishedPackages }}' || '[]');
+            const pythonRuntimePublished = publishedPackages.some(pkg => pkg.name === 'vercel-runtime');
+            if (pythonRuntimePublished) {
+              console.log('vercel-runtime was published, triggering Python runtime release workflow');
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'release-python-runtime.yml',
+                ref: 'main',
+              });
+            } else {
+              console.log('vercel-runtime was not in the published packages, skipping Python release');
+            }
+
       - name: Set latest Release to `vercel` (if a Publish Happened)
         if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,16 +68,16 @@ jobs:
             const script = require('./utils/trigger-update-workflow.js')
             await script({ github, context })
 
-      - name: Trigger Python Runtime Release (if vercel-runtime changed)
+      - name: Trigger Python Runtime Release (if @vercel/python-runtime changed)
         if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           script: |
             const publishedPackages = JSON.parse('${{ steps.changesets.outputs.publishedPackages }}' || '[]');
-            const pythonRuntimePublished = publishedPackages.some(pkg => pkg.name === 'vercel-runtime');
+            const pythonRuntimePublished = publishedPackages.some(pkg => pkg.name === '@vercel/python-runtime');
             if (pythonRuntimePublished) {
-              console.log('vercel-runtime was published, triggering Python runtime release workflow');
+              console.log('@vercel/python-runtime was published, triggering Python runtime release workflow');
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -85,7 +85,7 @@ jobs:
                 ref: 'main',
               });
             } else {
-              console.log('vercel-runtime was not in the published packages, skipping Python release');
+              console.log('@vercel/python-runtime was not in the published packages, skipping Python release');
             }
 
       - name: Set latest Release to `vercel` (if a Publish Happened)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier-check": "prettier --check .",
     "prepare": "husky install",
     "pack": "cd utils && node -r ts-eager/register ./pack.ts",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
+    "ci:version": "changeset version && node utils/sync-python-version.js && pnpm install --no-frozen-lockfile",
     "ci:publish": "pnpm publish -r && node utils/update-canary-tags.mjs && changeset tag",
     "type-check": "turbo type-check --concurrency=12 --output-logs=errors-only --summarize --continue"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2508,6 +2508,8 @@ importers:
         specifier: 4.9.5
         version: 4.9.5
 
+  python/vercel-runtime: {}
+
 packages:
 
   /@alex_neo/jest-expect-message@1.0.5:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'api'
   - 'examples'
   - 'internals/*'
+  - 'python/vercel-runtime'

--- a/python/vercel-runtime/CHANGELOG.md
+++ b/python/vercel-runtime/CHANGELOG.md
@@ -1,0 +1,8 @@
+# vercel-runtime
+
+## 0.1.0
+
+### Initial Release
+
+- Initial release of the `vercel-runtime` Python package
+- Provides runtime utilities for Python functions on Vercel

--- a/python/vercel-runtime/package.json
+++ b/python/vercel-runtime/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vercel/python-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Python runtime for Vercel Functions"
+}

--- a/utils/sync-python-version.js
+++ b/utils/sync-python-version.js
@@ -1,0 +1,106 @@
+/**
+ * Syncs version from package.json to pyproject.toml for Python packages.
+ *
+ * This script is used during the changeset version process to ensure
+ * Python packages have their pyproject.toml version updated when
+ * changesets bumps the version in package.json.
+ *
+ * Usage: node utils/sync-python-version.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PYTHON_PACKAGES = [
+  {
+    name: 'vercel-runtime',
+    packageJsonPath: 'python/vercel-runtime/package.json',
+    pyprojectPath: 'python/vercel-runtime/pyproject.toml',
+  },
+];
+
+function syncVersion(packageConfig) {
+  const { name, packageJsonPath, pyprojectPath } = packageConfig;
+
+  const packageJsonFullPath = path.join(__dirname, '..', packageJsonPath);
+  const pyprojectFullPath = path.join(__dirname, '..', pyprojectPath);
+
+  // Read package.json
+  if (!fs.existsSync(packageJsonFullPath)) {
+    console.log(
+      `Skipping ${name}: package.json not found at ${packageJsonPath}`
+    );
+    return false;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonFullPath, 'utf8'));
+  const version = packageJson.version;
+
+  if (!version) {
+    console.log(`Skipping ${name}: no version found in package.json`);
+    return false;
+  }
+
+  // Read pyproject.toml
+  if (!fs.existsSync(pyprojectFullPath)) {
+    console.log(
+      `Skipping ${name}: pyproject.toml not found at ${pyprojectPath}`
+    );
+    return false;
+  }
+
+  let pyprojectContent = fs.readFileSync(pyprojectFullPath, 'utf8');
+
+  // Extract current version from pyproject.toml
+  const versionMatch = pyprojectContent.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!versionMatch) {
+    console.log(`Skipping ${name}: no version field found in pyproject.toml`);
+    return false;
+  }
+
+  const currentPyVersion = versionMatch[1];
+
+  if (currentPyVersion === version) {
+    console.log(`${name}: versions already in sync (${version})`);
+    return false;
+  }
+
+  // Update version in pyproject.toml
+  pyprojectContent = pyprojectContent.replace(
+    /^version\s*=\s*"[^"]+"/m,
+    `version = "${version}"`
+  );
+
+  fs.writeFileSync(pyprojectFullPath, pyprojectContent);
+  console.log(`${name}: synced version ${currentPyVersion} -> ${version}`);
+  return true;
+}
+
+function main() {
+  console.log(
+    'Syncing Python package versions from package.json to pyproject.toml...\n'
+  );
+
+  let anyUpdated = false;
+
+  for (const packageConfig of PYTHON_PACKAGES) {
+    try {
+      const updated = syncVersion(packageConfig);
+      if (updated) {
+        anyUpdated = true;
+      }
+    } catch (error) {
+      console.error(`Error syncing ${packageConfig.name}:`, error.message);
+    }
+  }
+
+  if (anyUpdated) {
+    console.log(
+      '\nVersion sync complete. Remember to commit the updated pyproject.toml files.'
+    );
+  } else {
+    console.log('\nNo version changes needed.');
+  }
+}
+
+main();

--- a/utils/sync-python-version.js
+++ b/utils/sync-python-version.js
@@ -13,7 +13,7 @@ const path = require('path');
 
 const PYTHON_PACKAGES = [
   {
-    name: 'vercel-runtime',
+    name: '@vercel/python-runtime',
     packageJsonPath: 'python/vercel-runtime/package.json',
     pyprojectPath: 'python/vercel-runtime/pyproject.toml',
   },


### PR DESCRIPTION
Automate versioning and releases of `python/vercel-runtime` as if it was
a regular JS package.
