### PR TITLE
[cli][client] Add random skew to Retry-After logic

### DIFF
--- a/.changeset/fresh-mice-turn.md
+++ b/.changeset/fresh-mice-turn.md
@@ -1,0 +1,6 @@
+---
+'@vercel/client': patch
+'vercel': patch
+---
+
+Add up to 30 seconds of random skew to APIs returning `Retry-After` headers to prevent thundering herds fighting over a single rate limit token.

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -307,7 +307,12 @@ export default class Now {
         const error = await responseError(res, 'Failed to remove deployment');
         // Always respect Retry-After headers and retry
         if (typeof error.retryAfterMs === 'number') {
-          await sleep(error.retryAfterMs);
+          // The `Retry-After` header from the api tells us when the next rate
+          // limit token is available. There may only be a single rate limit
+          // token available at that time. Add a random skew to prevent creating
+          // a thundering herd.
+          const randomSkewMs = 30_000 * Math.random();
+          await sleep(error.retryAfterMs + randomSkewMs);
           throw error;
         }
         if (res.status > 200 && res.status < 500) {
@@ -372,7 +377,7 @@ export default class Now {
   }
 
   // public fetch with built-in retrying that can be
-  // used from external utilities. it optioanlly
+  // used from external utilities. it optionally
   // receives a `retry` object in the opts that is
   // passed to the retry utility
   // it accepts a `json` option, which defaults to `true`
@@ -406,7 +411,12 @@ export default class Now {
       const err = await responseError(res);
       // Always respect Retry-After headers and retry
       if (typeof err.retryAfterMs === 'number') {
-        await sleep(err.retryAfterMs);
+        // The `Retry-After` header from the api tells us when the next rate
+        // limit token is available. There may only be a single rate limit
+        // token available at that time. Add a random skew to prevent creating
+        // a thundering herd.
+        const randomSkewMs = 30_000 * Math.random();
+        await sleep(err.retryAfterMs + randomSkewMs);
         throw err;
       }
       if (res.status >= 400 && res.status < 500) {

--- a/packages/client/src/check-deployment-status.ts
+++ b/packages/client/src/check-deployment-status.ts
@@ -22,7 +22,7 @@ interface DeploymentStatus {
 }
 
 // If an error occurs, how should our retries behave?
-const RETRY_COUNT = 3;
+const RETRY_COUNT = 5;
 // Maximum value to cap `Retry-After` to in order to avoid hanging if we get a
 // `Retry-After` value in the far future. This limit is applied before
 // `RETRY_DELAY_SKEW_MS`, so the total duration can exceed this.

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -88,7 +88,7 @@ describe('checkDeploymentStatus()', () => {
       expect(sleep).toHaveBeenCalledWith(10_000);
     });
 
-    it('should retry up to 3 times on consecutive failures', async () => {
+    it('should retry up to 5 times on consecutive failures', async () => {
       mockFetch.mockResolvedValue(mockResponse(500, { error: 'mock error' }));
 
       const iterator = checkDeploymentStatus(
@@ -103,7 +103,7 @@ describe('checkDeploymentStatus()', () => {
       });
       // 5_000 + 3_000 skew (RETRY_DELAY_SKEW_MS * 0.1)
       expect(sleep).toHaveBeenCalledWith(8_000);
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/packages/client/tests/unit.check-deployment-status.test.ts
+++ b/packages/client/tests/unit.check-deployment-status.test.ts
@@ -51,6 +51,7 @@ describe('checkDeploymentStatus()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.1);
   });
 
   describe('retry logic', () => {
@@ -81,8 +82,10 @@ describe('checkDeploymentStatus()', () => {
         payload: expect.objectContaining({ readyState: 'READY' }),
       });
       expect(mockFetch).toHaveBeenCalledTimes(3);
-      expect(sleep).toHaveBeenCalledWith(6_000);
-      expect(sleep).toHaveBeenCalledWith(7_000);
+      // 6_000 + 3_000 skew (RETRY_DELAY_SKEW_MS * 0.1)
+      expect(sleep).toHaveBeenCalledWith(9_000);
+      // 7_000 + 3_000 skew
+      expect(sleep).toHaveBeenCalledWith(10_000);
     });
 
     it('should retry up to 3 times on consecutive failures', async () => {
@@ -98,7 +101,8 @@ describe('checkDeploymentStatus()', () => {
         type: 'error',
         payload: 'mock error',
       });
-      expect(sleep).toHaveBeenCalledWith(5_000);
+      // 5_000 + 3_000 skew (RETRY_DELAY_SKEW_MS * 0.1)
+      expect(sleep).toHaveBeenCalledWith(8_000);
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });


### PR DESCRIPTION
We're still seeing rate limit errors in the Next.js e2e deployment tests:

E.g. https://github.com/vercel/next.js/actions/runs/21373542150/job/61524648707#step:33:270
![Screenshot 2026-01-26 at 2.46.48 PM.png](https://app.graphite.com/user-attachments/assets/a12dc943-a61a-44b0-82f0-bb3df809118e.png)

This PR is a continuation of the efforts to fix rate limiting in:
- https://github.com/vercel/vercel/pull/14407
- https://github.com/vercel/vercel/pull/14443

My hypothesis with the current remaining 429 errors is:
* We've got a retry loop everywhere this API is called
* We use the HTTP `Retry-After` header to decide when to retry
* The backend doesn't use fixed 1 minute buckets, but rather a sliding window.
* The backend's `Retry-After` header tells us when the next rate limit token will be available.
* Every parallel deployment then ends up waiting on that one next rate limit token and there's a thundering herd when trying to recover from 429 errors.

So I think the retry logic on the client has to be to read the `Retry-After` header and then add a random duration to it, up to one minute, to prevent a thundering herd.

## Alternate Solutions

We could add this random skew on the backend. That might be better as clients don't have to be aware of this potential problem.

But also: What the backend is doing is technically correct. And this isn't really about the backend protecting itself, but rather about preventing clients from running out of retries.