### PR TITLE
feat(cli): improve api ls command with grouped output and separate help

### DIFF
--- a/.changeset/ten-beans-wash.md
+++ b/.changeset/ten-beans-wash.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improvements to vercel api command. Better ls, and help output

--- a/packages/cli/src/commands/api/command.ts
+++ b/packages/cli/src/commands/api/command.ts
@@ -1,4 +1,32 @@
 import { packageName } from '../../util/pkg-name';
+import { formatOption } from '../../util/arg-common';
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List all available API endpoints',
+  arguments: [],
+  options: [
+    formatOption,
+    {
+      name: 'refresh',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Force refresh the cached OpenAPI spec',
+    },
+  ],
+  examples: [
+    {
+      name: 'List all endpoints in table format',
+      value: `${packageName} api ls`,
+    },
+    {
+      name: 'List all endpoints as JSON',
+      value: `${packageName} api ls --format json`,
+    },
+  ],
+} as const;
 
 export const apiCommand = {
   name: 'api',
@@ -10,6 +38,7 @@ export const apiCommand = {
       required: false,
     },
   ],
+  subcommands: [listSubcommand],
   options: [
     {
       name: 'method',
@@ -104,15 +133,6 @@ export const apiCommand = {
       description:
         'Generate output instead of executing (e.g., --generate=curl)',
     },
-    {
-      name: 'format',
-      shorthand: null,
-      type: String,
-      argument: 'FORMAT',
-      deprecated: false,
-      description:
-        'Output format for ls command (table, json). Defaults to table',
-    },
   ],
   examples: [
     {
@@ -142,10 +162,6 @@ export const apiCommand = {
     {
       name: 'Add custom header',
       value: `${packageName} api /v2/user -H "X-Custom-Header: value"`,
-    },
-    {
-      name: 'List all available API endpoints',
-      value: `${packageName} api ls`,
     },
     {
       name: 'Interactive mode (select endpoint)',


### PR DESCRIPTION
## Summary

Improves the `vercel api ls` command output and help system:

- **Grouped endpoint display**: Endpoints are now grouped by path with HTTP methods listed underneath, making it easier to scan available endpoints
- **Colored HTTP methods**: Methods are color-coded for quick visual identification:
  - `GET` - cyan
  - `POST` - green  
  - `PUT` - yellow
  - `PATCH` - blue
  - `DELETE` - red
- **Separate help for subcommand**: `vercel api --help` and `vercel api ls --help` now show appropriate options for each command
- **Moved `--format` to ls subcommand**: The `--format` option is only relevant to the `ls` subcommand and is no longer shown in the main `api` help

### Before
```
METHOD   PATH                                    SUMMARY
-----------------------------------------------------------------------
GET      /v1/projects                            List projects
POST     /v1/projects                            Create a project
DELETE   /v1/projects/{id}                       Delete a project
GET      /v1/projects/{id}                       Get a project
PATCH    /v1/projects/{id}                       Update a project

Total: 225 endpoints
```

### After
```
/v1/projects
  GET      List projects
  POST     Create a project

/v1/projects/{id}
  GET      Get a project
  PATCH    Update a project
  DELETE   Delete a project

152 routes, 225 endpoints
```

## Test plan

- [ ] Run `vercel api ls` and verify grouped output with colors
- [ ] Run `vercel api ls --format json` and verify JSON output works
- [ ] Run `vercel api --help` and verify `--format` is NOT listed
- [ ] Run `vercel api ls --help` and verify `--format` IS listed
- [ ] Verify `--refresh` flag works for both commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)