### PR TITLE
feat(cli): Initial auto-provision support for integration install

### DIFF
--- a/.changeset/auto-provision-initial.md
+++ b/.changeset/auto-provision-initial.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add auto-provision flow for integration resources (behind feature flag)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,10 @@
 /packages/oidc                           @vercel/ci-cd @vercel/identity-and-access-management @vercel/ai-sdk
 /packages/oidc-aws-credentials-provider  @vercel/ci-cd @vercel/identity-and-access-management
 /packages/config                         @vercel/ci-cd @vercel/edge-ingress @pranavkarthik10 @MatthewStanciu
+/packages/cli/src/commands/integration/  @vercel/ci-cd @vercel/marketplace
+/packages/cli/src/util/integration/      @vercel/ci-cd @vercel/marketplace
+/packages/cli/test/mocks/integration.ts  @vercel/ci-cd @vercel/marketplace
+/packages/cli/test/unit/commands/integration/ @vercel/ci-cd @vercel/marketplace
 /packages/python*                        @vercel/ci-cd @vercel/team-python
 /python                                  @vercel/ci-cd @vercel/team-python
 /.github/workflows/*python*.yml          @vercel/ci-cd @vercel/team-python

--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -1,0 +1,275 @@
+import chalk from 'chalk';
+import open from 'open';
+import output from '../../output-manager';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { autoProvisionResource } from '../../util/integration/auto-provision-resource';
+import { fetchIntegration } from '../../util/integration/fetch-integration';
+import type {
+  AcceptedPolicies,
+  AutoProvisionResult,
+  IntegrationProduct,
+} from '../../util/integration/types';
+import { connectResourceToProject } from '../../util/integration-resource/connect-resource-to-project';
+import cmd from '../../util/output/cmd';
+import indent from '../../util/output/indent';
+import { packageName } from '../../util/pkg-name';
+import { getLinkedProject } from '../../util/projects/link';
+import { IntegrationAddTelemetryClient } from '../../util/telemetry/commands/integration/add';
+import { createMetadataWizard } from './wizard';
+
+export async function addAutoProvision(
+  client: Client,
+  integrationSlug: string
+) {
+  const telemetry = new IntegrationAddTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  // 1. Get team context
+  const { contextName, team } = await getScope(client);
+  if (!team) {
+    output.error('Team not found');
+    return 1;
+  }
+
+  // 2. Fetch integration
+  let integration;
+  let knownIntegrationSlug = false;
+  try {
+    integration = await fetchIntegration(client, integrationSlug);
+    knownIntegrationSlug = true;
+  } catch (error) {
+    output.error(
+      `Failed to get integration "${integrationSlug}": ${(error as Error).message}`
+    );
+    return 1;
+  } finally {
+    telemetry.trackCliArgumentName(integrationSlug, knownIntegrationSlug);
+  }
+
+  if (!integration.products?.length) {
+    output.error(
+      `Integration "${integrationSlug}" is not a Marketplace integration`
+    );
+    return 1;
+  }
+
+  // 3. Select product (or use only one if single product)
+  let product: IntegrationProduct;
+  if (integration.products.length === 1) {
+    product = integration.products[0];
+  } else {
+    product = await client.input.select({
+      message: 'Select a product',
+      choices: integration.products.map(p => ({
+        name: p.name,
+        value: p,
+        description: p.shortDescription,
+      })),
+    });
+  }
+
+  output.log(
+    `Installing ${chalk.bold(product.name)} by ${chalk.bold(integration.name)} under ${chalk.bold(contextName)}`
+  );
+  output.debug(`Selected product: ${product.slug} (id: ${product.id})`);
+  output.debug(
+    `Product metadataSchema: ${JSON.stringify(product.metadataSchema, null, 2)}`
+  );
+
+  const metadataWizard = createMetadataWizard(product.metadataSchema);
+  output.debug(`Metadata wizard supported: ${metadataWizard.isSupported}`);
+
+  // 4. Get resource name
+  const resourceName = await client.input.text({
+    message: 'What is the name of the resource?',
+    validate: value => (value.trim() ? true : 'Resource name is required'),
+  });
+
+  // 5. Collect metadata (if supported, otherwise let server use defaults)
+  const metadata = metadataWizard.isSupported
+    ? await metadataWizard.run(client)
+    : {};
+  output.debug(`Collected metadata: ${JSON.stringify(metadata)}`);
+  output.debug(`Resource name: ${resourceName}`);
+
+  // 6. First attempt with empty policies - discover what's required
+  output.spinner('Provisioning resource...');
+  let result: AutoProvisionResult;
+  try {
+    result = await autoProvisionResource(
+      client,
+      integration.slug,
+      product.slug,
+      resourceName,
+      metadata,
+      {} // Start with empty policies
+    );
+  } catch (error) {
+    output.stopSpinner();
+    output.error((error as Error).message);
+    return 1;
+  }
+  output.stopSpinner();
+  output.debug(`Auto-provision result: ${JSON.stringify(result, null, 2)}`);
+
+  // 7. If policies required, prompt and retry
+  if (result.kind === 'install') {
+    output.debug(`Policy acceptance required`);
+    const policies = result.integration.policies ?? {};
+    output.debug(`Policies to accept: ${JSON.stringify(policies)}`);
+    const acceptedPolicies: AcceptedPolicies = {};
+
+    if (policies.privacy) {
+      const accepted = await client.input.confirm(
+        `Accept privacy policy? (${policies.privacy})`,
+        false
+      );
+      if (!accepted) {
+        output.error('Privacy policy must be accepted to continue.');
+        return 1;
+      }
+      acceptedPolicies.privacy = new Date().toISOString();
+    }
+
+    if (policies.eula) {
+      const accepted = await client.input.confirm(
+        `Accept terms of service? (${policies.eula})`,
+        false
+      );
+      if (!accepted) {
+        output.error('Terms of service must be accepted to continue.');
+        return 1;
+      }
+      acceptedPolicies.eula = new Date().toISOString();
+    }
+
+    // Retry with accepted policies
+    output.debug(`Accepted policies: ${JSON.stringify(acceptedPolicies)}`);
+    output.spinner('Provisioning resource...');
+    try {
+      result = await autoProvisionResource(
+        client,
+        integration.slug,
+        product.slug,
+        resourceName,
+        metadata,
+        acceptedPolicies
+      );
+    } catch (error) {
+      output.stopSpinner();
+      output.error((error as Error).message);
+      return 1;
+    }
+    output.stopSpinner();
+    output.debug(
+      `Auto-provision retry result: ${JSON.stringify(result, null, 2)}`
+    );
+  }
+
+  // 8. Handle non-provisioned responses (metadata, unknown)
+  if (result.kind !== 'provisioned') {
+    output.debug(`Fallback required - kind: ${result.kind}`);
+    output.debug(`Fallback URL from API: ${result.url}`);
+
+    // Offer project linking before opening browser
+    const projectLink = await getOptionalLinkedProject(client);
+    if (projectLink?.status === 'error') {
+      return projectLink.exitCode;
+    }
+
+    output.log('Additional setup required. Opening browser...');
+    const url = new URL(result.url);
+    url.searchParams.set('defaultResourceName', resourceName);
+    url.searchParams.set('source', 'cli');
+    if (projectLink?.project) {
+      url.searchParams.set('projectSlug', projectLink.project.name);
+    }
+    output.debug(`Opening URL: ${url.href}`);
+    open(url.href);
+    return 0;
+  }
+
+  // 9. Success!
+  output.debug(
+    `Provisioned resource: ${JSON.stringify(result.resource, null, 2)}`
+  );
+  output.debug(`Installation: ${JSON.stringify(result.installation, null, 2)}`);
+  output.debug(`Billing plan: ${JSON.stringify(result.billingPlan, null, 2)}`);
+  output.success(`${product.name} successfully provisioned`);
+
+  // 10. Link to project (prompt)
+  const projectLink = await getOptionalLinkedProject(client);
+  if (projectLink?.status === 'error') {
+    return projectLink.exitCode;
+  }
+
+  if (!projectLink?.project) {
+    return 0;
+  }
+
+  // 11. Select environments and connect
+  const environments = await client.input.checkbox({
+    message: 'Select environments',
+    choices: [
+      { name: 'Production', value: 'production', checked: true },
+      { name: 'Preview', value: 'preview', checked: true },
+      { name: 'Development', value: 'development', checked: true },
+    ],
+  });
+  output.debug(`Selected environments: ${JSON.stringify(environments)}`);
+
+  output.spinner(`Connecting to ${chalk.bold(projectLink.project.name)}...`);
+  output.debug(
+    `Connecting resource ${result.resource.id} to project ${projectLink.project.id}`
+  );
+  try {
+    await connectResourceToProject(
+      client,
+      projectLink.project.id,
+      result.resource.id,
+      environments
+    );
+  } catch (error) {
+    output.stopSpinner();
+    output.error(`Failed to connect: ${(error as Error).message}`);
+    return 1;
+  }
+  output.stopSpinner();
+
+  output.success(`Connected to ${projectLink.project.name}`);
+  output.log(
+    indent(
+      `Run ${cmd(`${packageName} env pull`)} to update environment variables`,
+      4
+    )
+  );
+
+  return 0;
+}
+
+async function getOptionalLinkedProject(client: Client) {
+  const linkedProject = await getLinkedProject(client);
+
+  if (linkedProject.status === 'not_linked') {
+    return;
+  }
+
+  const shouldLinkToProject = await client.input.confirm(
+    'Do you want to link this resource to the current project?',
+    true
+  );
+
+  if (!shouldLinkToProject) {
+    return;
+  }
+
+  if (linkedProject.status === 'error') {
+    return { status: 'error' as const, exitCode: linkedProject.exitCode };
+  }
+
+  return { status: 'success' as const, project: linkedProject.project };
+}

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../util/integration/types';
 import { createMetadataWizard, type MetadataWizard } from './wizard';
 import { provisionStoreResource } from '../../util/integration/provision-store-resource';
+import { addAutoProvision } from './add-auto-provision';
 import { connectResourceToProject } from '../../util/integration-resource/connect-resource-to-project';
 import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
@@ -44,6 +45,11 @@ export async function add(client: Client, args: string[]) {
   if (!integrationSlug) {
     output.error('You must pass an integration slug');
     return 1;
+  }
+
+  // Auto-provision: completely separate code path
+  if (process.env.FF_AUTO_PROVISION_INSTALL === '1') {
+    return await addAutoProvision(client, integrationSlug);
   }
 
   const { contextName, team } = await getScope(client);

--- a/packages/cli/src/util/integration/auto-provision-resource.ts
+++ b/packages/cli/src/util/integration/auto-provision-resource.ts
@@ -1,0 +1,74 @@
+import output from '../../output-manager';
+import type Client from '../client';
+import { APIError } from '../errors-ts';
+import type {
+  AcceptedPolicies,
+  AutoProvisionFallback,
+  AutoProvisionResult,
+  Metadata,
+} from './types';
+
+function isAutoProvisionFallback(
+  error: unknown
+): error is AutoProvisionFallback {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'kind' in error &&
+    ['install', 'metadata', 'unknown'].includes(
+      (error as { kind: unknown }).kind as string
+    ) &&
+    'url' in error &&
+    'integration' in error &&
+    'product' in error
+  );
+}
+
+export async function autoProvisionResource(
+  client: Client,
+  integrationSlug: string,
+  productSlug: string,
+  name: string,
+  metadata: Metadata,
+  acceptedPolicies: AcceptedPolicies
+): Promise<AutoProvisionResult> {
+  const endpoint = `/v1/integrations/integration/${encodeURIComponent(integrationSlug)}/marketplace/auto-provision/${encodeURIComponent(productSlug)}`;
+  const body = {
+    name,
+    metadata,
+    acceptedPolicies,
+    source: 'cli',
+  };
+  output.debug(`Auto-provision request: POST ${endpoint}`);
+  output.debug(`Auto-provision body: ${JSON.stringify(body, null, 2)}`);
+
+  try {
+    const res = await client.fetch(endpoint, {
+      method: 'POST',
+      json: false,
+      body,
+    });
+
+    // 200/201/202 - success
+    if (res.ok) {
+      return res.json();
+    }
+
+    // Shouldn't reach here - client.fetch throws on non-ok responses
+    throw new Error(`Auto-provision failed: ${res.status}`);
+  } catch (error) {
+    // client.fetch throws APIError on 4xx - check if it's a 422 with fallback data
+    if (
+      error instanceof APIError &&
+      error.status === 422 &&
+      isAutoProvisionFallback(error)
+    ) {
+      output.debug(`Auto-provision returned 422 fallback response`);
+      return error;
+    }
+
+    output.debug(`Auto-provision error: ${error}`);
+    // Re-throw other errors (400/403/404/etc)
+    throw error;
+  }
+}

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -149,3 +149,58 @@ export interface MarketplaceBillingAuthorizationState {
   createdAt: number;
   updatedAt: number;
 }
+
+// Auto-provision types
+
+// AcceptedPolicies: key = policy name ('privacy' | 'eula'), value = ISO timestamp
+export type AcceptedPolicies = Record<string, string>;
+
+export interface AutoProvisionIntegration {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string;
+  policies: {
+    eula?: string; // URL to EULA doc
+    privacy?: string; // URL to privacy doc
+  };
+}
+
+export interface AutoProvisionProduct {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string;
+  iconBackgroundColor?: string;
+  metadataSchema: MetadataSchema;
+}
+
+export interface AutoProvisionResource {
+  id: string;
+  externalResourceId: string;
+  name: string;
+  status: string;
+  ownership?: unknown;
+  secretKeys?: string[];
+}
+
+export interface AutoProvisionedResponse {
+  kind: 'provisioned';
+  integration: AutoProvisionIntegration;
+  product: AutoProvisionProduct;
+  installation: { id: string };
+  resource: AutoProvisionResource;
+  billingPlan: BillingPlan | null;
+}
+
+export interface AutoProvisionFallback {
+  kind: 'install' | 'metadata' | 'unknown';
+  url: string;
+  integration: AutoProvisionIntegration;
+  product: AutoProvisionProduct;
+  installation?: { id: string };
+}
+
+export type AutoProvisionResult =
+  | AutoProvisionedResponse
+  | AutoProvisionFallback;

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -1,0 +1,465 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import open from 'open';
+import integrationCommand from '../../../../src/commands/integration';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { client } from '../../../mocks/client';
+import { useAutoProvision } from '../../../mocks/integration';
+import { defaultProject, useProject } from '../../../mocks/project';
+import { useTeams, type Team } from '../../../mocks/team';
+import { useUser } from '../../../mocks/user';
+
+vi.mock('open', () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+const openMock = vi.mocked(open);
+
+beforeEach(() => {
+  openMock.mockClear();
+  // Enable auto-provision feature flag
+  process.env.FF_AUTO_PROVISION_INSTALL = '1';
+});
+
+describe('integration add (auto-provision)', () => {
+  let team: Team;
+
+  beforeEach(() => {
+    useUser();
+    const teams = useTeams('team_dummy');
+    team = Array.isArray(teams) ? teams[0] : teams.teams[0];
+    client.config.currentTeam = team.id;
+  });
+
+  describe('successful provisioning', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+    });
+
+    it('should provision a resource without project context', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        `Installing Acme Product by Acme Integration under ${team.slug}`
+      );
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('should provision and connect to project', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        `Installing Acme Product by Acme Integration under ${team.slug}`
+      );
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      await expect(client.stderr).toOutput(
+        'Do you want to link this resource to the current project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Select environments');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Connected to vercel-integration-add'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('should provision without connecting when user declines', async () => {
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      await expect(client.stderr).toOutput(
+        'Do you want to link this resource to the current project?'
+      );
+      client.stdin.write('n\n');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should track telemetry', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      await exitCodePromise;
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:add',
+          value: 'add',
+        },
+        {
+          key: 'argument:name',
+          value: 'acme',
+        },
+      ]);
+    });
+  });
+
+  describe('policy acceptance flow', () => {
+    beforeEach(() => {
+      // First call returns 'install' (policies required), second call returns 'provisioned'
+      useAutoProvision({
+        responseKey: 'install',
+        secondResponseKey: 'provisioned',
+      });
+    });
+
+    it('should prompt for policy acceptance and retry', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Accept privacy policy?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Accept terms of service?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should exit with code 1 when privacy policy declined', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Accept privacy policy?');
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'Privacy policy must be accepted to continue.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+
+    it('should exit with code 1 when terms of service declined', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Accept privacy policy?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Accept terms of service?');
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'Terms of service must be accepted to continue.'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(1);
+    });
+  });
+
+  describe('fallback to browser', () => {
+    it('should open browser for metadata fallback with source and defaultResourceName', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://vercel.com/acme/~/integrations/checkout/acme'
+        )
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/defaultResourceName=test-resource/)
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/source=cli/)
+      );
+    });
+
+    it('should open browser for unknown fallback', async () => {
+      useAutoProvision({ responseKey: 'unknown' });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalled();
+    });
+
+    it('should include projectSlug when user consents to link project', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to link this resource to the current project?'
+      );
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/projectSlug=vercel-integration-add/)
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/source=cli/)
+      );
+    });
+
+    it('should not include projectSlug when user declines to link project', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+      useProject({
+        ...defaultProject,
+        id: 'vercel-integration-add',
+        name: 'vercel-integration-add',
+      });
+      const cwd = setupUnitFixture('vercel-integration-add');
+      client.cwd = cwd;
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Do you want to link this resource to the current project?'
+      );
+      client.stdin.write('n\n');
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.not.stringMatching(/projectSlug=/)
+      );
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/source=cli/)
+      );
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+    });
+
+    it('should reject empty resource name', async () => {
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('\n'); // Empty input
+
+      await expect(client.stderr).toOutput('Resource name is required');
+
+      // Provide valid name to continue
+      client.stdin.write('valid-name\n');
+
+      await expect(client.stderr).toOutput('Choose your region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should error when team not found', async () => {
+      client.config.currentTeam = undefined;
+      client.setArgv('integration', 'add', 'acme');
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Error: Team not found');
+    });
+
+    it('should error when integration not found', async () => {
+      client.setArgv('integration', 'add', 'does-not-exist');
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Failed to get integration "does-not-exist"'
+      );
+    });
+
+    it('should error when integration has no products', async () => {
+      client.setArgv('integration', 'add', 'acme-no-products');
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Integration "acme-no-products" is not a Marketplace integration'
+      );
+    });
+
+    it('should error when integration is external', async () => {
+      client.setArgv('integration', 'add', 'acme-external');
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Integration "acme-external" is not a Marketplace integration'
+      );
+    });
+  });
+
+  describe('multiple products', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+    });
+
+    it('should prompt for product selection when multiple products', async () => {
+      client.setArgv('integration', 'add', 'acme-two-products');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('Select a product');
+      client.stdin.write('\n'); // Select first product
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      // acme-two-products uses metadataSchema2 which has version and region
+      await expect(client.stderr).toOutput('Version');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('Region');
+      client.stdin.write('\n');
+
+      await expect(client.stderr).toOutput('successfully provisioned');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Server-managed auto-provision flow for Marketplace integrations. Gated behind `FF_AUTO_PROVISION_INSTALL=1`.

- Flag ON: Branches at line 51 to new flow - no legacy code runs
- Flag OFF: Zero changes to existing flow

### Files
| File | Purpose |
|------|---------|
| `add-auto-provision.ts` | Standalone flow (fetch integration → select product → collect metadata → provision → connect) |
| `auto-provision-resource.ts` | API helper for `/v1/integrations/.../auto-provision` endpoint |
| `types.ts` | `AcceptedPolicies`, `AutoProvisionResult`, `AutoProvisionFallback` types |
| `add-auto-provision.test.ts` | 14 unit tests |

### Flow
1. Fetch integration and product (prompt if multiple products)
2. Collect resource name and metadata (skips wizard if schema unsupported)
3. First provision attempt with empty policies
4. If policies required: prompt for privacy/EULA acceptance, retry
5. If `kind === 'provisioned'`: success, optionally connect to project
6. If `kind !== 'provisioned'`: fallback to browser with resourceName + projectId params

### Test coverage
- Successful provisioning (with/without project linking)
- Policy acceptance flow (accept both, decline privacy, decline EULA)
- Browser fallback for metadata/unknown responses
- Error handling (team not found, integration not found, no products, external integration)
- Multiple products selection
- Telemetry tracking

## Test plan
```bash
# Unit tests
pnpm --filter vercel vitest-run --run test/unit/commands/integration/add-auto-provision.test.ts

# Manual test (from repo root, in a linked project directory)
pnpm --filter vercel build
FF_AUTO_PROVISION_INSTALL=1 node packages/cli/dist/index.js integration add prisma
```

🤖 Generated with [Claude Code](https://claude.ai/code)
