### PR TITLE
[next] Remove 404.html prerenders from functions

### DIFF
--- a/.changeset/pink-eels-impress.md
+++ b/.changeset/pink-eels-impress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Remove 404.html prerenders from serverless function

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -87,7 +87,6 @@ import {
   normalizePackageJson,
   normalizePage,
   onPrerenderRoute,
-  onPrerenderRouteInitial,
   PseudoFile,
   PseudoLayer,
   PseudoLayerResult,
@@ -1184,9 +1183,9 @@ export const build: BuildV2 = async buildOptions => {
   const prerenders: { [key: string]: Prerender | FileFsRef } = {};
   let staticPages: { [key: string]: FileFsRef } = {};
   const dynamicPages: string[] = [];
-  let static404Page: string | undefined;
+  const static404Page = undefined;
   let page404Path = '';
-  let hasStatic500: undefined | boolean;
+  const hasStatic500: false = false as const;
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
@@ -1336,33 +1335,33 @@ export const build: BuildV2 = async buildOptions => {
       nextVersion,
       routesManifest
     );
-    hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
+    // hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
 
-    // this can be either 404.html in latest versions
-    // or _errors/404.html versions while this was experimental
-    static404Page =
-      staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
-        ? path.posix.join(entryDirectory, '404')
-        : staticPages[path.posix.join(entryDirectory, '_errors/404')]
-          ? path.posix.join(entryDirectory, '_errors/404')
-          : undefined;
+    // // this can be either 404.html in latest versions
+    // // or _errors/404.html versions while this was experimental
+    // static404Page =
+    //   staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
+    //     ? path.posix.join(entryDirectory, '404')
+    //     : staticPages[path.posix.join(entryDirectory, '_errors/404')]
+    //       ? path.posix.join(entryDirectory, '_errors/404')
+    //       : undefined;
 
-    const { i18n } = routesManifest || {};
+    // const { i18n } = routesManifest || {};
 
-    if (!static404Page && i18n) {
-      static404Page = staticPages[
-        path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-      ]
-        ? path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-        : undefined;
-    }
+    // if (!static404Page && i18n) {
+    //   static404Page = staticPages[
+    //     path.posix.join(entryDirectory, i18n.defaultLocale, '404')
+    //   ]
+    //     ? path.posix.join(entryDirectory, i18n.defaultLocale, '404')
+    //     : undefined;
+    // }
 
-    if (!hasStatic500 && i18n) {
-      hasStatic500 =
-        !!staticPages[
-          path.posix.join(entryDirectory, i18n.defaultLocale, '500')
-        ];
-    }
+    // if (!hasStatic500 && i18n) {
+    //   hasStatic500 =
+    //     !!staticPages[
+    //       path.posix.join(entryDirectory, i18n.defaultLocale, '500')
+    //     ];
+    // }
 
     if (routesManifest) {
       switch (routesManifest.version) {
@@ -1655,25 +1654,25 @@ export const build: BuildV2 = async buildOptions => {
 
     const nonLambdaSsgPages = new Set<string>();
 
-    Object.keys(prerenderManifest.staticRoutes).forEach(route => {
-      const result = onPrerenderRouteInitial(
-        prerenderManifest,
-        canUsePreviewMode,
-        entryDirectory,
-        nonLambdaSsgPages,
-        route,
-        hasPages404,
-        routesManifest
-      );
+    // Object.keys(prerenderManifest.staticRoutes).forEach(route => {
+    //   const result = onPrerenderRouteInitial(
+    //     prerenderManifest,
+    //     canUsePreviewMode,
+    //     entryDirectory,
+    //     nonLambdaSsgPages,
+    //     route,
+    //     hasPages404,
+    //     routesManifest
+    //   );
 
-      if (result && result.static404Page) {
-        static404Page = result.static404Page;
-      }
+    //   if (result && result.static404Page) {
+    //     static404Page = result.static404Page;
+    //   }
 
-      if (result && result.static500Page) {
-        hasStatic500 = true;
-      }
-    });
+    //   if (result && result.static500Page) {
+    //     hasStatic500 = true;
+    //   }
+    // });
     const pageTraces: {
       [page: string]: {
         [key: string]: FileFsRef;

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -87,6 +87,7 @@ import {
   normalizePackageJson,
   normalizePage,
   onPrerenderRoute,
+  onPrerenderRouteInitial,
   PseudoFile,
   PseudoLayer,
   PseudoLayerResult,
@@ -1183,9 +1184,9 @@ export const build: BuildV2 = async buildOptions => {
   const prerenders: { [key: string]: Prerender | FileFsRef } = {};
   let staticPages: { [key: string]: FileFsRef } = {};
   const dynamicPages: string[] = [];
-  const static404Page = undefined;
+  let static404Page: string | undefined;
   let page404Path = '';
-  const hasStatic500: false = false as const;
+  let hasStatic500: undefined | boolean;
 
   if (isLegacy) {
     const filesAfterBuild = await glob('**', entryPath);
@@ -1335,33 +1336,33 @@ export const build: BuildV2 = async buildOptions => {
       nextVersion,
       routesManifest
     );
-    // hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
+    hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
 
-    // // this can be either 404.html in latest versions
-    // // or _errors/404.html versions while this was experimental
-    // static404Page =
-    //   staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
-    //     ? path.posix.join(entryDirectory, '404')
-    //     : staticPages[path.posix.join(entryDirectory, '_errors/404')]
-    //       ? path.posix.join(entryDirectory, '_errors/404')
-    //       : undefined;
+    // this can be either 404.html in latest versions
+    // or _errors/404.html versions while this was experimental
+    static404Page =
+      staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
+        ? path.posix.join(entryDirectory, '404')
+        : staticPages[path.posix.join(entryDirectory, '_errors/404')]
+          ? path.posix.join(entryDirectory, '_errors/404')
+          : undefined;
 
-    // const { i18n } = routesManifest || {};
+    const { i18n } = routesManifest || {};
 
-    // if (!static404Page && i18n) {
-    //   static404Page = staticPages[
-    //     path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-    //   ]
-    //     ? path.posix.join(entryDirectory, i18n.defaultLocale, '404')
-    //     : undefined;
-    // }
+    if (!static404Page && i18n) {
+      static404Page = staticPages[
+        path.posix.join(entryDirectory, i18n.defaultLocale, '404')
+      ]
+        ? path.posix.join(entryDirectory, i18n.defaultLocale, '404')
+        : undefined;
+    }
 
-    // if (!hasStatic500 && i18n) {
-    //   hasStatic500 =
-    //     !!staticPages[
-    //       path.posix.join(entryDirectory, i18n.defaultLocale, '500')
-    //     ];
-    // }
+    if (!hasStatic500 && i18n) {
+      hasStatic500 =
+        !!staticPages[
+          path.posix.join(entryDirectory, i18n.defaultLocale, '500')
+        ];
+    }
 
     if (routesManifest) {
       switch (routesManifest.version) {
@@ -1654,25 +1655,25 @@ export const build: BuildV2 = async buildOptions => {
 
     const nonLambdaSsgPages = new Set<string>();
 
-    // Object.keys(prerenderManifest.staticRoutes).forEach(route => {
-    //   const result = onPrerenderRouteInitial(
-    //     prerenderManifest,
-    //     canUsePreviewMode,
-    //     entryDirectory,
-    //     nonLambdaSsgPages,
-    //     route,
-    //     hasPages404,
-    //     routesManifest
-    //   );
+    Object.keys(prerenderManifest.staticRoutes).forEach(route => {
+      const result = onPrerenderRouteInitial(
+        prerenderManifest,
+        canUsePreviewMode,
+        entryDirectory,
+        nonLambdaSsgPages,
+        route,
+        hasPages404,
+        routesManifest
+      );
 
-    //   if (result && result.static404Page) {
-    //     static404Page = result.static404Page;
-    //   }
+      if (result && result.static404Page) {
+        static404Page = result.static404Page;
+      }
 
-    //   if (result && result.static500Page) {
-    //     hasStatic500 = true;
-    //   }
-    // });
+      if (result && result.static500Page) {
+        hasStatic500 = true;
+      }
+    });
     const pageTraces: {
       [page: string]: {
         [key: string]: FileFsRef;

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -30,7 +30,6 @@ import {
   isDynamicRoute,
   normalizePage,
   getStaticFiles,
-  onPrerenderRouteInitial,
   onPrerenderRoute,
   normalizeLocalePath,
   PseudoFile,
@@ -432,7 +431,7 @@ export async function serverBuild({
     !experimentalAllowBundling &&
     semver.gte(nextVersion, CORRECTED_MANIFESTS_VERSION);
 
-  let hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
+  const hasStatic500 = false; //!!staticPages[path.posix.join(entryDirectory, '500')];
 
   if (lambdaPageKeys.length === 0) {
     throw new NowBuildError({
@@ -451,60 +450,62 @@ export async function serverBuild({
   };
 
   const { i18n } = routesManifest;
-  const hasPages404 = routesManifest.pages404;
+  // const hasPages404 = routesManifest.pages404;
 
-  let static404Page =
-    staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
-      ? path.posix.join(entryDirectory, '404')
-      : staticPages[path.posix.join(entryDirectory, '_errors/404')]
-        ? path.posix.join(entryDirectory, '_errors/404')
-        : undefined;
+  const static404Page = undefined;
+  // staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
+  //   ? path.posix.join(entryDirectory, '404')
+  //   : staticPages[path.posix.join(entryDirectory, '_errors/404')]
+  //     ? path.posix.join(entryDirectory, '_errors/404')
+  //     : undefined;
 
-  if (
-    !static404Page &&
-    i18n &&
-    staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
-  ) {
-    static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
-  }
+  // if (
+  //   !static404Page &&
+  //   i18n &&
+  //   staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
+  // ) {
+  //   static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
+  // }
 
-  if (!hasStatic500 && i18n) {
-    hasStatic500 =
-      !!staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '500')];
-  }
+  // if (!hasStatic500 && i18n) {
+  //   hasStatic500 =
+  //     !!staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '500')];
+  // }
 
   const lstatSema = new Sema(25);
   const lstatResults: { [key: string]: ReturnType<typeof lstat> } = {};
   const nonLambdaSsgPages = new Set<string>();
-  const static404Pages = new Set<string>(static404Page ? [static404Page] : []);
+  const static404Pages = new Set<string>(
+    /* static404Page ? [static404Page] : */ []
+  );
 
   // Only include internal pages that are actually existed
   const internalPages = [...INTERNAL_PAGES].filter(page => {
     return lambdaPages[page];
   });
 
-  Object.keys(prerenderManifest.staticRoutes).forEach(route => {
-    const result = onPrerenderRouteInitial(
-      prerenderManifest,
-      canUsePreviewMode,
-      entryDirectory,
-      nonLambdaSsgPages,
-      route,
-      routesManifest.pages404,
-      routesManifest,
-      appDir
-    );
+  // Object.keys(prerenderManifest.staticRoutes).forEach(route => {
+  //   const result = onPrerenderRouteInitial(
+  //     prerenderManifest,
+  //     canUsePreviewMode,
+  //     entryDirectory,
+  //     nonLambdaSsgPages,
+  //     route,
+  //     routesManifest.pages404,
+  //     routesManifest,
+  //     appDir
+  //   );
 
-    if (result && result.static404Page) {
-      // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
-      static404Pages.add(result.static404Page);
-      static404Page = result.static404Page;
-    }
+  //   if (result && result.static404Page) {
+  //     // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
+  //     // static404Pages.add(result.static404Page);
+  //     // static404Page = result.static404Page;
+  //   }
 
-    if (result && result.static500Page) {
-      hasStatic500 = true;
-    }
-  });
+  //   if (result && result.static500Page) {
+  //     hasStatic500 = true;
+  //   }
+  // });
   const hasLambdas =
     !static404Page ||
     lambdaPageKeys.some(
@@ -714,12 +715,12 @@ export async function serverBuild({
     if (static404Pages.size > 0) {
       // If we've generated a static 404 page, it's possible that we also
       // have a static 404 page for each locale.
-      if (i18n) {
-        for (const locale of i18n.locales) {
-          const static404Page = path.posix.join(entryDirectory, locale, '404');
-          static404Pages.add(static404Page);
-        }
-      }
+      // if (i18n) {
+      //   for (const locale of i18n.locales) {
+      //     const static404Page = path.posix.join(entryDirectory, locale, '404');
+      //     static404Pages.add(static404Page);
+      //   }
+      // }
 
       for (const static404Page of static404Pages) {
         let static404File = staticPages[static404Page];

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -30,6 +30,7 @@ import {
   isDynamicRoute,
   normalizePage,
   getStaticFiles,
+  onPrerenderRouteInitial,
   onPrerenderRoute,
   normalizeLocalePath,
   PseudoFile,
@@ -431,7 +432,7 @@ export async function serverBuild({
     !experimentalAllowBundling &&
     semver.gte(nextVersion, CORRECTED_MANIFESTS_VERSION);
 
-  const hasStatic500 = false; //!!staticPages[path.posix.join(entryDirectory, '500')];
+  let hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
 
   if (lambdaPageKeys.length === 0) {
     throw new NowBuildError({
@@ -450,62 +451,60 @@ export async function serverBuild({
   };
 
   const { i18n } = routesManifest;
-  // const hasPages404 = routesManifest.pages404;
+  const hasPages404 = routesManifest.pages404;
 
-  const static404Page = undefined;
-  // staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
-  //   ? path.posix.join(entryDirectory, '404')
-  //   : staticPages[path.posix.join(entryDirectory, '_errors/404')]
-  //     ? path.posix.join(entryDirectory, '_errors/404')
-  //     : undefined;
+  let static404Page =
+    staticPages[path.posix.join(entryDirectory, '404')] && hasPages404
+      ? path.posix.join(entryDirectory, '404')
+      : staticPages[path.posix.join(entryDirectory, '_errors/404')]
+        ? path.posix.join(entryDirectory, '_errors/404')
+        : undefined;
 
-  // if (
-  //   !static404Page &&
-  //   i18n &&
-  //   staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
-  // ) {
-  //   static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
-  // }
+  if (
+    !static404Page &&
+    i18n &&
+    staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '404')]
+  ) {
+    static404Page = path.posix.join(entryDirectory, i18n.defaultLocale, '404');
+  }
 
-  // if (!hasStatic500 && i18n) {
-  //   hasStatic500 =
-  //     !!staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '500')];
-  // }
+  if (!hasStatic500 && i18n) {
+    hasStatic500 =
+      !!staticPages[path.posix.join(entryDirectory, i18n.defaultLocale, '500')];
+  }
 
   const lstatSema = new Sema(25);
   const lstatResults: { [key: string]: ReturnType<typeof lstat> } = {};
   const nonLambdaSsgPages = new Set<string>();
-  const static404Pages = new Set<string>(
-    /* static404Page ? [static404Page] : */ []
-  );
+  const static404Pages = new Set<string>(static404Page ? [static404Page] : []);
 
   // Only include internal pages that are actually existed
   const internalPages = [...INTERNAL_PAGES].filter(page => {
     return lambdaPages[page];
   });
 
-  // Object.keys(prerenderManifest.staticRoutes).forEach(route => {
-  //   const result = onPrerenderRouteInitial(
-  //     prerenderManifest,
-  //     canUsePreviewMode,
-  //     entryDirectory,
-  //     nonLambdaSsgPages,
-  //     route,
-  //     routesManifest.pages404,
-  //     routesManifest,
-  //     appDir
-  //   );
+  Object.keys(prerenderManifest.staticRoutes).forEach(route => {
+    const result = onPrerenderRouteInitial(
+      prerenderManifest,
+      canUsePreviewMode,
+      entryDirectory,
+      nonLambdaSsgPages,
+      route,
+      routesManifest.pages404,
+      routesManifest,
+      appDir
+    );
 
-  //   if (result && result.static404Page) {
-  //     // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
-  //     // static404Pages.add(result.static404Page);
-  //     // static404Page = result.static404Page;
-  //   }
+    if (result && result.static404Page) {
+      // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
+      static404Pages.add(result.static404Page);
+      static404Page = result.static404Page;
+    }
 
-  //   if (result && result.static500Page) {
-  //     hasStatic500 = true;
-  //   }
-  // });
+    if (result && result.static500Page) {
+      hasStatic500 = true;
+    }
+  });
   const hasLambdas =
     !static404Page ||
     lambdaPageKeys.some(
@@ -715,12 +714,12 @@ export async function serverBuild({
     if (static404Pages.size > 0) {
       // If we've generated a static 404 page, it's possible that we also
       // have a static 404 page for each locale.
-      // if (i18n) {
-      //   for (const locale of i18n.locales) {
-      //     const static404Page = path.posix.join(entryDirectory, locale, '404');
-      //     static404Pages.add(static404Page);
-      //   }
-      // }
+      if (i18n) {
+        for (const locale of i18n.locales) {
+          const static404Page = path.posix.join(entryDirectory, locale, '404');
+          static404Pages.add(static404Page);
+        }
+      }
 
       for (const static404Page of static404Pages) {
         let static404File = staticPages[static404Page];

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -476,7 +476,6 @@ export async function serverBuild({
   const lstatSema = new Sema(25);
   const lstatResults: { [key: string]: ReturnType<typeof lstat> } = {};
   const nonLambdaSsgPages = new Set<string>();
-  const static404Pages = new Set<string>(static404Page ? [static404Page] : []);
 
   // Only include internal pages that are actually existed
   const internalPages = [...INTERNAL_PAGES].filter(page => {
@@ -494,12 +493,6 @@ export async function serverBuild({
       routesManifest,
       appDir
     );
-
-    if (result && result.static404Page) {
-      // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
-      static404Pages.add(result.static404Page);
-      static404Page = result.static404Page;
-    }
 
     if (result && result.static500Page) {
       hasStatic500 = true;
@@ -710,43 +703,6 @@ export async function serverBuild({
       mode: (await fs.lstat(nextServerFile)).mode,
       fsPath: nextServerFile,
     });
-
-    if (static404Pages.size > 0) {
-      // If we've generated a static 404 page, it's possible that we also
-      // have a static 404 page for each locale.
-      if (i18n) {
-        for (const locale of i18n.locales) {
-          const static404Page = path.posix.join(entryDirectory, locale, '404');
-          static404Pages.add(static404Page);
-        }
-      }
-
-      for (const static404Page of static404Pages) {
-        let static404File = staticPages[static404Page];
-
-        if (!static404File) {
-          // if we have a file ref already, we can use it. Otherwise, we need
-          // to create a new one, but we need to ensure it exists on disk
-          const static404FilePath = path.join(
-            pagesDir,
-            `${static404Page}.html`
-          );
-
-          if (fs.existsSync(static404FilePath)) {
-            static404File = new FileFsRef({
-              fsPath: static404FilePath,
-            });
-          }
-        }
-
-        // ensure each static 404 page file is included in all lambdas
-        // for notFound GS(S)P support
-        if (static404File) {
-          requiredFiles[path.relative(baseDir, static404File.fsPath)] =
-            static404File;
-        }
-      }
-    }
 
     // TODO: move this into Next.js' required server files manifest
     const envFiles = [];

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -760,3 +760,27 @@ describe('action-headers', () => {
     expect(foundActionNames.sort()).toMatchSnapshot();
   });
 });
+
+describe('determinism', () => {
+  /**
+   * @type {import('@vercel/build-utils').BuildResultV2Typical}
+   */
+  let buildResult;
+
+  beforeAll(async () => {
+    const result = await runBuildLambda(
+      path.join(__dirname, '../fixtures/00-app-dir-not-found-pages-interop')
+    );
+    buildResult = result.buildResult;
+  });
+
+  it('should not include prerenders in functions lambdas', async () => {
+    for (const entry of Object.values(buildResult.output)) {
+      if (entry.type === 'Lambda' || entry.type === 'EdgeFunction') {
+        expect(Object.keys(entry.files)).not.toContainEqual(
+          expect.stringMatching(/\.html$|.rsc$/)
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes PACK-6560

They were only there as an optimization, but introduce nondeterminism because the HTML contains the build id and deployment id