### PR TITLE
[cli] Add --follow flag and positional deployment argument to logsv2

### DIFF
--- a/.changeset/logsv2-positional-arg.md
+++ b/.changeset/logsv2-positional-arg.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add positional deployment argument to logsv2 command for backwards-compatible logs replacement

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -79,6 +79,14 @@ export const logsv2Command = {
       description: 'Output logs as JSON Lines for piping to other tools',
     },
     {
+      name: 'follow',
+      shorthand: 'f',
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Stream live runtime logs (requires --deployment, no other filters allowed)',
+    },
+    {
       name: 'query',
       shorthand: 'q',
       type: String,
@@ -121,6 +129,10 @@ export const logsv2Command = {
     {
       name: 'Display logs for a specific request',
       value: `${packageName} logsv2 --request-id req_xxxxx`,
+    },
+    {
+      name: 'Stream live logs for a deployment',
+      value: `${packageName} logsv2 --deployment dpl_xxxxx --follow`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -80,7 +80,7 @@ export const logsv2Command = {
     },
     {
       name: 'follow',
-      shorthand: 'f',
+      shorthand: null,
       type: Boolean,
       deprecated: false,
       description:

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -5,7 +5,12 @@ export const logsv2Command = {
   aliases: [],
   description: 'Display request logs for a project using the new logs API.',
   hidden: true,
-  arguments: [],
+  arguments: [
+    {
+      name: 'url|deploymentId',
+      required: false,
+    },
+  ],
   options: [
     {
       name: 'project',
@@ -19,7 +24,8 @@ export const logsv2Command = {
       shorthand: 'd',
       type: String,
       deprecated: false,
-      description: 'Filter logs to a specific deployment ID or URL',
+      description:
+        'Filter logs to a specific deployment ID or URL (alternative to positional argument)',
     },
     {
       name: 'environment',
@@ -84,7 +90,7 @@ export const logsv2Command = {
       type: Boolean,
       deprecated: false,
       description:
-        'Stream live runtime logs (requires --deployment, no other filters allowed)',
+        'Stream live runtime logs (requires deployment URL/ID, no other filters allowed)',
     },
     {
       name: 'query',
@@ -103,6 +109,14 @@ export const logsv2Command = {
   ],
   examples: [
     {
+      name: 'Stream live logs for a deployment URL',
+      value: `${packageName} logsv2 https://my-app-xxxxx.vercel.app --follow`,
+    },
+    {
+      name: 'Stream live logs for a deployment ID',
+      value: `${packageName} logsv2 dpl_xxxxx --follow`,
+    },
+    {
       name: 'Display recent logs for the linked project',
       value: `${packageName} logsv2`,
     },
@@ -112,7 +126,7 @@ export const logsv2Command = {
     },
     {
       name: 'Display logs for a specific deployment',
-      value: `${packageName} logsv2 --deployment dpl_xxxxx`,
+      value: `${packageName} logsv2 dpl_xxxxx`,
     },
     {
       name: 'Filter logs by status code and output as JSON',
@@ -129,10 +143,6 @@ export const logsv2Command = {
     {
       name: 'Display logs for a specific request',
       value: `${packageName} logsv2 --request-id req_xxxxx`,
-    },
-    {
-      name: 'Stream live logs for a deployment',
-      value: `${packageName} logsv2 --deployment dpl_xxxxx --follow`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -59,9 +59,21 @@ export default async function logsv2(client: Client) {
     return 2;
   }
 
+  const subArgs = parsedArguments.args.slice(1);
+  const [deploymentArgument] = subArgs;
+
   const projectOption = parsedArguments.flags['--project'];
-  const deploymentOption = parsedArguments.flags['--deployment'];
+  const deploymentFlag = parsedArguments.flags['--deployment'];
   const environmentOption = parsedArguments.flags['--environment'];
+
+  let deploymentOption: string | undefined = deploymentFlag;
+  if (deploymentArgument) {
+    let deploymentIdOrHost = deploymentArgument;
+    try {
+      deploymentIdOrHost = new URL(deploymentArgument).hostname;
+    } catch {}
+    deploymentOption = deploymentIdOrHost;
+  }
   const levelOption = parsedArguments.flags['--level'];
   const statusCodeOption = parsedArguments.flags['--status-code'];
   const sourceOption = parsedArguments.flags['--source'];
@@ -73,8 +85,9 @@ export default async function logsv2(client: Client) {
   const queryOption = parsedArguments.flags['--query'];
   const requestIdOption = parsedArguments.flags['--request-id'];
 
+  telemetry.trackCliArgumentUrlOrDeploymentId(deploymentArgument);
   telemetry.trackCliOptionProject(projectOption);
-  telemetry.trackCliOptionDeployment(deploymentOption);
+  telemetry.trackCliOptionDeployment(deploymentFlag);
   telemetry.trackCliOptionEnvironment(environmentOption);
   telemetry.trackCliOptionLevel(levelOption);
   telemetry.trackCliOptionStatusCode(statusCodeOption);
@@ -90,7 +103,7 @@ export default async function logsv2(client: Client) {
   if (followOption) {
     if (!deploymentOption) {
       output.error(
-        `The ${chalk.bold('--follow')} flag requires ${chalk.bold('--deployment')} to be specified.`
+        `The ${chalk.bold('--follow')} flag requires a deployment URL or ID to be specified.`
       );
       return 1;
     }

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -6,6 +6,15 @@ export class Logsv2TelemetryClient
   extends TelemetryClient
   implements TelemetryMethods<typeof logsv2Command>
 {
+  trackCliArgumentUrlOrDeploymentId(v: string | undefined) {
+    if (v) {
+      this.trackCliArgument({
+        arg: 'urlOrDeploymentId',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliOptionProject(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -109,6 +109,12 @@ export class Logsv2TelemetryClient
     }
   }
 
+  trackCliFlagFollow(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('follow');
+    }
+  }
+
   trackCliOptionQuery(v: string | undefined) {
     if (v) {
       this.trackCliOption({

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -666,4 +666,106 @@ describe('logsv2', () => {
       await expect(client.stderr).toOutput("isn't linked to a project");
     });
   });
+
+  describe('--follow option', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should error when --follow is used without --deployment', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--follow');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        '--follow flag requires --deployment'
+      );
+    });
+
+    it('should error when --follow is used with --level', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logsv2',
+        '--follow',
+        '--deployment',
+        'dpl_test',
+        '--level',
+        'error'
+      );
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --level');
+    });
+
+    it('should error when --follow is used with --environment', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logsv2',
+        '--follow',
+        '--deployment',
+        'dpl_test',
+        '--environment',
+        'production'
+      );
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --environment');
+    });
+
+    it('should error when --follow is used with --query', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logsv2',
+        '--follow',
+        '--deployment',
+        'dpl_test',
+        '--query',
+        'error'
+      );
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --query');
+    });
+
+    it('should error when --follow is used with multiple incompatible flags', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv(
+        'logsv2',
+        '--follow',
+        '--deployment',
+        'dpl_test',
+        '--level',
+        'error',
+        '--since',
+        '1h'
+      );
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Remove: --level, --since');
+    });
+
+    it('should track telemetry for --follow flag', async () => {
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', '--follow');
+      await logsv2(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:follow',
+          value: 'TRUE',
+        },
+      ]);
+    });
+  });
 });

--- a/packages/cli/test/unit/commands/logsv2/index.test.ts
+++ b/packages/cli/test/unit/commands/logsv2/index.test.ts
@@ -610,6 +610,104 @@ describe('logsv2', () => {
     });
   });
 
+  describe('positional deployment argument', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+      useProject({
+        ...defaultProject,
+        id: 'prj_logsv2test',
+        name: 'logsv2-test-project',
+      });
+    });
+
+    it('should accept deployment ID as positional argument', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', deployment.id);
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
+    it('should extract hostname from URL positional argument', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      client.scenario.get(`/v13/deployments/${deployment.url}`, (_req, res) => {
+        res.json(deployment);
+      });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', `https://${deployment.url}/some/path`);
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+
+    it('should work with --follow when positional argument is provided', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', deployment.id, '--follow');
+
+      client.scenario.get(
+        `/v1/projects/prj_logsv2test/deployments/${deployment.id}/runtime-logs`,
+        (_req, res) => {
+          res.status(200);
+          res.end();
+        }
+      );
+
+      const exitCode = await logsv2(client);
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should prioritize positional argument over --deployment flag', async () => {
+      const user = useUser();
+      const deployment = useDeployment({ creator: user });
+
+      let receivedDeploymentId: string | undefined;
+      client.scenario.get('/api/logs/request-logs', (req, res) => {
+        receivedDeploymentId = req.query.deploymentId as string;
+        res.json({
+          rows: [createMockLog({ deploymentId: deployment.id })],
+          hasMoreRows: false,
+        });
+      });
+
+      client.cwd = fixture('linked-project');
+      client.setArgv('logsv2', deployment.id, '--deployment', 'other_dpl_id');
+      const exitCode = await logsv2(client);
+
+      expect(exitCode).toEqual(0);
+      expect(receivedDeploymentId).toEqual(deployment.id);
+    });
+  });
+
   describe('--request-id option', () => {
     beforeEach(() => {
       useUser();
@@ -678,14 +776,14 @@ describe('logsv2', () => {
       });
     });
 
-    it('should error when --follow is used without --deployment', async () => {
+    it('should error when --follow is used without deployment', async () => {
       client.cwd = fixture('linked-project');
       client.setArgv('logsv2', '--follow');
       const exitCode = await logsv2(client);
 
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput(
-        '--follow flag requires --deployment'
+        '--follow flag requires a deployment URL or ID'
       );
     });
 


### PR DESCRIPTION
## Summary
- Adds `--follow` flag to stream live runtime logs using the existing `displayRuntimeLogs` API
- Adds positional `url|deploymentId` argument to match the existing `logs` command API
  - Accepts deployment ID directly: `vercel logsv2 dpl_xxx --follow`
  - Accepts full URLs (extracts hostname): `vercel logsv2 https://my-app.vercel.app --follow`
  - Positional argument takes priority over `--deployment` flag
- Enables non-breaking migration path from `logs` to `logsv2`

## Test plan
- [x] Unit tests added for:
  - `--follow` requiring deployment (positional or `--deployment`)
  - `--follow` rejecting incompatible filters
  - Positional deployment ID argument
  - URL hostname extraction
  - Positional argument priority over `--deployment` flag
  - Telemetry tracking
- [x] Manual testing with `vercel logsv2 <deployment> --follow`