### PR TITLE
feat(cli): Add --format=json option to integration add command

### DIFF
--- a/packages/cli/src/commands/integration/add.ts
+++ b/packages/cli/src/commands/integration/add.ts
@@ -28,7 +28,11 @@ import { createAuthorization } from '../../util/integration/create-authorization
 import sleep from '../../util/sleep';
 import { fetchAuthorization } from '../../util/integration/fetch-authorization';
 
-export async function add(client: Client, args: string[]) {
+export async function add(
+  client: Client,
+  args: string[],
+  jsonOutput = false
+) {
   const telemetry = new IntegrationAddTelemetryClient({
     opts: {
       store: client.telemetryEventStore,
@@ -49,7 +53,7 @@ export async function add(client: Client, args: string[]) {
 
   // Auto-provision: completely separate code path
   if (process.env.FF_AUTO_PROVISION_INSTALL === '1') {
-    return await addAutoProvision(client, integrationSlug);
+    return await addAutoProvision(client, integrationSlug, jsonOutput);
   }
 
   const { contextName, team } = await getScope(client);

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -1,4 +1,4 @@
-import { yesOption } from '../../util/arg-common';
+import { formatOption, yesOption } from '../../util/arg-common';
 import { packageName } from '../../util/pkg-name';
 
 export const addSubcommand = {
@@ -11,7 +11,7 @@ export const addSubcommand = {
       required: true,
     },
   ],
-  options: [],
+  options: [formatOption],
   examples: [
     {
       name: 'Install a marketplace integration',


### PR DESCRIPTION
## Summary
- Adds `--format=json` option to `vc integration add` command for scripting/automation
- When enabled, outputs structured JSON with resource, integration, product, installation, and billing plan details
- Skips interactive project linking prompt in JSON mode for non-interactive use
- Currently supported for the auto-provision code path (FF_AUTO_PROVISION_INSTALL=1)

## Test plan
- [x] All 89 existing integration command tests pass
- [x] Added 3 new tests for JSON output:
  - Verifies JSON output structure
  - Verifies non-interactive behavior in JSON mode  
  - Verifies error handling for invalid format values

Partially fixes: [MKT-2529](https://linear.app/vercel/issue/MKT-2529/json-formatting-in-responses-and-errors)

🤖 Generated with [Claude Code](https://claude.ai/code)