### PR TITLE
Accounts page features

### DIFF
--- a/.changeset/add-accounts-api-endpoints.md
+++ b/.changeset/add-accounts-api-endpoints.md
@@ -1,0 +1,20 @@
+---
+---
+
+Add accounts API endpoints for admin team accounts page
+
+This change adds three new API endpoints to support the team accounts page in the admin interface:
+
+- `/api/accounts/list` - Lists all accounts for a team with filtering, sorting, and pagination
+- `/api/accounts/info` - Gets detailed information about a specific account
+- `/api/accounts/stats` - Provides statistics about accounts for a team
+
+Features include:
+- Account filtering by role (owner, admin, member, viewer) and status (active, invited, suspended)
+- Search functionality for finding accounts by name or email
+- Sorting by name, email, join date, or last activity
+- Pagination support for large teams
+- Account statistics dashboard data
+- Mock data implementation for development/testing
+
+The endpoints are designed to be consumed by the admin UI at `https://admin.vercel.com/team/{team_id}/accounts`.

--- a/api/_lib/accounts/account-info.ts
+++ b/api/_lib/accounts/account-info.ts
@@ -42,8 +42,8 @@ export async function getAccountInfo(accountId: string): Promise<Account | null>
 export async function listAccounts(
   teamId: string,
   filters?: AccountFilters,
-  page: number = 1,
-  perPage: number = 20
+  page = 1,
+  perPage = 20
 ): Promise<{ accounts: Account[]; total: number }> {
   // Mock accounts data
   const allAccounts: Account[] = [
@@ -158,7 +158,7 @@ export async function listAccounts(
 /**
  * Get account statistics for a team
  */
-export async function getAccountStats(teamId: string) {
+export async function getAccountStats(_teamId: string) {
   return {
     total: 5,
     active: 4,

--- a/api/_lib/accounts/account-info.ts
+++ b/api/_lib/accounts/account-info.ts
@@ -4,11 +4,13 @@ import { Account, AccountFilters } from './types';
  * Mock function to get account information
  * In production, this would query a database or call an internal API
  */
-export async function getAccountInfo(accountId: string): Promise<Account | null> {
+export async function getAccountInfo(
+  accountId: string
+): Promise<Account | null> {
   // This is a mock implementation
   // In a real scenario, this would fetch from a database
   const mockAccounts: Record<string, Account> = {
-    'acc_1': {
+    acc_1: {
       id: 'acc_1',
       name: 'John Doe',
       email: 'john.doe@example.com',
@@ -19,7 +21,7 @@ export async function getAccountInfo(accountId: string): Promise<Account | null>
       avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=John',
       permissions: ['read', 'write', 'admin'],
     },
-    'acc_2': {
+    acc_2: {
       id: 'acc_2',
       name: 'Jane Smith',
       email: 'jane.smith@example.com',

--- a/api/_lib/accounts/account-info.ts
+++ b/api/_lib/accounts/account-info.ts
@@ -1,0 +1,174 @@
+import { Account, AccountFilters } from './types';
+
+/**
+ * Mock function to get account information
+ * In production, this would query a database or call an internal API
+ */
+export async function getAccountInfo(accountId: string): Promise<Account | null> {
+  // This is a mock implementation
+  // In a real scenario, this would fetch from a database
+  const mockAccounts: Record<string, Account> = {
+    'acc_1': {
+      id: 'acc_1',
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      role: 'owner',
+      status: 'active',
+      joinedAt: '2023-01-15T00:00:00.000Z',
+      lastActiveAt: '2024-01-29T12:00:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=John',
+      permissions: ['read', 'write', 'admin'],
+    },
+    'acc_2': {
+      id: 'acc_2',
+      name: 'Jane Smith',
+      email: 'jane.smith@example.com',
+      role: 'admin',
+      status: 'active',
+      joinedAt: '2023-03-20T00:00:00.000Z',
+      lastActiveAt: '2024-01-28T15:30:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Jane',
+      permissions: ['read', 'write'],
+    },
+  };
+
+  return mockAccounts[accountId] || null;
+}
+
+/**
+ * Mock function to list accounts for a team
+ * In production, this would query a database or call an internal API
+ */
+export async function listAccounts(
+  teamId: string,
+  filters?: AccountFilters,
+  page: number = 1,
+  perPage: number = 20
+): Promise<{ accounts: Account[]; total: number }> {
+  // Mock accounts data
+  const allAccounts: Account[] = [
+    {
+      id: 'acc_1',
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      role: 'owner',
+      status: 'active',
+      joinedAt: '2023-01-15T00:00:00.000Z',
+      lastActiveAt: '2024-01-29T12:00:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=John',
+      permissions: ['read', 'write', 'admin'],
+    },
+    {
+      id: 'acc_2',
+      name: 'Jane Smith',
+      email: 'jane.smith@example.com',
+      role: 'admin',
+      status: 'active',
+      joinedAt: '2023-03-20T00:00:00.000Z',
+      lastActiveAt: '2024-01-28T15:30:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Jane',
+      permissions: ['read', 'write'],
+    },
+    {
+      id: 'acc_3',
+      name: 'Bob Johnson',
+      email: 'bob.johnson@example.com',
+      role: 'member',
+      status: 'active',
+      joinedAt: '2023-06-10T00:00:00.000Z',
+      lastActiveAt: '2024-01-25T09:15:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Bob',
+      permissions: ['read'],
+    },
+    {
+      id: 'acc_4',
+      name: 'Alice Williams',
+      email: 'alice.williams@example.com',
+      role: 'member',
+      status: 'invited',
+      joinedAt: '2024-01-20T00:00:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Alice',
+      permissions: ['read'],
+    },
+    {
+      id: 'acc_5',
+      name: 'Charlie Brown',
+      email: 'charlie.brown@example.com',
+      role: 'viewer',
+      status: 'active',
+      joinedAt: '2023-09-05T00:00:00.000Z',
+      lastActiveAt: '2024-01-20T14:45:00.000Z',
+      avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Charlie',
+      permissions: ['read'],
+    },
+  ];
+
+  let filteredAccounts = [...allAccounts];
+
+  // Apply filters
+  if (filters) {
+    if (filters.role) {
+      filteredAccounts = filteredAccounts.filter(
+        acc => acc.role === filters.role
+      );
+    }
+    if (filters.status) {
+      filteredAccounts = filteredAccounts.filter(
+        acc => acc.status === filters.status
+      );
+    }
+    if (filters.search) {
+      const search = filters.search.toLowerCase();
+      filteredAccounts = filteredAccounts.filter(
+        acc =>
+          acc.name.toLowerCase().includes(search) ||
+          acc.email.toLowerCase().includes(search)
+      );
+    }
+
+    // Apply sorting
+    if (filters.sortBy) {
+      const sortOrder = filters.sortOrder === 'desc' ? -1 : 1;
+      filteredAccounts.sort((a, b) => {
+        const aVal = a[filters.sortBy!];
+        const bVal = b[filters.sortBy!];
+        if (aVal === undefined && bVal === undefined) return 0;
+        if (aVal === undefined) return 1;
+        if (bVal === undefined) return -1;
+        if (aVal < bVal) return -1 * sortOrder;
+        if (aVal > bVal) return 1 * sortOrder;
+        return 0;
+      });
+    }
+  }
+
+  const total = filteredAccounts.length;
+  const startIndex = (page - 1) * perPage;
+  const paginatedAccounts = filteredAccounts.slice(
+    startIndex,
+    startIndex + perPage
+  );
+
+  return {
+    accounts: paginatedAccounts,
+    total,
+  };
+}
+
+/**
+ * Get account statistics for a team
+ */
+export async function getAccountStats(teamId: string) {
+  return {
+    total: 5,
+    active: 4,
+    invited: 1,
+    suspended: 0,
+    byRole: {
+      owner: 1,
+      admin: 1,
+      member: 2,
+      viewer: 1,
+    },
+  };
+}

--- a/api/_lib/accounts/account-info.ts
+++ b/api/_lib/accounts/account-info.ts
@@ -158,7 +158,10 @@ export async function listAccounts(
 /**
  * Get account statistics for a team
  */
-export async function getAccountStats(_teamId: string) {
+export async function getAccountStats(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _teamId: string
+) {
   return {
     total: 5,
     active: 4,

--- a/api/_lib/accounts/types.ts
+++ b/api/_lib/accounts/types.ts
@@ -1,0 +1,43 @@
+export interface Account {
+  id: string;
+  name: string;
+  email: string;
+  role: 'owner' | 'admin' | 'member' | 'viewer';
+  status: 'active' | 'invited' | 'suspended';
+  joinedAt: string;
+  lastActiveAt?: string;
+  avatar?: string;
+  permissions?: string[];
+}
+
+export interface AccountListResponse {
+  accounts: Account[];
+  pagination: {
+    total: number;
+    page: number;
+    perPage: number;
+    hasMore: boolean;
+  };
+}
+
+export interface AccountDetailsResponse {
+  account: Account;
+  activity?: {
+    deployments: number;
+    projects: number;
+    lastDeploy?: string;
+  };
+  teams?: {
+    id: string;
+    name: string;
+    role: string;
+  }[];
+}
+
+export interface AccountFilters {
+  role?: string;
+  status?: string;
+  search?: string;
+  sortBy?: 'name' | 'email' | 'joinedAt' | 'lastActiveAt';
+  sortOrder?: 'asc' | 'desc';
+}

--- a/api/accounts/README.md
+++ b/api/accounts/README.md
@@ -11,6 +11,7 @@ This directory contains API endpoints for managing team accounts in the Vercel a
 Lists all accounts for a given team with filtering, sorting, and pagination.
 
 **Query Parameters:**
+
 - `teamId` (required): The team ID
 - `page` (optional): Page number (default: 1)
 - `perPage` (optional): Items per page (default: 20, max: 100)
@@ -21,11 +22,13 @@ Lists all accounts for a given team with filtering, sorting, and pagination.
 - `sortOrder` (optional): Sort order (`asc`, `desc`)
 
 **Example Request:**
+
 ```
 GET /api/accounts/list?teamId=team_nLlpyC6REAqxydlFKbrMDlud&page=1&perPage=20&role=admin&sortBy=name&sortOrder=asc
 ```
 
 **Example Response:**
+
 ```json
 {
   "accounts": [
@@ -69,14 +72,17 @@ GET /api/accounts/list?teamId=team_nLlpyC6REAqxydlFKbrMDlud&page=1&perPage=20&ro
 Get detailed information about a specific account.
 
 **Query Parameters:**
+
 - `accountId` (required): The account ID
 
 **Example Request:**
+
 ```
 GET /api/accounts/info?accountId=acc_1
 ```
 
 **Example Response:**
+
 ```json
 {
   "account": {
@@ -112,14 +118,17 @@ GET /api/accounts/info?accountId=acc_1
 Get statistics about accounts for a team.
 
 **Query Parameters:**
+
 - `teamId` (required): The team ID
 
 **Example Request:**
+
 ```
 GET /api/accounts/stats?teamId=team_nLlpyC6REAqxydlFKbrMDlud
 ```
 
 **Example Response:**
+
 ```json
 {
   "total": 5,
@@ -167,11 +176,13 @@ The current implementation uses mock data for demonstration purposes. In a produ
 ## Integration with Admin UI
 
 These endpoints are designed to be consumed by the admin UI at:
+
 ```
 https://admin.vercel.com/team/{team_id}/accounts
 ```
 
 The UI should:
+
 - Display a table of accounts with filtering and sorting
 - Show account statistics in a dashboard
 - Allow clicking on accounts to view detailed information

--- a/api/accounts/README.md
+++ b/api/accounts/README.md
@@ -1,0 +1,179 @@
+# Accounts API Endpoints
+
+This directory contains API endpoints for managing team accounts in the Vercel admin interface.
+
+## Endpoints
+
+### 1. List Accounts
+
+**Endpoint:** `GET /api/accounts/list`
+
+Lists all accounts for a given team with filtering, sorting, and pagination.
+
+**Query Parameters:**
+- `teamId` (required): The team ID
+- `page` (optional): Page number (default: 1)
+- `perPage` (optional): Items per page (default: 20, max: 100)
+- `role` (optional): Filter by role (`owner`, `admin`, `member`, `viewer`)
+- `status` (optional): Filter by status (`active`, `invited`, `suspended`)
+- `search` (optional): Search by name or email
+- `sortBy` (optional): Sort field (`name`, `email`, `joinedAt`, `lastActiveAt`)
+- `sortOrder` (optional): Sort order (`asc`, `desc`)
+
+**Example Request:**
+```
+GET /api/accounts/list?teamId=team_nLlpyC6REAqxydlFKbrMDlud&page=1&perPage=20&role=admin&sortBy=name&sortOrder=asc
+```
+
+**Example Response:**
+```json
+{
+  "accounts": [
+    {
+      "id": "acc_1",
+      "name": "John Doe",
+      "email": "john.doe@example.com",
+      "role": "owner",
+      "status": "active",
+      "joinedAt": "2023-01-15T00:00:00.000Z",
+      "lastActiveAt": "2024-01-29T12:00:00.000Z",
+      "avatar": "https://api.dicebear.com/7.x/avataaars/svg?seed=John",
+      "permissions": ["read", "write", "admin"]
+    }
+  ],
+  "pagination": {
+    "total": 5,
+    "page": 1,
+    "perPage": 20,
+    "hasMore": false
+  },
+  "stats": {
+    "total": 5,
+    "active": 4,
+    "invited": 1,
+    "suspended": 0,
+    "byRole": {
+      "owner": 1,
+      "admin": 1,
+      "member": 2,
+      "viewer": 1
+    }
+  }
+}
+```
+
+### 2. Account Info
+
+**Endpoint:** `GET /api/accounts/info`
+
+Get detailed information about a specific account.
+
+**Query Parameters:**
+- `accountId` (required): The account ID
+
+**Example Request:**
+```
+GET /api/accounts/info?accountId=acc_1
+```
+
+**Example Response:**
+```json
+{
+  "account": {
+    "id": "acc_1",
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "role": "owner",
+    "status": "active",
+    "joinedAt": "2023-01-15T00:00:00.000Z",
+    "lastActiveAt": "2024-01-29T12:00:00.000Z",
+    "avatar": "https://api.dicebear.com/7.x/avataaars/svg?seed=John",
+    "permissions": ["read", "write", "admin"]
+  },
+  "activity": {
+    "deployments": 42,
+    "projects": 8,
+    "lastDeploy": "2024-01-29T10:30:00.000Z"
+  },
+  "teams": [
+    {
+      "id": "team_1",
+      "name": "Engineering Team",
+      "role": "owner"
+    }
+  ]
+}
+```
+
+### 3. Account Stats
+
+**Endpoint:** `GET /api/accounts/stats`
+
+Get statistics about accounts for a team.
+
+**Query Parameters:**
+- `teamId` (required): The team ID
+
+**Example Request:**
+```
+GET /api/accounts/stats?teamId=team_nLlpyC6REAqxydlFKbrMDlud
+```
+
+**Example Response:**
+```json
+{
+  "total": 5,
+  "active": 4,
+  "invited": 1,
+  "suspended": 0,
+  "byRole": {
+    "owner": 1,
+    "admin": 1,
+    "member": 2,
+    "viewer": 1
+  }
+}
+```
+
+## Data Models
+
+### Account
+
+```typescript
+interface Account {
+  id: string;
+  name: string;
+  email: string;
+  role: 'owner' | 'admin' | 'member' | 'viewer';
+  status: 'active' | 'invited' | 'suspended';
+  joinedAt: string;
+  lastActiveAt?: string;
+  avatar?: string;
+  permissions?: string[];
+}
+```
+
+## Implementation Notes
+
+The current implementation uses mock data for demonstration purposes. In a production environment, these endpoints should:
+
+1. Authenticate requests and verify team membership
+2. Query a database for account information
+3. Implement proper error handling and logging
+4. Add rate limiting
+5. Cache frequently accessed data
+6. Support real-time updates for account status changes
+
+## Integration with Admin UI
+
+These endpoints are designed to be consumed by the admin UI at:
+```
+https://admin.vercel.com/team/{team_id}/accounts
+```
+
+The UI should:
+- Display a table of accounts with filtering and sorting
+- Show account statistics in a dashboard
+- Allow clicking on accounts to view detailed information
+- Support search functionality
+- Handle pagination for large teams

--- a/api/accounts/info.ts
+++ b/api/accounts/info.ts
@@ -1,0 +1,55 @@
+// API endpoint to get detailed account information
+// GET /api/accounts/info?accountId=acc_xxx
+
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { withApiHandler } from '../_lib/util/with-api-handler';
+import { getAccountInfo } from '../_lib/accounts/account-info';
+
+export default withApiHandler(async function (
+  req: VercelRequest,
+  res: VercelResponse
+) {
+  const accountId = req.query.accountId as string;
+
+  if (!accountId) {
+    return res.status(400).json({
+      error: {
+        code: 'missing_account_id',
+        message: 'The `accountId` parameter is required.',
+      },
+    });
+  }
+
+  const account = await getAccountInfo(accountId);
+
+  if (!account) {
+    return res.status(404).json({
+      error: {
+        code: 'account_not_found',
+        message: `Account with ID "${accountId}" not found.`,
+      },
+    });
+  }
+
+  // Mock activity data - in production this would come from analytics
+  const activity = {
+    deployments: 42,
+    projects: 8,
+    lastDeploy: '2024-01-29T10:30:00.000Z',
+  };
+
+  // Mock teams data - in production this would come from database
+  const teams = [
+    {
+      id: 'team_1',
+      name: 'Engineering Team',
+      role: account.role,
+    },
+  ];
+
+  return res.status(200).json({
+    account,
+    activity,
+    teams,
+  });
+});

--- a/api/accounts/list.ts
+++ b/api/accounts/list.ts
@@ -25,7 +25,7 @@ export default withApiHandler(async function (
   const page = parseInt((req.query.page as string) || '1', 10);
   const perPage = parseInt((req.query.perPage as string) || '20', 10);
 
-  if (page < 1 || perPage < 1 || perPage > 100) {
+  if (Number.isNaN(page) || Number.isNaN(perPage) || page < 1 || perPage < 1 || perPage > 100) {
     return res.status(400).json({
       error: {
         code: 'invalid_pagination',

--- a/api/accounts/list.ts
+++ b/api/accounts/list.ts
@@ -1,0 +1,64 @@
+// API endpoint to list accounts for a team
+// GET /api/accounts/list?teamId=team_xxx&page=1&perPage=20&role=admin&status=active&search=john&sortBy=name&sortOrder=asc
+
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { withApiHandler } from '../_lib/util/with-api-handler';
+import { listAccounts, getAccountStats } from '../_lib/accounts/account-info';
+import { AccountFilters } from '../_lib/accounts/types';
+
+export default withApiHandler(async function (
+  req: VercelRequest,
+  res: VercelResponse
+) {
+  const teamId = req.query.teamId as string;
+
+  if (!teamId) {
+    return res.status(400).json({
+      error: {
+        code: 'missing_team_id',
+        message: 'The `teamId` parameter is required.',
+      },
+    });
+  }
+
+  // Parse pagination parameters
+  const page = parseInt((req.query.page as string) || '1', 10);
+  const perPage = parseInt((req.query.perPage as string) || '20', 10);
+
+  if (page < 1 || perPage < 1 || perPage > 100) {
+    return res.status(400).json({
+      error: {
+        code: 'invalid_pagination',
+        message: 'Invalid pagination parameters. Page must be >= 1 and perPage must be between 1 and 100.',
+      },
+    });
+  }
+
+  // Parse filters
+  const filters: AccountFilters = {
+    role: req.query.role as string | undefined,
+    status: req.query.status as string | undefined,
+    search: req.query.search as string | undefined,
+    sortBy: (req.query.sortBy as any) || 'name',
+    sortOrder: (req.query.sortOrder as any) || 'asc',
+  };
+
+  // Get accounts and stats
+  const [{ accounts, total }, stats] = await Promise.all([
+    listAccounts(teamId, filters, page, perPage),
+    getAccountStats(teamId),
+  ]);
+
+  const hasMore = page * perPage < total;
+
+  return res.status(200).json({
+    accounts,
+    pagination: {
+      total,
+      page,
+      perPage,
+      hasMore,
+    },
+    stats,
+  });
+});

--- a/api/accounts/list.ts
+++ b/api/accounts/list.ts
@@ -25,11 +25,18 @@ export default withApiHandler(async function (
   const page = parseInt((req.query.page as string) || '1', 10);
   const perPage = parseInt((req.query.perPage as string) || '20', 10);
 
-  if (Number.isNaN(page) || Number.isNaN(perPage) || page < 1 || perPage < 1 || perPage > 100) {
+  if (
+    Number.isNaN(page) ||
+    Number.isNaN(perPage) ||
+    page < 1 ||
+    perPage < 1 ||
+    perPage > 100
+  ) {
     return res.status(400).json({
       error: {
         code: 'invalid_pagination',
-        message: 'Invalid pagination parameters. Page must be >= 1 and perPage must be between 1 and 100.',
+        message:
+          'Invalid pagination parameters. Page must be >= 1 and perPage must be between 1 and 100.',
       },
     });
   }

--- a/api/accounts/stats.ts
+++ b/api/accounts/stats.ts
@@ -1,0 +1,26 @@
+// API endpoint to get account statistics for a team
+// GET /api/accounts/stats?teamId=team_xxx
+
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { withApiHandler } from '../_lib/util/with-api-handler';
+import { getAccountStats } from '../_lib/accounts/account-info';
+
+export default withApiHandler(async function (
+  req: VercelRequest,
+  res: VercelResponse
+) {
+  const teamId = req.query.teamId as string;
+
+  if (!teamId) {
+    return res.status(400).json({
+      error: {
+        code: 'missing_team_id',
+        message: 'The `teamId` parameter is required.',
+      },
+    });
+  }
+
+  const stats = await getAccountStats(teamId);
+
+  return res.status(200).json(stats);
+});


### PR DESCRIPTION
Add API endpoints to support new features for the admin team accounts page.

This PR introduces three new API endpoints: `/api/accounts/list` for filtering, sorting, and pagination of team accounts; `/api/accounts/info` for detailed account views; and `/api/accounts/stats` for dashboard metrics.

---
[Slack Thread](https://vercel.slack.com/archives/C094RRDTW84/p1769732725295119?thread_ts=1769732725.295119&cid=C094RRDTW84)

<a href="https://cursor.com/background-agent?bcId=bc-983dad89-0cd1-4ad5-92ed-7497c4cd6391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-983dad89-0cd1-4ad5-92ed-7497c4cd6391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

