### PR TITLE
Only apply the uv python prefix filter for builds run on vercel infra.

### DIFF
--- a/.changeset/lovely-poems-add.md
+++ b/.changeset/lovely-poems-add.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+Skip filtering system pythons on local vercel builds.

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -68,8 +68,9 @@ export class UvRunner {
       );
     }
 
-    // Only apply the startsWith filter when not in Vercel Build Image
-    if (!process.env.VERCEL_BUILD_IMAGE) {
+    // Only apply the startsWith filter when in Vercel Build Image
+    // (local builds use system Python paths, not /uv/python/)
+    if (process.env.VERCEL_BUILD_IMAGE) {
       pyList = pyList.filter(
         entry =>
           entry.path !== null &&

--- a/packages/python/src/uv.ts
+++ b/packages/python/src/uv.ts
@@ -68,17 +68,24 @@ export class UvRunner {
       );
     }
 
+    // Only apply the startsWith filter when not in Vercel Build Image
+    if (!process.env.VERCEL_BUILD_IMAGE) {
+      pyList = pyList.filter(
+        entry =>
+          entry.path !== null &&
+          entry.path.startsWith(UV_PYTHON_PATH_PREFIX) &&
+          entry.implementation === 'cpython'
+      );
+    } else {
+      pyList = pyList.filter(
+        entry => entry.path !== null && entry.implementation === 'cpython'
+      );
+    }
+
     return new Set(
-      pyList
-        .filter(
-          entry =>
-            entry.path !== null &&
-            entry.path.startsWith(UV_PYTHON_PATH_PREFIX) &&
-            entry.implementation === 'cpython'
-        )
-        .map(
-          entry => `${entry.version_parts.major}.${entry.version_parts.minor}`
-        )
+      pyList.map(
+        entry => `${entry.version_parts.major}.${entry.version_parts.minor}`
+      )
     );
   }
 


### PR DESCRIPTION
Fixes broken local `vercel build` for python.