### PR TITLE
fix(next): use base metadata headers for segment fallback initial headers

### DIFF
--- a/.changeset/bright-waves-drive.md
+++ b/.changeset/bright-waves-drive.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+fix segment fallback initial headers to properly include cache tags for expiration

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3285,15 +3285,25 @@ export const onPrerenderRoute =
             // then therefore unexpirable.
             let segmentInitialHeaders = initialHeaders;
             if (
-              !segmentInitialHeaders &&
-              // Blocking/fallback routes don't emit per-segment headers from Next,
-              // so inherit the route meta headers to carry cache tags
               (isBlocking || isFallback) &&
               'headers' in meta &&
               typeof meta.headers === 'object' &&
               meta.headers !== null
             ) {
-              segmentInitialHeaders = meta.headers as Record<string, string>;
+              const metaHeaders = meta.headers as Record<string, string>;
+              const hasMissingMetaHeader =
+                !segmentInitialHeaders ||
+                Object.keys(metaHeaders).some(
+                  key => segmentInitialHeaders?.[key] == null
+                );
+              if (hasMissingMetaHeader) {
+                // Merge to fill any missing meta headers without overriding
+                // segment-specific values.
+                segmentInitialHeaders = {
+                  ...metaHeaders,
+                  ...segmentInitialHeaders,
+                };
+              }
             }
 
             for (const segmentPath of meta.segmentPaths) {

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3277,6 +3277,23 @@ export const onPrerenderRoute =
               ? htmlAllowQuery
               : allowQuery;
 
+            // No initial headers here means that the fallback is being served
+            // and it should infer the initial headers from the base metadata
+            // file which will be the ones which include the cache tags for
+            // the fallback render. Failing to do this will result in
+            // producing build output entries without any cache tags which are
+            // then therefore unexpirable.
+            let segmentInitialHeaders = initialHeaders;
+            if (
+              !segmentInitialHeaders &&
+              isBlocking &&
+              'headers' in meta &&
+              typeof meta.headers === 'object' &&
+              meta.headers !== null
+            ) {
+              segmentInitialHeaders = meta.headers as Record<string, string>;
+            }
+
             for (const segmentPath of meta.segmentPaths) {
               const outputSegmentPath =
                 path.join(
@@ -3319,7 +3336,7 @@ export const onPrerenderRoute =
                 experimentalBypassFor: undefined,
 
                 initialHeaders: {
-                  ...initialHeaders,
+                  ...segmentInitialHeaders,
                   vary: rscVaryHeader,
                   'content-type': rscContentTypeHeader,
                   [rscDidPostponeHeader]: '2',

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -3286,7 +3286,9 @@ export const onPrerenderRoute =
             let segmentInitialHeaders = initialHeaders;
             if (
               !segmentInitialHeaders &&
-              isBlocking &&
+              // Blocking/fallback routes don't emit per-segment headers from Next,
+              // so inherit the route meta headers to carry cache tags
+              (isBlocking || isFallback) &&
               'headers' in meta &&
               typeof meta.headers === 'object' &&
               meta.headers !== null

--- a/packages/next/test/integration/segment-cache-cc.test.js
+++ b/packages/next/test/integration/segment-cache-cc.test.js
@@ -1,0 +1,41 @@
+process.env.NEXT_TELEMETRY_DISABLED = '1';
+
+const path = require('path');
+const builder = require('../../');
+const {
+  createRunBuildLambda,
+} = require('../../../../test/lib/run-build-lambda');
+
+const runBuildLambda = createRunBuildLambda(builder);
+
+describe('clientSegmentCache prerender headers', () => {
+  it('should include cache tags on fallback segment prerenders', async () => {
+    const fixturePath = path.join(__dirname, 'segment-cache-cc');
+
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(fixturePath);
+
+    // should include cache tags on fallback segment prerenders
+    const key = 'careers/[slug].segments/_tree.segment.rsc';
+    expect(output[key]).toBeDefined();
+    expect(output[key].type).toBe('Prerender');
+    expect(output[key].initialHeaders).toBeDefined();
+    expect(output[key].initialHeaders['x-next-cache-tags']).toContain(
+      'segment-cache-tag'
+    );
+
+    // should include cache tags on static segment prerenders
+    const staticKeys = [
+      'careers/foobar-1.segments/_full.segment.rsc',
+      'careers.segments/_full.segment.rsc',
+      'index.segments/_full.segment.rsc',
+    ];
+
+    for (const staticKey of staticKeys) {
+      expect(output[staticKey]).toBeDefined();
+      expect(output[staticKey].type).toBe('Prerender');
+      expect(output[staticKey].initialHeaders).toBeDefined();
+    }
+  });
+});

--- a/packages/next/test/integration/segment-cache-cc/.gitignore
+++ b/packages/next/test/integration/segment-cache-cc/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/packages/next/test/integration/segment-cache-cc/app/api/revalidate-tag/route.js
+++ b/packages/next/test/integration/segment-cache-cc/app/api/revalidate-tag/route.js
@@ -1,0 +1,13 @@
+import { revalidateTag } from 'next/cache';
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const tag = searchParams.get('tag');
+
+  if (!tag) {
+    return Response.json({ revalidated: false }, { status: 400 });
+  }
+
+  revalidateTag(tag);
+  return Response.json({ revalidated: true, tag });
+}

--- a/packages/next/test/integration/segment-cache-cc/app/careers/[slug]/loading.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/careers/[slug]/loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="loading">Loading...</div>;
+}

--- a/packages/next/test/integration/segment-cache-cc/app/careers/[slug]/page.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/careers/[slug]/page.jsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation';
+
+export const generateStaticParams = async () => {
+  return [{ slug: 'foobar-1' }];
+};
+
+export default async function Page({ params }) {
+  const { slug } = await params;
+
+  console.log({ slug });
+
+  if (!slug.includes('foobar')) {
+    redirect('/careers');
+  }
+
+  return <div>Result Page: {slug}</div>;
+}

--- a/packages/next/test/integration/segment-cache-cc/app/careers/page.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/careers/page.jsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function Page() {
+  return (
+    <div>
+      <div>Listings Page:</div>
+      {['foobar-1', 'foobar-2'].map(i => (
+        <div key={i}>
+          <Link href={`/careers/${i}`}>{i}</Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/next/test/integration/segment-cache-cc/app/layout.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/layout.jsx
@@ -1,0 +1,19 @@
+import { cacheTag } from 'next/cache';
+
+async function getTaggedData() {
+  'use cache';
+  cacheTag('segment-cache-tag');
+  return Date.now().toString();
+}
+
+export default async function Layout({ children }) {
+  const taggedValue = await getTaggedData();
+  return (
+    <html>
+      <body>
+        <div id="tagged">tagged:{taggedValue}</div>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/packages/next/test/integration/segment-cache-cc/app/page.jsx
+++ b/packages/next/test/integration/segment-cache-cc/app/page.jsx
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+
+export default function Page() {
+  return (
+    <div>
+      To test page: <Link href="/careers">/careers</Link>
+    </div>
+  );
+}

--- a/packages/next/test/integration/segment-cache-cc/next.config.js
+++ b/packages/next/test/integration/segment-cache-cc/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  cacheComponents: true,
+};

--- a/packages/next/test/integration/segment-cache-cc/package.json
+++ b/packages/next/test/integration/segment-cache-cc/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "ignoreNextjsUpdates": true
+}

--- a/packages/next/test/integration/segment-cache-cc/vercel.json
+++ b/packages/next/test/integration/segment-cache-cc/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ]
+}


### PR DESCRIPTION
fix(next): use base metadata headers for segment fallback initial headers

When serving segment fallbacks, the initial headers should be inferred
from the base metadata file which includes the cache tags for the
fallback render. Without this, build output entries are produced without
cache tags and become unexpirable.

chore: add changeset for segment fallback headers fix