### PR TITLE
fix(cli): Make `env rm --yes` work in non-TTY environments

### DIFF
--- a/.changeset/fix-env-rm-yes-flag.md
+++ b/.changeset/fix-env-rm-yes-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed `vercel env rm --yes` to work in non-TTY environments (e.g., CI) by also bypassing the HTTP-level DELETE confirmation prompt introduced in v50.9.0.

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -106,6 +106,13 @@ export default async function rm(client: Client, argv: string[]) {
   const env = envs[0];
 
   const skipConfirmation = opts['--yes'];
+
+  // When --yes is used, also skip the HTTP-level DELETE confirmation
+  // This ensures the flag works in non-TTY environments (e.g., CI)
+  if (skipConfirmation) {
+    client.dangerouslySkipPermissions = true;
+  }
+
   if (
     !skipConfirmation &&
     !(await client.input.confirm(

--- a/packages/cli/test/unit/commands/env/rm.test.ts
+++ b/packages/cli/test/unit/commands/env/rm.test.ts
@@ -72,6 +72,14 @@ describe('env rm', () => {
           },
         ]);
       });
+
+      it('sets dangerouslySkipPermissions when --yes is used', async () => {
+        // Start with dangerouslySkipPermissions=false to verify --yes sets it
+        client.dangerouslySkipPermissions = false;
+        client.setArgv('env', 'rm', 'ENVIRONMENT_NAME', '--yes');
+        await env(client);
+        expect(client.dangerouslySkipPermissions).toBe(true);
+      });
     });
 
     describe('[environment]', () => {


### PR DESCRIPTION
## Summary

- Fixed `vercel env rm --yes` to work in non-TTY environments (e.g., CI pipelines)
- The `--yes` flag now properly bypasses the HTTP-level DELETE confirmation prompt introduced in v50.9.0
- Added unit test to verify this behavior

## Background

In v50.9.0, a new security feature was introduced that adds confirmation prompts for DELETE HTTP operations at the client level. This caused `vercel env rm --yes` to fail in CI environments because:

1. The `--yes` flag only bypassed the command-level confirmation
2. The new HTTP-level DELETE confirmation required `--dangerously-skip-permissions` in non-TTY mode

This fix propagates the `--yes` flag to also set `client.dangerouslySkipPermissions = true`, ensuring backwards compatibility for existing CI workflows.

## Test plan

- [ ] Verify existing `env rm` tests pass
- [ ] New test `sets dangerouslySkipPermissions when --yes is used` passes
- [ ] Manual test: `vercel env rm <name> <env> --yes --token=<token>` works in non-TTY mode