### PR TITLE
cli: load local .env files in `vercel env run`

### DIFF
--- a/.changeset/gentle-items-knock.md
+++ b/.changeset/gentle-items-knock.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+cli: load local .env files in `vercel env run`

--- a/packages/cli/src/commands/env/run.ts
+++ b/packages/cli/src/commands/env/run.ts
@@ -1,3 +1,4 @@
+import { loadEnvConfig } from '@next/env';
 import execa from 'execa';
 import type Client from '../../util/client';
 import { parseArguments } from '../../util/get-args';
@@ -105,14 +106,22 @@ export default async function run(client: Client): Promise<number> {
     `Running command with ${Object.keys(records.env).length} environment variables`
   );
 
+  let localEnv: Record<string, string | undefined> = {};
+  try {
+    localEnv = loadEnvConfig(client.cwd, true).combinedEnv;
+  } catch (err) {
+    output.debug(`Failed to load local env files: ${err}`);
+  }
+
   try {
     const result = await execa(userCommand[0], userCommand.slice(1), {
       cwd: client.cwd,
       stdio: 'inherit',
       reject: false,
       env: {
-        ...process.env,
         ...records.env,
+        ...localEnv,
+        ...process.env,
       },
     });
 


### PR DESCRIPTION
## Summary

- Loads local `.env` files (`.env.local`, `.env.development.local`, etc.) when running `vercel env run`
- Uses `@next/env` which was already a dependency but unused
- Fixes env var precedence so local overrides can take effect

## Env var precedence (lowest to highest)

1. Vercel project env vars (from API)
2. Local `.env` files
3. Shell environment variables

Previously, Vercel env vars would override everything, and then the subprocess (e.g. `next dev`) would load `.env.local` but couldn't override already-set vars. Now local `.env` files are loaded by the CLI itself and applied with the right precedence.

## Test plan

- [ ] Run `vercel env run -- env | grep MY_VAR` with `MY_VAR` set in Vercel and `.env.local`
- [ ] Verify `.env.local` value wins over Vercel
- [ ] Verify `MY_VAR=shell vercel env run -- env | grep MY_VAR` shows "shell"

Made with [Cursor](https://cursor.com)