### PR TITLE
[services] build time service url env vars

### DIFF
--- a/.changeset/olive-turtles-destroy.md
+++ b/.changeset/olive-turtles-destroy.md
@@ -1,0 +1,6 @@
+---
+"@vercel/build-utils": patch
+"vercel": patch
+---
+
+[services] build time service url env vars

--- a/packages/build-utils/src/get-service-url-env-vars.ts
+++ b/packages/build-utils/src/get-service-url-env-vars.ts
@@ -1,0 +1,108 @@
+import type { Service } from './types';
+
+type Envs = { [key: string]: string | undefined };
+
+interface FrameworkInfo {
+  slug: string | null;
+  envPrefix?: string;
+}
+
+export interface GetServiceUrlEnvVarsOptions {
+  services: Service[];
+  frameworkList: readonly FrameworkInfo[];
+  currentEnv?: Envs;
+  deploymentUrl?: string;
+}
+
+/**
+ * Convert service name to environment variable name.
+ * e.g., "frontend" → "FRONTEND_URL", "api-users" → "API_USERS_URL"
+ */
+function serviceNameToEnvVar(name: string): string {
+  return `${name.replace(/-/g, '_').toUpperCase()}_URL`;
+}
+
+function computeServiceUrl(deploymentUrl: string, routePrefix: string): string {
+  if (routePrefix === '/') {
+    return `https://${deploymentUrl}`;
+  }
+
+  const normalizedPrefix = routePrefix.startsWith('/')
+    ? routePrefix.slice(1)
+    : routePrefix;
+  return `https://${deploymentUrl}/${normalizedPrefix}`;
+}
+
+/**
+ * Get the framework's envPrefix (e.g., "VITE_", "NEXT_PUBLIC_") from the framework slug.
+ */
+function getFrameworkEnvPrefix(
+  frameworkSlug: string | undefined,
+  frameworkList: readonly FrameworkInfo[]
+): string | undefined {
+  if (!frameworkSlug) return undefined;
+  const framework = frameworkList.find(
+    f => f.slug !== null && f.slug === frameworkSlug
+  );
+  return framework?.envPrefix;
+}
+
+/**
+ * Generate environment variables for service URLs.
+ *
+ * For each web service, generates:
+ * 1. A base env var (e.g., BACKEND_URL)
+ * 2. Framework-prefixed versions for each frontend framework in the deployment
+ *    (e.g., VITE_BACKEND_URL, NEXT_PUBLIC_BACKEND_URL) so they can be accessed
+ *    in client-side code.
+ *
+ * Environment variables that are already set in `currentEnv` will NOT be overwritten,
+ * allowing user-defined values to take precedence.
+ */
+export function getServiceUrlEnvVars(
+  options: GetServiceUrlEnvVarsOptions
+): Record<string, string> {
+  const { services, frameworkList, currentEnv = {}, deploymentUrl } = options;
+
+  // Can't generate service URLs without a deployment URL
+  if (!deploymentUrl || !services || services.length === 0) {
+    return {};
+  }
+
+  const envVars: Record<string, string> = {};
+
+  // Collect all unique env prefixes from frontend frameworks in the deployment
+  const frameworkPrefixes = new Set<string>();
+  for (const service of services) {
+    const prefix = getFrameworkEnvPrefix(service.framework, frameworkList);
+    if (prefix) {
+      frameworkPrefixes.add(prefix);
+    }
+  }
+
+  for (const service of services) {
+    // Only web services have URLs - skip crons and workers
+    if (service.type !== 'web' || !service.routePrefix) {
+      continue;
+    }
+
+    const baseEnvVarName = serviceNameToEnvVar(service.name);
+    const url = computeServiceUrl(deploymentUrl, service.routePrefix);
+
+    // Add the base env var (e.g., BACKEND_URL) if not already set
+    if (!(baseEnvVarName in currentEnv)) {
+      envVars[baseEnvVarName] = url;
+    }
+
+    // Add framework-prefixed versions for each frontend framework in the deployment
+    // e.g., VITE_BACKEND_URL, NEXT_PUBLIC_BACKEND_URL
+    for (const prefix of frameworkPrefixes) {
+      const prefixedEnvVarName = `${prefix}${baseEnvVarName}`;
+      if (!(prefixedEnvVarName in currentEnv)) {
+        envVars[prefixedEnvVarName] = url;
+      }
+    }
+  }
+
+  return envVars;
+}

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -51,6 +51,7 @@ import debug from './debug';
 import getIgnoreFilter from './get-ignore-filter';
 import { getPlatformEnv } from './get-platform-env';
 import { getPrefixedEnvVars } from './get-prefixed-env-vars';
+import { getServiceUrlEnvVars } from './get-service-url-env-vars';
 import { cloneEnv } from './clone-env';
 import { hardLinkDir } from './hard-link-dir';
 import { validateNpmrc } from './validate-npmrc';
