### PR TITLE
feat(cli): colorize HTTP verbs in interactive `vercel api` mode

### DIFF
--- a/.changeset/yellow-masks-pretend.md
+++ b/.changeset/yellow-masks-pretend.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add improved styling to vercel api interactive mode

--- a/packages/cli/src/commands/api/format-utils.ts
+++ b/packages/cli/src/commands/api/format-utils.ts
@@ -1,0 +1,59 @@
+import chalk from 'chalk';
+
+/**
+ * Colorize HTTP method for terminal output
+ */
+export function colorizeMethod(method: string): string {
+  switch (method) {
+    case 'GET':
+      return chalk.cyan(method);
+    case 'POST':
+      return chalk.green(method);
+    case 'PUT':
+      return chalk.yellow(method);
+    case 'PATCH':
+      return chalk.blue(method);
+    case 'DELETE':
+      return chalk.red(method);
+    default:
+      return method;
+  }
+}
+
+/**
+ * Colorize HTTP method with padding for aligned display
+ */
+export function colorizeMethodPadded(method: string, width = 7): string {
+  const colored = colorizeMethod(method);
+  const padding = ' '.repeat(Math.max(0, width - method.length));
+  return colored + padding;
+}
+
+/**
+ * Format path parameter placeholder (e.g., {projectId}) with highlighting
+ */
+export function formatPathParam(paramName: string): string {
+  return chalk.cyan(`{${paramName}}`);
+}
+
+/**
+ * Format type hint (e.g., [string]) with dim styling
+ */
+export function formatTypeHint(type: string): string {
+  return chalk.dim(`[${type}]`);
+}
+
+/**
+ * Format description text with gray styling
+ */
+export function formatDescription(description?: string): string {
+  if (!description) return '';
+  return chalk.gray(` (${description})`);
+}
+
+/**
+ * Format "required" indicator
+ */
+export function formatRequired(): string {
+  return chalk.red('*');
+}


### PR DESCRIPTION
## Summary
- Colorize HTTP verbs in the interactive `vercel api` endpoint selection to match `vercel api ls` styling
- Extract `colorizeMethod` to shared `format-utils.ts` to avoid duplication
- Add additional colorization throughout the interactive flow for improved usability:
  - Path parameters like `{projectId}` highlighted in cyan
  - Query/body parameter names in cyan
  - Type hints dimmed
  - Descriptions grayed out

## Test plan
- [x] Run `pnpm build` - builds successfully
- [x] Run `pnpm vitest run test/unit/commands/api` - all 61 tests pass
- [ ] Manual test: Run `vercel api` interactively and verify verbs are colorized
- [ ] Manual test: Run `vercel api ls` and verify colors match the interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)