### PR TITLE
Add new `vc link ls` command

### DIFF
--- a/packages/cli/src/commands/link/command.ts
+++ b/packages/cli/src/commands/link/command.ts
@@ -1,11 +1,30 @@
 import { packageName } from '../../util/pkg-name';
-import { confirmOption, yesOption } from '../../util/arg-common';
+import { confirmOption, formatOption, yesOption } from '../../util/arg-common';
+
+export const listSubcommand = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List linked Vercel projects in the current directory',
+  arguments: [],
+  options: [formatOption],
+  examples: [
+    {
+      name: 'List all linked projects',
+      value: `${packageName} link ls`,
+    },
+    {
+      name: 'Output as JSON',
+      value: `${packageName} link ls --format json`,
+    },
+  ],
+} as const;
 
 export const linkCommand = {
   name: 'link',
   aliases: [],
   description: 'Link a local directory to a Vercel Project.',
   arguments: [],
+  subcommands: [listSubcommand],
   options: [
     {
       name: 'repo',

--- a/packages/cli/src/commands/link/ls.ts
+++ b/packages/cli/src/commands/link/ls.ts
@@ -1,0 +1,89 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import { parseArguments } from '../../util/get-args';
+import { getFlagsSpecification } from '../../util/get-flags-specification';
+import { printError } from '../../util/error';
+import { validateJsonOutput } from '../../util/output-format';
+import formatTable from '../../util/format-table';
+import output from '../../output-manager';
+import { listSubcommand } from './command';
+import { findAllProjectLinks } from '../../util/link/find-local-links';
+import { LinkLsTelemetryClient } from '../../util/telemetry/commands/link/ls';
+
+export default async function ls(client: Client, argv: string[]) {
+  const telemetryClient = new LinkLsTelemetryClient({
+    opts: {
+      store: client.telemetryEventStore,
+    },
+  });
+
+  let parsedArgs;
+  const flagsSpecification = getFlagsSpecification(listSubcommand.options);
+  try {
+    parsedArgs = parseArguments(argv, flagsSpecification);
+  } catch (err) {
+    printError(err);
+    return 1;
+  }
+  const { flags } = parsedArgs;
+
+  const formatResult = validateJsonOutput(flags);
+  if (!formatResult.valid) {
+    output.error(formatResult.error);
+    return 1;
+  }
+  const asJson = formatResult.jsonOutput;
+
+  telemetryClient.trackCliSubcommandList('ls');
+  telemetryClient.trackCliFlagFormat(flags['--format']);
+
+  const projects = await findAllProjectLinks(client, client.cwd);
+
+  if (projects.length === 0) {
+    if (asJson) {
+      output.stopSpinner();
+      client.stdout.write(`${JSON.stringify({ projects: [] }, null, 2)}\n`);
+    } else {
+      output.log('No linked projects found in this directory.');
+    }
+    return 0;
+  }
+
+  if (asJson) {
+    output.stopSpinner();
+    const jsonOutput = {
+      projects: projects.map(p => ({
+        path: p.path,
+        orgId: p.orgId,
+        projectId: p.projectId,
+      })),
+    };
+    client.stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+  } else {
+    output.log(
+      `Found ${chalk.bold(projects.length)} linked ${projects.length === 1 ? 'project' : 'projects'}`
+    );
+    client.stdout.write(`${getTable(projects)}\n`);
+  }
+
+  return 0;
+}
+
+function getTable(
+  projects: Array<{ path: string; orgId: string; projectId: string }>
+) {
+  return formatTable(
+    ['path', 'orgId', 'projectId'],
+    ['l', 'l', 'l'],
+    [
+      {
+        name: '',
+        rows: projects.map(p => [
+          chalk.bold(p.path),
+          chalk.gray(p.orgId),
+          chalk.cyan(p.projectId),
+        ]),
+      },
+    ]
+  );
+}

--- a/packages/cli/src/util/link/find-local-links.ts
+++ b/packages/cli/src/util/link/find-local-links.ts
@@ -1,0 +1,190 @@
+import { join, relative } from 'path';
+import { readdir, stat } from 'fs/promises';
+import {
+  getLinkFromDir,
+  VERCEL_DIR,
+  VERCEL_DIR_FALLBACK,
+} from '../projects/link';
+import { getRepoLink } from './repo';
+import type Client from '../client';
+
+export interface ProjectLinkInfo {
+  path: string;
+  orgId: string;
+  projectId: string;
+}
+
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  '.vercel',
+  '.now',
+  '.next',
+  'dist',
+  'build',
+  '.turbo',
+  '.cache',
+  '.output',
+  '__pycache__',
+  '.venv',
+  'venv',
+]);
+
+async function findProjectLinksRecursive(
+  basePath: string,
+  currentPath: string,
+  results: ProjectLinkInfo[],
+  maxDepth: number,
+  currentDepth: number
+): Promise<void> {
+  if (maxDepth > 0 && currentDepth > maxDepth) {
+    return;
+  }
+
+  const vercelDir = join(currentPath, VERCEL_DIR);
+  const vercelDirFallback = join(currentPath, VERCEL_DIR_FALLBACK);
+
+  let linkDir: string | null = null;
+  try {
+    const vercelStat = await stat(vercelDir);
+    if (vercelStat.isDirectory()) {
+      linkDir = vercelDir;
+    }
+  } catch {
+    try {
+      const fallbackStat = await stat(vercelDirFallback);
+      if (fallbackStat.isDirectory()) {
+        linkDir = vercelDirFallback;
+      }
+    } catch {
+      // Neither directory exists
+    }
+  }
+
+  if (linkDir) {
+    const link = await getLinkFromDir(linkDir);
+    if (link) {
+      const relativePath = relative(basePath, currentPath) || '.';
+      results.push({
+        path: relativePath,
+        orgId: link.orgId,
+        projectId: link.projectId,
+      });
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(currentPath);
+  } catch {
+    return;
+  }
+
+  const subdirPromises: Promise<void>[] = [];
+
+  for (const entry of entries) {
+    if (IGNORED_DIRECTORIES.has(entry)) {
+      continue;
+    }
+
+    const entryPath = join(currentPath, entry);
+    try {
+      const entryStat = await stat(entryPath);
+      if (entryStat.isDirectory()) {
+        subdirPromises.push(
+          findProjectLinksRecursive(
+            basePath,
+            entryPath,
+            results,
+            maxDepth,
+            currentDepth + 1
+          )
+        );
+      }
+    } catch {
+      // Skip entries we can't stat
+    }
+  }
+
+  await Promise.all(subdirPromises);
+}
+
+export async function findLocalProjectLinks(
+  cwd: string,
+  options?: { maxDepth?: number }
+): Promise<ProjectLinkInfo[]> {
+  const results: ProjectLinkInfo[] = [];
+  const maxDepth = options?.maxDepth ?? 0;
+
+  await findProjectLinksRecursive(cwd, cwd, results, maxDepth, 0);
+
+  results.sort((a, b) => {
+    if (a.path === '.') return -1;
+    if (b.path === '.') return 1;
+    return a.path.localeCompare(b.path);
+  });
+
+  return results;
+}
+
+export async function findAllProjectLinks(
+  client: Client,
+  cwd: string
+): Promise<ProjectLinkInfo[]> {
+  const results = new Map<string, ProjectLinkInfo>();
+
+  const repoLink = await getRepoLink(client, cwd);
+  if (repoLink?.repoConfig) {
+    for (const project of repoLink.repoConfig.projects) {
+      const projectPath = project.directory === '.' ? '' : project.directory;
+      const relativeToRoot = relative(repoLink.rootPath, cwd);
+
+      const isProjectUnderCwd =
+        relativeToRoot === '' ||
+        projectPath === relativeToRoot ||
+        projectPath.startsWith(`${relativeToRoot}/`);
+
+      const isCwdUnderProject =
+        projectPath === '' ||
+        relativeToRoot === projectPath ||
+        relativeToRoot.startsWith(`${projectPath}/`);
+
+      if (isProjectUnderCwd || isCwdUnderProject) {
+        let displayPath: string;
+        if (relativeToRoot === '') {
+          displayPath = projectPath || '.';
+        } else if (projectPath.startsWith(`${relativeToRoot}/`)) {
+          displayPath = projectPath.slice(relativeToRoot.length + 1);
+        } else if (
+          relativeToRoot === projectPath ||
+          relativeToRoot.startsWith(`${projectPath}/`)
+        ) {
+          displayPath = '.';
+        } else {
+          displayPath = projectPath || '.';
+        }
+
+        results.set(displayPath, {
+          path: displayPath,
+          orgId: repoLink.repoConfig.orgId,
+          projectId: project.id,
+        });
+      }
+    }
+  }
+
+  const localLinks = await findLocalProjectLinks(cwd, { maxDepth: 5 });
+  for (const link of localLinks) {
+    if (!results.has(link.path)) {
+      results.set(link.path, link);
+    }
+  }
+
+  const sortedResults = Array.from(results.values()).sort((a, b) => {
+    if (a.path === '.') return -1;
+    if (b.path === '.') return 1;
+    return a.path.localeCompare(b.path);
+  });
+
+  return sortedResults;
+}

--- a/packages/cli/src/util/telemetry/commands/link/ls.ts
+++ b/packages/cli/src/util/telemetry/commands/link/ls.ts
@@ -1,0 +1,19 @@
+import { TelemetryClient } from '../..';
+import type { TelemetryMethods } from '../../types';
+import type { listSubcommand } from '../../../../commands/link/command';
+
+export class LinkLsTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof listSubcommand>
+{
+  trackCliSubcommandList(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'list',
+      value: actual,
+    });
+  }
+
+  trackCliFlagFormat(format: string | undefined) {
+    this.trackCliOptionFormat(format);
+  }
+}

