### PR TITLE
[cli] Normalize items in the `routes` array to the `routes` syntax

### DIFF
--- a/.changeset/small-radios-hammer.md
+++ b/.changeset/small-radios-hammer.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+vercel.ts: normalize items in `routes` array to routes format

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -28,7 +28,6 @@ function toRouteFormat(item: any, isRedirect: boolean): any {
   };
 
   if (isRedirect) {
-    route.redirect = true;
     route.status = statusCode || (permanent ? 308 : 307);
   } else {
     if (respectOriginCacheControl !== undefined) {

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -28,6 +28,7 @@ function toRouteFormat(item: any, isRedirect: boolean): any {
   };
 
   if (isRedirect) {
+    route.redirect = true;
     route.status = statusCode || (permanent ? 308 : 307);
   } else {
     if (respectOriginCacheControl !== undefined) {

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -97,7 +97,13 @@ export function normalizeConfig(config: any): any {
   }
 
   if (allRoutes.length > 0) {
-    normalized.routes = allRoutes;
+    normalized.routes = allRoutes.map(item => {
+      if (isRouteFormat(item)) {
+        return item;
+      }
+      const isRedirect = 'permanent' in item || 'statusCode' in item;
+      return toRouteFormat(item, isRedirect);
+    });
   }
 
   return normalized;

--- a/packages/cli/src/util/compile-vercel-config.ts
+++ b/packages/cli/src/util/compile-vercel-config.ts
@@ -101,7 +101,7 @@ export function normalizeConfig(config: any): any {
       if (isRouteFormat(item)) {
         return item;
       }
-      const isRedirect = 'permanent' in item || 'statusCode' in item;
+      const isRedirect = 'permanent' in item;
       return toRouteFormat(item, isRedirect);
     });
   }

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -125,7 +125,7 @@ describe('normalizeConfig', () => {
     const config = {
       redirects: [
         { source: '/old', destination: '/new', permanent: true },
-        { src: '/complex', dest: '/dest', status: 308 },
+        { src: '/complex', dest: '/dest', redirect: true, status: 308 },
       ],
     };
 
@@ -133,8 +133,8 @@ describe('normalizeConfig', () => {
 
     expect(result.redirects).toBeUndefined();
     expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', status: 308 },
-      { src: '/complex', dest: '/dest', status: 308 },
+      { src: '/old', dest: '/new', redirect: true, status: 308 },
+      { src: '/complex', dest: '/dest', redirect: true, status: 308 },
     ]);
   });
 
@@ -204,6 +204,7 @@ describe('normalizeConfig', () => {
       {
         src: '/test-build',
         dest: 'https://httpbin.org/headers',
+        redirect: true,
         status: 307,
       },
     ]);
@@ -239,7 +240,9 @@ describe('normalizeConfig', () => {
 
     const result = normalizeConfig(config);
 
-    expect(result.routes).toEqual([{ src: '/old', dest: '/new', status: 301 }]);
+    expect(result.routes).toEqual([
+      { src: '/old', dest: '/new', redirect: true, status: 301 },
+    ]);
   });
 });
 

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -226,7 +226,7 @@ describe('normalizeConfig', () => {
     ]);
   });
 
-  it('should normalize redirects with statusCode in routes array', () => {
+  it('should normalize redirects in routes array', () => {
     const config = {
       routes: [
         {

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -228,7 +228,14 @@ describe('normalizeConfig', () => {
 
   it('should normalize redirects with statusCode in routes array', () => {
     const config = {
-      routes: [{ source: '/old', destination: '/new', statusCode: 301 }],
+      routes: [
+        {
+          source: '/old',
+          destination: '/new',
+          statusCode: 301,
+          permanent: true,
+        },
+      ],
     };
 
     const result = normalizeConfig(config);

--- a/packages/cli/test/unit/util/compile-vercel-config.test.ts
+++ b/packages/cli/test/unit/util/compile-vercel-config.test.ts
@@ -125,7 +125,7 @@ describe('normalizeConfig', () => {
     const config = {
       redirects: [
         { source: '/old', destination: '/new', permanent: true },
-        { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+        { src: '/complex', dest: '/dest', status: 308 },
       ],
     };
 
@@ -133,8 +133,8 @@ describe('normalizeConfig', () => {
 
     expect(result.redirects).toBeUndefined();
     expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 308 },
-      { src: '/complex', dest: '/dest', redirect: true, status: 308 },
+      { src: '/old', dest: '/new', status: 308 },
+      { src: '/complex', dest: '/dest', status: 308 },
     ]);
   });
 
@@ -204,7 +204,6 @@ describe('normalizeConfig', () => {
       {
         src: '/test-build',
         dest: 'https://httpbin.org/headers',
-        redirect: true,
         status: 307,
       },
     ]);
@@ -240,9 +239,7 @@ describe('normalizeConfig', () => {
 
     const result = normalizeConfig(config);
 
-    expect(result.routes).toEqual([
-      { src: '/old', dest: '/new', redirect: true, status: 301 },
-    ]);
+    expect(result.routes).toEqual([{ src: '/old', dest: '/new', status: 301 }]);
   });
 });
 


### PR DESCRIPTION
2 days ago I opened https://github.com/vercel/vercel/pull/14679 to put to rest a gnarly DX issue with vercel.ts where it was very easy to generate a mixed array (—> invalid config) when you had header transforms. See that PR description for a very detailed description of the issue.

The solution proposed in that PR was to always convert everything to the routes format no matter what. This solves all current and future problems related to mixed arrays, but creates a new problem because `routes` and `rewrites`/`redirects`/`headers` have different routing orders in different frameworks, so landing that change would change where in the stack routes are processed.

After chatting with @mknichel, we landed on optimizing for this use case:

```ts
export const config: VercelConfig = {
  routes: [
    routes.rewrite('/test-header', 'https://httpbin.org/headers', {
      requestHeaders: {
        authorization: `Bearer token`,
      },
    }),
    routes.redirect('/test-build', 'https://httpbin.org/headers'),
  ]
};
```

Currently this fails because the `rewrite` gets compiled to the `routes` format since it has a header transform, but the `redirect` compiles to the `redirects` format. So although both are placed in `routes`, it still generates a mixed array.

This PR solves this issue. This is more reasonable than converting everything to `routes`. It does force you to move everything into `routes` if you have a header transform, but this is also the current `vercel.json` behavior, so it is actually more in line with what people expect from vercel.json.