### PR TITLE
[CLI] Add redirects to top level help

### DIFF
--- a/.changeset/slow-knives-lick.md
+++ b/.changeset/slow-knives-lick.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add redirects command to top level help message.

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -45,6 +45,7 @@ export const help = () => `
       logs                 [url]       Displays the logs for a deployment
       microfrontends                   Manages your microfrontends
       projects                         Manages your Projects
+      redirects            [cmd]       Manages redirects for your current Project
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams
       upgrade                          Upgrade the Vercel CLI to the latest version

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -43,6 +43,7 @@ exports[`base level help output > help 1`] = `
       logs                 [url]       Displays the logs for a deployment
       microfrontends                   Manages your microfrontends
       projects                         Manages your Projects
+      redirects            [cmd]       Manages redirects for your current Project
       rm | remove          [id]        Removes a deployment
       teams                            Manages your teams
       upgrade                          Upgrade the Vercel CLI to the latest version


### PR DESCRIPTION
The `redirects` command was missing from the top level help when you ran `vercel -h`. This PR adds it so that users know it's available.