### PR TITLE
ai: add runtime skill

### DIFF
--- a/.claude/skills/vercel-runtime-implementation-guide.md
+++ b/.claude/skills/vercel-runtime-implementation-guide.md
@@ -1,0 +1,156 @@
+# Vercel Runtime Implementation Guide
+
+Guide for building Vercel runtimes that implement the Fluid IPC protocol.
+
+**Reference implementations:**
+
+- Node.js: `packages/node/` (interpreted, primary reference)
+- Python: `packages/python/` (interpreted, WSGI/ASGI)
+- Rust: `packages/rust/` + `crates/vercel_runtime/` (compiled)
+
+**Documentation:** `DEVELOPING_A_RUNTIME.md`
+
+## Fluid Compute Overview
+
+Fluid compute enables HTTP streaming, request multiplexing, and efficient resource utilization via a secure TCP-based IPC protocol between Vercel's infrastructure and function instances.
+
+The **Rust core** wraps language processes, communicating via HTTP locally and IPC to the Function Router for response streaming and health metrics.
+
+## IPC Protocol
+
+Connect to Unix socket at `VERCEL_IPC_PATH`. Messages are JSON terminated with `\0`.
+
+### Message Types
+
+**`server-started`** (required, once at startup):
+
+```json
+{
+  "type": "server-started",
+  "payload": { "initDuration": 150, "httpPort": 3000 }
+}
+```
+
+**`handler-started`** (required, per request):
+
+```json
+{
+  "type": "handler-started",
+  "payload": {
+    "handlerStartedAt": 1704067200000,
+    "context": { "invocationId": "abc123", "requestId": 42 }
+  }
+}
+```
+
+**`end`** (required, per request):
+
+```json
+{
+  "type": "end",
+  "payload": {
+    "context": { "invocationId": "abc123", "requestId": 42 },
+    "error": null
+  }
+}
+```
+
+**`log`** (optional, base64-encoded message):
+
+```json
+{
+  "type": "log",
+  "payload": {
+    "context": { "invocationId": "abc123", "requestId": 42 },
+    "message": "SGVsbG8=",
+    "level": "info"
+  }
+}
+```
+
+Use `"stream": "stdout"` or `"stderr"` instead of `level` for raw output.
+
+**`metric`** (optional, for fetch instrumentation):
+
+```json
+{"type": "metric", "payload": {"context": {...}, "type": "fetch-metric", "payload": {"pathname": "/api", "duration": 45, "host": "example.com", "statusCode": 200, "method": "GET", "id": 1}}}
+```
+
+### Request Context Headers
+
+Extract and remove before passing to user code:
+
+- `x-vercel-internal-invocation-id` → `invocationId` (string)
+- `x-vercel-internal-request-id` → `requestId` (integer)
+- `x-vercel-internal-span-id`, `x-vercel-internal-trace-id` → remove
+
+### Health Check
+
+Return HTTP 200 for `/_vercel/ping`. Do NOT send IPC messages.
+
+## Implementation Checklist
+
+### Runtime (Language-side)
+
+- [ ] Connect to `VERCEL_IPC_PATH` Unix socket
+- [ ] Send `server-started` after HTTP server binds
+- [ ] Extract/remove `x-vercel-internal-*` headers per request
+- [ ] Send `handler-started` at request start
+- [ ] Set up request context storage (thread-local/context vars)
+- [ ] Intercept stdout/stderr/logging → IPC with context
+- [ ] Send `end` after each request (even on errors)
+- [ ] Handle `/_vercel/ping` health checks
+- [ ] Buffer logs before `server-started`, flush after or to stderr on exit
+- [ ] Support concurrent requests
+- [ ] Implement `waitUntil` API (wait for promises before exit with 30s timeout)
+
+### Builder (TypeScript)
+
+- [ ] Export `version = 3`
+- [ ] Export `build()` → `{ output: Lambda }`
+- [ ] Export `startDevServer()` for `vercel dev` (optional)
+- [ ] Export `prepareCache()` for build caching (optional)
+
+## Builder Implementation
+
+See `DEVELOPING_A_RUNTIME.md` for full API documentation.
+
+### Interpreted Languages
+
+Reference: `packages/node/src/build.ts`, `packages/python/src/index.ts`
+
+Use standard Lambda runtimes (`nodejs22.x`, `python3.12`, etc.).
+
+### Compiled Languages
+
+Reference: `packages/rust/src/index.ts`
+
+Use `runtime: 'executable'` with `runtimeLanguage: 'rust' | 'go'` for IPC orchestration. The handler must be named `executable`.
+
+### Key Lambda Options
+
+| Property                    | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| `handler`                   | Entry point (`index.handler` for node, `executable` for compiled) |
+| `runtime`                   | `nodejs22.x`, `python3.12`, or `executable` for compiled          |
+| `runtimeLanguage`           | `'go'` or `'rust'` for executable runtime                         |
+| `architecture`              | `'x86_64'` or `'arm64'`                                           |
+| `supportsResponseStreaming` | Enable streaming responses                                        |
+| `supportsWrapper`           | Enable large env support (64KB)                                   |
+
+## Common Pitfalls
+
+1. Missing `\0` terminator on IPC messages
+2. Forgetting base64 encoding for log messages
+3. Not removing `x-vercel-internal-*` headers
+4. Blocking on IPC during init (buffer logs first)
+5. Missing `/_vercel/ping` handler
+6. Not sending `end` on errors
+7. Blocking concurrent requests (limits Fluid compute benefits)
+8. Buffering entire responses (stream chunks instead)
+
+## Publishing
+
+- Use `peerDependencies` for `@vercel/build-utils`
+- Reference via `"use": "@vercel/your-runtime"` in vercel.json
+- Create changeset: `pnpm changeset`

