### PR TITLE
Add support for `VERCEL_TOKEN` environment variable

### DIFF
--- a/.changeset/add-vercel-token-env.md
+++ b/.changeset/add-vercel-token-env.md
@@ -1,0 +1,9 @@
+---
+'vercel': patch
+---
+
+Add support for `VERCEL_TOKEN` environment variable
+
+The CLI now reads the `VERCEL_TOKEN` environment variable as an alternative to the `--token` flag. This allows for easier scripting and CI/CD integration without needing to pass the token as a command-line argument.
+
+The `--token` flag takes precedence over the environment variable when both are provided.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -451,6 +451,14 @@ const main = async () => {
     }
   }
 
+  // Check for VERCEL_TOKEN environment variable if --token flag not provided
+  if (
+    typeof parsedArgs.flags['--token'] !== 'string' &&
+    process.env.VERCEL_TOKEN
+  ) {
+    parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
+  }
+
   if (
     typeof parsedArgs.flags['--token'] === 'string' &&
     subcommand === 'switch'
@@ -463,14 +471,6 @@ const main = async () => {
     });
 
     return 1;
-  }
-
-  // Check for VERCEL_TOKEN environment variable if --token flag not provided
-  if (
-    typeof parsedArgs.flags['--token'] !== 'string' &&
-    process.env.VERCEL_TOKEN
-  ) {
-    parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
   }
 
   if (typeof parsedArgs.flags['--token'] === 'string') {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -465,6 +465,14 @@ const main = async () => {
     return 1;
   }
 
+  // Check for VERCEL_TOKEN environment variable if --token flag not provided
+  if (
+    typeof parsedArgs.flags['--token'] !== 'string' &&
+    process.env.VERCEL_TOKEN
+  ) {
+    parsedArgs.flags['--token'] = process.env.VERCEL_TOKEN;
+  }
+
   if (typeof parsedArgs.flags['--token'] === 'string') {
     const token: string = parsedArgs.flags['--token'];
 


### PR DESCRIPTION
Added support for the `VERCEL_TOKEN` environment variable as an alternative to the `--token` flag.

### What changed?

- Added logic to check for and use the `VERCEL_TOKEN` environment variable when the `--token` flag is not provided
- Implemented precedence logic where the `--token` flag takes priority over the environment variable when both are present

### How to test?

1. Set the `VERCEL_TOKEN` environment variable with a valid token:
   ```bash
   export VERCEL_TOKEN=your_token_here
   ```
2. Run a Vercel CLI command without specifying the `--token` flag:
   ```bash
   vercel deploy
   ```
3. Verify the command uses the token from the environment variable
4. Test precedence by providing both:
   ```bash
   export VERCEL_TOKEN=env_token
   vercel deploy --token flag_token
   ```
5. Confirm the flag token is used instead of the environment variable

### Why make this change?

This enhancement improves the developer experience when using the Vercel CLI in automated environments like CI/CD pipelines. It allows for more secure token management by avoiding command-line arguments (which can be visible in process lists) and follows common CLI tool patterns where sensitive credentials can be provided via environment variables.