### PR TITLE
[services] remove empty detectors

### DIFF
--- a/.changeset/old-rules-roll.md
+++ b/.changeset/old-rules-roll.md
@@ -1,0 +1,5 @@
+---
+"@vercel/frameworks": patch
+---
+
+[services] remove empty detectors

--- a/packages/frameworks/src/frameworks.ts
+++ b/packages/frameworks/src/frameworks.ts
@@ -4338,7 +4338,6 @@ export const frameworks = [
     description:
       'Multiple services deployed as serverless functions within your project.',
     website: 'https://vercel.com',
-    detectors: {},
     settings: {
       installCommand: {
         placeholder: 'None',


### PR DESCRIPTION
Empty detectors meant it always got evaluated to true so we'd never reach "other" (still feature flagged so only evaluated to true when the feature flag was set)