### PR TITLE
fix(cli): prevent env auto-pull from interfering with explicit environment targeting

### DIFF
--- a/.changeset/fix-env-auto-pull-ci.md
+++ b/.changeset/fix-env-auto-pull-ci.md
@@ -1,0 +1,8 @@
+---
+'vercel': patch
+---
+
+Fix environment variable auto-pull during project linking to not interfere with explicit environment targeting.
+
+- `vercel pull --environment=X` no longer auto-pulls development env vars during linking
+- Skip env pull prompt in non-TTY environments (CI) during `vercel link`

--- a/packages/cli/src/commands/pull/index.ts
+++ b/packages/cli/src/commands/pull/index.ts
@@ -114,7 +114,10 @@ export async function pullCommandLogic(
   environment: string,
   flags: PullCommandFlags
 ): Promise<number> {
-  const link = await ensureLink('pull', client, cwd, { autoConfirm });
+  const link = await ensureLink('pull', client, cwd, {
+    autoConfirm,
+    pullEnv: false,
+  });
   if (typeof link === 'number') {
     return link;
   }

--- a/packages/cli/src/util/link/setup-and-link.ts
+++ b/packages/cli/src/util/link/setup-and-link.ts
@@ -57,6 +57,7 @@ export interface SetupAndLinkOptions {
   successEmoji?: EmojiLabel;
   setupMsg?: string;
   projectName?: string;
+  pullEnv?: boolean;
 }
 
 export default async function setupAndLink(
@@ -69,6 +70,7 @@ export default async function setupAndLink(
     successEmoji = 'link',
     setupMsg = 'Set up',
     projectName = basename(path),
+    pullEnv = true,
   }: SetupAndLinkOptions
 ): Promise<ProjectLinkResult> {
   const { config } = client;
@@ -156,7 +158,8 @@ export default async function setupAndLink(
       project.name,
       org.slug,
       successEmoji,
-      autoConfirm
+      autoConfirm,
+      pullEnv
     );
     return { status: 'linked', org, project };
   }

--- a/packages/cli/src/util/projects/link.ts
+++ b/packages/cli/src/util/projects/link.ts
@@ -305,7 +305,7 @@ export async function linkFolderToProject(
   orgSlug: string,
   successEmoji: EmojiLabel = 'link',
   autoConfirm: boolean = false,
-  shouldPullEnv: boolean = true
+  pullEnv: boolean = true
 ) {
   // if the project is already linked, we skip linking
   if (await hasProjectLink(client, projectLink, path)) {
@@ -347,7 +347,12 @@ export async function linkFolderToProject(
     ) + '\n'
   );
 
-  if (!shouldPullEnv) {
+  if (!pullEnv) {
+    return;
+  }
+
+  // Skip env pull in non-TTY environments (CI)
+  if (!client.stdin.isTTY) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes an issue where the recent DX improvement (auto env pull after project linking) interferes with CI workflows and explicit environment targeting.

### Problem

After #13697, linking a project automatically pulls development environment variables. This causes issues when:

1. Running `vercel pull --environment=preview` on an unlinked project - it pulls development env vars during linking, then preview env vars, leaking development variables into CI
2. Running `vercel link` in CI followed by explicit `vercel env pull --environment=production` - development env vars are unexpectedly pulled first

### Solution

- **`vercel pull`**: Disable auto env pull during linking since the command will pull env vars explicitly with the correct environment
- **Non-TTY check**: Skip env pull prompt in non-TTY environments (CI) during `vercel link`

This approach doesn't require a new flag - CI environments are automatically detected via TTY check.

## Changes

- Added `pullEnv` option to `SetupAndLinkOptions` interface
- Pass `pullEnv: false` when `vercel pull` triggers linking
- Skip env pull in non-TTY environments (CI)

## Test plan

- [ ] `vercel pull --environment=preview` on unlinked project only creates `.vercel/.env.preview.local`
- [ ] `vercel link --yes` in CI (non-TTY) does not pull env vars
- [ ] `vercel link --yes` in interactive terminal still auto-pulls development env vars
- [ ] `vercel link` (interactive) still prompts to pull env vars