### PR TITLE
[python] Preserve error code handling in uv runner

### DIFF
--- a/.changeset/fix-error-code-preservation.md
+++ b/.changeset/fix-error-code-preservation.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Preserve error code when re-throwing errors in UvRunner methods

--- a/.changeset/warm-actors-lick.md
+++ b/.changeset/warm-actors-lick.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Preserve error code when throwing errors from uvrunner

--- a/.changeset/warm-actors-lick.md
+++ b/.changeset/warm-actors-lick.md
@@ -1,5 +1,0 @@
----
-'@vercel/python': patch
----
-
-Preserve error code when throwing errors from uvrunner

--- a/packages/python/src/install.ts
+++ b/packages/python/src/install.ts
@@ -210,7 +210,7 @@ export async function createPyprojectToml({
   pyprojectPath: string;
   dependencies: string[];
 }) {
-  const requiresPython = `~=${DEFAULT_PYTHON_VERSION}`;
+  const requiresPython = `~=${DEFAULT_PYTHON_VERSION}.0`;
 
   const depsToml =
     dependencies.length > 0

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -106,18 +106,11 @@ export class UvRunner {
         env: getProtectedUvEnv(process.env),
       });
     } catch (err) {
-      const error: Error & { code?: unknown } = new Error(
-        `Failed to run "${pretty}": ${err instanceof Error ? err.message : String(err)}`
+      throw new Error(
+        `Failed to run "${pretty}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
       );
-      // Preserve error code for proper error reporting
-      if (err && typeof err === 'object') {
-        if ('code' in err) {
-          error.code = err.code;
-        } else if ('signal' in err) {
-          error.code = err.signal;
-        }
-      }
-      throw error;
     }
   }
 
@@ -163,14 +156,15 @@ export class UvRunner {
       const error: Error & { code?: unknown } = new Error(
         `Failed to run "${pretty}": ${err instanceof Error ? err.message : String(err)}`
       );
-      // Preserve error code for proper error reporting
+      // retain code/signal to ensure it's treated as a build error
       if (err && typeof err === 'object') {
         if ('code' in err) {
-          error.code = err.code;
+          error.code = (err as { code: number | string }).code;
         } else if ('signal' in err) {
-          error.code = err.signal;
+          error.code = (err as { signal: string }).signal;
         }
       }
+
       throw error;
     }
   }

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -106,9 +106,18 @@ export class UvRunner {
         env: getProtectedUvEnv(process.env),
       });
     } catch (err) {
-      throw new Error(
+      const error: Error & { code?: unknown } = new Error(
         `Failed to run "${pretty}": ${err instanceof Error ? err.message : String(err)}`
       );
+      // Preserve error code for proper error reporting
+      if (err && typeof err === 'object') {
+        if ('code' in err) {
+          error.code = err.code;
+        } else if ('signal' in err) {
+          error.code = err.signal;
+        }
+      }
+      throw error;
     }
   }
 
@@ -151,9 +160,18 @@ export class UvRunner {
         env: this.getVenvEnv(venvPath),
       });
     } catch (err) {
-      throw new Error(
+      const error: Error & { code?: unknown } = new Error(
         `Failed to run "${pretty}": ${err instanceof Error ? err.message : String(err)}`
       );
+      // Preserve error code for proper error reporting
+      if (err && typeof err === 'object') {
+        if ('code' in err) {
+          error.code = err.code;
+        } else if ('signal' in err) {
+          error.code = err.signal;
+        }
+      }
+      throw error;
     }
   }
 

--- a/packages/python/test/unit.test.ts
+++ b/packages/python/test/unit.test.ts
@@ -429,7 +429,7 @@ describe('createPyprojectToml', () => {
 
       const content = fs.readFileSync(pyprojectPath, 'utf8');
       expect(content).toContain(
-        `requires-python = "~=${DEFAULT_PYTHON_VERSION}"`
+        `requires-python = "~=${DEFAULT_PYTHON_VERSION}.0"`
       );
     } finally {
       if (fs.existsSync(tempDir)) {


### PR DESCRIPTION
A build container integration test fails because the error code was not preserved from the uv runner