### PR TITLE
fix(cli): Move DELETE confirmation prompt to `vercel api` command only

### DIFF
--- a/.changeset/fix-env-rm-non-tty.md
+++ b/.changeset/fix-env-rm-non-tty.md
@@ -1,0 +1,7 @@
+---
+"vercel": patch
+---
+
+fix(cli): Move DELETE confirmation prompt to `vercel api` command only
+
+The DELETE confirmation prompt introduced in #14769 was incorrectly applied to all `client.fetch()` calls, which broke commands like `vercel env rm` in non-TTY environments (CI/CD). This fix moves the confirmation logic to only apply to the `vercel api` command as originally intended, allowing other commands with their own confirmation flows (like `--yes` flag) to work properly in non-interactive mode.

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -237,6 +237,15 @@ async function executeSingleRequest(
   flags: ParsedFlags
 ): Promise<number> {
   try {
+    // Confirm DELETE operations before proceeding
+    const confirmed = await client.confirmMutatingOperation(
+      config.url,
+      config.method
+    );
+    if (!confirmed) {
+      return 1;
+    }
+
     const response: Response = await client.fetch(config.url, {
       method: config.method,
       body: config.body,

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -260,7 +260,7 @@ export default class Client extends EventEmitter implements Stdio {
    *
    * @returns true if the operation should proceed, false if canceled
    */
-  private async confirmMutatingOperation(
+  async confirmMutatingOperation(
     url: string,
     method: string | undefined
   ): Promise<boolean> {
@@ -370,12 +370,6 @@ export default class Client extends EventEmitter implements Stdio {
   fetch(url: string, opts: FetchOptions & { json: false }): Promise<Response>;
   fetch<T>(url: string, opts?: FetchOptions): Promise<T>;
   async fetch(url: string, opts: FetchOptions = {}) {
-    // Check for confirmation before proceeding with mutating operations
-    const confirmed = await this.confirmMutatingOperation(url, opts.method);
-    if (!confirmed) {
-      throw new Error('Operation canceled by user');
-    }
-
     return this.retry(async bail => {
       const res = await this._fetch(url, opts);
 

--- a/packages/cli/test/unit/util/client-confirmation.test.ts
+++ b/packages/cli/test/unit/util/client-confirmation.test.ts
@@ -1,84 +1,69 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { client } from '../../mocks/client';
 
-describe('Client confirmation prompts', () => {
+describe('Client confirmMutatingOperation', () => {
   beforeEach(() => {
     // Reset client state
     client.reset();
-
-    // Mock a simple endpoint for testing
-    client.scenario.get('/v9/test', (_req, res) => {
-      res.json({ success: true });
-    });
-    client.scenario.post('/v9/test', (_req, res) => {
-      res.json({ created: true });
-    });
-    client.scenario.put('/v9/test', (_req, res) => {
-      res.json({ updated: true });
-    });
-    client.scenario.patch('/v9/test', (_req, res) => {
-      res.json({ patched: true });
-    });
-    client.scenario.delete('/v9/test', (_req, res) => {
-      res.json({ deleted: true });
-    });
   });
 
   describe('DELETE operations', () => {
     it('should prompt for confirmation on DELETE', async () => {
-      // Disable skip to test confirmation prompt
       client.dangerouslySkipPermissions = false;
-      // Mock confirm to return true
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'DELETE' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
       expect(client.input.confirm).toHaveBeenCalledTimes(1);
       expect(client.input.confirm).toHaveBeenCalledWith(
         expect.stringContaining('DELETE'),
         false
       );
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
     });
 
-    it('should cancel DELETE when user says no', async () => {
-      // Disable skip to test confirmation prompt
+    it('should return false when user cancels DELETE', async () => {
       client.dangerouslySkipPermissions = false;
-      // Mock confirm to return false
       client.input.confirm = vi.fn().mockResolvedValue(false);
 
-      await expect(
-        client.fetch('/v9/test', { method: 'DELETE' })
-      ).rejects.toThrow('Operation canceled by user');
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
       expect(client.input.confirm).toHaveBeenCalledTimes(1);
+      expect(result).toBe(false);
     });
 
     it('should skip confirmation with --dangerously-skip-permissions flag', async () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'DELETE' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
-      // Confirm should NOT be called when dangerouslySkipPermissions is true
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
     });
 
-    it('should show error in non-TTY mode without --dangerously-skip-permissions', async () => {
-      // Disable skip to test non-TTY error behavior
+    it('should return false in non-TTY mode without --dangerously-skip-permissions', async () => {
       client.dangerouslySkipPermissions = false;
       client.stdin.isTTY = false;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      await expect(
-        client.fetch('/v9/test', { method: 'DELETE' })
-      ).rejects.toThrow('Operation canceled by user');
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
-      // Confirm should NOT be called in non-TTY mode
       expect(client.input.confirm).not.toHaveBeenCalled();
+      expect(result).toBe(false);
 
-      // Should show error message
       const output = client.stderr.getFullOutput();
       expect(output).toContain('DELETE operations require confirmation');
       expect(output).toContain('--dangerously-skip-permissions');
@@ -89,10 +74,12 @@ describe('Client confirmation prompts', () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'DELETE' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
-      expect(result).toEqual({ deleted: true });
-      // Confirm should NOT be called when dangerouslySkipPermissions is true
+      expect(result).toBe(true);
       expect(client.input.confirm).not.toHaveBeenCalled();
     });
   });
@@ -104,9 +91,12 @@ describe('Client confirmation prompts', () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'DELETE' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
 
       const output = client.stderr.getFullOutput();
       expect(output).toContain('WARNING');
@@ -122,62 +112,67 @@ describe('Client confirmation prompts', () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'DELETE' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'DELETE'
+      );
 
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
 
       const output = client.stderr.getFullOutput();
       expect(output).toContain('WARNING');
       expect(output).toContain('AGENT MODE');
-      // Should NOT contain the agent name info when not provided
       expect(output).not.toContain('(undefined)');
     });
   });
 
   describe('Non-DELETE operations', () => {
-    it('should not prompt for GET requests', async () => {
+    it('should return true for GET requests without prompting', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'GET' });
+      const result = await client.confirmMutatingOperation('/v9/test', 'GET');
 
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ success: true });
+      expect(result).toBe(true);
     });
 
-    it('should not prompt for POST requests', async () => {
+    it('should return true for POST requests without prompting', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'POST' });
+      const result = await client.confirmMutatingOperation('/v9/test', 'POST');
 
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ created: true });
+      expect(result).toBe(true);
     });
 
-    it('should not prompt for PUT requests', async () => {
+    it('should return true for PUT requests without prompting', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'PUT' });
+      const result = await client.confirmMutatingOperation('/v9/test', 'PUT');
 
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ updated: true });
+      expect(result).toBe(true);
     });
 
-    it('should not prompt for PATCH requests', async () => {
+    it('should return true for PATCH requests without prompting', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'PATCH' });
+      const result = await client.confirmMutatingOperation('/v9/test', 'PATCH');
 
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ patched: true });
+      expect(result).toBe(true);
     });
 
-    it('should not prompt for requests with no method specified (defaults to GET)', async () => {
+    it('should return true for undefined method (defaults to GET)', async () => {
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test');
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        undefined
+      );
 
       expect(client.input.confirm).not.toHaveBeenCalled();
-      expect(result).toEqual({ success: true });
+      expect(result).toBe(true);
     });
   });
 
@@ -186,26 +181,31 @@ describe('Client confirmation prompts', () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'delete' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'delete'
+      );
 
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
     });
 
     it('should handle mixed case DELETE method', async () => {
       client.dangerouslySkipPermissions = true;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      const result = await client.fetch('/v9/test', { method: 'Delete' });
+      const result = await client.confirmMutatingOperation(
+        '/v9/test',
+        'Delete'
+      );
 
-      expect(result).toEqual({ deleted: true });
+      expect(result).toBe(true);
     });
 
     it('should include URL in confirmation message', async () => {
-      // Disable skip to test confirmation message content
       client.dangerouslySkipPermissions = false;
       client.input.confirm = vi.fn().mockResolvedValue(true);
 
-      await client.fetch('/v9/test', { method: 'DELETE' });
+      await client.confirmMutatingOperation('/v9/test', 'DELETE');
 
       expect(client.input.confirm).toHaveBeenCalledWith(
         expect.stringContaining('/v9/test'),


### PR DESCRIPTION
## Problem

PR #14769 introduced a DELETE confirmation prompt for AI agent safety, but incorrectly placed the `confirmMutatingOperation()` call inside `client.fetch()`. This caused **ALL commands using DELETE API calls** (e.g., `vercel env rm`, `vercel remove`) to fail in non-TTY environments (CI/CD pipelines).

### Error Message
```
Error: DELETE operations require confirmation. Use --dangerously-skip-permissions to skip confirmation in non-interactive mode.
```

### Root Cause
1. `confirmMutatingOperation()` was called on every `client.fetch()` with DELETE method
2. In non-TTY mode, it requires `--dangerously-skip-permissions` flag to proceed
3. But this flag was only added to the `vercel api` command
4. Other commands like `env rm` have their own `--yes` flag for confirmation, which became ineffective

## Solution

Move the DELETE confirmation logic to only apply to `vercel api` command:

1. Remove `confirmMutatingOperation()` call from `client.fetch()`
2. Change `confirmMutatingOperation()` from private to public method
3. Call `confirmMutatingOperation()` directly in `vercel api`'s `executeSingleRequest()`
4. Update tests to call `confirmMutatingOperation()` directly instead of through `fetch()`

## Changes

### `packages/cli/src/util/client.ts`
- Remove confirmation call from `fetch()` method (6 lines removed)
- Change `confirmMutatingOperation` visibility from `private` to `public`

### `packages/cli/src/commands/api/index.ts`
- Add `confirmMutatingOperation()` call at the start of `executeSingleRequest()`
- Place it inside try-catch block for proper error handling

### `packages/cli/test/unit/util/client-confirmation.test.ts`
- Update all tests to call `client.confirmMutatingOperation()` directly
- Remove mock endpoint setup (no longer needed)
- Update assertions from response objects to boolean values

## Testing

- [x] All 15 unit tests pass
- [x] `vercel env rm` now works with `--yes` flag in CI/CD environments
- [x] `vercel api -X DELETE` still prompts for confirmation as intended

## Related

- Fixes regression introduced in #14769