### PR TITLE
[next] Make adapters flag explicit value for opt-in

### DIFF
--- a/.changeset/large-emus-fold.md
+++ b/.changeset/large-emus-fold.md
@@ -1,0 +1,5 @@
+---
+'@vercel/next': patch
+---
+
+Make adapters flag explicit value for opt-in

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -513,7 +513,7 @@ export const build: BuildV2 = async buildOptions => {
   if (
     // integration tests expect outputs object
     !process.env.NEXT_BUILDER_INTEGRATION &&
-    process.env.NEXT_ENABLE_ADAPTER &&
+    process.env.NEXT_ENABLE_ADAPTER === '1' &&
     semver.gte(nextVersion, MINIMUM_NEXT_ADAPTER_VERSION)
   ) {
     env.NEXT_ADAPTER_PATH = path.join(__dirname, 'adapter/index.js');


### PR DESCRIPTION
Makes it easier to override with opt-out if needed by setting to `0` or flasey value instead of `1`