### PR TITLE
feat(build-utils): add graceful-fs style EMFILE retry handling

### DIFF
--- a/.changeset/graceful-fs-emfile-handling.md
+++ b/.changeset/graceful-fs-emfile-handling.md
@@ -1,0 +1,5 @@
+---
+"@vercel/build-utils": patch
+---
+
+Add graceful-fs style EMFILE/ENFILE retry handling behind feature flag `VERCEL_BUILD_UTILS_GRACEFUL_FS_OPEN`

--- a/packages/build-utils/src/graceful-fs.ts
+++ b/packages/build-utils/src/graceful-fs.ts
@@ -1,0 +1,181 @@
+/**
+ * Graceful filesystem operations with EMFILE/ENFILE retry handling.
+ *
+ * This implementation is inspired by the graceful-fs package
+ * (https://github.com/isaacs/node-graceful-fs) which is licensed under
+ * the Blue Oak Model License 1.0.0 (https://blueoakcouncil.org/license/1.0.0).
+ *
+ * Unlike graceful-fs, this module does not patch the global fs module.
+ * It provides a standalone function for creating read streams with retry logic.
+ */
+
+import fs from 'fs';
+import debug from './debug';
+
+// Timeout for EMFILE retries (in milliseconds)
+const GRACEFUL_FS_TIMEOUT = 30_000;
+
+interface QueueItem {
+  fn: () => void;
+  error: Error;
+  startTime: number;
+  lastTime: number;
+}
+
+const queue: QueueItem[] = [];
+let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Clears the internal retry queue and timer.
+ * Exported for testing purposes only.
+ * @internal
+ */
+export function _resetGracefulFsState(): void {
+  queue.length = 0;
+  if (retryTimer !== undefined) {
+    clearTimeout(retryTimer);
+    retryTimer = undefined;
+  }
+}
+
+/**
+ * Track successfully opened streams so we can trigger queue processing
+ * when they close (making file descriptors available).
+ */
+function trackStreamClose(stream: fs.ReadStream): void {
+  const onClose = () => {
+    stream.removeListener('close', onClose);
+    stream.removeListener('error', onClose);
+    // Reset queue timestamps and trigger retry when a file descriptor becomes available
+    resetQueue();
+  };
+  stream.on('close', onClose);
+  stream.on('error', onClose);
+}
+
+/**
+ * Reset timestamps on queued items and trigger retry.
+ * Called when a tracked stream closes, indicating file descriptors may be available.
+ */
+function resetQueue(): void {
+  const now = Date.now();
+  for (const item of queue) {
+    item.startTime = now;
+    item.lastTime = now;
+  }
+  retry();
+}
+
+function enqueue(item: QueueItem): void {
+  debug(
+    `[graceful-fs] EMFILE/ENFILE error, enqueueing retry. Queue length: ${queue.length + 1}`
+  );
+  queue.push(item);
+  retry();
+}
+
+function retry(): void {
+  if (retryTimer !== undefined) {
+    clearTimeout(retryTimer);
+    retryTimer = undefined;
+  }
+
+  if (queue.length === 0) return;
+
+  const elem = queue.shift()!;
+  const { fn, startTime, lastTime } = elem;
+
+  const now = Date.now();
+
+  if (now - startTime >= GRACEFUL_FS_TIMEOUT) {
+    // Timeout - the fn will check timeout internally and reject
+    debug(
+      `[graceful-fs] EMFILE/ENFILE retry timeout after ${now - startTime}ms`
+    );
+    elem.fn();
+  } else {
+    const sinceAttempt = now - lastTime;
+    const sinceStart = Math.max(lastTime - startTime, 1);
+    const desiredDelay = Math.min(sinceStart * 1.2, 100);
+
+    if (sinceAttempt >= desiredDelay) {
+      debug(
+        `[graceful-fs] Retrying after EMFILE/ENFILE, waited ${sinceAttempt}ms`
+      );
+      fn();
+    } else {
+      // Not ready yet, put back in queue
+      queue.push(elem);
+    }
+  }
+
+  // Schedule next retry with unref() so timer doesn't block process exit
+  if (retryTimer === undefined && queue.length > 0) {
+    retryTimer = setTimeout(retry, 0);
+    retryTimer.unref();
+  }
+}
+
+/**
+ * Callback to increment error count on the caller's object.
+ */
+export type OnEmfileError = () => void;
+
+/**
+ * Creates a read stream with graceful EMFILE/ENFILE handling.
+ * Retries on file descriptor exhaustion with exponential backoff.
+ *
+ * @param fsPath - Path to the file to read
+ * @param onEmfileError - Optional callback invoked each time an EMFILE/ENFILE error occurs
+ * @returns Promise resolving to the readable stream
+ */
+export function createGracefulReadStream(
+  fsPath: string,
+  onEmfileError?: OnEmfileError
+): Promise<NodeJS.ReadableStream> {
+  return new Promise((resolve, reject) => {
+    let startTime: number | undefined;
+
+    function attemptOpen(): void {
+      const now = Date.now();
+
+      // Check for timeout before attempting
+      if (startTime !== undefined && now - startTime >= GRACEFUL_FS_TIMEOUT) {
+        debug(`[graceful-fs] EMFILE/ENFILE retry timeout for ${fsPath}`);
+        reject(
+          Object.assign(new Error('EMFILE retry timeout'), { code: 'EMFILE' })
+        );
+        return;
+      }
+
+      const stream = fs.createReadStream(fsPath);
+
+      stream.on('open', () => {
+        // Track this stream so closing it triggers queue processing
+        trackStreamClose(stream);
+        resolve(stream);
+      });
+
+      stream.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EMFILE' || err.code === 'ENFILE') {
+          // Notify caller about the error
+          onEmfileError?.();
+
+          if (startTime === undefined) {
+            startTime = now;
+          }
+          enqueue({
+            fn: attemptOpen,
+            error: err,
+            startTime,
+            lastTime: now,
+          });
+        } else {
+          reject(err);
+        }
+      });
+    }
+
+    attemptOpen();
+  });
+}