--- a/packages/cli/test/fixtures/unit/commands/link/mixed-links/.vercel/repo.json
+++ b/packages/cli/test/fixtures/unit/commands/link/mixed-links/.vercel/repo.json
@@ -1,0 +1,16 @@
+{
+  "orgId": "team_mixed",
+  "remoteName": "origin",
+  "projects": [
+    {
+      "id": "prj_web_repo",
+      "name": "mixed-web",
+      "directory": "apps/web"
+    },
+    {
+      "id": "prj_api",
+      "name": "mixed-api",
+      "directory": "apps/api"
+    }
+  ]
+}

--- a/packages/cli/test/fixtures/unit/commands/link/mixed-links/apps/web/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/link/mixed-links/apps/web/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_mixed_override",
+  "projectId": "prj_web_local"
+}

--- a/packages/cli/test/fixtures/unit/commands/link/monorepo-ls/.vercel/repo.json
+++ b/packages/cli/test/fixtures/unit/commands/link/monorepo-ls/.vercel/repo.json
@@ -1,0 +1,21 @@
+{
+  "orgId": "team_monorepo",
+  "remoteName": "origin",
+  "projects": [
+    {
+      "id": "prj_dashboard",
+      "name": "monorepo-dashboard",
+      "directory": "apps/dashboard"
+    },
+    {
+      "id": "prj_marketing",
+      "name": "monorepo-marketing",
+      "directory": "apps/marketing"
+    },
+    {
+      "id": "prj_lib",
+      "name": "monorepo-lib",
+      "directory": "packages/lib"
+    }
+  ]
+}

