### PR TITLE
[next] Add deployment id header for soft navigation responses

### DIFF
--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -1888,6 +1888,9 @@ export async function serverBuild({
   const rscVaryHeader =
     routesManifest?.rsc?.varyHeader ||
     'RSC, Next-Router-State-Tree, Next-Router-Prefetch';
+  // TODO remove default again
+  const navDeploymentIdHeader =
+    routesManifest?.navDeploymentIdHeader ?? 'x-nextjs-deployment-id';
   const appNotFoundPath = path.posix.join('.', entryDirectory, '_not-found');
 
   if (isAppPPREnabled && !rscPrefetchHeader) {
@@ -2030,6 +2033,34 @@ export async function serverBuild({
                 },
               ],
               continue: true,
+            },
+          ]
+        : []),
+
+      ...(process.env.VERCEL_DEPLOYMENT_ID
+        ? [
+            {
+              src: '.*',
+              has: [
+                {
+                  type: 'header',
+                  key: 'rsc',
+                  value: '1',
+                },
+              ],
+              headers: {
+                [navDeploymentIdHeader]: process.env.VERCEL_DEPLOYMENT_ID,
+              },
+              continue: true,
+              override: true,
+            },
+            {
+              src: '/_next/data/(.*)',
+              headers: {
+                [navDeploymentIdHeader]: process.env.VERCEL_DEPLOYMENT_ID,
+              },
+              continue: true,
+              override: true,
             },
           ]
         : []),

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -320,6 +320,7 @@ type RoutesManifestOld = {
     pathHeader: string;
     queryHeader: string;
   };
+
   /**
    * Header for navigation data responses (both App and Pages, respecitively RSC and _next/data)
    */
@@ -2951,8 +2952,6 @@ export const onPrerenderRoute =
       const rscContentTypeHeader =
         routesManifest?.rsc?.contentTypeHeader || RSC_CONTENT_TYPE;
       const rscDidPostponeHeader = routesManifest?.rsc?.didPostponeHeader;
-      const navDeploymentIdHeader = routesManifest?.navDeploymentIdHeader;
-      const deploymentId = routesManifest?.deploymentId;
 
       let sourcePath: string | undefined;
       if (`/${outputPathPage}` !== srcRoute && srcRoute) {
@@ -3088,11 +3087,6 @@ export const onPrerenderRoute =
                 initialHeaders: {
                   ...initialHeaders,
                   vary: rscVaryHeader,
-                  ...(navDeploymentIdHeader && deploymentId
-                    ? {
-                        [navDeploymentIdHeader]: deploymentId,
-                      }
-                    : {}),
                 },
               }
             : {}),
@@ -3156,11 +3150,6 @@ export const onPrerenderRoute =
                     : {}),
                   ...(didPostpone && rscDidPostponeHeader && !isFallback
                     ? { [rscDidPostponeHeader]: '1' }
-                    : {}),
-                  ...(navDeploymentIdHeader && deploymentId
-                    ? {
-                        [navDeploymentIdHeader]: deploymentId,
-                      }
                     : {}),
                 },
               }
@@ -3245,11 +3234,6 @@ export const onPrerenderRoute =
               'cache-control':
                 'private, no-store, no-cache, max-age=0, must-revalidate',
               vary: rscVaryHeader,
-              ...(navDeploymentIdHeader && deploymentId
-                ? {
-                    [navDeploymentIdHeader]: deploymentId,
-                  }
-                : {}),
             },
           });
         }
@@ -3345,11 +3329,6 @@ export const onPrerenderRoute =
                   vary: rscVaryHeader,
                   'content-type': rscContentTypeHeader,
                   [rscDidPostponeHeader]: '2',
-                  ...(navDeploymentIdHeader && deploymentId
-                    ? {
-                        [navDeploymentIdHeader]: deploymentId,
-                      }
-                    : {}),
                 },
               });
             }

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -320,6 +320,11 @@ type RoutesManifestOld = {
     pathHeader: string;
     queryHeader: string;
   };
