### PR TITLE
[cli] Add Authorization header placeholder to `vercel api --generate=curl`

### DIFF
--- a/.changeset/sixty-bikes-learn.md
+++ b/.changeset/sixty-bikes-learn.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improved curl generation with auth header placeholder

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -176,7 +176,7 @@ export default async function api(client: Client): Promise<number> {
         'https://api.vercel.com'
       );
       output.log('');
-      output.log('Add your authorization header to the curl command below:');
+      output.log('Replace <TOKEN> with your auth token:');
       output.log('');
       client.stdout.write(curlCmd + '\n');
       return 0;

--- a/packages/cli/src/commands/api/request-builder.ts
+++ b/packages/cli/src/commands/api/request-builder.ts
@@ -170,6 +170,9 @@ export function generateCurlCommand(
     parts.push(`-X ${config.method}`);
   }
 
+  // Authorization header with placeholder
+  parts.push(`-H 'Authorization: Bearer <TOKEN>'`);
+
   // Headers
   for (const [key, value] of Object.entries(config.headers)) {
     parts.push(`-H '${key}: ${escapeShellArg(value)}'`);

--- a/packages/cli/test/unit/commands/api/request-builder.test.ts
+++ b/packages/cli/test/unit/commands/api/request-builder.test.ts
@@ -306,6 +306,16 @@ describe('request-builder', () => {
       expect(result).not.toContain('-X');
     });
 
+    it('includes Authorization header with placeholder', () => {
+      const config: RequestConfig = {
+        url: '/v2/user',
+        method: 'GET',
+        headers: {},
+      };
+      const result = generateCurlCommand(config, baseUrl);
+      expect(result).toContain("-H 'Authorization: Bearer <TOKEN>'");
+    });
+
     it('joins parts with line continuation', () => {
       const config: RequestConfig = {
         url: '/api',


### PR DESCRIPTION
## Summary
- Adds an `Authorization: Bearer <TOKEN>` header placeholder to the curl output generated by `vercel api --generate=curl`
- Updates the user message to instruct users to replace `<TOKEN>` with their auth token
- Adds a unit test for the new behavior

## Test plan
- [x] Run `node packages/cli/dist/index.js api /v6/deployments --generate=curl` and verify the output includes the Authorization header
- [x] Unit tests pass (`npx vitest run test/unit/commands/api/request-builder.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)