### PR TITLE
fix(cli): use linked project's orgId for team context in getScope

### DIFF
--- a/packages/cli/src/util/get-scope.ts
+++ b/packages/cli/src/util/get-scope.ts
@@ -3,6 +3,7 @@ import getUser from './get-user';
 import getTeamById from './teams/get-team-by-id';
 import { TeamDeleted } from './errors-ts';
 import type { Team } from '@vercel-internals/types';
+import { getProjectLink } from './projects/link';
 
 interface GetScopeOptions {
   getTeam?: boolean;
@@ -15,12 +16,26 @@ export default async function getScope(
   const user = await getUser(client);
   let contextName = user.username || user.email;
   let team: Team | null = null;
-  const defaultTeamId =
-    user.version === 'northstar' ? user.defaultTeamId : undefined;
-  const currentTeamOrDefaultTeamId = client.config.currentTeam || defaultTeamId;
 
-  if (currentTeamOrDefaultTeamId && opts.getTeam !== false) {
-    team = await getTeamById(client, currentTeamOrDefaultTeamId);
+  // Priority order for determining team context:
+  // 1. Linked project's orgId (if in a linked project directory)
+  // 2. currentTeam (set via `vc switch`)
+  // 3. defaultTeamId (user's default team for northstar users)
+  let teamId: string | undefined;
+
+  const projectLink = await getProjectLink(client, client.cwd);
+  if (projectLink?.orgId?.startsWith('team_')) {
+    teamId = projectLink.orgId;
+  }
+
+  if (!teamId) {
+    const defaultTeamId =
+      user.version === 'northstar' ? user.defaultTeamId : undefined;
+    teamId = client.config.currentTeam || defaultTeamId;
+  }
+
+  if (teamId && opts.getTeam !== false) {
+    team = await getTeamById(client, teamId);
 
     if (!team) {
       throw new TeamDeleted();

--- a/packages/cli/test/unit/util/get-scope.test.ts
+++ b/packages/cli/test/unit/util/get-scope.test.ts
@@ -1,14 +1,21 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { client } from '../../mocks/client';
 import { useUser } from '../../mocks/user';
-import { useTeam } from '../../mocks/team';
+import { useTeam, createTeam } from '../../mocks/team';
 import getScope from '../../../src/util/get-scope';
+import * as linkModule from '../../../src/util/projects/link';
+
+vi.mock('../../../src/util/projects/link');
+const mockedGetProjectLink = vi.mocked(linkModule.getProjectLink);
 
 describe('getScope', () => {
   let mockTeam: ReturnType<typeof useTeam>;
   let mockUser: ReturnType<typeof useUser>;
   beforeEach(() => {
+    vi.clearAllMocks();
     mockTeam = useTeam();
+    // Default: no linked project
+    mockedGetProjectLink.mockResolvedValue(null);
   });
 
   describe('non-northstar', () => {
@@ -64,6 +71,82 @@ describe('getScope', () => {
       await expect(user.id).toEqual(mockUser.id);
       await expect(team).toBeNull();
       await expect(contextName).toEqual(mockUser.username);
+    });
+  });
+
+  describe('linked project', () => {
+    let linkedTeam: ReturnType<typeof createTeam>;
+
+    beforeEach(() => {
+      mockUser = useUser({
+        version: 'northstar',
+        defaultTeamId: mockTeam.id,
+      });
+      // Create a different team for the linked project (use createTeam to add to existing teams)
+      linkedTeam = createTeam(`team_linked_${Date.now()}`);
+      // Register route for the linked team
+      client.scenario.get(`/teams/${linkedTeam.id}`, (_req, res) => {
+        res.json(linkedTeam);
+      });
+    });
+
+    it('should use linked project orgId over currentTeam', async () => {
+      // Set currentTeam to mockTeam
+      client.config.currentTeam = mockTeam.id;
+
+      // But linked project points to linkedTeam
+      mockedGetProjectLink.mockResolvedValue({
+        orgId: linkedTeam.id,
+        projectId: 'prj_test',
+      });
+
+      const { contextName, team, user } = await getScope(client);
+      await expect(user.id).toEqual(mockUser.id);
+      // Should use linkedTeam, not mockTeam
+      await expect(team?.id).toEqual(linkedTeam.id);
+      await expect(contextName).toEqual(linkedTeam.slug);
+    });
+
+    it('should use linked project orgId over defaultTeamId', async () => {
+      // No currentTeam set, defaultTeamId is mockTeam
+      // Linked project points to linkedTeam
+      mockedGetProjectLink.mockResolvedValue({
+        orgId: linkedTeam.id,
+        projectId: 'prj_test',
+      });
+
+      const { contextName, team, user } = await getScope(client);
+      await expect(user.id).toEqual(mockUser.id);
+      // Should use linkedTeam, not defaultTeamId (mockTeam)
+      await expect(team?.id).toEqual(linkedTeam.id);
+      await expect(contextName).toEqual(linkedTeam.slug);
+    });
+
+    it('should fall back to currentTeam if linked project has no team orgId', async () => {
+      client.config.currentTeam = mockTeam.id;
+
+      // Linked project with user orgId (not a team)
+      mockedGetProjectLink.mockResolvedValue({
+        orgId: 'user_123', // Not a team_ prefix
+        projectId: 'prj_test',
+      });
+
+      const { contextName, team, user } = await getScope(client);
+      await expect(user.id).toEqual(mockUser.id);
+      // Should fall back to currentTeam
+      await expect(team?.id).toEqual(mockTeam.id);
+      await expect(contextName).toEqual(mockTeam.slug);
+    });
+
+    it('should fall back to defaultTeamId if no linked project and no currentTeam', async () => {
+      // No linked project
+      mockedGetProjectLink.mockResolvedValue(null);
+
+      const { contextName, team, user } = await getScope(client);
+      await expect(user.id).toEqual(mockUser.id);
+      // Should use defaultTeamId (mockTeam)
+      await expect(team?.id).toEqual(mockTeam.id);
+      await expect(contextName).toEqual(mockTeam.slug);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix `getScope()` to check the linked project's `orgId` first when determining team context
- Previously, CLI commands ignored the project link and used `currentTeam` or `defaultTeamId` instead
- This caused commands like `vc integration add` to redirect to the wrong team's checkout page

## Changes
Changed priority order for determining team:
1. Linked project's `orgId` (from `.vercel/project.json`)
2. `currentTeam` (set via `vc switch`)  
3. `defaultTeamId` (user's default team for northstar users)

## Test plan
- [x] Added unit tests for linked project team resolution
- [x] Tested `vc integration add prisma` from a linked project directory
- [x] Verified it now shows "under <correct-team>" instead of the wrong default team

🤖 Generated with [Claude Code](https://claude.ai/code)