### PR TITLE
[cli] Use promote flow when targeting production alias

### DIFF
--- a/.changeset/smart-alias-promote.md
+++ b/.changeset/smart-alias-promote.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Updated `vercel alias` command to use the promote flow when aliasing to a production alias. When the target alias matches one of the project's configured production domains, the command now calls the promote API instead of directly assigning the alias, ensuring proper production deployment handling.

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -428,9 +428,7 @@ async function tryPromoteForProductionAlias(
     return null;
   }
 
-  output.log(
-    `${chalk.bold(aliasTarget)} is a production alias - promoting.`
-  );
+  output.log(`${chalk.bold(aliasTarget)} is a production alias - promoting.`);
 
   return requestPromote({
     client,

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -429,7 +429,7 @@ async function tryPromoteForProductionAlias(
   }
 
   output.log(
-    `Alias ${chalk.bold(aliasTarget)} is a production alias. Using promote flow.`
+    `${chalk.bold(aliasTarget)} is a production alias - promoting.`
   );
 
   return requestPromote({

--- a/packages/cli/src/commands/alias/set.ts
+++ b/packages/cli/src/commands/alias/set.ts
@@ -407,9 +407,7 @@ function isProductionAlias(project: Project, alias: string): boolean {
     return false;
   }
   const normalizedAlias = toHost(alias);
-  return productionAliases.some(
-    prodAlias => prodAlias === normalizedAlias || prodAlias.endsWith(normalizedAlias)
-  );
+  return productionAliases.includes(normalizedAlias);
 }
 
 async function tryPromoteForProductionAlias(

--- a/packages/cli/test/unit/commands/alias/set.test.ts
+++ b/packages/cli/test/unit/commands/alias/set.test.ts
@@ -81,6 +81,7 @@ describe('alias set', () => {
   describe('[deployment url] [custom domain]', () => {
     it('tracks arguments', async () => {
       const user = useUser();
+      useProject();
       const { url } = useDeployment({ creator: user });
       client.scenario.post(
         '/:version/deployments/:id/aliases',
@@ -178,7 +179,7 @@ describe('alias set', () => {
     it('uses regular alias flow when alias target is not a production alias', async () => {
       const user = useUser();
       const productionAlias = 'my-app.vercel.app';
-      const customAlias = 'custom-alias.example.com';
+      const customAlias = 'custom-alias.vercel.app';
       const { project } = useProject({
         ...defaultProject,
         id: 'test-project',

--- a/packages/cli/test/unit/commands/alias/set.test.ts
+++ b/packages/cli/test/unit/commands/alias/set.test.ts
@@ -165,7 +165,7 @@ describe('alias set', () => {
       const exitCodePromise = alias(client);
 
       await expect(client.stderr).toOutput(
-        `Alias ${chalk.bold(productionAlias)} is a production alias. Using promote flow.`
+        `${chalk.bold(productionAlias)} is a production alias - promoting.`
       );
       await expect(client.stderr).toOutput(
         `Success! ${chalk.bold(project.name)} was promoted to`

--- a/packages/cli/test/unit/commands/alias/set.test.ts
+++ b/packages/cli/test/unit/commands/alias/set.test.ts
@@ -1,8 +1,11 @@
+import chalk from 'chalk';
 import { describe, it, expect, vi } from 'vitest';
 import alias from '../../../../src/commands/alias';
 import { client } from '../../../mocks/client';
 import { useUser } from '../../../mocks/user';
 import { useDeployment } from '../../../mocks/deployment';
+import { defaultProject, useProject } from '../../../mocks/project';
+import type { LastAliasRequest } from '@vercel-internals/types';
 
 vi.setConfig({ testTimeout: 600000 });
 
@@ -103,6 +106,123 @@ describe('alias set', () => {
           value: '[REDACTED]',
         },
       ]);
+    });
+  });
+
+  describe('production alias detection', () => {
+    it('uses promote flow when alias target matches production alias', async () => {
+      const user = useUser();
+      const productionAlias = 'my-app.vercel.app';
+      const { project } = useProject({
+        ...defaultProject,
+        id: 'test-project',
+        name: 'test-project',
+        targets: {
+          production: {
+            ...defaultProject.targets?.production,
+            alias: [productionAlias],
+          } as any,
+        },
+      });
+
+      const deployment = useDeployment({
+        creator: user,
+        project,
+        target: 'production',
+      });
+
+      let promoteEndpointCalled = false;
+      let lastAliasRequest: LastAliasRequest | null = null;
+
+      client.scenario.post(
+        '/:version/projects/:project/promote/:id',
+        (req, res) => {
+          promoteEndpointCalled = true;
+          const { id } = req.params;
+
+          lastAliasRequest = {
+            fromDeploymentId: 'old-deploy',
+            jobStatus: 'succeeded',
+            requestedAt: Date.now(),
+            toDeploymentId: id,
+            type: 'promote',
+          };
+
+          Object.defineProperty(project, 'lastAliasRequest', {
+            get(): LastAliasRequest | null {
+              return lastAliasRequest;
+            },
+            configurable: true,
+          });
+
+          res.statusCode = 201;
+          res.end();
+        }
+      );
+
+      client.setArgv('alias', 'set', deployment.url, productionAlias);
+      const exitCodePromise = alias(client);
+
+      await expect(client.stderr).toOutput(
+        `Alias ${chalk.bold(productionAlias)} is a production alias. Using promote flow.`
+      );
+      await expect(client.stderr).toOutput(
+        `Success! ${chalk.bold(project.name)} was promoted to`
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode, 'exit code of "alias"').toEqual(0);
+      expect(promoteEndpointCalled).toBe(true);
+    });
+
+    it('uses regular alias flow when alias target is not a production alias', async () => {
+      const user = useUser();
+      const productionAlias = 'my-app.vercel.app';
+      const customAlias = 'custom-alias.example.com';
+      const { project } = useProject({
+        ...defaultProject,
+        id: 'test-project',
+        name: 'test-project',
+        targets: {
+          production: {
+            ...defaultProject.targets?.production,
+            alias: [productionAlias],
+          } as any,
+        },
+      });
+
+      const deployment = useDeployment({
+        creator: user,
+        project,
+        target: 'production',
+      });
+
+      let regularAliasEndpointCalled = false;
+      let promoteEndpointCalled = false;
+
+      client.scenario.post(
+        '/:version/deployments/:id/aliases',
+        (request, response) => {
+          regularAliasEndpointCalled = true;
+          response.json({ alias: customAlias });
+        }
+      );
+
+      client.scenario.post(
+        '/:version/projects/:project/promote/:id',
+        (req, res) => {
+          promoteEndpointCalled = true;
+          res.statusCode = 201;
+          res.end();
+        }
+      );
+
+      client.setArgv('alias', 'set', deployment.url, customAlias);
+      const exitCode = await alias(client);
+
+      expect(exitCode, 'exit code of "alias"').toEqual(0);
+      expect(regularAliasEndpointCalled).toBe(true);
+      expect(promoteEndpointCalled).toBe(false);
     });
   });
 });


### PR DESCRIPTION
`vc alias set [alias] [production alias]` causes problems when users expect that to promote the alias. For example, https://linear.app/vercel/issue/PIPE-5641/unexpected-rollback-when-an-aliased-domain-is-edited-oror-00922719.

This updates `vc alias set` so that if we detect the target alias is a production alias, we use the promote flow.

<img width="1271" height="99" alt="image" src="https://github.com/user-attachments/assets/315515f7-ecd8-4f8d-8410-9785cf50c3d0" />
