### PR TITLE
fix(go): Update deprecated tar@6.2.1 to tar@7.5.7

### DIFF
--- a/.changeset/afraid-dragons-complain.md
+++ b/.changeset/afraid-dragons-complain.md
@@ -1,0 +1,6 @@
+---
+'vercel': patch
+'@vercel/go': patch
+---
+
+Update deprecated tar package

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "@vercel/elysia": "workspace:*",
     "@vercel/express": "workspace:*",
     "@vercel/fastify": "workspace:*",
-    "@vercel/fun": "1.2.1",
+    "@vercel/fun": "1.3.0",
     "@vercel/go": "workspace:*",
     "@vercel/h3": "workspace:*",
     "@vercel/hono": "workspace:*",

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -27,7 +27,6 @@
     "@types/jest": "28.1.6",
     "@types/node": "20.11.0",
     "@types/node-fetch": "^2.3.0",
-    "@types/tar": "6.1.5",
     "@types/yauzl-promise": "2.1.0",
     "@vercel/build-utils": "workspace:*",
     "async-retry": "1.3.3",
@@ -36,7 +35,7 @@
     "jest-junit": "16.0.0",
     "node-fetch": "^2.2.1",
     "string-argv": "0.3.1",
-    "tar": "6.2.1",
+    "tar": "7.5.7",
     "typescript": "4.3.4",
     "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"

--- a/packages/go/src/go-helpers.ts
+++ b/packages/go/src/go-helpers.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import tar from 'tar';
+import { extract } from 'tar';
 import execa from 'execa';
 import fetch from 'node-fetch';
 import {
@@ -438,7 +438,7 @@ async function download({ dest, version }: { dest: string; version: string }) {
   await new Promise((resolve, reject) => {
     res.body
       .on('error', reject)
-      .pipe(tar.extract({ cwd: dest, strip: 1 }))
+      .pipe(extract({ cwd: dest, strip: 1 }))
       .on('error', reject)
       .on('finish', resolve);
   });

--- a/packages/go/src/tar.d.ts
+++ b/packages/go/src/tar.d.ts
@@ -1,0 +1,17 @@
+declare module 'tar' {
+  import { Writable } from 'stream';
+
+  export interface ExtractOptions {
+    cwd?: string;
+    strip?: number;
+    filter?: (path: string, entry: unknown) => boolean;
+    onwarn?: (code: string, message: string, data: unknown) => void;
+    strict?: boolean;
+    preservePaths?: boolean;
+    unlink?: boolean;
+    chmod?: boolean;
+    maxDepth?: number;
+  }
+
+  export function extract(options?: ExtractOptions): Writable;
+}

--- a/packages/go/tsconfig.json
+++ b/packages/go/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "tar": ["./src/tar.d.ts"]
+    }
   },
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ importers:
         specifier: workspace:*
         version: link:../fastify
       '@vercel/fun':
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 1.3.0
+        version: 1.3.0
       '@vercel/go':
         specifier: workspace:*
         version: link:../go
@@ -1470,9 +1470,6 @@ importers:
       '@types/node-fetch':
         specifier: ^2.3.0
         version: 2.5.4
-      '@types/tar':
-        specifier: 6.1.5
-        version: 6.1.5
       '@types/yauzl-promise':
         specifier: 2.1.0
         version: 2.1.0
@@ -1498,8 +1495,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1
       tar:
-        specifier: 6.2.1
-        version: 6.2.1
+        specifier: 7.5.7
+        version: 7.5.7
       typescript:
         specifier: 4.3.4
         version: 4.3.4
@@ -5878,7 +5875,6 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       minipass: 7.1.2
-    dev: false
 
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -6235,7 +6231,7 @@ packages:
       node-fetch: 2.6.9
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.4.3
+      tar: 7.5.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9220,13 +9216,6 @@ packages:
       '@types/node': 20.11.0
     dev: true
 
-  /@types/tar@6.1.5:
-    resolution: {integrity: sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==}
-    dependencies:
-      '@types/node': 20.11.0
-      minipass: 4.2.8
-    dev: true
-
   /@types/text-table@0.2.1:
     resolution: {integrity: sha512-dchbFCWfVgUSWEvhOkXGS7zjm+K7jCUvGrQkAHPk2Fmslfofp4HQTH2pqnQ3Pw5GPYv0zWa2AQjKtsfZThuemQ==}
     dev: true
@@ -9932,8 +9921,8 @@ packages:
       undici: 5.28.4
     dev: false
 
-  /@vercel/fun@1.2.1:
-    resolution: {integrity: sha512-p0IuyxKAnaV9P7xApKBDYXdPheErVyoi68tt2l8i2g20n26FgZ7IQoDsFfmTg/ClllxhdOnaArNAFu2XBmfCxw==}
+  /@vercel/fun@1.3.0:
+    resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
     engines: {node: '>= 18'}
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -9948,7 +9937,7 @@ packages:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 6.2.1
+      tar: 7.5.7
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -11499,14 +11488,9 @@ packages:
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  /chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   /chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
-    dev: false
 
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -13942,12 +13926,6 @@ packages:
       universalify: 0.1.2
     dev: true
 
-  /fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -16373,38 +16351,20 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
-    engines: {node: '>=8'}
-    dev: true
-
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  /minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
-  /minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+  /minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
     dependencies:
       minipass: 7.1.2
-    dev: false
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -16416,12 +16376,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  /mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: false
 
   /mock-fs@5.5.0:
     resolution: {integrity: sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==}