--- a/packages/build-utils/src/graceful-fs.ts
+++ b/packages/build-utils/src/graceful-fs.ts
@@ -148,7 +148,10 @@ export function createGracefulReadStream(
       const now = Date.now();
 
       // Check for timeout before attempting
-      if (timeRef !== undefined && now - timeRef.startTime >= GRACEFUL_FS_TIMEOUT) {
+      if (
+        timeRef !== undefined &&
+        now - timeRef.startTime >= GRACEFUL_FS_TIMEOUT
+      ) {
         debug(`[graceful-fs] EMFILE/ENFILE retry timeout for ${fsPath}`);
         reject(
           Object.assign(new Error('EMFILE retry timeout'), { code: 'EMFILE' })

--- a/packages/build-utils/test/unit.graceful-fs.test.ts
+++ b/packages/build-utils/test/unit.graceful-fs.test.ts
@@ -1,0 +1,211 @@
+import fs from 'fs';
+import path from 'path';
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createGracefulReadStream,
+  _resetGracefulFsState,
+} from '../src/graceful-fs';
+
+// Mock the debug module
+vi.mock('../src/debug', () => ({
+  default: vi.fn(),
+}));
+
+/**
+ * Creates a mock ReadStream that emits events in the expected order.
+ * The real fs.createReadStream emits 'open' before data is available,
+ * and 'error' if there's a problem opening the file.
+ */
+function createMockStream(shouldError: Error | null = null): fs.ReadStream {
+  const stream = new EventEmitter() as fs.ReadStream;
+
+  // Add required ReadStream properties
+  Object.assign(stream, {
+    path: '/mock/path',
+    fd: null,
+    flags: 'r',
+    mode: 0o666,
+    bytesRead: 0,
+    pending: true,
+    close: vi.fn(),
+    destroy: vi.fn(),
+    pipe: vi.fn(),
+    read: vi.fn(),
+  });
+
+  // Schedule the event emission
+  process.nextTick(() => {
+    if (shouldError) {
+      stream.emit('error', shouldError);
+    } else {
+      (stream as any).fd = 123;
+      (stream as any).pending = false;
+      stream.emit('open', 123);
+    }
+  });
+
+  return stream;
+}
+
+describe('createGracefulReadStream', () => {
+  const testFilePath = path.join(__dirname, 'fixtures', 'test-file.txt');
+
+  beforeEach(async () => {
+    // Create a test file
+    await fs.promises.mkdir(path.dirname(testFilePath), { recursive: true });
+    await fs.promises.writeFile(testFilePath, 'test content');
+  });
+
+  afterEach(async () => {
+    // Reset the graceful-fs internal state to prevent test pollution
+    _resetGracefulFsState();
+    vi.restoreAllMocks();
+    // Clean up test file
+    try {
+      await fs.promises.unlink(testFilePath);
+    } catch {
+      // Ignore if file doesn't exist
+    }
+  });
+
+  it('should successfully create a read stream for an existing file', async () => {
+    const stream = await createGracefulReadStream(testFilePath);
+    expect(stream).toBeDefined();
+
+    // Read the content to verify stream works
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const content = Buffer.concat(chunks).toString();
+    expect(content).toBe('test content');
+  });
+
+  it('should reject with ENOENT for non-existent file', async () => {
+    await expect(
+      createGracefulReadStream('/non/existent/file.txt')
+    ).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('should call onEmfileError callback when EMFILE error occurs', async () => {
+    const onEmfileError = vi.fn();
+    const emfileError = Object.assign(
+      new Error('EMFILE: too many open files'),
+      {
+        code: 'EMFILE',
+      }
+    );
+
+    let callCount = 0;
+    vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: simulate EMFILE error
+        return createMockStream(emfileError);
+      }
+      // Subsequent calls: succeed with real stream
+      return createMockStream(null);
+    });
+
+    const stream = await createGracefulReadStream(testFilePath, onEmfileError);
+    expect(stream).toBeDefined();
+    expect(onEmfileError).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onEmfileError callback when ENFILE error occurs', async () => {
+    const onEmfileError = vi.fn();
+    const enfileError = Object.assign(
+      new Error('ENFILE: file table overflow'),
+      {
+        code: 'ENFILE',
+      }
+    );
+
+    let callCount = 0;
+    vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: simulate ENFILE error
+        return createMockStream(enfileError);
+      }
+      // Subsequent calls: succeed
+      return createMockStream(null);
+    });
+
+    const stream = await createGracefulReadStream(testFilePath, onEmfileError);
+    expect(stream).toBeDefined();
+    expect(onEmfileError).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry and succeed after EMFILE error', async () => {
+    const emfileError = Object.assign(
+      new Error('EMFILE: too many open files'),
+      {
+        code: 'EMFILE',
+      }
+    );
+
+    let callCount = 0;
+    vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: simulate EMFILE error
+        return createMockStream(emfileError);
+      }
+      // Second call: succeed
+      return createMockStream(null);
+    });
+
+    const stream = await createGracefulReadStream(testFilePath);
+    expect(stream).toBeDefined();
+    expect(callCount).toBe(2); // First call failed, second succeeded
+  });
+
+  it('should increment emfileErrorCount multiple times for multiple EMFILE errors', async () => {
+    const onEmfileError = vi.fn();
+    const emfileError = Object.assign(
+      new Error('EMFILE: too many open files'),
+      {
+        code: 'EMFILE',
+      }
+    );
+
+    let callCount = 0;
+    vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+      callCount++;
+      if (callCount <= 3) {
+        // First 3 calls: simulate EMFILE error
+        return createMockStream(emfileError);
+      }
+      // 4th call and onwards: succeed
+      return createMockStream(null);
+    });
+
+    const stream = await createGracefulReadStream(testFilePath, onEmfileError);
+    expect(stream).toBeDefined();
+    expect(onEmfileError).toHaveBeenCalledTimes(3);
+    expect(callCount).toBe(4);
+  });
+
+  it('should not call onEmfileError for non-EMFILE errors', async () => {
+    const onEmfileError = vi.fn();
+    const eaccesError = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES',
+    });
+
+    vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+      return createMockStream(eaccesError);
+    });
+
+    await expect(
+      createGracefulReadStream(testFilePath, onEmfileError)
+    ).rejects.toMatchObject({
+      code: 'EACCES',
+    });
+
+    expect(onEmfileError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds queue-based EMFILE/ENFILE retry mechanism inspired by graceful-fs
- Adds `emfileErrorCount` property to `FileFsRef` for monitoring in both modes
- All changes behind feature flag: `VERCEL_BUILD_UTILS_GRACEFUL_FS_OPEN=1`