### PR TITLE
Add experimental manual deployment

### DIFF
--- a/.changeset/chilled-baboons-compete.md
+++ b/.changeset/chilled-baboons-compete.md
@@ -1,0 +1,6 @@
+---
+"vercel": patch
+"@vercel/client": patch
+---
+
+Add experimental manual deployment support

--- a/packages/cli/src/commands/deploy/command.ts
+++ b/packages/cli/src/commands/deploy/command.ts
@@ -2,6 +2,141 @@ import { confirmOption, forceOption, yesOption } from '../../util/arg-common';
 
 export const deprecatedArchiveSplitTgz = 'split-tgz';
 
+export const initSubcommand = {
+  name: 'init',
+  aliases: [],
+  description: 'Create a manual deployment that can be continued later',
+  hidden: true as const,
+  arguments: [],
+  options: [
+    {
+      ...forceOption,
+      description: 'Force a new deployment even if nothing has changed',
+    },
+    {
+      name: 'with-cache',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description: 'Retain build cache when using "--force"',
+    },
+    {
+      name: 'public',
+      shorthand: 'p',
+      type: Boolean,
+      deprecated: false,
+      description: 'Deployment is public (`/_src`) is exposed)',
+    },
+    {
+      name: 'env',
+      shorthand: 'e',
+      type: [String],
+      argument: 'KEY=VALUE',
+      deprecated: false,
+      description:
+        'Specify environment variables during run-time (e.g. `-e KEY1=value1 -e KEY2=value2`)',
+    },
+    {
+      name: 'build-env',
+      shorthand: 'b',
+      type: [String],
+      argument: 'KEY=VALUE',
+      deprecated: false,
+      description:
+        'Specify environment variables during build-time (e.g. `-b KEY1=value1 -b KEY2=value2`)',
+    },
+    {
+      name: 'meta',
+      shorthand: 'm',
+      type: [String],
+      argument: 'KEY=VALUE',
+      deprecated: false,
+      description:
+        'Specify metadata for the deployment (e.g. `-m KEY1=value1 -m KEY2=value2`)',
+    },
+    {
+      name: 'regions',
+      shorthand: null,
+      type: String,
+      argument: 'REGION',
+      deprecated: false,
+      description: 'Set default regions to enable the deployment on',
+    },
+    {
+      name: 'prod',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Create a production deployment (shorthand for `--target=production`)',
+    },
+    {
+      name: 'archive',
+      shorthand: null,
+      type: String,
+      argument: 'FORMAT',
+      deprecated: false,
+      description:
+        'Compress the deployment code into an archive before uploading it',
+    },
+    {
+      name: 'skip-domain',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+      description:
+        'Disable the automatic promotion (aliasing) of the relevant domains to a new production deployment. You can use `vc promote` to complete the domain-assignment process later',
+    },
+    {
+      ...yesOption,
+      description: 'Use default options to skip all prompts',
+    },
+    {
+      name: 'target',
+      shorthand: null,
+      type: String,
+      argument: 'TARGET',
+      deprecated: false,
+      description: 'Specify the target deployment environment',
+    },
+    confirmOption,
+  ],
+  examples: [
+    {
+      name: 'Create a manual deployment',
+      value: 'vercel deploy init',
+    },
+    {
+      name: 'Create a manual production deployment',
+      value: 'vercel deploy init --prod',
+    },
+  ],
+} as const;
+
+export const continueSubcommand = {
+  name: 'continue',
+  aliases: [],
+  description: 'Continue a manual deployment by uploading build outputs',
+  hidden: true as const,
+  arguments: [],
+  options: [
+    {
+      name: 'id',
+      shorthand: null,
+      type: String,
+      argument: 'ID',
+      deprecated: false,
+      description: 'The deployment ID to continue (e.g. dpl_xxx)',
+    },
+  ],
+  examples: [
+    {
+      name: 'Continue a deployment by ID',
+      value: 'vercel deploy continue --id dpl_xxx',
+    },
+  ],
+} as const;
+
 export const deployCommand = {
   name: 'deploy',
   aliases: [],
@@ -13,6 +148,7 @@ export const deployCommand = {
       required: false,
     },
   ],
