### PR TITLE
[next]: attach segment fallbacks when client param parsing is enabled

### DIFF
--- a/.changeset/smooth-balloons-pay.md
+++ b/.changeset/smooth-balloons-pay.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+attach segment fallbacks when client param parsing is enabled

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3285,13 +3285,15 @@ export const onPrerenderRoute =
                 ) + prefetchSegmentSuffix;
 
               // Only use the fallback value when the allowQuery is defined and
-              // is empty, which means that the segments do not vary based on
-              // the route parameters. This is safer than ensuring that we only
-              // use the fallback when this is not a fallback because we know in
-              // this new logic that it doesn't vary based on the route
-              // parameters and therefore can be used for all requests instead.
+              // either: (1) it is empty, meaning segments do not vary by params,
+              // or (2) client param parsing is enabled, meaning the segment
+              // payloads are safe to reuse across params.
               let fallback: FileFsRef | null = null;
-              if (segmentAllowQuery && segmentAllowQuery.length === 0) {
+              const shouldAttachSegmentFallback =
+                segmentAllowQuery &&
+                (segmentAllowQuery.length === 0 ||
+                  isAppClientParamParsingEnabled);
+              if (shouldAttachSegmentFallback) {
                 const fsPath = path.join(
                   segmentsDir,
                   segmentPath + prefetchSegmentSuffix

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -598,6 +598,27 @@ describe('PPR', () => {
       // cache posioning.
       expect(output['[lang]'].fallback).toEqual(null);
     });
+
+    it('should attach segment fallbacks when client param parsing is enabled', async () => {
+      const {
+        buildResult: { output },
+      } = await runBuildLambda(path.join(__dirname, 'ppr-root-params'));
+
+      const segmentKeys = Object.keys(output).filter(
+        key =>
+          key.includes('[lang]/skills/[skill].segments/') &&
+          key.endsWith('.segment.rsc')
+      );
+
+      expect(segmentKeys.length).toBeGreaterThan(0);
+
+      for (const key of segmentKeys) {
+        expect(output[key].type).toBe('Prerender');
+        expect(output[key].fallback).toBeDefined();
+        expect(output[key].fallback).not.toBeNull();
+        expect(output[key].fallback.fsPath).toBeDefined();
+      }
+    });
   });
 });
 

--- a/packages/next/test/integration/ppr-root-params/app/[lang]/skills/[skill]/page.js
+++ b/packages/next/test/integration/ppr-root-params/app/[lang]/skills/[skill]/page.js
@@ -1,0 +1,9 @@
+export default async function Page({ params }) {
+  const { lang, skill } = await params;
+
+  return (
+    <div>
+      Skill {skill} in {lang}
+    </div>
+  );
+}

--- a/packages/next/test/integration/ppr-root-params/next.config.js
+++ b/packages/next/test/integration/ppr-root-params/next.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  experimental: {
-    cacheComponents: true,
-    dynamicIO: true,
-  },
+  cacheComponents: true,
 };


### PR DESCRIPTION
Next.js builds segment prefetch files at build time, but the builder only attached fallbacks when allowQuery was empty. This meant segment prefetches for parametrized routes hit the function even though usable segment fallbacks existed. This change allows attaching segment fallbacks when client param parsing is enabled (which is always true when cache components is on), aligning Vercel behavior with next start.

Cache keys still vary by `allowQuery`, so param isolation is preserved. 