### PR TITLE
feat(cli): Introduce contract cmd

### DIFF
--- a/.changeset/cuddly-mugs-enjoy.md
+++ b/.changeset/cuddly-mugs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `contract` cli cmd for checking contract commitments

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -10,6 +10,7 @@ export { default as api } from './commands/api';
 export { default as bisect } from './commands/bisect';
 export { default as blob } from './commands/blob';
 export { default as cache } from './commands/cache';
+export { default as contract } from './commands/contract';
 export { default as certs } from './commands/certs';
 export { default as curl } from './commands/curl';
 export { default as dns } from './commands/dns';

--- a/packages/cli/src/commands-bulk.ts
+++ b/packages/cli/src/commands-bulk.ts
@@ -41,5 +41,6 @@ export { default as target } from './commands/target';
 export { default as teams } from './commands/teams';
 export { default as telemetry } from './commands/telemetry';
 export { default as upgrade } from './commands/upgrade';
+export { default as usage } from './commands/usage';
 export { default as webhooks } from './commands/webhooks';
 export { default as whoami } from './commands/whoami';

--- a/packages/cli/src/commands/contract/command.ts
+++ b/packages/cli/src/commands/contract/command.ts
@@ -1,0 +1,20 @@
+import { formatOption, jsonOption } from '../../util/arg-common';
+import { packageName } from '../../util/pkg-name';
+
+export const contractCommand = {
+  name: 'contract',
+  aliases: [],
+  description: 'Show contract information for all billing periods',
+  arguments: [],
+  options: [formatOption, jsonOption],
+  examples: [
+    {
+      name: 'Show contract information for all billing periods',
+      value: `${packageName} contract`,
+    },
+    {
+      name: 'Show contract information for all billing periods as JSON',
+      value: `${packageName} contract --format json`,
+    },
+  ],
+} as const;

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -1,0 +1,209 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import { parseArguments } from '../../util/get-args';
+import { printError } from '../../util/error';
+import elapsed from '../../util/output/elapsed';
+import type Client from '../../util/client';
+import getScope from '../../util/get-scope';
+import { help } from '../help';
+import { contractCommand } from './command';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { ContractTelemetryClient } from '../../util/telemetry/commands/contract';
+import { validateJsonOutput } from '../../util/output-format';
+import output from '../../output-manager';
+import { isErrnoException } from '@vercel/error-utils';
+import type { FocusContractCommitment } from '../../util/billing/focus-contract-commitment';
+import {
+  formatCurrency,
+  formatQuantity,
+  extractDatePortion,
+} from '../../util/billing/format';
+
+export default async function contract(client: Client): Promise<number> {
+  const { print, log, error, spinner } = output;
+
+  const flagsSpecification = getFlagsSpecification(contractCommand.options);
+
+  let parsedArgs;
+  try {
+    parsedArgs = parseArguments(client.argv.slice(2), flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+
+  const telemetry = new ContractTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  if (parsedArgs.flags['--help']) {
+    telemetry.trackCliFlagHelp('contract');
+    print(help(contractCommand, { columns: client.stderr.columns }));
+    return 0;
+  }
+
+  const formatResult = validateJsonOutput(parsedArgs.flags);
+  if (!formatResult.valid) {
+    error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  telemetry.trackCliOptionFormat(parsedArgs.flags['--format']);
+
+  let contextName: string;
+  let teamId: string | undefined;
+
+  try {
+    const scope = await getScope(client);
+    contextName = scope.contextName;
+    teamId = scope.team?.id;
+  } catch (err: unknown) {
+    if (
+      isErrnoException(err) &&
+      (err.code === 'NOT_AUTHORIZED' || err.code === 'TEAM_DELETED')
+    ) {
+      error(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  const start = Date.now();
+  if (!asJson) {
+    spinner(`Fetching contract commitments for ${chalk.bold(contextName)}`);
+  }
+
+  const query = new URLSearchParams();
+  if (teamId) {
+    query.set('teamId', teamId);
+  }
+
+  try {
+    const queryString = query.toString();
+    const url = queryString
+      ? `/v1/billing/contract-commitments?${queryString}`
+      : '/v1/billing/contract-commitments';
+
+    const response = await client.fetch(url, {
+      json: false,
+      useCurrentTeam: false,
+    });
+
+    if (!response.ok) {
+      error(`Failed to fetch contract commitments: ${response.status}`);
+      return 1;
+    }
+
+    // Handle empty response body (API returns nothing when no commitments)
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    const commitments: FocusContractCommitment[] = Array.isArray(data)
+      ? data
+      : [];
+
+    if (asJson) {
+      const jsonOutput = {
+        context: contextName,
+        commitments: commitments.map(c => ({
+          contractId: c.ContractId,
+          contractPeriodStart: c.ContractPeriodStart,
+          contractPeriodEnd: c.ContractPeriodEnd,
+          commitmentId: c.ContractCommitmentId,
+          commitmentType: c.ContractCommitmentType,
+          commitmentCategory: c.ContractCommitmentCategory,
+          commitmentPeriodStart: c.ContractCommitmentPeriodStart,
+          commitmentPeriodEnd: c.ContractCommitmentPeriodEnd,
+          commitmentCost: c.ContractCommitmentCost,
+          commitmentQuantity: c.ContractCommitmentQuantity,
+          commitmentUnit: c.ContractCommitmentUnit,
+          billingCurrency: c.BillingCurrency,
+          description: c.ContractCommitmentDescription,
+        })),
+        totalCommitments: commitments.length,
+      };
+      client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+      return 0;
+    }
+
+    log(
+      `Contract commitments for ${chalk.bold(contextName)} ${elapsed(Date.now() - start)}`
+    );
+    log('');
+
+    if (commitments.length === 0) {
+      log('No contract commitments found.');
+      return 0;
+    }
+
+    // Group commitments by contract
+    const contractGroups = new Map<string, FocusContractCommitment[]>();
+    for (const commitment of commitments) {
+      const existing = contractGroups.get(commitment.ContractId) || [];
+      existing.push(commitment);
+      contractGroups.set(commitment.ContractId, existing);
+    }
+
+    for (const [contractId, contractCommitments] of contractGroups) {
+      const firstCommitment = contractCommitments[0];
+      log(chalk.bold(`Contract: ${contractId}`));
+      log(
+        `${chalk.gray('Period:')} ${extractDatePortion(firstCommitment.ContractPeriodStart)} to ${extractDatePortion(firstCommitment.ContractPeriodEnd)}`
+      );
+      log('');
+
+      const headers = [
+        'Type',
+        'Category',
+        'Period',
+        'Commitment',
+        'Description',
+      ];
+      const rows = contractCommitments.map(c => {
+        const periodStr = `${extractDatePortion(c.ContractCommitmentPeriodStart)} - ${extractDatePortion(c.ContractCommitmentPeriodEnd)}`;
+
+        let commitmentValue: string;
+        if (
+          c.ContractCommitmentCategory === 'Spend' &&
+          c.ContractCommitmentCost !== undefined
+        ) {
+          commitmentValue = formatCurrency(c.ContractCommitmentCost);
+        } else if (
+          c.ContractCommitmentCategory === 'Usage' &&
+          c.ContractCommitmentQuantity !== undefined
+        ) {
+          commitmentValue = formatQuantity(
+            c.ContractCommitmentQuantity,
+            c.ContractCommitmentUnit
+          );
+        } else {
+          commitmentValue = '-';
+        }
+
+        return [
+          c.ContractCommitmentType,
+          c.ContractCommitmentCategory,
+          periodStr,
+          commitmentValue,
+          c.ContractCommitmentDescription || '-',
+        ];
+      });
+
+      const tablePrint = table(
+        [headers.map(h => chalk.bold(chalk.cyan(h))), ...rows],
+        { hsep: 3, align: ['l', 'l', 'l', 'r', 'l'] }
+      ).replace(/^/gm, '  ');
+
+      print(`${tablePrint}\n\n`);
+    }
+
+    log(`${chalk.gray('Total commitments:')} ${commitments.length}`);
+
+    return 0;
+  } catch (err) {
+    output.prettyError(err);
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/contract/index.ts
+++ b/packages/cli/src/commands/contract/index.ts
@@ -82,18 +82,19 @@ export default async function contract(client: Client): Promise<number> {
   }
 
   try {
-    const queryString = query.toString();
-    const url = queryString
-      ? `/v1/billing/contract-commitments?${queryString}`
-      : '/v1/billing/contract-commitments';
-
-    const response = await client.fetch(url, {
-      json: false,
-      useCurrentTeam: false,
-    });
+    const response = await client.fetch(
+      `/v1/billing/contract-commitments?${query}`,
+      {
+        json: false,
+        useCurrentTeam: false,
+      }
+    );
 
     if (!response.ok) {
-      error(`Failed to fetch contract commitments: ${response.status}`);
+      const errorText = await response.text();
+      error(
+        `Failed to fetch contract commitments: ${response.status} ${errorText}`
+      );
       return 1;
     }
 
@@ -138,7 +139,6 @@ export default async function contract(client: Client): Promise<number> {
       return 0;
     }
 
-    // Group commitments by contract
     const contractGroups = new Map<string, FocusContractCommitment[]>();
     for (const commitment of commitments) {
       const existing = contractGroups.get(commitment.ContractId) || [];

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,6 +4,7 @@ import { bisectCommand } from './bisect/command';
 import { buildCommand } from './build/command';
 import { cacheCommand } from './cache/command';
 import { certsCommand } from './certs/command';
+import { contractCommand } from './contract/command';
 import { curlCommand } from './curl/command';
 import { deployCommand } from './deploy/command';
 import { devCommand } from './dev/command';
@@ -54,6 +55,7 @@ const commandsStructs = [
   buildCommand,
   cacheCommand,
   certsCommand,
+  contractCommand,
   curlCommand,
   deployCommand,
   devCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -676,41 +676,9 @@ const main = async () => {
       let func: any;
       switch (targetCommand) {
         // Priority commands - separate bundles for fast loading
-        case 'alias':
-          telemetry.trackCliCommandAlias(userSuppliedSubCommand);
-          func = require('./commands/alias').default;
-          break;
-        case 'api':
-          telemetry.trackCliCommandApi(userSuppliedSubCommand);
-          func = require('./commands/api').default;
-          break;
-        case 'bisect':
-          telemetry.trackCliCommandBisect(userSuppliedSubCommand);
-          func = require('./commands/bisect').default;
-          break;
-        case 'blob':
-          telemetry.trackCliCommandBlob(userSuppliedSubCommand);
-          func = require('./commands/blob').default;
-          break;
-        case 'build':
-          telemetry.trackCliCommandBuild(userSuppliedSubCommand);
-          func = require('./commands/build').default;
-          break;
-        case 'cache':
-          telemetry.trackCliCommandCache(userSuppliedSubCommand);
-          func = require('./commands/cache').default;
-          break;
-        case 'certs':
-          telemetry.trackCliCommandCerts(userSuppliedSubCommand);
-          func = require('./commands/certs').default;
-          break;
         case 'contract':
           telemetry.trackCliCommandContract(userSuppliedSubCommand);
-          func = require('./commands/contract').default;
-          break;
-        case 'curl':
-          telemetry.trackCliCommandCurl(userSuppliedSubCommand);
-          func = require('./commands/curl').default;
+          func = (await import('./commands/contract/index.js')).default;
           break;
         case 'deploy':
           telemetry.trackCliCommandDeploy(userSuppliedSubCommand);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -676,6 +676,42 @@ const main = async () => {
       let func: any;
       switch (targetCommand) {
         // Priority commands - separate bundles for fast loading
+        case 'alias':
+          telemetry.trackCliCommandAlias(userSuppliedSubCommand);
+          func = require('./commands/alias').default;
+          break;
+        case 'api':
+          telemetry.trackCliCommandApi(userSuppliedSubCommand);
+          func = require('./commands/api').default;
+          break;
+        case 'bisect':
+          telemetry.trackCliCommandBisect(userSuppliedSubCommand);
+          func = require('./commands/bisect').default;
+          break;
+        case 'blob':
+          telemetry.trackCliCommandBlob(userSuppliedSubCommand);
+          func = require('./commands/blob').default;
+          break;
+        case 'build':
+          telemetry.trackCliCommandBuild(userSuppliedSubCommand);
+          func = require('./commands/build').default;
+          break;
+        case 'cache':
+          telemetry.trackCliCommandCache(userSuppliedSubCommand);
+          func = require('./commands/cache').default;
+          break;
+        case 'certs':
+          telemetry.trackCliCommandCerts(userSuppliedSubCommand);
+          func = require('./commands/certs').default;
+          break;
+        case 'contract':
+          telemetry.trackCliCommandContract(userSuppliedSubCommand);
+          func = require('./commands/contract').default;
+          break;
+        case 'curl':
+          telemetry.trackCliCommandCurl(userSuppliedSubCommand);
+          func = require('./commands/curl').default;
+          break;
         case 'deploy':
           telemetry.trackCliCommandDeploy(userSuppliedSubCommand);
           telemetry.trackCliDefaultDeploy(defaultDeploy);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -866,7 +866,7 @@ const main = async () => {
           break;
         case 'usage':
           telemetry.trackCliCommandUsage(userSuppliedSubCommand);
-          func = require('./commands/usage').default;
+          func = (await import('./commands-bulk.js')).usage;
           break;
         case 'whoami':
           telemetry.trackCliCommandWhoami(userSuppliedSubCommand);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -676,10 +676,6 @@ const main = async () => {
       let func: any;
       switch (targetCommand) {
         // Priority commands - separate bundles for fast loading
-        case 'contract':
-          telemetry.trackCliCommandContract(userSuppliedSubCommand);
-          func = (await import('./commands/contract/index.js')).default;
-          break;
         case 'deploy':
           telemetry.trackCliCommandDeploy(userSuppliedSubCommand);
           telemetry.trackCliDefaultDeploy(defaultDeploy);
@@ -730,6 +726,10 @@ const main = async () => {
         case 'cache':
           telemetry.trackCliCommandCache(userSuppliedSubCommand);
           func = (await import('./commands-bulk.js')).cache;
+          break;
+        case 'contract':
+          telemetry.trackCliCommandContract(userSuppliedSubCommand);
+          func = (await import('./commands-bulk.js')).contract;
           break;
         case 'certs':
           telemetry.trackCliCommandCerts(userSuppliedSubCommand);

--- a/packages/cli/src/util/billing/focus-contract-commitment.ts
+++ b/packages/cli/src/util/billing/focus-contract-commitment.ts
@@ -1,0 +1,92 @@
+/**
+ * FOCUS v1.3 specification types for contract commitments.
+ * These types match the API response from /v1/billing/contract-commitments.
+ * @see https://focus.finops.org/focus-specification/v1-3/
+ *
+ * Note: These types are copied from @api/billing-types which is a private
+ * internal package. If the API types change, these should be updated.
+ */
+
+/**
+ * Currency used for billing (ISO 4217).
+ * @see https://focus.finops.org/focus-specification/v1-3/#billingcurrency
+ */
+export interface FocusContractBilling {
+  BillingCurrency: string;
+}
+
+/**
+ * Highest-level classification of a contract commitment.
+ * @see https://focus.finops.org/focus-specification/v1-3/#contractcommitmentcategory
+ */
+export type FocusContractCommitmentCategory = 'Spend' | 'Usage';
+
+/**
+ * Contract information linking charges to contractual agreements.
+ * New in FOCUS v1.3 - supplemental dataset for contract terms.
+ * @see https://focus.finops.org/focus-specification/v1-3/#contractcommitments
+ */
+export interface FocusContract {
+  /**
+   * Service-provider-assigned identifier for a contract.
+   * Maps to Orb Subscription ID for Vercel.
+   */
+  ContractId: string;
+  /** Inclusive start of the overall contract period (ISO 8601 UTC) */
+  ContractPeriodStart: string;
+  /** Exclusive end of the overall contract period (ISO 8601 UTC) */
+  ContractPeriodEnd: string;
+}
+
+/**
+ * Contract commitment information describing terms within a contract.
+ * New in FOCUS v1.3 - tracks commitment terms separate from cost/usage rows.
+ *
+ * For Vercel:
+ * - Pro: $20 monthly spend commitment
+ * - Enterprise: MIU allocation per period (usage commitment)
+ *
+ * @see https://focus.finops.org/focus-specification/v1-3/#contractcommitments
+ */
+export interface FocusContractCommitment
+  extends FocusContract,
+    FocusContractBilling {
+  /**
+   * Highest-level classification of the contract commitment.
+   * 'Spend' for Pro ($20/month), 'Usage' for Enterprise (MIU allocation).
+   */
+  ContractCommitmentCategory: FocusContractCommitmentCategory;
+  /**
+   * Monetary value of the contract commitment (in BillingCurrency).
+   * Required when ContractCommitmentCategory is 'Spend'.
+   * For Pro: 20 (USD)
+   */
+  ContractCommitmentCost: number | undefined;
+  /** Self-contained summary of the contract commitment's terms */
+  ContractCommitmentDescription: string | undefined;
+  /**
+   * Unique identifier for a single contract term within a contract.
+   * Maps to specific commitment period or allocation ID.
+   */
+  ContractCommitmentId: string;
+  /** Inclusive start of the commitment term period (ISO 8601 UTC) */
+  ContractCommitmentPeriodStart: string;
+  /** Exclusive end of the commitment term period (ISO 8601 UTC) */
+  ContractCommitmentPeriodEnd: string;
+  /**
+   * Amount associated with the commitment (in ContractCommitmentUnit).
+   * Required when ContractCommitmentCategory is 'Usage'.
+   * For Enterprise: MIU allocation amount.
+   */
+  ContractCommitmentQuantity: number | undefined;
+  /**
+   * Service-provider-assigned name identifying the commitment type.
+   * 'Pro' or 'Enterprise' for Vercel.
+   */
+  ContractCommitmentType: string;
+  /**
+   * Measurement unit for ContractCommitmentQuantity.
+   * 'MIUs' for Enterprise, 'USD' for Pro spend commitments.
+   */
+  ContractCommitmentUnit: string;
+}

--- a/packages/cli/src/util/telemetry/commands/contract/index.ts
+++ b/packages/cli/src/util/telemetry/commands/contract/index.ts
@@ -1,0 +1,14 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { contractCommand } from '../../../../commands/contract/command';
+
+export class ContractTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof contractCommand>
+{
+  trackCliFlagJson(json: boolean | undefined) {
+    if (json) {
+      this.trackCliFlag('json');
+    }
+  }
+}

--- a/packages/cli/src/util/telemetry/root.ts
+++ b/packages/cli/src/util/telemetry/root.ts
@@ -61,6 +61,13 @@ export class RootTelemetryClient extends TelemetryClient {
     });
   }
 
+  trackCliCommandContract(actual: string) {
+    this.trackCliCommand({
+      command: 'contract',
+      value: actual,
+    });
+  }
+
   trackCliCommandCurl(actual: string) {
     this.trackCliCommand({
       command: 'curl',

--- a/packages/cli/test/unit/commands/contract/index.test.ts
+++ b/packages/cli/test/unit/commands/contract/index.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useTeams } from '../../../mocks/team';
+import contract from '../../../../src/commands/contract';
+import type { FocusContractCommitment } from '../../../../src/util/billing/focus-contract-commitment';
+
+function createMockCommitment(
+  overrides: Partial<FocusContractCommitment> = {}
+): FocusContractCommitment {
+  return {
+    ContractId: 'sub_123456',
+    ContractPeriodStart: '2025-01-01T00:00:00.000Z',
+    ContractPeriodEnd: '2026-01-01T00:00:00.000Z',
+    BillingCurrency: 'USD',
+    ContractCommitmentCategory: 'Spend',
+    ContractCommitmentCost: 20,
+    ContractCommitmentDescription: 'Pro plan monthly commitment',
+    ContractCommitmentId: 'commitment_123',
+    ContractCommitmentPeriodStart: '2025-01-01T00:00:00.000Z',
+    ContractCommitmentPeriodEnd: '2025-02-01T00:00:00.000Z',
+    ContractCommitmentQuantity: undefined,
+    ContractCommitmentType: 'Pro',
+    ContractCommitmentUnit: 'USD',
+    ...overrides,
+  };
+}
+
+function useContractCommitments(
+  commitments: FocusContractCommitment[] | null = []
+) {
+  client.scenario.get('/v1/billing/contract-commitments', (_req, res) => {
+    if (commitments === null || commitments.length === 0) {
+      // Simulate empty response (API returns nothing when no commitments)
+      res.end();
+    } else {
+      res.json(commitments);
+    }
+  });
+}
+
+describe('contract', () => {
+  describe('--help', () => {
+    it('should display help and track telemetry', async () => {
+      client.setArgv('contract', '--help');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: 'contract',
+        },
+      ]);
+    });
+
+    it('should display help with options', async () => {
+      client.setArgv('contract', '--help');
+      await contract(client);
+
+      const output = client.getFullOutput();
+      expect(output).toContain('Show contract information');
+      expect(output).toContain('--format');
+    });
+  });
+
+  describe('with team context', () => {
+    beforeEach(() => {
+      useUser();
+      useTeams('team_dummy');
+    });
+
+    it('should fetch and display contract commitments', async () => {
+      const mockCommitments = [
+        createMockCommitment({
+          ContractCommitmentType: 'Pro',
+          ContractCommitmentCategory: 'Spend',
+          ContractCommitmentCost: 20,
+        }),
+      ];
+      useContractCommitments(mockCommitments);
+
+      client.setArgv('contract');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Pro');
+      expect(output).toContain('Spend');
+    });
+
+    it('should display Enterprise usage commitments', async () => {
+      const mockCommitments = [
+        createMockCommitment({
+          ContractCommitmentType: 'Enterprise',
+          ContractCommitmentCategory: 'Usage',
+          ContractCommitmentCost: undefined,
+          ContractCommitmentQuantity: 1000000,
+          ContractCommitmentUnit: 'MIUs',
+          ContractCommitmentDescription: 'Enterprise MIU allocation',
+        }),
+      ];
+      useContractCommitments(mockCommitments);
+
+      client.setArgv('contract');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Enterprise');
+      expect(output).toContain('Usage');
+    });
+
+    it('should output JSON with --format json', async () => {
+      const mockCommitments = [
+        createMockCommitment({
+          ContractCommitmentType: 'Pro',
+          ContractCommitmentCategory: 'Spend',
+          ContractCommitmentCost: 20,
+        }),
+      ];
+      useContractCommitments(mockCommitments);
+
+      client.setArgv('contract', '--format', 'json');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      const json = JSON.parse(output);
+      expect(json.commitments).toHaveLength(1);
+      expect(json.commitments[0].commitmentType).toEqual('Pro');
+      expect(json.commitments[0].commitmentCategory).toEqual('Spend');
+      expect(json.commitments[0].commitmentCost).toEqual(20);
+    });
+
+    it('should track telemetry for format option', async () => {
+      useContractCommitments([]);
+
+      client.setArgv('contract', '--format', 'json');
+      await contract(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'option:format', value: 'json' },
+      ]);
+    });
+
+    it('should handle empty response', async () => {
+      useContractCommitments([]);
+
+      client.setArgv('contract');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('No contract commitments found');
+    });
+
+    it('should group multiple commitments by contract', async () => {
+      const mockCommitments = [
+        createMockCommitment({
+          ContractId: 'sub_123',
+          ContractCommitmentId: 'commitment_1',
+          ContractCommitmentPeriodStart: '2025-01-01T00:00:00.000Z',
+          ContractCommitmentPeriodEnd: '2025-02-01T00:00:00.000Z',
+        }),
+        createMockCommitment({
+          ContractId: 'sub_123',
+          ContractCommitmentId: 'commitment_2',
+          ContractCommitmentPeriodStart: '2025-02-01T00:00:00.000Z',
+          ContractCommitmentPeriodEnd: '2025-03-01T00:00:00.000Z',
+        }),
+      ];
+      useContractCommitments(mockCommitments);
+
+      client.setArgv('contract');
+      const exitCode = await contract(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      expect(output).toContain('Contract: sub_123');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/index.test.ts
+++ b/packages/cli/test/unit/commands/index.test.ts
@@ -13,6 +13,7 @@ describe('index', () => {
         ['cache', 'cache'],
         ['cert', 'certs'],
         ['certs', 'certs'],
+        ['contract', 'contract'],
         ['curl', 'curl'],
         ['deploy', 'deploy'],
         ['dev', 'dev'],


### PR DESCRIPTION
# Introduce contract cmd

Introduces a new cmd to the CLI for getting all contract commitment data across periods.

This is an extension of a new endpoint that just recently GAed: `api.vercel.com/v1/billing/contract-commitments`. See the docs here: https://docs.vercel.com/docs/rest-api/reference/endpoints/billing/list-focus-contract-commitments