### PR TITLE
[next] Fix assertion for cacheComponents with getStaticProps route

### DIFF
--- a/.changeset/spicy-schools-flash.md
+++ b/.changeset/spicy-schools-flash.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Fix assertion for cacheComponents with getStaticProps route

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -2725,7 +2725,9 @@ export const onPrerenderRoute =
       !isBlocking &&
       (!isNotFound || static404Page) &&
       dataRoute &&
-      (!isAppClientParamParsingEnabled || prefetchDataRoute)
+      // When this is an App route, either isAppClientParamParsingEnabled is disabled
+      // or there's a prefetchDataRoute
+      (!isAppPathRoute || !isAppClientParamParsingEnabled || prefetchDataRoute)
     ) {
       const basePath =
         isAppPathRoute && !isOmittedOrNotFound && appDir ? appDir : pagesDir;

--- a/packages/next/test/integration/integration-2.test.js
+++ b/packages/next/test/integration/integration-2.test.js
@@ -620,6 +620,24 @@ describe('PPR', () => {
       }
     });
   });
+
+  it('should still support getStaticProps', async () => {
+    const {
+      buildResult: { output },
+    } = await runBuildLambda(path.join(__dirname, 'ppr-gsp'));
+
+    const html = output['gsp'];
+    expect(html).toBeDefined();
+    expect(html.type).toBe('FileFsRef');
+    expect(html.fsPath.endsWith('.next/server/pages/gsp.html')).toBe(true);
+
+    const data = Object.entries(output).find(
+      ([k]) => k.startsWith('_next/data/') && k.endsWith('/gsp.json')
+    );
+    expect(data).toBeDefined();
+    expect(data[1].type).toBe('FileFsRef');
+    expect(data[1].fsPath.endsWith('.next/server/pages/gsp.json')).toBe(true);
+  });
 });
 
 describe('rewrite headers', () => {

--- a/packages/next/test/integration/ppr-gsp/next.config.js
+++ b/packages/next/test/integration/ppr-gsp/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  cacheComponents: true,
+};

--- a/packages/next/test/integration/ppr-gsp/package.json
+++ b/packages/next/test/integration/ppr-gsp/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/next/test/integration/ppr-gsp/pages/gsp.js
+++ b/packages/next/test/integration/ppr-gsp/pages/gsp.js
@@ -1,0 +1,17 @@
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'world',
+      random: Math.random(),
+    },
+  };
+};
+
+export default function Page(props) {
+  return (
+    <>
+      <p id="gsp">getStaticProps page</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  );
+}

--- a/packages/next/test/integration/ppr-gsp/vercel.json
+++ b/packages/next/test/integration/ppr-gsp/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
+}


### PR DESCRIPTION
Fixes this invariant when trying to `vc build` a Next.js app with a Pages `getStaticProps` route and `cacheComponents: true`

```
Error: invariant: htmlFsRef != null && jsonFsRef != null /gsp
```