### PR TITLE
fix(cli): Simplify update prompt to yes/no confirmation

### DIFF
--- a/.changeset/simplify-update-prompt.md
+++ b/.changeset/simplify-update-prompt.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Simplify CLI update prompt to yes/no confirmation with changelog link in body

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -945,10 +945,10 @@ main()
             `Changelog: ${output.link(changelog, changelog, { fallback: false })}\n`
           );
 
-          const shouldUpgrade = await client.input.confirm({
-            message: 'Would you like to upgrade now?',
-            default: true,
-          });
+          const shouldUpgrade = await client.input.confirm(
+            'Would you like to upgrade now?',
+            true
+          );
 
           if (shouldUpgrade) {
             const upgradeExitCode = await executeUpgrade();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,7 +77,6 @@ import { checkTelemetryStatus } from './util/telemetry/check-status';
 import output from './output-manager';
 import { checkGuidanceStatus } from './util/guidance/check-status';
 import { determineAgent } from '@vercel/detect-agent';
-import open from 'open';
 
 const VERCEL_DIR = getGlobalPathConfig();
 const VERCEL_CONFIG_PATH = configFiles.getConfigFilePath();
@@ -942,23 +941,19 @@ main()
               `v${pkg.version}`
             )} → ${chalk.green(`v${latest}`)})${errorMsg}\n`
           );
+          output.print(
+            `Changelog: ${output.link(changelog, changelog, { fallback: false })}\n`
+          );
 
-          const action = await client.input.expand({
-            message: 'What would you like to do?',
-            default: 'u',
-            choices: [
-              { key: 'u', name: 'Upgrade now', value: 'upgrade' },
-              { key: 'c', name: 'View changelog', value: 'changelog' },
-              { key: 's', name: 'Skip', value: 'skip' },
-            ],
+          const shouldUpgrade = await client.input.confirm({
+            message: 'Would you like to upgrade now?',
+            default: true,
           });
 
-          if (action === 'upgrade') {
+          if (shouldUpgrade) {
             const upgradeExitCode = await executeUpgrade();
             process.exitCode = upgradeExitCode;
             return;
-          } else if (action === 'changelog') {
-            await open(changelog);
           }
         } else {
           const errorMsg =


### PR DESCRIPTION
## Summary
- Replace the expand menu (u=upgrade, c=changelog, s=skip) with a simple yes/no confirmation prompt
- Move changelog link to the prompt body instead of being a menu option
- Remove unused `open` import

## Test plan
- [ ] Run `vercel` CLI with an outdated version to trigger the update prompt
- [ ] Verify the changelog link is displayed and clickable in terminal
- [ ] Verify the yes/no prompt works correctly

Fixes CLI-574

🤖 Generated with [Claude Code](https://claude.com/claude-code)