@@ -19191,29 +19145,15 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
-  /tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+  /tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
       minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
+      minizlib: 3.1.0
       yallist: 5.0.0
-    dev: false
 
   /teeny-request@7.0.1:
     resolution: {integrity: sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==}
@@ -20868,7 +20808,6 @@ packages:
   /yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
-    dev: false
 
   /yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}

--- a/test/deprecated-dependencies.test.js
+++ b/test/deprecated-dependencies.test.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * This test ensures we catch deprecated subdependencies in the lockfile.
+ * When a dependency is deprecated, it should be reviewed and either:
+ * 1. Updated to a non-deprecated version
+ * 2. Added to the allowlist with a comment explaining why
+ */
+
+// Allowlist of deprecated packages that are acceptable for now.
+// Each entry should have a comment explaining why it's acceptable.
+const DEPRECATED_ALLOWLIST = {
+  // ESLint 8.x is deprecated but migration to 9.x requires significant effort
+  '@humanwhocodes/config-array':
+    'ESLint 8.x dependency, will be removed when migrating to ESLint 9',
+  '@humanwhocodes/object-schema':
+    'ESLint 8.x dependency, will be removed when migrating to ESLint 9',
+  eslint: 'Monorepo uses ESLint 8.x, migration to 9.x planned',
+
+  // Glob 7.x/8.x deprecation
+  glob: 'Transitive dependency, will be updated when upstream packages migrate',
+
+  // Other known acceptable deprecations
+  inflight:
+    'Transitive dependency from glob, will be removed when glob is updated',
+  rimraf: 'Used for compatibility, migration to newer version planned',
+  querystring: 'Legacy API, but still functional for current use cases',
+  '@types/find-up': 'Stub types, no runtime impact',
+  '@types/resolve-from': 'Stub types, no runtime impact',
+  'create-svelte': 'Dev dependency for testing, migration to sv planned',
+  osenv: 'Transitive dependency, will be removed when upstream packages update',
+  argv: 'Transitive dependency, no direct usage',
+};
+
+/**
+ * Parse deprecated packages from pnpm-lock.yaml
+ * Looks for patterns like:
+ *   /package@version:
+ *     ...
+ *     deprecated: message
+ */
+function parseDeprecatedPackages(lockfileContent) {
+  const deprecated = [];
+  const lines = lockfileContent.split('\n');
+
+  let currentPackage = null;
+  let currentVersion = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Match package entries like "  /tar@6.2.1:" or "  /@scope/pkg@1.0.0:"
+    const pkgMatch = line.match(/^\s{2}\/(.+)@([^@:]+):$/);
+    if (pkgMatch) {
+      currentPackage = pkgMatch[1];
+      currentVersion = pkgMatch[2];
+      continue;
+    }
+
+    // Match deprecated field
+    const deprecatedMatch = line.match(/^\s{4}deprecated:\s*(.+)$/);
+    if (deprecatedMatch && currentPackage) {
+      deprecated.push({
+        name: currentPackage,
+        version: currentVersion,
+        message: deprecatedMatch[1],
+      });
+      currentPackage = null;
+      currentVersion = null;
+    }
+
+    // Reset on new top-level entry (not indented or different indent level)
+    if (!line.startsWith('    ') && !line.startsWith('  /')) {
+      currentPackage = null;
+      currentVersion = null;
+    }
+  }
+
+  return deprecated;
+}
+
+describe('Deprecated Dependencies', () => {
+  let deprecatedPackages;
+
+  beforeAll(() => {
+    const lockfilePath = path.join(__dirname, '..', 'pnpm-lock.yaml');
+    const lockfileContent = fs.readFileSync(lockfilePath, 'utf8');
+    deprecatedPackages = parseDeprecatedPackages(lockfileContent);
+  });
+
+  it('should not have new deprecated subdependencies', () => {
+    const newDeprecated = deprecatedPackages.filter(pkg => {
+      // Check if it's in the allowlist (by package name)
+      return !DEPRECATED_ALLOWLIST[pkg.name];
+    });
+
+    const allowedCount = deprecatedPackages.length - newDeprecated.length;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `Deprecated packages: ${deprecatedPackages.length} total, ${allowedCount} in allowlist`
+    );
+
+    if (newDeprecated.length > 0) {
+      const message = newDeprecated
+        .map(pkg => `  - ${pkg.name}@${pkg.version}: ${pkg.message}`)
+        .join('\n');
+
+      throw new Error(
+        `Found ${newDeprecated.length} new deprecated subdependency(s) not in allowlist:\n${message}\n\n` +
+          'To fix this:\n' +
+          '1. Update the dependency to a non-deprecated version, or\n' +
+          '2. Add it to DEPRECATED_ALLOWLIST in test/deprecated-dependencies.test.js with a justification'
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the deprecated `tar@6.2.1` subdependency warning shown during CLI installation:

```
WARN 1 deprecated subdependencies found: tar@6.2.1
```

## Changes

- **packages/go**: Update `tar` from `6.2.1` to `7.5.7`
- **packages/go**: Use tree-shakeable import `import { extract } from 'tar'`
- **packages/go**: Add local type declaration for tar (TS 4.9.5 compatible)
- **test**: Add `deprecated-dependencies.test.js` to catch future deprecated subdependencies

## Test Plan

- [x] `pnpm install` no longer shows tar deprecation warning
- [x] `@vercel/go` TypeScript check passes
- [x] `@vercel/go` build passes
- [x] All 23 `@vercel/go` unit tests pass
- [x] New deprecated dependencies test passes

Closes CLI-110
