### PR TITLE
[functions] use JSON serialization in InMemoryCache for RuntimeCache consistency

### DIFF
--- a/.changeset/smooth-clouds-dance.md
+++ b/.changeset/smooth-clouds-dance.md
@@ -2,6 +2,6 @@
 '@vercel/functions': patch
 ---
 
-Fix InMemoryCache to use JSON serialization for consistency with BuildCache
+Fix InMemoryCache to use JSON serialization for consistency with RuntimeCache
 
-InMemoryCache now serializes values with `JSON.stringify()` on set and deserializes with `JSON.parse()` on get, matching the behavior of BuildCache. This ensures consistent behavior when switching between cache implementations (e.g., in-memory for development, remote for production), particularly for types that don't survive JSON round-trips like `Date`, `Map`, `Set`, and `undefined`.
+InMemoryCache now serializes values with `JSON.stringify()` on set and deserializes with `JSON.parse()` on get, matching the behavior of RuntimeCache. This ensures consistent behavior when switching between cache implementations (e.g., in-memory for development, remote for production), particularly for types that don't survive JSON round-trips like `Date`, `Map`, `Set`, and `undefined`.

--- a/.changeset/smooth-clouds-dance.md
+++ b/.changeset/smooth-clouds-dance.md
@@ -1,0 +1,7 @@
+---
+'@vercel/functions': patch
+---
+
+Fix InMemoryCache to use JSON serialization for consistency with BuildCache
+
+InMemoryCache now serializes values with `JSON.stringify()` on set and deserializes with `JSON.parse()` on get, matching the behavior of BuildCache. This ensures consistent behavior when switching between cache implementations (e.g., in-memory for development, remote for production), particularly for types that don't survive JSON round-trips like `Date`, `Map`, `Set`, and `undefined`.

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -1,7 +1,7 @@
 import { RuntimeCache } from './types';
 
 interface CacheEntry {
-  value: unknown;
+  value: string; // JSON-serialized value for consistency with BuildCache
   tags: Set<string>;
   lastModified: number; // Timestamp of when the entry was last modified in epoch milliseconds
   ttl?: number; // Time to live in seconds
@@ -18,7 +18,7 @@ export class InMemoryCache implements RuntimeCache {
         await this.delete(key);
         return null;
       }
-      return entry.value;
+      return JSON.parse(entry.value);
     }
     return null;
   }
