### PR TITLE
feat(cli): improve logsv2 output format

### DIFF
--- a/.changeset/logsv2-compact-output.md
+++ b/.changeset/logsv2-compact-output.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Improve logsv2 command output format with compact single-line display, text-based level labels, dynamic column widths, and smart date display

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -3,7 +3,9 @@ import { packageName } from '../../util/pkg-name';
 export const logsv2Command = {
   name: 'logsv2',
   aliases: [],
-  description: 'Display request logs for a project using the new logs API.',
+  description:
+    'Display request logs for a project using the new logs API.\n\n' +
+    'Source types: λ = serverless, ε = edge, ◇ = static',
   hidden: true,
   arguments: [
     {

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -5,7 +5,7 @@ export const logsv2Command = {
   aliases: [],
   description:
     'Display request logs for a project using the new logs API.\n\n' +
-    'Source types: λ = serverless, ε = edge, ◇ = static',
+    'Source types: λ = serverless, ε = edge/middleware, ◇ = static/external',
   hidden: true,
   arguments: [
     {

--- a/packages/cli/src/commands/logsv2/command.ts
+++ b/packages/cli/src/commands/logsv2/command.ts
@@ -106,6 +106,13 @@ export const logsv2Command = {
       deprecated: false,
       description: 'Filter by request ID',
     },
+    {
+      name: 'expand',
+      shorthand: 'x',
+      type: Boolean,
+      deprecated: false,
+      description: 'Show full log message below each request line',
+    },
   ],
   examples: [
     {
@@ -143,6 +150,10 @@ export const logsv2Command = {
     {
       name: 'Display logs for a specific request',
       value: `${packageName} logsv2 --request-id req_xxxxx`,
+    },
+    {
+      name: 'Display logs with full message details',
+      value: `${packageName} logsv2 --expand`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -320,7 +320,7 @@ export default async function logsv2(client: Client) {
   if (!jsonOption) {
     if (logs.length === 0) {
       output.print(
-        chalk.gray('No logs found matching the specified filters.\n')
+        chalk.dim(`No logs found for project ${projectId} in ${contextName}\n`)
       );
     } else {
       const maxMethodWidth = Math.max(...logs.map(l => l.requestMethod.length));

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -339,7 +339,7 @@ export default async function logsv2(client: Client) {
       }
       output.print(
         chalk.gray(
-          `\nFetched ${logs.length} logs for project ${projectId} in ${contextName}\n`
+          `Fetched ${logs.length} logs for project ${projectId} in ${contextName}\n`
         )
       );
     }

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -23,7 +23,7 @@ import { logsv2Command } from './command';
 import output from '../../output-manager';
 
 const TIME_ONLY_FORMAT = 'HH:mm:ss.SS';
-const DATE_TIME_FORMAT = 'MMM dd HH:mm:ss.SS';
+const DATE_TIME_FORMAT = 'MMM DD HH:mm:ss.SS';
 
 const COL_TIME_ONLY = 11;
 const COL_TIME_WITH_DATE = 18;

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -330,7 +330,7 @@ function prettyPrintLogEntry(log: RequestLogEntry, options: PrintOptions = {}) {
   const level = getLevelLabel(log.level);
   const method = log.requestMethod.padEnd(4);
   const status =
-    log.responseStatusCode <= 0
+    !log.responseStatusCode || log.responseStatusCode <= 0
       ? chalk.gray('---')
       : getStatusColor(log.responseStatusCode);
   const source = getSourceIcon(log.source);

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -445,7 +445,7 @@ function getSourceIcon(source: string): string {
     case 'redirect':
       return '◇';
     default:
-      return '○';
+      return ' ';
   }
 }
 

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -6,6 +6,7 @@ import { printError } from '../../util/error';
 import { parseArguments } from '../../util/get-args';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import getScope from '../../util/get-scope';
+import { formatProject } from '../../util/projects/format-project';
 import getProjectByIdOrName from '../../util/projects/get-project-by-id-or-name';
 import { getLinkedProject } from '../../util/projects/link';
 import {
@@ -268,7 +269,8 @@ export default async function logsv2(client: Client) {
   }
 
   let projectId: string;
-  let projectName: string;
+  let projectSlug: string;
+  let orgSlug: string;
   let ownerId: string;
 
   if (projectOption) {
@@ -285,7 +287,8 @@ export default async function logsv2(client: Client) {
       return 1;
     }
     projectId = project.id;
-    projectName = project.name;
+    projectSlug = project.name;
+    orgSlug = contextName!;
     ownerId = project.accountId;
   } else {
     const link = await getLinkedProject(client);
@@ -302,7 +305,8 @@ export default async function logsv2(client: Client) {
     client.config.currentTeam =
       link.org.type === 'team' ? link.org.id : undefined;
     projectId = link.project.id;
-    projectName = link.project.name;
+    projectSlug = link.project.name;
+    orgSlug = link.org.slug;
     ownerId = link.org.id;
   }
 
@@ -427,7 +431,9 @@ export default async function logsv2(client: Client) {
 
   if (!jsonOption) {
     if (logs.length === 0) {
-      output.print(chalk.dim(`No logs found for ${projectName}\n`));
+      output.print(
+        chalk.dim(`No logs found for ${formatProject(orgSlug, projectSlug)}\n`)
+      );
     } else {
       const showDate = logsSpanMultipleDays(logs);
       const timeFormat = showDate ? DATE_TIME_FORMAT : TIME_ONLY_FORMAT;
@@ -526,7 +532,9 @@ export default async function logsv2(client: Client) {
       }
 
       output.print(
-        chalk.gray(`Fetched ${logs.length} logs for ${projectName}\n`)
+        chalk.gray(
+          `Fetched ${logs.length} logs for ${formatProject(orgSlug, projectSlug)}\n`
+        )
       );
     }
   }

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -359,7 +359,7 @@ interface PrintOptions {
 function printHeader(options: PrintOptions) {
   const { expand, showDate, methodWidth = 4, pathWidth = 10 } = options;
   const colTime = showDate ? COL_TIME_WITH_DATE : COL_TIME_ONLY;
-  const pathColWidth = COL_SOURCE + 1 + methodWidth + 1 + pathWidth; // source + space + method + space + path
+  const pathColWidth = COL_SOURCE + 1 + methodWidth + 1 + pathWidth + 3; // source + space + method + space + path + padding
   const cols: string[] = [];
 
   cols.push('TIME'.padEnd(colTime));

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -410,10 +410,7 @@ function prettyPrintLogEntry(log: RequestLogEntry, options: PrintOptions = {}) {
       20
     );
     const msg = log.message
-      ? colorizeMessage(
-          `"${truncateMessage(log.message, msgWidth - 2)}"`,
-          log.level
-        )
+      ? colorizeMessage(truncateMessage(log.message, msgWidth), log.level)
       : chalk.dim('(no message)');
 
     const cols = [chalk.dim(time), level, pathPart, status, msg];

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -280,12 +280,6 @@ export default async function logsv2(client: Client) {
 
   const limit = limitOption ?? 100;
 
-  if (!jsonOption) {
-    output.print(
-      `Fetching logs for project ${chalk.bold(projectId)} in ${chalk.bold(contextName)}...\n\n`
-    );
-  }
-
   output.spinner('Fetching logs...', 1000);
 
   const terminalWidth = client.stderr.isTTY
@@ -343,7 +337,11 @@ export default async function logsv2(client: Client) {
       for (const log of logs) {
         prettyPrintLogEntry(log, printOpts);
       }
-      output.print(chalk.gray(`\nDisplayed ${logs.length} log entries.\n`));
+      output.print(
+        chalk.gray(
+          `\nFetched ${logs.length} logs for project ${projectId} in ${contextName}\n`
+        )
+      );
     }
   }
 

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -226,7 +226,7 @@ export default async function logsv2(client: Client) {
   if (followOption) {
     if (!jsonOption) {
       output.print(
-        `Streaming logs for deployment ${chalk.bold(deploymentId)} starting from ${chalk.bold(format(Date.now(), TIME_FORMAT))}\n\n`
+        `Streaming logs for deployment ${chalk.bold(deploymentId)} starting from ${chalk.bold(format(Date.now(), TIME_ONLY_FORMAT))}\n\n`
       );
     }
     const abortController = new AbortController();

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -23,10 +23,10 @@ import { logsv2Command } from './command';
 import output from '../../output-manager';
 
 const TIME_ONLY_FORMAT = 'HH:mm:ss.SS';
-const DATE_TIME_FORMAT = 'MMM dd HH:mm:ss';
+const DATE_TIME_FORMAT = 'MMM dd HH:mm:ss.SS';
 
 const COL_TIME_ONLY = 11;
-const COL_TIME_WITH_DATE = 15;
+const COL_TIME_WITH_DATE = 18;
 const COL_LEVEL = 5;
 const COL_SOURCE = 1;
 const COL_STATUS = 6;
@@ -362,7 +362,7 @@ function printHeader(options: PrintOptions) {
 
   cols.push((showDate ? 'DATE/TIME' : 'TIME').padEnd(colTime));
   cols.push('LEVEL'.padEnd(COL_LEVEL));
-  cols.push('PATH');
+  cols.push('  PATH'); // 2-char indent to align with method (after source icon + space)
 
   if (expand) {
     output.print(chalk.dim(cols.join('  ') + '\n'));

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -268,6 +268,7 @@ export default async function logsv2(client: Client) {
   }
 
   let projectId: string;
+  let projectName: string;
   let ownerId: string;
 
   if (projectOption) {
@@ -284,6 +285,7 @@ export default async function logsv2(client: Client) {
       return 1;
     }
     projectId = project.id;
+    projectName = project.name;
     ownerId = project.accountId;
   } else {
     const link = await getLinkedProject(client);
@@ -300,6 +302,7 @@ export default async function logsv2(client: Client) {
     client.config.currentTeam =
       link.org.type === 'team' ? link.org.id : undefined;
     projectId = link.project.id;
+    projectName = link.project.name;
     ownerId = link.org.id;
   }
 
@@ -424,9 +427,7 @@ export default async function logsv2(client: Client) {
 
   if (!jsonOption) {
     if (logs.length === 0) {
-      output.print(
-        chalk.dim(`No logs found for project ${projectId} in ${contextName}\n`)
-      );
+      output.print(chalk.dim(`No logs found for ${projectName}\n`));
     } else {
       const showDate = logsSpanMultipleDays(logs);
       const timeFormat = showDate ? DATE_TIME_FORMAT : TIME_ONLY_FORMAT;
@@ -525,9 +526,7 @@ export default async function logsv2(client: Client) {
       }
 
       output.print(
-        chalk.gray(
-          `Fetched ${logs.length} logs for project ${projectId} in ${contextName}\n`
-        )
+        chalk.gray(`Fetched ${logs.length} logs for ${projectName}\n`)
       );
     }
   }

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -360,7 +360,7 @@ function printHeader(options: PrintOptions) {
   const colTime = showDate ? COL_TIME_WITH_DATE : COL_TIME_ONLY;
   const cols: string[] = [];
 
-  cols.push((showDate ? 'DATE/TIME' : 'TIME').padEnd(colTime));
+  cols.push('TIME'.padEnd(colTime));
   cols.push('LEVEL'.padEnd(COL_LEVEL));
   cols.push('  PATH'); // 2-char indent to align with method (after source icon + space)
 

--- a/packages/cli/src/commands/logsv2/index.ts
+++ b/packages/cli/src/commands/logsv2/index.ts
@@ -434,14 +434,18 @@ function getLevelLabel(level: string): string {
 function getSourceIcon(source: string): string {
   switch (source) {
     case 'serverless':
+    case 'lambda':
       return 'λ';
     case 'edge-function':
     case 'edge-middleware':
+    case 'middleware':
       return 'ε';
     case 'static':
+    case 'external':
+    case 'redirect':
       return '◇';
     default:
-      return ' ';
+      return '○';
   }
 }
 

--- a/packages/cli/src/util/telemetry/commands/logsv2/index.ts
+++ b/packages/cli/src/util/telemetry/commands/logsv2/index.ts
@@ -141,4 +141,10 @@ export class Logsv2TelemetryClient
       });
     }
   }
+
+  trackCliFlagExpand(v: boolean | undefined) {
+    if (v) {
+      this.trackCliFlag('expand');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Improve the `logsv2` command output to be more compact and terminal-friendly.

## Changes

- **Single-line compact format** with inline message snippets
- **Text-based level labels** (`info`, `warn`, `error`, `fatal`) instead of emojis
- **Simplified source icons**: `λ` (serverless), `ε` (edge), `◇` (static)
- **Dynamic column widths** based on actual data (method width adapts to visible methods)
- **Smart date display**: shows date only when logs span multiple days (with milliseconds)
- **Color-coded output**: levels, status codes, and messages colored by severity
- **`--expand` flag** (`-x`) to show full message details below each request line
- **Automatic color disable** in non-TTY mode (piping/redirects)

## Output Format

**Same day:**
```
TIME         LEVEL    PATH                            STATUS  MESSAGE
14:23:45.23  error  λ GET    /api/users               500     TypeError: Cannot read property...
14:23:46.12  info   λ POST   /api/posts               201     Created post id=123
14:23:47.89  warn   ε DELETE /api/items/123           204     Item deleted
```

**Multiple days:**
```
DATE/TIME           LEVEL    PATH                        STATUS  MESSAGE
Jan 27 14:23:45.23  error  λ GET /api/users              500     TypeError: Cannot read...
Jan 28 09:15:22.45  info   λ GET /api/posts              200     Success
```

**Expanded mode (`--expand`):**
```
TIME         LEVEL    PATH
14:23:45.23  error  λ GET /api/users
TypeError: Cannot read property 'id' of undefined
    at UserController.getUser (/api/users.js:42:15)

14:23:46.12  info   λ POST /api/posts
Created post id=123
```

## Color Scheme

| Element | Color |
|---------|-------|
| Level `fatal` | red bold |
| Level `error` | red |
| Level `warn` | yellow |
| Level `info` | dim |
| Status 5xx | red |
| Status 4xx | yellow |
| Status 3xx | cyan |
| Status 2xx | green |
| Message (error/fatal) | red |
| Message (warning) | yellow |
| Message (info) | dim |