### PR TITLE
feat(cli): Add period breakdown option for usage cmd

### DIFF
--- a/.changeset/wicked-grapes-learn.md
+++ b/.changeset/wicked-grapes-learn.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `--breakdown` option to `vercel usage` for viewing usage broken down by period

--- a/packages/cli/src/commands/usage/command.ts
+++ b/packages/cli/src/commands/usage/command.ts
@@ -24,6 +24,15 @@ export const usageCommand = {
       description: 'End date (YYYY-MM-DD, interpreted as end of day LA time)',
       deprecated: false,
     },
+    {
+      name: 'breakdown',
+      shorthand: null,
+      type: String,
+      argument: 'PERIOD',
+      description:
+        'Show usage breakdown by time period instead of aggregated totals (daily, weekly, monthly)',
+      deprecated: false,
+    },
     formatOption,
     jsonOption,
   ],
@@ -35,6 +44,14 @@ export const usageCommand = {
     {
       name: 'Show usage for a custom date range',
       value: `${packageName} usage --from 2025-01-01 --to 2025-01-31`,
+    },
+    {
+      name: 'Show daily usage breakdown',
+      value: `${packageName} usage --breakdown daily`,
+    },
+    {
+      name: 'Show weekly usage breakdown',
+      value: `${packageName} usage --breakdown weekly`,
     },
     {
       name: 'Output usage data as JSON',

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import jsonlines from 'jsonlines';
+import type { Response } from 'node-fetch';
 import { parseArguments } from '../../util/get-args';
 import { printError } from '../../util/error';
 import type Client from '../../util/client';

--- a/packages/cli/src/commands/usage/output-aggregated.ts
+++ b/packages/cli/src/commands/usage/output-aggregated.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import output from '../../output-manager';
+import elapsed from '../../util/output/elapsed';
+import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import type { OutputOptions } from './types';
+
+export function outputAggregated({ data, startTime }: OutputOptions): void {
+  const { print, log } = output;
+
+  log(
+    `Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
+  );
+  log('');
+  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  log(
+    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
+  );
+  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
+  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
+  log('');
+
+  const sortedServices = [...data.services.entries()].sort(
+    (a, b) => b[1].billedCost - a[1].billedCost
+  );
+
+  if (sortedServices.length === 0) {
+    log('No usage data found for this period.');
+    return;
+  }
+
+  const quantityHeader =
+    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
+  const headers = ['Service', quantityHeader, 'Effective Cost', 'Billed Cost'];
+  const rows = sortedServices.map(([name, svc]) => [
+    name,
+    formatQuantity(svc.pricingQuantity, svc.pricingUnit),
+    formatCurrency(svc.effectiveCost),
+    formatCurrency(svc.billedCost),
+  ]);
+
+  rows.push([
+    chalk.bold('Total'),
+    chalk.bold(
+      formatQuantity(data.grandTotals.pricingQuantity, data.pricingUnit)
+    ),
+    chalk.bold(formatCurrency(data.grandTotals.effectiveCost)),
+    chalk.bold(formatCurrency(data.grandTotals.billedCost)),
+  ]);
+
+  const tablePrint = table(
+    [headers.map(h => chalk.bold(chalk.cyan(h))), ...rows],
+    { hsep: 4, align: ['l', 'r', 'r', 'r'] }
+  ).replace(/^/gm, '  ');
+
+  print(`\n${tablePrint}\n\n`);
+
+  log(
+    `${chalk.gray('Amount due:')} ${chalk.bold(formatCurrency(data.grandTotals.billedCost))}`
+  );
+}

--- a/packages/cli/src/commands/usage/output-breakdown.ts
+++ b/packages/cli/src/commands/usage/output-breakdown.ts
@@ -1,0 +1,81 @@
+import chalk from 'chalk';
+import table from '../../util/output/table';
+import output from '../../output-manager';
+import elapsed from '../../util/output/elapsed';
+import { formatCurrency, formatQuantity } from '../../util/billing/format';
+import type { OutputOptions, BreakdownPeriod } from './types';
+
+function getPeriodLabel(period: BreakdownPeriod): string {
+  switch (period) {
+    case 'daily':
+      return 'Daily';
+    case 'weekly':
+      return 'Weekly';
+    case 'monthly':
+      return 'Monthly';
+    default:
+      return 'Period';
+  }
+}
+
+export function outputBreakdown({
+  data,
+  breakdownPeriod,
+  startTime,
+}: OutputOptions): void {
+  const { print, log } = output;
+
+  const periodLabel = getPeriodLabel(breakdownPeriod!);
+
+  log(
+    `${periodLabel} Usage for ${chalk.bold(data.contextName)} ${elapsed(Date.now() - startTime)}`
+  );
+  log('');
+  const periodSuffix = data.usingDefaults ? ' (current month)' : '';
+  log(
+    `${chalk.gray('Period:')} ${data.fromDisplay} to ${data.toDisplay}${periodSuffix}`
+  );
+  log(`${chalk.gray('Charges processed:')} ${data.chargeCount}`);
+  log(`${chalk.gray('Pricing unit:')} ${data.pricingUnit}`);
+  log('');
+
+  const sortedServices = [...data.services.entries()].sort(
+    (a, b) => b[1].billedCost - a[1].billedCost
+  );
+
+  if (sortedServices.length === 0) {
+    log('No usage data found for this period.');
+    return;
+  }
+
+  const quantityHeader =
+    data.pricingUnit === 'USD' ? 'Usage (USD)' : data.pricingUnit;
+
+  // Sort periods chronologically
+  const sortedPeriods = [...data.periodUsage.keys()].sort();
+
+  for (const periodKey of sortedPeriods) {
+    const periodData = data.periodUsage.get(periodKey)!;
+    const sortedPeriodServices = [...periodData.services.entries()].sort(
+      (a, b) => b[1].billedCost - a[1].billedCost
+    );
+
+    log(
+      `${chalk.bold(chalk.cyan(periodKey))} (Total: ${formatQuantity(periodData.totalPricingQuantity, data.pricingUnit)}, ${formatCurrency(periodData.totalBilledCost)})`
+    );
+
+    const headers = ['Service', quantityHeader, 'Billed Cost'];
+    const rows = sortedPeriodServices.map(([name, svc]) => [
+      name,
+      formatQuantity(svc.pricingQuantity, svc.pricingUnit),
+      formatCurrency(svc.billedCost),
+    ]);
+
+    const tablePrint = table(
+      [headers.map(h => chalk.bold(chalk.gray(h))), ...rows],
+      { hsep: 4, align: ['l', 'r', 'r'] }
+    ).replace(/^/gm, '  ');
+
+    print(`${tablePrint}\n`);
+  }
+}

--- a/packages/cli/src/commands/usage/output-json.ts
+++ b/packages/cli/src/commands/usage/output-json.ts
@@ -1,0 +1,68 @@
+import type Client from '../../util/client';
+import type { JsonOutputOptions } from './types';
+
+export function outputJson(
+  client: Client,
+  { data, fromDate, toDate, breakdownPeriod }: JsonOutputOptions
+): void {
+  const sortedServices = [...data.services.entries()].sort(
+    (a, b) => b[1].billedCost - a[1].billedCost
+  );
+
+  const sortedPeriods = [...data.periodUsage.keys()].sort();
+
+  const jsonOutput: Record<string, unknown> = {
+    period: {
+      from: fromDate,
+      to: toDate,
+    },
+    context: data.contextName,
+    pricingUnit: data.pricingUnit,
+  };
+
+  // Include breakdown data if a breakdown period is specified
+  if (breakdownPeriod) {
+    jsonOutput.breakdown = {
+      period: breakdownPeriod,
+      data: sortedPeriods.map(periodKey => {
+        const periodData = data.periodUsage.get(periodKey)!;
+        const sortedPeriodServices = [...periodData.services.entries()].sort(
+          (a, b) => b[1].billedCost - a[1].billedCost
+        );
+        return {
+          periodKey,
+          services: sortedPeriodServices.map(([name, svc]) => ({
+            name,
+            pricingQuantity: svc.pricingQuantity,
+            pricingUnit: svc.pricingUnit,
+            effectiveCost: svc.effectiveCost,
+            billedCost: svc.billedCost,
+          })),
+          totals: {
+            pricingQuantity: periodData.totalPricingQuantity,
+            effectiveCost: periodData.totalEffectiveCost,
+            billedCost: periodData.totalBilledCost,
+          },
+        };
+      }),
+    };
+  }
+
+  jsonOutput.services = sortedServices.map(([name, svc]) => ({
+    name,
+    pricingQuantity: svc.pricingQuantity,
+    pricingUnit: svc.pricingUnit,
+    effectiveCost: svc.effectiveCost,
+    billedCost: svc.billedCost,
+  }));
+
+  jsonOutput.totals = {
+    pricingQuantity: data.grandTotals.pricingQuantity,
+    effectiveCost: data.grandTotals.effectiveCost,
+    billedCost: data.grandTotals.billedCost,
+  };
+
+  jsonOutput.chargeCount = data.chargeCount;
+
+  client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+}

--- a/packages/cli/src/commands/usage/types.ts
+++ b/packages/cli/src/commands/usage/types.ts
@@ -1,0 +1,44 @@
+export type BreakdownPeriod = 'daily' | 'weekly' | 'monthly';
+
+export interface ServiceAggregation {
+  pricingQuantity: number;
+  effectiveCost: number;
+  billedCost: number;
+  pricingUnit: string;
+}
+
+export interface PeriodAggregation {
+  services: Map<string, ServiceAggregation>;
+  totalPricingQuantity: number;
+  totalEffectiveCost: number;
+  totalBilledCost: number;
+}
+
+export interface UsageData {
+  contextName: string;
+  fromDisplay: string;
+  toDisplay: string;
+  usingDefaults: boolean;
+  pricingUnit: string;
+  chargeCount: number;
+  services: Map<string, ServiceAggregation>;
+  periodUsage: Map<string, PeriodAggregation>;
+  grandTotals: {
+    pricingQuantity: number;
+    effectiveCost: number;
+    billedCost: number;
+  };
+}
+
+export interface OutputOptions {
+  data: UsageData;
+  breakdownPeriod?: BreakdownPeriod;
+  startTime: number;
+}
+
+export interface JsonOutputOptions {
+  data: UsageData;
+  fromDate: string;
+  toDate: string;
+  breakdownPeriod?: BreakdownPeriod;
+}

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -8,3 +8,7 @@ export function formatQuantity(quantity: number, unit: string): string {
   }
   return quantity.toFixed(4);
 }
+
+export function extractDatePortion(isoString: string): string {
+  return isoString.slice(0, 10);
+}

--- a/packages/cli/src/util/billing/format.ts
+++ b/packages/cli/src/util/billing/format.ts
@@ -1,76 +1,3 @@
-import { DateTime } from 'luxon';
-
-// Vercel billing periods are aligned to LA (Pacific) time
-export const LA_TIMEZONE = 'America/Los_Angeles';
-
-function toISOOrThrow(dt: DateTime): string {
-  if (!dt.isValid) {
-    throw new Error(`Invalid DateTime: ${dt.invalidReason}`);
-  }
-  const iso = dt.toISO();
-  if (!iso) {
-    throw new Error(`Failed to convert DateTime to ISO`);
-  }
-  return iso;
-}
-
-function getDefaultFromDateTime(): DateTime {
-  return DateTime.now().setZone(LA_TIMEZONE).startOf('month');
-}
-
-function getDefaultToDateTime(): DateTime {
-  return DateTime.utc();
-}
-
-export function getDefaultFromDate(): string {
-  const dt = getDefaultFromDateTime();
-  return toISOOrThrow(dt.toUTC());
-}
-
-export function getDefaultToDate(): string {
-  const dt = getDefaultToDateTime();
-  return toISOOrThrow(dt.toUTC());
-}
-
-export function getDefaultFromDateDisplay(): string {
-  const dt = getDefaultFromDateTime();
-  return dt.toFormat('yyyy-MM-dd');
-}
-
-export function getDefaultToDateDisplay(): string {
-  const dt = getDefaultToDateTime();
-  return dt.toFormat('yyyy-MM-dd');
-}
-
-export function parseBillingDate(
-  dateStr: string,
-  isEndDate: boolean = false
-): string {
-  if (dateStr.includes('T')) {
-    const dt = DateTime.fromISO(dateStr);
-    if (!dt.isValid) {
-      throw new Error(
-        `Invalid date: "${dateStr}". Expected ISO 8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss)`
-      );
-    }
-    return dateStr;
-  }
-
-  // Validate YYYY-MM-DD format
-  const laDateTime = DateTime.fromISO(dateStr, { zone: LA_TIMEZONE }).startOf(
-    'day'
-  );
-
-  if (!laDateTime.isValid) {
-    throw new Error(
-      `Invalid date: "${dateStr}". Expected ISO 8601 format (YYYY-MM-DD)`
-    );
-  }
-
-  const finalDateTime = isEndDate ? laDateTime.plus({ days: 1 }) : laDateTime;
-  return toISOOrThrow(finalDateTime.toUTC());
-}
-
 export function formatCurrency(amount: number): string {
   return `$${amount.toFixed(4)}`;
 }
@@ -80,8 +7,4 @@ export function formatQuantity(quantity: number, unit: string): string {
     return `$${quantity.toFixed(4)}`;
   }
   return quantity.toFixed(4);
-}
-
-export function extractDatePortion(isoString: string): string {
-  return isoString.substring(0, 10);
 }

--- a/packages/cli/src/util/billing/period-utils.ts
+++ b/packages/cli/src/util/billing/period-utils.ts
@@ -72,15 +72,6 @@ export function parseBillingDate(
   return toISOOrThrow(finalDateTime.toUTC());
 }
 
-function getWeekStart(dateStr: string): string {
-  const date = new Date(dateStr);
-  const day = date.getUTCDay();
-  // Adjust to get Monday (ISO week start)
-  const diff = day === 0 ? -6 : 1 - day;
-  date.setUTCDate(date.getUTCDate() + diff);
-  return date.toISOString().substring(0, 10);
-}
-
 function getISOWeekNumber(dateStr: string): number {
   const date = new Date(dateStr);
   date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
@@ -89,6 +80,12 @@ function getISOWeekNumber(dateStr: string): number {
     ((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7
   );
   return weekNo;
+}
+
+function getISOWeekYear(dateStr: string): number {
+  const date = new Date(dateStr);
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  return date.getUTCFullYear();
 }
 
 export function getPeriodKey(
@@ -106,10 +103,9 @@ export function getPeriodKey(
 
     case 'weekly': {
       // Return YYYY-Www format (ISO week)
-      const weekStart = getWeekStart(chargePeriodStart);
-      const year = weekStart.substring(0, 4);
+      const weekYear = getISOWeekYear(chargePeriodStart);
       const weekNum = getISOWeekNumber(chargePeriodStart);
-      return `${year}-W${weekNum.toString().padStart(2, '0')}`;
+      return `${weekYear}-W${weekNum.toString().padStart(2, '0')}`;
     }
 
     case 'monthly':

--- a/packages/cli/src/util/billing/period-utils.ts
+++ b/packages/cli/src/util/billing/period-utils.ts
@@ -1,0 +1,137 @@
+import { DateTime } from 'luxon';
+import type { BreakdownPeriod } from '../../commands/usage/types';
+
+// Vercel billing periods are aligned to LA (Pacific) time
+export const LA_TIMEZONE = 'America/Los_Angeles';
+
+function toISOOrThrow(dt: DateTime): string {
+  if (!dt.isValid) {
+    throw new Error(`Invalid DateTime: ${dt.invalidReason}`);
+  }
+  const iso = dt.toISO();
+  if (!iso) {
+    throw new Error(`Failed to convert DateTime to ISO`);
+  }
+  return iso;
+}
+
+function getDefaultFromDateTime(): DateTime {
+  return DateTime.now().setZone(LA_TIMEZONE).startOf('month');
+}
+
+function getDefaultToDateTime(): DateTime {
+  return DateTime.utc();
+}
+
+export function getDefaultFromDate(): string {
+  const dt = getDefaultFromDateTime();
+  return toISOOrThrow(dt.toUTC());
+}
+
+export function getDefaultToDate(): string {
+  const dt = getDefaultToDateTime();
+  return toISOOrThrow(dt.toUTC());
+}
+
+export function getDefaultFromDateDisplay(): string {
+  const dt = getDefaultFromDateTime();
+  return dt.toFormat('yyyy-MM-dd');
+}
+
+export function getDefaultToDateDisplay(): string {
+  const dt = getDefaultToDateTime();
+  return dt.toFormat('yyyy-MM-dd');
+}
+
+export function parseBillingDate(
+  dateStr: string,
+  isEndDate: boolean = false
+): string {
+  if (dateStr.includes('T')) {
+    const dt = DateTime.fromISO(dateStr);
+    if (!dt.isValid) {
+      throw new Error(
+        `Invalid date: "${dateStr}". Expected ISO 8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss)`
+      );
+    }
+    return dateStr;
+  }
+
+  // Validate YYYY-MM-DD format
+  const laDateTime = DateTime.fromISO(dateStr, { zone: LA_TIMEZONE }).startOf(
+    'day'
+  );
+
+  if (!laDateTime.isValid) {
+    throw new Error(
+      `Invalid date: "${dateStr}". Expected ISO 8601 format (YYYY-MM-DD)`
+    );
+  }
+
+  const finalDateTime = isEndDate ? laDateTime.plus({ days: 1 }) : laDateTime;
+  return toISOOrThrow(finalDateTime.toUTC());
+}
+
+function getWeekStart(dateStr: string): string {
+  const date = new Date(dateStr);
+  const day = date.getUTCDay();
+  // Adjust to get Monday (ISO week start)
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setUTCDate(date.getUTCDate() + diff);
+  return date.toISOString().substring(0, 10);
+}
+
+function getISOWeekNumber(dateStr: string): number {
+  const date = new Date(dateStr);
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(
+    ((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7
+  );
+  return weekNo;
+}
+
+export function getPeriodKey(
+  chargePeriodStart: string,
+  breakdownPeriod: BreakdownPeriod
+): string {
+  if (!chargePeriodStart) {
+    return 'Unknown';
+  }
+
+  switch (breakdownPeriod) {
+    case 'daily':
+      // Return YYYY-MM-DD
+      return chargePeriodStart.substring(0, 10);
+
+    case 'weekly': {
+      // Return YYYY-Www format (ISO week)
+      const weekStart = getWeekStart(chargePeriodStart);
+      const year = weekStart.substring(0, 4);
+      const weekNum = getISOWeekNumber(chargePeriodStart);
+      return `${year}-W${weekNum.toString().padStart(2, '0')}`;
+    }
+
+    case 'monthly':
+      // Return YYYY-MM
+      return chargePeriodStart.substring(0, 7);
+
+    default:
+      return chargePeriodStart.substring(0, 10);
+  }
+}
+
+export const VALID_BREAKDOWN_PERIODS: BreakdownPeriod[] = [
+  'daily',
+  'weekly',
+  'monthly',
+];
+
+export function isValidBreakdownPeriod(
+  value: string | undefined
+): value is BreakdownPeriod {
+  return (
+    value !== undefined &&
+    VALID_BREAKDOWN_PERIODS.includes(value as BreakdownPeriod)
+  );
+}

--- a/packages/cli/src/util/telemetry/commands/usage/index.ts
+++ b/packages/cli/src/util/telemetry/commands/usage/index.ts
@@ -29,4 +29,13 @@ export class UsageTelemetryClient
       this.trackCliFlag('json');
     }
   }
+
+  trackCliOptionBreakdown(breakdown: string | undefined) {
+    if (breakdown) {
+      this.trackCliOption({
+        option: 'breakdown',
+        value: breakdown,
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -195,8 +195,6 @@ describe('usage', () => {
       // Should show daily breakdown with dates
       expect(output).toContain('2025-12-01');
       expect(output).toContain('2025-12-02');
-      // Should show Grand Total section
-      expect(output).toContain('Grand Total');
       // Should show services
       expect(output).toContain('Serverless Function Execution');
       expect(output).toContain('Edge Middleware Invocations');
@@ -237,8 +235,6 @@ describe('usage', () => {
       // Should show weekly breakdown with week identifiers
       expect(output).toContain('2025-W49');
       expect(output).toContain('2025-W50');
-      // Should show Grand Total section
-      expect(output).toContain('Grand Total');
     });
 
     it('should display monthly breakdown with --breakdown monthly', async () => {
@@ -276,8 +272,6 @@ describe('usage', () => {
       // Should show monthly breakdown
       expect(output).toContain('2025-11');
       expect(output).toContain('2025-12');
-      // Should show Grand Total section
-      expect(output).toContain('Grand Total');
     });
 
     it('should output JSON with breakdown data when --breakdown daily and --format json', async () => {

--- a/packages/cli/test/unit/commands/usage/index.test.ts
+++ b/packages/cli/test/unit/commands/usage/index.test.ts
@@ -63,6 +63,7 @@ describe('usage', () => {
       expect(output).toContain('Show billing usage');
       expect(output).toContain('--from');
       expect(output).toContain('--to');
+      expect(output).toContain('--breakdown');
       expect(output).toContain('--format');
     });
   });
@@ -150,6 +151,220 @@ describe('usage', () => {
       expect(exitCode).toEqual(0);
       const output = client.getFullOutput();
       expect(output).toContain('No usage data found');
+    });
+
+    it('should display daily breakdown with --breakdown daily', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          ChargePeriodStart: '2025-12-01T08:00:00.000Z',
+        }),
+        createMockCharge({
+          ServiceName: 'Edge Middleware Invocations',
+          PricingQuantity: 50,
+          BilledCost: 5,
+          EffectiveCost: 4,
+          ChargePeriodStart: '2025-12-01T08:00:00.000Z',
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          ChargePeriodStart: '2025-12-02T08:00:00.000Z',
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'daily'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      // Should show daily breakdown with dates
+      expect(output).toContain('2025-12-01');
+      expect(output).toContain('2025-12-02');
+      // Should show Grand Total section
+      expect(output).toContain('Grand Total');
+      // Should show services
+      expect(output).toContain('Serverless Function Execution');
+      expect(output).toContain('Edge Middleware Invocations');
+    });
+
+    it('should display weekly breakdown with --breakdown weekly', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          ChargePeriodStart: '2025-12-01T08:00:00.000Z',
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          ChargePeriodStart: '2025-12-08T08:00:00.000Z',
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'weekly'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      // Should show weekly breakdown with week identifiers
+      expect(output).toContain('2025-W49');
+      expect(output).toContain('2025-W50');
+      // Should show Grand Total section
+      expect(output).toContain('Grand Total');
+    });
+
+    it('should display monthly breakdown with --breakdown monthly', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          ChargePeriodStart: '2025-11-15T08:00:00.000Z',
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          ChargePeriodStart: '2025-12-15T08:00:00.000Z',
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-11-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'monthly'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.getFullOutput();
+      // Should show monthly breakdown
+      expect(output).toContain('2025-11');
+      expect(output).toContain('2025-12');
+      // Should show Grand Total section
+      expect(output).toContain('Grand Total');
+    });
+
+    it('should output JSON with breakdown data when --breakdown daily and --format json', async () => {
+      const mockCharges = [
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 100,
+          BilledCost: 10,
+          EffectiveCost: 8,
+          ChargePeriodStart: '2025-12-01T08:00:00.000Z',
+        }),
+        createMockCharge({
+          ServiceName: 'Serverless Function Execution',
+          PricingQuantity: 200,
+          BilledCost: 20,
+          EffectiveCost: 16,
+          ChargePeriodStart: '2025-12-02T08:00:00.000Z',
+        }),
+      ];
+      useBillingCharges(mockCharges);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'daily',
+        '--format',
+        'json'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(0);
+      const output = client.stdout.getFullOutput();
+      const json = JSON.parse(output);
+      expect(json.breakdown).toBeDefined();
+      expect(json.breakdown.period).toEqual('daily');
+      expect(json.breakdown.data).toHaveLength(2);
+      expect(json.breakdown.data[0].periodKey).toEqual('2025-12-01');
+      expect(json.breakdown.data[1].periodKey).toEqual('2025-12-02');
+      expect(json.breakdown.data[0].totals.billedCost).toEqual(10);
+      expect(json.breakdown.data[1].totals.billedCost).toEqual(20);
+      // Grand totals should still be present
+      expect(json.totals.billedCost).toEqual(30);
+    });
+
+    it('should track telemetry for --breakdown option', async () => {
+      useBillingCharges([]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'daily'
+      );
+      await usage(client);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        { key: 'option:from', value: '[REDACTED]' },
+        { key: 'option:to', value: '[REDACTED]' },
+        { key: 'option:breakdown', value: 'daily' },
+      ]);
+    });
+
+    it('should error on invalid breakdown period', async () => {
+      useBillingCharges([]);
+
+      client.setArgv(
+        'usage',
+        '--from',
+        '2025-12-01',
+        '--to',
+        '2025-12-31',
+        '--breakdown',
+        'yearly'
+      );
+      const exitCode = await usage(client);
+
+      expect(exitCode).toEqual(1);
+      const output = client.getFullOutput();
+      expect(output).toContain('Invalid breakdown period');
+      expect(output).toContain('daily, weekly, monthly');
     });
   });
 });


### PR DESCRIPTION
# Add period breakdown option for usage cmd

Part of the new `vercel usage` cli. Allows for breakdowns and aggregations across days, weeks, and months, as well as the previous default full accumulation