### PR TITLE
[cli] Skip update check when running on Vercel

### DIFF
--- a/.changeset/quiet-planes-rescue.md
+++ b/.changeset/quiet-planes-rescue.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Skip update check when running on Vercel to prevent unnecessary worker spawning in build container

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -916,18 +916,18 @@ const main = async () => {
 
 main()
   .then(async exitCode => {
-    // Print update information, if available
-    if (!process.env.NO_UPDATE_NOTIFIER) {
-      // Check if an update is available. If so, `latest` will contain a string
-      // of the latest version, otherwise `undefined`.
+    const shouldCheckForUpdates =
+      !process.env.NO_UPDATE_NOTIFIER && !process.env.VERCEL;
+
+    if (shouldCheckForUpdates) {
       const latest = getLatestVersion({
         pkg,
       });
       if (latest) {
-        const changelog = 'https://github.com/vercel/vercel/releases';
+        const changelog = `https://github.com/vercel/vercel/releases/tag/vercel%40${latest}`;
 
         if (isTTY) {
-          // Interactive mode: show condensed prompt
+          // Interactive mode: prompt user to update now
           const errorMsg =
             exitCode && exitCode !== 2
               ? chalk.magenta(
@@ -961,7 +961,6 @@ main()
             await open(changelog);
           }
         } else {
-          // Non-interactive mode: show full update box
           const errorMsg =
             exitCode && exitCode !== 2
               ? chalk.magenta(


### PR DESCRIPTION
## Summary

Fixes an issue where the CLI update check worker was being spawned inside the Vercel build container, causing unnecessary debug output:

```
[debug] [2026-01-29T17:43:08.308Z] Spawning /vercel/f238228/node_modules/vercel/dist/get-latest-worker.cjs
```

### Changes

The fix checks for the `VERCEL` environment variable to skip the update notification entirely when running on Vercel infrastructure:

- **On Vercel (`VERCEL=1`)**: No update check or notification
- **TTY mode**: Interactive prompt with upgrade/changelog/skip options
- **Non-TTY mode (other CI)**: Show update box with instructions

This preserves the update notification for users running the CLI in other CI environments while preventing the worker from spawning in the Vercel build container.

## Test plan

- [ ] Verify CLI still shows interactive update prompt in TTY mode when an update is available
- [ ] Verify CLI shows update box in non-TTY CI environments (not on Vercel)
- [ ] Verify no update check runs when `VERCEL=1` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)