### PR TITLE
fix(build-utils): eliminate redundant lstat call in glob

### DIFF
--- a/.changeset/swift-lions-glow.md
+++ b/.changeset/swift-lions-glow.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Eliminate redundant `lstat` call in glob when `follow` option is enabled


### PR DESCRIPTION
## Summary

- Fixes redundant `lstat` call in `glob.ts` when `options.follow` is true
- Migrates from `fs-extra` to native `fs/promises` for `lstat` and `readlink`

## Problem

When `options.follow` is true and a file is a symlink, `lstat` was being called twice for the same file:
1. First call (line 68) to check if it's a symlink pointing outside `cwd` - result was discarded
2. Second call (line 79) to get the stat for `FileFsRef`

## Solution

Cache the `lstat` result from the first call in a `symlinkStat` variable and reuse it via the null coalescing operator (`??`).