### PR TITLE
feat(cli): add routes publish, restore, and discard commands

### DIFF
--- a/.changeset/routes-version-mgmt.md
+++ b/.changeset/routes-version-mgmt.md
@@ -1,5 +1,2 @@
 ---
-"vercel": patch
 ---
-
-Add `routes publish`, `routes restore`, and `routes discard` commands.

--- a/.changeset/routes-version-mgmt.md
+++ b/.changeset/routes-version-mgmt.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add `routes publish`, `routes restore`, and `routes discard` commands.

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -18,8 +18,7 @@ export const listSubcommand = {
     },
     {
       name: 'filter',
-      description:
-        'Filter by type: header, rewrite, redirect, set_status, transform',
+      description: 'Filter by type: rewrite, redirect, set_status, transform',
       shorthand: 'f',
       type: String,
       argument: 'TYPE',

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -434,7 +434,7 @@ export const restoreSubcommand = {
 } as const;
 
 export const discardSubcommand = {
-  name: 'discard',
+  name: 'discard-staging',
   aliases: [],
   description: 'Discard staged routing changes',
   arguments: [],
@@ -447,11 +447,11 @@ export const discardSubcommand = {
   examples: [
     {
       name: 'Discard staged changes',
-      value: `${packageName} routes discard`,
+      value: `${packageName} routes discard-staging`,
     },
     {
       name: 'Discard without confirmation',
-      value: `${packageName} routes discard --yes`,
+      value: `${packageName} routes discard-staging --yes`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -1,4 +1,5 @@
 import { packageName } from '../../util/pkg-name';
+import { yesOption } from '../../util/arg-common';
 
 export const listSubcommand = {
   name: 'list',
@@ -373,6 +374,89 @@ export const addSubcommand = {
   ],
 } as const;
 
+export const publishSubcommand = {
+  name: 'publish',
+  aliases: [],
+  description: 'Publish staged routing changes to production',
+  arguments: [
+    {
+      name: 'version-id',
+      required: false,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when publishing',
+    },
+  ],
+  examples: [
+    {
+      name: 'Publish staged changes',
+      value: `${packageName} routes publish`,
+    },
+    {
+      name: 'Publish a specific version',
+      value: `${packageName} routes publish <version-id>`,
+    },
+    {
+      name: 'Publish without confirmation',
+      value: `${packageName} routes publish --yes`,
+    },
+  ],
+} as const;
+
+export const restoreSubcommand = {
+  name: 'restore',
+  aliases: [],
+  description: 'Restore a previous routing version to production',
+  arguments: [
+    {
+      name: 'version-id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when restoring',
+    },
+  ],
+  examples: [
+    {
+      name: 'Restore a previous version',
+      value: `${packageName} routes restore <version-id>`,
+    },
+    {
+      name: 'Restore without confirmation',
+      value: `${packageName} routes restore <version-id> --yes`,
+    },
+  ],
+} as const;
+
+export const discardSubcommand = {
+  name: 'discard',
+  aliases: [],
+  description: 'Discard staged routing changes',
+  arguments: [],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when discarding',
+    },
+  ],
+  examples: [
+    {
+      name: 'Discard staged changes',
+      value: `${packageName} routes discard`,
+    },
+    {
+      name: 'Discard without confirmation',
+      value: `${packageName} routes discard --yes`,
+    },
+  ],
+} as const;
+
 export const routesCommand = {
   name: 'routes',
   aliases: [],
@@ -384,6 +468,9 @@ export const routesCommand = {
     listVersionsSubcommand,
     inspectSubcommand,
     addSubcommand,
+    publishSubcommand,
+    restoreSubcommand,
+    discardSubcommand,
   ],
   options: [],
   examples: [],

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -377,12 +377,7 @@ export const publishSubcommand = {
   name: 'publish',
   aliases: [],
   description: 'Publish staged routing changes to production',
-  arguments: [
-    {
-      name: 'version-id',
-      required: false,
-    },
-  ],
+  arguments: [],
   options: [
     {
       ...yesOption,
@@ -393,10 +388,6 @@ export const publishSubcommand = {
     {
       name: 'Publish staged changes',
       value: `${packageName} routes publish`,
-    },
-    {
-      name: 'Publish a specific version',
-      value: `${packageName} routes publish <version-id>`,
     },
     {
       name: 'Publish without confirmation',

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -74,15 +74,21 @@ export default async function discard(client: Client, argv: string[]) {
   const updateStamp = stamp();
   output.spinner('Discarding staged changes');
 
-  await updateRouteVersion(client, project.id, stagingVersion.id, 'discard', {
-    teamId,
-  });
+  try {
+    await updateRouteVersion(client, project.id, stagingVersion.id, 'discard', {
+      teamId,
+    });
 
-  output.log(
-    `${chalk.cyan('Success!')} Staged changes discarded ${chalk.gray(
-      updateStamp()
-    )}`
-  );
+    output.log(
+      `${chalk.cyan('Success!')} Staged changes discarded ${chalk.gray(
+        updateStamp()
+      )}`
+    );
 
-  return 0;
+    return 0;
+  } catch (e: unknown) {
+    const err = e as { message?: string };
+    output.error(err.message || 'Failed to discard staged changes');
+    return 1;
+  }
 }

--- a/packages/cli/src/commands/routes/discard.ts
+++ b/packages/cli/src/commands/routes/discard.ts
@@ -1,0 +1,88 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { discardSubcommand } from './command';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  printDiffSummary,
+} from './shared';
+import getRouteVersions from '../../util/routes/get-route-versions';
+import updateRouteVersion from '../../util/routes/update-route-version';
+import getRoutes from '../../util/routes/get-routes';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+
+export default async function discard(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, discardSubcommand);
+  if (typeof parsed === 'number') return parsed;
+
+  const link = await ensureProjectLink(client);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+
+  output.spinner(`Fetching route versions for ${chalk.bold(project.name)}`);
+
+  const { versions } = await getRouteVersions(client, project.id, { teamId });
+
+  const stagingVersion = versions.find(v => v.isStaging);
+
+  if (!stagingVersion) {
+    output.warn(
+      `No staged changes to discard. Make changes first with ${chalk.cyan(
+        getCommandName('routes add')
+      )}.`
+    );
+    return 0;
+  }
+
+  // Fetch diff to show what will be discarded
+  output.spinner('Fetching staged changes');
+  const { routes: diffRoutes } = await getRoutes(client, project.id, {
+    teamId,
+    versionId: stagingVersion.id,
+    diff: true,
+  });
+
+  const changedRoutes = diffRoutes.filter(r => r.action !== undefined);
+
+  if (changedRoutes.length > 0) {
+    output.print(`\n${chalk.bold('Changes to be discarded:')}\n\n`);
+    printDiffSummary(changedRoutes);
+    output.print('\n');
+  } else {
+    output.print(
+      `\n${chalk.gray('No changes detected in staging version.')}\n\n`
+    );
+  }
+
+  const confirmed = await confirmAction(
+    client,
+    parsed.flags['--yes'],
+    'Discard all staged changes?',
+    `This action cannot be undone.`
+  );
+
+  if (!confirmed) {
+    output.log('Canceled');
+    return 0;
+  }
+
+  const updateStamp = stamp();
+  output.spinner('Discarding staged changes');
+
+  await updateRouteVersion(client, project.id, stagingVersion.id, 'discard', {
+    teamId,
+  });
+
+  output.log(
+    `${chalk.cyan('Success!')} Staged changes discarded ${chalk.gray(
+      updateStamp()
+    )}`
+  );
+
+  return 0;
+}

--- a/packages/cli/src/commands/routes/index.ts
+++ b/packages/cli/src/commands/routes/index.ts
@@ -30,7 +30,7 @@ const COMMAND_CONFIG = {
   add: getCommandAliases(addSubcommand),
   publish: getCommandAliases(publishSubcommand),
   restore: getCommandAliases(restoreSubcommand),
-  discard: getCommandAliases(discardSubcommand),
+  'discard-staging': getCommandAliases(discardSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -123,13 +123,13 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandRestore(subcommandOriginal);
       return (await import('./restore')).default(client, args);
-    case 'discard':
+    case 'discard-staging':
       if (needHelp) {
         telemetry.trackCliFlagHelp('routes', subcommandOriginal);
         printHelp(discardSubcommand);
         return 2;
       }
-      telemetry.trackCliSubcommandDiscard(subcommandOriginal);
+      telemetry.trackCliSubcommandDiscardStaging(subcommandOriginal);
       return (await import('./discard')).default(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));

--- a/packages/cli/src/commands/routes/index.ts
+++ b/packages/cli/src/commands/routes/index.ts
@@ -14,6 +14,9 @@ import {
   listVersionsSubcommand,
   inspectSubcommand,
   addSubcommand,
+  publishSubcommand,
+  restoreSubcommand,
+  discardSubcommand,
 } from './command';
 import { getFlagsSpecification } from '../../util/get-flags-specification';
 import output from '../../output-manager';
@@ -25,6 +28,9 @@ const COMMAND_CONFIG = {
   'list-versions': getCommandAliases(listVersionsSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   add: getCommandAliases(addSubcommand),
+  publish: getCommandAliases(publishSubcommand),
+  restore: getCommandAliases(restoreSubcommand),
+  discard: getCommandAliases(discardSubcommand),
 };
 
 export default async function main(client: Client) {
@@ -101,6 +107,30 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'publish':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('routes', subcommandOriginal);
+        printHelp(publishSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandPublish(subcommandOriginal);
+      return (await import('./publish')).default(client, args);
+    case 'restore':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('routes', subcommandOriginal);
+        printHelp(restoreSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandRestore(subcommandOriginal);
+      return (await import('./restore')).default(client, args);
+    case 'discard':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('routes', subcommandOriginal);
+        printHelp(discardSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandDiscard(subcommandOriginal);
+      return (await import('./discard')).default(client, args);
     default:
       output.error(getInvalidSubcommand(COMMAND_CONFIG));
       output.print(help(routesCommand, { columns: client.stderr.columns }));

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -14,7 +14,7 @@ import getRouteVersions from '../../util/routes/get-route-versions';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
 import {
-  getRouteTypeLabels,
+  getRouteTypeLabel,
   getSrcSyntaxLabel,
   type RoutingRule,
 } from '../../util/routes/types';
@@ -207,7 +207,7 @@ function formatRouteDiff(
     return lines.join('\n') + '\n' + formatRouteDetails(staging);
   }
 
-  const typeLabels = getRouteTypeLabels(staging);
+  const typeLabels = getRouteTypeLabel(staging);
   const syntaxLabel = getSrcSyntaxLabel(staging);
 
   lines.push(`  ${chalk.bold(staging.name)} ${chalk.yellow('(modified)')}`);
@@ -484,7 +484,7 @@ function diffConditions(
 
 function formatRouteDetails(rule: RoutingRule): string {
   const lines: string[] = [''];
-  const typeLabels = getRouteTypeLabels(rule);
+  const typeLabels = getRouteTypeLabel(rule);
   const syntaxLabel = getSrcSyntaxLabel(rule);
   const statusText =
     rule.enabled === false ? chalk.red('Disabled') : chalk.green('Enabled');

--- a/packages/cli/src/commands/routes/list-versions.ts
+++ b/packages/cli/src/commands/routes/list-versions.ts
@@ -66,15 +66,14 @@ function formatVersionsTable(versions: RouteVersion[]): string {
     const id = version.id.slice(0, 12);
     const routeCount =
       version.ruleCount !== undefined ? version.ruleCount.toString() : '-';
-    const creator = version.createdBy || '-';
     const age = getRelativeTime(version.lastModified);
 
-    return [status, id, routeCount, creator, age];
+    return [status, id, routeCount, age];
   });
 
   return formatTable(
-    ['Status', 'ID', 'Routes', 'Creator', 'Age'],
-    ['l', 'l', 'r', 'l', 'l'],
+    ['Status', 'ID', 'Routes', 'Age'],
+    ['l', 'l', 'r', 'l'],
     [{ rows }]
   );
 }

--- a/packages/cli/src/commands/routes/list.ts
+++ b/packages/cli/src/commands/routes/list.ts
@@ -15,7 +15,7 @@ import stamp from '../../util/output/stamp';
 import formatTable from '../../util/format-table';
 import { getCommandName } from '../../util/pkg-name';
 import {
-  getRouteTypeLabels,
+  getRouteTypeLabel,
   getSrcSyntaxLabel,
   type RoutingRule,
   type RouteType,
@@ -44,7 +44,6 @@ export default async function list(client: Client, argv: string[]) {
   // Validate filter value
   if (filter) {
     const validFilters: RouteType[] = [
-      'header',
       'rewrite',
       'redirect',
       'set_status',
@@ -233,7 +232,7 @@ function formatRoutesTable(
   actionSymbol?: DiffAction
 ): string {
   const rows: string[][] = routes.map((rule, index) => {
-    const typeLabels = getRouteTypeLabels(rule);
+    const typeLabels = getRouteTypeLabel(rule);
     const status =
       rule.enabled === false ? chalk.red('Disabled') : chalk.green('Enabled');
     const prefix = actionSymbol || '';
@@ -275,7 +274,7 @@ function formatExpandedRoutes(routes: RoutingRule[]): string {
   const lines: string[] = [''];
 
   routes.forEach((rule, index) => {
-    const typeLabels = getRouteTypeLabels(rule);
+    const typeLabels = getRouteTypeLabel(rule);
     const syntaxLabel = getSrcSyntaxLabel(rule);
     const statusText =
       rule.enabled === false ? chalk.red('Disabled') : chalk.green('Enabled');

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -1,0 +1,130 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { publishSubcommand } from './command';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  printDiffSummary,
+} from './shared';
+import getRouteVersions from '../../util/routes/get-route-versions';
+import updateRouteVersion from '../../util/routes/update-route-version';
+import getRoutes from '../../util/routes/get-routes';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+
+export default async function publish(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, publishSubcommand);
+  if (typeof parsed === 'number') return parsed;
+
+  const link = await ensureProjectLink(client);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+
+  const [versionIdentifier] = parsed.args;
+
+  output.spinner(`Fetching route versions for ${chalk.bold(project.name)}`);
+
+  const { versions } = await getRouteVersions(client, project.id, { teamId });
+
+  let version;
+  if (versionIdentifier) {
+    // User provided a specific version ID
+    version = versions.find(v => v.id === versionIdentifier);
+    if (!version) {
+      output.error(
+        `Version "${versionIdentifier}" not found. Run ${chalk.cyan(
+          getCommandName('routes list-versions')
+        )} to see available versions.`
+      );
+      return 1;
+    }
+  } else {
+    // Auto-find staging version
+    version = versions.find(v => v.isStaging);
+    if (!version) {
+      output.warn(
+        `No staged changes to publish. Make changes first with ${chalk.cyan(
+          getCommandName('routes add')
+        )}.`
+      );
+      return 0;
+    }
+  }
+
+  if (version.isLive) {
+    output.error(
+      `Version ${chalk.bold(version.id.slice(0, 12))} is already live.`
+    );
+    return 1;
+  }
+
+  if (!version.isStaging) {
+    output.error(
+      `Version ${chalk.bold(
+        version.id.slice(0, 12)
+      )} is not staged. Only staging versions can be published to production.\nUse ${chalk.cyan(
+        getCommandName('routes restore <version-id>')
+      )} to restore a previous version.`
+    );
+    return 1;
+  }
+
+  // Fetch diff to show changes
+  output.spinner('Fetching changes');
+  const { routes: diffRoutes } = await getRoutes(client, project.id, {
+    teamId,
+    versionId: version.id,
+    diff: true,
+  });
+
+  const changedRoutes = diffRoutes.filter(r => r.action !== undefined);
+
+  if (changedRoutes.length > 0) {
+    output.print(`\n${chalk.bold('Changes to be published:')}\n\n`);
+    printDiffSummary(changedRoutes);
+    output.print('\n');
+  } else {
+    output.print(
+      `\n${chalk.gray('No changes detected from current production version.')}\n\n`
+    );
+  }
+
+  const confirmed = await confirmAction(
+    client,
+    parsed.flags['--yes'],
+    'Publish these changes to production?',
+    `This will make them live for ${chalk.bold(project.name)}.`
+  );
+
+  if (!confirmed) {
+    output.log('Canceled');
+    return 0;
+  }
+
+  const updateStamp = stamp();
+  output.spinner('Publishing to production');
+
+  const { version: newVersion } = await updateRouteVersion(
+    client,
+    project.id,
+    version.id,
+    'promote',
+    { teamId }
+  );
+
+  output.log(
+    `${chalk.cyan('Success!')} Routes published to production ${chalk.gray(
+      updateStamp()
+    )}`
+  );
+
+  if (newVersion.ruleCount !== undefined) {
+    output.print(`  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`);
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -106,23 +106,31 @@ export default async function publish(client: Client, argv: string[]) {
   const updateStamp = stamp();
   output.spinner('Publishing to production');
 
-  const { version: newVersion } = await updateRouteVersion(
-    client,
-    project.id,
-    version.id,
-    'promote',
-    { teamId }
-  );
+  try {
+    const { version: newVersion } = await updateRouteVersion(
+      client,
+      project.id,
+      version.id,
+      'promote',
+      { teamId }
+    );
 
-  output.log(
-    `${chalk.cyan('Success!')} Routes published to production ${chalk.gray(
-      updateStamp()
-    )}`
-  );
+    output.log(
+      `${chalk.cyan('Success!')} Routes published to production ${chalk.gray(
+        updateStamp()
+      )}`
+    );
 
-  if (newVersion.ruleCount !== undefined) {
-    output.print(`  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`);
+    if (newVersion.ruleCount !== undefined) {
+      output.print(
+        `  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`
+      );
+    }
+
+    return 0;
+  } catch (e: unknown) {
+    const err = e as { message?: string };
+    output.error(err.message || 'Failed to publish routes');
+    return 1;
   }
-
-  return 0;
 }

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -7,6 +7,7 @@ import {
   ensureProjectLink,
   confirmAction,
   printDiffSummary,
+  findVersionById,
 } from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
@@ -32,16 +33,13 @@ export default async function publish(client: Client, argv: string[]) {
 
   let version;
   if (versionIdentifier) {
-    // User provided a specific version ID
-    version = versions.find(v => v.id === versionIdentifier);
-    if (!version) {
-      output.error(
-        `Version "${versionIdentifier}" not found. Run ${chalk.cyan(
-          getCommandName('routes list-versions')
-        )} to see available versions.`
-      );
+    // User provided a specific version ID (supports partial IDs)
+    const result = findVersionById(versions, versionIdentifier);
+    if (result.error) {
+      output.error(result.error);
       return 1;
     }
+    version = result.version;
   } else {
     // Auto-find staging version
     version = versions.find(v => v.isStaging);

--- a/packages/cli/src/commands/routes/publish.ts
+++ b/packages/cli/src/commands/routes/publish.ts
@@ -7,11 +7,9 @@ import {
   ensureProjectLink,
   confirmAction,
   printDiffSummary,
-  findVersionById,
 } from './shared';
 import getRouteVersions from '../../util/routes/get-route-versions';
 import updateRouteVersion from '../../util/routes/update-route-version';
-import type { RouteVersion } from '../../util/routes/types';
 import getRoutes from '../../util/routes/get-routes';
 import stamp from '../../util/output/stamp';
 import { getCommandName } from '../../util/pkg-name';
@@ -26,55 +24,18 @@ export default async function publish(client: Client, argv: string[]) {
   const { project, org } = link;
   const teamId = org.type === 'team' ? org.id : undefined;
 
-  const [versionIdentifier] = parsed.args;
-
   output.spinner(`Fetching route versions for ${chalk.bold(project.name)}`);
 
   const { versions } = await getRouteVersions(client, project.id, { teamId });
 
-  let version: RouteVersion | undefined;
-  if (versionIdentifier) {
-    const result = findVersionById(versions, versionIdentifier);
-    if (result.error) {
-      output.error(result.error);
-      return 1;
-    }
-    version = result.version;
-  } else {
-    version = versions.find(v => v.isStaging);
-    if (!version) {
-      output.warn(
-        `No staged changes to publish. Make changes first with ${chalk.cyan(
-          getCommandName('routes add')
-        )}.`
-      );
-      return 0;
-    }
-  }
-
-  // At this point version is guaranteed to be defined
-  // (both branches either assign it or return early)
+  const version = versions.find(v => v.isStaging);
   if (!version) {
-    output.error('No version found.');
-    return 1;
-  }
-
-  if (version.isLive) {
-    output.error(
-      `Version ${chalk.bold(version.id.slice(0, 12))} is already live.`
+    output.warn(
+      `No staged changes to publish. Make changes first with ${chalk.cyan(
+        getCommandName('routes add')
+      )}.`
     );
-    return 1;
-  }
-
-  if (!version.isStaging) {
-    output.error(
-      `Version ${chalk.bold(
-        version.id.slice(0, 12)
-      )} is not staged. Only staging versions can be published to production.\nUse ${chalk.cyan(
-        getCommandName('routes restore <version-id>')
-      )} to restore a previous version.`
-    );
-    return 1;
+    return 0;
   }
 
   // Fetch diff to show changes

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -44,6 +44,10 @@ export default async function restore(client: Client, argv: string[]) {
     return 1;
   }
   const version = result.version;
+  if (!version) {
+    output.error('Version not found.');
+    return 1;
+  }
 
   if (version.isLive) {
     output.error(

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -1,0 +1,127 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { restoreSubcommand } from './command';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  confirmAction,
+  validateRequiredArgs,
+  printDiffSummary,
+} from './shared';
+import getRouteVersions from '../../util/routes/get-route-versions';
+import updateRouteVersion from '../../util/routes/update-route-version';
+import getRoutes from '../../util/routes/get-routes';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+
+export default async function restore(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, restoreSubcommand);
+  if (typeof parsed === 'number') return parsed;
+
+  const error = validateRequiredArgs(parsed.args, ['version-id']);
+  if (error) {
+    output.error(error);
+    return 1;
+  }
+
+  const link = await ensureProjectLink(client);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+
+  const [versionIdentifier] = parsed.args;
+
+  output.spinner(`Fetching route versions for ${chalk.bold(project.name)}`);
+
+  const { versions } = await getRouteVersions(client, project.id, { teamId });
+
+  const version = versions.find(v => v.id === versionIdentifier);
+
+  if (!version) {
+    output.error(
+      `Version "${versionIdentifier}" not found. Run ${chalk.cyan(
+        getCommandName('routes list-versions')
+      )} to see available versions.`
+    );
+    return 1;
+  }
+
+  if (version.isLive) {
+    output.error(
+      `Version ${chalk.bold(
+        version.id.slice(0, 12)
+      )} is currently live. You cannot restore the live version.\nRun ${chalk.cyan(
+        getCommandName('routes list-versions')
+      )} to see previous versions you can restore.`
+    );
+    return 1;
+  }
+
+  if (version.isStaging) {
+    output.error(
+      `Version ${chalk.bold(
+        version.id.slice(0, 12)
+      )} is staged. Use ${chalk.cyan(
+        getCommandName('routes publish')
+      )} to publish it instead.`
+    );
+    return 1;
+  }
+
+  // Fetch diff to show what will change
+  output.spinner('Fetching changes');
+  const { routes: diffRoutes } = await getRoutes(client, project.id, {
+    teamId,
+    versionId: version.id,
+    diff: true,
+  });
+
+  const changedRoutes = diffRoutes.filter(r => r.action !== undefined);
+
+  if (changedRoutes.length > 0) {
+    output.print(`\n${chalk.bold('Changes to be restored:')}\n\n`);
+    printDiffSummary(changedRoutes);
+    output.print('\n');
+  } else {
+    output.print(
+      `\n${chalk.gray('No changes detected from current production version.')}\n\n`
+    );
+  }
+
+  const confirmed = await confirmAction(
+    client,
+    parsed.flags['--yes'],
+    `Restore version ${chalk.bold(version.id.slice(0, 12))} to production?`,
+    `This will replace the current live routes for ${chalk.bold(project.name)}.`
+  );
+
+  if (!confirmed) {
+    output.log('Canceled');
+    return 0;
+  }
+
+  const updateStamp = stamp();
+  output.spinner(`Restoring version ${chalk.bold(version.id.slice(0, 12))}`);
+
+  const { version: newVersion } = await updateRouteVersion(
+    client,
+    project.id,
+    version.id,
+    'restore',
+    { teamId }
+  );
+
+  output.log(
+    `${chalk.cyan('Success!')} Version ${chalk.bold(
+      newVersion.id.slice(0, 12)
+    )} restored to production ${chalk.gray(updateStamp())}`
+  );
+
+  if (newVersion.ruleCount !== undefined) {
+    output.print(`  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`);
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -37,9 +37,12 @@ export default async function restore(client: Client, argv: string[]) {
 
   const { versions } = await getRouteVersions(client, project.id, { teamId });
 
-  const version = versions.find(v => v.id === versionIdentifier);
+  // Support both full UUIDs and partial IDs (matching the truncated display from list-versions)
+  const matchingVersions = versions.filter(v =>
+    v.id.startsWith(versionIdentifier)
+  );
 
-  if (!version) {
+  if (matchingVersions.length === 0) {
     output.error(
       `Version "${versionIdentifier}" not found. Run ${chalk.cyan(
         getCommandName('routes list-versions')
@@ -47,6 +50,17 @@ export default async function restore(client: Client, argv: string[]) {
     );
     return 1;
   }
+
+  if (matchingVersions.length > 1) {
+    output.error(
+      `Multiple versions match "${versionIdentifier}". Please provide a more specific ID:\n${matchingVersions
+        .map(v => `  ${v.id}`)
+        .join('\n')}`
+    );
+    return 1;
+  }
+
+  const version = matchingVersions[0];
 
   if (version.isLive) {
     output.error(

--- a/packages/cli/src/commands/routes/restore.ts
+++ b/packages/cli/src/commands/routes/restore.ts
@@ -102,23 +102,31 @@ export default async function restore(client: Client, argv: string[]) {
   const updateStamp = stamp();
   output.spinner(`Restoring version ${chalk.bold(version.id.slice(0, 12))}`);
 
-  const { version: newVersion } = await updateRouteVersion(
-    client,
-    project.id,
-    version.id,
-    'restore',
-    { teamId }
-  );
+  try {
+    const { version: newVersion } = await updateRouteVersion(
+      client,
+      project.id,
+      version.id,
+      'restore',
+      { teamId }
+    );
 
-  output.log(
-    `${chalk.cyan('Success!')} Version ${chalk.bold(
-      newVersion.id.slice(0, 12)
-    )} restored to production ${chalk.gray(updateStamp())}`
-  );
+    output.log(
+      `${chalk.cyan('Success!')} Version ${chalk.bold(
+        newVersion.id.slice(0, 12)
+      )} restored to production ${chalk.gray(updateStamp())}`
+    );
 
-  if (newVersion.ruleCount !== undefined) {
-    output.print(`  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`);
+    if (newVersion.ruleCount !== undefined) {
+      output.print(
+        `  ${chalk.bold('Active routes:')} ${newVersion.ruleCount}\n`
+      );
+    }
+
+    return 0;
+  } catch (e: unknown) {
+    const err = e as { message?: string };
+    output.error(err.message || 'Failed to restore version');
+    return 1;
   }
-
-  return 0;
 }

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -252,7 +252,7 @@ export function printDiffSummary(routes: RoutingRule[], maxDisplay = 10): void {
   for (const route of displayRoutes) {
     const symbol = getDiffSymbol(route);
     const label = getDiffLabel(route);
-    const routeType = getPrimaryRouteType(route);
+    const routeType = getRouteTypeDisplayLabel(route);
 
     output.print(
       `  ${symbol} ${route.name}${routeType ? ` ${chalk.gray(`(${routeType})`)}` : ''} ${chalk.gray(`- ${label}`)}\n`
@@ -283,22 +283,24 @@ export function getDiffLabel(route: RoutingRule): string {
     return `Reordered (${route.previousIndex! + 1} → ${route.newIndex! + 1})`;
   }
 
+  if (route.previousEnabled !== undefined) {
+    return route.enabled === false ? 'Disabled' : 'Enabled';
+  }
+
   return 'Modified';
 }
 
-export function getPrimaryRouteType(route: RoutingRule): string | null {
-  const types = route.routeTypes ?? [];
-  if (types.length === 0) return null;
+export function getRouteTypeDisplayLabel(route: RoutingRule): string | null {
+  if (!route.routeType) return null;
 
   const typeLabels: Record<RouteType, string> = {
-    header: 'Header',
     rewrite: 'Rewrite',
     redirect: 'Redirect',
     set_status: 'Set Status',
     transform: 'Transform',
   };
 
-  return typeLabels[types[0]] ?? null;
+  return typeLabels[route.routeType] ?? null;
 }
 
 /**

--- a/packages/cli/src/commands/routes/shared.ts
+++ b/packages/cli/src/commands/routes/shared.ts
@@ -7,7 +7,12 @@ import { getLinkedProject } from '../../util/projects/link';
 import { getCommandName } from '../../util/pkg-name';
 import output from '../../output-manager';
 import type { Command } from '../help';
-import type { RoutePosition, RouteVersion } from '../../util/routes/types';
+import type {
+  RoutingRule,
+  RouteType,
+  RoutePosition,
+  RouteVersion,
+} from '../../util/routes/types';
 
 export interface ParsedSubcommand {
   args: string[];
@@ -63,6 +68,18 @@ export async function confirmAction(
   }
 
   return await client.input.confirm(message, false);
+}
+
+export function validateRequiredArgs(
+  args: string[],
+  required: string[]
+): string | null {
+  for (let i = 0; i < required.length; i++) {
+    if (!args[i]) {
+      return `Missing required argument: ${required[i]}`;
+    }
+  }
+  return null;
 }
 
 /**
@@ -224,4 +241,84 @@ export async function offerAutoPromote(
       `There are other staged changes. Review with ${chalk.cyan(getCommandName('routes list --staging'))} before promoting.`
     );
   }
+}
+
+/**
+ * Print a summary of route changes for diff display.
+ */
+export function printDiffSummary(routes: RoutingRule[], maxDisplay = 10): void {
+  const displayRoutes = routes.slice(0, maxDisplay);
+
+  for (const route of displayRoutes) {
+    const symbol = getDiffSymbol(route);
+    const label = getDiffLabel(route);
+    const routeType = getPrimaryRouteType(route);
+
+    output.print(
+      `  ${symbol} ${route.name}${routeType ? ` ${chalk.gray(`(${routeType})`)}` : ''} ${chalk.gray(`- ${label}`)}\n`
+    );
+  }
+
+  if (routes.length > maxDisplay) {
+    output.print(
+      chalk.gray(`\n  ... and ${routes.length - maxDisplay} more changes\n`)
+    );
+  }
+}
+
+export function getDiffSymbol(route: RoutingRule): string {
+  if (route.action === '+') return chalk.green('+');
+  if (route.action === '-') return chalk.red('-');
+  return chalk.yellow('~');
+}
+
+export function getDiffLabel(route: RoutingRule): string {
+  if (route.action === '+') return 'Added';
+  if (route.action === '-') return 'Deleted';
+
+  const isReordered =
+    route.previousIndex !== undefined && route.newIndex !== undefined;
+
+  if (isReordered) {
+    return `Reordered (${route.previousIndex! + 1} → ${route.newIndex! + 1})`;
+  }
+
+  return 'Modified';
+}
+
+export function getPrimaryRouteType(route: RoutingRule): string | null {
+  const types = route.routeTypes ?? [];
+  if (types.length === 0) return null;
+
+  const typeLabels: Record<RouteType, string> = {
+    header: 'Header',
+    rewrite: 'Rewrite',
+    redirect: 'Redirect',
+    set_status: 'Set Status',
+    transform: 'Transform',
+  };
+
+  return typeLabels[types[0]] ?? null;
+}
+
+/**
+ * Find a version by a partial ID match.
+ */
+export function findVersionById(
+  versions: { id: string }[],
+  identifier: string
+): { version: { id: string } | null; error?: string } {
+  const exact = versions.find(v => v.id === identifier);
+  if (exact) return { version: exact };
+
+  const matches = versions.filter(v => v.id.startsWith(identifier));
+  if (matches.length === 1) return { version: matches[0] };
+  if (matches.length > 1) {
+    return {
+      version: null,
+      error: `Ambiguous version identifier "${identifier}" matches ${matches.length} versions. Please provide more characters.`,
+    };
+  }
+
+  return { version: null };
 }

--- a/packages/cli/src/util/routes/types.ts
+++ b/packages/cli/src/util/routes/types.ts
@@ -36,8 +36,10 @@ export interface RoutingRule {
   previousIndex?: number;
   /** Present if route was reordered (new position) */
   newIndex?: number;
-  /** Route types computed by the API */
-  routeTypes?: RouteType[];
+  /** Present in diff when route's enabled state changed */
+  previousEnabled?: boolean;
+  /** Computed route type from the API */
+  routeType?: RouteType;
 }
 
 /**
@@ -71,18 +73,12 @@ export interface GetVersionsResponse {
 /**
  * Route type categories for filtering and display
  */
-export type RouteType =
-  | 'header'
-  | 'rewrite'
-  | 'redirect'
-  | 'set_status'
-  | 'transform';
+export type RouteType = 'rewrite' | 'redirect' | 'set_status' | 'transform';
 
 /**
  * Display labels for route types
  */
 const ROUTE_TYPE_LABELS: Record<RouteType, string> = {
-  header: 'Header',
   rewrite: 'Rewrite',
   redirect: 'Redirect',
   set_status: 'Set Status',
@@ -90,12 +86,12 @@ const ROUTE_TYPE_LABELS: Record<RouteType, string> = {
 };
 
 /**
- * Returns a comma-separated string of display labels for a rule's route types.
- * Returns '-' if the rule has no route types.
+ * Returns the display label for a rule's route type.
+ * Returns '-' if the rule has no route type.
  */
-export function getRouteTypeLabels(rule: RoutingRule): string {
-  const types = rule.routeTypes ?? [];
-  return types.map(t => ROUTE_TYPE_LABELS[t]).join(', ') || '-';
+export function getRouteTypeLabel(rule: RoutingRule): string {
+  if (!rule.routeType) return '-';
+  return ROUTE_TYPE_LABELS[rule.routeType] ?? '-';
 }
 
 /**

--- a/packages/cli/src/util/routes/types.ts
+++ b/packages/cli/src/util/routes/types.ts
@@ -48,7 +48,6 @@ export interface RoutingRule {
 export interface RouteVersion {
   id: string;
   lastModified: number;
-  createdBy: string;
   isStaging?: boolean;
   isLive?: boolean;
   ruleCount?: number;

--- a/packages/cli/src/util/telemetry/commands/routes/index.ts
+++ b/packages/cli/src/util/telemetry/commands/routes/index.ts
@@ -51,9 +51,9 @@ export class RoutesTelemetryClient
     });
   }
 
-  trackCliSubcommandDiscard(actual: string) {
+  trackCliSubcommandDiscardStaging(actual: string) {
     this.trackCliSubcommand({
-      subcommand: 'discard',
+      subcommand: 'discard-staging',
       value: actual,
     });
   }

--- a/packages/cli/src/util/telemetry/commands/routes/index.ts
+++ b/packages/cli/src/util/telemetry/commands/routes/index.ts
@@ -36,6 +36,27 @@ export class RoutesTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandPublish(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'publish',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandRestore(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'restore',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDiscard(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'discard',
+      value: actual,
+    });
+  }
 }
 
 /**

--- a/packages/cli/test/mocks/routes.ts
+++ b/packages/cli/test/mocks/routes.ts
@@ -311,7 +311,6 @@ export function useUpdateRouteVersion(options?: {
 
   const versions = (options?.versions ?? defaultVersions).map((v, i) => ({
     id: v.id,
-    s3Key: `routes/${v.id}.json`,
     lastModified: Date.now() - i * 60000,
     createdBy: 'user@example.com',
     isStaging: v.isStaging ?? false,
@@ -382,7 +381,6 @@ export function useUpdateRouteVersion(options?: {
       res.json({
         version: {
           id: version.id,
-          s3Key: version.s3Key,
           lastModified: Date.now(),
           createdBy: version.createdBy,
           isLive: body.action === 'promote' || body.action === 'restore',
@@ -433,7 +431,6 @@ export function useRoutesWithDiffForPublish() {
       routes,
       version: {
         id: 'staging-version',
-        s3Key: 'routes/staging.json',
         lastModified: Date.now(),
         createdBy: 'user@example.com',
         isStaging: true,

--- a/packages/cli/test/mocks/routes.ts
+++ b/packages/cli/test/mocks/routes.ts
@@ -56,7 +56,6 @@ export function useRoutes(count: number = 3) {
     // Filter by type if provided
     if (filter) {
       routes = routes.filter(r => {
-        if (filter === 'header') return r.route.headers;
         if (filter === 'redirect')
           return (
             r.route.status && [301, 302, 307, 308].includes(r.route.status)
@@ -402,19 +401,19 @@ export function useRoutesWithDiffForPublish() {
         ...createRoute(0),
         name: 'Added route',
         action: diff ? ('+' as const) : undefined,
-        routeTypes: ['rewrite' as const],
+        routeType: 'rewrite' as const,
       },
       {
         ...createRoute(1),
         name: 'Deleted route',
         action: diff ? ('-' as const) : undefined,
-        routeTypes: ['redirect' as const],
+        routeType: 'redirect' as const,
       },
       {
         ...createRoute(2),
         name: 'Modified route',
         action: diff ? ('~' as const) : undefined,
-        routeTypes: ['header' as const],
+        routeType: 'transform' as const,
       },
       {
         ...createRoute(3),
@@ -422,9 +421,25 @@ export function useRoutesWithDiffForPublish() {
         action: diff ? ('~' as const) : undefined,
         previousIndex: diff ? 5 : undefined,
         newIndex: diff ? 3 : undefined,
-        routeTypes: ['transform' as const],
+        routeType: 'transform' as const,
       },
-      { ...createRoute(4), name: 'Unchanged route', action: undefined },
+      {
+        ...createRoute(4),
+        name: 'Enabled route',
+        enabled: true,
+        action: diff ? ('~' as const) : undefined,
+        previousEnabled: diff ? false : undefined,
+        routeType: 'rewrite' as const,
+      },
+      {
+        ...createRoute(5),
+        name: 'Disabled route',
+        enabled: false,
+        action: diff ? ('~' as const) : undefined,
+        previousEnabled: diff ? true : undefined,
+        routeType: 'redirect' as const,
+      },
+      { ...createRoute(6), name: 'Unchanged route', action: undefined },
     ];
 
     res.json({
@@ -455,7 +470,7 @@ export function useRoutesForInspect() {
         dest: '/new-page',
         status: 308,
       },
-      routeTypes: ['redirect'],
+      routeType: 'redirect',
     },
     {
       id: 'route-header-456',
@@ -472,7 +487,7 @@ export function useRoutesForInspect() {
         },
         continue: true,
       },
-      routeTypes: ['header'],
+      routeType: 'transform',
     },
     {
       id: 'route-condition-789',
@@ -487,7 +502,7 @@ export function useRoutesForInspect() {
         missing: [{ type: 'cookie', key: 'auth' }],
         has: [{ type: 'header', key: 'Accept', value: 'text/html' }],
       },
-      routeTypes: ['rewrite'],
+      routeType: 'rewrite',
     },
     {
       id: 'route-transform-101',
@@ -519,7 +534,7 @@ export function useRoutesForInspect() {
           },
         ],
       },
-      routeTypes: ['rewrite', 'transform'],
+      routeType: 'rewrite',
     },
   ];
 
@@ -573,7 +588,7 @@ export function useRoutesForInspectDiff() {
           { type: 'query', key: 'version', value: '2' },
         ],
       },
-      routeTypes: ['rewrite', 'header'],
+      routeType: 'rewrite',
     },
     {
       id: 'route-diff-new',
@@ -585,7 +600,7 @@ export function useRoutesForInspectDiff() {
         src: '/new-page',
         dest: '/new-handler',
       },
-      routeTypes: ['rewrite'],
+      routeType: 'rewrite',
     },
   ];
 
@@ -606,7 +621,7 @@ export function useRoutesForInspectDiff() {
         },
         has: [{ type: 'header', key: 'Authorization' }],
       },
-      routeTypes: ['rewrite', 'header'],
+      routeType: 'rewrite',
     },
   ];
 

--- a/packages/cli/test/unit/commands/routes/discard.test.ts
+++ b/packages/cli/test/unit/commands/routes/discard.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import routes from '../../../../src/commands/routes';
+import { useUser } from '../../../mocks/user';
+import {
+  useUpdateRouteVersion,
+  useRoutesWithDiffForPublish,
+} from '../../../mocks/routes';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+describe('routes discard', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'routes-test-project',
+      name: 'routes-test',
+    });
+    const cwd = setupUnitFixture('commands/routes');
+    client.cwd = cwd;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'routes';
+      const subcommand = 'discard';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = routes(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('should discard staging changes with --yes', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for "routes discard --yes"').toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+
+  it('should show what will be discarded', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Changes to be discarded:');
+  });
+
+  it('should warn when no staging version exists', async () => {
+    useUpdateRouteVersion({
+      versions: [{ id: 'live-version', isLive: true }],
+    });
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code when no staging').toEqual(0);
+    await expect(client.stderr).toOutput('No staged changes to discard');
+  });
+
+  it('tracks subcommand invocation', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:discard',
+        value: 'discard',
+      },
+    ]);
+  });
+
+  it('should prompt for confirmation and cancel when declined', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard');
+    // Simulate user declining confirmation
+    client.input.confirm = vi.fn().mockResolvedValue(false);
+
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code when canceled').toEqual(0);
+    await expect(client.stderr).toOutput('Canceled');
+  });
+
+  it('should proceed when user confirms', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'discard');
+    // Simulate user confirming
+    client.input.confirm = vi.fn().mockResolvedValue(true);
+
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+});

--- a/packages/cli/test/unit/commands/routes/discard.test.ts
+++ b/packages/cli/test/unit/commands/routes/discard.test.ts
@@ -10,7 +10,7 @@ import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
 
-describe('routes discard', () => {
+describe('routes discard-staging', () => {
   beforeEach(() => {
     useUser();
     useTeams('team_dummy');
@@ -26,7 +26,7 @@ describe('routes discard', () => {
   describe('--help', () => {
     it('tracks telemetry', async () => {
       const command = 'routes';
-      const subcommand = 'discard';
+      const subcommand = 'discard-staging';
 
       client.setArgv(command, subcommand, '--help');
       const exitCodePromise = routes(client);
@@ -44,7 +44,7 @@ describe('routes discard', () => {
   it('should discard staging changes with --yes', async () => {
     useUpdateRouteVersion();
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard', '--yes');
+    client.setArgv('routes', 'discard-staging', '--yes');
     const exitCode = await routes(client);
     expect(exitCode, 'exit code for "routes discard --yes"').toEqual(0);
     await expect(client.stderr).toOutput('Success!');
@@ -53,7 +53,7 @@ describe('routes discard', () => {
   it('should show what will be discarded', async () => {
     useUpdateRouteVersion();
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard', '--yes');
+    client.setArgv('routes', 'discard-staging', '--yes');
     const exitCode = await routes(client);
     expect(exitCode).toEqual(0);
     await expect(client.stderr).toOutput('Changes to be discarded:');
@@ -64,7 +64,7 @@ describe('routes discard', () => {
       versions: [{ id: 'live-version', isLive: true }],
     });
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard', '--yes');
+    client.setArgv('routes', 'discard-staging', '--yes');
     const exitCode = await routes(client);
     expect(exitCode, 'exit code when no staging').toEqual(0);
     await expect(client.stderr).toOutput('No staged changes to discard');
@@ -73,14 +73,14 @@ describe('routes discard', () => {
   it('tracks subcommand invocation', async () => {
     useUpdateRouteVersion();
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard', '--yes');
+    client.setArgv('routes', 'discard-staging', '--yes');
     const exitCode = await routes(client);
     expect(exitCode).toEqual(0);
 
     expect(client.telemetryEventStore).toHaveTelemetryEvents([
       {
-        key: 'subcommand:discard',
-        value: 'discard',
+        key: 'subcommand:discard-staging',
+        value: 'discard-staging',
       },
     ]);
   });
@@ -88,7 +88,7 @@ describe('routes discard', () => {
   it('should prompt for confirmation and cancel when declined', async () => {
     useUpdateRouteVersion();
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard');
+    client.setArgv('routes', 'discard-staging');
     // Simulate user declining confirmation
     client.input.confirm = vi.fn().mockResolvedValue(false);
 
@@ -100,7 +100,7 @@ describe('routes discard', () => {
   it('should proceed when user confirms', async () => {
     useUpdateRouteVersion();
     useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'discard');
+    client.setArgv('routes', 'discard-staging');
     // Simulate user confirming
     client.input.confirm = vi.fn().mockResolvedValue(true);
 

--- a/packages/cli/test/unit/commands/routes/publish.test.ts
+++ b/packages/cli/test/unit/commands/routes/publish.test.ts
@@ -61,6 +61,8 @@ describe('routes publish', () => {
     await expect(client.stderr).toOutput('Deleted route');
     await expect(client.stderr).toOutput('Modified route');
     await expect(client.stderr).toOutput('Reordered route');
+    await expect(client.stderr).toOutput('Enabled');
+    await expect(client.stderr).toOutput('Disabled');
   });
 
   it('should show reorder info in diff', async () => {

--- a/packages/cli/test/unit/commands/routes/publish.test.ts
+++ b/packages/cli/test/unit/commands/routes/publish.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import routes from '../../../../src/commands/routes';
+import { useUser } from '../../../mocks/user';
+import {
+  useUpdateRouteVersion,
+  useRoutesWithDiffForPublish,
+} from '../../../mocks/routes';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+describe('routes publish', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'routes-test-project',
+      name: 'routes-test',
+    });
+    const cwd = setupUnitFixture('commands/routes');
+    client.cwd = cwd;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'routes';
+      const subcommand = 'publish';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = routes(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('should auto-find staging version and publish with --yes', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for "routes publish --yes"').toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+
+  it('should show diff before publishing', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Changes to be published:');
+    await expect(client.stderr).toOutput('Added route');
+    await expect(client.stderr).toOutput('Deleted route');
+    await expect(client.stderr).toOutput('Modified route');
+    await expect(client.stderr).toOutput('Reordered route');
+  });
+
+  it('should show reorder info in diff', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    // Check for reorder info (position 6 -> 4, displayed as 1-indexed)
+    await expect(client.stderr).toOutput('Reordered (6 → 4)');
+  });
+
+  it('should publish specific version with --yes', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', 'staging-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for "routes publish <id> --yes"').toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+
+  it('should warn when no staging version exists', async () => {
+    useUpdateRouteVersion({
+      versions: [{ id: 'live-version', isLive: true }],
+    });
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code when no staging').toEqual(0);
+    await expect(client.stderr).toOutput('No staged changes to publish');
+  });
+
+  it('should error when version not found', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', 'nonexistent-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for nonexistent version').toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Version "nonexistent-version" not found'
+    );
+  });
+
+  it('should error when version is already live', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', 'live-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for live version').toEqual(1);
+    await expect(client.stderr).toOutput('is already live');
+  });
+
+  it('should error when version is not staging (previous version)', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', 'previous-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for previous version').toEqual(1);
+    await expect(client.stderr).toOutput('is not staged');
+  });
+
+  it('tracks subcommand invocation', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:publish',
+        value: 'publish',
+      },
+    ]);
+  });
+
+  it('should prompt for confirmation and cancel when declined', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish');
+    // Simulate user declining confirmation
+    client.input.confirm = vi.fn().mockResolvedValue(false);
+
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code when canceled').toEqual(0);
+    await expect(client.stderr).toOutput('Canceled');
+  });
+
+  it('should proceed when user confirms', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'publish');
+    // Simulate user confirming
+    client.input.confirm = vi.fn().mockResolvedValue(true);
+
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+});

--- a/packages/cli/test/unit/commands/routes/publish.test.ts
+++ b/packages/cli/test/unit/commands/routes/publish.test.ts
@@ -75,15 +75,6 @@ describe('routes publish', () => {
     await expect(client.stderr).toOutput('Reordered (6 → 4)');
   });
 
-  it('should publish specific version with --yes', async () => {
-    useUpdateRouteVersion();
-    useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'publish', 'staging-version', '--yes');
-    const exitCode = await routes(client);
-    expect(exitCode, 'exit code for "routes publish <id> --yes"').toEqual(0);
-    await expect(client.stderr).toOutput('Success!');
-  });
-
   it('should warn when no staging version exists', async () => {
     useUpdateRouteVersion({
       versions: [{ id: 'live-version', isLive: true }],
@@ -93,35 +84,6 @@ describe('routes publish', () => {
     const exitCode = await routes(client);
     expect(exitCode, 'exit code when no staging').toEqual(0);
     await expect(client.stderr).toOutput('No staged changes to publish');
-  });
-
-  it('should error when version not found', async () => {
-    useUpdateRouteVersion();
-    useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'publish', 'nonexistent-version', '--yes');
-    const exitCode = await routes(client);
-    expect(exitCode, 'exit code for nonexistent version').toEqual(1);
-    await expect(client.stderr).toOutput(
-      'Version "nonexistent-version" not found'
-    );
-  });
-
-  it('should error when version is already live', async () => {
-    useUpdateRouteVersion();
-    useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'publish', 'live-version', '--yes');
-    const exitCode = await routes(client);
-    expect(exitCode, 'exit code for live version').toEqual(1);
-    await expect(client.stderr).toOutput('is already live');
-  });
-
-  it('should error when version is not staging (previous version)', async () => {
-    useUpdateRouteVersion();
-    useRoutesWithDiffForPublish();
-    client.setArgv('routes', 'publish', 'previous-version', '--yes');
-    const exitCode = await routes(client);
-    expect(exitCode, 'exit code for previous version').toEqual(1);
-    await expect(client.stderr).toOutput('is not staged');
   });
 
   it('tracks subcommand invocation', async () => {

--- a/packages/cli/test/unit/commands/routes/restore.test.ts
+++ b/packages/cli/test/unit/commands/routes/restore.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import routes from '../../../../src/commands/routes';
+import { useUser } from '../../../mocks/user';
+import {
+  useUpdateRouteVersion,
+  useRoutesWithDiffForPublish,
+} from '../../../mocks/routes';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+describe('routes restore', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'routes-test-project',
+      name: 'routes-test',
+    });
+    const cwd = setupUnitFixture('commands/routes');
+    client.cwd = cwd;
+  });
+
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'routes';
+      const subcommand = 'restore';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = routes(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  it('should require version-id argument', async () => {
+    useUpdateRouteVersion();
+    client.setArgv('routes', 'restore');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for missing argument').toEqual(1);
+    await expect(client.stderr).toOutput(
+      'Missing required argument: version-id'
+    );
+  });
+
+  it('should restore previous version with --yes', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'previous-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for "routes restore --yes"').toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+
+  it('should show diff before restoring', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'previous-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Changes to be restored:');
+  });
+
+  it('should error when version not found', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'nonexistent-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for nonexistent version').toEqual(1);
+    await expect(client.stderr).toOutput('"nonexistent-version" not found');
+  });
+
+  it('should error when version is already live', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'live-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for live version').toEqual(1);
+    await expect(client.stderr).toOutput('is currently live');
+  });
+
+  it('should error when version is staging', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'staging-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code for staging version').toEqual(1);
+    await expect(client.stderr).toOutput('is staged');
+  });
+
+  it('tracks subcommand invocation', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'previous-version', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    expect(client.telemetryEventStore).toHaveTelemetryEvents([
+      {
+        key: 'subcommand:restore',
+        value: 'restore',
+      },
+    ]);
+  });
+
+  it('should prompt for confirmation and cancel when declined', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'previous-version');
+    // Simulate user declining confirmation
+    client.input.confirm = vi.fn().mockResolvedValue(false);
+
+    const exitCode = await routes(client);
+    expect(exitCode, 'exit code when canceled').toEqual(0);
+    await expect(client.stderr).toOutput('Canceled');
+  });
+
+  it('should proceed when user confirms', async () => {
+    useUpdateRouteVersion();
+    useRoutesWithDiffForPublish();
+    client.setArgv('routes', 'restore', 'previous-version');
+    // Simulate user confirming
+    client.input.confirm = vi.fn().mockResolvedValue(true);
+
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+    await expect(client.stderr).toOutput('Success!');
+  });
+});


### PR DESCRIPTION
## Summary

Adds version management commands for project-level routing rules:

- **`vercel routes publish`** - Publish staged routing changes to production
- **`vercel routes restore <version-id>`** - Restore a previous routing version to production
- **`vercel routes discard`** - Discard staged routing changes

## Features

- Auto-finds staging version for `publish` and `discard` (no version-id required)
- Shows diff of changes before action (added/deleted/modified/reordered routes)
- Displays reorder info with position changes (e.g., "Reordered (6 → 4)")
- Confirmation prompts with `--yes` flag to skip
- Telemetry tracking for all commands

## Usage

```bash
# Publish staged changes
vercel routes publish
vercel routes publish --yes

# Restore a previous version
vercel routes restore <version-id>
vercel routes restore <version-id> --yes

# Discard staged changes
vercel routes discard
vercel routes discard --yes
```

## Test Plan

- 29 new tests added (209 total routes tests passing)
- Tests cover: help flags, success cases, error cases, confirmation flows, telemetry