### PR TITLE
feat(cli): Add `api` command to help output

### DIFF
--- a/.changeset/afraid-rules-flow.md
+++ b/.changeset/afraid-rules-flow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Update help command for API

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -37,6 +37,7 @@ export const help = () => `
     ${chalk.dim('Advanced')}
 
       alias                [cmd]       Manages your domain aliases
+      api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]
       bisect                           Use binary search to find the deployment that introduced a bug
       certs                [cmd]       Manages your SSL certificates
       curl                 [path]      cURL requests to your linked project's deployment [beta]

--- a/packages/cli/test/unit/__snapshots__/args.test.ts.snap
+++ b/packages/cli/test/unit/__snapshots__/args.test.ts.snap
@@ -35,6 +35,7 @@ exports[`base level help output > help 1`] = `
     Advanced
 
       alias                [cmd]       Manages your domain aliases
+      api                  [endpoint]  Make authenticated HTTP requests to the Vercel API [beta]
       bisect                           Use binary search to find the deployment that introduced a bug
       certs                [cmd]       Manages your SSL certificates
       curl                 [path]      cURL requests to your linked project's deployment [beta]


### PR DESCRIPTION
## Summary
- Add the `api` command to CLI help documentation in the Advanced section
- Update test snapshot to reflect the change
- Makes the beta API command discoverable via `vercel --help`

## Test plan
- [ ] Run `vercel --help` and verify `api` appears in the Advanced section
- [ ] Run unit tests for args.ts

Linear: CLI-2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)