### PR TITLE
feat(cli): add api command

### DIFF
--- a/.changeset/tiny-students-drum.md
+++ b/.changeset/tiny-students-drum.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+api command

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
     "@inquirer/expand": "2.1.2",
     "@inquirer/input": "2.1.2",
     "@inquirer/password": "2.1.2",
+    "@inquirer/search": "2.0.1",
     "@inquirer/select": "2.2.2",
     "@next/env": "11.1.2",
     "@sentry/node": "7.120.1",

--- a/packages/cli/src/commands/api/command.ts
+++ b/packages/cli/src/commands/api/command.ts
@@ -145,7 +145,7 @@ export const apiCommand = {
     },
     {
       name: 'List all available API endpoints',
-      value: `${packageName} api --ls`,
+      value: `${packageName} api ls`,
     },
     {
       name: 'Interactive mode (select endpoint)',

--- a/packages/cli/src/commands/api/command.ts
+++ b/packages/cli/src/commands/api/command.ts
@@ -144,6 +144,10 @@ export const apiCommand = {
       value: `${packageName} api /v2/user -H "X-Custom-Header: value"`,
     },
     {
+      name: 'List all available API endpoints',
+      value: `${packageName} api --ls`,
+    },
+    {
       name: 'Interactive mode (select endpoint)',
       value: `${packageName} api`,
     },

--- a/packages/cli/src/commands/api/command.ts
+++ b/packages/cli/src/commands/api/command.ts
@@ -1,0 +1,151 @@
+import { packageName } from '../../util/pkg-name';
+
+export const apiCommand = {
+  name: 'api',
+  aliases: [],
+  description: 'Make authenticated HTTP requests to the Vercel API',
+  arguments: [
+    {
+      name: 'endpoint',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      name: 'method',
+      shorthand: 'X',
+      type: String,
+      argument: 'METHOD',
+      deprecated: false,
+      description:
+        'HTTP method (GET, POST, PUT, PATCH, DELETE). Defaults to GET, or POST if body is provided',
+    },
+    {
+      name: 'field',
+      shorthand: 'F',
+      type: [String],
+      argument: 'KEY=VALUE',
+      deprecated: false,
+      description:
+        'Add a typed parameter (numbers, booleans parsed). Use @file for file contents',
+    },
+    {
+      name: 'raw-field',
+      shorthand: 'f',
+      type: [String],
+      argument: 'KEY=VALUE',
+      deprecated: false,
+      description: 'Add a string parameter (no type parsing)',
+    },
+    {
+      name: 'header',
+      shorthand: 'H',
+      type: [String],
+      argument: 'KEY:VALUE',
+      deprecated: false,
+      description: 'Add a custom HTTP header',
+    },
+    {
+      name: 'input',
+      shorthand: null,
+      type: String,
+      argument: 'FILE',
+      deprecated: false,
+      description: 'Read request body from file (use - for stdin)',
+    },
+    {
+      name: 'paginate',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Fetch all pages of results',
+    },
+    {
+      name: 'include',
+      shorthand: 'i',
+      type: Boolean,
+      deprecated: false,
+      description: 'Include response headers in output',
+    },
+    {
+      name: 'silent',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Suppress response output',
+    },
+    {
+      name: 'verbose',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Show debug information including full request/response',
+    },
+    {
+      name: 'raw',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Output raw JSON without pretty-printing',
+    },
+    {
+      name: 'refresh',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Force refresh the cached OpenAPI spec',
+    },
+    {
+      name: 'generate',
+      shorthand: null,
+      type: String,
+      argument: 'FORMAT',
+      deprecated: false,
+      description:
+        'Generate output instead of executing (e.g., --generate=curl)',
+    },
+    {
+      name: 'format',
+      shorthand: null,
+      type: String,
+      argument: 'FORMAT',
+      deprecated: false,
+      description:
+        'Output format for ls command (table, json). Defaults to table',
+    },
+  ],
+  examples: [
+    {
+      name: 'Get current user information',
+      value: `${packageName} api /v2/user`,
+    },
+    {
+      name: 'List projects with team scope',
+      value: `${packageName} api /v9/projects --scope my-team`,
+    },
+    {
+      name: 'Create a new project',
+      value: `${packageName} api /v10/projects -X POST -F name=my-project`,
+    },
+    {
+      name: 'Delete a deployment',
+      value: `${packageName} api /v13/deployments/dpl_abc123 -X DELETE`,
+    },
+    {
+      name: 'Paginate through all deployments',
+      value: `${packageName} api /v6/deployments --paginate`,
+    },
+    {
+      name: 'Post JSON from file',
+      value: `${packageName} api /v10/projects -X POST --input config.json`,
+    },
+    {
+      name: 'Add custom header',
+      value: `${packageName} api /v2/user -H "X-Custom-Header: value"`,
+    },
+    {
+      name: 'Interactive mode (select endpoint)',
+      value: `${packageName} api`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/api/constants.ts
+++ b/packages/cli/src/commands/api/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Base URL for the Vercel API
+ */
+export const API_BASE_URL = 'https://api.vercel.com';
+
+/**
+ * URL for the Vercel OpenAPI specification
+ */
+export const OPENAPI_URL = 'https://openapi.vercel.sh/';
+
+/**
+ * Filename for the cached OpenAPI spec
+ */
+export const CACHE_FILE = 'openapi-spec.json';
+
+/**
+ * Cache TTL in milliseconds (24 hours)
+ */
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -21,6 +21,7 @@ import type {
   BodyField,
   SelectedEndpoint,
   PromptResult,
+  RequestConfig,
 } from './types';
 
 export default async function api(client: Client): Promise<number> {

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -1,0 +1,624 @@
+import type Client from '../../util/client';
+import type { Response } from 'node-fetch';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { help } from '../help';
+import { apiCommand } from './command';
+import { ApiTelemetryClient } from '../../util/telemetry/commands/api';
+import {
+  buildRequest,
+  formatOutput,
+  generateCurlCommand,
+} from './request-builder';
+import { OpenApiCache } from './openapi-cache';
+import { API_BASE_URL } from './constants';
+import output from '../../output-manager';
+import type {
+  ParsedFlags,
+  EndpointInfo,
+  Parameter,
+  BodyField,
+  SelectedEndpoint,
+  PromptResult,
+} from './types';
+
+export default async function api(client: Client): Promise<number> {
+  const telemetryClient = new ApiTelemetryClient({
+    opts: { store: client.telemetryEventStore },
+  });
+
+  // Parse arguments
+  let parsedArgs;
+  const flagsSpec = getFlagsSpecification(apiCommand.options);
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpec);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const { args, flags } = parsedArgs;
+
+  // Handle --help
+  if (flags['--help']) {
+    telemetryClient.trackCliFlagHelp('api');
+    output.print(help(apiCommand, { columns: client.stderr.columns }));
+    return 2;
+  }
+
+  // Handle 'ls' or 'list' subcommand
+  const firstArg = args[1];
+  if (firstArg === 'ls' || firstArg === 'list') {
+    telemetryClient.trackCliSubcommandList();
+    if (flags['--refresh']) telemetryClient.trackCliFlagRefresh(true);
+    if (flags['--format'])
+      telemetryClient.trackCliOptionFormat(flags['--format']);
+    return listEndpoints(
+      client,
+      flags['--refresh'] ?? false,
+      flags['--format'] ?? 'table'
+    );
+  }
+
+  // Get endpoint from args (args[0] is 'api', args[1] is the endpoint)
+  let endpoint = firstArg;
+  let selectedMethod: string | undefined;
+  let selectedBodyFields: string[] = [];
+
+  if (!endpoint) {
+    // Interactive mode: prompt for endpoint selection
+    if (client.stdin.isTTY) {
+      const selected = await promptEndpointSelection(
+        client,
+        flags['--refresh'] ?? false
+      );
+      if (!selected) {
+        return 1;
+      }
+      endpoint = selected.finalUrl;
+      selectedMethod = selected.method;
+      selectedBodyFields = selected.bodyFields;
+    } else {
+      output.error('Endpoint is required. Usage: vercel api <endpoint>');
+      return 1;
+    }
+  }
+
+  // Validate endpoint format and prevent SSRF
+  // The URL constructor treats '//host' as protocol-relative, which would
+  // redirect requests to arbitrary hosts. We must validate the resolved URL.
+  if (!endpoint.startsWith('/')) {
+    output.error('Endpoint must start with /');
+    return 1;
+  }
+
+  try {
+    const resolvedUrl = new URL(endpoint, API_BASE_URL);
+    if (resolvedUrl.origin !== API_BASE_URL) {
+      output.error(
+        'Invalid endpoint: must be a Vercel API path, not an external URL'
+      );
+      return 1;
+    }
+  } catch {
+    output.error('Invalid endpoint URL format');
+    return 1;
+  }
+
+  // Track telemetry
+  telemetryClient.trackCliArgumentEndpoint(endpoint);
+  telemetryClient.trackCliOptionMethod(flags['--method']);
+  telemetryClient.trackCliOptionHeader(flags['--header']);
+  telemetryClient.trackCliOptionInput(flags['--input']);
+  if (flags['--paginate']) telemetryClient.trackCliFlagPaginate(true);
+  if (flags['--include']) telemetryClient.trackCliFlagInclude(true);
+  if (flags['--silent']) telemetryClient.trackCliFlagSilent(true);
+  if (flags['--verbose']) telemetryClient.trackCliFlagVerbose(true);
+  if (flags['--raw']) telemetryClient.trackCliFlagRaw(true);
+  if (flags['--refresh']) telemetryClient.trackCliFlagRefresh(true);
+  if (flags['--generate'])
+    telemetryClient.trackCliOptionGenerate(flags['--generate']);
+
+  // Use method from interactive selection if not overridden by flag
+  const finalFlags = { ...flags } as ParsedFlags;
+  if (selectedMethod && !flags['--method']) {
+    finalFlags['--method'] = selectedMethod;
+  }
+
+  // Merge body fields from interactive selection with any existing --field flags
+  if (selectedBodyFields.length > 0) {
+    const existingFields = finalFlags['--field'] || [];
+    finalFlags['--field'] = [...existingFields, ...selectedBodyFields];
+  }
+
+  // If generate mode, build request config and output in requested format
+  if (flags['--generate'] === 'curl') {
+    try {
+      const requestConfig = await buildRequest(endpoint, finalFlags);
+      const curlCmd = generateCurlCommand(
+        requestConfig,
+        'https://api.vercel.com'
+      );
+      output.log('');
+      output.log('Add your authorization header to the curl command below:');
+      output.log('');
+      client.stdout.write(curlCmd + '\n');
+      return 0;
+    } catch (err) {
+      printError(err);
+      return 1;
+    }
+  }
+
+  return executeApiRequest(client, endpoint, finalFlags);
+}
+
+async function executeApiRequest(
+  client: Client,
+  endpoint: string,
+  flags: ParsedFlags
+): Promise<number> {
+  // Build request from flags
+  let requestConfig: RequestConfig;
+  try {
+    requestConfig = await buildRequest(endpoint, flags);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  // Verbose mode: show request details
+  if (flags['--verbose']) {
+    output.debug(`Request: ${requestConfig.method} ${requestConfig.url}`);
+    if (Object.keys(requestConfig.headers).length > 0) {
+      output.debug(`Headers: ${JSON.stringify(requestConfig.headers)}`);
+    }
+    if (requestConfig.body) {
+      output.debug(
+        `Body: ${typeof requestConfig.body === 'string' ? requestConfig.body : JSON.stringify(requestConfig.body)}`
+      );
+    }
+  }
+
+  // Execute request (handles pagination if needed)
+  if (flags['--paginate']) {
+    return executePaginatedRequest(client, requestConfig, flags);
+  }
+
+  return executeSingleRequest(client, requestConfig, flags);
+}
+
+async function executeSingleRequest(
+  client: Client,
+  config: RequestConfig,
+  flags: ParsedFlags
+): Promise<number> {
+  try {
+    const response: Response = await client.fetch(config.url, {
+      method: config.method,
+      body: config.body,
+      headers: config.headers,
+      json: false, // Get raw response
+    });
+
+    return handleResponse(client, response, flags);
+  } catch (err) {
+    output.prettyError(err);
+    return 1;
+  }
+}
+
+async function executePaginatedRequest(
+  client: Client,
+  config: RequestConfig,
+  flags: ParsedFlags
+): Promise<number> {
+  const results: unknown[] = [];
+
+  try {
+    for await (const page of client.fetchPaginated<Record<string, unknown>>(
+      config.url,
+      {
+        method: config.method,
+        body: config.body,
+        headers: config.headers,
+      }
+    )) {
+      // Extract array data from response
+      const data = extractPaginatedData(page);
+      results.push(...data);
+    }
+
+    // Output combined results
+    return outputResults(client, results, flags);
+  } catch (err) {
+    output.prettyError(err);
+    return 1;
+  }
+}
+
+/**
+ * Extract array data from a paginated response
+ * Vercel API returns data in various keys like 'deployments', 'projects', 'domains', etc.
+ */
+function extractPaginatedData(page: Record<string, unknown>): unknown[] {
+  // Find the first array value in the response (skip pagination metadata)
+  for (const [key, value] of Object.entries(page)) {
+    if (key !== 'pagination' && Array.isArray(value)) {
+      return value;
+    }
+  }
+
+  // If no array found, return the page without pagination as a single item
+  const { pagination, ...rest } = page;
+  void pagination; // Explicitly ignore pagination
+  return [rest];
+}
+
+async function handleResponse(
+  client: Client,
+  response: Response,
+  flags: ParsedFlags
+): Promise<number> {
+  // Include headers if requested
+  if (flags['--include']) {
+    outputHeaders(client, response);
+  }
+
+  // Silent mode
+  if (flags['--silent']) {
+    return response.ok ? 0 : 1;
+  }
+
+  // Get response body
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    const json = await response.json();
+
+    // Verbose mode: show response details
+    if (flags['--verbose']) {
+      output.debug(
+        `Response status: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return outputResults(client, json, flags);
+  }
+
+  // Non-JSON response
+  const text = await response.text();
+  client.stdout.write(text);
+
+  return response.ok ? 0 : 1;
+}
+
+function outputHeaders(client: Client, response: Response): void {
+  client.stdout.write(`HTTP ${response.status} ${response.statusText}\n`);
+  response.headers.forEach((value, key) => {
+    client.stdout.write(`${key}: ${value}\n`);
+  });
+  client.stdout.write('\n');
+}
+
+function outputResults(
+  client: Client,
+  data: unknown,
+  flags: ParsedFlags
+): number {
+  const formatted = formatOutput(data, {
+    raw: flags['--raw'],
+  });
+
+  client.stdout.write(formatted + '\n');
+  return 0;
+}
+
+async function promptEndpointSelection(
+  client: Client,
+  forceRefresh: boolean
+): Promise<SelectedEndpoint | null> {
+  try {
+    const openApi = new OpenApiCache();
+    const success = await openApi.loadWithSpinner(forceRefresh);
+    if (!success) {
+      output.error('Could not load API specification for endpoint selection');
+      return null;
+    }
+
+    const endpoints = openApi.getEndpoints();
+    const selectedEndpoint = await promptForEndpoint(client, endpoints);
+
+    // Get body fields from schema and prompt for required parameters
+    const bodyFieldsSpec = openApi.getBodyFields(selectedEndpoint);
+    const { finalUrl, bodyFields } = await promptForParameters(
+      client,
+      selectedEndpoint.path,
+      selectedEndpoint.parameters,
+      bodyFieldsSpec
+    );
+
+    return {
+      path: selectedEndpoint.path,
+      method: selectedEndpoint.method,
+      finalUrl,
+      bodyFields,
+    };
+  } catch (err) {
+    output.stopSpinner();
+    output.debug(`Endpoint selection failed: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Interactive endpoint search prompt
+ */
+async function promptForEndpoint(
+  client: Client,
+  endpoints: EndpointInfo[]
+): Promise<EndpointInfo> {
+  const allChoices = endpoints.map(ep => ({
+    name: `${ep.method.padEnd(7)} ${ep.path}`,
+    value: ep,
+    // Show full description if available, otherwise show summary
+    description: ep.description || ep.summary || undefined,
+    // Include summary in searchable metadata
+    summary: ep.summary,
+    tags: ep.tags,
+  }));
+
+  const total = allChoices.length;
+
+  return client.input.search<EndpointInfo>({
+    message: `Search for an API endpoint (${total} available):`,
+    source: async (term: string | undefined) => {
+      if (!term) {
+        return allChoices;
+      }
+
+      const lowerTerm = term.toLowerCase();
+      return allChoices.filter(choice => {
+        const searchableText = [
+          choice.name,
+          choice.summary || '',
+          choice.description || '',
+          ...(choice.tags || []),
+        ]
+          .join(' ')
+          .toLowerCase();
+        return searchableText.includes(lowerTerm);
+      });
+    },
+  });
+}
+
+/**
+ * List all available API endpoints
+ */
+async function listEndpoints(
+  client: Client,
+  forceRefresh: boolean,
+  format: string
+): Promise<number> {
+  const openApi = new OpenApiCache();
+  const success = await openApi.loadWithSpinner(forceRefresh);
+  if (!success) {
+    output.error('Could not load API specification');
+    return 1;
+  }
+
+  const endpoints = openApi.getEndpoints();
+
+  if (format === 'json') {
+    return outputEndpointsAsJson(client, endpoints);
+  }
+
+  return outputEndpointsAsTable(endpoints);
+}
+
+function outputEndpointsAsJson(
+  client: Client,
+  endpoints: EndpointInfo[]
+): number {
+  const jsonOutput = endpoints.map(ep => ({
+    method: ep.method,
+    path: ep.path,
+    summary: ep.summary || null,
+    description: ep.description || null,
+    operationId: ep.operationId || null,
+    tags: ep.tags,
+  }));
+  client.stdout.write(JSON.stringify(jsonOutput, null, 2) + '\n');
+  return 0;
+}
+
+function outputEndpointsAsTable(endpoints: EndpointInfo[]): number {
+  const methodWidth = 7;
+  const pathWidth = Math.min(
+    60,
+    Math.max(...endpoints.map(ep => ep.path.length))
+  );
+
+  output.log('');
+  output.log(
+    `${'METHOD'.padEnd(methodWidth)}  ${'PATH'.padEnd(pathWidth)}  SUMMARY`
+  );
+  output.log('-'.repeat(methodWidth + pathWidth + 50));
+
+  for (const ep of endpoints) {
+    const method = ep.method.padEnd(methodWidth);
+    const path =
+      ep.path.length > pathWidth
+        ? ep.path.substring(0, pathWidth - 3) + '...'
+        : ep.path.padEnd(pathWidth);
+    output.log(`${method}  ${path}  ${ep.summary || ''}`);
+  }
+
+  output.log('');
+  output.log(`Total: ${endpoints.length} endpoints`);
+  return 0;
+}
+
+/**
+ * Create a validator that requires non-empty input
+ */
+function createRequiredValidator(fieldName: string) {
+  return (input: string) => {
+    if (!input.trim()) {
+      return `${fieldName} is required`;
+    }
+    return true;
+  };
+}
+
+/**
+ * Format description hint for prompt messages
+ */
+function formatDescription(description?: string): string {
+  return description ? ` (${description})` : '';
+}
+
+/**
+ * Build URL query string from params object
+ */
+function buildQueryString(params: Record<string, string>): string {
+  return Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+/**
+ * Prompt for required path parameters, query parameters, and body fields
+ */
+async function promptForParameters(
+  client: Client,
+  path: string,
+  parameters: Parameter[],
+  bodyFieldsSpec: BodyField[]
+): Promise<PromptResult> {
+  // Global query params handled by CLI infrastructure (--scope flag)
+  const globalParams = new Set(['teamId', 'slug']);
+
+  const pathParams = parameters.filter(p => p.in === 'path');
+  const requiredQueryParams = parameters.filter(
+    p => p.in === 'query' && p.required && !globalParams.has(p.name)
+  );
+  const optionalQueryParams = parameters.filter(
+    p => p.in === 'query' && !p.required && !globalParams.has(p.name)
+  );
+  const requiredBodyFields = bodyFieldsSpec.filter(f => f.required);
+  const optionalBodyFields = bodyFieldsSpec.filter(f => !f.required);
+
+  // Collect path parameter values (always required)
+  let finalPath = path;
+  for (const param of pathParams) {
+    const value = await client.input.text({
+      message: `Enter value for {${param.name}}${formatDescription(param.description)}:`,
+      validate: createRequiredValidator(param.name),
+    });
+    finalPath = finalPath.replace(`{${param.name}}`, encodeURIComponent(value));
+  }
+
+  // Collect required query parameter values
+  const queryValues: Record<string, string> = {};
+  for (const param of requiredQueryParams) {
+    queryValues[param.name] = await client.input.text({
+      message: `Enter value for ${param.name}${formatDescription(param.description)}:`,
+      validate: createRequiredValidator(param.name),
+    });
+  }
+
+  // Select which optional query parameters to provide
+  if (optionalQueryParams.length > 0) {
+    const selectedOptionalParams = await client.input.checkbox<string>({
+      message: 'Select optional query parameters to include:',
+      pageSize: 20,
+      choices: optionalQueryParams.map(p => ({
+        name: `${p.name}${formatDescription(p.description)}`,
+        value: p.name,
+      })),
+    });
+
+    // Prompt for values of selected optional query params
+    for (const paramName of selectedOptionalParams) {
+      const param = optionalQueryParams.find(p => p.name === paramName)!;
+      queryValues[param.name] = await client.input.text({
+        message: `Enter value for ${param.name}${formatDescription(param.description)}:`,
+        validate: createRequiredValidator(param.name),
+      });
+    }
+  }
+
+  // Collect required body field values
+  const bodyFieldValues: string[] = [];
+  for (const field of requiredBodyFields) {
+    const value = await promptForBodyField(client, field, true);
+    bodyFieldValues.push(`${field.name}=${value}`);
+  }
+
+  // Select which optional body fields to provide
+  if (optionalBodyFields.length > 0) {
+    const selectedOptionalFields = await client.input.checkbox<string>({
+      message: 'Select optional body fields to include:',
+      pageSize: 20,
+      choices: optionalBodyFields.map(f => ({
+        name: `${f.name}${f.type ? ` [${f.type}]` : ''}${formatDescription(f.description)}`,
+        value: f.name,
+      })),
+    });
+
+    // Prompt for values of selected optional body fields
+    for (const fieldName of selectedOptionalFields) {
+      const field = optionalBodyFields.find(f => f.name === fieldName)!;
+      const value = await promptForBodyField(client, field, true);
+      bodyFieldValues.push(`${field.name}=${value}`);
+    }
+  }
+
+  // Build final URL with query string
+  const queryString = buildQueryString(queryValues);
+  if (queryString) {
+    finalPath += `?${queryString}`;
+  }
+
+  return { finalUrl: finalPath, bodyFields: bodyFieldValues };
+}
+
+/**
+ * Prompt for a single body field value (text input or enum select)
+ */
+async function promptForBodyField(
+  client: Client,
+  field: BodyField,
+  required: boolean
+): Promise<string> {
+  const description = formatDescription(field.description);
+  const optionalHint = required ? '' : ' (optional)';
+
+  // Use select for enum fields
+  if (field.enumValues && field.enumValues.length > 0) {
+    const choices = field.enumValues.map(v => ({
+      name: String(v),
+      value: String(v),
+    }));
+
+    // Add empty option for optional enum fields
+    if (!required) {
+      choices.unshift({ name: '(skip)', value: '' });
+    }
+
+    return client.input.select({
+      message: `Select value for ${field.name}${optionalHint}${description}:`,
+      choices,
+    });
+  }
+
+  // Use text input for other fields
+  const typeHint = field.type ? ` [${field.type}]` : '';
+  return client.input.text({
+    message: `Enter value for ${field.name}${optionalHint}${typeHint}${description}:`,
+    validate: required ? createRequiredValidator(field.name) : undefined,
+  });
+}

--- a/packages/cli/src/commands/api/openapi-cache.ts
+++ b/packages/cli/src/commands/api/openapi-cache.ts
@@ -113,7 +113,10 @@ export class OpenApiCache {
     const requiredFields = new Set(schema.required || []);
     const fields: BodyField[] = [];
 
-    for (const [name, propSchema] of Object.entries(schema.properties)) {
+    for (const [name, propSchema] of Object.entries(schema.properties) as [
+      string,
+      Schema,
+    ][]) {
       const resolvedProp = this.resolveSchemaRef(propSchema);
 
       fields.push({
@@ -143,7 +146,7 @@ export class OpenApiCache {
   /**
    * Ensure the spec is loaded before accessing it
    */
-  private ensureLoaded(): asserts this is this & { spec: OpenApiSpec } {
+  private ensureLoaded(): void {
     if (!this.spec) {
       throw new Error(
         'OpenAPI spec not loaded. Call load() or loadWithSpinner() first.'

--- a/packages/cli/src/commands/api/openapi-cache.ts
+++ b/packages/cli/src/commands/api/openapi-cache.ts
@@ -1,0 +1,288 @@
+import { join } from 'path';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import getGlobalPathConfig from '../../util/config/global-path';
+import output from '../../output-manager';
+import { OPENAPI_URL, CACHE_FILE, CACHE_TTL_MS } from './constants';
+import type {
+  OpenApiSpec,
+  CachedSpec,
+  EndpointInfo,
+  Schema,
+  BodyField,
+} from './types';
+
+/**
+ * Manages OpenAPI spec fetching, caching, and parsing.
+ *
+ * Usage:
+ * ```typescript
+ * const cache = new OpenApiCache();
+ * await cache.load();
+ * const endpoints = cache.getEndpoints();
+ * const bodyFields = cache.getBodyFields(endpoint);
+ * ```
+ */
+export class OpenApiCache {
+  private readonly cachePath: string;
+  private spec: OpenApiSpec | null = null;
+
+  constructor() {
+    this.cachePath = join(getGlobalPathConfig(), CACHE_FILE);
+  }
+
+  /**
+   * Check if the spec has been loaded
+   */
+  get isLoaded(): boolean {
+    return this.spec !== null;
+  }
+
+  /**
+   * Load the OpenAPI spec, using cache if available and fresh.
+   * Returns true if successful, false otherwise.
+   */
+  async load(forceRefresh = false): Promise<boolean> {
+    // Try to read from cache
+    if (!forceRefresh) {
+      const cached = await this.readCache();
+      if (cached && !this.isExpired(cached.fetchedAt)) {
+        output.debug('Using cached OpenAPI spec');
+        this.spec = cached.spec;
+        return true;
+      }
+    }
+
+    // Fetch fresh spec
+    try {
+      output.debug('Fetching OpenAPI spec from ' + OPENAPI_URL);
+      this.spec = await this.fetchSpec();
+      await this.saveCache(this.spec);
+      return true;
+    } catch (err) {
+      output.debug(`Failed to fetch OpenAPI spec: ${err}`);
+      // If fetch fails, try to use stale cache
+      const stale = await this.readCache();
+      if (stale) {
+        output.debug('Using stale cached OpenAPI spec');
+        this.spec = stale.spec;
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Load the OpenAPI spec with spinner UI.
+   * Returns true if successful, false otherwise.
+   */
+  async loadWithSpinner(forceRefresh = false): Promise<boolean> {
+    output.spinner(
+      forceRefresh ? 'Refreshing API endpoints...' : 'Loading API endpoints...'
+    );
+    const success = await this.load(forceRefresh);
+    output.stopSpinner();
+    return success;
+  }
+
+  /**
+   * Get all available endpoints from the loaded spec, sorted by path then method.
+   * Throws if spec hasn't been loaded yet.
+   */
+  getEndpoints(): EndpointInfo[] {
+    this.ensureLoaded();
+    const endpoints = this.extractEndpoints();
+    return this.sortEndpoints(endpoints);
+  }
+
+  /**
+   * Extract body fields from a requestBody schema.
+   * Throws if spec hasn't been loaded yet.
+   */
+  getBodyFields(endpoint: EndpointInfo): BodyField[] {
+    this.ensureLoaded();
+
+    if (!endpoint.requestBody?.content) return [];
+
+    // Get the JSON content schema
+    const jsonContent = endpoint.requestBody.content['application/json'];
+    if (!jsonContent?.schema) return [];
+
+    const schema = this.resolveSchemaRef(jsonContent.schema);
+    if (!schema?.properties) return [];
+
+    const requiredFields = new Set(schema.required || []);
+    const fields: BodyField[] = [];
+
+    for (const [name, propSchema] of Object.entries(schema.properties)) {
+      const resolvedProp = this.resolveSchemaRef(propSchema);
+
+      fields.push({
+        name,
+        required: requiredFields.has(name),
+        description: resolvedProp?.description || propSchema.description,
+        type: resolvedProp?.type || propSchema.type,
+        enumValues: resolvedProp?.enum || propSchema.enum,
+      });
+    }
+
+    // Sort by required first, then alphabetically
+    fields.sort((a, b) => {
+      if (a.required !== b.required) {
+        return a.required ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    return fields;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Private methods
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Ensure the spec is loaded before accessing it
+   */
+  private ensureLoaded(): asserts this is this & { spec: OpenApiSpec } {
+    if (!this.spec) {
+      throw new Error(
+        'OpenAPI spec not loaded. Call load() or loadWithSpinner() first.'
+      );
+    }
+  }
+
+  /**
+   * Read cached spec from disk
+   */
+  private async readCache(): Promise<CachedSpec | null> {
+    try {
+      const content = await readFile(this.cachePath, 'utf-8');
+      return JSON.parse(content) as CachedSpec;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Save spec to disk cache
+   */
+  private async saveCache(spec: OpenApiSpec): Promise<void> {
+    const cached: CachedSpec = {
+      fetchedAt: Date.now(),
+      spec,
+    };
+
+    // Ensure directory exists
+    const dir = join(this.cachePath, '..');
+    await mkdir(dir, { recursive: true });
+
+    await writeFile(this.cachePath, JSON.stringify(cached));
+    output.debug('Saved OpenAPI spec to cache');
+  }
+
+  /**
+   * Fetch OpenAPI spec from remote
+   */
+  private async fetchSpec(): Promise<OpenApiSpec> {
+    const response = await fetch(OPENAPI_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OpenAPI spec: ${response.status}`);
+    }
+    return (await response.json()) as OpenApiSpec;
+  }
+
+  /**
+   * Check if cached spec is expired
+   */
+  private isExpired(fetchedAt: number): boolean {
+    return Date.now() - fetchedAt > CACHE_TTL_MS;
+  }
+
+  /**
+   * Sort endpoints by path, then by method
+   */
+  private sortEndpoints(endpoints: EndpointInfo[]): EndpointInfo[] {
+    return endpoints.sort((a, b) => {
+      const pathCompare = a.path.localeCompare(b.path);
+      if (pathCompare !== 0) return pathCompare;
+      return a.method.localeCompare(b.method);
+    });
+  }
+
+  /**
+   * Extract all available endpoints from the spec
+   */
+  private extractEndpoints(): EndpointInfo[] {
+    const endpoints: EndpointInfo[] = [];
+
+    for (const [path, pathItem] of Object.entries(this.spec!.paths)) {
+      const methods = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+      for (const method of methods) {
+        const operation = pathItem[method];
+        if (operation) {
+          // Merge path-level and operation-level parameters
+          const pathParams = pathItem.parameters || [];
+          const opParams = operation.parameters || [];
+          const allParams = [...pathParams, ...opParams];
+
+          endpoints.push({
+            path,
+            method: method.toUpperCase(),
+            summary: operation.summary || pathItem.summary || '',
+            description: operation.description || pathItem.description || '',
+            operationId: operation.operationId || '',
+            tags: operation.tags || [],
+            parameters: allParams,
+            requestBody: operation.requestBody,
+          });
+        }
+      }
+    }
+
+    return endpoints;
+  }
+
+  /**
+   * Resolve a $ref to its actual schema
+   */
+  private resolveSchemaRef(schema: Schema | undefined): Schema | undefined {
+    if (!schema) return undefined;
+
+    if (schema.$ref) {
+      // Parse $ref like "#/components/schemas/SchemaName"
+      const match = schema.$ref.match(/^#\/components\/schemas\/(.+)$/);
+      if (match && this.spec!.components?.schemas) {
+        const resolved = this.spec!.components.schemas[match[1]];
+        // Recursively resolve if the resolved schema also has a $ref
+        return this.resolveSchemaRef(resolved);
+      }
+      return undefined;
+    }
+
+    // Handle allOf by merging schemas
+    if (schema.allOf && schema.allOf.length > 0) {
+      const merged: Schema = { type: 'object', properties: {}, required: [] };
+      for (const subSchema of schema.allOf) {
+        const resolved = this.resolveSchemaRef(subSchema);
+        if (resolved) {
+          if (resolved.properties) {
+            merged.properties = {
+              ...merged.properties,
+              ...resolved.properties,
+            };
+          }
+          if (resolved.required) {
+            merged.required = [
+              ...(merged.required || []),
+              ...resolved.required,
+            ];
+          }
+        }
+      }
+      return merged;
+    }
+
+    return schema;
+  }
+}

--- a/packages/cli/src/commands/api/request-builder.ts
+++ b/packages/cli/src/commands/api/request-builder.ts
@@ -1,0 +1,202 @@
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import type { JSONObject, JSONValue } from '@vercel-internals/types';
+import type { RequestConfig, ParsedFlags } from './types';
+
+/**
+ * Build a request configuration from CLI flags
+ */
+export async function buildRequest(
+  endpoint: string,
+  flags: ParsedFlags
+): Promise<RequestConfig> {
+  const headers: Record<string, string> = {};
+  let body: JSONObject | string | undefined;
+
+  // Parse custom headers (-H key:value)
+  const customHeaders = flags['--header'] || [];
+  for (const header of customHeaders) {
+    const colonIndex = header.indexOf(':');
+    if (colonIndex > 0) {
+      const key = header.substring(0, colonIndex).trim();
+      const value = header.substring(colonIndex + 1).trim();
+      headers[key] = value;
+    }
+  }
+
+  // Build body from fields
+  const fields = flags['--field'] || [];
+  const rawFields = flags['--raw-field'] || [];
+
+  if (fields.length > 0 || rawFields.length > 0) {
+    body = {};
+
+    // Parse typed fields (-F key=value)
+    for (const field of fields) {
+      const { key, value } = await parseField(field, true);
+      body[key] = value;
+    }
+
+    // Parse raw (string) fields (-f key=value)
+    for (const field of rawFields) {
+      const { key, value } = await parseField(field, false);
+      body[key] = value;
+    }
+  }
+
+  // Read body from file (--input)
+  if (flags['--input']) {
+    const inputPath = flags['--input'];
+    if (inputPath === '-') {
+      body = await readStdin();
+    } else {
+      body = await readFile(resolve(inputPath), 'utf-8');
+    }
+
+    // Try to parse as JSON
+    if (typeof body === 'string') {
+      try {
+        body = JSON.parse(body) as JSONObject;
+      } catch {
+        // Keep as string if not valid JSON
+      }
+    }
+  }
+
+  // Determine method
+  let method = flags['--method']?.toUpperCase() || 'GET';
+  if (!flags['--method'] && body) {
+    method = 'POST';
+  }
+
+  return {
+    url: endpoint,
+    method,
+    headers,
+    body,
+  };
+}
+
+/**
+ * Parse a field string into key-value pair
+ * @param field - The field string (key=value)
+ * @param typed - Whether to parse value types (bool, int, file)
+ */
+async function parseField(
+  field: string,
+  typed: boolean
+): Promise<{ key: string; value: JSONValue }> {
+  const eqIndex = field.indexOf('=');
+  if (eqIndex === -1) {
+    throw new Error(`Invalid field format: ${field}. Expected key=value`);
+  }
+
+  const key = field.substring(0, eqIndex);
+  let value: JSONValue = field.substring(eqIndex + 1);
+
+  if (typed && typeof value === 'string') {
+    // File reference (@filename)
+    if (value.startsWith('@')) {
+      const filePath = value.substring(1);
+      if (filePath === '-') {
+        value = await readStdin();
+      } else {
+        value = await readFile(resolve(filePath), 'utf-8');
+      }
+      // Try to parse file contents as JSON
+      if (typeof value === 'string') {
+        try {
+          value = JSON.parse(value);
+        } catch {
+          // Keep as string
+        }
+      }
+    } else if (value === 'true') {
+      value = true;
+    } else if (value === 'false') {
+      value = false;
+    } else if (value === 'null') {
+      value = null;
+    } else if (/^-?\d+$/.test(value)) {
+      value = parseInt(value, 10);
+    } else if (/^-?\d*\.\d+$/.test(value)) {
+      value = parseFloat(value);
+    }
+  }
+
+  return { key, value };
+}
+
+/**
+ * Read all input from stdin
+ */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/**
+ * Format output data
+ */
+export function formatOutput(
+  data: unknown,
+  options: { raw?: boolean }
+): string {
+  if (options.raw) {
+    if (typeof data === 'string') {
+      return data;
+    }
+    return JSON.stringify(data);
+  }
+
+  // Pretty print JSON with 2-space indentation
+  return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Generate a curl command from a RequestConfig
+ */
+export function generateCurlCommand(
+  config: RequestConfig,
+  baseUrl: string
+): string {
+  const parts: string[] = ['curl'];
+
+  // Method (if not GET)
+  if (config.method !== 'GET') {
+    parts.push(`-X ${config.method}`);
+  }
+
+  // Headers
+  for (const [key, value] of Object.entries(config.headers)) {
+    parts.push(`-H '${key}: ${escapeShellArg(value)}'`);
+  }
+
+  // Body
+  if (config.body) {
+    const bodyStr =
+      typeof config.body === 'string'
+        ? config.body
+        : JSON.stringify(config.body);
+    parts.push(`-H 'Content-Type: application/json'`);
+    parts.push(`-d '${escapeShellArg(bodyStr)}'`);
+  }
+
+  // URL (with placeholder for auth header)
+  const fullUrl = `${baseUrl}${config.url}`;
+  parts.push(`'${fullUrl}'`);
+
+  return parts.join(' \\\n  ');
+}
+
+/**
+ * Escape a string for use in a shell single-quoted argument
+ */
+function escapeShellArg(str: string): string {
+  // In single quotes, only single quotes need escaping
+  // We escape by ending the quote, adding escaped quote, and starting new quote
+  return str.replace(/'/g, "'\\''");
+}

--- a/packages/cli/src/commands/api/types.ts
+++ b/packages/cli/src/commands/api/types.ts
@@ -1,0 +1,135 @@
+import type { JSONObject } from '@vercel-internals/types';
+
+export interface RequestConfig {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string | JSONObject;
+}
+
+export interface OpenApiSpec {
+  openapi: string;
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+  };
+  paths: Record<string, PathItem>;
+  servers?: Array<{ url: string; description?: string }>;
+  components?: {
+    schemas?: Record<string, Schema>;
+  };
+}
+
+export interface PathItem {
+  get?: Operation;
+  post?: Operation;
+  put?: Operation;
+  patch?: Operation;
+  delete?: Operation;
+  summary?: string;
+  description?: string;
+  parameters?: Parameter[];
+}
+
+export interface Operation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses?: Record<string, Response>;
+  tags?: string[];
+  security?: Array<Record<string, string[]>>;
+}
+
+export interface Parameter {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie';
+  required?: boolean;
+  description?: string;
+  schema?: Schema;
+}
+
+export interface RequestBody {
+  required?: boolean;
+  description?: string;
+  content?: Record<string, MediaType>;
+}
+
+export interface MediaType {
+  schema?: Schema;
+}
+
+export interface Schema {
+  type?: string;
+  properties?: Record<string, Schema>;
+  items?: Schema;
+  $ref?: string;
+  required?: string[];
+  description?: string;
+  enum?: (string | number | boolean)[];
+  default?: unknown;
+  format?: string;
+  oneOf?: Schema[];
+  anyOf?: Schema[];
+  allOf?: Schema[];
+}
+
+export interface Response {
+  description?: string;
+  content?: Record<string, MediaType>;
+}
+
+export interface CachedSpec {
+  fetchedAt: number;
+  spec: OpenApiSpec;
+}
+
+export interface EndpointInfo {
+  path: string;
+  method: string;
+  summary: string;
+  description: string;
+  operationId: string;
+  tags: string[];
+  parameters: Parameter[];
+  requestBody?: RequestBody;
+}
+
+export interface BodyField {
+  name: string;
+  required: boolean;
+  description?: string;
+  type?: string;
+  enumValues?: (string | number | boolean)[];
+}
+
+export interface ParsedFlags {
+  '--help'?: boolean;
+  '--method'?: string;
+  '--field'?: string[];
+  '--raw-field'?: string[];
+  '--header'?: string[];
+  '--input'?: string;
+  '--paginate'?: boolean;
+  '--include'?: boolean;
+  '--silent'?: boolean;
+  '--verbose'?: boolean;
+  '--raw'?: boolean;
+  '--refresh'?: boolean;
+  '--generate'?: string;
+  '--format'?: string;
+}
+
+export interface SelectedEndpoint {
+  path: string;
+  method: string;
+  finalUrl: string;
+  bodyFields: string[];
+}
+
+export interface PromptResult {
+  finalUrl: string;
+  bodyFields: string[];
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 import { aliasCommand } from './alias/command';
+import { apiCommand } from './api/command';
 import { bisectCommand } from './bisect/command';
 import { buildCommand } from './build/command';
 import { cacheCommand } from './cache/command';
@@ -45,6 +46,7 @@ import output from '../output-manager';
 
 const commandsStructs = [
   aliasCommand,
+  apiCommand,
   blobCommand,
   bisectCommand,
   buildCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -195,7 +195,7 @@ const main = async () => {
   const subSubCommand = parsedArgs.args[3];
 
   // If empty, leave this code here for easy adding of beta commands later
-  const betaCommands: string[] = ['curl'];
+  const betaCommands: string[] = ['api', 'curl'];
   if (betaCommands.includes(targetOrSubcommand)) {
     output.print(
       `${chalk.grey(
@@ -639,6 +639,10 @@ const main = async () => {
         case 'alias':
           telemetry.trackCliCommandAlias(userSuppliedSubCommand);
           func = require('./commands/alias').default;
+          break;
+        case 'api':
+          telemetry.trackCliCommandApi(userSuppliedSubCommand);
+          func = require('./commands/api').default;
           break;
         case 'bisect':
           telemetry.trackCliCommandBisect(userSuppliedSubCommand);

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -4,6 +4,7 @@ import confirm from '@inquirer/confirm';
 import expand from '@inquirer/expand';
 import input from '@inquirer/input';
 import password from '@inquirer/password';
+import search from '@inquirer/search';
 import select from '@inquirer/select';
 import { EventEmitter } from 'events';
 import { URL } from 'url';
@@ -142,6 +143,11 @@ export default class Client extends EventEmitter implements Stdio {
         ),
       select: <T>(opts: Parameters<typeof select<T>>[0]) =>
         select<T>(
+          { theme, ...opts },
+          { input: this.stdin, output: this.stderr }
+        ),
+      search: <T>(opts: Parameters<typeof search<T>>[0]) =>
+        search<T>(
           { theme, ...opts },
           { input: this.stdin, output: this.stderr }
         ),

--- a/packages/cli/src/util/telemetry/commands/api/index.ts
+++ b/packages/cli/src/util/telemetry/commands/api/index.ts
@@ -31,16 +31,22 @@ export class ApiTelemetryClient
     }
   }
 
-  // We deliberately don't track field values for privacy - just satisfy the interface
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  trackCliOptionField(value: string[] | undefined) {
-    // Not tracked
+  trackCliOptionField(fields: string[] | undefined) {
+    if (fields && fields.length > 0) {
+      this.trackCliOption({
+        option: 'field',
+        value: this.redactedArgumentsLength(fields),
+      });
+    }
   }
 
-  // We deliberately don't track raw-field values for privacy - just satisfy the interface
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  trackCliOptionRawField(value: string[] | undefined) {
-    // Not tracked
+  trackCliOptionRawField(fields: string[] | undefined) {
+    if (fields && fields.length > 0) {
+      this.trackCliOption({
+        option: 'raw-field',
+        value: this.redactedArgumentsLength(fields),
+      });
+    }
   }
 
   trackCliOptionHeader(headers: string[] | undefined) {

--- a/packages/cli/src/util/telemetry/commands/api/index.ts
+++ b/packages/cli/src/util/telemetry/commands/api/index.ts
@@ -1,0 +1,126 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { apiCommand } from '../../../../commands/api/command';
+
+export class ApiTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof apiCommand>
+{
+  trackCliArgumentEndpoint(endpoint: string | undefined) {
+    if (endpoint) {
+      // Normalize endpoint by replacing IDs with placeholders for privacy
+      const normalized = this.normalizeEndpoint(endpoint);
+      this.trackCliArgument({
+        arg: 'endpoint',
+        value: normalized,
+      });
+    }
+  }
+
+  trackCliOptionMethod(method: string | undefined) {
+    if (method) {
+      const validMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'];
+      const upperMethod = method.toUpperCase();
+      const value = validMethods.includes(upperMethod)
+        ? upperMethod
+        : this.redactedValue;
+      this.trackCliOption({
+        option: 'method',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionHeader(headers: string[] | undefined) {
+    if (headers && headers.length > 0) {
+      this.trackCliOption({
+        option: 'header',
+        value: this.redactedArgumentsLength(headers),
+      });
+    }
+  }
+
+  trackCliOptionInput(input: string | undefined) {
+    if (input) {
+      const value = input === '-' ? 'stdin' : 'file';
+      this.trackCliOption({
+        option: 'input',
+        value,
+      });
+    }
+  }
+
+  trackCliFlagPaginate(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('paginate');
+    }
+  }
+
+  trackCliFlagInclude(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('include');
+    }
+  }
+
+  trackCliFlagSilent(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('silent');
+    }
+  }
+
+  trackCliFlagVerbose(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('verbose');
+    }
+  }
+
+  trackCliFlagRaw(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('raw');
+    }
+  }
+
+  trackCliFlagRefresh(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('refresh');
+    }
+  }
+
+  trackCliOptionGenerate(format: string | undefined) {
+    if (format) {
+      const validFormats = ['curl'];
+      const value = validFormats.includes(format) ? format : this.redactedValue;
+      this.trackCliOption({
+        option: 'generate',
+        value,
+      });
+    }
+  }
+
+  trackCliSubcommandList() {
+    this.trackCliSubcommand('list');
+  }
+
+  trackCliOptionFormat(format: string | undefined) {
+    if (format) {
+      const validFormats = ['table', 'json'];
+      const value = validFormats.includes(format) ? format : this.redactedValue;
+      this.trackCliOption({
+        option: 'format',
+        value,
+      });
+    }
+  }
+
+  /**
+   * Normalize endpoint by replacing IDs with placeholders for privacy
+   */
+  private normalizeEndpoint(endpoint: string): string {
+    return endpoint
+      .replace(/\/dpl_[a-zA-Z0-9]+/g, '/:deploymentId')
+      .replace(/\/prj_[a-zA-Z0-9]+/g, '/:projectId')
+      .replace(/\/team_[a-zA-Z0-9]+/g, '/:teamId')
+      .replace(/\/[a-f0-9]{24}/g, '/:id')
+      .replace(/\/[a-f0-9-]{36}/g, '/:uuid');
+  }
+}

--- a/packages/cli/src/util/telemetry/commands/api/index.ts
+++ b/packages/cli/src/util/telemetry/commands/api/index.ts
@@ -31,6 +31,18 @@ export class ApiTelemetryClient
     }
   }
 
+  // We deliberately don't track field values for privacy - just satisfy the interface
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  trackCliOptionField(value: string[] | undefined) {
+    // Not tracked
+  }
+
+  // We deliberately don't track raw-field values for privacy - just satisfy the interface
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  trackCliOptionRawField(value: string[] | undefined) {
+    // Not tracked
+  }
+
   trackCliOptionHeader(headers: string[] | undefined) {
     if (headers && headers.length > 0) {
       this.trackCliOption({
@@ -98,7 +110,7 @@ export class ApiTelemetryClient
   }
 
   trackCliSubcommandList() {
-    this.trackCliSubcommand('list');
+    this.trackCliSubcommand({ subcommand: 'list', value: 'list' });
   }
 
   trackCliOptionFormat(format: string | undefined) {

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -19,6 +19,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandApi(actual: string) {
+    this.trackCliCommand({
+      command: 'api',
+      value: actual,
+    });
+  }
+
   trackCliCommandBisect(actual: string) {
     this.trackCliCommand({
       command: 'bisect',

--- a/packages/cli/test/unit/commands/api/index.test.ts
+++ b/packages/cli/test/unit/commands/api/index.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import api from '../../../../src/commands/api';
+
+describe('api', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('--help', () => {
+    it('prints help message', async () => {
+      client.setArgv('api', '--help');
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(2);
+      expect(client.getFullOutput()).toContain(
+        'Make authenticated HTTP requests to the Vercel API'
+      );
+    });
+  });
+
+  describe('endpoint validation', () => {
+    it('should reject endpoint without leading slash', async () => {
+      client.setArgv('api', 'v2/user');
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(1);
+      expect(client.getFullOutput()).toContain('Endpoint must start with /');
+    });
+
+    it('should reject protocol-relative URLs to prevent SSRF', async () => {
+      client.setArgv('api', '//evil.com/steal-token');
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(1);
+      expect(client.getFullOutput()).toContain(
+        'must be a Vercel API path, not an external URL'
+      );
+    });
+
+    it('should reject URLs that resolve to external hosts', async () => {
+      client.setArgv('api', '//attacker.com');
+      const exitCode = await api(client);
+      expect(exitCode).toEqual(1);
+      expect(client.getFullOutput()).toContain(
+        'must be a Vercel API path, not an external URL'
+      );
+    });
+  });
+
+  describe('GET requests', () => {
+    it('makes GET request to endpoint', async () => {
+      // Use a custom endpoint to avoid conflict with useUser()
+      client.scenario.get('/v5/test-endpoint', (_req, res) => {
+        res.json({ data: { id: 'test_123', name: 'testdata' } });
+      });
+
+      client.setArgv('api', '/v5/test-endpoint');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.stdout.getFullOutput()).toContain('test_123');
+      expect(client.stdout.getFullOutput()).toContain('testdata');
+    });
+
+    it('includes team scope when configured', async () => {
+      client.config.currentTeam = 'team_abc123';
+
+      client.scenario.get('/v9/projects', (req, res) => {
+        expect(req.query.teamId).toBe('team_abc123');
+        res.json({ projects: [] });
+      });
+
+      client.setArgv('api', '/v9/projects');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('POST requests', () => {
+    it('makes POST request with -F fields', async () => {
+      client.scenario.post('/v10/projects', (req, res) => {
+        expect(req.body.name).toBe('my-project');
+        res.json({ id: 'prj_123', name: 'my-project' });
+      });
+
+      client.setArgv('api', '/v10/projects', '-F', 'name=my-project');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.stdout.getFullOutput()).toContain('prj_123');
+    });
+
+    it('parses typed fields correctly', async () => {
+      client.scenario.post('/v10/projects', (req, res) => {
+        expect(req.body.public).toBe(true);
+        expect(req.body.count).toBe(42);
+        expect(req.body.name).toBe('test');
+        res.json({ success: true });
+      });
+
+      client.setArgv(
+        'api',
+        '/v10/projects',
+        '-F',
+        'public=true',
+        '-F',
+        'count=42',
+        '-F',
+        'name=test'
+      );
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+    });
+
+    it('uses explicit method with -X', async () => {
+      client.scenario.put('/v10/projects/prj_123', (req, res) => {
+        expect(req.body.name).toBe('updated');
+        res.json({ id: 'prj_123', name: 'updated' });
+      });
+
+      client.setArgv(
+        'api',
+        '/v10/projects/prj_123',
+        '-X',
+        'PUT',
+        '-F',
+        'name=updated'
+      );
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('DELETE requests', () => {
+    it('makes DELETE request', async () => {
+      client.scenario.delete('/v13/deployments/dpl_abc123', (_req, res) => {
+        res.json({ uid: 'dpl_abc123' });
+      });
+
+      client.setArgv('api', '/v13/deployments/dpl_abc123', '-X', 'DELETE');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('custom headers', () => {
+    it('sends custom headers', async () => {
+      client.scenario.get('/v5/test-headers', (req, res) => {
+        expect(req.headers['x-custom-header']).toBe('custom-value');
+        res.json({ success: true });
+      });
+
+      client.setArgv(
+        'api',
+        '/v5/test-headers',
+        '-H',
+        'X-Custom-Header: custom-value'
+      );
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+    });
+  });
+
+  describe('output formatting', () => {
+    it('pretty prints JSON by default', async () => {
+      client.scenario.get('/v5/test-format', (_req, res) => {
+        res.json({ data: { id: 'test_123' } });
+      });
+
+      client.setArgv('api', '/v5/test-format');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      // Check for indented output (pretty print)
+      const output = client.stdout.getFullOutput();
+      expect(output).toContain('  '); // Has indentation
+    });
+
+    it('outputs raw JSON with --raw', async () => {
+      client.scenario.get('/v5/test-raw', (_req, res) => {
+        res.json({ data: { id: 'raw_123' } });
+      });
+
+      client.setArgv('api', '/v5/test-raw', '--raw');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput().trim();
+      // Raw output should be compact (no extra indentation)
+      expect(output).toBe('{"data":{"id":"raw_123"}}');
+    });
+  });
+
+  describe('--include flag', () => {
+    it('includes response headers when --include is used', async () => {
+      client.scenario.get('/v5/test-include', (_req, res) => {
+        res.set('X-Custom-Response', 'header-value');
+        res.json({ data: { id: 'include_123' } });
+      });
+
+      client.setArgv('api', '/v5/test-include', '--include');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      expect(output).toContain('HTTP');
+      expect(output).toContain('200');
+    });
+  });
+
+  describe('--silent flag', () => {
+    it('suppresses output when --silent is used', async () => {
+      client.scenario.get('/v5/test-silent', (_req, res) => {
+        res.json({ data: { id: 'silent_123' } });
+      });
+
+      client.setArgv('api', '/v5/test-silent', '--silent');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      expect(output).toBe('');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns non-zero for error responses', async () => {
+      client.scenario.get('/v2/nonexistent', (_req, res) => {
+        res
+          .status(404)
+          .json({ error: { code: 'not_found', message: 'Not found' } });
+      });
+
+      client.setArgv('api', '/v2/nonexistent');
+      const exitCode = await api(client);
+
+      expect(exitCode).toEqual(1);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('tracks endpoint with normalized IDs', async () => {
+      client.scenario.get('/v13/deployments/dpl_abc123', (_req, res) => {
+        res.json({ uid: 'dpl_abc123' });
+      });
+
+      client.setArgv('api', '/v13/deployments/dpl_abc123');
+      await api(client);
+
+      // Check that the endpoint is tracked with normalized IDs
+      const events = client.telemetryEventStore.readonlyEvents;
+      const endpointEvent = events.find(e => e.key === 'argument:endpoint');
+      expect(endpointEvent).toBeDefined();
+      expect(endpointEvent?.value).toBe('/v13/deployments/:deploymentId');
+    });
+
+    it('tracks HTTP method', async () => {
+      client.scenario.post('/v10/projects', (_req, res) => {
+        res.json({ id: 'prj_123' });
+      });
+
+      client.setArgv('api', '/v10/projects', '-X', 'POST', '-F', 'name=test');
+      await api(client);
+
+      // Check that the method is tracked
+      const events = client.telemetryEventStore.readonlyEvents;
+      const methodEvent = events.find(e => e.key === 'option:method');
+      expect(methodEvent).toBeDefined();
+      expect(methodEvent?.value).toBe('POST');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/api/request-builder.test.ts
+++ b/packages/cli/test/unit/commands/api/request-builder.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRequest,
+  formatOutput,
+  generateCurlCommand,
+} from '../../../../src/commands/api/request-builder';
+import type { RequestConfig } from '../../../../src/commands/api/types';
+
+describe('request-builder', () => {
+  describe('buildRequest', () => {
+    it('builds GET request by default', async () => {
+      const result = await buildRequest('/v2/user', {});
+
+      expect(result.url).toBe('/v2/user');
+      expect(result.method).toBe('GET');
+      expect(result.body).toBeUndefined();
+    });
+
+    it('builds POST request when body is provided', async () => {
+      const result = await buildRequest('/v10/projects', {
+        '--field': ['name=my-project'],
+      });
+
+      expect(result.method).toBe('POST');
+      expect(result.body).toEqual({ name: 'my-project' });
+    });
+
+    it('uses explicit method with --method flag', async () => {
+      const result = await buildRequest('/v10/projects', {
+        '--method': 'PUT',
+        '--field': ['name=updated'],
+      });
+
+      expect(result.method).toBe('PUT');
+    });
+
+    it.each([
+      // Boolean values
+      {
+        input: 'enabled=true',
+        expected: { enabled: true },
+        desc: 'true boolean',
+      },
+      {
+        input: 'disabled=false',
+        expected: { disabled: false },
+        desc: 'false boolean',
+      },
+      // Integer values
+      { input: 'count=42', expected: { count: 42 }, desc: 'positive integer' },
+      {
+        input: 'negative=-10',
+        expected: { negative: -10 },
+        desc: 'negative integer',
+      },
+      { input: 'zero=0', expected: { zero: 0 }, desc: 'zero' },
+      // Float values
+      {
+        input: 'price=19.99',
+        expected: { price: 19.99 },
+        desc: 'positive float',
+      },
+      { input: 'rate=0.5', expected: { rate: 0.5 }, desc: 'decimal float' },
+      { input: 'neg=-3.14', expected: { neg: -3.14 }, desc: 'negative float' },
+      // Null values
+      { input: 'value=null', expected: { value: null }, desc: 'null value' },
+      // String values (not matching special patterns)
+      {
+        input: 'name=hello',
+        expected: { name: 'hello' },
+        desc: 'simple string',
+      },
+      {
+        input: 'text=hello world',
+        expected: { text: 'hello world' },
+        desc: 'string with space',
+      },
+      {
+        input: 'notbool=trueish',
+        expected: { notbool: 'trueish' },
+        desc: 'string starting with true',
+      },
+      {
+        input: 'notnum=42abc',
+        expected: { notnum: '42abc' },
+        desc: 'string starting with number',
+      },
+    ])('parses typed field: $desc', async ({ input, expected }) => {
+      const result = await buildRequest('/api', { '--field': [input] });
+      expect(result.body).toEqual(expected);
+    });
+
+    it.each([
+      {
+        input: 'number=42',
+        expected: { number: '42' },
+        desc: 'number as string',
+      },
+      {
+        input: 'bool=true',
+        expected: { bool: 'true' },
+        desc: 'boolean as string',
+      },
+      {
+        input: 'null=null',
+        expected: { null: 'null' },
+        desc: 'null as string',
+      },
+      {
+        input: 'float=3.14',
+        expected: { float: '3.14' },
+        desc: 'float as string',
+      },
+    ])('keeps raw-field as string: $desc', async ({ input, expected }) => {
+      const result = await buildRequest('/api', { '--raw-field': [input] });
+      expect(result.body).toEqual(expected);
+    });
+
+    it.each([
+      {
+        desc: 'simple header',
+        input: 'X-Custom: value',
+        expected: { 'X-Custom': 'value' },
+      },
+      {
+        desc: 'content-type header',
+        input: 'Content-Type: application/json',
+        expected: { 'Content-Type': 'application/json' },
+      },
+      {
+        desc: 'header with colons in value',
+        input: 'X-URL: https://example.com',
+        expected: { 'X-URL': 'https://example.com' },
+      },
+      {
+        desc: 'header with multiple colons in value',
+        input: 'X-Time: 12:30:45',
+        expected: { 'X-Time': '12:30:45' },
+      },
+      {
+        desc: 'header with whitespace around colon',
+        input: 'X-Spaced :   value  ',
+        expected: { 'X-Spaced': 'value' },
+      },
+    ])('parses header: $desc', async ({ input, expected }) => {
+      const result = await buildRequest('/api', { '--header': [input] });
+      expect(result.headers).toEqual(expected);
+    });
+
+    it('throws error for invalid field format', async () => {
+      await expect(
+        buildRequest('/api', { '--field': ['invalid'] })
+      ).rejects.toThrow('Invalid field format');
+    });
+  });
+
+  describe('formatOutput', () => {
+    it('pretty prints JSON by default', () => {
+      const result = formatOutput({ key: 'value' }, {});
+      expect(result).toBe('{\n  "key": "value"\n}');
+    });
+
+    it('outputs compact JSON with raw option', () => {
+      const result = formatOutput({ key: 'value' }, { raw: true });
+      expect(result).toBe('{"key":"value"}');
+    });
+
+    it('returns string values as-is with raw option', () => {
+      const result = formatOutput('plain text', { raw: true });
+      expect(result).toBe('plain text');
+    });
+  });
+
+  describe('generateCurlCommand', () => {
+    const baseUrl = 'https://api.vercel.com';
+
+    it.each<{ desc: string; config: RequestConfig; contains: string[] }>([
+      {
+        desc: 'simple GET request',
+        config: { url: '/v2/user', method: 'GET', headers: {} },
+        contains: ['curl', "'https://api.vercel.com/v2/user'"],
+      },
+      {
+        desc: 'POST request with method flag',
+        config: { url: '/v10/projects', method: 'POST', headers: {} },
+        contains: ['-X POST', "'https://api.vercel.com/v10/projects'"],
+      },
+      {
+        desc: 'PUT request',
+        config: { url: '/v10/projects/prj_123', method: 'PUT', headers: {} },
+        contains: ['-X PUT'],
+      },
+      {
+        desc: 'DELETE request',
+        config: { url: '/v10/projects/prj_123', method: 'DELETE', headers: {} },
+        contains: ['-X DELETE'],
+      },
+      {
+        desc: 'PATCH request',
+        config: { url: '/v10/projects/prj_123', method: 'PATCH', headers: {} },
+        contains: ['-X PATCH'],
+      },
+    ])('generates curl for $desc', ({ config, contains }) => {
+      const result = generateCurlCommand(config, baseUrl);
+      for (const expected of contains) {
+        expect(result).toContain(expected);
+      }
+    });
+
+    it.each<{ desc: string; config: RequestConfig; contains: string[] }>([
+      {
+        desc: 'single header',
+        config: {
+          url: '/api',
+          method: 'GET',
+          headers: { 'X-Custom': 'value' },
+        },
+        contains: ["-H 'X-Custom: value'"],
+      },
+      {
+        desc: 'multiple headers',
+        config: {
+          url: '/api',
+          method: 'GET',
+          headers: { 'X-One': 'first', 'X-Two': 'second' },
+        },
+        contains: ["-H 'X-One: first'", "-H 'X-Two: second'"],
+      },
+      {
+        desc: 'header with special characters',
+        config: {
+          url: '/api',
+          method: 'GET',
+          headers: { Authorization: "Bearer abc'123" },
+        },
+        contains: ["-H 'Authorization: Bearer abc'\\''123'"],
+      },
+    ])('generates curl with $desc', ({ config, contains }) => {
+      const result = generateCurlCommand(config, baseUrl);
+      for (const expected of contains) {
+        expect(result).toContain(expected);
+      }
+    });
+
+    it.each<{ desc: string; config: RequestConfig; contains: string[] }>([
+      {
+        desc: 'JSON object body',
+        config: {
+          url: '/api',
+          method: 'POST',
+          headers: {},
+          body: { name: 'test' },
+        },
+        contains: [
+          "-H 'Content-Type: application/json'",
+          '-d \'{"name":"test"}\'',
+        ],
+      },
+      {
+        desc: 'string body',
+        config: {
+          url: '/api',
+          method: 'POST',
+          headers: {},
+          body: 'raw body content',
+        },
+        contains: [
+          "-H 'Content-Type: application/json'",
+          "-d 'raw body content'",
+        ],
+      },
+      {
+        desc: 'body with special characters',
+        config: {
+          url: '/api',
+          method: 'POST',
+          headers: {},
+          body: { message: "it's working" },
+        },
+        contains: ["-d '{\"message\":\"it'\\''s working\"}'"],
+      },
+      {
+        desc: 'nested JSON body',
+        config: {
+          url: '/api',
+          method: 'POST',
+          headers: {},
+          body: { outer: { inner: 'value' } },
+        },
+        contains: ['-d \'{"outer":{"inner":"value"}}\''],
+      },
+    ])('generates curl with $desc', ({ config, contains }) => {
+      const result = generateCurlCommand(config, baseUrl);
+      for (const expected of contains) {
+        expect(result).toContain(expected);
+      }
+    });
+
+    it('does not include -X flag for GET requests', () => {
+      const config: RequestConfig = {
+        url: '/v2/user',
+        method: 'GET',
+        headers: {},
+      };
+      const result = generateCurlCommand(config, baseUrl);
+      expect(result).not.toContain('-X');
+    });
+
+    it('joins parts with line continuation', () => {
+      const config: RequestConfig = {
+        url: '/api',
+        method: 'POST',
+        headers: { 'X-Test': 'value' },
+        body: { key: 'value' },
+      };
+      const result = generateCurlCommand(config, baseUrl);
+      expect(result).toContain(' \\\n  ');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -6,6 +6,7 @@ describe('index', () => {
       new Map([
         ['alias', 'alias'],
         ['aliases', 'alias'],
+        ['api', 'api'],
         ['bisect', 'bisect'],
         ['blob', 'blob'],
         ['build', 'build'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       '@inquirer/password':
         specifier: 2.1.2
         version: 2.1.2
+      '@inquirer/search':
+        specifier: 2.0.1
+        version: 2.0.1
       '@inquirer/select':
         specifier: 2.2.2
         version: 2.2.2
@@ -5772,6 +5775,24 @@ packages:
       wrap-ansi: 6.2.0
     dev: true
 
+  /@inquirer/core@9.2.1:
+    resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 2.0.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.19.7
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    dev: true
+
   /@inquirer/expand@2.1.2:
     resolution: {integrity: sha512-QTcmxuKBXvsitEmHrz7Nrr30OPTYQWZf+hWrPUHoLSs1Qg1CLIUxFUfKDguiHZGubXmMydKB9m6TJZlAmU+WTA==}
     engines: {node: '>=18'}
@@ -5817,6 +5838,16 @@ packages:
       ansi-escapes: 4.3.2
     dev: true
 
+  /@inquirer/search@2.0.1:
+    resolution: {integrity: sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
+    dev: true
+
   /@inquirer/select@2.2.2:
     resolution: {integrity: sha512-WaoleV3O/7iDAHFC0GArOkl7Yg/7wQ/UptxEkfM+bG67h65v0troAjkNASBbNiz9vvoNZxOGhVrug0LNDftCoQ==}
     engines: {node: '>=18'}
@@ -5830,6 +5861,13 @@ packages:
 
   /@inquirer/type@1.5.5:
     resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
+    engines: {node: '>=18'}
+    dependencies:
+      mute-stream: 1.0.0
+    dev: true
+
+  /@inquirer/type@2.0.0:
+    resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
     engines: {node: '>=18'}
     dependencies:
       mute-stream: 1.0.0
@@ -8860,6 +8898,12 @@ packages:
       undici-types: 6.19.8
     dev: true
 
+  /@types/node@22.19.7:
+    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+    dependencies:
+      undici-types: 6.21.0
+    dev: true
+
   /@types/node@24.7.0:
     resolution: {integrity: sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==}
     dependencies:
@@ -9853,7 +9897,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.24.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.24.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.24.0)
@@ -9900,7 +9944,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9947,7 +9991,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -9994,7 +10038,7 @@ packages:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.35.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.35.0)(jest@29.5.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.35.0)
       eslint-plugin-playwright: 0.11.2(eslint-plugin-jest@27.9.0)(eslint@8.35.0)
@@ -12543,7 +12587,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -12572,7 +12616,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.24.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12598,7 +12642,7 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.35.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
@@ -12608,7 +12652,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12629,11 +12673,11 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       debug: 3.2.7
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.24.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12660,7 +12704,7 @@ packages:
       ignore: 5.3.2
     dev: true
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0):
+  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -12671,16 +12715,16 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.24.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.35.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.24.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.24.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.35.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19822,6 +19866,10 @@ packages:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
     dev: true
 
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    dev: true
+
   /undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
     dev: true
@@ -20648,6 +20696,11 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
     dev: true
 
   /zod@3.22.4:


### PR DESCRIPTION
Introduces a new vercel api command that allows making authenticated HTTP requests to the Vercel API. Similar in API to `gh api`

Designed to improve discovery of our APIs for agents. 

```
Vercel CLI 50.4.11 api (beta) — https://vercel.com/feedback

  ▲ vercel api [endpoint] [options]

  Make authenticated HTTP requests to the Vercel API        

  Options:

  -F,  --field <KEY=VALUE>      Add a typed parameter       
                                (numbers, booleans parsed). 
                                Use @file for file contents 
       --format <FORMAT>        Output format for ls command
                                (table, json). Defaults to  
                                table                       
       --generate <FORMAT>      Generate output instead of  
                                executing (e.g.,            
                                --generate=curl)            
  -H,  --header <KEY:VALUE>     Add a custom HTTP header    
  -i,  --include                Include response headers in 
                                output                      
       --input <FILE>           Read request body from file 
                                (use - for stdin)           
  -X,  --method <METHOD>        HTTP method (GET, POST, PUT,
                                PATCH, DELETE). Defaults to 
                                GET, or POST if body is     
                                provided                    
       --paginate               Fetch all pages of results  
       --raw                    Output raw JSON without     
                                pretty-printing             
  -f,  --raw-field <KEY=VALUE>  Add a string parameter (no  
                                type parsing)               
       --refresh                Force refresh the cached    
                                OpenAPI spec                
       --silent                 Suppress response output    
       --verbose                Show debug information      
                                including full              
                                request/response              


  Examples:

  - Get current user information

    $ vercel api /v2/user

  - List projects with team scope

    $ vercel api /v9/projects --scope my-team

  - Create a new project

    $ vercel api /v10/projects -X POST -F name=my-project

  - Delete a deployment

    $ vercel api /v13/deployments/dpl_abc123 -X DELETE

  - Paginate through all deployments

    $ vercel api /v6/deployments --paginate

  - Post JSON from file

    $ vercel api /v10/projects -X POST --input config.json

  - Add custom header

    $ vercel api /v2/user -H "X-Custom-Header: value"

  - List all available API endpoints

    $ vercel api --ls

  - Interactive mode (select endpoint)

    $ vercel api
```