--- a/.claude/skills/vercel-runtime-implementation-guide.md
+++ b/.claude/skills/vercel-runtime-implementation-guide.md
@@ -136,7 +136,6 @@ Use `runtime: 'executable'` with `runtimeLanguage: 'rust' | 'go'` for IPC orches
 | `runtimeLanguage`           | `'go'` or `'rust'` for executable runtime                         |
 | `architecture`              | `'x86_64'` or `'arm64'`                                           |
 | `supportsResponseStreaming` | Enable streaming responses                                        |
-| `supportsWrapper`           | Enable large env support (64KB)                                   |
 
 ## Common Pitfalls
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /packages/python*                        @vercel/ci-cd @vercel/team-python
 /python                                  @vercel/ci-cd @vercel/team-python
 /.github/workflows/*python*.yml          @vercel/ci-cd @vercel/team-python
+/.claude/skills/vercel-runtime-*         @vercel/ci-cd @vercel/compute
 
 # Unrestricted Paths
 # These paths are updated by the changeset CLI for "Version Packages" pull requests

--- a/DEVELOPING_A_RUNTIME.md
+++ b/DEVELOPING_A_RUNTIME.md
@@ -5,6 +5,8 @@ the Runtime API interface. It's a way to add support for a new programming langu
 
 > Note: If you're the author of a web framework, please use the [Build Output API](https://vercel.com/docs/build-output-api/v3) instead to make your framework compatible with Vercel.
 
+> **See also:** The agent skill at [`.claude/skills/vercel-runtime-implementation-guide.md`](.claude/skills/vercel-runtime-implementation-guide.md) for Fluid protocol documentation and implementation checklists.
+
 A Runtime is an npm module that implements the following interface:
 
 ```typescript


### PR DESCRIPTION
This skill will help when creating new language runtimes or updating existing ones (e.g., migrating the Go runtime to use runtime: 'executable' with full IPC support).

Adds an agent skill for building new Vercel runtimes that implement the Fluid IPC protocol.
- Documents the IPC message protocol (server-started, handler-started, end, log, metric)
- Provides implementation checklists for both runtime (language-side) and builder (TypeScript-side)
- Links to reference implementations (Node.js, Python, Rust) instead of duplicating code
- Covers key Lambda options for interpreted vs compiled languages (runtime: 'executable')
- Lists common pitfalls to avoid
