### PR TITLE
feat(cli): Add source and defaultResourceName to legacy `integration add` path

### DIFF
--- a/.changeset/cli-old-path-fixes.md
+++ b/.changeset/cli-old-path-fixes.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add source and defaultResourceName query params to legacy integration add web UI path

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -193,14 +193,19 @@ function provisionResourceViaWebUI(
   teamId: string,
   integrationId: string,
   productId: string,
-  projectId?: string
+  projectId?: string,
+  resourceName?: string
 ) {
   const url = new URL('/api/marketplace/cli', 'https://vercel.com');
   url.searchParams.set('teamId', teamId);
   url.searchParams.set('integrationId', integrationId);
   url.searchParams.set('productId', productId);
+  url.searchParams.set('source', 'cli');
   if (projectId) {
     url.searchParams.set('projectId', projectId);
+  }
+  if (resourceName) {
+    url.searchParams.set('defaultResourceName', resourceName);
   }
   url.searchParams.set('cmd', 'add');
   output.print('Opening the Vercel Dashboard to continue the installation...');
@@ -267,7 +272,8 @@ async function provisionResourceViaCLI(
         teamId,
         integration.id,
         product.id,
-        projectLink?.project?.id
+        projectLink?.project?.id,
+        name
       );
     }
 
@@ -505,6 +511,7 @@ function handleManualVerificationAction(
   const url = new URL('/api/marketplace/cli', 'https://vercel.com');
   url.searchParams.set('teamId', teamId);
   url.searchParams.set('authorizationId', authorizationId);
+  url.searchParams.set('source', 'cli');
   url.searchParams.set('cmd', 'authorize');
   output.print('Opening the Vercel Dashboard to continue the installation...');
   open(url.href);

--- a/packages/cli/test/unit/commands/integration/add.test.ts
+++ b/packages/cli/test/unit/commands/integration/add.test.ts
@@ -98,7 +98,7 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&projectId=vercel-integration-add&cmd=add'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&projectId=vercel-integration-add&cmd=add'
           );
         });
 
@@ -126,7 +126,7 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&cmd=add'
           );
         });
 
@@ -143,7 +143,7 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&cmd=add'
           );
         });
 
@@ -333,7 +333,7 @@ describe('integration', () => {
           client.stdin.write('Y\n');
           await expect(exitCodePromise).resolves.toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&cmd=add'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme&productId=acme-product&source=cli&cmd=add'
           );
         });
 
@@ -397,7 +397,7 @@ describe('integration', () => {
           client.stdin.write('Y\n');
           await expect(exitCodePromise).resolves.toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme-prepayment&productId=acme-product&cmd=add'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&integrationId=acme-prepayment&productId=acme-product&source=cli&defaultResourceName=test-resource&cmd=add'
           );
         });
       });
@@ -485,7 +485,7 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(0);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&authorizationId=success-case&cmd=authorize'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&authorizationId=success-case&source=cli&cmd=authorize'
           );
         });
 
@@ -571,7 +571,7 @@ describe('integration', () => {
           const exitCode = await exitCodePromise;
           expect(exitCode, 'exit code for "integration"').toEqual(1);
           expect(openMock).toHaveBeenCalledWith(
-            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&authorizationId=failure-case&cmd=authorize'
+            'https://vercel.com/api/marketplace/cli?teamId=team_dummy&authorizationId=failure-case&source=cli&cmd=authorize'
           );
         });
       });


### PR DESCRIPTION
## Summary

Updates the legacy `integration add` path (`add.ts`) to pass CLI context parameters to the web checkout flow:

- Add `source=cli` to `provisionResourceViaWebUI` and `handleManualVerificationAction` URLs
- Add `defaultResourceName` parameter to pre-fill resource name in checkout
- Keep `projectId` (Front derives `projectSlug` from it)

## How the two code paths work

```
OLD PATH (this PR) - via /api/marketplace/cli route
───────────────────────────────────────────────────
CLI (add.ts)                    Front (/api/marketplace/cli)      Front (checkout)
────────────                    ────────────────────────────      ────────────────
teamId ─────────────────────→   (auth)
integrationId ──────────────→   ────────────────────────────────→ (URL path)
productId ──────────────────→   → derives productSlug ──────────→ productSlug
projectId ──────────────────→   → fetches project ──────────────→ projectSlug (derived)
source=cli ─────────────────→   → forwards ─────────────────────→ source=cli ✅
defaultResourceName ────────→   → forwards ─────────────────────→ defaultResourceName ✅

NEW PATH - via auto-provision API (already working)
───────────────────────────────────────────────────
CLI (add-auto-provision.ts)     API (auto-provision)              Front (checkout)
───────────────────────────     ────────────────────              ────────────────
POST with name, metadata        Returns 422 fallback:
                                  url = checkout URL ───────────→ (base URL)
                                
CLI appends to returned URL:
  projectSlug ──────────────────────────────────────────────────→ projectSlug ✅
  source=cli ───────────────────────────────────────────────────→ source=cli ✅
  defaultResourceName ──────────────────────────────────────────→ defaultResourceName ✅
```

**Key difference:** The NEW path bypasses `/api/marketplace/cli` and goes directly to checkout. The OLD path goes through the Front route which rebuilds the URL - so the Front route must explicitly forward params.

## Dependencies

**This CLI PR requires [vercel/front#61528](https://github.com/vercel/front/pull/61528)** to forward `source` and `defaultResourceName` through the `/api/marketplace/cli` route. Without that Front PR, these params are stripped before reaching checkout.

## Linear

- [MKT-2440](https://linear.app/vercel/issue/MKT-2440) - Track cli-sourced installs (`source=cli`)
- [MKT-2467](https://linear.app/vercel/issue/MKT-2467) - Resource name not preserved from CLI -> web (`defaultResourceName`)
- [MKT-2502](https://linear.app/vercel/issue/MKT-2502) - CLI web fallback should auto connect projects (`projectSlug` - handled by existing `projectId` flow)

## Related PRs

**This PR:**
- Depends on: [vercel/front#61528](https://github.com/vercel/front/pull/61528) (forwards params through `/api/marketplace/cli`)

**Previous work:**
- #14734: feat(cli): Initial auto-provision support (NEW path)
- #14713: Track CLI as source for marketplace installations
- [vercel/front#60881](https://github.com/vercel/front/pull/60881): Auto-connect resource to project (checkout page support)

## Test plan

- [ ] Merge Front PR first
- [ ] Run `vc integration add <slug>` with linked project - verify URL includes `source=cli`, `projectId`
- [ ] Run `vc integration add <slug>` without linked project - verify URL includes `source=cli` only  
- [ ] Test non-subscription billing fallback - verify `defaultResourceName` is passed
- [ ] Test manual verification flow - verify authorization URL includes `source=cli`