### PR TITLE
[build-utils] Improve memory efficiency in FileBlob.fromStream()

### DIFF
--- a/.changeset/funky-boxes-find.md
+++ b/.changeset/funky-boxes-find.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Improve memory efficiency in `FileBlob.fromStream()` by avoiding unnecessary buffer copies when chunks are already Buffers

--- a/packages/build-utils/src/file-blob.ts
+++ b/packages/build-utils/src/file-blob.ts
@@ -39,7 +39,11 @@ export default class FileBlob implements FileBase {
     const chunks: Buffer[] = [];
 
     await new Promise<void>((resolve, reject) => {
-      stream.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      stream.on('data', chunk =>
+        // Usually the chunks we receive here are already buffers, so we
+        // avoid the extra buffer copy in those cases to save memory
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      );
       stream.on('error', error => reject(error));
       stream.on('end', () => resolve());
     });


### PR DESCRIPTION
## Summary

- Avoids unnecessary buffer copies in `FileBlob.fromStream()` when stream chunks are already `Buffer` instances
- Reduces peak memory usage from ~3x to ~2x file size during stream collection

## Details

The previous implementation always called `Buffer.from(chunk)`, which copies data even when `chunk` is already a `Buffer`. For a 100MB file with 64KB chunks, this created ~1,600 unnecessary buffer copies, effectively doubling memory usage during stream collection.

The fix adds a `Buffer.isBuffer()` check to only copy when necessary (e.g., when chunks are strings or other types).