--- a/packages/cli/test/fixtures/unit/commands/link/nested-links/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/link/nested-links/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_nested",
+  "projectId": "prj_root"
+}

--- a/packages/cli/test/fixtures/unit/commands/link/nested-links/packages/app-a/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/link/nested-links/packages/app-a/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_nested",
+  "projectId": "prj_app_a"
+}

--- a/packages/cli/test/fixtures/unit/commands/link/nested-links/packages/app-b/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/link/nested-links/packages/app-b/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_nested",
+  "projectId": "prj_app_b"
+}

--- a/packages/cli/test/fixtures/unit/commands/link/single-project/.vercel/project.json
+++ b/packages/cli/test/fixtures/unit/commands/link/single-project/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "orgId": "team_single",
+  "projectId": "prj_single_project"
+}

--- a/packages/cli/test/unit/commands/link/ls.test.ts
+++ b/packages/cli/test/unit/commands/link/ls.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import link from '../../../../src/commands/link';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+
+describe('link ls', () => {
+  describe('--help', () => {
+    it('tracks telemetry', async () => {
+      const command = 'link';
+      const subcommand = 'ls';
+
+      client.setArgv(command, subcommand, '--help');
+      const exitCodePromise = link(client);
+      await expect(exitCodePromise).resolves.toEqual(2);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'flag:help',
+          value: `${command}:${subcommand}`,
+        },
+      ]);
+    });
+  });
+
+  describe('single project link', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/single-project');
+      client.cwd = cwd;
+    });
+
+    it('should list the linked project', async () => {
+      client.setArgv('link', 'ls');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      const stdout = client.stdout.getFullOutput();
+      expect(stderr).toContain('Found 1 linked project');
+      expect(stdout).toContain('prj_single_project');
+      expect(stdout).toContain('team_single');
+    });
+
+    it('tracks telemetry', async () => {
+      client.setArgv('link', 'ls');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:list',
+          value: 'ls',
+        },
+      ]);
+    });
+  });
+
+  describe('monorepo link (repo.json)', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/monorepo-ls');
+      client.cwd = cwd;
+    });
+
+    it('should list all projects from repo.json', async () => {
+      client.setArgv('link', 'ls');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      const stdout = client.stdout.getFullOutput();
+      expect(stderr).toContain('Found 3 linked projects');
+      expect(stdout).toContain('prj_dashboard');
+      expect(stdout).toContain('prj_marketing');
+      expect(stdout).toContain('prj_lib');
+      expect(stdout).toContain('apps/dashboard');
+      expect(stdout).toContain('apps/marketing');
+      expect(stdout).toContain('packages/lib');
+    });
+  });
+
+  describe('nested project links', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/nested-links');
+      client.cwd = cwd;
+    });
+
+    it('should list root and nested projects', async () => {
+      client.setArgv('link', 'ls');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      const stdout = client.stdout.getFullOutput();
+      expect(stderr).toContain('Found 3 linked projects');
+      expect(stdout).toContain('prj_root');
+      expect(stdout).toContain('prj_app_a');
+      expect(stdout).toContain('prj_app_b');
+    });
+  });
+
+  describe('no links found', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/no-links');
+      client.cwd = cwd;
+    });
+
+    it('should show message when no links exist', async () => {
+      client.setArgv('link', 'ls');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const stderr = client.stderr.getFullOutput();
+      expect(stderr).toContain('No linked projects found');
+    });
+  });
+
+  describe('--format json', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/single-project');
+      client.cwd = cwd;
+    });
+
+    it('tracks telemetry for --format json', async () => {
+      client.setArgv('link', 'ls', '--format', 'json');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      expect(client.telemetryEventStore).toHaveTelemetryEvents([
+        {
+          key: 'subcommand:list',
+          value: 'ls',
+        },
+        {
+          key: 'option:format',
+          value: 'json',
+        },
+      ]);
+    });
+
+    it('outputs valid JSON', async () => {
+      client.setArgv('link', 'ls', '--format', 'json');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput();
+      const jsonOutput = JSON.parse(output);
+
+      expect(jsonOutput).toHaveProperty('projects');
+      expect(Array.isArray(jsonOutput.projects)).toBe(true);
+    });
+
+    it('outputs correct project structure', async () => {
+      client.setArgv('link', 'ls', '--format', 'json');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput();
+      const jsonOutput = JSON.parse(output);
+
+      expect(jsonOutput.projects.length).toBeGreaterThan(0);
+      const firstProject = jsonOutput.projects[0];
+      expect(firstProject).toHaveProperty('path');
+      expect(firstProject).toHaveProperty('orgId');
+      expect(firstProject).toHaveProperty('projectId');
+      expect(firstProject.path).toEqual('.');
+      expect(firstProject.orgId).toEqual('team_single');
+      expect(firstProject.projectId).toEqual('prj_single_project');
+    });
+
+    it('outputs empty array when no links exist', async () => {
+      const cwd = setupUnitFixture('commands/link/no-links');
+      client.cwd = cwd;
+
+      client.setArgv('link', 'ls', '--format', 'json');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput();
+      const jsonOutput = JSON.parse(output);
+
+      expect(jsonOutput).toHaveProperty('projects');
+      expect(jsonOutput.projects).toEqual([]);
+    });
+  });
+
+  describe('monorepo JSON output', () => {
+    beforeEach(() => {
+      const cwd = setupUnitFixture('commands/link/monorepo-ls');
+      client.cwd = cwd;
+    });
+
+    it('outputs all projects with correct paths', async () => {
+      client.setArgv('link', 'ls', '--format', 'json');
+      const exitCode = await link(client);
+      expect(exitCode).toEqual(0);
+
+      const output = client.stdout.getFullOutput();
+      const jsonOutput = JSON.parse(output);
+
+      expect(jsonOutput.projects.length).toEqual(3);
+
+      const paths = jsonOutput.projects.map((p: { path: string }) => p.path);
+      expect(paths).toContain('apps/dashboard');
+      expect(paths).toContain('apps/marketing');
+      expect(paths).toContain('packages/lib');
+    });
+  });
+});


### PR DESCRIPTION
Adds `vc link ls` command to show linked projects in the current directory

Supports both projects linked via `vc link` and repos linked via `vc link --repo`