### PR TITLE
Revert "[next] Remove 404.html prerenders from functions"

### DIFF
--- a/.changeset/brown-ligers-dress.md
+++ b/.changeset/brown-ligers-dress.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Revert "[next] Remove 404.html prerenders from functions"

--- a/.changeset/pink-eels-impress.md
+++ b/.changeset/pink-eels-impress.md
@@ -1,5 +1,0 @@
----
-'@vercel/next': patch
----
-
-Remove 404.html prerenders from serverless function

--- a/packages/next/src/server-build.ts
+++ b/packages/next/src/server-build.ts
@@ -476,6 +476,7 @@ export async function serverBuild({
   const lstatSema = new Sema(25);
   const lstatResults: { [key: string]: ReturnType<typeof lstat> } = {};
   const nonLambdaSsgPages = new Set<string>();
+  const static404Pages = new Set<string>(static404Page ? [static404Page] : []);
 
   // Only include internal pages that are actually existed
   const internalPages = [...INTERNAL_PAGES].filter(page => {
@@ -493,6 +494,12 @@ export async function serverBuild({
       routesManifest,
       appDir
     );
+
+    if (result && result.static404Page) {
+      // there can be multiple 404 pages (eg i18n) so we want to keep track of all of them
+      static404Pages.add(result.static404Page);
+      static404Page = result.static404Page;
+    }
 
     if (result && result.static500Page) {
       hasStatic500 = true;
@@ -703,6 +710,43 @@ export async function serverBuild({
       mode: (await fs.lstat(nextServerFile)).mode,
       fsPath: nextServerFile,
     });
+
+    if (static404Pages.size > 0) {
+      // If we've generated a static 404 page, it's possible that we also
+      // have a static 404 page for each locale.
+      if (i18n) {
+        for (const locale of i18n.locales) {
+          const static404Page = path.posix.join(entryDirectory, locale, '404');
+          static404Pages.add(static404Page);
+        }
+      }
+
+      for (const static404Page of static404Pages) {
+        let static404File = staticPages[static404Page];
+
+        if (!static404File) {
+          // if we have a file ref already, we can use it. Otherwise, we need
+          // to create a new one, but we need to ensure it exists on disk
+          const static404FilePath = path.join(
+            pagesDir,
+            `${static404Page}.html`
+          );
+
+          if (fs.existsSync(static404FilePath)) {
+            static404File = new FileFsRef({
+              fsPath: static404FilePath,
+            });
+          }
+        }
+
+        // ensure each static 404 page file is included in all lambdas
+        // for notFound GS(S)P support
+        if (static404File) {
+          requiredFiles[path.relative(baseDir, static404File.fsPath)] =
+            static404File;
+        }
+      }
+    }
 
     // TODO: move this into Next.js' required server files manifest
     const envFiles = [];

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -760,27 +760,3 @@ describe('action-headers', () => {
     expect(foundActionNames.sort()).toMatchSnapshot();
   });
 });
-
-describe('determinism', () => {
-  /**
-   * @type {import('@vercel/build-utils').BuildResultV2Typical}
-   */
-  let buildResult;
-
-  beforeAll(async () => {
-    const result = await runBuildLambda(
-      path.join(__dirname, '../fixtures/00-app-dir-not-found-pages-interop')
-    );
-    buildResult = result.buildResult;
-  });
-
-  it('should not include prerenders in functions lambdas', async () => {
-    for (const entry of Object.values(buildResult.output)) {
-      if (entry.type === 'Lambda' || entry.type === 'EdgeFunction') {
-        expect(Object.keys(entry.files)).not.toContainEqual(
-          expect.stringMatching(/\.html$|.rsc$/)
-        );
-      }
-    }
-  });
-});


### PR DESCRIPTION
Reverts vercel/vercel#14754

e2e tests are failing ([x-ref](https://github.com/vercel/vercel/actions/runs/21491669577/job/61915647732?pr=14792)) so pulling this out of the upcoming release so we can investigate separately. 