### PR TITLE
feat(cli): Forward metadata to checkout URL on browser fallback

### DIFF
--- a/packages/cli/src/commands/integration/add-auto-provision.ts
+++ b/packages/cli/src/commands/integration/add-auto-provision.ts
@@ -185,6 +185,12 @@ export async function addAutoProvision(
     const url = new URL(result.url);
     url.searchParams.set('defaultResourceName', resourceName);
     url.searchParams.set('source', 'cli');
+    const definedMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([, v]) => v !== undefined)
+    );
+    if (Object.keys(definedMetadata).length > 0) {
+      url.searchParams.set('metadata', JSON.stringify(definedMetadata));
+    }
     if (projectLink?.project) {
       url.searchParams.set('projectSlug', projectLink.project.name);
     }

--- a/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
+++ b/packages/cli/test/unit/commands/integration/add-auto-provision.test.ts
@@ -270,6 +270,14 @@ describe('integration add (auto-provision)', () => {
       expect(openMock).toHaveBeenCalledWith(
         expect.stringMatching(/source=cli/)
       );
+      expect(openMock).toHaveBeenCalledWith(
+        expect.stringMatching(/metadata=/)
+      );
+      const calledUrl = new URL(openMock.mock.calls[0][0] as string);
+      const metadata = JSON.parse(
+        calledUrl.searchParams.get('metadata') ?? '{}'
+      );
+      expect(metadata).toEqual({ region: 'us-west-1' });
     });
 
     it('should open browser for unknown fallback', async () => {
@@ -291,6 +299,11 @@ describe('integration add (auto-provision)', () => {
       const exitCode = await exitCodePromise;
       expect(exitCode).toEqual(0);
       expect(openMock).toHaveBeenCalled();
+      const calledUrl = new URL(openMock.mock.calls[0][0] as string);
+      const metadata = JSON.parse(
+        calledUrl.searchParams.get('metadata') ?? '{}'
+      );
+      expect(metadata).toEqual({ region: 'us-west-1' });
     });
 
     it('should include projectSlug when user consents to link project', async () => {


### PR DESCRIPTION
## Summary

When the CLI falls back to the web checkout, the metadata the user already entered (e.g., region, version selections from the wizard) was lost. This PR forwards the collected metadata as a JSON-encoded `metadata` query param on the fallback URL for **both** CLI paths.

### Flow Diagram

```
vercel integration add <slug>
           │
           ▼
┌────────────────────────────────┐
│  FF_AUTO_PROVISION_INSTALL=1?  │
└──────┬─────────────────┬───────┘
       │ Yes             │ No
       ▼                 ▼
┌──────────────┐  ┌──────────────────────┐
│  NEW PATH    │  │  LEGACY PATH         │
│  auto-       │  │  add.ts              │
│  provision   │  │                      │
└──────┬───────┘  │  Wizard supported?   │
       │          └──────┬────────┬──────┘
       │                 │ Yes    │ No
       ▼                 ▼        ▼
┌──────────────┐  ┌────────┐  ┌────────┐
│ Collect      │  │ Run    │  │ Skip   │
│ metadata via │  │ wizard │  │ wizard │
│ wizard       │  │ 🔥 NEW │  │ ({})   │
└──────┬───────┘  └───┬────┘  └───┬────┘
       │              │           │
       ▼              ▼           ▼
┌──────────────┐  ┌──────────────────────┐
│ POST /auto-  │  │ Open browser to      │
│ provision    │  │ /api/marketplace/cli  │
│              │  │ 🔥 with &metadata=   │
│ 201? Done ✅ │  │ {JSON} if non-empty   │
│              │  └──────────┬───────────┘
│ 422 fallback │             │
└──────┬───────┘             │
       │                     │
       ▼                     │
┌──────────────────────┐     │
│ Open browser         │     │
│ DIRECTLY to checkout │     │
│ 🔥 with &metadata=  │     │
│ {JSON} if non-empty  │     │
└──────────┬───────────┘     │
           │                 │
           ▼                 ▼
┌────────────────────────────────┐
│  Checkout page (front#61589)   │
│                                │
│  JSON.parse(metadata)          │
│  → merge with schema defaults  │
│  → pre-fill form               │
│                                │
│  Region:  [us-west-1 ✓] 👈    │
│  Version: [5.6]         👈    │
└────────────────────────────────┘
```

### What this PR does

**Auto-provision path** (`add-auto-provision.ts`): Serializes metadata as a JSON query param on the fallback URL. Filters `undefined` values before serializing.

**Legacy path** (`add.ts`): 🔥 NEW — Runs the metadata wizard before the browser fallback when the wizard is supported (even without an installation). Forwards collected metadata through `provisionResourceViaWebUI`.

### Changes

| File | Change |
|------|--------|
| `add-auto-provision.ts` | Filter undefined values, add `metadata` param to fallback URL |
| `add.ts` | Run wizard before browser fallback, forward metadata to `provisionResourceViaWebUI` |
| `add-auto-provision.test.ts` | Assert metadata in URL for `metadata` and `unknown` fallbacks |
| `add.test.ts` | Handle wizard prompt in missing-installation tests, assert metadata in URL |

### Safety

- `undefined` values filtered before serialization (prevents sending empty `{}`)
- Only added when metadata has defined values
- Legacy path: wizard only runs when `metadataWizard.isSupported` — unsupported wizards (expressions) still skip to browser
- `URLSearchParams.set` handles URL encoding automatically

### Test results

```
✓ add.test.ts           22 tests passed
✓ add-auto-provision.test.ts  17 tests passed
Total: 39 passed, 0 failed
```

## Test plan

- [x] Unit tests pass for both paths
- [x] Manual test: legacy path with Neon (unsupported wizard) — no metadata param ✅
- [x] Manual test: auto-provision path with Neon (unsupported wizard) — no metadata param ✅
- [x] Manual test: auto-provision path with Prisma (supported wizard) — provisioned directly, no fallback needed ✅
- [ ] Manual test with integration that triggers 422 fallback + supported wizard

## Related

- Companion Front PR: https://github.com/vercel/front/pull/61589
- Parent Front PR: vercel/front#61528 (forwarded `source` and `defaultResourceName`)

Fixes: [MKT-2467](https://linear.app/vercel/issue/MKT-2467/resource-name-not-preserved-from-cli-web)