### PR TITLE
[services] service framework + python entrypoint discovery fix

### DIFF
--- a/.changeset/fix-python-service-entrypoint.md
+++ b/.changeset/fix-python-service-entrypoint.md
@@ -1,0 +1,14 @@
+---
+'@vercel/python': patch
+'@vercel/fs-detectors': patch
+'vercel': patch
+---
+
+Fixed Python service entrypoint detection for services in subdirectories.
+
+When a Python backend framework (FastAPI, Flask, etc.) was used as a service in a subdirectory (e.g. `backend/`), the build would generate a handler referencing the pseudo entrypoint `backend/index.py` instead of the real entrypoint (e.g. `backend/main.py`), causing a `FileNotFoundError` at runtime.
+
+Three issues were fixed:
+- The CLI build no longer overrides the per-service framework with the project-level `'services'` framework, allowing the Python builder's entrypoint detection to trigger correctly.
+- The service resolver now passes `serviceWorkspace` through the builder config so builders know the workspace boundary without inferring it.
+- The Python entrypoint detection uses the explicit workspace to scope its search correctly, then falls back to the project root.

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -723,6 +723,11 @@ async function doBuild(
       }
 
       const isFrontendBuilder = build.config && 'framework' in build.config;
+      // For services builds, the builder framework is set by the service resolver,
+      // the project-level framework is 'services'.
+      const builderFramework =
+        build.config?.framework ?? projectSettings.framework;
+
       const buildConfig: Config = isZeroConfig
         ? {
             outputDirectory: projectSettings.outputDirectory ?? undefined,
@@ -731,7 +736,7 @@ async function doBuild(
             installCommand: projectSettings.installCommand ?? undefined,
             devCommand: projectSettings.devCommand ?? undefined,
             buildCommand: projectSettings.buildCommand ?? undefined,
-            framework: projectSettings.framework,
+            framework: builderFramework,
             nodeVersion: projectSettings.nodeVersion,
             bunVersion: localConfig.bunVersion ?? undefined,
           }

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -179,6 +179,9 @@ export function resolveConfiguredService(
   if (config.framework) {
     builderConfig.framework = config.framework;
   }
+  if (!isRoot) {
+    builderConfig.serviceWorkspace = workspace;
+  }
 
   return {
     name,

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -110,6 +110,9 @@ export const build: BuildV3 = async ({
     throw err;
   }
 
+  console.log('BUILDING PYTHON');
+  console.log('framework', framework);
+
   // For Python frameworks, also honor project install/build commands (vercel.json/dashboard)
   if (isPythonFramework(framework)) {
     const {
@@ -166,7 +169,8 @@ export const build: BuildV3 = async ({
     const detected = await detectPythonEntrypoint(
       config.framework as PythonFramework,
       workPath,
-      entrypoint
+      entrypoint,
+      config.serviceWorkspace as string | undefined
     );
     if (detected) {
       debug(

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -110,9 +110,6 @@ export const build: BuildV3 = async ({
     throw err;
   }
 
-  console.log('BUILDING PYTHON');
-  console.log('framework', framework);
-
   // For Python frameworks, also honor project install/build commands (vercel.json/dashboard)
   if (isPythonFramework(framework)) {
     const {


### PR DESCRIPTION
Fixes a couple issues that were leading to python services not building correctly:

* The framework we pass to the Python builder should be 'fastapi' or 'python', for the specific service, not 'services'
* The entrypoint discovery should happen inside the /backend or /services/service-name workspace, not at the project root