### PR TITLE
feat(cli): Add integration/product slash syntax and dynamic help

### DIFF
--- a/.changeset/product-slash-syntax.md
+++ b/.changeset/product-slash-syntax.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add `integration add <integration>/<product>` slash syntax to skip product selection prompt, and dynamic help listing available products for multi-product integrations

--- a/packages/cli/src/commands/install/command.ts
+++ b/packages/cli/src/commands/install/command.ts
@@ -18,5 +18,9 @@ export const installCommand: Command = {
       name: 'Install an integration from the marketplace',
       value: `${packageName} install acme`,
     },
+    {
+      name: 'Install a specific product',
+      value: `${packageName} install acme/acme-redis`,
+    },
   ],
 };

--- a/packages/cli/src/commands/integration/command.ts
+++ b/packages/cli/src/commands/integration/command.ts
@@ -20,6 +20,17 @@ export const addSubcommand = {
         `${packageName} integration add acme`,
       ],
     },
+    {
+      name: 'Install a specific product from an integration',
+      value: [
+        `${packageName} integration add <integration>/<product>`,
+        `${packageName} integration add acme/acme-redis`,
+      ],
+    },
+    {
+      name: 'Show available products for an integration',
+      value: `${packageName} integration add acme --help`,
+    },
   ],
 } as const;
 
@@ -159,5 +170,10 @@ export const integrationCommand = {
     openSubcommand,
     removeSubcommand,
   ],
-  examples: [],
+  examples: [
+    {
+      name: 'Install a specific product from an integration',
+      value: `${packageName} integration add acme/acme-redis`,
+    },
+  ],
 } as const;

--- a/packages/cli/src/util/integration/format-product-help.ts
+++ b/packages/cli/src/util/integration/format-product-help.ts
@@ -1,0 +1,37 @@
+import chalk from 'chalk';
+import { packageName } from '../pkg-name';
+import type { IntegrationProduct } from './types';
+
+/**
+ * Format available products as help text for CLI display.
+ * Only shown for multi-product integrations.
+ */
+export function formatProductHelp(
+  integrationSlug: string,
+  products: IntegrationProduct[]
+): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(
+    `  ${chalk.dim('Available products for')} "${chalk.bold(integrationSlug)}"${chalk.dim(':')}`
+  );
+  lines.push('');
+
+  // Find longest slug for alignment
+  const maxSlugLen = Math.max(...products.map(p => p.slug.length));
+
+  for (const product of products) {
+    const paddedSlug = product.slug.padEnd(maxSlugLen);
+    lines.push(`    ${chalk.cyan(paddedSlug)}  ${product.name}`);
+  }
+
+  lines.push('');
+  lines.push(`  ${chalk.dim('Usage:')}`);
+  lines.push('');
+  lines.push(
+    `    ${chalk.cyan(`$ ${packageName} integration add ${integrationSlug}/<product-slug>`)}`
+  );
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/util/integration/select-product.ts
+++ b/packages/cli/src/util/integration/select-product.ts
@@ -1,0 +1,39 @@
+import output from '../../output-manager';
+import type Client from '../client';
+import type { IntegrationProduct } from './types';
+
+/**
+ * Select a product by slug, auto-select if only one, or prompt interactively.
+ * Callers must ensure `products` is non-empty before calling.
+ * Returns `undefined` if the specified slug doesn't match any product.
+ */
+export async function selectProduct(
+  client: Client,
+  products: IntegrationProduct[],
+  productSlug?: string
+): Promise<IntegrationProduct | undefined> {
+  if (productSlug) {
+    const match = products.find(p => p.slug === productSlug);
+    if (!match) {
+      const available = products.map(p => p.slug).join(', ');
+      output.error(
+        `Product "${productSlug}" not found. Available products: ${available}`
+      );
+      return;
+    }
+    return match;
+  }
+
+  if (products.length === 1) {
+    return products[0];
+  }
+
+  return client.input.select({
+    message: 'Select a product',
+    choices: products.map(p => ({
+      name: p.name,
+      value: p,
+      description: p.shortDescription,
+    })),
+  });
+}

