### PR TITLE
Track CLI as source for marketplace installations

### DIFF
--- a/.changeset/cli-source-tracking.md
+++ b/.changeset/cli-source-tracking.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Track CLI as source for marketplace integration installations

--- a/packages/cli/src/util/integration/provision-store-resource.ts
+++ b/packages/cli/src/util/integration/provision-store-resource.ts
@@ -22,6 +22,7 @@ export async function provisionStoreResource(
         metadata,
         name,
         authorizationId,
+        source: 'cli',
       },
     }
   );


### PR DESCRIPTION
## Summary
- Add `source: 'cli'` to the request body when provisioning marketplace integration resources via the CLI
- This enables tracking CLI-initiated installations separately in telemetry/analytics (complements vercel/api#58640)

## Test plan
- [ ] Verify `vercel integration add <slug>` sends `source: 'cli'` in the POST to `/v1/storage/stores/integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)