### PR TITLE
[cli] Add feature flag check for auto-provision in integration add

### DIFF
--- a/.changeset/orange-masks-shave.md
+++ b/.changeset/orange-masks-shave.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add auto-provision flow for `integration add` command

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -26,6 +26,8 @@ import { IntegrationAddTelemetryClient } from '../../util/telemetry/commands/int
 import { createAuthorization } from '../../util/integration/create-authorization';
 import sleep from '../../util/sleep';
 import { fetchAuthorization } from '../../util/integration/fetch-authorization';
+import { getTeamWithFlags } from '../../util/teams/get-team-with-flags';
+import { AUTO_PROVISION_FLAG } from '../../util/integration/auto-provision-resource';
 
 export async function add(client: Client, args: string[]) {
   const telemetry = new IntegrationAddTelemetryClient({
@@ -50,6 +52,19 @@ export async function add(client: Client, args: string[]) {
 
   if (!team) {
     output.error('Team not found');
+    return 1;
+  }
+
+  let useAutoProvision = false;
+  try {
+    const teamWithFlags = await getTeamWithFlags(client, team.id);
+    useAutoProvision = teamWithFlags.flags?.[AUTO_PROVISION_FLAG] === true;
+  } catch {
+    useAutoProvision = false;
+  }
+
+  if (useAutoProvision) {
+    output.error('Auto-provision flow is not yet implemented');
     return 1;
   }
 

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -1,0 +1,5 @@
+/**
+ * Feature flag name for enabling auto-provision in CLI.
+ */
+export const AUTO_PROVISION_FLAG =
+  'marketplace-enable-auto-provision-install-for-cli';

--- a/packages/cli/src/util/teams/get-team-with-flags.ts
+++ b/packages/cli/src/util/teams/get-team-with-flags.ts
@@ -1,0 +1,25 @@
+import type Client from '../client';
+import type { Team } from '@vercel-internals/types';
+
+/**
+ * Team object extended with feature flags.
+ * Returned when fetching a team with `?flags=true`.
+ */
+export interface TeamWithFlags extends Team {
+  flags?: Record<string, boolean | number | string | null>;
+}
+
+/**
+ * Fetches a team by ID with feature flags included.
+ * This is used to check feature flags for gating CLI behavior.
+ *
+ * @param client - The CLI client instance
+ * @param teamId - The team ID to fetch
+ * @returns Team object with flags property
+ */
+export async function getTeamWithFlags(
+  client: Client,
+  teamId: string
+): Promise<TeamWithFlags> {
+  return client.fetch<TeamWithFlags>(`/v2/teams/${teamId}?flags=true`);
+}


### PR DESCRIPTION
## Summary
- Adds infrastructure for the auto-provision flow in the `integration add` command
- Includes preparation work for the feature rollout
- When enabled, shows placeholder message (implementation coming in follow-up PR)
- When not enabled, continues with existing flow

## Changes
- New utility: `getTeamWithFlags` to fetch team with feature flags
- Feature flag constant for auto-provision
- Flag check in `integration add` command

## Test plan
- [x] Unit tests pass
- [ ] Manual test with feature enabled - shows placeholder message
- [ ] Manual test with feature disabled - existing flow works

Generated with [Claude Code](https://claude.com/claude-code)