### PR TITLE
[cli] Improve beta command messaging clarity

### DIFF
--- a/.changeset/warm-roses-dance.md
+++ b/.changeset/warm-roses-dance.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update styling for beta commands

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -200,9 +200,7 @@ const main = async () => {
   if (betaCommands.includes(targetOrSubcommand)) {
     output.print(
       `${chalk.grey(
-        `${getTitleName()} CLI ${
-          pkg.version
-        } ${targetOrSubcommand} (beta) — https://vercel.com/feedback`
+        `${getTitleName()} CLI ${pkg.version} | ${chalk.bold(targetOrSubcommand)} is a beta command — https://vercel.com/feedback`
       )}\n`
     );
   } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -200,7 +200,7 @@ const main = async () => {
   if (betaCommands.includes(targetOrSubcommand)) {
     output.print(
       `${chalk.grey(
-        `${getTitleName()} CLI ${pkg.version} | ${chalk.bold(targetOrSubcommand)} is a beta command — https://vercel.com/feedback`
+        `${getTitleName()} CLI ${pkg.version} | ${chalk.bold(targetOrSubcommand)} is in beta — https://vercel.com/feedback`
       )}\n`
     );
   } else {


### PR DESCRIPTION
## Summary
- Updates the beta command banner to make it clearer that only the specific command is in beta, not the entire CLI
- Changes format from `Vercel CLI 50.6.0 api (beta) — https://vercel.com/feedback` to `Vercel CLI 50.6.0 | api is a beta command — https://vercel.com/feedback`
- Makes the command name bold for better visibility

## Test plan
- [x] Run `vercel api --help` and verify the beta message format
- [x] Run `vercel curl --help` and verify the beta message format
- [x] Run `vercel deploy --help` and verify no beta message appears
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)