### PR TITLE
vercel/oidc: favor existing expired oidc token claims instead of filesystem settings when refreshing an oidc token

### DIFF
--- a/.changeset/grumpy-fans-protect.md
+++ b/.changeset/grumpy-fans-protect.md
@@ -1,0 +1,5 @@
+---
+'@vercel/oidc': patch
+---
+
+favor existing expired oidc token claims instead of filesystem settings when refreshing an oidc token

--- a/packages/oidc/src/get-vercel-oidc-token.ts
+++ b/packages/oidc/src/get-vercel-oidc-token.ts
@@ -45,7 +45,7 @@ export async function getVercelOidcToken(): Promise<string> {
       ]);
 
     if (!token || isExpired(getTokenPayload(token))) {
-      await refreshToken();
+      await refreshToken(token || undefined);
       token = getVercelOidcTokenSync();
     }
   } catch (error) {

--- a/packages/oidc/src/token-util.ts
+++ b/packages/oidc/src/token-util.ts
@@ -165,6 +165,8 @@ interface TokenPayload {
   sub: string;
   name: string;
   exp: number;
+  project_id?: string;
+  owner_id?: string;
 }
 
 export function getTokenPayload(token: string): TokenPayload {

--- a/packages/oidc/src/token.ts
+++ b/packages/oidc/src/token.ts
@@ -9,8 +9,24 @@ import {
   saveToken,
 } from './token-util';
 
-export async function refreshToken(): Promise<void> {
-  const { projectId, teamId } = findProjectInfo();
+export async function refreshToken(existingToken?: string): Promise<void> {
+  let projectId: string | undefined;
+  let teamId: string | undefined;
+
+  if (existingToken) {
+    // Extract project info from existing token (unverified decode)
+    const payload = getTokenPayload(existingToken);
+    projectId = payload.project_id;
+    teamId = payload.owner_id;
+  }
+
+  if (!projectId) {
+    // Fall back to filesystem if no token or token doesn't have project info
+    const info = findProjectInfo();
+    projectId = info.projectId;
+    teamId = info.teamId;
+  }
+
   let maybeToken = loadToken(projectId);
 
   if (!maybeToken || isExpired(getTokenPayload(maybeToken.token))) {


### PR DESCRIPTION
## Problem

Token refresh always required reading project_id and owner_id from the filesystem (.vercel/project.json), even when an existing OIDC token was available containing this information in its JWT claims.

## Solution

Extract project_id and owner_id directly from the existing token's unverified JWT payload when refreshing, falling back to the filesystem only when the token is unavailable or lacks these claims.
