### PR TITLE
[config] Remove references to `redirect` property

### DIFF
--- a/.changeset/tough-clouds-beam.md
+++ b/.changeset/tough-clouds-beam.md
@@ -1,0 +1,5 @@
+---
+'@vercel/config': patch
+---
+
+Remove references to nonexistent `redirects` property

--- a/packages/config/src/router.test.ts
+++ b/packages/config/src/router.test.ts
@@ -289,7 +289,6 @@ describe('Router', () => {
       expect(route).toMatchObject({
         src: '/old',
         dest: '/new',
-        redirect: true,
         status: 308,
         transforms: [
           {

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -338,8 +338,6 @@ export interface Route {
   has?: Condition[];
   /** Optional conditions that must be absent */
   missing?: Condition[];
-  /** If true, this is a redirect (status defaults to 308 or specified) */
-  redirect?: boolean;
   /** Status code for the response */
   status?: number;
   /** Headers to set (alternative to using transforms) */

--- a/packages/config/src/router.ts
+++ b/packages/config/src/router.ts
@@ -975,7 +975,6 @@ export class Router {
       const route: Route = {
         src: source,
         dest: destination,
-        redirect: true,
         status: statusCode || (permanent ? 308 : 307),
         transforms,
       };
@@ -1000,7 +999,6 @@ export class Router {
       const route: Route = {
         src: source,
         dest: destination,
-        redirect: true,
         status: statusCode || (permanent ? 308 : 307),
         env: destEnvVars,
       };
@@ -1176,7 +1174,6 @@ export class Router {
           const route: Route = {
             src: redirectRule.source,
             dest: redirectRule.destination,
-            redirect: true,
             status:
               redirectRule.statusCode || (redirectRule.permanent ? 308 : 307),
           };


### PR DESCRIPTION
IIUC this property was hallucinated while initially writing the `@vercel/config` package and it's been confusing LLMs when trying to work with these properties in other places in the repo.

Remove all references to `redirect`.