@@ -29,7 +29,7 @@ export class InMemoryCache implements RuntimeCache {
     options?: { ttl?: number; tags?: string[] }
   ): Promise<void> {
     this.cache[key] = {
-      value,
+      value: JSON.stringify(value),
       lastModified: Date.now(),
       ttl: options?.ttl,
       tags: new Set(options?.tags || []),

--- a/packages/functions/src/cache/in-memory-cache.ts
+++ b/packages/functions/src/cache/in-memory-cache.ts
@@ -28,8 +28,10 @@ export class InMemoryCache implements RuntimeCache {
     value: unknown,
     options?: { ttl?: number; tags?: string[] }
   ): Promise<void> {
+    // JSON.stringify(undefined) returns undefined (not a string), so coerce to null
+    const serialized = JSON.stringify(value ?? null);
     this.cache[key] = {
-      value: JSON.stringify(value),
+      value: serialized,
       lastModified: Date.now(),
       ttl: options?.ttl,
       tags: new Set(options?.tags || []),

--- a/packages/functions/test/unit/cache/in-memory-cache.test.ts
+++ b/packages/functions/test/unit/cache/in-memory-cache.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { InMemoryCache } from '../../../src/cache/in-memory-cache';
+
+describe('InMemoryCache', () => {
+  let cache: InMemoryCache;
+
+  beforeEach(() => {
+    cache = new InMemoryCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('get/set', () => {
+    it('should return null for non-existent key', async () => {
+      const result = await cache.get('non-existent');
+      expect(result).toBeNull();
+    });
+
+    it('should store and retrieve string values', async () => {
+      await cache.set('key', 'value');
+      const result = await cache.get('key');
+      expect(result).toBe('value');
+    });
+
+    it('should store and retrieve object values', async () => {
+      const obj = { foo: 'bar', count: 42 };
+      await cache.set('key', obj);
+      const result = await cache.get('key');
+      expect(result).toEqual(obj);
+    });
+
+    it('should store and retrieve array values', async () => {
+      const arr = [1, 2, 3, { nested: true }];
+      await cache.set('key', arr);
+      const result = await cache.get('key');
+      expect(result).toEqual(arr);
+    });
+
+    it('should store and retrieve null values', async () => {
+      await cache.set('key', null);
+      const result = await cache.get('key');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('JSON serialization consistency with BuildCache', () => {
+    it('should convert Date objects to ISO strings', async () => {
+      const date = new Date('2024-01-15T12:00:00.000Z');
+      await cache.set('key', { date });
+      const result = (await cache.get('key')) as { date: unknown };
+      expect(result.date).toBe('2024-01-15T12:00:00.000Z');
+      expect(result.date).not.toBeInstanceOf(Date);
+    });
+
+    it('should lose undefined values in objects', async () => {
+      const obj = { a: 1, b: undefined, c: 3 };
+      await cache.set('key', obj);
+      const result = (await cache.get('key')) as Record<string, unknown>;
+      expect(result).toEqual({ a: 1, c: 3 });
+      expect('b' in result).toBe(false);
+    });
+
+    it('should convert undefined to null in arrays', async () => {
+      const arr = [1, undefined, 3];
+      await cache.set('key', arr);
+      const result = await cache.get('key');
+      expect(result).toEqual([1, null, 3]);
+    });
+
+    it('should not preserve object references', async () => {
+      const obj = { foo: 'bar' };
+      await cache.set('key', obj);
+      const result = await cache.get('key');
+      expect(result).toEqual(obj);
+      expect(result).not.toBe(obj);
+    });
+
+    it('should lose Map and Set types', async () => {
+      const map = new Map([['a', 1]]);
+      const set = new Set([1, 2, 3]);
+      await cache.set('map', map);
+      await cache.set('set', set);
+      expect(await cache.get('map')).toEqual({});
+      expect(await cache.get('set')).toEqual({});
+    });
+
+    it('should lose function properties', async () => {
+      const obj = { a: 1, fn: () => 'test' };
+      await cache.set('key', obj);
+      const result = (await cache.get('key')) as Record<string, unknown>;
+      expect(result).toEqual({ a: 1 });
+      expect('fn' in result).toBe(false);
+    });
+  });
+
+  describe('TTL expiration', () => {
+    it('should return value before TTL expires', async () => {
+      await cache.set('key', 'value', { ttl: 60 });
+      vi.advanceTimersByTime(59 * 1000);
+      const result = await cache.get('key');
+      expect(result).toBe('value');
+    });
+
+    it('should return null after TTL expires', async () => {
+      await cache.set('key', 'value', { ttl: 60 });
+      vi.advanceTimersByTime(61 * 1000);
+      const result = await cache.get('key');
+      expect(result).toBeNull();
+    });
+
+    it('should not expire entries without TTL', async () => {
+      await cache.set('key', 'value');
+      vi.advanceTimersByTime(1000 * 60 * 60 * 24); // 24 hours
+      const result = await cache.get('key');
+      expect(result).toBe('value');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete existing key', async () => {
+      await cache.set('key', 'value');
+      await cache.delete('key');
+      const result = await cache.get('key');
+      expect(result).toBeNull();
+    });
+
+    it('should not throw when deleting non-existent key', async () => {
+      await expect(cache.delete('non-existent')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('expireTag', () => {
+    it('should expire entries with matching tag', async () => {
+      await cache.set('key1', 'value1', { tags: ['tag-a'] });
+      await cache.set('key2', 'value2', { tags: ['tag-b'] });
+      await cache.expireTag('tag-a');
+      expect(await cache.get('key1')).toBeNull();
+      expect(await cache.get('key2')).toBe('value2');
+    });
+
+    it('should expire entries with any matching tag from array', async () => {
+      await cache.set('key1', 'value1', { tags: ['tag-a'] });
+      await cache.set('key2', 'value2', { tags: ['tag-b'] });
+      await cache.set('key3', 'value3', { tags: ['tag-c'] });
+      await cache.expireTag(['tag-a', 'tag-b']);
+      expect(await cache.get('key1')).toBeNull();
+      expect(await cache.get('key2')).toBeNull();
+      expect(await cache.get('key3')).toBe('value3');
+    });
+
+    it('should expire entries with multiple tags if any match', async () => {
+      await cache.set('key', 'value', { tags: ['tag-a', 'tag-b', 'tag-c'] });
+      await cache.expireTag('tag-b');
+      expect(await cache.get('key')).toBeNull();
+    });
+
+    it('should not affect entries without tags', async () => {
+      await cache.set('key', 'value');
+      await cache.expireTag('any-tag');
+      expect(await cache.get('key')).toBe('value');
+    });
+  });
+});

--- a/packages/functions/test/unit/cache/in-memory-cache.test.ts
+++ b/packages/functions/test/unit/cache/in-memory-cache.test.ts
@@ -44,6 +44,12 @@ describe('InMemoryCache', () => {
       const result = await cache.get('key');
       expect(result).toBeNull();
     });
+
+    it('should coerce undefined to null', async () => {
+      await cache.set('key', undefined);
+      const result = await cache.get('key');
+      expect(result).toBeNull();
+    });
   });
 
   describe('JSON serialization consistency with BuildCache', () => {


### PR DESCRIPTION
### TL;DR

Updated `InMemoryCache` to use JSON serialization for cache values, ensuring consistency with `RuntimeCache`.

### What changed?

- Modified `InMemoryCache` to serialize values with `JSON.stringify()` when storing and deserialize with `JSON.parse()` when retrieving
- Changed the `value` type in `CacheEntry` interface from `unknown` to `string` to reflect the serialized storage format
- Added comprehensive unit tests to verify serialization behavior and ensure compatibility with `RuntimeCache`

### How to test?

Run the new unit tests that verify:
- Basic get/set functionality for various data types
- JSON serialization behavior (Date objects, undefined values, Maps, Sets, etc.)
- TTL expiration functionality
- Cache deletion and tag expiration

```
pnpm test packages/functions/test/unit/cache/in-memory-cache.test.ts
```

### Why make this change?

This change ensures consistent behavior when switching between cache implementations (in-memory for development, remote for production). Previously, the `InMemoryCache` stored values directly while `RuntimeCache` used JSON serialization, leading to inconsistencies with types that don't survive JSON round-trips like `Date`, `Map`, `Set`, and `undefined`. Now both implementations handle data types the same way, preventing unexpected behavior when moving between environments.