### PR TITLE
feat(cli): add --metadata flag to integration add command

### DIFF
--- a/.changeset/integration-add-metadata-flag.md
+++ b/.changeset/integration-add-metadata-flag.md
@@ -1,0 +1,5 @@
+---
+'vercel': minor
+---
+
+Add `--metadata` / `-m` flag to `vercel integration add` for non-interactive provisioning

--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -22,12 +22,13 @@ import { provisionStoreResource } from '../../util/integration/provision-store-r
 import { resolveResourceName } from '../../util/integration/generate-resource-name';
 import {
   parseMetadataFlags,
+  validateAndPrintRequiredMetadata,
   validateRequiredMetadata,
 } from '../../util/integration/parse-metadata';
 import { addAutoProvision } from './add-auto-provision';
 import { fetchBillingPlans } from '../../util/integration/fetch-billing-plans';
 import { fetchInstallations } from '../../util/integration/fetch-installations';
-import { fetchIntegration } from '../../util/integration/fetch-integration';
+import { fetchIntegrationWithTelemetry } from '../../util/integration/fetch-integration';
 import { selectProduct } from '../../util/integration/select-product';
 import output from '../../output-manager';
 import { IntegrationAddTelemetryClient } from '../../util/telemetry/commands/integration/add';
@@ -44,11 +45,6 @@ export async function add(
   metadataFlags?: string[],
   options: AddOptions = {}
 ) {
-  const telemetry = new IntegrationAddTelemetryClient({
-    opts: {
-      store: client.telemetryEventStore,
-    },
-  });
   if (args.length > 1) {
     output.error('Cannot install more than one integration at a time');
     return 1;
@@ -81,7 +77,7 @@ export async function add(
   // Note: Resource name validation happens after product selection
   // to apply product-specific validation rules
 
-  // Auto-provision: completely separate code path (tracks its own telemetry)
+  // Auto-provision: completely separate code path (self-contained telemetry)
   if (process.env.FF_AUTO_PROVISION_INSTALL === '1') {
     return await addAutoProvision(client, integrationSlug, resourceNameArg, {
       productSlug,
@@ -91,7 +87,13 @@ export async function add(
     });
   }
 
+  const telemetry = new IntegrationAddTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
   telemetry.trackCliOptionName(resourceNameArg);
+  telemetry.trackCliOptionMetadata(metadataFlags);
   telemetry.trackCliFlagNoConnect(options.noConnect);
   telemetry.trackCliFlagNoEnvPull(options.noEnvPull);
 
@@ -102,21 +104,13 @@ export async function add(
     return 1;
   }
 
-  let integration: Integration | undefined;
-  let knownIntegrationSlug = false;
-  try {
-    integration = await fetchIntegration(client, integrationSlug);
-    knownIntegrationSlug = true;
-  } catch (error) {
-    output.error(
-      `Failed to get integration "${integrationSlug}": ${(error as Error).message}`
-    );
+  const integration = await fetchIntegrationWithTelemetry(
+    client,
+    integrationSlug,
+    telemetry
+  );
+  if (!integration) {
     return 1;
-  } finally {
-    telemetry.trackCliArgumentIntegration(
-      integrationSlug,
-      knownIntegrationSlug
-    );
   }
 
   if (!integration.products?.length) {
@@ -189,14 +183,19 @@ export async function add(
   const { resourceName } = nameResult;
 
   // Validate --metadata flags early (fail fast, even if CLI provisioning not supported)
+  let parsedMetadata: Metadata | undefined;
   if (metadataFlags?.length) {
-    const { errors } = parseMetadataFlags(metadataFlags, metadataSchema);
+    const { metadata: parsed, errors } = parseMetadataFlags(
+      metadataFlags,
+      metadataSchema
+    );
     if (errors.length) {
       for (const error of errors) {
         output.error(error);
       }
       return 1;
     }
+    parsedMetadata = parsed;
   }
 
   // The provisioning via cli is possible when
@@ -204,7 +203,7 @@ export async function add(
   // 2. EITHER metadata is provided via flags OR wizard is supported
   // 3. The selected billing plan is supported (handled at time of billing plan selection)
   const provisionResourceViaCLIIsSupported =
-    installation && (metadataFlags?.length || metadataWizard.isSupported);
+    installation && (parsedMetadata || metadataWizard.isSupported);
 
   if (!provisionResourceViaCLIIsSupported) {
     const projectLink = await getLinkedProjectField(
@@ -229,7 +228,8 @@ export async function add(
         integration.id,
         product.id,
         projectLink.value,
-        resourceName
+        resourceName,
+        parsedMetadata
       );
     }
 
@@ -245,7 +245,7 @@ export async function add(
     product,
     metadataWizard,
     resourceName,
-    metadataFlags,
+    parsedMetadata,
     options
   );
 }
@@ -255,7 +255,8 @@ function provisionResourceViaWebUI(
   integrationId: string,
   productId: string,
   projectId?: string,
-  resourceName?: string
+  resourceName?: string,
+  metadata?: Metadata
 ) {
   const url = new URL('/api/marketplace/cli', 'https://vercel.com');
   url.searchParams.set('teamId', teamId);
@@ -267,6 +268,9 @@ function provisionResourceViaWebUI(
   }
   if (resourceName) {
     url.searchParams.set('defaultResourceName', resourceName);
+  }
+  if (metadata && Object.keys(metadata).length > 0) {
+    url.searchParams.set('metadata', JSON.stringify(metadata));
   }
   url.searchParams.set('cmd', 'add');
   output.print('Opening the Vercel Dashboard to continue the installation...');
@@ -283,46 +287,39 @@ async function provisionResourceViaCLI(
   product: IntegrationProduct,
   metadataWizard: MetadataWizard,
   name: string,
-  metadataFlags?: string[],
+  parsedMetadata?: Metadata,
   options: AddOptions = {}
 ) {
-  // Validate/collect metadata BEFORE billing plan selection (fail fast)
+  // Get metadata from flags, wizard, or hybrid
   let metadata: Metadata;
-  if (metadataFlags?.length) {
-    // Parse metadata from CLI flags
-    output.debug(
-      `Parsing metadata from flags: ${JSON.stringify(metadataFlags)}`
-    );
-    const { metadata: parsed, errors } = parseMetadataFlags(
-      metadataFlags,
-      product.metadataSchema
-    );
-    if (errors.length) {
-      for (const error of errors) {
-        output.error(error);
+  if (parsedMetadata) {
+    if (client.stdin.isTTY && metadataWizard.isSupported) {
+      // TTY with supported wizard: run wizard, pre-filling with flag values
+      metadata = await metadataWizard.run(client, parsedMetadata);
+    } else {
+      // Non-TTY or unsupported wizard: all required fields must come from flags
+      if (
+        !validateAndPrintRequiredMetadata(
+          parsedMetadata,
+          product.metadataSchema
+        )
+      ) {
+        return 1;
       }
-      return 1;
+      metadata = parsedMetadata;
     }
-    // OLD path: validate required fields (server won't fill defaults)
-    const missingErrors = validateRequiredMetadata(
-      parsed,
-      product.metadataSchema
-    );
-    if (missingErrors.length) {
-      for (const error of missingErrors) {
-        output.error(error);
-      }
-      return 1;
-    }
-    metadata = parsed;
   } else if (!client.stdin.isTTY) {
-    // Non-interactive without flags: error (OLD path doesn't have server defaults)
-    output.error(
-      'Metadata is required in non-interactive mode. Use --metadata KEY=VALUE flags.'
-    );
-    return 1;
+    // Non-TTY without metadata: check if required fields need user input
+    if (validateRequiredMetadata({}, product.metadataSchema).length > 0) {
+      output.error(
+        "Metadata is required in non-interactive mode. Use --metadata KEY=VALUE flags. Run 'vercel integration add <name> --help' to see available keys."
+      );
+      return 1;
+    }
+    // No required fields need user input — proceed with empty metadata
+    metadata = {};
   } else {
-    // Run wizard in interactive mode without --metadata flags
+    // TTY without metadata: run full wizard
     metadata = await metadataWizard.run(client);
   }
 
@@ -376,7 +373,8 @@ async function provisionResourceViaCLI(
         integration.id,
         product.id,
         projectLink.value,
-        name
+        name,
+        metadata
       );
     }
 

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -22,6 +22,15 @@ export const addSubcommand = {
       argument: 'NAME',
     },
     {
+      name: 'metadata',
+      description:
+        'Metadata for the resource as KEY=VALUE (can be repeated). Run `vercel integration add <name> --help` to see available keys.',
+      shorthand: 'm',
+      type: [String],
+      deprecated: false,
+      argument: 'KEY=VALUE',
+    },
+    {
       name: 'no-connect',
       shorthand: null,
       type: Boolean,
@@ -57,6 +66,13 @@ export const addSubcommand = {
       value: [
         `${packageName} integration add acme --name my-database`,
         `${packageName} integration add acme -n my-database`,
+      ],
+    },
+    {
+      name: 'Install with metadata options',
+      value: [
+        `${packageName} integration add acme --metadata region=us-east-1`,
+        `${packageName} integration add acme -m region=us-east-1 -m version=16`,
       ],
     },
     {

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -73,6 +73,8 @@ export const addSubcommand = {
       value: [
         `${packageName} integration add acme --metadata region=us-east-1`,
         `${packageName} integration add acme -m region=us-east-1 -m version=16`,
+        `${packageName} integration add acme -m auth=true`,
+        `${packageName} integration add acme -m "readRegions=sfo1,iad1"`,
       ],
     },
     {

--- a/packages/cli/src/util/integration/fetch-integration.ts
+++ b/packages/cli/src/util/integration/fetch-integration.ts
@@ -1,3 +1,5 @@
+import output from '../../output-manager';
+import type { IntegrationAddTelemetryClient } from '../telemetry/commands/integration/add';
 import type Client from '../client';
 import type { Integration } from './types';
 
@@ -5,4 +7,31 @@ export async function fetchIntegration(client: Client, slug: string) {
   return client.fetch<Integration>(`/v2/integrations/integration/${slug}`, {
     json: true,
   });
+}
+
+/**
+ * Fetch an integration by slug, print errors, and track telemetry.
+ * Returns the integration on success, or null on failure (after printing the error).
+ */
+export async function fetchIntegrationWithTelemetry(
+  client: Client,
+  integrationSlug: string,
+  telemetry: IntegrationAddTelemetryClient
+): Promise<Integration | null> {
+  let knownIntegrationSlug = false;
+  try {
+    const integration = await fetchIntegration(client, integrationSlug);
+    knownIntegrationSlug = true;
+    return integration;
+  } catch (error) {
+    output.error(
+      `Failed to get integration "${integrationSlug}": ${(error as Error).message}`
+    );
+    return null;
+  } finally {
+    telemetry.trackCliArgumentIntegration(
+      integrationSlug,
+      knownIntegrationSlug
+    );
+  }
 }

--- a/packages/cli/src/util/integration/format-dynamic-examples.ts
+++ b/packages/cli/src/util/integration/format-dynamic-examples.ts
@@ -1,0 +1,102 @@
+import chalk from 'chalk';
+import { packageName } from '../pkg-name';
+import { getVisibleOptions, isHiddenOnCreate } from './format-schema-help';
+import type { IntegrationProduct } from './types';
+
+/**
+ * Format dynamic CLI examples using the actual integration slug and product schemas.
+ * Replaces the static "acme" examples when we know the real integration.
+ */
+export function formatDynamicExamples(
+  integrationSlug: string,
+  products: IntegrationProduct[]
+): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`  ${chalk.dim('Examples:')}`);
+
+  // Basic install
+  lines.push('');
+  lines.push(`  ${chalk.dim('-')} Install ${integrationSlug}`);
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}`)}`
+  );
+
+  // Slash syntax for multi-product
+  if (products.length > 1) {
+    const firstProduct = products[0];
+    lines.push('');
+    lines.push(`  ${chalk.dim('-')} Install a specific product`);
+    lines.push('');
+    lines.push(
+      `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}/${firstProduct.slug}`)}`
+    );
+  }
+
+  // Custom name
+  lines.push('');
+  lines.push(`  ${chalk.dim('-')} Install with a custom resource name`);
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug} --name my-resource`)}`
+  );
+
+  // Metadata example — pick the first product with a schema and build a real example
+  const metadataExample = buildMetadataExample(integrationSlug, products);
+  if (metadataExample) {
+    lines.push('');
+    lines.push(`  ${chalk.dim('-')} Install with metadata`);
+    lines.push('');
+    lines.push(`    ${chalk.cyan(`$ ${metadataExample}`)}`);
+  }
+
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function buildMetadataExample(
+  integrationSlug: string,
+  products: IntegrationProduct[]
+): string | undefined {
+  // Find first product with a schema that has visible fields
+  for (const product of products) {
+    const schema = product.metadataSchema;
+    if (!schema) continue;
+
+    const flags: string[] = [];
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      if (isHiddenOnCreate(prop)) {
+        continue;
+      }
+
+      if (prop.type === 'boolean') {
+        flags.push(`-m ${key}=true`);
+      } else if (prop.type === 'array') {
+        const visible = getVisibleOptions(prop);
+        if (visible && visible.length > 0) {
+          flags.push(`-m "${key}=${visible.slice(0, 2).join(',')}"`);
+        }
+      } else {
+        const visible = getVisibleOptions(prop);
+        if (visible && visible.length > 0) {
+          flags.push(`-m ${key}=${visible[0]}`);
+        }
+      }
+
+      // Show at most 2 flags in the example
+      if (flags.length >= 2) break;
+    }
+
+    if (flags.length > 0) {
+      const slug =
+        products.length > 1
+          ? `${integrationSlug}/${product.slug}`
+          : integrationSlug;
+      return `${packageName} integration add ${slug} ${flags.join(' ')}`;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/cli/src/util/integration/format-schema-help.ts
+++ b/packages/cli/src/util/integration/format-schema-help.ts
@@ -1,0 +1,72 @@
+import chalk from 'chalk';
+import type { MetadataSchema } from './types';
+
+/**
+ * Format metadata schema as help text for CLI display
+ */
+export function formatMetadataSchemaHelp(
+  schema: MetadataSchema,
+  integrationName: string
+): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(chalk.bold(`  Metadata options for "${integrationName}":`));
+  lines.push('');
+
+  const required = new Set(schema.required ?? []);
+  const entries = Object.entries(schema.properties);
+
+  if (entries.length === 0) {
+    lines.push('    No metadata options available.');
+    return lines.join('\n');
+  }
+
+  for (const [key, prop] of entries) {
+    // Skip hidden fields
+    if (prop['ui:hidden'] === true || prop['ui:hidden'] === 'create') {
+      continue;
+    }
+
+    const isRequired = required.has(key);
+    const requiredSuffix = isRequired ? chalk.red(' (required)') : '';
+
+    lines.push(`    ${chalk.cyan(key)}${requiredSuffix}`);
+
+    if (prop.description) {
+      lines.push(`      ${prop.description}`);
+    }
+
+    // Show options for select fields
+    if (prop['ui:options']) {
+      const rawOptions = prop['ui:options'];
+      const options: string[] = [];
+      for (const opt of rawOptions) {
+        if (typeof opt === 'string') {
+          options.push(opt);
+        } else if (!opt.hidden) {
+          options.push(opt.value);
+        }
+      }
+      if (options.length > 0) {
+        lines.push(`      Options: ${options.join(', ')}`);
+      }
+    }
+
+    // Show range for number fields
+    if (prop.minimum !== undefined || prop.maximum !== undefined) {
+      const range = [];
+      if (prop.minimum !== undefined) range.push(`min: ${prop.minimum}`);
+      if (prop.maximum !== undefined) range.push(`max: ${prop.maximum}`);
+      lines.push(`      Range: ${range.join(', ')}`);
+    }
+
+    // Show default value
+    if (prop.default !== undefined) {
+      lines.push(`      Default: ${prop.default}`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/util/integration/format-schema-help.ts
+++ b/packages/cli/src/util/integration/format-schema-help.ts
@@ -1,16 +1,105 @@
 import chalk from 'chalk';
-import type { MetadataSchema } from './types';
+import type { MetadataSchema, MetadataSchemaProperty } from './types';
+
+/**
+ * Whether a field is hidden during resource creation.
+ * Expression-based `ui:hidden` is NOT treated as hidden (CLI can't evaluate expressions).
+ */
+export function isHiddenOnCreate(prop: MetadataSchemaProperty): boolean {
+  return prop['ui:hidden'] === true || prop['ui:hidden'] === 'create';
+}
+
+/**
+ * Get ALL option values from a field's `ui:options` (including hidden ones).
+ * Used for validation — hidden options are still valid values.
+ */
+export function getAllOptionValues(
+  prop: MetadataSchemaProperty
+): string[] | undefined {
+  const raw = prop['ui:options'];
+  if (!raw) return undefined;
+  const values = raw.map((opt: string | { value: string }) =>
+    typeof opt === 'string' ? opt : opt.value
+  );
+  return values.length > 0 ? values : undefined;
+}
+
+export function getVisibleOptions(
+  prop: MetadataSchemaProperty
+): string[] | undefined {
+  const raw = prop['ui:options'];
+  if (!raw) return undefined;
+  const options: string[] = [];
+  for (const opt of raw) {
+    if (typeof opt === 'string') {
+      if (opt) options.push(opt);
+    } else if (!opt.hidden && opt.value) {
+      options.push(opt.value);
+    }
+  }
+  return options.length > 0 ? options : undefined;
+}
+
+function generateExample(
+  key: string,
+  prop: MetadataSchemaProperty
+): string | undefined {
+  if (prop.type === 'boolean') {
+    return `-m ${key}=true`;
+  }
+
+  if (prop.type === 'array') {
+    const options = getVisibleOptions(prop);
+    if (options && options.length >= 2) {
+      return `-m "${key}=${options[0]},${options[1]}"`;
+    }
+    if (options && options.length === 1) {
+      return `-m "${key}=${options[0]}"`;
+    }
+    if (prop.items?.type === 'number') {
+      if (prop.default !== undefined) {
+        return `-m ${key}=${prop.default}`;
+      }
+      return `-m ${key}=N,N`;
+    }
+    return `-m "${key}=value1,value2"`;
+  }
+
+  if (prop.type === 'number') {
+    if (prop.default !== undefined) {
+      return `-m ${key}=${prop.default}`;
+    }
+    if (prop.minimum !== undefined) {
+      return `-m ${key}=${prop.minimum}`;
+    }
+    return `-m ${key}=N`;
+  }
+
+  // string type
+  const options = getVisibleOptions(prop);
+  if (options && options.length > 0) {
+    return `-m ${key}=${options[0]}`;
+  }
+  return `-m ${key}=<value>`;
+}
 
 /**
  * Format metadata schema as help text for CLI display
+ * @param schema The metadata schema to format
+ * @param integrationName The integration slug/name
+ * @param productSlug Optional product slug (for multi-product integrations, shown as integration/product)
  */
 export function formatMetadataSchemaHelp(
   schema: MetadataSchema,
-  integrationName: string
+  integrationName: string,
+  productSlug?: string
 ): string {
   const lines: string[] = [];
   lines.push('');
-  lines.push(chalk.bold(`  Metadata options for "${integrationName}":`));
+  const header = productSlug
+    ? `  Metadata options for "${integrationName}/${productSlug}":`
+    : `  Metadata options for "${integrationName}":`;
+  lines.push(chalk.bold(header));
   lines.push('');
 
   const required = new Set(schema.required ?? []);
@@ -23,33 +112,29 @@ export function formatMetadataSchemaHelp(
 
   for (const [key, prop] of entries) {
     // Skip hidden fields
-    if (prop['ui:hidden'] === true || prop['ui:hidden'] === 'create') {
+    if (isHiddenOnCreate(prop)) {
       continue;
     }
 
     const isRequired = required.has(key);
     const requiredSuffix = isRequired ? chalk.red(' (required)') : '';
 
-    lines.push(`    ${chalk.cyan(key)}${requiredSuffix}`);
+    const typeHint =
+      prop.type === 'boolean'
+        ? chalk.dim(' (true/false)')
+        : prop.type === 'array'
+          ? chalk.dim(' (comma-separated)')
+          : '';
+    lines.push(`    ${chalk.cyan(key)}${requiredSuffix}${typeHint}`);
 
     if (prop.description) {
       lines.push(`      ${prop.description}`);
     }
 
     // Show options for select fields
-    if (prop['ui:options']) {
-      const rawOptions = prop['ui:options'];
-      const options: string[] = [];
-      for (const opt of rawOptions) {
-        if (typeof opt === 'string') {
-          options.push(opt);
-        } else if (!opt.hidden) {
-          options.push(opt.value);
-        }
-      }
-      if (options.length > 0) {
-        lines.push(`      Options: ${options.join(', ')}`);
-      }
+    const visibleOptions = getVisibleOptions(prop);
+    if (visibleOptions) {
+      lines.push(`      Options: ${visibleOptions.join(', ')}`);
     }
 
     // Show range for number fields
@@ -63,6 +148,12 @@ export function formatMetadataSchemaHelp(
     // Show default value
     if (prop.default !== undefined) {
       lines.push(`      Default: ${prop.default}`);
+    }
+
+    // Show usage example
+    const example = generateExample(key, prop);
+    if (example) {
+      lines.push(`      Example: ${chalk.dim(example)}`);
     }
 
     lines.push('');

--- a/packages/cli/src/util/integration/parse-metadata.ts
+++ b/packages/cli/src/util/integration/parse-metadata.ts
@@ -1,0 +1,104 @@
+import type { Metadata, MetadataSchema } from './types';
+
+export interface ParseMetadataResult {
+  metadata: Metadata;
+  errors: string[];
+}
+
+/**
+ * Parse metadata flags from CLI arguments (KEY=VALUE format)
+ */
+export function parseMetadataFlags(
+  rawMetadata: string[] | undefined,
+  schema: MetadataSchema
+): ParseMetadataResult {
+  const metadata: Metadata = {};
+  const errors: string[] = [];
+
+  if (!rawMetadata?.length) {
+    return { metadata, errors };
+  }
+
+  for (const item of rawMetadata) {
+    const eqIndex = item.indexOf('=');
+    if (eqIndex === -1) {
+      errors.push(`Invalid metadata format: "${item}". Expected KEY=VALUE`);
+      continue;
+    }
+
+    const key = item.slice(0, eqIndex);
+    const value = item.slice(eqIndex + 1);
+
+    const propSchema = schema.properties[key];
+    if (!propSchema) {
+      errors.push(`Unknown metadata key: "${key}"`);
+      continue;
+    }
+
+    // Type coercion and validation
+    if (propSchema.type === 'number') {
+      const num = Number(value);
+      if (Number.isNaN(num)) {
+        errors.push(`Metadata "${key}" must be a number, got: "${value}"`);
+        continue;
+      }
+      if (propSchema.minimum !== undefined && num < propSchema.minimum) {
+        errors.push(`Metadata "${key}" must be >= ${propSchema.minimum}`);
+        continue;
+      }
+      if (propSchema.maximum !== undefined && num > propSchema.maximum) {
+        errors.push(`Metadata "${key}" must be <= ${propSchema.maximum}`);
+        continue;
+      }
+      metadata[key] = num;
+    } else {
+      // Validate select options if present
+      if (propSchema['ui:options']) {
+        const options = propSchema['ui:options'];
+        const validValues = options.map((opt: string | { value: string }) =>
+          typeof opt === 'string' ? opt : opt.value
+        );
+        if (!validValues.includes(value)) {
+          errors.push(
+            `Metadata "${key}" must be one of: ${validValues.join(', ')}`
+          );
+          continue;
+        }
+      }
+      metadata[key] = value;
+    }
+  }
+
+  return { metadata, errors };
+}
+
+/**
+ * Validate that all required metadata fields are provided.
+ * Used by OLD path where server doesn't fill defaults.
+ */
+export function validateRequiredMetadata(
+  metadata: Metadata,
+  schema: MetadataSchema
+): string[] {
+  const errors: string[] = [];
+  const required = schema.required ?? [];
+
+  for (const key of required) {
+    const propSchema = schema.properties[key];
+
+    // Skip hidden fields (they use defaults server-side)
+    if (
+      propSchema?.['ui:hidden'] === true ||
+      propSchema?.['ui:hidden'] === 'create'
+    ) {
+      continue;
+    }
+
+    // Check if value is provided or has a default
+    if (metadata[key] === undefined && propSchema?.default === undefined) {
+      errors.push(`Required metadata missing: "${key}"`);
+    }
+  }
+
+  return errors;
+}

--- a/packages/cli/src/util/integration/types.ts
+++ b/packages/cli/src/util/integration/types.ts
@@ -1,9 +1,10 @@
 export interface MetadataSchemaProperty {
-  type: 'string' | 'number' | string;
+  type: 'string' | 'number' | 'boolean' | 'array' | string;
   description?: string;
-  default?: string;
+  default?: string | boolean | number;
   minimum?: number;
   maximum?: number;
+  items?: { type: 'string' | 'number' | string };
   'ui:control': 'input' | 'select' | 'vercel-region' | string;
   'ui:disabled'?: 'create' | Expression | boolean | string;
   'ui:hidden'?: 'create' | Expression | boolean | string;
@@ -23,7 +24,10 @@ export interface Expression {
   expr: string;
 }
 
-export type Metadata = Record<string, string | number | undefined>;
+export type Metadata = Record<
+  string,
+  string | number | boolean | string[] | number[] | undefined
+>;
 export type MetadataEntry = Readonly<[string, Metadata[string]]>;
 
 export interface MetadataSchema {

--- a/packages/cli/src/util/telemetry/commands/integration/add.ts
+++ b/packages/cli/src/util/telemetry/commands/integration/add.ts
@@ -24,6 +24,15 @@ export class IntegrationAddTelemetryClient
     }
   }
 
+  trackCliOptionMetadata(v: string[] | undefined) {
+    if (v?.length) {
+      this.trackCliOption({
+        option: 'metadata',
+        value: this.redactedValue,
+      });
+    }
+  }
+
   trackCliFlagNoConnect(v: boolean | undefined) {
     if (v) {
       this.trackCliFlag('no-connect');

--- a/packages/cli/test/mocks/integration.ts
+++ b/packages/cli/test/mocks/integration.ts
@@ -148,6 +148,33 @@ const metadataSchema3: MetadataSchema = {
   required: ['Region'],
 };
 
+const metadataFullTypes: MetadataSchema = {
+  type: 'object',
+  properties: {
+    region: {
+      'ui:control': 'select',
+      'ui:label': 'Region',
+      type: 'string',
+      'ui:options': ['iad1', 'sfo1'],
+    },
+    auth: {
+      'ui:control': 'toggle',
+      'ui:label': 'Auth',
+      description: 'Enable built-in authentication',
+      type: 'boolean',
+      default: false,
+    },
+    readRegions: {
+      type: 'array',
+      'ui:control': 'multi-vercel-region',
+      'ui:label': 'Read Regions',
+      items: { type: 'string' },
+      'ui:options': ['iad1', 'sfo1', 'fra1'],
+    },
+  },
+  required: ['region'],
+};
+
 const metadataUnsupported: MetadataSchema = {
   type: 'object',
   properties: {
@@ -180,6 +207,19 @@ const metadataUnsupported: MetadataSchema = {
     },
   },
   required: ['region'],
+};
+
+const metadataNoDefaults: MetadataSchema = {
+  type: 'object',
+  properties: {
+    tier: {
+      'ui:control': 'select',
+      'ui:label': 'Tier',
+      type: 'string',
+      'ui:options': ['starter', 'pro', 'enterprise'],
+    },
+  },
+  required: ['tier'],
 };
 
 const integrations: Record<string, Integration> = {
@@ -247,6 +287,21 @@ const integrations: Record<string, Integration> = {
     slug: 'acme-no-products',
     products: [],
   },
+  'acme-full-schema': {
+    id: 'acme-full-schema',
+    name: 'Acme Full Schema',
+    slug: 'acme-full-schema',
+    products: [
+      {
+        id: 'acme-product',
+        name: 'Acme Product',
+        slug: 'acme',
+        type: 'storage',
+        shortDescription: 'The Acme product with all field types',
+        metadataSchema: metadataFullTypes,
+      },
+    ],
+  },
   'acme-prepayment': {
     id: 'acme-prepayment',
     name: 'Acme Prepayment',
@@ -259,6 +314,36 @@ const integrations: Record<string, Integration> = {
         type: 'ai',
         shortDescription: 'The Acme product',
         metadataSchema: metadataSchema1,
+      },
+    ],
+  },
+  'acme-required': {
+    id: 'acme-required',
+    name: 'Acme Required',
+    slug: 'acme-required',
+    products: [
+      {
+        id: 'acme-product',
+        name: 'Acme Product',
+        slug: 'acme',
+        type: 'storage',
+        shortDescription: 'The Acme product with required metadata',
+        metadataSchema: metadataNoDefaults,
+      },
+    ],
+  },
+  'acme-multi': {
+    id: 'acme-multi',
+    name: 'Acme Multi',
+    slug: 'acme-multi',
+    products: [
+      {
+        id: 'acme-product',
+        name: 'Acme Product',
+        slug: 'acme',
+        type: 'storage',
+        shortDescription: 'The Acme product with multiple fields',
+        metadataSchema: metadataSchema2,
       },
     ],
   },
@@ -432,6 +517,20 @@ const integrationPlans: Record<string, unknown> = {
           },
         ],
         disabled: true,
+      },
+    ],
+  },
+  'acme-multi': {
+    plans: [
+      {
+        id: 'pro',
+        type: 'subscription',
+        name: 'Pro Plan',
+        scope: 'installation',
+        description: 'Pro Plan',
+        paymentMethodRequired: true,
+        details: [],
+        highlightedDetails: [],
       },
     ],
   },

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -72,7 +72,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -98,7 +98,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -126,7 +126,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -159,9 +159,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -182,9 +180,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--no-connect');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -205,9 +201,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--no-env-pull');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -225,7 +219,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -236,6 +230,38 @@ describe('integration add (auto-provision)', () => {
         {
           key: 'subcommand:add',
           value: 'add',
+        },
+        {
+          key: 'argument:integration',
+          value: 'acme',
+        },
+      ]);
+    });
+
+    it('should track metadata telemetry when --metadata is used', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Acme Product successfully provisioned'
+      );
+
+      await exitCodePromise;
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:add',
+          value: 'add',
+        },
+        {
+          key: 'option:metadata',
+          value: '[REDACTED]',
         },
         {
           key: 'argument:integration',
@@ -258,7 +284,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -277,7 +303,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('n\n');
 
@@ -293,7 +319,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -316,7 +342,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -334,15 +360,75 @@ describe('integration add (auto-provision)', () => {
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/source=cli/)
       );
+      // No --metadata flags, so metadata should NOT be in the URL
+      expect(openMock).toHaveBeenCalledWith(
+        expect.not.stringMatching(/metadata=/)
+      );
     });
 
-    it('should open browser for unknown fallback', async () => {
+    it('should forward --metadata to browser fallback URL', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      const calledUrl = openMock.mock.calls[0]?.[0] as string;
+      const parsed = new URL(calledUrl);
+      expect(parsed.searchParams.get('metadata')).toEqual(
+        JSON.stringify({ region: 'us-east-1' })
+      );
+    });
+
+    it('should forward --metadata to browser URL with slash syntax, --name, and --metadata together', async () => {
+      useAutoProvision({ responseKey: 'metadata' });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-two-products/acme-a',
+        '--name',
+        'my-db',
+        '--metadata',
+        'version=5.4',
+        '--metadata',
+        'region=pdx1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      const calledUrl = openMock.mock.calls[0]?.[0] as string;
+      const parsed = new URL(calledUrl);
+      expect(parsed.searchParams.get('defaultResourceName')).toEqual('my-db');
+      expect(parsed.searchParams.get('metadata')).toEqual(
+        JSON.stringify({ version: '5.4', region: 'pdx1' })
+      );
+      expect(parsed.searchParams.get('source')).toEqual('cli');
+    });
+
+    it('should open browser for unknown fallback without metadata in URL', async () => {
       useAutoProvision({ responseKey: 'unknown' });
 
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -350,6 +436,99 @@ describe('integration add (auto-provision)', () => {
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expect(openMock).toHaveBeenCalled();
+      // No --metadata flags, so metadata should NOT be in the URL
+      expect(openMock).toHaveBeenCalledWith(
+        expect.not.stringMatching(/metadata=/)
+      );
+    });
+
+    it('should forward --metadata to browser URL on unknown fallback', async () => {
+      useAutoProvision({ responseKey: 'unknown' });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      const calledUrl = openMock.mock.calls[0]?.[0] as string;
+      const parsed = new URL(calledUrl);
+      expect(parsed.searchParams.get('metadata')).toEqual(
+        JSON.stringify({ region: 'us-east-1' })
+      );
+    });
+
+    it('should forward --metadata to browser URL after policy retry falls back', async () => {
+      // First call returns 'install' (policies required), second returns 'metadata' (still needs web)
+      useAutoProvision({
+        responseKey: 'install',
+        secondResponseKey: 'metadata',
+      });
+
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      // Accept policies
+      await expect(client.stderr).toOutput('Accept privacy policy?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Accept terms of service?');
+      client.stdin.write('y\n');
+
+      // After retry, still falls back to browser
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      const calledUrl = openMock.mock.calls[0]?.[0] as string;
+      const parsed = new URL(calledUrl);
+      expect(parsed.searchParams.get('metadata')).toEqual(
+        JSON.stringify({ region: 'us-east-1' })
+      );
+      expect(parsed.searchParams.get('source')).toEqual('cli');
+    });
+
+    it('should not include metadata in URL after policy retry falls back without --metadata', async () => {
+      useAutoProvision({
+        responseKey: 'install',
+        secondResponseKey: 'metadata',
+      });
+
+      client.setArgv('integration', 'add', 'acme');
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('Accept privacy policy?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput('Accept terms of service?');
+      client.stdin.write('y\n');
+
+      await expect(client.stderr).toOutput(
+        'Additional setup required. Opening browser...'
+      );
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+      expect(openMock).toHaveBeenCalledWith(
+        expect.not.stringMatching(/metadata=/)
+      );
     });
 
     it('should include all three URL params (projectSlug, defaultResourceName, source) when project is linked', async () => {
@@ -365,9 +544,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -399,9 +576,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--no-connect');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -426,9 +601,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', 'my-custom-db');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -456,7 +629,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', 'my-proj-db');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: server fills defaults, no wizard prompt
+      // Server fills defaults, no wizard prompt
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -494,7 +667,7 @@ describe('integration add (auto-provision)', () => {
       );
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -522,7 +695,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', 'my-custom-name');
       const exitCodePromise = integrationCommand(client);
 
-      // NEW path: --name flag provides the name, server fills metadata defaults — no prompts
+      // --name flag provides the name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: my-custom-name'
       );
@@ -572,9 +745,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '-n', 'shorthand-name');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: shorthand-name'
       );
@@ -588,9 +759,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', maxName);
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput(
         `Acme Product successfully provisioned: ${maxName}`
       );
@@ -680,7 +849,7 @@ describe('integration add (auto-provision)', () => {
       await expect(client.stderr).toOutput('Select a product');
       client.stdin.write('\n'); // Select first product
 
-      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      // Auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;
@@ -756,12 +925,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      // Should prompt for resource name
-      await expect(client.stderr).toOutput('What is the name of the resource?');
-      client.stdin.write('test-resource\n');
-
-      // Should skip region wizard since --metadata provided
-      // Goes straight to provisioning
+      // Auto-generated name, --metadata provides metadata — no prompts
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;
@@ -783,14 +947,93 @@ describe('integration add (auto-provision)', () => {
       await expect(client.stderr).toOutput('Select a product');
       client.stdin.write('\n'); // Select first product (uses metadataSchema2)
 
-      await expect(client.stderr).toOutput('What is the name of the resource?');
-      client.stdin.write('test-resource\n');
-
-      // Should skip version and region wizard since --metadata provided
+      // Auto-generated name, --metadata provides metadata — no prompts
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
+    });
+
+    it('should coerce boolean metadata to true/false', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-full-schema',
+        '--metadata',
+        'region=iad1',
+        '--metadata',
+        'auth=true'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('successfully provisioned');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should reject invalid boolean metadata value', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-full-schema',
+        '--metadata',
+        'auth=yes'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Metadata "auth" must be "true" or "false", got: "yes"'
+      );
+    });
+
+    it('should parse comma-separated array metadata', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-full-schema',
+        '--metadata',
+        'region=iad1',
+        '--metadata',
+        'readRegions=iad1,sfo1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('successfully provisioned');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should error when required metadata is missing', async () => {
+      // acme-full-schema has required: ['region'] and region has no default
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-full-schema',
+        '--metadata',
+        'auth=true'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Required metadata missing: "region"'
+      );
+    });
+
+    it('should reject invalid array item against ui:options', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-full-schema',
+        '--metadata',
+        'readRegions=iad1,invalid'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Metadata "readRegions" contains invalid value: "invalid". Must be one of: iad1, sfo1, fra1'
+      );
     });
   });
 
@@ -808,12 +1051,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product A by Acme Integration Two Products under ${team.slug}`
       );
 
-      await expect(client.stderr).toOutput('Version');
-      client.stdin.write('\n');
-
-      await expect(client.stderr).toOutput('Region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;
@@ -848,13 +1086,36 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product A by Acme Integration Two Products under ${team.slug}`
       );
 
-      await expect(client.stderr).toOutput('Version');
-      client.stdin.write('\n');
-
-      await expect(client.stderr).toOutput('Region');
-      client.stdin.write('\n');
-
+      // --name flag provides the name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput('successfully provisioned');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should use --name, --metadata, and slash syntax together', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-two-products/acme-a',
+        '--name',
+        'my-db',
+        '--metadata',
+        'version=5.4',
+        '--metadata',
+        'region=pdx1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      // Slash syntax selects product, --name provides name, --metadata provides config
+      await expect(client.stderr).toOutput(
+        `Installing Acme Product A by Acme Integration Two Products under ${team.slug}`
+      );
+
+      // Fully non-interactive — no product selection, no name prompt, no wizard
+      await expect(client.stderr).toOutput(
+        'Acme Product A successfully provisioned: my-db'
+      );
 
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
@@ -895,9 +1156,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // Auto-generated name, server fills metadata defaults — no wizard prompts
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -72,9 +72,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -100,9 +98,7 @@ describe('integration add (auto-provision)', () => {
         `Installing Acme Product by Acme Integration under ${team.slug}`
       );
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -130,9 +126,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -231,9 +225,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: acme-gray-apple'
       );
@@ -266,9 +258,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -287,9 +277,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('n\n');
 
@@ -305,9 +293,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput('Accept privacy policy?');
       client.stdin.write('y\n');
 
@@ -330,9 +316,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -358,9 +342,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -474,9 +456,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', 'my-proj-db');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: server fills defaults, no wizard prompt
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -514,9 +494,7 @@ describe('integration add (auto-provision)', () => {
       );
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Additional setup required. Opening browser...'
       );
@@ -544,9 +522,7 @@ describe('integration add (auto-provision)', () => {
       client.setArgv('integration', 'add', 'acme', '--name', 'my-custom-name');
       const exitCodePromise = integrationCommand(client);
 
-      await expect(client.stderr).toOutput('Choose your region');
-      client.stdin.write('\n');
-
+      // NEW path: --name flag provides the name, server fills metadata defaults — no prompts
       await expect(client.stderr).toOutput(
         'Acme Product successfully provisioned: my-custom-name'
       );
@@ -704,13 +680,113 @@ describe('integration add (auto-provision)', () => {
       await expect(client.stderr).toOutput('Select a product');
       client.stdin.write('\n'); // Select first product
 
-      // acme-two-products uses metadataSchema2 which has version and region
-      await expect(client.stderr).toOutput('Version');
-      client.stdin.write('\n');
+      // NEW path: auto-generated name, server fills metadata defaults — no prompts
+      await expect(client.stderr).toOutput('successfully provisioned');
 
-      await expect(client.stderr).toOutput('Region');
-      client.stdin.write('\n');
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+  });
 
+  describe('--metadata flag', () => {
+    beforeEach(() => {
+      useAutoProvision({ responseKey: 'provisioned' });
+    });
+
+    it('should error on invalid metadata value before prompting for resource name', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=invalid-region'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Metadata "region" must be one of: us-west-1, us-east-1'
+      );
+      // Should NOT prompt for resource name since validation fails first
+      await expect(client.stderr).not.toOutput(
+        'What is the name of the resource?'
+      );
+    });
+
+    it('should error on unknown metadata key', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'unknown=value'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Unknown metadata key: "unknown"'
+      );
+    });
+
+    it('should error on invalid metadata format', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'no-equals-sign'
+      );
+      const exitCode = await integrationCommand(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput(
+        'Error: Invalid metadata format: "no-equals-sign". Expected KEY=VALUE'
+      );
+    });
+
+    it('should accept valid metadata and skip wizard prompts', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme',
+        '--metadata',
+        'region=us-east-1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput(
+        `Installing Acme Product by Acme Integration under ${team.slug}`
+      );
+
+      // Should prompt for resource name
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      // Should skip region wizard since --metadata provided
+      // Goes straight to provisioning
+      await expect(client.stderr).toOutput('successfully provisioned');
+
+      const exitCode = await exitCodePromise;
+      expect(exitCode).toEqual(0);
+    });
+
+    it('should accept multiple metadata flags', async () => {
+      client.setArgv(
+        'integration',
+        'add',
+        'acme-two-products',
+        '--metadata',
+        'version=5.4',
+        '--metadata',
+        'region=pdx1'
+      );
+      const exitCodePromise = integrationCommand(client);
+
+      await expect(client.stderr).toOutput('Select a product');
+      client.stdin.write('\n'); // Select first product (uses metadataSchema2)
+
+      await expect(client.stderr).toOutput('What is the name of the resource?');
+      client.stdin.write('test-resource\n');
+
+      // Should skip version and region wizard since --metadata provided
       await expect(client.stderr).toOutput('successfully provisioned');
 
       const exitCode = await exitCodePromise;

--- a/packages/cli/test/unit/util/integration/parse-metadata.test.ts
+++ b/packages/cli/test/unit/util/integration/parse-metadata.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseMetadataFlags,
+  validateRequiredMetadata,
+} from '../../../../src/util/integration/parse-metadata';
+import type { MetadataSchema } from '../../../../src/util/integration/types';
+
+describe('parseMetadataFlags', () => {
+  const basicSchema: MetadataSchema = {
+    type: 'object',
+    properties: {
+      region: {
+        type: 'string',
+        'ui:control': 'select',
+        'ui:options': ['us-east-1', 'us-west-2', 'eu-central-1'],
+      },
+      version: {
+        type: 'string',
+        'ui:control': 'select',
+        'ui:options': [
+          { value: '14', label: 'PostgreSQL 14' },
+          { value: '15', label: 'PostgreSQL 15' },
+          { value: '16', label: 'PostgreSQL 16' },
+        ],
+        default: '16',
+      },
+      storage: {
+        type: 'number',
+        'ui:control': 'input',
+        minimum: 1,
+        maximum: 256,
+      },
+    },
+    required: ['region'],
+  };
+
+  it('parses valid KEY=VALUE pairs', () => {
+    const result = parseMetadataFlags(['region=us-east-1'], basicSchema);
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({ region: 'us-east-1' });
+  });
+
+  it('handles multiple metadata flags', () => {
+    const result = parseMetadataFlags(
+      ['region=us-east-1', 'version=15'],
+      basicSchema
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({ region: 'us-east-1', version: '15' });
+  });
+
+  it('rejects invalid format (no equals sign)', () => {
+    const result = parseMetadataFlags(['region'], basicSchema);
+    expect(result.errors).toEqual([
+      'Invalid metadata format: "region". Expected KEY=VALUE',
+    ]);
+    expect(result.metadata).toEqual({});
+  });
+
+  it('rejects unknown keys', () => {
+    const result = parseMetadataFlags(['unknown=value'], basicSchema);
+    expect(result.errors).toEqual(['Unknown metadata key: "unknown"']);
+    expect(result.metadata).toEqual({});
+  });
+
+  it('validates select options (string array)', () => {
+    const result = parseMetadataFlags(['region=invalid-region'], basicSchema);
+    expect(result.errors).toEqual([
+      'Metadata "region" must be one of: us-east-1, us-west-2, eu-central-1',
+    ]);
+  });
+
+  it('validates select options (object array)', () => {
+    const result = parseMetadataFlags(['version=99'], basicSchema);
+    expect(result.errors).toEqual([
+      'Metadata "version" must be one of: 14, 15, 16',
+    ]);
+  });
+
+  it('coerces number types', () => {
+    const result = parseMetadataFlags(['storage=100'], basicSchema);
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({ storage: 100 });
+    expect(typeof result.metadata.storage).toBe('number');
+  });
+
+  it('validates number must be a number', () => {
+    const result = parseMetadataFlags(['storage=abc'], basicSchema);
+    expect(result.errors).toEqual([
+      'Metadata "storage" must be a number, got: "abc"',
+    ]);
+  });
+
+  it('validates minimum constraint', () => {
+    const result = parseMetadataFlags(['storage=0'], basicSchema);
+    expect(result.errors).toEqual(['Metadata "storage" must be >= 1']);
+  });
+
+  it('validates maximum constraint', () => {
+    const result = parseMetadataFlags(['storage=500'], basicSchema);
+    expect(result.errors).toEqual(['Metadata "storage" must be <= 256']);
+  });
+
+  it('handles empty/undefined input', () => {
+    const result = parseMetadataFlags(undefined, basicSchema);
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({});
+  });
+
+  it('handles empty array', () => {
+    const result = parseMetadataFlags([], basicSchema);
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({});
+  });
+
+  it('handles values with equals signs', () => {
+    const schemaWithInput: MetadataSchema = {
+      type: 'object',
+      properties: {
+        connection: {
+          type: 'string',
+          'ui:control': 'input',
+        },
+      },
+    };
+    const result = parseMetadataFlags(
+      ['connection=postgres://user:pass=word@host'],
+      schemaWithInput
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toEqual({
+      connection: 'postgres://user:pass=word@host',
+    });
+  });
+
+  it('collects multiple errors', () => {
+    const result = parseMetadataFlags(
+      ['unknown=x', 'storage=abc', 'region=invalid'],
+      basicSchema
+    );
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors).toContain('Unknown metadata key: "unknown"');
+    expect(result.errors).toContain(
+      'Metadata "storage" must be a number, got: "abc"'
+    );
+    expect(result.errors).toContain(
+      'Metadata "region" must be one of: us-east-1, us-west-2, eu-central-1'
+    );
+  });
+});
+
+describe('validateRequiredMetadata', () => {
+  const schemaWithRequired: MetadataSchema = {
+    type: 'object',
+    properties: {
+      region: {
+        type: 'string',
+        'ui:control': 'select',
+      },
+      version: {
+        type: 'string',
+        'ui:control': 'select',
+        default: '16',
+      },
+      hidden: {
+        type: 'string',
+        'ui:control': 'input',
+        'ui:hidden': true,
+        default: 'hidden-value',
+      },
+      hiddenOnCreate: {
+        type: 'string',
+        'ui:control': 'input',
+        'ui:hidden': 'create',
+        default: 'create-hidden-value',
+      },
+    },
+    required: ['region', 'version', 'hidden', 'hiddenOnCreate'],
+  };
+
+  it('returns error for missing required field', () => {
+    const errors = validateRequiredMetadata({}, schemaWithRequired);
+    expect(errors).toEqual(['Required metadata missing: "region"']);
+  });
+
+  it('skips fields with defaults', () => {
+    // version has a default, so it should not error
+    const errors = validateRequiredMetadata(
+      { region: 'us-east-1' },
+      schemaWithRequired
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('skips hidden fields', () => {
+    // hidden and hiddenOnCreate should be skipped
+    const errors = validateRequiredMetadata(
+      { region: 'us-east-1' },
+      schemaWithRequired
+    );
+    expect(errors).not.toContain('Required metadata missing: "hidden"');
+    expect(errors).not.toContain('Required metadata missing: "hiddenOnCreate"');
+  });
+
+  it('returns empty array when all required fields provided', () => {
+    const errors = validateRequiredMetadata(
+      { region: 'us-east-1', version: '15' },
+      schemaWithRequired
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('handles schema with no required fields', () => {
+    const schemaNoRequired: MetadataSchema = {
+      type: 'object',
+      properties: {
+        optional: { type: 'string', 'ui:control': 'input' },
+      },
+    };
+    const errors = validateRequiredMetadata({}, schemaNoRequired);
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Add `--metadata` / `-m` flag to `vercel integration add` for non-interactive provisioning. Metadata values are validated against the product's schema before provisioning.

Also adds **dynamic help**: `vercel integration add <name> --help` shows the integration's actual metadata fields with types, constraints, and copy-pasteable examples — replacing the generic static examples with integration-specific ones.

**Partial metadata + wizard hybrid**: When `--metadata` provides some but not all values in TTY mode, the wizard runs with pre-filled values — skipping prompts for provided fields while still prompting for the rest. This enables workflows like `vc integration add supabase -m region=iad1` where `region` is pre-filled and the wizard only asks for remaining fields.

## Help Output

### Single-product integration: `vercel integration add neon --help`

```
  Examples:

  - Install neon

    $ vercel integration add neon

  - Install with a custom resource name

    $ vercel integration add neon --name my-resource

  - Install with metadata

    $ vercel integration add neon -m region=cle1 -m auth=true

  Metadata options for "neon":

    region (required)
      Choose your database region
      Options: cle1, iad1, pdx1, fra1, lhr1, syd1, sin1, gru1
      Example: -m region=cle1

    auth (true/false)
      Provide built-in authentication for app users, with profiles synced to Postgres.
      Default: false
      Example: -m auth=true
```

### Multi-product integration: `vercel integration add upstash --help`

```
  Examples:

  - Install upstash

    $ vercel integration add upstash

  - Install a specific product

    $ vercel integration add upstash/upstash-qstash

  - Install with a custom resource name

    $ vercel integration add upstash --name my-resource

  - Install with metadata

    $ vercel integration add upstash/upstash-search -m primaryRegion=dub1

  Available products for "upstash":

    upstash-qstash  Upstash QStash/Workflow
    upstash-search  Upstash Search
    upstash-vector  Upstash Vector
    upstash-kv      Upstash for Redis

  Usage:

    $ vercel integration add upstash/<product-slug>

  Metadata options for "upstash/upstash-kv":

    primaryRegion (required)
      Choose the region where most of your writes will take place.
      Options: sfo1, iad1, pdx1, cle1, fra1, dub1, lhr1, bom1, hnd1, sin1, syd1, gru1, cpt1, yul1
      Example: -m primaryRegion=sfo1

    readRegions (comma-separated)
      Choose the region where most of your reads will take place
      Example: -m "readRegions=value1,value2"

    eviction (true/false)
      Enable to evict entries when max data size is reached. (Can be modified from `Open in Upstash`)
      Example: -m eviction=true

    prodPack (true/false)
      Recommended for production. Includes SLA, SOC2, RBAC etc.
      Default: false
      Example: -m prodPack=true

    autoUpgrade (true/false)
      Enable to auto upgrade your plan when reaching to plan limits. (Can be modified from `Open in Upstash`)
      Default: true
      Example: -m autoUpgrade=true
```

### Fallback: `vercel integration add --help` (no slug, or slug not found)

Shows generic static examples with `acme`.

## Usage

### String metadata
```bash
vercel integration add neon -m region=iad1
```

### Boolean metadata
```bash
vercel integration add neon -m auth=true
```

### Array metadata (comma-separated)
```bash
vercel integration add upstash/upstash-kv -m "readRegions=sfo1,dub1"
```

### Multiple flags
```bash
vercel integration add neon -m region=iad1 -m auth=true
```

### Fully non-interactive (slash syntax + name + metadata)
```bash
vercel integration add upstash/upstash-kv --name my-redis -m primaryRegion=iad1
```

### Partial metadata (wizard fills the rest)
```bash
# Provides region, wizard prompts for remaining fields (e.g. publicEnvVarPrefix)
vercel integration add supabase -m region=iad1
```

### Discover available keys
```bash
vercel integration add neon --help
vercel integration add upstash --help
```

## What the metadata flag does

| Scenario | Behavior |
|----------|----------|
| `--metadata` with all values (TTY) | Wizard runs but skips all prompts (pre-filled) |
| `--metadata` with partial values (TTY) | Wizard skips pre-filled fields, prompts for the rest |
| `--metadata` with all values (non-TTY) | Validates all required fields, provisions directly |
| `--metadata` with partial values (non-TTY, unsupported wizard) | Validates all required fields present, errors if missing |
| `--metadata` with invalid value | Fails fast before prompting for name |
| `--metadata` with unknown key | Fails fast: `Error: Unknown metadata key: "foo"` |
| `--metadata` with bad format | Fails fast: `Error: Invalid metadata format: "no-equals". Expected KEY=VALUE` |
| `--metadata` missing required field (non-TTY) | Fails fast: `Error: Required metadata missing: "region"` |
| No `--metadata` in non-TTY | Succeeds if all required fields have defaults; errors with guidance otherwise |
| `--metadata` with unsupported wizard | Bypasses wizard, enables CLI provisioning (all required fields must be in flags) |
| `--metadata` forwarded to browser | When falling back to browser, values pre-fill the checkout form |

## Per-field `Example:` line logic

Each field in `--help` shows a copy-pasteable `Example:` based on its type:

| Type | Example shown |
|------|---------------|
| string with options | `-m region=cle1` (first visible option) |
| string without options | `-m dbName=<value>` |
| number with default | `-m storage=10` |
| number with min | `-m storage=1` |
| number bare | `-m dimensionCount=N` |
| boolean | `-m auth=true` |
| array with options | `-m "readRegions=sfo1,dub1"` (first two) |
| array without options | `-m "tags=value1,value2"` |
| slider with default | `-m computeSize=0.25,0.25` |
| slider without default | `-m computeSize=N,N` |

Hidden options (empty strings, `hidden: true`) are filtered out of both `Options:` and `Example:` lines.

## Dynamic examples

When `--help` is invoked with a known integration slug (e.g. `vercel integration add neon --help`), the static `acme` examples are replaced with integration-specific examples built from the actual product schemas. This includes:

- Install command using the real slug
- Slash syntax for multi-product integrations (e.g. `upstash/upstash-qstash`)
- Metadata example with real field names and values from the schema

If the integration can't be fetched (not found, network error), falls back to the standard static examples.

## Test Plan

### Unit Tests

```
$ cd packages/cli && npx vitest run test/unit/util/integration/parse-metadata.test.ts test/unit/commands/integration/add-auto-provision.test.ts test/unit/commands/integration/add.test.ts

 ✓ test/unit/util/integration/parse-metadata.test.ts  (32 tests)
 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (51 tests)
 ✓ test/unit/commands/integration/add.test.ts  (56 tests)

 Test Files  3 passed (3)
      Tests  139 passed (139)
```

### Manual Testing

**Full `--metadata` (wizard skipped):**
```
$ vc integration add prisma --metadata region=sfo1
> Installing Prisma Postgres by Prisma under acme-marketplace-team-vtest314
? Choose a billing plan
```
✅ Wizard skipped, went straight to billing plan.

**No `--metadata` (wizard prompts):**
```
$ vc integration add prisma
> Installing Prisma Postgres by Prisma under acme-marketplace-team-vtest314
? Region (Use arrow keys)
  sfo1 / cdg1 / hnd1 / ❯ iad1 / sin1 / fra1
```
✅ Wizard prompted for region.

**Partial `--metadata` with supported wizard (hybrid):**
```
$ vc integration add supabase --metadata region=iad1
> Installing Supabase by Supabase under acme-marketplace-team-vtest314
? NEXT_PUBLIC_ (NEXT_PUBLIC_)
```
✅ Wizard skipped region (pre-filled) and prompted for publicEnvVarPrefix (shown as `NEXT_PUBLIC_`).

**Partial `--metadata` with supported wizard (hybrid):**
```
$ vc integration add mongodbatlas --metadata vercelRegion=iad1
> Installing MongoDB Atlas by MongoDB Atlas under acme-marketplace-team-vtest314
? Choose cluster type Free ($0 | Storage: 512 MB | RAM: Shared | vCPU: Shared)
```
✅ Wizard skipped vercelRegion (pre-filled) and prompted for clusterTier.

**Partial `--metadata`, unsupported wizard:**
```
$ vc integration add upstash/upstash-kv --metadata primaryRegion=sfo1
> Installing Upstash for Redis by Upstash under acme-marketplace-team-vtest314
? Choose a billing plan
```
✅ Wizard unsupported (multi-vercel-region control), validation passed (primaryRegion is only required field), went to billing.

**Partial `--metadata`, unsupported wizard, missing required:**
```
$ vc integration add upstash/upstash-vector --metadata primaryRegion=iad1
> Installing Upstash Vector by Upstash under acme-marketplace-team-vtest314
Error: Required metadata missing: "indexType"
```
✅ Correctly failed validation for missing required field.

**Invalid metadata validation:**
```
$ vc integration add prisma --metadata region=invalid-region
Error: Metadata "region" must be one of: sfo1, cdg1, hnd1, iad1, sin1, fra1
```
✅ Fast fail on invalid value.

**No installation, metadata forwarded to browser:**
```
$ vc integration add prisma --metadata region=sfo1 --scope team_XgYksaCJwUbPD01UWu2Tw6G1
> Installing Prisma Postgres by Prisma under templates-test-vtest314
? Terms have not been accepted. Open Vercel Dashboard? yes
```
✅ No installation → browser fallback.

**`--help` still works:**
```
$ vc integration add prisma --help
  Metadata options for "prisma":
    region (required)
```
✅ Dynamic help with metadata options.

### Code Paths Covered

| Path | Tested by |
|------|-----------|
| Full `--metadata` in TTY → wizard skips all prompts | Unit + manual (prisma) |
| Partial `--metadata` in TTY + supported wizard → wizard prompts remaining fields | Unit (acme-multi) + manual (supabase, mongodbatlas) |
| Partial `--metadata` in TTY + unsupported wizard → validation-only | Manual (upstash-kv, upstash-vector) |
| No `--metadata` in TTY → full wizard | Unit + manual (prisma) |
| `--metadata` in non-TTY → validation + direct provision | Unit |
| No `--metadata` in non-TTY, required fields → error | Unit |
| No `--metadata` in non-TTY, all defaults → empty metadata | Unit |
| Invalid metadata → fast fail | Unit + manual |
| No installation → browser fallback with metadata in URL | Unit + manual |
| Unsupported wizard + `--metadata` → enables CLI provisioning | Unit + manual |
| Prepayment plan → browser fallback with metadata in URL | Unit |

## Related

- Companion frontend PR: https://github.com/vercel/front/pull/61589 (pre-fill checkout metadata from CLI)

Fixes: [MKT-2443](https://linear.app/vercel/issue/MKT-2443/accept-cli-params-for-all-interactive-flows-except-accept-terms)

🤖 Generated with [Claude Code](https://claude.ai/code)