### PR TITLE
update fixture runtime

### DIFF
--- a/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/main.js
+++ b/packages/cli/test/fixtures/unit/commands/build/functions-symlink/.vercel/builders/node_modules/functions-symlink/main.js
@@ -3,7 +3,7 @@ const { Lambda, EdgeFunction } = require('@vercel/build-utils');
 exports.build = async () => {
     const lambda = new Lambda({
         files: {},
-        runtime: 'provided',
+        runtime: 'provided.al2023',
         handler: 'example.js'
     });
     const edge = new EdgeFunction({


### PR DESCRIPTION
AL2 will be soon deprecated by AWS and with that the `provided` runtime as well.
The Vercel build system [doesn't support](https://github.com/vercel/api/pull/59194#discussion_r2732041003) `provided` either anymore, use `provided.al2023` instead.