--- a/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
+++ b/packages/cli/test/unit/commands/__snapshots__/help.test.ts.snap
@@ -2885,6 +2885,7 @@ exports[`help command > integration help output snapshots > integration balance 
   -h,  --help                 Output usage information                                                                  
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
@@ -2985,6 +2986,12 @@ exports[`help command > integration help output snapshots > integration help col
                               number    
 
 
+  Examples:
+
+  - Install a specific product from an integration
+
+    $ vercel integration add acme/acme-redis
+
 "
 `;
 
@@ -3021,6 +3028,12 @@ exports[`help command > integration help output snapshots > integration help col
   -v,  --version              Output the version number                         
 
 
+  Examples:
+
+  - Install a specific product from an integration
+
+    $ vercel integration add acme/acme-redis
+
 "
 `;
 
@@ -3052,6 +3065,12 @@ exports[`help command > integration help output snapshots > integration help col
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 
 
+
+  Examples:
+
+  - Install a specific product from an integration
+
+    $ vercel integration add acme/acme-redis
 
 "
 `;
@@ -3121,6 +3140,7 @@ exports[`help command > integration-resource help output snapshots > integration
   -h,  --help                 Output usage information                                                                  
   -A,  --local-config <FILE>  Path to the local \`vercel.json\` file                                                      
        --no-color             No color mode (default off)                                                               
+       --non-interactive      Run without interactive prompts; when an agent is detected this is the default            
   -S,  --scope                Set a custom scope                                                                        
   -t,  --token <TOKEN>        Login token                                                                               
   -v,  --version              Output the version number                                                                 

--- a/packages/cli/test/unit/util/integration/format-product-help.test.ts
+++ b/packages/cli/test/unit/util/integration/format-product-help.test.ts
@@ -1,0 +1,52 @@
+import stripAnsi from 'strip-ansi';
+import { describe, expect, it } from 'vitest';
+import { formatProductHelp } from '../../../../src/util/integration/format-product-help';
+import type { IntegrationProduct } from '../../../../src/util/integration/types';
+
+function makeProduct(
+  overrides: Partial<IntegrationProduct> & { slug: string; name: string }
+): IntegrationProduct {
+  return {
+    id: overrides.slug,
+    shortDescription: '',
+    metadataSchema: { type: 'object', properties: {}, required: [] },
+    ...overrides,
+  };
+}
+
+describe('formatProductHelp', () => {
+  it('should list all products with aligned columns', () => {
+    const products = [
+      makeProduct({ slug: 'short', name: 'Short Name' }),
+      makeProduct({ slug: 'much-longer-slug', name: 'Long Slug Name' }),
+    ];
+    const result = stripAnsi(formatProductHelp('acme', products));
+
+    expect(result).toContain('Available products for "acme"');
+    expect(result).toContain('short             Short Name');
+    expect(result).toContain('much-longer-slug  Long Slug Name');
+  });
+
+  it('should show usage example with packageName', () => {
+    const products = [makeProduct({ slug: 'prod-a', name: 'Product A' })];
+    const result = stripAnsi(formatProductHelp('acme', products));
+
+    // Should use packageName (which is "vercel") rather than a hardcoded value
+    expect(result).toContain('$ vercel integration add acme/<product-slug>');
+  });
+
+  it('should include Usage section', () => {
+    const products = [makeProduct({ slug: 'prod-a', name: 'Product A' })];
+    const result = stripAnsi(formatProductHelp('acme', products));
+
+    expect(result).toContain('Usage:');
+  });
+
+  it('should use the integration slug in the header and usage example', () => {
+    const products = [makeProduct({ slug: 'db', name: 'Database' })];
+    const result = stripAnsi(formatProductHelp('my-integration', products));
+
+    expect(result).toContain('Available products for "my-integration"');
+    expect(result).toContain('my-integration/<product-slug>');
+  });
+});

--- a/packages/cli/test/unit/util/integration/select-product.test.ts
+++ b/packages/cli/test/unit/util/integration/select-product.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { selectProduct } from '../../../../src/util/integration/select-product';
+import type { IntegrationProduct } from '../../../../src/util/integration/types';
+import { client } from '../../../mocks/client';
+
+function makeProduct(
+  overrides: Partial<IntegrationProduct> & { slug: string; name: string }
+): IntegrationProduct {
+  return {
+    id: overrides.slug,
+    shortDescription: '',
+    metadataSchema: { type: 'object', properties: {}, required: [] },
+    ...overrides,
+  };
+}
+
+describe('selectProduct', () => {
+  describe('with productSlug', () => {
+    it('should return matching product', async () => {
+      const products = [
+        makeProduct({ slug: 'kv', name: 'KV Store' }),
+        makeProduct({ slug: 'redis', name: 'Redis' }),
+      ];
+      const result = await selectProduct(client, products, 'redis');
+      expect(result).toEqual(products[1]);
+    });
+
+    it('should return undefined and print error when slug not found', async () => {
+      const products = [makeProduct({ slug: 'kv', name: 'KV Store' })];
+      const result = await selectProduct(client, products, 'nope');
+      expect(result).toBeUndefined();
+      expect(client.stderr.getFullOutput()).toContain(
+        'Product "nope" not found'
+      );
+      expect(client.stderr.getFullOutput()).toContain('Available products: kv');
+    });
+
+    it('should list all available slugs when slug not found', async () => {
+      const products = [
+        makeProduct({ slug: 'a', name: 'A' }),
+        makeProduct({ slug: 'b', name: 'B' }),
+        makeProduct({ slug: 'c', name: 'C' }),
+      ];
+      const result = await selectProduct(client, products, 'z');
+      expect(result).toBeUndefined();
+      expect(client.stderr.getFullOutput()).toContain(
+        'Available products: a, b, c'
+      );
+    });
+  });
+
+  describe('without productSlug', () => {
+    it('should auto-select when only one product', async () => {
+      const products = [makeProduct({ slug: 'only', name: 'Only Product' })];
+      const result = await selectProduct(client, products);
+      expect(result).toEqual(products[0]);
+    });
+
+    it('should prompt when multiple products', async () => {
+      const products = [
+        makeProduct({ slug: 'a', name: 'Product A' }),
+        makeProduct({ slug: 'b', name: 'Product B' }),
+      ];
+
+      // Mock the interactive select to return the second product
+      const selectSpy = vi
+        .spyOn(client.input, 'select')
+        .mockResolvedValueOnce(products[1]);
+
+      const result = await selectProduct(client, products);
+      expect(result).toEqual(products[1]);
+      expect(selectSpy).toHaveBeenCalledWith({
+        message: 'Select a product',
+        choices: [
+          {
+            name: 'Product A',
+            value: products[0],
+            description: '',
+          },
+          {
+            name: 'Product B',
+            value: products[1],
+            description: '',
+          },
+        ],
+      });
+
+      selectSpy.mockRestore();
+    });
+  });
+});

--- a/utils/chunk-tests.js
+++ b/utils/chunk-tests.js
@@ -104,7 +104,9 @@ const E2E_TEST_SCRIPTS = [
 ];
 
 const packageOptionsOverrides = {
-  // 'some-package': { min: 1, max: 1 },
+  // The vercel CLI package has enough test files that passing them all as
+  // command-line arguments exceeds the Windows cmd.exe ~8191 character limit.
+  vercel: { max: 2 },
 };
 
 function getRunnerOptions(scriptName, packageName) {


### PR DESCRIPTION
Inspired by #14654 by @mtoth-vercel.

## Summary

Multi-product integrations (like Upstash with 4 products) currently require an interactive prompt to select which product to install. This PR adds two features to make product selection easier:

1. **Slash syntax** — specify the product directly: `vc integration add upstash/upstash-kv`
2. **Dynamic help** — discover available products: `vc integration add upstash --help`

## Before / After

**Before** — multi-product integrations always show an interactive prompt:
```
$ vc integration add upstash
? Select a product (Use arrow keys)
❯ Upstash QStash/Workflow
  Upstash Search
  Upstash Vector
  Upstash for Redis
```

**After** — skip the prompt with slash syntax:
```
$ vc integration add upstash/upstash-kv
> Installing Upstash for Redis by Upstash under vercel
? What is the name of the resource?
```

**After** — discover product slugs with `--help`:
```
$ vc integration add upstash --help

  Available products for "upstash":

    upstash-qstash  Upstash QStash/Workflow
    upstash-search  Upstash Search
    upstash-vector  Upstash Vector
    upstash-kv      Upstash for Redis

  Usage:

    $ vercel integration add upstash/<product-slug>
```

## Test Plan

### Unit Tests

```
$ cd packages/cli && npx vitest run \
    test/unit/commands/integration/add.test.ts \
    test/unit/commands/integration/add-auto-provision.test.ts \
    test/unit/util/integration/format-product-help.test.ts

 ✓ test/unit/util/integration/format-product-help.test.ts  (4 tests) 2ms
 ✓ test/unit/commands/integration/add-auto-provision.test.ts  (23 tests) 311ms
 ✓ test/unit/commands/integration/add.test.ts  (30 tests) 967ms

 Test Files  3 passed (3)
      Tests  57 passed (57)
```

### Manual Testing

**Slash syntax — valid product skips prompt (legacy path):**
```
$ vc integration add upstash/upstash-kv
> Installing Upstash for Redis by Upstash under vercel
? Do you want to link this resource to the current project?
```
✅ No "Select a product" prompt — went straight to install.

**Slash syntax — valid product skips prompt (auto-provision path):**
```
$ FF_AUTO_PROVISION_INSTALL=1 vc integration add upstash/upstash-kv
> Installing Upstash for Redis by Upstash under vercel
? What is the name of the resource?
```
✅ No "Select a product" prompt — went straight to resource naming.

**Slash syntax — invalid product slug:**
```
$ vc integration add upstash/nonexistent
Error: Product "nonexistent" not found. Available products: upstash-qstash, upstash-search, upstash-vector, upstash-kv
```
✅ Clear error with available product slugs listed.

**Slash syntax — empty product slug:**
```
$ vc integration add upstash/
Error: Invalid format. Expected: <integration-name>/<product-slug>
```
✅ Format validation error.

**Slash syntax — empty integration slug:**
```
$ vc integration add /product
Error: Invalid format. Expected: <integration-name>/<product-slug>
```
✅ Format validation error.

**Slash syntax — single-product integration with explicit slug:**
```
$ vc integration add neon/neon
> Installing Neon by Neon under vercel
? Do you want to link this resource to the current project?
```
✅ Works — selects the single product by slug.

**Dynamic help — multi-product integration:**
```
$ vc integration add upstash --help

  Available products for "upstash":

    upstash-qstash  Upstash QStash/Workflow
    upstash-search  Upstash Search
    upstash-vector  Upstash Vector
    upstash-kv      Upstash for Redis

  Usage:

    $ vercel integration add upstash/<product-slug>
```
✅ Product listing with aligned columns and usage example.

**Dynamic help — single-product integration:**
```
$ vc integration add neon --help
```
✅ Standard help only — no product listing appended (correct for single-product).

Fixes: [MKT-2520](https://linear.app/vercel/issue/MKT-2520/make-it-easy-to-add-products-eg-awsdynamodb)