### PR TITLE
Add guideline to verify tests fail without code changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ describe('feature', () => {
 });
 ```
 
+**Verify tests fail without the code change**: When writing a test alongside a code change, always verify the test fails without the accompanying code. This confirms the test actually validates the new behavior rather than passing trivially. Temporarily revert or comment out the code change, run the test to see it fail, then restore the code.
+
 ## Package Development
 
 Each package follows this structure:


### PR DESCRIPTION
## Summary
Added a guideline to the Testing Patterns section of AGENTS.md reminding agents to verify that tests fail without the accompanying code changes. This ensures tests actually validate new behavior rather than passing trivially.

## Test plan
This is a documentation update with no code changes to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)