### PR TITLE
rust: make toolchain download optional

### DIFF
--- a/.changeset/angry-forks-explain.md
+++ b/.changeset/angry-forks-explain.md
@@ -1,0 +1,5 @@
+---
+'@vercel/rust': patch
+---
+
+Make rust toolchain download optional

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -45,7 +45,9 @@ async function buildHandler(options: BuildOptions): Promise<BuildResultV3> {
     );
   }
 
-  await installRustToolchain();
+  if (process.env.VERCEL_FORCE_DL_RUST_TOOLCHAIN) {
+    await installRustToolchain();
+  }
 
   debug('Creating file system');
   const downloadedFiles = await download(files, workPath, meta);


### PR DESCRIPTION
Once we have the toolchain available for Vercel builds, it's not required to download it anymore (except for local dev purposes)