### PR TITLE
Remove useTypescript5 option and always use TypeScript 5

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -41,8 +41,7 @@
     "path-to-regexp": "6.1.0",
     "ts-morph": "12.0.0",
     "ts-node": "10.9.1",
-    "typescript": "4.9.5",
-    "typescript5": "npm:typescript@5.9.3",
+    "typescript": "5.9.3",
     "undici": "5.28.4"
   },
   "devDependencies": {

--- a/packages/node/src/build.ts
+++ b/packages/node/src/build.ts
@@ -145,8 +145,7 @@ async function compile(
   config: Config,
   meta: Meta,
   nodeVersion: NodeVersion,
-  isEdgeFunction: boolean,
-  useTypescript5 = false
+  isEdgeFunction: boolean
 ): Promise<{
   preparedFiles: Files;
   shouldAddSourcemapSupport: boolean;
@@ -188,7 +187,6 @@ async function compile(
         project: path, // Resolve tsconfig.json from entrypoint dir
         files: true, // Include all files such as global `.d.ts`
         nodeVersionMajor: nodeVersion.major,
-        useTypescript5,
       });
     }
     const { code, map } = tsCompile(source, path);
@@ -514,8 +512,6 @@ export const build = async ({
     isBun: isBunVersion(nodeVersion),
   });
 
-  // Opt backend builders to use typescript5
-  const useTypescript5 = considerBuildCommand;
   debug('Tracing input files...');
   const traceTime = Date.now();
   const { preparedFiles, shouldAddSourcemapSupport } = await compile(
@@ -525,8 +521,7 @@ export const build = async ({
     config,
     meta,
     nodeVersion,
-    isEdgeFunction,
-    useTypescript5
+    isEdgeFunction
   );
   debug(`Trace complete [${Date.now() - traceTime}ms]`);
 

--- a/packages/node/src/typescript.ts
+++ b/packages/node/src/typescript.ts
@@ -124,9 +124,7 @@ const configFileToBuildMap = new Map<string, GetOutputFunction>();
 /**
  * Register TypeScript compiler.
  */
-export function register(
-  opts: Options & { useTypescript5?: boolean } = {}
-): Register {
+export function register(opts: Options = {}): Register {
   const options = Object.assign({}, DEFAULTS, opts);
 
   const ignoreDiagnostics = [
@@ -144,11 +142,11 @@ export function register(
       paths: [options.project || cwd],
     });
   } catch (e) {
-    compiler = opts.useTypescript5 ? 'typescript5' : 'typescript';
+    compiler = 'typescript';
   }
   //eslint-disable-next-line @typescript-eslint/no-var-requires
   const ts: typeof _ts = require_(compiler);
-  if (compiler === 'typescript' || compiler === 'typescript5') {
+  if (compiler === 'typescript') {
     console.log(
       `Using built-in TypeScript ${ts.version} since "typescript" is missing from "devDependencies"`
     );


### PR DESCRIPTION
## Summary
- Remove conditional `useTypescript5` option from @vercel/node package
- Always use TypeScript 5.9.3 instead of maintaining two versions
- Simplify package.json by removing `typescript5` npm alias
- Clean up code by removing all `useTypescript5` parameters and logic

## Changes Made
- **package.json**: Updated `typescript` from 4.9.5 to 5.9.3, removed `typescript5` alias
- **build.ts**: Removed `useTypescript5` parameter from `compile` function and its usage
- **typescript.ts**: Removed `useTypescript5` option from `register` function, simplified compiler fallback logic

## Test Plan
- [ ] Verify TypeScript compilation works correctly for Node.js functions
- [ ] Ensure edge functions still compile properly
- [ ] Test both development and production builds
- [ ] Verify no breaking changes in existing functionality


Made with [Cursor](https://cursor.com)