### PR TITLE
Enable unit tests for Version Packages PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   setup:
     name: Find Changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
+    if: github.event_name == 'pull_request'
     outputs:
       tests: ${{ steps['set-tests'].outputs['tests'] }}
       dplUrl: ${{ steps.waitForTarball.outputs.url }}
@@ -94,7 +94,7 @@ jobs:
   comment-test-strategy:
     name: Comment Test Strategy
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Version Packages'
+    if: github.event_name == 'pull_request'
     needs:
       - setup
     steps:


### PR DESCRIPTION
Version Packages PRs should run both unit tests and e2e tests. Currently they only run e2e tests because of an exclusion condition in the unit test workflow.

This change removes the `Version Packages` title check from the `setup` and `comment-test-strategy` jobs, allowing unit tests to run alongside e2e tests for these PRs.

Regular PRs continue to run unit tests only, while e2e tests are controlled separately via the `run-e2e-tests` label or by being a Version Packages PR.