+  /**
+   * Header for navigation data responses (both App and Pages, respecitively RSC and _next/data)
+   */
+  navDeploymentIdHeader?: string;
+
   skipMiddlewareUrlNormalize?: boolean;
   /**
    * Configuration related to Partial Prerendering.
@@ -2946,6 +2951,8 @@ export const onPrerenderRoute =
       const rscContentTypeHeader =
         routesManifest?.rsc?.contentTypeHeader || RSC_CONTENT_TYPE;
       const rscDidPostponeHeader = routesManifest?.rsc?.didPostponeHeader;
+      const navDeploymentIdHeader = routesManifest?.navDeploymentIdHeader;
+      const deploymentId = routesManifest?.deploymentId;
 
       let sourcePath: string | undefined;
       if (`/${outputPathPage}` !== srcRoute && srcRoute) {
@@ -3081,6 +3088,11 @@ export const onPrerenderRoute =
                 initialHeaders: {
                   ...initialHeaders,
                   vary: rscVaryHeader,
+                  ...(navDeploymentIdHeader && deploymentId
+                    ? {
+                        [navDeploymentIdHeader]: deploymentId,
+                      }
+                    : {}),
                 },
               }
             : {}),
@@ -3144,6 +3156,11 @@ export const onPrerenderRoute =
                     : {}),
                   ...(didPostpone && rscDidPostponeHeader && !isFallback
                     ? { [rscDidPostponeHeader]: '1' }
+                    : {}),
+                  ...(navDeploymentIdHeader && deploymentId
+                    ? {
+                        [navDeploymentIdHeader]: deploymentId,
+                      }
                     : {}),
                 },
               }
@@ -3228,6 +3245,11 @@ export const onPrerenderRoute =
               'cache-control':
                 'private, no-store, no-cache, max-age=0, must-revalidate',
               vary: rscVaryHeader,
+              ...(navDeploymentIdHeader && deploymentId
+                ? {
+                    [navDeploymentIdHeader]: deploymentId,
+                  }
+                : {}),
             },
           });
         }
@@ -3323,6 +3345,11 @@ export const onPrerenderRoute =
                   vary: rscVaryHeader,
                   'content-type': rscContentTypeHeader,
                   [rscDidPostponeHeader]: '2',
+                  ...(navDeploymentIdHeader && deploymentId
+                    ? {
+                        [navDeploymentIdHeader]: deploymentId,
+                      }
+                    : {}),
                 },
               });
             }

--- a/packages/next/test/fixtures/39-softnav-headers/app/app-dynamic/page.jsx
+++ b/packages/next/test/fixtures/39-softnav-headers/app/app-dynamic/page.jsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+import { connection } from 'next/server';
+
+export default async function Page() {
+  await connection();
+  return (
+    <div>
+      app get dynamic
+      <Link href="/app-static">goto other</Link>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/39-softnav-headers/app/app-static/page.jsx
+++ b/packages/next/test/fixtures/39-softnav-headers/app/app-static/page.jsx
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+export default function Page() {
+  return (
+    <div>
+      app get static
+      <Link href="/app-dynamic">goto other</Link>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/39-softnav-headers/app/layout.jsx
+++ b/packages/next/test/fixtures/39-softnav-headers/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children, params }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/next/test/fixtures/39-softnav-headers/index.test.js
+++ b/packages/next/test/fixtures/39-softnav-headers/index.test.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const { deployAndTest } = require('../../utils');
+
+describe(`${__dirname.split(path.sep).pop()}`, () => {
+  it('should deploy and pass probe checks', async () => {
+    await deployAndTest(__dirname);
+  });
+});

--- a/packages/next/test/fixtures/39-softnav-headers/next.config.js
+++ b/packages/next/test/fixtures/39-softnav-headers/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id'
+  },
+  deploymentId: 'testing-deployment-id',
+};

--- a/packages/next/test/fixtures/39-softnav-headers/package.json
+++ b/packages/next/test/fixtures/39-softnav-headers/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/fixtures/39-softnav-headers/pages/_app.js
+++ b/packages/next/test/fixtures/39-softnav-headers/pages/_app.js
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <div>
+      <Component {...pageProps} />
+      <nav>
+        <ul>
+          <li>
+            <Link href="/pages-gsp-revalidate">goto gsp-revalidate</Link>
+          </li>
+          <li>
+            <Link href="/pages-gsp">goto gsp</Link>
+          </li>
+          <li>
+            <Link href="/pages-gssp">goto gssp</Link>
+          </li>
+        </ul>{' '}
+      </nav>
+    </div>
+  );
+}

--- a/packages/next/test/fixtures/39-softnav-headers/pages/pages-gsp-revalidate.js
+++ b/packages/next/test/fixtures/39-softnav-headers/pages/pages-gsp-revalidate.js
@@ -1,0 +1,10 @@
+export default function Page({ name }) {
+  return <div>{name}</div>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: { name: 'pages get static props revalidate ' + Date.now() },
+    revalidate: 1000000,
+  };
+}

--- a/packages/next/test/fixtures/39-softnav-headers/pages/pages-gsp.js
+++ b/packages/next/test/fixtures/39-softnav-headers/pages/pages-gsp.js
@@ -1,0 +1,7 @@
+export default function Page({ name }) {
+  return <div>{name}</div>;
+}
+
+export async function getStaticProps() {
+  return { props: { name: 'pages get static props' } };
+}

--- a/packages/next/test/fixtures/39-softnav-headers/pages/pages-gssp.js
+++ b/packages/next/test/fixtures/39-softnav-headers/pages/pages-gssp.js
@@ -1,0 +1,7 @@
+export default function Page({ name }) {
+  return <div>{name}</div>;
+}
+
+export async function getServerSideProps() {
+  return { props: { name: 'pages get server side props' } };
+}

--- a/packages/next/test/fixtures/39-softnav-headers/vercel.json
+++ b/packages/next/test/fixtures/39-softnav-headers/vercel.json
@@ -1,0 +1,67 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "probes": [
+    {
+      "path": "/_next/data/testing-build-id/pages-gsp.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id"
+      },
+      "mustContain": "pages get static props"
+    },
+    {
+      "path": "/_next/data/testing-build-id/pages-gssp.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id"
+      },
+      "mustContain": "pages get server side props"
+    },
+    {
+      "path": "/_next/data/testing-build-id/pages-gsp-revalidate.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id",
+        "x-vercel-cache": "PRERENDER"
+      },
+      "mustContain": "pages get static props revalidate"
+    },
+    {
+      "path": "/_next/data/testing-build-id/pages-gsp-revalidate.json",
+      "status": 200,
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id",
+        "x-vercel-cache": "HIT"
+      },
+      "mustContain": "pages get static props revalidate"
+    },
+    {
+      "path": "/app-dynamic?_rsc=",
+      "status": 200,
+      "headers": {
+        "rsc": 1
+      },
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id"
+      },
+      "mustContain": "app get dynamic"
+    },
+    {
+      "path": "/app-static?_rsc=",
+      "status": 200,
+      "headers": {
+        "rsc": 1
+      },
+      "responseHeaders": {
+        "x-nextjs-deployment-id": "testing-deployment-id"
+      },
+      "mustContain": "app get static"
+    }
+  ]
+}

--- a/packages/next/test/unit/fixtures/01-normalize-paths/package.json
+++ b/packages/next/test/unit/fixtures/01-normalize-paths/package.json
@@ -8,5 +8,6 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/packages/next/test/unit/fixtures/02-edge-function-basepath/package.json
+++ b/packages/next/test/unit/fixtures/02-edge-function-basepath/package.json
@@ -11,5 +11,6 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/packages/next/test/unit/fixtures/03-with-api-routes/package.json
+++ b/packages/next/test/unit/fixtures/03-with-api-routes/package.json
@@ -9,5 +9,6 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/packages/next/test/unit/fixtures/04-edge-function-i18n/package.json
+++ b/packages/next/test/unit/fixtures/04-edge-function-i18n/package.json
@@ -11,5 +11,6 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Superseded by
- https://github.com/vercel/next.js/pull/88855
- https://github.com/vercel/next.js/pull/88959