@@ -98,6 +99,7 @@ export {
   getSpawnOptions,
   getPlatformEnv,
   getPrefixedEnvVars,
+  getServiceUrlEnvVars,
   streamToBuffer,
   streamToBufferChunks,
   debug,

--- a/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
+++ b/packages/build-utils/test/unit.get-service-url-env-vars.test.ts
@@ -1,0 +1,172 @@
+import { getServiceUrlEnvVars } from '../src';
+import type { Service } from '../src';
+import { describe, expect, it } from 'vitest';
+
+const createService = (overrides: Partial<Service>): Service => ({
+  name: 'test',
+  type: 'web',
+  workspace: '.',
+  routePrefix: '/',
+  builder: { use: '@vercel/static-build', src: 'package.json' },
+  ...overrides,
+});
+
+describe('getServiceUrlEnvVars', () => {
+  it('generates service URLs for web services', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'frontend',
+          type: 'web',
+          routePrefix: '/',
+          framework: 'vite',
+        }),
+        createService({
+          name: 'backend',
+          type: 'web',
+          routePrefix: '/_/backend',
+        }),
+      ],
+      frameworkList: [{ slug: 'vite', envPrefix: 'VITE_' }],
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    expect(result).toEqual({
+      FRONTEND_URL: 'https://my-app.vercel.app',
+      BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+      VITE_FRONTEND_URL: 'https://my-app.vercel.app',
+      VITE_BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+    });
+  });
+
+  it('converts service names with hyphens to underscores', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'api-users',
+          type: 'web',
+          routePrefix: '/_/api-users',
+        }),
+      ],
+      frameworkList: [],
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    expect(result).toEqual({
+      API_USERS_URL: 'https://my-app.vercel.app/_/api-users',
+    });
+  });
+
+  it('generates prefixed env vars for all frontend frameworks in deployment', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'web',
+          type: 'web',
+          routePrefix: '/',
+          framework: 'nextjs',
+        }),
+        createService({
+          name: 'admin',
+          type: 'web',
+          routePrefix: '/admin',
+          framework: 'vite',
+        }),
+        createService({
+          name: 'api',
+          type: 'web',
+          routePrefix: '/_/api',
+        }),
+      ],
+      frameworkList: [
+        { slug: 'nextjs', envPrefix: 'NEXT_PUBLIC_' },
+        { slug: 'vite', envPrefix: 'VITE_' },
+      ],
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    expect(result).toEqual({
+      WEB_URL: 'https://my-app.vercel.app',
+      ADMIN_URL: 'https://my-app.vercel.app/admin',
+      API_URL: 'https://my-app.vercel.app/_/api',
+      // Both prefixes applied to all services
+      NEXT_PUBLIC_WEB_URL: 'https://my-app.vercel.app',
+      NEXT_PUBLIC_ADMIN_URL: 'https://my-app.vercel.app/admin',
+      NEXT_PUBLIC_API_URL: 'https://my-app.vercel.app/_/api',
+      VITE_WEB_URL: 'https://my-app.vercel.app',
+      VITE_ADMIN_URL: 'https://my-app.vercel.app/admin',
+      VITE_API_URL: 'https://my-app.vercel.app/_/api',
+    });
+  });
+
+  it('does not overwrite existing env vars', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'backend',
+          type: 'web',
+          routePrefix: '/_/backend',
+          framework: 'vite',
+        }),
+      ],
+      frameworkList: [{ slug: 'vite', envPrefix: 'VITE_' }],
+      currentEnv: {
+        BACKEND_URL: 'https://custom-backend.com',
+      },
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    // BACKEND_URL is not in result because it already exists
+    expect(result).toEqual({
+      VITE_BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+    });
+  });
+
+  it('does not overwrite existing prefixed env vars', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'backend',
+          type: 'web',
+          routePrefix: '/_/backend',
+          framework: 'vite',
+        }),
+      ],
+      frameworkList: [{ slug: 'vite', envPrefix: 'VITE_' }],
+      currentEnv: {
+        VITE_BACKEND_URL: 'https://custom-backend.com',
+      },
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    expect(result).toEqual({
+      BACKEND_URL: 'https://my-app.vercel.app/_/backend',
+    });
+  });
+
+  it('returns empty object when no deploymentUrl provided', () => {
+    const result = getServiceUrlEnvVars({
+      services: [
+        createService({
+          name: 'backend',
+          type: 'web',
+          routePrefix: '/_/backend',
+        }),
+      ],
+      frameworkList: [],
+      deploymentUrl: undefined,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('returns empty object when no services provided', () => {
+    const result = getServiceUrlEnvVars({
+      services: [],
+      frameworkList: [],
+      deploymentUrl: 'my-app.vercel.app',
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -354,16 +354,7 @@ export default async function main(client: Client): Promise<number> {
       await rootSpan
         .child('vc.doBuild')
         .trace(span =>
-          doBuild(
-            client,
-            project,
-            buildsJson,
-            cwd,
-            outputDir,
-            span,
-            standalone,
-            envToUnset
-          )
+          doBuild(client, project, buildsJson, cwd, outputDir, span, standalone)
         );
     } finally {
       await rootSpan.stop();
@@ -422,8 +413,7 @@ async function doBuild(
   cwd: string,
   outputDir: string,
   span: Span,
-  standalone: boolean = false,
-  envToUnset: Set<string> = new Set()
+  standalone: boolean = false
 ): Promise<void> {
   const { localConfigPath } = client;
 
@@ -618,7 +608,6 @@ async function doBuild(
 
       for (const [key, value] of Object.entries(serviceUrlEnvVars)) {
         process.env[key] = value;
-        envToUnset.add(key);
         output.debug(`Injected service URL env var: ${key}=${value}`);
       }
     }


### PR DESCRIPTION
* Injects `{SERVICE_NAME}_URL` (and `{FRAMEWORK_PREFIX}_{SERVICE_NAME}_URL`) environment variables for all the web services that are part of the deployment
* These consist of `{VERCEL_URL}/{SERVICE_ROUTE_PREFIX}`
* This is so they are available during the build, as some frontend frameworks, e.g. Next and Vite require them to be available during build time, not just runtime