### PR TITLE
[next] Strip routes-manifest.json for determinism

### DIFF
--- a/.changeset/large-mice-reply.md
+++ b/.changeset/large-mice-reply.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Strip routes-manifest.json for determinism

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -428,9 +428,11 @@ export async function serverBuild({
   );
   // experimental bundling prevents filtering manifests
   // as we don't know what to filter by at this stage
-  const isCorrectManifests =
-    !experimentalAllowBundling &&
-    semver.gte(nextVersion, CORRECTED_MANIFESTS_VERSION);
+  const mayFilterManifests = !experimentalAllowBundling;
+  const isCorrectManifests = semver.gte(
+    nextVersion,
+    CORRECTED_MANIFESTS_VERSION
+  );
 
   let hasStatic500 = !!staticPages[path.posix.join(entryDirectory, '500')];
 
@@ -1231,93 +1233,95 @@ export async function serverBuild({
 
       const updatedManifestFiles: { [name: string]: FileBlob } = {};
 
-      for (const manifest of isCorrectManifests
-        ? [
-            'routes-manifest.json',
-            'server/pages-manifest.json',
-            ...(appPathRoutesManifest
-              ? ['server/app-paths-manifest.json']
-              : []),
-          ]
-        : ['routes-manifest.json']) {
-        const fsPath = path.join(entryPath, outputDirectory, manifest);
+      if (isCorrectManifests) {
+        for (const manifest of mayFilterManifests
+          ? [
+              'routes-manifest.json',
+              'server/pages-manifest.json',
+              ...(appPathRoutesManifest
+                ? ['server/app-paths-manifest.json']
+                : []),
+            ]
+          : ['routes-manifest.json']) {
+          const fsPath = path.join(entryPath, outputDirectory, manifest);
 
-        const relativePath = path.relative(baseDir, fsPath);
-        delete group.pseudoLayer[relativePath];
+          const relativePath = path.relative(baseDir, fsPath);
+          delete group.pseudoLayer[relativePath];
 
-        const manifestData = await fs.readJSON(fsPath);
+          const manifestData = await fs.readJSON(fsPath);
 
-        if (manifest === 'routes-manifest.json') {
-          // Filter `headers` and `deploymentId` out of the routes-manifest.json for deterministic
-          // functions. In Next.js minimal mode, they aren't used (the builder reads them and
-          // generates the config.json for Vercel)
-          manifestData.headers = [];
-          delete manifestData.deploymentId;
-        }
+          if (manifest === 'routes-manifest.json') {
+            // Filter `headers` and `deploymentId` out of the routes-manifest.json for deterministic
+            // functions. In Next.js minimal mode, they aren't used (the builder reads them and
+            // generates the config.json for Vercel)
+            manifestData.headers = [];
+            delete manifestData.deploymentId;
+          }
 
-        if (isCorrectManifests) {
-          // filter dynamic routes to only the included dynamic routes
-          // in this specific serverless function so that we don't
-          // accidentally match a dynamic route while resolving that
-          // is not actually in this specific serverless function
+          if (mayFilterManifests) {
+            // filter dynamic routes to only the included dynamic routes
+            // in this specific serverless function so that we don't
+            // accidentally match a dynamic route while resolving that
+            // is not actually in this specific serverless function
 
-          const normalizedPages = new Set(
-            group.pages.map(page => {
-              page = `/${page.replace(/\.js$/, '')}`;
-              if (page === '/index') page = '/';
-              return page;
-            })
-          );
+            const normalizedPages = new Set(
+              group.pages.map(page => {
+                page = `/${page.replace(/\.js$/, '')}`;
+                if (page === '/index') page = '/';
+                return page;
+              })
+            );
 
-          switch (manifest) {
-            case 'routes-manifest.json': {
-              const filterItem = (item: { page: string }) =>
-                normalizedPages.has(item.page);
-              manifestData.dynamicRoutes =
-                manifestData.dynamicRoutes?.filter(filterItem);
-              manifestData.staticRoutes =
-                manifestData.staticRoutes?.filter(filterItem);
-              break;
-            }
-            case 'server/pages-manifest.json': {
-              for (const key of Object.keys(manifestData)) {
-                if (
-                  isDynamicRoute(key, nextVersion) &&
-                  !normalizedPages.has(key)
-                ) {
-                  delete manifestData[key];
-                }
+            switch (manifest) {
+              case 'routes-manifest.json': {
+                const filterItem = (item: { page: string }) =>
+                  normalizedPages.has(item.page);
+                manifestData.dynamicRoutes =
+                  manifestData.dynamicRoutes?.filter(filterItem);
+                manifestData.staticRoutes =
+                  manifestData.staticRoutes?.filter(filterItem);
+                break;
               }
-              break;
-            }
-            case 'server/app-paths-manifest.json': {
-              for (const key of Object.keys(manifestData)) {
-                const normalizedKey =
-                  appPathRoutesManifest?.[key] ||
-                  key.replace(/(^|\/)(page|route)$/, '');
-
-                if (
-                  isDynamicRoute(normalizedKey, nextVersion) &&
-                  !normalizedPages.has(normalizedKey)
-                ) {
-                  delete manifestData[key];
+              case 'server/pages-manifest.json': {
+                for (const key of Object.keys(manifestData)) {
+                  if (
+                    isDynamicRoute(key, nextVersion) &&
+                    !normalizedPages.has(key)
+                  ) {
+                    delete manifestData[key];
+                  }
                 }
+                break;
               }
-              break;
-            }
-            default: {
-              throw new NowBuildError({
-                message: `Unexpected manifest value ${manifest}, please contact support if this continues`,
-                code: 'NEXT_MANIFEST_INVARIANT',
-              });
+              case 'server/app-paths-manifest.json': {
+                for (const key of Object.keys(manifestData)) {
+                  const normalizedKey =
+                    appPathRoutesManifest?.[key] ||
+                    key.replace(/(^|\/)(page|route)$/, '');
+
+                  if (
+                    isDynamicRoute(normalizedKey, nextVersion) &&
+                    !normalizedPages.has(normalizedKey)
+                  ) {
+                    delete manifestData[key];
+                  }
+                }
+                break;
+              }
+              default: {
+                throw new NowBuildError({
+                  message: `Unexpected manifest value ${manifest}, please contact support if this continues`,
+                  code: 'NEXT_MANIFEST_INVARIANT',
+                });
+              }
             }
           }
-        }
 
-        updatedManifestFiles[relativePath] = new FileBlob({
-          contentType: 'application/json',
-          data: JSON.stringify(manifestData),
-        });
+          updatedManifestFiles[relativePath] = new FileBlob({
+            contentType: 'application/json',
+            data: JSON.stringify(manifestData),
+          });
+        }
       }
 
       let launcherData = group.isAppRouter ? appLauncher : launcher;

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -807,8 +807,7 @@ describe('determinism', () => {
       )
     );
     expect(originalManifest.deploymentId).toBeDefined();
-    // Not merged yet in Next.js
-    // expect(originalManifest.headers.length).not.toBe(0);
+    expect(originalManifest.headers.length).not.toBe(0);
 
     for (const entry of Object.values(buildResult.output)) {
       if (entry.type === 'Lambda' || entry.type === 'EdgeFunction') {

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -778,3 +778,48 @@ describe('action-headers', () => {
     expect(foundActionNames.sort()).toMatchSnapshot();
   });
 });
+
+describe('determinism', () => {
+  /**
+   * @type {import('@vercel/build-utils').BuildResultV2Typical}
+   */
+  let buildResult;
+  let workPath;
+
+  beforeAll(async () => {
+    const oldValue = process.env.NEXT_DEPLOYMENT_ID;
+    try {
+      process.env.NEXT_DEPLOYMENT_ID = '123456789';
+      const result = await runBuildLambda(
+        path.join(__dirname, '../fixtures/00-app-dir-not-found-pages-interop')
+      );
+      ({ buildResult, workPath } = result);
+    } finally {
+      process.env.NEXT_DEPLOYMENT_ID = oldValue;
+    }
+  });
+
+  it('should strip routes-manifest', async () => {
+    let originalManifest = JSON.parse(
+      await fs.readFile(
+        path.join(workPath, '.next', 'routes-manifest.json'),
+        'utf8'
+      )
+    );
+    expect(originalManifest.deploymentId).toBeDefined();
+    // Not merged yet in Next.js
+    // expect(originalManifest.headers.length).not.toBe(0);
+
+    for (const entry of Object.values(buildResult.output)) {
+      if (entry.type === 'Lambda' || entry.type === 'EdgeFunction') {
+        const manifest = entry.files['.next/routes-manifest.json'];
+        if (manifest) {
+          expect(manifest.type).toBe('FileBlob');
+          let parsed = JSON.parse(manifest.data);
+          expect(parsed.deploymentId).toBeUndefined();
+          expect(parsed.headers.length).toBe(0);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes PACK-6754


In minimal mode, these fields aren't needed at runtime (they were already incorporated into the config.json for Vercel CDN)