### PR TITLE
Adding/updating environment variables shows warnings for key and values

### DIFF
--- a/.changeset/cool-students-doubt.md
+++ b/.changeset/cool-students-doubt.md
@@ -1,0 +1,9 @@
+---
+'vercel': patch
+---
+
+Add warning when adding/updating env vars
+
+1. When keys have prefixes that expose values to the client
+2. The value has whitespace
+3. The values are exposed and the key matches a pattern for a sensitive value like a password

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -11,6 +11,14 @@ import readStandardInput from '../../util/input/read-standard-input';
 import param from '../../util/output/param';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
+import {
+  getEnvValueWarnings,
+  getEnvKeyWarnings,
+  formatWarnings,
+  hasOnlyWhitespaceWarnings,
+  trimValue,
+  removePublicPrefix,
+} from '../../util/env/validate-env';
 import { getCommandName } from '../../util/pkg-name';
 import { isAPIError } from '../../util/errors-ts';
 import { getCustomEnvironments } from '../../util/target/get-custom-environments';
@@ -51,6 +59,7 @@ export default async function add(client: Client, argv: string[]) {
   telemetryClient.trackCliFlagSensitive(opts['--sensitive']);
   telemetryClient.trackCliFlagForce(opts['--force']);
   telemetryClient.trackCliFlagGuidance(opts['--guidance']);
+  telemetryClient.trackCliFlagYes(opts['--yes']);
 
   if (args.length > 3) {
     output.error(
@@ -80,6 +89,61 @@ export default async function add(client: Client, argv: string[]) {
       message: `What's the name of the variable?`,
       validate: val => (val ? true : 'Name cannot be empty'),
     });
+  }
+
+  // Validate key name early (before value entry) with re-entry option
+  const skipConfirm = opts['--yes'] || !!stdInput;
+  if (!skipConfirm) {
+    let keyAccepted = false;
+    while (!keyAccepted) {
+      const keyWarnings = getEnvKeyWarnings(envName);
+      const sensitiveWarning = keyWarnings.find(w => w.requiresConfirmation);
+
+      if (!sensitiveWarning) {
+        // Non-sensitive public prefix: just show info, no action needed
+        for (const w of keyWarnings) {
+          output.warn(w.message);
+        }
+        keyAccepted = true;
+        break;
+      }
+
+      // Sensitive public variable: show all warnings then options
+      for (const w of keyWarnings) {
+        output.warn(w.message);
+      }
+
+      const nameWithoutPrefix = removePublicPrefix(envName);
+      const choices = [
+        { name: 'Leave as is', value: 'c' },
+        { name: `Rename to ${nameWithoutPrefix}`, value: 'p' },
+        { name: 'Re-enter', value: 'r' },
+      ];
+
+      const action = await client.input.select({
+        message: 'How to proceed?',
+        choices,
+      });
+
+      if (action === 'c') {
+        keyAccepted = true;
+      } else if (action === 'p') {
+        envName = nameWithoutPrefix;
+        output.log(`Renamed to ${envName}`);
+        keyAccepted = true;
+      } else {
+        envName = await client.input.text({
+          message: `What's the name of the variable?`,
+          validate: val => (val ? true : 'Name cannot be empty'),
+        });
+      }
+    }
+  } else {
+    // Non-interactive: just show warnings
+    const keyWarnings = getEnvKeyWarnings(envName);
+    for (const w of keyWarnings) {
+      output.warn(w.message);
+    }
   }
 
   const link = await getLinkedProject(client);
@@ -161,6 +225,61 @@ export default async function add(client: Client, argv: string[]) {
     });
   }
 
