### PR TITLE
Control-C output display

### DIFF
--- a/.changeset/graceful-ctrl-c-handling.md
+++ b/.changeset/graceful-ctrl-c-handling.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Gracefully handle CTRL+C during prompts to prevent displaying ugly error stack traces

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -122,6 +122,13 @@ const handleUnexpected = async (err: Error) => {
     return;
   }
 
+  // Handle user pressing Ctrl+C to cancel a prompt
+  if (message === 'User force closed the prompt with 0 null') {
+    output.debug(`User canceled the prompt`);
+    process.exit(0);
+    return;
+  }
+
   output.error(`An unexpected error occurred!\n${err.stack}`);
   await reportError(getSentry(), client, err);
 


### PR DESCRIPTION
Silently handle CTRL+C during prompts to prevent an ugly stack trace from being displayed.

Previously, pressing CTRL+C during a prompt would cause the `handleUnexpected` function to display a full stack trace for "User force closed the prompt". This change aligns the behavior of `handleUnexpected` with `printError`, which already handles this specific error silently.

---
[Slack Thread](https://vercel.slack.com/archives/C09MK639NMN/p1770091249867089?thread_ts=1770091249.867089&cid=C09MK639NMN)

<a href="https://cursor.com/background-agent?bcId=bc-ee2c397e-bfd9-56f9-8e8b-590e98ac535d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee2c397e-bfd9-56f9-8e8b-590e98ac535d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