+  subcommands: [initSubcommand, continueSubcommand],
   options: [
     {
       ...forceOption,

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -267,6 +267,10 @@ export function buildSubcommandLines(
     })
   );
 
+  if (rows.length === 0) {
+    return null;
+  }
+
   table.push(...rows);
   return [
     `${INDENT}${chalk.dim('Commands')}:`,

--- a/packages/cli/src/util/deploy/print-deployment-status.ts
+++ b/packages/cli/src/util/deploy/print-deployment-status.ts
@@ -35,7 +35,8 @@ export async function printDeploymentStatus(
   },
   deployStamp: () => string,
   noWait: boolean,
-  guidanceMode: boolean
+  guidanceMode: boolean,
+  isInit?: boolean
 ): Promise<number> {
   indications = indications || [];
 
@@ -43,12 +44,10 @@ export async function printDeploymentStatus(
   if (noWait) {
     if (isDeploying(readyState)) {
       isStillBuilding = true;
-      output.print(
-        prependEmoji(
-          'Note: Deployment is still processing...',
-          emoji('notice')
-        ) + '\n'
-      );
+      const message = isInit
+        ? 'Deployment is awaiting continuation...'
+        : 'Note: Deployment is still processing...';
+      output.print(prependEmoji(message, emoji('notice')) + '\n');
     }
   }
 

--- a/packages/cli/src/util/deploy/process-deployment.ts
+++ b/packages/cli/src/util/deploy/process-deployment.ts
@@ -50,6 +50,7 @@ export default async function processDeployment({
   noWait,
   withFullLogs,
   agent,
+  manual,
   ...args
 }: {
   now: Now;
@@ -72,6 +73,7 @@ export default async function processDeployment({
   withFullLogs?: boolean;
   agent?: Agent;
   bulkRedirectsPath?: string | null;
+  manual?: boolean;
 }) {
   const {
     now,
@@ -112,6 +114,7 @@ export default async function processDeployment({
     agent,
     projectName,
     bulkRedirectsPath,
+    manual,
   };
 
   const deployingSpinnerVal = isSettingUpProject

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -54,6 +54,7 @@ export interface CreateOptions {
   withFullLogs?: boolean;
   autoAssignCustomDomains?: boolean;
   agentName?: string;
+  manual?: boolean;
 }
 
 export interface RemoveOptions {
@@ -130,6 +131,7 @@ export default class Now {
       withFullLogs,
       autoAssignCustomDomains,
       agentName,
+      manual,
     }: CreateOptions,
     org: Org,
     isSettingUpProject: boolean,
@@ -180,6 +182,7 @@ export default class Now {
       noWait,
       withFullLogs,
       bulkRedirectsPath: nowConfig.bulkRedirectsPath,
+      manual,
     });
 
     if (deployment && deployment.warnings) {

--- a/packages/cli/src/util/telemetry/commands/deploy/index.ts
+++ b/packages/cli/src/util/telemetry/commands/deploy/index.ts
@@ -119,6 +119,18 @@ export class DeployTelemetryClient
       this.trackCliFlag('prebuilt');
     }
   }
+  trackCliSubcommandInit(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'init',
+      value: actual,
+    });
+  }
+  trackCliSubcommandContinue(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'continue',
+      value: actual,
+    });
+  }
   trackCliFlagProd(flag: boolean | undefined) {
     if (flag) {
       this.trackCliFlag('prod');

--- a/packages/client/src/continue.ts
+++ b/packages/client/src/continue.ts
@@ -47,7 +47,7 @@ export async function* continueDeployment(options: {
   }
 
   const { fileList } = await buildFileTree(
-    outputDir,
+    options.path,
     { isDirectory: true, prebuilt: true, vercelOutputDir: outputDir },
     debug
   );
@@ -61,6 +61,7 @@ export async function* continueDeployment(options: {
     deploymentId: options.deploymentId,
     files,
     outputDir,
+    path: options.path,
     token: options.token,
     teamId: options.teamId,
     apiUrl: options.apiUrl,
@@ -104,6 +105,7 @@ export async function* continueDeployment(options: {
       deploymentId: options.deploymentId,
       files,
       outputDir,
+      path: options.path,
       token: options.token,
       teamId: options.teamId,
       apiUrl: options.apiUrl,
@@ -166,6 +168,7 @@ async function postContinue(options: {
   deploymentId: string;
   files: FilesMap;
   outputDir: string;
+  path: string;
   teamId?: string;
   token: string;
   userAgent?: string;
@@ -191,7 +194,7 @@ async function postContinue(options: {
       body: JSON.stringify({
         files: prepareFiles(options.files, {
           isDirectory: true,
-          path: options.outputDir,
+          path: options.path,
           token: options.token,
         }),
       }),

--- a/packages/client/src/continue.ts
+++ b/packages/client/src/continue.ts
@@ -1,0 +1,239 @@
+import { join } from 'path';
+import fs from 'fs-extra';
+
+import type { Agent } from 'http';
+import type { Deployment, DeploymentEventType } from './types';
+import { checkDeploymentStatus } from './check-deployment-status';
+import { fetch, buildFileTree, createDebug, prepareFiles } from './utils';
+import { hashes, mapToObject, FilesMap } from './utils/hashes';
+import { isReady, isAliasAssigned } from './utils/ready-state';
+import { uploadFiles, UploadProgress } from './upload';
+import { DeploymentError } from './errors';
+
+/**
+ * Continues a manual deployment by uploading build outputs and calling the
+ * continue endpoint. Waits for READY state unless the caller stops consuming
+ * events early.
+ */
+export async function* continueDeployment(options: {
+  agent?: Agent;
+  apiUrl?: string;
+  debug?: boolean;
+  deploymentId: string;
+  path: string;
+  teamId?: string;
+  token: string;
+  userAgent?: string;
+  vercelOutputDir?: string;
+}): AsyncIterableIterator<{ type: DeploymentEventType; payload: any }> {
+  const debug = createDebug(options.debug);
+  debug(`Continuing deployment: ${options.deploymentId}`);
+  const outputDir =
+    options.vercelOutputDir || join(options.path, '.vercel', 'output');
+
+  /**
+   * We need to ensure that the output directory exists before proceeding with
+   * the continuation. This is important because we only allow continuing for
+   * prebuilt deployments.
+   */
+  if (!(await fs.pathExists(outputDir))) {
+    return yield {
+      type: 'error',
+      payload: new DeploymentError({
+        code: 'output_dir_not_found',
+        message: `Output directory not found at ${outputDir}. Run 'vercel build' first.`,
+      }),
+    };
+  }
+
+  const { fileList } = await buildFileTree(
+    outputDir,
+    { isDirectory: true, prebuilt: true, vercelOutputDir: outputDir },
+    debug
+  );
+
+  const files = await hashes(fileList);
+  debug(`Calculated ${files.size} unique hashes`);
+  yield { type: 'hashes-calculated', payload: mapToObject(files) };
+
+  let deployment: Deployment | undefined;
+  let result = await postContinue({
+    deploymentId: options.deploymentId,
+    files,
+    outputDir,
+    token: options.token,
+    teamId: options.teamId,
+    apiUrl: options.apiUrl,
+    userAgent: options.userAgent,
+    agent: options.agent,
+    debug: options.debug,
+  });
+
+  if (result.type === 'missing_files') {
+    debug(`Uploading ${result.missing.length} missing files...`);
+
+    const uploads = result.missing.map(
+      sha => new UploadProgress(sha, files.get(sha)!)
+    );
+
+    yield {
+      type: 'file-count',
+      payload: { total: files, missing: result.missing, uploads },
+    };
+
+    for await (const event of uploadFiles({
+      agent: options.agent,
+      apiUrl: options.apiUrl,
+      debug: options.debug,
+      teamId: options.teamId,
+      token: options.token,
+      userAgent: options.userAgent,
+      shas: result.missing,
+      files,
+      uploads,
+    })) {
+      if (event.type === 'error') {
+        return yield event;
+      }
+      yield event;
+    }
+
+    yield { type: 'all-files-uploaded', payload: files };
+
+    result = await postContinue({
+      deploymentId: options.deploymentId,
+      files,
+      outputDir,
+      token: options.token,
+      teamId: options.teamId,
+      apiUrl: options.apiUrl,
+      userAgent: options.userAgent,
+      agent: options.agent,
+      debug: options.debug,
+    });
+
+    if (result.type === 'missing_files') {
+      return yield {
+        type: 'error',
+        payload: {
+          code: 'missing_files',
+          message: 'Missing files',
+          missing: result.missing,
+        },
+      };
+    }
+  }
+
+  if (result.type === 'error') {
+    return yield { type: 'error', payload: result.error };
+  }
+
+  if (result.type === 'success') {
+    deployment = result.deployment;
+    yield { type: 'created', payload: deployment };
+  }
+
+  if (!deployment) {
+    return yield {
+      type: 'error',
+      payload: new DeploymentError({
+        code: 'continue_failed',
+        message: 'Failed to continue deployment after uploading files',
+      }),
+    };
+  }
+
+  if (isReady(deployment) && isAliasAssigned(deployment)) {
+    yield { type: 'ready', payload: deployment };
+    return yield { type: 'alias-assigned', payload: deployment };
+  }
+
+  yield* checkDeploymentStatus(deployment, {
+    agent: options.agent,
+    apiUrl: options.apiUrl,
+    debug: options.debug,
+    path: options.path,
+    teamId: options.teamId,
+    token: options.token,
+    userAgent: options.userAgent,
+  });
+}
+
+async function postContinue(options: {
+  agent?: Agent;
+  apiUrl?: string;
+  debug?: boolean;
+  deploymentId: string;
+  files: FilesMap;
+  outputDir: string;
+  teamId?: string;
+  token: string;
+  userAgent?: string;
+}): Promise<
+  | { type: 'success'; deployment: Deployment }
+  | { type: 'missing_files'; missing: string[] }
+  | { type: 'error'; error: any }
+> {
+  const debug = createDebug(options.debug);
+
+  debug(`Calling continue deployment endpoint for ${options.deploymentId}`);
+  const response = await fetch(
+    `/deployments/${options.deploymentId}/continue${
+      options.teamId ? `?teamId=${options.teamId}` : ''
+    }`,
+    options.token,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        files: prepareFiles(options.files, {
+          isDirectory: true,
+          path: options.outputDir,
+          token: options.token,
+        }),
+      }),
+      apiUrl: options.apiUrl,
+      userAgent: options.userAgent,
+      agent: options.agent,
+    }
+  );
+
+  let result;
+  try {
+    result = await response.json();
+  } catch {
+    return {
+      type: 'error',
+      error: new Error('Invalid JSON response from continue endpoint'),
+    };
+  }
+
+  if (!response.ok || result.error) {
+    if (
+      result.error?.code === 'missing_files' ||
+      result.code === 'missing_files'
+    ) {
+      debug(
+        `Continue deployment returned missing_files: ${(result.error?.missing || result.missing || []).length} files`
+      );
+      return {
+        type: 'missing_files',
+        missing: result.error?.missing || result.missing || [],
+      };
+    }
+
+    debug('Continue deployment request failed');
+    return {
+      type: 'error',
+      error: result.error
+        ? { ...result.error, status: response.status }
+        : { ...result, status: response.status },
+    };
+  }
+
+  debug('Continue deployment succeeded');
+  return { type: 'success', deployment: result };
+}

--- a/packages/client/src/deploy.ts
+++ b/packages/client/src/deploy.ts
@@ -134,7 +134,7 @@ export async function* deploy(
   files: FilesMap,
   clientOptions: VercelClientOptions,
   deploymentOptions: DeploymentOptions
-): AsyncIterableIterator<{ type: string; payload: any }> {
+): AsyncIterableIterator<{ type: DeploymentEventType; payload: any }> {
   const debug = createDebug(clientOptions.debug);
 
   // Check if we should default to a static deployment
@@ -179,6 +179,15 @@ export async function* deploy(
   } catch (e) {
     debug('An unexpected error occurred when creating the deployment');
     return yield { type: 'error', payload: e };
+  }
+
+  /**
+   * When using manual, the deployment will remain INITIALIZING until it is
+   * manually continued so we skip waiting for Ready State.
+   */
+  if (clientOptions.manual) {
+    debug('Manual mode - skipping ready state check');
+    return;
   }
 
   if (deployment) {

--- a/packages/client/src/deploy.ts
+++ b/packages/client/src/deploy.ts
@@ -138,7 +138,7 @@ export async function* deploy(
   const debug = createDebug(clientOptions.debug);
 
   // Check if we should default to a static deployment
-  if (!deploymentOptions.name) {
+  if (!deploymentOptions.name && files.size > 0) {
     deploymentOptions.version = 2;
     deploymentOptions.name =
       files.size === 1 ? 'file' : getDefaultName(files, clientOptions);
@@ -148,7 +148,7 @@ export async function* deploy(
     }
   }
 
-  if (!deploymentOptions.name) {
+  if (!deploymentOptions.name && files.size > 0) {
     deploymentOptions.name =
       clientOptions.defaultName || getDefaultName(files, clientOptions);
     debug('No name provided. Defaulting to', deploymentOptions.name);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 import buildCreateDeployment from './create-deployment';
 
+export { continueDeployment } from './continue';
 export { checkDeploymentStatus } from './check-deployment-status';
 export { getVercelIgnore, buildFileTree } from './utils/index';
 export const createDeployment = buildCreateDeployment();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -42,6 +42,11 @@ export interface VercelClientOptions {
    * This file will be included in prebuilt deployments.
    */
   bulkRedirectsPath?: string | null;
+  /**
+   * When true, creates an experimental manual deployment. This mode requires
+   * that the user later continues the deployment with an API call.
+   */
+  manual?: boolean;
 }
 
 /** @deprecated Use VercelClientOptions instead. */

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -121,7 +121,7 @@ export async function* upload(
 /**
  * Uploads files to the /v2/files endpoint with retry and fault tolerance.
  */
-async function* uploadFiles(options: {
+export async function* uploadFiles(options: {
   agent?: Agent;
   apiUrl?: string;
   debug?: boolean;
@@ -295,7 +295,7 @@ async function* uploadFiles(options: {
   }
 }
 
-class UploadProgress extends EventEmitter {
+export class UploadProgress extends EventEmitter {
   sha: string;
   file: DeploymentFile;
   bytesUploaded: number;

--- a/packages/client/src/upload.ts
+++ b/packages/client/src/upload.ts
@@ -100,12 +100,17 @@ export async function* upload(
         await semaphore.acquire();
 
         if (aborted) {
+          semaphore.release();
           return bail(new Error('Upload aborted'));
         }
 
         const { data } = file;
+        /**
+         * Note: This branch is unreachable. Directories have undefined hash
+         * in FilesMap and are filtered out by mapToObject before being sent
+         * to the server, so they can't appear in the missing_files response.
+         */
         if (typeof data === 'undefined') {
-          // Directories don't need to be uploaded
           return;
         }
 

--- a/packages/client/tests/unit.manual-deployment.test.ts
+++ b/packages/client/tests/unit.manual-deployment.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Deployment } from '../src/types';
+
+const { mockFetch, mockBuildFileTree } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockBuildFileTree: vi.fn(),
+}));
+
+const { mockHashes } = vi.hoisted(() => ({
+  mockHashes: vi.fn(),
+}));
+
+const { mockLstatSync, mockPathExists } = vi.hoisted(() => ({
+  mockLstatSync: vi.fn(),
+  mockPathExists: vi.fn(),
+}));
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual('../src/utils');
+  return {
+    ...actual,
+    fetch: mockFetch,
+    buildFileTree: mockBuildFileTree,
+  };
+});
+
+vi.mock('../src/utils/hashes', async () => {
+  const actual = await vi.importActual('../src/utils/hashes');
+  return {
+    ...actual,
+    hashes: mockHashes,
+  };
+});
+
+vi.mock('fs-extra', async () => {
+  const actual = await vi.importActual('fs-extra');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      lstatSync: mockLstatSync,
+      pathExists: mockPathExists,
+    },
+    lstatSync: mockLstatSync,
+    pathExists: mockPathExists,
+  };
+});
+
+function mockDeploymentResponse(): Deployment {
+  return {
+    id: 'dpl_123',
+    name: 'test-deployment',
+    url: 'test.vercel.app',
+    readyState: 'INITIALIZING',
+  } as Deployment;
+}
+
+function mockResponse(status: number, body: any = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: () => null,
+      entries: () => [][Symbol.iterator](),
+    },
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe('manual deployment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock for lstatSync - returns directory
+    mockLstatSync.mockReturnValue({
+      isDirectory: () => true,
+      isFile: () => false,
+      mode: 0o755,
+    });
+  });
+
+  describe('createDeployment with manual option', () => {
+    it('should throw error when manual is true but prebuilt is false', async () => {
+      const { default: buildCreateDeployment } = await import(
+        '../src/create-deployment'
+      );
+      const createDeployment = buildCreateDeployment();
+
+      const iterator = createDeployment(
+        {
+          token: 'test-token',
+          path: '/test/path',
+          manual: true,
+          prebuilt: false,
+        },
+        {}
+      );
+
+      await expect(iterator.next()).rejects.toThrow(
+        'The `manual` option requires `prebuilt` to be true'
+      );
+    });
+
+    it('should set VERCEL_MANUAL_PROVISIONING env var and call deploy with empty files', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, {
+          ...mockDeploymentResponse(),
+          readyState: 'INITIALIZING',
+        })
+      );
+
+      const { default: buildCreateDeployment } = await import(
+        '../src/create-deployment'
+      );
+      const createDeployment = buildCreateDeployment();
+
+      const iterator = createDeployment(
+        {
+          token: 'test-token',
+          path: '/test/path',
+          manual: true,
+          prebuilt: true,
+        },
+        { name: 'test-deployment' }
+      );
+
+      const result = await iterator.next();
+
+      expect(result.value).toEqual({
+        type: 'created',
+        payload: expect.objectContaining({
+          id: 'dpl_123',
+          readyState: 'INITIALIZING',
+        }),
+      });
+
+      // Verify the deployment request included the env var
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/v13/deployments?prebuilt=1',
+        'test-token',
+        expect.objectContaining({
+          body: expect.stringContaining('VERCEL_MANUAL_PROVISIONING'),
+        })
+      );
+    });
+
+    it('should not wait for ready state in manual mode', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, {
+          ...mockDeploymentResponse(),
+          readyState: 'INITIALIZING',
+        })
+      );
+
+      const { default: buildCreateDeployment } = await import(
+        '../src/create-deployment'
+      );
+      const createDeployment = buildCreateDeployment();
+
+      const iterator = createDeployment(
+        {
+          token: 'test-token',
+          path: '/test/path',
+          manual: true,
+          prebuilt: true,
+        },
+        { name: 'test-deployment' }
+      );
+
+      const events: any[] = [];
+      for await (const event of iterator) {
+        events.push(event);
+      }
+
+      // Should only have 'created' event, no 'ready' or 'alias-assigned'
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('created');
+    });
+  });
+
+  describe('continueDeployment', () => {
+    it('should error when output directory does not exist', async () => {
+      mockPathExists.mockResolvedValueOnce(false);
+
+      const { continueDeployment } = await import('../src/continue');
+
+      const iterator = continueDeployment({
+        deploymentId: 'dpl_123',
+        path: '/test/path',
+        token: 'test-token',
+      });
+
+      const result = await iterator.next();
+
+      expect(result.value).toEqual({
+        type: 'error',
+        payload: expect.objectContaining({
+          code: 'output_dir_not_found',
+        }),
+      });
+    });
+
+    it('should hash files and call continue endpoint', async () => {
+      mockPathExists.mockResolvedValueOnce(true);
+      mockBuildFileTree.mockResolvedValueOnce({
+        fileList: ['/test/path/.vercel/output/index.html'],
+      });
+
+      const mockFilesMap = new Map([
+        [
+          'abc123',
+          {
+            names: ['index.html'],
+            data: Buffer.from('test'),
+            mode: 0o644,
+          },
+        ],
+      ]);
+      mockHashes.mockResolvedValueOnce(mockFilesMap);
+
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, {
+          ...mockDeploymentResponse(),
+          readyState: 'READY',
+          aliasAssigned: true,
+        })
+      );
+
+      const { continueDeployment } = await import('../src/continue');
+
+      const iterator = continueDeployment({
+        deploymentId: 'dpl_123',
+        path: '/test/path',
+        token: 'test-token',
+      });
+
+      const events: any[] = [];
+      for await (const event of iterator) {
+        events.push(event);
+      }
+
+      expect(events.map(e => e.type)).toContain('hashes-calculated');
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/deployments/dpl_123/continue',
+        'test-token',
+        expect.objectContaining({
+          method: 'POST',
+        })
+      );
+    });
+
+    it('should handle missing_files response from continue endpoint', async () => {
+      mockPathExists.mockResolvedValueOnce(true);
+      mockBuildFileTree.mockResolvedValueOnce({
+        fileList: ['/test/path/.vercel/output/index.html'],
+      });
+
+      const mockFilesMap = new Map([
+        [
+          'abc123',
+          {
+            names: ['index.html'],
+            data: Buffer.from('test'),
+            mode: 0o644,
+          },
+        ],
+      ]);
+      mockHashes.mockResolvedValueOnce(mockFilesMap);
+
+      // First call returns missing_files error
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(400, {
+          error: {
+            code: 'missing_files',
+            missing: ['abc123'],
+          },
+        })
+      );
+
+      const { continueDeployment } = await import('../src/continue');
+
+      const iterator = continueDeployment({
+        deploymentId: 'dpl_123',
+        path: '/test/path',
+        token: 'test-token',
+      });
+
+      const events: any[] = [];
+      for await (const event of iterator) {
+        events.push(event);
+        // Stop after file-count to avoid needing to mock upload
+        if (event.type === 'file-count') break;
+      }
+
+      const eventTypes = events.map(e => e.type);
+      expect(eventTypes).toContain('hashes-calculated');
+      expect(eventTypes).toContain('file-count');
+    });
+  });
+});


### PR DESCRIPTION
Add experimental support for manual (two-phase) deployments via two new hidden subcommands on `vercel deploy`:

- **`vercel deploy init`** — Creates a deployment in "manual" mode without uploading build outputs. The deployment is initialized on the server and returns a deployment ID.
- **`vercel deploy continue --id dpl_xxx`** — Uploads the `.vercel/output` directory (from a local `vercel build`) to an existing manual deployment and triggers the server-side build/ready flow.

This enables workflows where the user controls the build step locally and then pushes outputs to an existing deployment, useful for CI pipelines and monorepo setups where build orchestration happens outside Vercel.

On the `@vercel/client` side, the `uploadFiles` function was extracted from the monolithic `upload` generator into a standalone reusable export, and a new `continueDeployment` async generator handles the continue flow (hash files, upload missing ones, POST to `/deployments/:id/continue`, poll for ready state). A missing semaphore release on abort was also fixed.

Both subcommands are hidden/experimental for now.