+  // Validate and handle value warnings with re-entry option
+  let finalValue = envValue;
+
+  if (!skipConfirm) {
+    let valueAccepted = false;
+    while (!valueAccepted) {
+      const valueWarnings = getEnvValueWarnings(finalValue);
+      const warningMessage = formatWarnings(valueWarnings);
+
+      if (!warningMessage) {
+        valueAccepted = true;
+        break;
+      }
+
+      output.warn(warningMessage);
+
+      const canTrim = hasOnlyWhitespaceWarnings(valueWarnings);
+      const choices = canTrim
+        ? [
+            { name: 'Leave as is', value: 'c' },
+            { name: 'Re-enter', value: 'r' },
+            { name: 'Trim whitespace', value: 't' },
+          ]
+        : [
+            { name: 'Leave as is', value: 'c' },
+            { name: 'Re-enter', value: 'r' },
+          ];
+
+      const action = await client.input.select({
+        message: 'How to proceed?',
+        choices,
+      });
+
+      if (action === 'c') {
+        valueAccepted = true;
+      } else if (action === 't') {
+        finalValue = trimValue(finalValue);
+        output.log('Trimmed whitespace');
+        valueAccepted = true;
+      } else {
+        finalValue = await client.input.password({
+          message: `What's the value of ${envName}?`,
+          mask: true,
+        });
+      }
+    }
+  } else {
+    // Non-interactive: just show warning
+    const valueWarnings = getEnvValueWarnings(finalValue);
+    const warningMessage = formatWarnings(valueWarnings);
+    if (warningMessage) {
+      output.warn(warningMessage);
+    }
+  }
+
   while (envTargets.length === 0) {
     envTargets = await client.input.checkbox({
       message: `Add ${envName} to which Environments (select multiple)?`,
@@ -194,7 +313,7 @@ export default async function add(client: Client, argv: string[]) {
       upsert,
       type,
       envName,
-      envValue,
+      finalValue,
       envTargets,
       envGitBranch
     );

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -130,7 +130,7 @@ export default async function add(client: Client, argv: string[]) {
       } else if (action === 'p') {
         envName = nameWithoutPrefix;
         output.log(`Renamed to ${envName}`);
-        keyAccepted = true;
+        // Loop back to re-validate (might have nested prefix)
       } else {
         envName = await client.input.text({
           message: `What's the name of the variable?`,
@@ -263,7 +263,7 @@ export default async function add(client: Client, argv: string[]) {
       } else if (action === 't') {
         finalValue = trimValue(finalValue);
         output.log('Trimmed whitespace');
-        valueAccepted = true;
+        // Loop back to re-validate (trimmed value might be empty)
       } else {
         finalValue = await client.input.password({
           message: `What's the value of ${envName}?`,

--- a/packages/cli/src/commands/env/command.ts
+++ b/packages/cli/src/commands/env/command.ts
@@ -58,6 +58,11 @@ export const addSubcommand = {
       shorthand: null,
     },
     {
+      ...yesOption,
+      description:
+        'Skip the confirmation prompt when adding an Environment Variable',
+    },
+    {
       name: 'guidance',
       description: 'Receive command suggestions once command is complete',
       shorthand: null,

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -8,6 +8,12 @@ import readStandardInput from '../../util/input/read-standard-input';
 import param from '../../util/output/param';
 import { emoji, prependEmoji } from '../../util/emoji';
 import { isKnownError } from '../../util/env/known-error';
+import {
+  getEnvValueWarnings,
+  formatWarnings,
+  hasOnlyWhitespaceWarnings,
+  trimValue,
+} from '../../util/env/validate-env';
 import formatEnvironments from '../../util/env/format-environments';
 import { getCommandName } from '../../util/pkg-name';
 import { isAPIError } from '../../util/errors-ts';
@@ -180,8 +186,68 @@ export default async function update(client: Client, argv: string[]) {
     });
   }
 
-  // Confirm the update unless --yes flag is provided
-  if (!opts['--yes']) {
+  // Validate and handle value warnings with re-entry option
+  let finalValue = envValue;
+  const skipConfirm = opts['--yes'] || !!stdInput;
+  let alreadyConfirmed = false;
+
+  if (!skipConfirm) {
+    let valueAccepted = false;
+    while (!valueAccepted) {
+      const valueWarnings = getEnvValueWarnings(finalValue);
+      const warningMessage = formatWarnings(valueWarnings);
+
+      if (!warningMessage) {
+        valueAccepted = true;
+        break;
+      }
+
+      output.warn(warningMessage);
+
+      const canTrim = hasOnlyWhitespaceWarnings(valueWarnings);
+      const choices = canTrim
+        ? [
+            { name: 'Leave as is', value: 'c' },
+            { name: 'Re-enter', value: 'r' },
+            { name: 'Trim whitespace', value: 't' },
+          ]
+        : [
+            { name: 'Leave as is', value: 'c' },
+            { name: 'Re-enter', value: 'r' },
+          ];
+
+      const action = await client.input.select({
+        message: 'How to proceed?',
+        choices,
+      });
+
+      if (action === 'c') {
+        valueAccepted = true;
+        // Check if any warnings require confirmation
+        if (valueWarnings.some(w => w.requiresConfirmation)) {
+          alreadyConfirmed = true;
+        }
+      } else if (action === 't') {
+        finalValue = trimValue(finalValue);
+        output.log('Trimmed whitespace');
+        valueAccepted = true;
+      } else {
+        finalValue = await client.input.text({
+          message: `What's the new value of ${envName}?`,
+        });
+      }
+    }
+  } else {
+    // Non-interactive: just show warning
+    const valueWarnings = getEnvValueWarnings(finalValue);
+    const warningMessage = formatWarnings(valueWarnings);
+    if (warningMessage) {
+      output.warn(warningMessage);
+    }
+  }
+
+  // Confirm the update unless --yes flag is provided or already confirmed from validation
+  if (!opts['--yes'] && !alreadyConfirmed) {
     const currentTargets = formatEnvironments(
       link,
       selectedEnv,
@@ -215,7 +281,7 @@ export default async function update(client: Client, argv: string[]) {
       selectedEnv.id,
       type,
       envName,
-      envValue,
+      finalValue,
       allTargets,
       selectedEnv.gitBranch || ''
     );

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -230,7 +230,7 @@ export default async function update(client: Client, argv: string[]) {
       } else if (action === 't') {
         finalValue = trimValue(finalValue);
         output.log('Trimmed whitespace');
-        valueAccepted = true;
+        // Loop back to re-validate (trimmed value might be empty)
       } else {
         finalValue = await client.input.text({
           message: `What's the new value of ${envName}?`,

--- a/packages/cli/src/util/env/validate-env.ts
+++ b/packages/cli/src/util/env/validate-env.ts
@@ -1,0 +1,162 @@
+export interface EnvWarning {
+  message: string;
+  requiresConfirmation: boolean;
+}
+
+export function getEnvValueWarnings(value: string): EnvWarning[] {
+  const warnings: EnvWarning[] = [];
+
+  // Strip single trailing \n (common in piped input from `echo`) for all checks
+  const normalized = value.replace(/\n$/, '');
+
+  if (/^[ \t]+/.test(normalized)) {
+    warnings.push({
+      message: 'starts with whitespace',
+      requiresConfirmation: false,
+    });
+  }
+  if (/[ \t]+$/.test(normalized)) {
+    warnings.push({
+      message: 'ends with whitespace',
+      requiresConfirmation: false,
+    });
+  }
+  if (normalized.includes('\r') || normalized.includes('\n')) {
+    warnings.push({
+      message: 'contains newlines',
+      requiresConfirmation: false,
+    });
+  }
+  if (value.includes('\0')) {
+    warnings.push({
+      message: 'contains null characters',
+      requiresConfirmation: false,
+    });
+  }
+  if (value === '') {
+    warnings.push({
+      message: 'is empty',
+      requiresConfirmation: true,
+    });
+  }
+  if (
+    value.length > 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    warnings.push({
+      message: 'includes surrounding quotes (these will be stored literally)',
+      requiresConfirmation: false,
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Combines warning messages into a single sentence.
+ * e.g. ["starts with whitespace", "ends with whitespace"] -> "Value starts and ends with whitespace"
+ */
+export function formatWarnings(warnings: EnvWarning[]): string | null {
+  if (warnings.length === 0) return null;
+  const messages = warnings.map(w => w.message);
+
+  // Special case: combine "starts with whitespace" + "ends with whitespace"
+  const startsIdx = messages.indexOf('starts with whitespace');
+  const endsIdx = messages.indexOf('ends with whitespace');
+  if (startsIdx !== -1 && endsIdx !== -1) {
+    messages.splice(Math.max(startsIdx, endsIdx), 1);
+    messages[Math.min(startsIdx, endsIdx)] = 'starts and ends with whitespace';
+  }
+
+  if (messages.length === 1) {
+    return `Value ${messages[0]}`;
+  }
+  if (messages.length === 2) {
+    return `Value ${messages[0]} and ${messages[1]}`;
+  }
+  const last = messages.pop();
+  return `Value ${messages.join(', ')}, and ${last}`;
+}
+
+/** Framework prefixes that expose variables to the browser. */
+const PUBLIC_PREFIXES = [
+  'NEXT_PUBLIC_', // Next.js
+  'REACT_APP_', // Create React App
+  'VUE_APP_', // Vue CLI
+  'VITE_', // Vite (Vue, Svelte, React, etc.)
+  'GATSBY_', // Gatsby
+  'GRIDSOME_', // Gridsome
+  'NUXT_PUBLIC_', // Nuxt 3
+  'NUXT_ENV_', // Nuxt 2
+  'STORYBOOK_', // Storybook
+  'EXPO_PUBLIC_', // Expo
+  'PUBLIC_', // Generic / SvelteKit default
+];
+
+// Require word boundaries: pattern must be preceded/followed by _ or string boundary
+// Matches: _PASSWORD_, _SECRET, KEY_, etc. but not KEYBOARD, ACCESSIBLE
+const SENSITIVE_PATTERN =
+  /(?:^|_)(password|secret|private|token|key|auth|jwt|signature|access)(?:_|$)/i;
+
+/**
+ * Returns true if all warnings are whitespace-related (can be trimmed).
+ */
+export function hasOnlyWhitespaceWarnings(warnings: EnvWarning[]): boolean {
+  return (
+    warnings.length > 0 &&
+    warnings.every(
+      w =>
+        w.message === 'starts with whitespace' ||
+        w.message === 'ends with whitespace'
+    )
+  );
+}
+
+/**
+ * Trims trailing newline (common from piped input) and whitespace.
+ */
+export function trimValue(value: string): string {
+  return value.replace(/\n$/, '').trim();
+}
+
+/**
+ * Returns the public prefix if the key starts with one, null otherwise.
+ */
+export function getPublicPrefix(key: string): string | null {
+  const upperKey = key.toUpperCase();
+  return PUBLIC_PREFIXES.find(p => upperKey.startsWith(p)) || null;
+}
+
+/**
+ * Removes the public prefix from a key.
+ * e.g. "NEXT_PUBLIC_API_KEY" -> "API_KEY"
+ */
+export function removePublicPrefix(key: string): string {
+  const prefix = getPublicPrefix(key);
+  if (!prefix) return key;
+  return key.slice(prefix.length);
+}
+
+export function getEnvKeyWarnings(key: string): EnvWarning[] {
+  const warnings: EnvWarning[] = [];
+  const matchingPrefix = getPublicPrefix(key);
+
+  if (matchingPrefix) {
+    const sensitiveMatch = SENSITIVE_PATTERN.exec(key);
+    const nameWithoutPrefix = key.slice(matchingPrefix.length);
+    if (sensitiveMatch) {
+      warnings.push({
+        message: `The ${matchingPrefix} prefix will make ${nameWithoutPrefix} visible to anyone visiting your site`,
+        requiresConfirmation: true,
+      });
+    } else {
+      warnings.push({
+        message: `${matchingPrefix} variables can be seen by anyone visiting your site`,
+        requiresConfirmation: false,
+      });
+    }
+  }
+
+  return warnings;
+}

--- a/packages/cli/src/util/telemetry/commands/env/add.ts
+++ b/packages/cli/src/util/telemetry/commands/env/add.ts
@@ -56,4 +56,10 @@ export class EnvAddTelemetryClient
       this.trackCliFlag('guidance');
     }
   }
+
+  trackCliFlagYes(yes: boolean | undefined) {
+    if (yes) {
+      this.trackCliFlag('yes');
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -1795,9 +1795,10 @@ exports[`help command > env help output snapshots > env add help output snapshot
 
   Options:
 
-   --force      Force overwrites when a command would normally fail                                                      
-   --guidance   Receive command suggestions once command is complete                                                     
-   --sensitive  Add a sensitive Environment Variable                                                                     
+       --force      Force overwrites when a command would normally fail                                                      
+       --guidance   Receive command suggestions once command is complete                                                     
+       --sensitive  Add a sensitive Environment Variable                                                                     
+  -y,  --yes        Skip the confirmation prompt when adding an Environment Variable                                         
 
 
   Global Options:

--- a/packages/cli/test/unit/commands/env/add.test.ts
+++ b/packages/cli/test/unit/commands/env/add.test.ts
@@ -184,6 +184,198 @@ describe('env add', () => {
       });
     });
 
+    describe('--yes', () => {
+      it('tracks telemetry', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'TEST_YES_FLAG',
+          'preview',
+          'branchName',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of TEST_YES_FLAG?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+
+        expect(client.telemetryEventStore).toHaveTelemetryEvents([
+          {
+            key: `subcommand:add`,
+            value: 'add',
+          },
+          {
+            key: `argument:name`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `argument:environment`,
+            value: 'preview',
+          },
+          {
+            key: `argument:git-branch`,
+            value: '[REDACTED]',
+          },
+          {
+            key: `flag:yes`,
+            value: 'TRUE',
+          },
+        ]);
+      });
+
+      it('skips confirmation for empty value', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'EMPTY_VALUE_YES',
+          'preview',
+          'branchName',
+          '--yes'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of EMPTY_VALUE_YES?"
+        );
+        client.stdin.write('\n');
+        await expect(client.stderr).toOutput('Value is empty');
+        await expect(client.stderr).toOutput('Added Environment Variable');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+    });
+
+    describe('validation warnings', () => {
+      it('warns for public prefix (informational)', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'NEXT_PUBLIC_TEST',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        // Key warning shown early, before value entry
+        await expect(client.stderr).toOutput(
+          'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
+        );
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of NEXT_PUBLIC_TEST?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+
+      it('shows options for sensitive public key', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'NEXT_PUBLIC_API_KEY',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        // Key warning shown early with options
+        await expect(client.stderr).toOutput(
+          'The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site'
+        );
+        await expect(client.stderr).toOutput('How to proceed?');
+        client.stdin.write('\n'); // Select "Leave as is"
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of NEXT_PUBLIC_API_KEY?"
+        );
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+
+      it('allows renaming to remove prefix for sensitive key', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'NEXT_PUBLIC_SECRET',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput(
+          'The NEXT_PUBLIC_ prefix will make SECRET visible to anyone visiting your site'
+        );
+        await expect(client.stderr).toOutput('How to proceed?');
+        // Select "Rename to SECRET" (second option)
+        client.stdin.write('\x1B[B\n');
+        await expect(client.stderr).toOutput('Renamed to SECRET');
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput("What's the value of SECRET?");
+        client.stdin.write('testvalue\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+
+      it('warns for quoted value and allows continue', async () => {
+        client.setArgv('env', 'add', 'QUOTED_VALUE', 'preview', 'branchName');
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of QUOTED_VALUE?"
+        );
+        client.stdin.write('"my-value"\n');
+        await expect(client.stderr).toOutput('includes surrounding quotes');
+        await expect(client.stderr).toOutput('How to proceed?');
+        client.stdin.write('\n'); // Select "Leave as is"
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+
+      it('allows re-entering value when warned', async () => {
+        client.setArgv('env', 'add', 'REENTER_VALUE', 'preview', 'branchName');
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of REENTER_VALUE?"
+        );
+        client.stdin.write('"quoted"\n');
+        await expect(client.stderr).toOutput('includes surrounding quotes');
+        await expect(client.stderr).toOutput('How to proceed?');
+        client.stdin.write('\x1B[B\n'); // Select Re-enter
+        await expect(client.stderr).toOutput(
+          "What's the value of REENTER_VALUE?"
+        );
+        client.stdin.write('clean-value\n');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+
+      it('offers trim option for whitespace warnings', async () => {
+        client.setArgv(
+          'env',
+          'add',
+          'WHITESPACE_VALUE',
+          'preview',
+          'branchName'
+        );
+        const exitCodePromise = env(client);
+        await expect(client.stderr).toOutput('Mark as sensitive?');
+        client.stdin.write('n\n');
+        await expect(client.stderr).toOutput(
+          "What's the value of WHITESPACE_VALUE?"
+        );
+        client.stdin.write(' spaced \n');
+        await expect(client.stderr).toOutput('starts and ends with whitespace');
+        await expect(client.stderr).toOutput('How to proceed?');
+        client.stdin.write('\x1B[B\x1B[B\n'); // Select Trim
+        await expect(client.stderr).toOutput('Trimmed whitespace');
+        await expect(exitCodePromise).resolves.toBe(0);
+      });
+    });
+
     describe('[environment]', () => {
       it('should redact custom [environment] values', async () => {
         client.setArgv('env', 'add', 'environment-variable', 'custom-env-name');

--- a/packages/cli/test/unit/util/env/validate-env.test.ts
+++ b/packages/cli/test/unit/util/env/validate-env.test.ts
@@ -1,0 +1,551 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getEnvValueWarnings,
+  getEnvKeyWarnings,
+  formatWarnings,
+  hasOnlyWhitespaceWarnings,
+  trimValue,
+  getPublicPrefix,
+  removePublicPrefix,
+} from '../../../../src/util/env/validate-env';
+
+describe('validate-env', () => {
+  describe('getEnvValueWarnings', () => {
+    it('returns no warnings for normal value', () => {
+      expect(getEnvValueWarnings('normal-value')).toEqual([]);
+    });
+
+    it('warns when value starts with whitespace', () => {
+      const warnings = getEnvValueWarnings(' value');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('starts with whitespace');
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('warns when value starts with tab', () => {
+      const warnings = getEnvValueWarnings('\tvalue');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('starts with whitespace');
+    });
+
+    it('warns when value ends with whitespace', () => {
+      const warnings = getEnvValueWarnings('value ');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('ends with whitespace');
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('warns when value ends with tab', () => {
+      const warnings = getEnvValueWarnings('value\t');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('ends with whitespace');
+    });
+
+    it('warns when value contains return character (\\r)', () => {
+      const warnings = getEnvValueWarnings('line1\rline2');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('contains newlines');
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('warns when value contains newline character (\\n)', () => {
+      const warnings = getEnvValueWarnings('line1\nline2');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('contains newlines');
+    });
+
+    it('warns when value contains null character', () => {
+      const warnings = getEnvValueWarnings('value\0more');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('contains null characters');
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('requires confirmation for empty value', () => {
+      const warnings = getEnvValueWarnings('');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe('is empty');
+      expect(warnings[0].requiresConfirmation).toBe(true);
+    });
+
+    it('warns when value is wrapped in double quotes', () => {
+      const warnings = getEnvValueWarnings('"my-value"');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'includes surrounding quotes (these will be stored literally)'
+      );
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('warns when value is wrapped in single quotes', () => {
+      const warnings = getEnvValueWarnings("'my-value'");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'includes surrounding quotes (these will be stored literally)'
+      );
+    });
+
+    it('does not warn for 2-char quoted value (edge case)', () => {
+      expect(getEnvValueWarnings('""')).toEqual([]);
+      expect(getEnvValueWarnings("''")).toEqual([]);
+    });
+
+    it('does not warn for value with only opening quote', () => {
+      expect(getEnvValueWarnings('"value')).toEqual([]);
+      expect(getEnvValueWarnings("'value")).toEqual([]);
+    });
+
+    it('does not warn for value with only closing quote', () => {
+      expect(getEnvValueWarnings('value"')).toEqual([]);
+      expect(getEnvValueWarnings("value'")).toEqual([]);
+    });
+
+    it('returns multiple warnings for value with multiple issues', () => {
+      // Note: ' "value" ' starts/ends with whitespace, not quotes
+      const warnings = getEnvValueWarnings(' "value" ');
+      expect(warnings).toHaveLength(2);
+      expect(warnings.map(w => w.message)).toContain('starts with whitespace');
+      expect(warnings.map(w => w.message)).toContain('ends with whitespace');
+    });
+
+    it('returns multiple warnings for quoted value with newline', () => {
+      const warnings = getEnvValueWarnings('"line1\nline2"');
+      expect(warnings).toHaveLength(2);
+      expect(warnings.map(w => w.message)).toContain('contains newlines');
+      expect(warnings.map(w => w.message)).toContain(
+        'includes surrounding quotes (these will be stored literally)'
+      );
+    });
+
+    // Stdin normalization tests
+    describe('stdin normalization (trailing newline)', () => {
+      it('does not warn for single trailing newline (echo "value")', () => {
+        expect(getEnvValueWarnings('value\n')).toEqual([]);
+      });
+
+      it('warns for space before trailing newline (echo "value ")', () => {
+        const warnings = getEnvValueWarnings('value \n');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe('ends with whitespace');
+      });
+
+      it('warns for multiline with trailing newline', () => {
+        const warnings = getEnvValueWarnings('line1\nline2\n');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe('contains newlines');
+      });
+
+      it('warns for multiline without trailing newline', () => {
+        const warnings = getEnvValueWarnings('line1\nline2');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe('contains newlines');
+      });
+
+      it('does not treat single newline as empty', () => {
+        const warnings = getEnvValueWarnings('\n');
+        expect(warnings.map(w => w.message)).not.toContain('is empty');
+      });
+    });
+  });
+
+  describe('getEnvKeyWarnings', () => {
+    it('returns no warnings for normal key', () => {
+      expect(getEnvKeyWarnings('DATABASE_URL')).toEqual([]);
+    });
+
+    it('warns for NEXT_PUBLIC_ prefix', () => {
+      const warnings = getEnvKeyWarnings('NEXT_PUBLIC_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
+      );
+      expect(warnings[0].requiresConfirmation).toBe(false);
+    });
+
+    it('warns for REACT_APP_ prefix', () => {
+      const warnings = getEnvKeyWarnings('REACT_APP_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'REACT_APP_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for VITE_ prefix', () => {
+      const warnings = getEnvKeyWarnings('VITE_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'VITE_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for VUE_APP_ prefix', () => {
+      const warnings = getEnvKeyWarnings('VUE_APP_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'VUE_APP_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for GATSBY_ prefix', () => {
+      const warnings = getEnvKeyWarnings('GATSBY_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'GATSBY_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for GRIDSOME_ prefix', () => {
+      const warnings = getEnvKeyWarnings('GRIDSOME_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'GRIDSOME_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for NUXT_PUBLIC_ prefix', () => {
+      const warnings = getEnvKeyWarnings('NUXT_PUBLIC_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'NUXT_PUBLIC_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for NUXT_ENV_ prefix', () => {
+      const warnings = getEnvKeyWarnings('NUXT_ENV_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'NUXT_ENV_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for STORYBOOK_ prefix', () => {
+      const warnings = getEnvKeyWarnings('STORYBOOK_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'STORYBOOK_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for EXPO_PUBLIC_ prefix', () => {
+      const warnings = getEnvKeyWarnings('EXPO_PUBLIC_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'EXPO_PUBLIC_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('warns for PUBLIC_ prefix', () => {
+      const warnings = getEnvKeyWarnings('PUBLIC_API_URL');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'PUBLIC_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    it('is case-insensitive for prefix matching', () => {
+      const warnings = getEnvKeyWarnings('next_public_api_url');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toBe(
+        'NEXT_PUBLIC_ variables can be seen by anyone visiting your site'
+      );
+    });
+
+    // Sensitive pattern tests
+    describe('sensitive patterns', () => {
+      it('requires confirmation for public + KEY', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_API_KEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The NEXT_PUBLIC_ prefix will make API_KEY visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + PASSWORD', () => {
+        const warnings = getEnvKeyWarnings('REACT_APP_PASSWORD');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The REACT_APP_ prefix will make PASSWORD visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + SECRET', () => {
+        const warnings = getEnvKeyWarnings('VITE_SECRET');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The VITE_ prefix will make SECRET visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + PRIVATE', () => {
+        const warnings = getEnvKeyWarnings('GATSBY_PRIVATE_KEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The GATSBY_ prefix will make PRIVATE_KEY visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + TOKEN', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_ACCESS_TOKEN');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The NEXT_PUBLIC_ prefix will make ACCESS_TOKEN visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + AUTH', () => {
+        const warnings = getEnvKeyWarnings('NUXT_PUBLIC_AUTH_TOKEN');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The NUXT_PUBLIC_ prefix will make AUTH_TOKEN visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + JWT', () => {
+        const warnings = getEnvKeyWarnings('PUBLIC_JWT_SECRET');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The PUBLIC_ prefix will make JWT_SECRET visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + SIGNATURE', () => {
+        const warnings = getEnvKeyWarnings('VITE_SIGNATURE_KEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The VITE_ prefix will make SIGNATURE_KEY visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('requires confirmation for public + ACCESS', () => {
+        const warnings = getEnvKeyWarnings('REACT_APP_ACCESS_KEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toBe(
+          'The REACT_APP_ prefix will make ACCESS_KEY visible to anyone visiting your site'
+        );
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      // Word boundary tests - should NOT match
+      it('does not match KEYBOARD (no word boundary)', () => {
+        const warnings = getEnvKeyWarnings('REACT_APP_KEYBOARD');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(false);
+      });
+
+      it('does not match MONKEY (no word boundary)', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_MONKEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(false);
+      });
+
+      it('does not match PASSWORDLESS (no word boundary)', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_PASSWORDLESS');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(false);
+      });
+
+      it('does not match ACCESSIBLE (no word boundary)', () => {
+        const warnings = getEnvKeyWarnings('VITE_ACCESSIBLE');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(false);
+      });
+
+      it('matches KEY_ at start of word', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_KEY_ID');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('matches _KEY at end of word', () => {
+        const warnings = getEnvKeyWarnings('NEXT_PUBLIC_API_KEY');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+
+      it('is case-insensitive for sensitive patterns', () => {
+        const warnings = getEnvKeyWarnings('next_public_api_key');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].requiresConfirmation).toBe(true);
+      });
+    });
+  });
+
+  describe('formatWarnings', () => {
+    it('returns null for empty warnings', () => {
+      expect(formatWarnings([])).toBeNull();
+    });
+
+    it('formats single warning', () => {
+      const warnings = [{ message: 'is empty', requiresConfirmation: true }];
+      expect(formatWarnings(warnings)).toBe('Value is empty');
+    });
+
+    it('formats two warnings with "and"', () => {
+      const warnings = [
+        { message: 'is empty', requiresConfirmation: true },
+        { message: 'is wrapped in quotes', requiresConfirmation: false },
+      ];
+      expect(formatWarnings(warnings)).toBe(
+        'Value is empty and is wrapped in quotes'
+      );
+    });
+
+    it('combines start/end whitespace warnings', () => {
+      const warnings = [
+        { message: 'starts with whitespace', requiresConfirmation: false },
+        { message: 'ends with whitespace', requiresConfirmation: false },
+      ];
+      expect(formatWarnings(warnings)).toBe(
+        'Value starts and ends with whitespace'
+      );
+    });
+
+    it('formats three+ warnings with commas and "and"', () => {
+      const warnings = [
+        { message: 'is empty', requiresConfirmation: true },
+        { message: 'contains newlines', requiresConfirmation: false },
+        { message: 'is wrapped in quotes', requiresConfirmation: false },
+      ];
+      expect(formatWarnings(warnings)).toBe(
+        'Value is empty, contains newlines, and is wrapped in quotes'
+      );
+    });
+
+    it('combines whitespace with other warnings', () => {
+      const warnings = [
+        { message: 'starts with whitespace', requiresConfirmation: false },
+        { message: 'ends with whitespace', requiresConfirmation: false },
+        { message: 'contains newlines', requiresConfirmation: false },
+      ];
+      expect(formatWarnings(warnings)).toBe(
+        'Value starts and ends with whitespace and contains newlines'
+      );
+    });
+  });
+
+  describe('hasOnlyWhitespaceWarnings', () => {
+    it('returns false for empty warnings', () => {
+      expect(hasOnlyWhitespaceWarnings([])).toBe(false);
+    });
+
+    it('returns true for only "starts with whitespace"', () => {
+      const warnings = [
+        { message: 'starts with whitespace', requiresConfirmation: false },
+      ];
+      expect(hasOnlyWhitespaceWarnings(warnings)).toBe(true);
+    });
+
+    it('returns true for only "ends with whitespace"', () => {
+      const warnings = [
+        { message: 'ends with whitespace', requiresConfirmation: false },
+      ];
+      expect(hasOnlyWhitespaceWarnings(warnings)).toBe(true);
+    });
+
+    it('returns true for both whitespace warnings', () => {
+      const warnings = [
+        { message: 'starts with whitespace', requiresConfirmation: false },
+        { message: 'ends with whitespace', requiresConfirmation: false },
+      ];
+      expect(hasOnlyWhitespaceWarnings(warnings)).toBe(true);
+    });
+
+    it('returns false for non-whitespace warnings', () => {
+      const warnings = [
+        { message: 'is wrapped in quotes', requiresConfirmation: false },
+      ];
+      expect(hasOnlyWhitespaceWarnings(warnings)).toBe(false);
+    });
+
+    it('returns false for mixed whitespace and other warnings', () => {
+      const warnings = [
+        { message: 'starts with whitespace', requiresConfirmation: false },
+        { message: 'contains newlines', requiresConfirmation: false },
+      ];
+      expect(hasOnlyWhitespaceWarnings(warnings)).toBe(false);
+    });
+  });
+
+  describe('trimValue', () => {
+    it('trims leading whitespace', () => {
+      expect(trimValue('  value')).toBe('value');
+    });
+
+    it('trims trailing whitespace', () => {
+      expect(trimValue('value  ')).toBe('value');
+    });
+
+    it('trims both leading and trailing whitespace', () => {
+      expect(trimValue('  value  ')).toBe('value');
+    });
+
+    it('strips trailing newline before trimming', () => {
+      expect(trimValue('value\n')).toBe('value');
+    });
+
+    it('handles trailing newline with whitespace', () => {
+      expect(trimValue('  value  \n')).toBe('value');
+    });
+
+    it('preserves value with no whitespace', () => {
+      expect(trimValue('value')).toBe('value');
+    });
+
+    it('trims tabs', () => {
+      expect(trimValue('\tvalue\t')).toBe('value');
+    });
+  });
+
+  describe('getPublicPrefix', () => {
+    it('returns NEXT_PUBLIC_ for Next.js public vars', () => {
+      expect(getPublicPrefix('NEXT_PUBLIC_API_KEY')).toBe('NEXT_PUBLIC_');
+    });
+
+    it('returns REACT_APP_ for Create React App vars', () => {
+      expect(getPublicPrefix('REACT_APP_URL')).toBe('REACT_APP_');
+    });
+
+    it('returns VITE_ for Vite vars', () => {
+      expect(getPublicPrefix('VITE_SECRET')).toBe('VITE_');
+    });
+
+    it('is case-insensitive', () => {
+      expect(getPublicPrefix('next_public_key')).toBe('NEXT_PUBLIC_');
+    });
+
+    it('returns null for non-public vars', () => {
+      expect(getPublicPrefix('DATABASE_URL')).toBeNull();
+      expect(getPublicPrefix('API_KEY')).toBeNull();
+    });
+  });
+
+  describe('removePublicPrefix', () => {
+    it('removes NEXT_PUBLIC_ prefix', () => {
+      expect(removePublicPrefix('NEXT_PUBLIC_API_KEY')).toBe('API_KEY');
+    });
+
+    it('removes REACT_APP_ prefix', () => {
+      expect(removePublicPrefix('REACT_APP_URL')).toBe('URL');
+    });
+
+    it('removes VITE_ prefix', () => {
+      expect(removePublicPrefix('VITE_SECRET')).toBe('SECRET');
+    });
+
+    it('preserves case of remaining key', () => {
+      expect(removePublicPrefix('next_public_api_key')).toBe('api_key');
+    });
+
+    it('returns key unchanged if no public prefix', () => {
+      expect(removePublicPrefix('DATABASE_URL')).toBe('DATABASE_URL');
+    });
+  });
+});


### PR DESCRIPTION
Goal is to provide better guidance for humans and Agents for adding/updating env vars.

Handles these scenarios that might have unassuming behaviors

1. The value contains a whitespace character
2. The key starts with a prefix where a framework will expose the value to the client
3. The key starts with a public prefix and contains a sensitive keyword (like PASSWORD)

**Value warnings** (whitespace, quotes, newlines, empty):
```
WARN! Value includes surrounding quotes (these will be stored literally)
? How to proceed?
❯ Leave as is
  Re-enter
  Trim whitespace  ← only shown for whitespace warnings
```

**Sensitive key warnings** (e.g., `NEXT_PUBLIC_PASSWORD`):
```
WARN! The NEXT_PUBLIC_ prefix will make PASSWORD visible to anyone visiting your site
? How to proceed?
❯ Leave as is
  Rename to PASSWORD
  Re-enter
```

https://github.com/user-attachments/assets/dab215a5-21b6-4e9b-87b6-afbdfce1ffe8


https://github.com/user-attachments/assets/e285aef9-2335-4009-b56b-f6286770217a



