### PR TITLE
fix(cli): Scope DELETE confirmation prompt to `vercel api` command only

### DIFF
--- a/.changeset/fix-api-delete-scope.md
+++ b/.changeset/fix-api-delete-scope.md
@@ -1,0 +1,7 @@
+---
+'vercel': patch
+---
+
+fix(cli): Scope DELETE confirmation prompt to `vercel api` command only
+
+This fixes a regression from #14769 where the DELETE confirmation prompt was incorrectly applied to all DELETE operations (e.g., `vercel env rm`, `vercel alias rm`) instead of only the `vercel api` command. Commands like `env rm` and `alias rm` have their own `--yes` flags for confirmation and should not be affected.

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -237,6 +237,15 @@ async function executeSingleRequest(
   flags: ParsedFlags
 ): Promise<number> {
   try {
+    // Check for confirmation before proceeding with DELETE operations
+    const confirmed = await client.confirmMutatingOperation(
+      config.url,
+      config.method
+    );
+    if (!confirmed) {
+      return 1;
+    }
+
     const response: Response = await client.fetch(config.url, {
       method: config.method,
       body: config.body,
@@ -259,6 +268,15 @@ async function executePaginatedRequest(
   const results: unknown[] = [];
 
   try {
+    // Check for confirmation before proceeding with DELETE operations
+    const confirmed = await client.confirmMutatingOperation(
+      config.url,
+      config.method
+    );
+    if (!confirmed) {
+      return 1;
+    }
+
     for await (const page of client.fetchPaginated<Record<string, unknown>>(
       config.url,
       {

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -260,7 +260,7 @@ export default class Client extends EventEmitter implements Stdio {
    *
    * @returns true if the operation should proceed, false if canceled
    */
-  private async confirmMutatingOperation(
+  async confirmMutatingOperation(
     url: string,
     method: string | undefined
   ): Promise<boolean> {
@@ -369,13 +369,7 @@ export default class Client extends EventEmitter implements Stdio {
 
   fetch(url: string, opts: FetchOptions & { json: false }): Promise<Response>;
   fetch<T>(url: string, opts?: FetchOptions): Promise<T>;
-  async fetch(url: string, opts: FetchOptions = {}) {
-    // Check for confirmation before proceeding with mutating operations
-    const confirmed = await this.confirmMutatingOperation(url, opts.method);
-    if (!confirmed) {
-      throw new Error('Operation canceled by user');
-    }
-
+  fetch(url: string, opts: FetchOptions = {}) {
     return this.retry(async bail => {
       const res = await this._fetch(url, opts);
 

--- a/packages/cli/test/mocks/client.ts
+++ b/packages/cli/test/mocks/client.ts
@@ -256,12 +256,9 @@ export class MockClient extends Client {
     this.telemetryEventStore.reset();
 
     // Reset agent and confirmation flags
-    // Note: dangerouslySkipPermissions defaults to true in tests to prevent
-    // DELETE confirmation prompts from hanging tests. Tests that specifically
-    // test confirmation behavior should set this to false and mock input.confirm.
     this.isAgent = false;
     this.agentName = undefined;
-    this.dangerouslySkipPermissions = true;
+    this.dangerouslySkipPermissions = false;
   }
 
   events = {

--- a/packages/cli/test/unit/commands/api/index.test.ts
+++ b/packages/cli/test/unit/commands/api/index.test.ts
@@ -138,6 +138,9 @@ describe('api', () => {
         res.json({ uid: 'dpl_abc123' });
       });
 
+      // Skip confirmation prompt for this test (testing request, not confirmation)
+      client.dangerouslySkipPermissions = true;
+
       client.setArgv('api', '/v13/deployments/dpl_abc123', '-X', 'DELETE');
       const exitCode = await api(client);
 


### PR DESCRIPTION
## Summary

Fixes a regression from #14769 where the DELETE confirmation prompt was incorrectly applied to **all** DELETE operations instead of only the `vercel api` command.

This was breaking CI/CD pipelines that use commands like:
- `vercel env rm <name> --yes`
- `vercel alias rm <alias> --yes`
- `vercel remove <deployment> --yes`

These commands have their own `--yes` flags for confirmation and should not be affected by the new `--dangerously-skip-permissions` flag which was designed specifically for the `vercel api` command.

## Changes

- **`packages/cli/src/util/client.ts`**: Made `confirmMutatingOperation()` public and removed the call from `fetch()` method
- **`packages/cli/src/commands/api/index.ts`**: Added `confirmMutatingOperation()` calls in `executeSingleRequest()` and `executePaginatedRequest()` - scoping confirmation to only the `vercel api` command
- **`packages/cli/test/mocks/client.ts`**: Removed workaround that set `dangerouslySkipPermissions = true` by default
- **`packages/cli/test/unit/util/client-confirmation.test.ts`**: Updated tests to call `confirmMutatingOperation()` directly

## Test plan

- [x] All 15 unit tests pass
- [x] TypeScript compiles without errors
- [x] `vercel env rm --yes` works in non-TTY mode (no longer blocked)
- [x] `vercel api -X DELETE` still prompts for confirmation as intended

## Related

- Fixes regression introduced in #14769
- Supersedes #14784

🤖 Generated with [Claude Code](https://claude.com/claude-code)