### PR TITLE
[build-utils] Add exposeErrBody property on Prerender

### DIFF
--- a/.changeset/prerender-expose-err-body.md
+++ b/.changeset/prerender-expose-err-body.md
@@ -1,0 +1,5 @@
+---
+'@vercel/build-utils': patch
+---
+
+Add `exposeErrBody` optional boolean property to Prerender object

--- a/packages/build-utils/src/prerender.ts
+++ b/packages/build-utils/src/prerender.ts
@@ -17,6 +17,7 @@ interface PrerenderOptions {
   experimentalBypassFor?: HasField;
   experimentalStreamingLambdaPath?: string;
   chain?: Chain;
+  exposeErrBody?: boolean;
 }
 
 export class Prerender {
@@ -45,6 +46,7 @@ export class Prerender {
   public experimentalBypassFor?: HasField;
   public experimentalStreamingLambdaPath?: string;
   public chain?: Chain;
+  public exposeErrBody?: boolean;
 
   constructor({
     expiration,
@@ -62,6 +64,7 @@ export class Prerender {
     experimentalBypassFor,
     experimentalStreamingLambdaPath,
     chain,
+    exposeErrBody,
   }: PrerenderOptions) {
     this.type = 'Prerender';
     this.expiration = expiration;
@@ -229,6 +232,17 @@ export class Prerender {
       }
 
       this.chain = chain;
+    }
+
+    if (exposeErrBody === true) {
+      this.exposeErrBody = true;
+    } else if (
+      typeof exposeErrBody !== 'boolean' &&
+      typeof exposeErrBody !== 'undefined'
+    ) {
+      throw new Error(
+        `The \`exposeErrBody\` argument for \`Prerender\` must be a boolean.`
+      );
     }
   }
 }

--- a/packages/build-utils/test/unit.test.ts
+++ b/packages/build-utils/test/unit.test.ts
@@ -595,6 +595,69 @@ it('should support passQuery correctly', async () => {
   );
 });
 
+it('should support exposeErrBody correctly', async () => {
+  const prerenderWithTrue = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    exposeErrBody: true,
+  });
+  expect(prerenderWithTrue.exposeErrBody).toBe(true);
+
+  const prerenderWithFalse = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    exposeErrBody: false,
+  });
+  expect(prerenderWithFalse.exposeErrBody).toBeUndefined();
+
+  const prerenderWithUndefined = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+    exposeErrBody: undefined,
+  });
+  expect(prerenderWithUndefined.exposeErrBody).toBeUndefined();
+
+  const prerenderWithoutProperty = new Prerender({
+    expiration: 1,
+    fallback: null,
+    group: 1,
+    bypassToken: 'some-long-bypass-token-to-make-it-work',
+  });
+  expect(prerenderWithoutProperty.exposeErrBody).toBeUndefined();
+
+  expect(() => {
+    new Prerender({
+      expiration: 1,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      // @ts-expect-error testing invalid field
+      exposeErrBody: 'true',
+    });
+  }).toThrowError(
+    `The \`exposeErrBody\` argument for \`Prerender\` must be a boolean.`
+  );
+
+  expect(() => {
+    new Prerender({
+      expiration: 1,
+      fallback: null,
+      group: 1,
+      bypassToken: 'some-long-bypass-token-to-make-it-work',
+      // @ts-expect-error testing invalid field
+      exposeErrBody: 1,
+    });
+  }).toThrowError(
+    `The \`exposeErrBody\` argument for \`Prerender\` must be a boolean.`
+  );
+});
+
 it('should support experimentalStreamingLambdaPath correctly', async () => {
   new Prerender({
     expiration: 1,


### PR DESCRIPTION
Add an optional `exposeErrBody` boolean property to the `Prerender` object to control error body exposure.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e040502-cb88-44f5-af1f-8fd34ae0cf22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e040502-cb88-44f5-af1f-8fd34ae0cf22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

