### PR TITLE
add retries for flaky firewall e2e test

### DIFF
--- a/.changeset/yellow-vans-shake.md
+++ b/.changeset/yellow-vans-shake.md
@@ -1,0 +1,5 @@
+---
+"@vercel/firewall": patch
+---
+
+add retries for flaky firewall e2e test


### PR DESCRIPTION
add retries for flaky  firewall e2e test:
[E2E Tests / vitest-e2e-node-20 (@vercel/firewall, 1, ubuntu-latest, Node v20) (pull_request)](https://github.com/vercel/vercel/actions/runs/21196520941/job/60973633737?pr=14683)