### PR TITLE
Update sockjs version from 0.3.19 to 0.3.20

### DIFF
--- a/packages/cli/test/dev/fixtures/03-aurelia/package-lock.json
+++ b/packages/cli/test/dev/fixtures/03-aurelia/package-lock.json
@@ -13589,8 +13589,8 @@
       "dev": true
     },
     "node_modules/sockjs": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
Improper Input Validation in SocksJS-Node

Incorrect handling of Upgrade header with the value websocket leads in crashing of containers hosting sockjs apps. This affects the package sockjs before 0.3.20.

