### PR TITLE
[next]: ensure static data routes are used

### DIFF
--- a/.changeset/many-terms-whisper.md
+++ b/.changeset/many-terms-whisper.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+ensure static .rsc outputs are served as fallbacks


### PR DESCRIPTION
In legacy versions of PPR, the `prefetchDataRoute` entries would be populated with `.prefetch.rsc` values containing static RSC payloads. This regressed in cache components, and the only static RSC payloads were in the `.segments` directory. However, when Next.js triggers a regular RSC request (non-prefetch), either because the prefetch hadn't completed yet or `prefetch={false}` was configured, we'd route to the empty fallback and trigger a function invocation.

Normally just setting `prefetchDataRoute` in Next.js would have been sufficient, but with Cache Components, all `.rsc` outputs contain both a `prefetchDataRoute` and a `dataRoute`. Prior to this change, the builder would have created a fallback file containing the payload specified by `prefetchDataRoute`, but in the PPR dynamic branch it was overwriting that entry with a “dynamic RSC” prerender that has no fallback, which effectively turned the static `.rsc` into an empty fallback on Vercel. Without this, the new Next signal is ignored and static navigations still trigger dynamic renders on Vercel.