### PR TITLE
fix(cli): Fix typos in CLI help examples

### DIFF
--- a/.changeset/fix-cli-help-typos.md
+++ b/.changeset/fix-cli-help-typos.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Fix typos in CLI help examples for marketplace integration commands

--- a/packages/cli/src/commands/integration-resource/command.ts
+++ b/packages/cli/src/commands/integration-resource/command.ts
@@ -73,7 +73,7 @@ export const disconnectSubcommand = {
   ],
   examples: [
     {
-      name: 'Disconnect a resource from the current projecct',
+      name: 'Disconnect a resource from the current project',
       value: [
         `${packageName} integration-resource disconnect <resource>`,
         `${packageName} integration-resource disconnect my-acme-resource`,
@@ -82,7 +82,7 @@ export const disconnectSubcommand = {
     {
       name: 'Disconnect all projects from a resource',
       value: [
-        `${packageName} integration-resource disconnect <resource> --unlink-all`,
+        `${packageName} integration-resource disconnect <resource> --all`,
         `${packageName} integration-resource disconnect my-acme-resource --all`,
         `${packageName} integration-resource disconnect my-acme-resource -a`,
       ],

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -139,7 +139,7 @@ export const removeSubcommand = {
     {
       name: 'Uninstall an integration',
       value: [
-        `${packageName} integration remove <inegration>`,
+        `${packageName} integration remove <integration>`,
         `${packageName} integration remove acme`,
       ],
     },

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2911,14 +2911,14 @@ exports[`help command > integration-resource help output snapshots > integration
 
   Examples:
 
-  - Disconnect a resource from the current projecct
+  - Disconnect a resource from the current project
 
     $ vercel integration-resource disconnect <resource>
     $ vercel integration-resource disconnect my-acme-resource
 
   - Disconnect all projects from a resource
 
-    $ vercel integration-resource disconnect <resource> --unlink-all
+    $ vercel integration-resource disconnect <resource> --all
     $ vercel integration-resource disconnect my-acme-resource --all
     $ vercel integration-resource disconnect my-acme-resource -a
 


### PR DESCRIPTION
## Summary

Fixes typos in CLI help examples for marketplace integration commands:

- `<inegration>` → `<integration>` in `integration remove` example
- `projecct` → `project` in `integration-resource disconnect` example
- `--unlink-all` → `--all` in `integration-resource disconnect` example (the flag is `--all`, not `--unlink-all`)

Found during documentation review of marketplace CLI commands.

## Test plan

- [ ] Run `vct integration remove --help` and verify example shows `<integration>` (not `<inegration>`)
- [ ] Run `vct integration-resource disconnect --help` and verify:
  - Example says "current project" (not "current projecct")
  - Example shows `--all` (not `--unlink-all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)