### PR TITLE
[remix] Prevent 404 responses from being cached with immutable headers

### DIFF
--- a/.changeset/rare-rivers-attack.md
+++ b/.changeset/rare-rivers-attack.md
@@ -1,0 +1,5 @@
+---
+"@vercel/remix-builder": patch
+---
+
+[remix] Prevent 404 responses from being cached with immutable headers

--- a/packages/remix/src/build-legacy.ts
+++ b/packages/remix/src/build-legacy.ts
@@ -546,12 +546,8 @@ module.exports = config;`;
     ...staticFiles,
     ...transformedBuildAssets,
   };
+  const assetsPath = remixConfig.publicPath.replace(/^\/|\/$/g, '');
   const routes: any[] = [
-    {
-      src: `^/${remixConfig.publicPath.replace(/^\/|\/$/g, '')}/(.*)$`,
-      headers: { 'cache-control': 'public, max-age=31536000, immutable' },
-      continue: true,
-    },
     {
       handle: 'filesystem',
     },
@@ -606,6 +602,18 @@ module.exports = config;`;
   routes.push({
     src: '/(.*)',
     dest: '/404',
+  });
+
+  // Routes to call after a file has been matched.
+  // Cache headers are set here so they only apply to files that exist,
+  // preventing 404 responses from being cached with immutable headers.
+  routes.push({
+    handle: 'hit',
+  });
+  routes.push({
+    src: `^/${assetsPath}/(.*)$`,
+    headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+    continue: true,
   });
 
   return { routes, output, framework: { version: remixVersion } };

--- a/packages/remix/src/build-vite.ts
+++ b/packages/remix/src/build-vite.ts
@@ -505,11 +505,6 @@ export const build: BuildV2 = async ({
   const assetsDir = viteConfig?.build?.assetsDir || 'assets';
   const routes: any[] = [
     {
-      src: `^/${assetsDir}/(.*)$`,
-      headers: { 'cache-control': 'public, max-age=31536000, immutable' },
-      continue: true,
-    },
-    {
       handle: 'filesystem',
     },
   ];
@@ -548,6 +543,18 @@ export const build: BuildV2 = async ({
   routes.push({
     src: '/(.*)',
     dest: '/',
+  });
+
+  // Routes to call after a file has been matched.
+  // Cache headers are set here so they only apply to files that exist,
+  // preventing 404 responses from being cached with immutable headers.
+  routes.push({
+    handle: 'hit',
+  });
+  routes.push({
+    src: `^/${assetsDir}/(.*)$`,
+    headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+    continue: true,
   });
 
   return { routes, output, framework: { version: frameworkVersion } };

--- a/packages/remix/test/fixtures-vite/01-no-preset/probes.json
+++ b/packages/remix/test/fixtures-vite/01-no-preset/probes.json
@@ -9,6 +9,13 @@
       "path": "/does-not-exist",
       "status": 404,
       "mustContain": "Not Found"
+    },
+    {
+      "path": "/assets/does-not-exist-abc123.js",
+      "status": 404,
+      "notResponseHeaders": {
+        "cache-control": "public, max-age=31536000, immutable"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Move cache-control headers for static assets from before `handle: 'filesystem'` to after `handle: 'hit'`
- This ensures immutable cache headers are only applied when a file actually exists
- Prevents 404 responses from being cached for 1 year with immutable headers

## Background

When cache-control headers were placed BEFORE `handle: 'filesystem'`, the headers would be applied to all matching requests, including 404s. This caused 404 responses for non-existent assets to be cached for 1 year with immutable headers, making them impossible to fix without cache purging.

The correct pattern (used by Next.js) is to place cache headers AFTER `handle: 'hit'`, which only applies them when a file is found:

```
// routes to call after a file has been matched
{ handle: 'hit' },
// Before we handle static files we need to set proper caching headers
{
  src: '/_next/static/...',
  headers: { 'cache-control': 'public,max-age=31536000,immutable' },
  ...
}
```

See: https://github.com/vercel/vercel/blob/main/packages/next/src/server-build.ts#L2748-L2766

## Test plan

- [x] Added integration test probe to verify 404 responses don't get immutable cache headers
- Similar test assertion pattern used here: https://github.com/vercel/vercel/blob/623e43f865e927406200849aa3d7b6a9e9c2dcfc/packages/next/test/fixtures/01-cache-headers/vercel.json#L18-L21

Fixes: https://linear.app/vercel/issue/BE-415

Manual curl of test fixture vs older behavior

```
➜  vercel-2 git:(main) curl -I https://01-no-preset-g45ffbb2a-zero-conf-vtest314.vercel.app/assets/does-not-exist-abc123.js
HTTP/2 404 
age: 0
cache-control: public, max-age=0, must-revalidate
content-type: text/html
date: Mon, 02 Feb 2026 17:38:53 GMT
server: Vercel
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-robots-tag: noindex
x-vercel-cache: MISS
x-vercel-id: sfo1::iad1::b2sp6-1770053933572-302fafb09751

➜  vercel-2 git:(main) curl -I https://01-no-preset-hw782p5gz-zero-conf-vtest314.vercel.app/assets/does-not-exist-abc123.js
HTTP/2 404 
age: 0
cache-control: public, max-age=31536000, immutable
content-type: text/html
date: Mon, 02 Feb 2026 17:39:04 GMT
server: Vercel
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-robots-tag: noindex
x-vercel-cache: MISS
x-vercel-id: sfo1::iad1::cf57s-1770053944387-bb701ce00343
```

🤖 Generated with [Claude Code](https://claude.ai/code)