### PR TITLE
Add service configuration to BuildOptions

### DIFF
--- a/.changeset/cyan-pans-study.md
+++ b/.changeset/cyan-pans-study.md
@@ -1,0 +1,7 @@
+---
+"@vercel/build-utils": patch
+"vercel": patch
+"@vercel/fs-detectors": patch
+---
+
+Add service configuration to BuildOptions

--- a/packages/build-utils/src/types.ts
+++ b/packages/build-utils/src/types.ts
@@ -113,6 +113,17 @@ export interface BuildOptions {
    * The current trace state from the internal vc tracing
    */
   span?: Span;
+
+  /**
+   * Service-specific options. Only present when the build is part of a
+   * multi-service project.
+   */
+  service?: {
+    /** URL path prefix where the service is mounted (e.g., "/api"). */
+    routePrefix?: string;
+    /** Workspace directory for this service, relative to the project root. */
+    workspace?: string;
+  };
 }
 
 export interface PrepareCacheOptions {

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -720,6 +720,8 @@ async function doBuild(
         name: builderPkg.name,
       });
 
+      const serviceRoutePrefix = build.config?.routePrefix;
+      const serviceWorkspace = build.config?.workspace;
       const buildOptions: BuildOptions = {
         files: filesMap,
         entrypoint: build.src,
@@ -728,6 +730,21 @@ async function doBuild(
         config: buildConfig,
         meta,
         span: builderSpan,
+        ...(typeof serviceRoutePrefix === 'string' ||
+        typeof serviceWorkspace === 'string'
+          ? {
+              service: {
+                routePrefix:
+                  typeof serviceRoutePrefix === 'string'
+                    ? serviceRoutePrefix
+                    : undefined,
+                workspace:
+                  typeof serviceWorkspace === 'string'
+                    ? serviceWorkspace
+                    : undefined,
+              },
+            }
+          : undefined),
       };
       output.debug(
         `Building entrypoint "${build.src}" with "${builderPkg.name}"`

--- a/packages/cli/src/util/dev/builder.ts
+++ b/packages/cli/src/util/dev/builder.ts
@@ -139,6 +139,8 @@ export async function executeBuild(
     buildProcess = await createBuildProcess(match, envConfigs, workPath);
   }
 
+  const serviceRoutePrefix = config.routePrefix;
+  const serviceWorkspace = config.workspace;
   const buildOptions: BuildOptions = {
     files,
     entrypoint,
@@ -156,6 +158,21 @@ export async function executeBuild(
       env: { ...envConfigs.runEnv },
       buildEnv: { ...envConfigs.buildEnv },
     },
+    ...(typeof serviceRoutePrefix === 'string' ||
+    typeof serviceWorkspace === 'string'
+      ? {
+          service: {
+            routePrefix:
+              typeof serviceRoutePrefix === 'string'
+                ? serviceRoutePrefix
+                : undefined,
+            workspace:
+              typeof serviceWorkspace === 'string'
+                ? serviceWorkspace
+                : undefined,
+          },
+        }
+      : undefined),
   };
 
   let buildResultOrOutputs;

--- a/packages/fs-detectors/src/services/resolve.ts
+++ b/packages/fs-detectors/src/services/resolve.ts
@@ -167,6 +167,10 @@ export function resolveConfiguredService(
       : routePrefix;
     builderConfig.routePrefix = stripped || '.';
   }
+  // Pass workspace to builder config for builders that need to know the service's workspace
+  if (workspace && workspace !== '.') {
+    builderConfig.workspace = workspace;
+  }
   if (config.framework) {
     builderConfig.framework = config.framework;
   }


### PR DESCRIPTION
Expose routePrefix and workspace as direct BuildOptions properties namespaced under a service key, allowing builders to easily access service-specific context without digging into builder config.