### PR TITLE
feat(cli): add routes edit command with interactive and flag-based modes

### DIFF
--- a/.changeset/routes-edit.md
+++ b/.changeset/routes-edit.md
@@ -1,0 +1,5 @@
+---
+"vercel": patch
+---
+
+Add `routes edit` command with interactive and flag-based modes. Require explicit `--action` flag for `routes add`.

--- a/.changeset/routes-edit.md
+++ b/.changeset/routes-edit.md
@@ -1,5 +1,2 @@
 ---
-"vercel": patch
 ---
-
-Add `routes edit` command with interactive and flag-based modes. Require explicit `--action` flag for `routes add`.

--- a/packages/cli/src/commands/routes/add.ts
+++ b/packages/cli/src/commands/routes/add.ts
@@ -23,7 +23,6 @@ import {
   stripQuotes,
   extractTransformFlags,
   collectHeadersAndTransforms,
-  hasAnyTransformFlags,
   validateActionFlags,
   ALL_ACTION_CHOICES,
   collectActionDetails,
@@ -200,7 +199,6 @@ export default async function add(client: Client, argv: string[]) {
     ? stripQuotes(flags['--dest'] as string)
     : undefined;
   const status = flags['--status'] as number | undefined;
-  const hasTransforms = hasAnyTransformFlags(flags);
 
   // In flag-based mode, --action is required when --dest or --status is provided
   const actionError = validateActionFlags(actionFlag, dest, status);

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -290,7 +290,7 @@ export const addSubcommand = {
     {
       name: 'has',
       description:
-        'Condition that must match (repeatable). Format: type:key, type:key:value, or type:key:op=value. Types: header, cookie, query, host. Operators: eq, contains, re, exists. Examples: header:Authorization, header:Accept:contains=json, cookie:session:eq=abc, host:eq=example.com',
+        'Condition that must match: type:key or type:key:value (repeatable)',
       shorthand: null,
       type: [String],
       argument: 'CONDITION',
@@ -299,7 +299,7 @@ export const addSubcommand = {
     {
       name: 'missing',
       description:
-        'Condition that must NOT match (repeatable). Format: type:key, type:key:value, or type:key:op=value. Types: header, cookie, query, host. Operators: eq, contains, re, exists. Examples: cookie:session, header:X-Block:eq=true',
+        'Condition that must NOT match: type:key or type:key:value (repeatable)',
       shorthand: null,
       type: [String],
       argument: 'CONDITION',
@@ -592,10 +592,10 @@ export const reorderSubcommand = {
   ],
 } as const;
 
-export const deleteSubcommand = {
-  name: 'delete',
-  aliases: ['rm'],
-  description: 'Delete one or more routing rules',
+export const editSubcommand = {
+  name: 'edit',
+  aliases: [],
+  description: 'Edit an existing routing rule',
   arguments: [
     {
       name: 'name-or-id',
@@ -603,136 +603,221 @@ export const deleteSubcommand = {
     },
   ],
   options: [
+    // Metadata
     {
-      ...yesOption,
-      description: 'Skip the confirmation prompt when deleting',
-    },
-  ],
-  examples: [
-    {
-      name: 'Delete a route by name',
-      value: `${packageName} routes delete "Old Redirect"`,
-    },
-    {
-      name: 'Delete a route by ID',
-      value: `${packageName} routes delete abc123`,
-    },
-    {
-      name: 'Delete multiple routes',
-      value: `${packageName} routes delete "Route A" "Route B"`,
-    },
-    {
-      name: 'Delete without confirmation',
-      value: `${packageName} routes delete "Old Route" --yes`,
-    },
-  ],
-} as const;
-
-export const enableSubcommand = {
-  name: 'enable',
-  aliases: [],
-  description: 'Enable a disabled routing rule',
-  arguments: [
-    {
-      name: 'name-or-id',
-      required: true,
-    },
-  ],
-  options: [],
-  examples: [
-    {
-      name: 'Enable a route by name',
-      value: `${packageName} routes enable "API Proxy"`,
-    },
-    {
-      name: 'Enable a route by ID',
-      value: `${packageName} routes enable abc123`,
-    },
-  ],
-} as const;
-
-export const disableSubcommand = {
-  name: 'disable',
-  aliases: [],
-  description: 'Disable a routing rule without deleting it',
-  arguments: [
-    {
-      name: 'name-or-id',
-      required: true,
-    },
-  ],
-  options: [],
-  examples: [
-    {
-      name: 'Disable a route by name',
-      value: `${packageName} routes disable "API Proxy"`,
-    },
-    {
-      name: 'Disable a route by ID',
-      value: `${packageName} routes disable abc123`,
-    },
-  ],
-} as const;
-
-export const reorderSubcommand = {
-  name: 'reorder',
-  aliases: ['move'],
-  description: 'Move a routing rule to a different position',
-  arguments: [
-    {
-      name: 'name-or-id',
-      required: true,
-    },
-  ],
-  options: [
-    {
-      name: 'position',
-      description:
-        'Target position: start, end, a number (1-based), before:<id>, after:<id>',
+      name: 'name',
+      description: 'Change route name',
       shorthand: null,
       type: String,
-      argument: 'POSITION',
+      argument: 'NAME',
       deprecated: false,
     },
     {
-      name: 'first',
-      description: 'Move to the first position (highest priority)',
+      name: 'description',
+      description: 'Change description (use "" to clear)',
+      shorthand: null,
+      type: String,
+      argument: 'TEXT',
+      deprecated: false,
+    },
+    // Path & Matching
+    {
+      name: 'src',
+      description: 'Change source path pattern',
+      shorthand: null,
+      type: String,
+      argument: 'PATTERN',
+      deprecated: false,
+    },
+    {
+      name: 'src-syntax',
+      description: 'Change path syntax: regex, path-to-regexp, equals',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+    },
+    // Primary action
+    {
+      name: 'action',
+      description:
+        'Set action type: rewrite, redirect, or set-status (required when switching types)',
+      shorthand: null,
+      type: String,
+      argument: 'TYPE',
+      deprecated: false,
+    },
+    {
+      name: 'dest',
+      description: 'Set destination URL',
+      shorthand: null,
+      type: String,
+      argument: 'URL',
+      deprecated: false,
+    },
+    {
+      name: 'status',
+      description: 'Set status code',
+      shorthand: null,
+      type: Number,
+      argument: 'CODE',
+      deprecated: false,
+    },
+    {
+      name: 'no-dest',
+      description: 'Remove destination',
       shorthand: null,
       type: Boolean,
       deprecated: false,
     },
     {
-      name: 'last',
-      description: 'Move to the last position (lowest priority)',
+      name: 'no-status',
+      description: 'Remove status code',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    // Response Headers
+    {
+      name: 'set-response-header',
+      description: 'Set response header: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'HEADER',
+      deprecated: false,
+    },
+    {
+      name: 'append-response-header',
+      description: 'Append to response header: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'HEADER',
+      deprecated: false,
+    },
+    {
+      name: 'delete-response-header',
+      description: 'Delete response header: key (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'KEY',
+      deprecated: false,
+    },
+    // Request Headers
+    {
+      name: 'set-request-header',
+      description: 'Set request header: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'HEADER',
+      deprecated: false,
+    },
+    {
+      name: 'append-request-header',
+      description: 'Append to request header: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'HEADER',
+      deprecated: false,
+    },
+    {
+      name: 'delete-request-header',
+      description: 'Delete request header: key (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'KEY',
+      deprecated: false,
+    },
+    // Request Query
+    {
+      name: 'set-request-query',
+      description: 'Set query parameter: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'PARAM',
+      deprecated: false,
+    },
+    {
+      name: 'append-request-query',
+      description: 'Append to query parameter: key=value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'PARAM',
+      deprecated: false,
+    },
+    {
+      name: 'delete-request-query',
+      description: 'Delete query parameter: key (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'KEY',
+      deprecated: false,
+    },
+    // Conditions
+    {
+      name: 'has',
+      description:
+        'Add a has condition: type:key or type:key:value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'CONDITION',
+      deprecated: false,
+    },
+    {
+      name: 'missing',
+      description:
+        'Add a missing condition: type:key or type:key:value (repeatable)',
+      shorthand: null,
+      type: [String],
+      argument: 'CONDITION',
+      deprecated: false,
+    },
+    // Clearing
+    {
+      name: 'clear-conditions',
+      description: 'Remove all has/missing conditions',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'clear-headers',
+      description: 'Remove all response headers',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'clear-transforms',
+      description: 'Remove all transforms (request headers, request query)',
       shorthand: null,
       type: Boolean,
       deprecated: false,
     },
     {
       ...yesOption,
-      description: 'Skip the confirmation prompt when reordering',
+      description: 'Skip confirmation prompts',
     },
   ],
   examples: [
     {
-      name: 'Move to first position',
-      value: `${packageName} routes reorder "Catch All" --first`,
+      name: 'Interactive mode',
+      value: `${packageName} routes edit "API Proxy"`,
     },
     {
-      name: 'Move to last position',
-      value: `${packageName} routes reorder "Catch All" --last`,
+      name: 'Change destination',
+      value: `${packageName} routes edit "API Proxy" --dest "https://new-api.example.com/:path*"`,
     },
     {
-      name: 'Move to a specific position',
-      value: `${packageName} routes reorder "API Proxy" --position 3`,
+      name: 'Switch to redirect',
+      value: `${packageName} routes edit "Old Route" --action redirect --dest "/new" --status 301`,
     },
     {
-      name: 'Move after another route',
-      value: `${packageName} routes reorder "API Proxy" --position after:route-id-123`,
+      name: 'Add a response header',
+      value: `${packageName} routes edit "My Route" --set-response-header "Cache-Control=public, max-age=3600"`,
     },
     {
-      name: 'Interactive reorder (prompts for position)',
-      value: `${packageName} routes reorder "API Proxy"`,
+      name: 'Clear all conditions and add new ones',
+      value: `${packageName} routes edit "My Route" --clear-conditions --has "header:Authorization"`,
     },
   ],
 } as const;
@@ -748,6 +833,7 @@ export const routesCommand = {
     listVersionsSubcommand,
     inspectSubcommand,
     addSubcommand,
+    editSubcommand,
     deleteSubcommand,
     enableSubcommand,
     disableSubcommand,

--- a/packages/cli/src/commands/routes/command.ts
+++ b/packages/cli/src/commands/routes/command.ts
@@ -592,6 +592,151 @@ export const reorderSubcommand = {
   ],
 } as const;
 
+export const deleteSubcommand = {
+  name: 'delete',
+  aliases: ['rm'],
+  description: 'Delete one or more routing rules',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when deleting',
+    },
+  ],
+  examples: [
+    {
+      name: 'Delete a route by name',
+      value: `${packageName} routes delete "Old Redirect"`,
+    },
+    {
+      name: 'Delete a route by ID',
+      value: `${packageName} routes delete abc123`,
+    },
+    {
+      name: 'Delete multiple routes',
+      value: `${packageName} routes delete "Route A" "Route B"`,
+    },
+    {
+      name: 'Delete without confirmation',
+      value: `${packageName} routes delete "Old Route" --yes`,
+    },
+  ],
+} as const;
+
+export const enableSubcommand = {
+  name: 'enable',
+  aliases: [],
+  description: 'Enable a disabled routing rule',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Enable a route by name',
+      value: `${packageName} routes enable "API Proxy"`,
+    },
+    {
+      name: 'Enable a route by ID',
+      value: `${packageName} routes enable abc123`,
+    },
+  ],
+} as const;
+
+export const disableSubcommand = {
+  name: 'disable',
+  aliases: [],
+  description: 'Disable a routing rule without deleting it',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [],
+  examples: [
+    {
+      name: 'Disable a route by name',
+      value: `${packageName} routes disable "API Proxy"`,
+    },
+    {
+      name: 'Disable a route by ID',
+      value: `${packageName} routes disable abc123`,
+    },
+  ],
+} as const;
+
+export const reorderSubcommand = {
+  name: 'reorder',
+  aliases: ['move'],
+  description: 'Move a routing rule to a different position',
+  arguments: [
+    {
+      name: 'name-or-id',
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: 'position',
+      description:
+        'Target position: start, end, a number (1-based), before:<id>, after:<id>',
+      shorthand: null,
+      type: String,
+      argument: 'POSITION',
+      deprecated: false,
+    },
+    {
+      name: 'first',
+      description: 'Move to the first position (highest priority)',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      name: 'last',
+      description: 'Move to the last position (lowest priority)',
+      shorthand: null,
+      type: Boolean,
+      deprecated: false,
+    },
+    {
+      ...yesOption,
+      description: 'Skip the confirmation prompt when reordering',
+    },
+  ],
+  examples: [
+    {
+      name: 'Move to first position',
+      value: `${packageName} routes reorder "Catch All" --first`,
+    },
+    {
+      name: 'Move to last position',
+      value: `${packageName} routes reorder "Catch All" --last`,
+    },
+    {
+      name: 'Move to a specific position',
+      value: `${packageName} routes reorder "API Proxy" --position 3`,
+    },
+    {
+      name: 'Move after another route',
+      value: `${packageName} routes reorder "API Proxy" --position after:route-id-123`,
+    },
+    {
+      name: 'Interactive reorder (prompts for position)',
+      value: `${packageName} routes reorder "API Proxy"`,
+    },
+  ],
+} as const;
+
 export const routesCommand = {
   name: 'routes',
   aliases: [],

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -976,34 +976,38 @@ export default async function edit(client: Client, argv: string[]) {
       ).length;
       const requestQuery = getTransformsByType(route, 'request.query').length;
 
+      const editChoices = [
+        { name: 'Name', value: 'name' },
+        { name: 'Description', value: 'description' },
+        { name: 'Source pattern & syntax', value: 'source' },
+        {
+          name: `Primary action (${getPrimaryActionLabel(route)})`,
+          value: 'action',
+        },
+        {
+          name: `Conditions (${hasConds} has, ${missingConds} missing)`,
+          value: 'conditions',
+        },
+        {
+          name: `Response Headers (${responseHeaders})`,
+          value: 'response-headers',
+        },
+        {
+          name: `Request Headers (${requestHeaders})`,
+          value: 'request-headers',
+        },
+        {
+          name: `Request Query (${requestQuery})`,
+          value: 'request-query',
+        },
+        { name: 'Done - save changes', value: 'done' },
+      ];
+
       const choice = await client.input.select({
         message: 'What would you like to edit?',
-        choices: [
-          { name: 'Name', value: 'name' },
-          { name: 'Description', value: 'description' },
-          { name: 'Source pattern & syntax', value: 'source' },
-          {
-            name: `Primary action (${getPrimaryActionLabel(route)})`,
-            value: 'action',
-          },
-          {
-            name: `Conditions (${hasConds} has, ${missingConds} missing)`,
-            value: 'conditions',
-          },
-          {
-            name: `Response Headers (${responseHeaders})`,
-            value: 'response-headers',
-          },
-          {
-            name: `Request Headers (${requestHeaders})`,
-            value: 'request-headers',
-          },
-          {
-            name: `Request Query (${requestQuery})`,
-            value: 'request-query',
-          },
-          { name: 'Done - save changes', value: 'done' },
-        ],
+        choices: editChoices,
+        pageSize: editChoices.length,
+        loop: false,
       });
 
       switch (choice) {

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -527,7 +527,7 @@ async function editConditions(
   client: Client,
   route: RoutingRule
 ): Promise<void> {
-  while (true) {
+  for (;;) {
     const hasConds = ((route.route as any).has ?? []) as Array<{
       type: string;
       key?: string;
@@ -713,7 +713,7 @@ async function editResponseHeaders(
   client: Client,
   route: RoutingRule
 ): Promise<void> {
-  while (true) {
+  for (;;) {
     const allHeaders = getAllResponseHeaders(route);
 
     if (allHeaders.length > 0) {
@@ -850,7 +850,7 @@ async function editTransformsByType(
   const itemName =
     transformType === 'request.headers' ? 'request header' : 'query parameter';
 
-  while (true) {
+  for (;;) {
     const allTransforms = ((route.route as any).transforms ??
       []) as Transform[];
     const matching = allTransforms.filter(t => t.type === transformType);
@@ -1079,7 +1079,7 @@ export default async function edit(client: Client, argv: string[]) {
     output.log(`\nEditing route "${originalRoute.name}"`);
     printRouteConfig(route);
 
-    while (true) {
+    for (;;) {
       const hasConds = ((route.route as any).has ?? []).length;
       const missingConds = ((route.route as any).missing ?? []).length;
       const responseHeaders = getAllResponseHeaders(route).length;

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -343,6 +343,16 @@ function applyFlagMutations(
     return `Too many conditions: ${totalConditions}. Maximum is ${MAX_CONDITIONS}.`;
   }
 
+  // Validate the route still has some action after mutations
+  const hasDest = !!route.route.dest;
+  const hasStatus = !!route.route.status;
+  const hasHeaders = Object.keys(route.route.headers ?? {}).length > 0;
+  const hasTransforms = ((route.route as any).transforms ?? []).length > 0;
+
+  if (!hasDest && !hasStatus && !hasHeaders && !hasTransforms) {
+    return 'This edit would leave the route with no action. Add --action, headers, or transforms.';
+  }
+
   return null;
 }
 
@@ -1035,7 +1045,22 @@ export default async function edit(client: Client, argv: string[]) {
           break;
       }
 
-      if (choice === 'done') break;
+      if (choice === 'done') {
+        // Validate route has some action before saving
+        const hasDest = !!route.route.dest;
+        const hasStatus = !!route.route.status;
+        const hasHeaders = Object.keys(route.route.headers ?? {}).length > 0;
+        const hasTransforms =
+          ((route.route as any).transforms ?? []).length > 0;
+
+        if (!hasDest && !hasStatus && !hasHeaders && !hasTransforms) {
+          output.warn(
+            'Route has no action (no destination, status, or headers). Add an action before saving.'
+          );
+          continue;
+        }
+        break;
+      }
     }
   }
 

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -654,6 +654,7 @@ async function editConditions(
         const existing = ((route.route as any).missing ?? []) as HasField[];
         (route.route as any).missing = [...existing, ...parsed];
       }
+      break; // Return to main menu after adding
     }
   }
 }
@@ -833,6 +834,7 @@ async function editResponseHeaders(
       if (newTransforms.length > 0) {
         (route.route as any).transforms = [...existing, ...newTransforms];
       }
+      break; // Return to main menu after adding
     }
   }
 }
@@ -919,6 +921,7 @@ async function editTransformsByType(
       if (transforms.length > 0) {
         (route.route as any).transforms = [...allTransforms, ...transforms];
       }
+      break; // Return to main menu after adding
     }
   }
 }

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -976,10 +976,30 @@ export default async function edit(client: Client, argv: string[]) {
       ).length;
       const requestQuery = getTransformsByType(route, 'request.query').length;
 
+      const syntaxLabel =
+        route.srcSyntax === 'path-to-regexp'
+          ? 'Pattern'
+          : route.srcSyntax === 'equals'
+            ? 'Exact'
+            : 'Regex';
+      const descriptionPreview = route.description
+        ? route.description.length > 40
+          ? route.description.slice(0, 40) + '...'
+          : route.description
+        : '';
+
       const editChoices = [
-        { name: 'Name', value: 'name' },
-        { name: 'Description', value: 'description' },
-        { name: 'Source pattern & syntax', value: 'source' },
+        { name: `Name (${route.name})`, value: 'name' },
+        {
+          name: descriptionPreview
+            ? `Description (${descriptionPreview})`
+            : 'Description',
+          value: 'description',
+        },
+        {
+          name: `Source (${syntaxLabel}: ${route.route.src})`,
+          value: 'source',
+        },
         {
           name: `Primary action (${getPrimaryActionLabel(route)})`,
           value: 'action',

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -731,9 +731,9 @@ async function editResponseHeaders(
 
     const choices = [];
     if (allHeaders.length > 0) {
-      choices.push({ name: 'Remove a header', value: 'remove' });
+      choices.push({ name: 'Remove a response header', value: 'remove' });
     }
-    choices.push({ name: 'Add/modify a header', value: 'add' });
+    choices.push({ name: 'Add a response header', value: 'add' });
     choices.push({ name: 'Back', value: 'back' });
 
     const action = await client.input.select({
@@ -745,7 +745,7 @@ async function editResponseHeaders(
 
     if (action === 'remove') {
       const toRemove = await client.input.select({
-        message: 'Select header to remove:',
+        message: 'Select response header to remove:',
         choices: [
           ...allHeaders.map((h, i) => ({
             name:
@@ -847,6 +847,8 @@ async function editTransformsByType(
 ): Promise<void> {
   const label =
     transformType === 'request.headers' ? 'Request Headers' : 'Request Query';
+  const itemName =
+    transformType === 'request.headers' ? 'request header' : 'query parameter';
 
   while (true) {
     const allTransforms = ((route.route as any).transforms ??
@@ -868,9 +870,9 @@ async function editTransformsByType(
 
     const choices = [];
     if (matching.length > 0) {
-      choices.push({ name: 'Remove a transform', value: 'remove' });
+      choices.push({ name: `Remove a ${itemName}`, value: 'remove' });
     }
-    choices.push({ name: 'Add a transform', value: 'add' });
+    choices.push({ name: `Add a ${itemName}`, value: 'add' });
     choices.push({ name: 'Back', value: 'back' });
 
     const action = await client.input.select({
@@ -882,7 +884,7 @@ async function editTransformsByType(
 
     if (action === 'remove') {
       const toRemove = await client.input.select({
-        message: 'Select transform to remove:',
+        message: `Select ${itemName} to remove:`,
         choices: [
           ...matching.map((t, i) => ({
             name: formatTransformDisplay(t),

--- a/packages/cli/src/commands/routes/edit.ts
+++ b/packages/cli/src/commands/routes/edit.ts
@@ -1,0 +1,1024 @@
+import chalk from 'chalk';
+import type Client from '../../util/client';
+import output from '../../output-manager';
+import { editSubcommand } from './command';
+import {
+  parseSubcommandArgs,
+  ensureProjectLink,
+  resolveRoute,
+  offerAutoPromote,
+  formatCondition as formatConditionDisplay,
+  formatTransform as formatTransformDisplay,
+} from './shared';
+import getRoutes from '../../util/routes/get-routes';
+import getRouteVersions from '../../util/routes/get-route-versions';
+import editRoute from '../../util/routes/edit-route';
+import { parseConditions } from '../../util/routes/parse-conditions';
+import stamp from '../../util/output/stamp';
+import { getCommandName } from '../../util/pkg-name';
+import {
+  MAX_NAME_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_CONDITIONS,
+  VALID_SYNTAXES,
+  REDIRECT_STATUS_CODES,
+  VALID_ACTION_TYPES,
+  stripQuotes,
+  extractTransformFlags,
+  collectHeadersAndTransforms,
+  hasAnyTransformFlags,
+  collectActionDetails,
+  collectInteractiveConditions,
+  collectInteractiveHeaders,
+} from '../../util/routes/interactive';
+import type {
+  RoutingRule,
+  HasField,
+  Transform,
+  SrcSyntax,
+} from '../../util/routes/types';
+
+// ---------------------------------------------------------------------------
+// Helpers for displaying current route state
+// ---------------------------------------------------------------------------
+
+/**
+ * Determines the primary action type of a route based on its dest/status fields.
+ */
+function getPrimaryActionType(
+  route: RoutingRule
+): 'rewrite' | 'redirect' | 'set-status' | null {
+  const { dest, status } = route.route;
+  if (dest && status && REDIRECT_STATUS_CODES.includes(status)) {
+    return 'redirect';
+  }
+  if (dest) return 'rewrite';
+  if (status) return 'set-status';
+  return null;
+}
+
+/**
+ * Returns a human-readable label for the primary action.
+ */
+function getPrimaryActionLabel(route: RoutingRule): string {
+  const actionType = getPrimaryActionType(route);
+  switch (actionType) {
+    case 'rewrite':
+      return `Rewrite → ${route.route.dest}`;
+    case 'redirect':
+      return `Redirect → ${route.route.dest} (${route.route.status})`;
+    case 'set-status':
+      return `Set Status ${route.route.status}`;
+    default:
+      return '(none)';
+  }
+}
+
+/**
+ * Gets response headers from the route's headers object.
+ */
+function getResponseHeaders(
+  route: RoutingRule
+): { key: string; value: string }[] {
+  const headers = route.route.headers ?? {};
+  return Object.entries(headers).map(([key, value]) => ({ key, value }));
+}
+
+/**
+ * Gets transforms of a specific type from the route.
+ */
+function getTransformsByType(route: RoutingRule, type: string): Transform[] {
+  const transforms = (route.route.transforms ?? []) as Transform[];
+  return transforms.filter(t => t.type === type);
+}
+
+/**
+ * Prints the current route configuration in detail.
+ */
+function printRouteConfig(route: RoutingRule): void {
+  output.print('\n');
+  output.print(`  ${chalk.cyan('Name:')}         ${route.name}\n`);
+  if (route.description) {
+    output.print(`  ${chalk.cyan('Description:')}  ${route.description}\n`);
+  }
+  output.print(
+    `  ${chalk.cyan('Source:')}       ${route.route.src}  ${chalk.gray(`(${route.srcSyntax ?? 'regex'})`)}\n`
+  );
+  output.print(
+    `  ${chalk.cyan('Status:')}       ${route.enabled === false ? chalk.red('Disabled') : chalk.green('Enabled')}\n`
+  );
+
+  // Primary action
+  const actionLabel = getPrimaryActionLabel(route);
+  output.print(`  ${chalk.cyan('Action:')}       ${actionLabel}\n`);
+
+  // Has conditions
+  const hasConds = (route.route.has ?? []) as Array<{
+    type: string;
+    key?: string;
+    value?: unknown;
+  }>;
+  if (hasConds.length > 0) {
+    output.print(`\n  ${chalk.cyan('Has conditions:')}\n`);
+    for (const c of hasConds) {
+      output.print(`    ${formatConditionDisplay(c)}\n`);
+    }
+  }
+
+  // Missing conditions
+  const missingConds = (route.route.missing ?? []) as Array<{
+    type: string;
+    key?: string;
+    value?: unknown;
+  }>;
+  if (missingConds.length > 0) {
+    output.print(`\n  ${chalk.cyan('Missing conditions:')}\n`);
+    for (const c of missingConds) {
+      output.print(`    ${formatConditionDisplay(c)}\n`);
+    }
+  }
+
+  // Response headers
+  const responseHeaders = getResponseHeaders(route);
+  if (responseHeaders.length > 0) {
+    output.print(`\n  ${chalk.cyan('Response Headers:')}\n`);
+    for (const h of responseHeaders) {
+      output.print(`    ${chalk.cyan(h.key)} = ${h.value}\n`);
+    }
+  }
+
+  // Request headers
+  const requestHeaders = getTransformsByType(route, 'request.headers');
+  if (requestHeaders.length > 0) {
+    output.print(`\n  ${chalk.cyan('Request Headers:')}\n`);
+    for (const t of requestHeaders) {
+      output.print(`    ${formatTransformDisplay(t)}\n`);
+    }
+  }
+
+  // Request query
+  const requestQuery = getTransformsByType(route, 'request.query');
+  if (requestQuery.length > 0) {
+    output.print(`\n  ${chalk.cyan('Request Query:')}\n`);
+    for (const t of requestQuery) {
+      output.print(`    ${formatTransformDisplay(t)}\n`);
+    }
+  }
+
+  output.print('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Deep clone helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep-clones a routing rule so we can safely mutate it.
+ */
+function cloneRoute(route: RoutingRule): RoutingRule {
+  return JSON.parse(JSON.stringify(route));
+}
+
+// ---------------------------------------------------------------------------
+// Flag-based mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies flag-based mutations to a cloned route.
+ * Returns an error message if invalid, or null on success.
+ */
+function applyFlagMutations(
+  route: RoutingRule,
+  flags: Record<string, unknown>
+): string | null {
+  // Metadata
+  if (flags['--name'] !== undefined) {
+    const name = flags['--name'] as string;
+    if (name.length > MAX_NAME_LENGTH) {
+      return `Name must be ${MAX_NAME_LENGTH} characters or less.`;
+    }
+    route.name = name;
+  }
+
+  if (flags['--description'] !== undefined) {
+    const desc = flags['--description'] as string;
+    if (desc.length > MAX_DESCRIPTION_LENGTH) {
+      return `Description must be ${MAX_DESCRIPTION_LENGTH} characters or less.`;
+    }
+    route.description = desc || undefined;
+  }
+
+  // Source
+  if (flags['--src'] !== undefined) {
+    route.route.src = stripQuotes(flags['--src'] as string);
+  }
+
+  if (flags['--src-syntax'] !== undefined) {
+    const syntax = flags['--src-syntax'] as string;
+    if (!VALID_SYNTAXES.includes(syntax as SrcSyntax)) {
+      return `Invalid syntax: "${syntax}". Valid options: ${VALID_SYNTAXES.join(', ')}`;
+    }
+    route.srcSyntax = syntax as SrcSyntax;
+  }
+
+  // Primary action
+  const actionFlag = flags['--action'] as string | undefined;
+  const destFlag = flags['--dest'] as string | undefined;
+  const statusFlag = flags['--status'] as number | undefined;
+  const noDest = flags['--no-dest'] as boolean | undefined;
+  const noStatus = flags['--no-status'] as boolean | undefined;
+
+  if (actionFlag) {
+    // Explicit action type change
+    if (!VALID_ACTION_TYPES.includes(actionFlag as any)) {
+      return `Invalid action type: "${actionFlag}". Valid types: ${VALID_ACTION_TYPES.join(', ')}`;
+    }
+
+    switch (actionFlag) {
+      case 'rewrite': {
+        const dest = destFlag ? stripQuotes(destFlag) : undefined;
+        if (!dest) return '--action rewrite requires --dest.';
+        route.route.dest = dest;
+        delete (route.route as any).status;
+        break;
+      }
+      case 'redirect': {
+        const dest = destFlag ? stripQuotes(destFlag) : undefined;
+        if (!dest) return '--action redirect requires --dest.';
+        if (statusFlag === undefined)
+          return '--action redirect requires --status (301, 302, 307, or 308).';
+        if (!REDIRECT_STATUS_CODES.includes(statusFlag))
+          return `Invalid redirect status: ${statusFlag}. Must be one of: ${REDIRECT_STATUS_CODES.join(', ')}`;
+        route.route.dest = dest;
+        route.route.status = statusFlag;
+        break;
+      }
+      case 'set-status': {
+        if (statusFlag === undefined)
+          return '--action set-status requires --status.';
+        if (statusFlag < 100 || statusFlag > 599)
+          return 'Status code must be between 100 and 599.';
+        delete (route.route as any).dest;
+        route.route.status = statusFlag;
+        break;
+      }
+    }
+  } else {
+    // No --action: modify existing values in-place
+    if (destFlag !== undefined) {
+      route.route.dest = stripQuotes(destFlag);
+    }
+    if (statusFlag !== undefined) {
+      route.route.status = statusFlag;
+    }
+    if (noDest) {
+      delete (route.route as any).dest;
+    }
+    if (noStatus) {
+      delete (route.route as any).status;
+    }
+  }
+
+  // Clear flags (applied before additive flags)
+  if (flags['--clear-conditions']) {
+    (route.route as any).has = [];
+    (route.route as any).missing = [];
+  }
+
+  if (flags['--clear-headers']) {
+    route.route.headers = {};
+  }
+
+  if (flags['--clear-transforms']) {
+    (route.route as any).transforms = [];
+  }
+
+  // Additive: response headers
+  const transformFlags = extractTransformFlags(flags);
+  try {
+    const { headers, transforms } = collectHeadersAndTransforms(transformFlags);
+
+    // Merge response headers (set headers overwrite same key)
+    if (Object.keys(headers).length > 0) {
+      route.route.headers = {
+        ...(route.route.headers ?? {}),
+        ...headers,
+      };
+    }
+
+    // Append new transforms
+    if (transforms.length > 0) {
+      const existing = ((route.route as any).transforms ?? []) as Transform[];
+      (route.route as any).transforms = [...existing, ...transforms];
+    }
+  } catch (e) {
+    return `Invalid transform format. ${e instanceof Error ? e.message : ''}`;
+  }
+
+  // Additive: conditions
+  const hasFlags = flags['--has'] as string[] | undefined;
+  const missingFlags = flags['--missing'] as string[] | undefined;
+
+  try {
+    if (hasFlags) {
+      const newHas = parseConditions(hasFlags);
+      const existingHas = ((route.route as any).has ?? []) as HasField[];
+      (route.route as any).has = [...existingHas, ...newHas];
+    }
+    if (missingFlags) {
+      const newMissing = parseConditions(missingFlags);
+      const existingMissing = ((route.route as any).missing ??
+        []) as HasField[];
+      (route.route as any).missing = [...existingMissing, ...newMissing];
+    }
+  } catch (e) {
+    return e instanceof Error ? e.message : 'Invalid condition format';
+  }
+
+  // Validate max conditions
+  const totalConditions =
+    ((route.route as any).has ?? []).length +
+    ((route.route as any).missing ?? []).length;
+  if (totalConditions > MAX_CONDITIONS) {
+    return `Too many conditions: ${totalConditions}. Maximum is ${MAX_CONDITIONS}.`;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Interactive edit sub-menus
+// ---------------------------------------------------------------------------
+
+async function editName(client: Client, route: RoutingRule): Promise<void> {
+  const name = await client.input.text({
+    message: `Name (current: ${route.name}):`,
+    validate: val => {
+      if (!val) return 'Route name is required';
+      if (val.length > MAX_NAME_LENGTH)
+        return `Name must be ${MAX_NAME_LENGTH} characters or less`;
+      return true;
+    },
+  });
+  route.name = name;
+}
+
+async function editDescription(
+  client: Client,
+  route: RoutingRule
+): Promise<void> {
+  const desc = await client.input.text({
+    message: `Description (current: ${route.description ?? '(none)'}):`,
+    validate: val =>
+      val && val.length > MAX_DESCRIPTION_LENGTH
+        ? `Description must be ${MAX_DESCRIPTION_LENGTH} characters or less`
+        : true,
+  });
+  route.description = desc || undefined;
+}
+
+async function editSource(client: Client, route: RoutingRule): Promise<void> {
+  const syntaxChoice = await client.input.select({
+    message: `Path syntax (current: ${route.srcSyntax ?? 'regex'}):`,
+    choices: [
+      {
+        name: 'Path pattern (e.g., /api/:version/users/:id)',
+        value: 'path-to-regexp',
+      },
+      { name: 'Exact match (e.g., /about)', value: 'equals' },
+      { name: 'Regular expression (e.g., ^/api/(.*)$)', value: 'regex' },
+    ],
+  });
+  route.srcSyntax = syntaxChoice as SrcSyntax;
+
+  const src = await client.input.text({
+    message: `Path pattern (current: ${route.route.src}):`,
+    validate: val => {
+      if (!val) return 'Path pattern is required';
+      return true;
+    },
+  });
+  route.route.src = src;
+}
+
+async function editPrimaryAction(
+  client: Client,
+  route: RoutingRule
+): Promise<void> {
+  const currentType = getPrimaryActionType(route);
+
+  const choices: Array<{ name: string; value: string }> = [];
+
+  if (currentType === 'rewrite' || currentType === 'redirect') {
+    choices.push({ name: 'Change destination', value: 'change-dest' });
+  }
+  if (currentType === 'redirect' || currentType === 'set-status') {
+    choices.push({ name: 'Change status code', value: 'change-status' });
+  }
+
+  // Offer to switch to a different type
+  if (currentType !== 'rewrite') {
+    choices.push({ name: 'Switch to Rewrite', value: 'switch-rewrite' });
+  }
+  if (currentType !== 'redirect') {
+    choices.push({ name: 'Switch to Redirect', value: 'switch-redirect' });
+  }
+  if (currentType !== 'set-status') {
+    choices.push({
+      name: 'Switch to Set Status Code',
+      value: 'switch-set-status',
+    });
+  }
+  if (currentType) {
+    choices.push({
+      name: 'Remove primary action',
+      value: 'remove',
+    });
+  } else {
+    choices.push({ name: 'Add Rewrite', value: 'switch-rewrite' });
+    choices.push({ name: 'Add Redirect', value: 'switch-redirect' });
+    choices.push({ name: 'Add Set Status Code', value: 'switch-set-status' });
+  }
+
+  choices.push({ name: 'Back', value: 'back' });
+
+  const action = await client.input.select({
+    message: `Primary action (current: ${getPrimaryActionLabel(route)}):`,
+    choices,
+  });
+
+  const flags: Record<string, unknown> = {};
+
+  switch (action) {
+    case 'change-dest': {
+      const dest = await client.input.text({
+        message: `Destination (current: ${route.route.dest}):`,
+        validate: val => (val ? true : 'Destination is required'),
+      });
+      route.route.dest = dest;
+      break;
+    }
+    case 'change-status': {
+      if (currentType === 'redirect') {
+        const status = await client.input.select({
+          message: `Status code (current: ${route.route.status}):`,
+          choices: [
+            { name: '307 - Temporary Redirect', value: 307 },
+            { name: '308 - Permanent Redirect', value: 308 },
+            { name: '301 - Moved Permanently', value: 301 },
+            { name: '302 - Found', value: 302 },
+          ],
+        });
+        route.route.status = status as number;
+      } else {
+        const statusCode = await client.input.text({
+          message: `Status code (current: ${route.route.status}):`,
+          validate: val => {
+            const num = parseInt(val, 10);
+            if (isNaN(num) || num < 100 || num > 599) {
+              return 'Status code must be between 100 and 599';
+            }
+            return true;
+          },
+        });
+        route.route.status = parseInt(statusCode, 10);
+      }
+      break;
+    }
+    case 'switch-rewrite': {
+      await collectActionDetails(client, 'rewrite', flags);
+      route.route.dest = flags['--dest'] as string;
+      delete (route.route as any).status;
+      break;
+    }
+    case 'switch-redirect': {
+      await collectActionDetails(client, 'redirect', flags);
+      route.route.dest = flags['--dest'] as string;
+      route.route.status = flags['--status'] as number;
+      break;
+    }
+    case 'switch-set-status': {
+      await collectActionDetails(client, 'set-status', flags);
+      delete (route.route as any).dest;
+      route.route.status = flags['--status'] as number;
+      break;
+    }
+    case 'remove': {
+      delete (route.route as any).dest;
+      delete (route.route as any).status;
+      break;
+    }
+    // 'back' — do nothing
+  }
+}
+
+async function editConditions(
+  client: Client,
+  route: RoutingRule
+): Promise<void> {
+  while (true) {
+    const hasConds = ((route.route as any).has ?? []) as Array<{
+      type: string;
+      key?: string;
+      value?: unknown;
+    }>;
+    const missingConds = ((route.route as any).missing ?? []) as Array<{
+      type: string;
+      key?: string;
+      value?: unknown;
+    }>;
+
+    if (hasConds.length > 0 || missingConds.length > 0) {
+      output.print('\n');
+      if (hasConds.length > 0) {
+        output.print(`  ${chalk.cyan('Has conditions:')}\n`);
+        hasConds.forEach((c, i) => {
+          output.print(
+            `    ${chalk.gray(`${i + 1}.`)} ${formatConditionDisplay(c)}\n`
+          );
+        });
+      }
+      if (missingConds.length > 0) {
+        output.print(`  ${chalk.cyan('Missing conditions:')}\n`);
+        missingConds.forEach((c, i) => {
+          output.print(
+            `    ${chalk.gray(`${hasConds.length + i + 1}.`)} ${formatConditionDisplay(c)}\n`
+          );
+        });
+      }
+      output.print('\n');
+    } else {
+      output.print('\n  No conditions set.\n\n');
+    }
+
+    const choices = [];
+    if (hasConds.length > 0 || missingConds.length > 0) {
+      choices.push({ name: 'Remove a condition', value: 'remove' });
+    }
+    choices.push({ name: 'Add a new condition', value: 'add' });
+    choices.push({ name: 'Back', value: 'back' });
+
+    const action = await client.input.select({
+      message: 'Conditions:',
+      choices,
+    });
+
+    if (action === 'back') break;
+
+    if (action === 'remove') {
+      const allConds = [
+        ...hasConds.map((c, i) => ({
+          label: `[has] ${formatConditionDisplay(c)}`,
+          idx: i,
+          kind: 'has' as const,
+        })),
+        ...missingConds.map((c, i) => ({
+          label: `[missing] ${formatConditionDisplay(c)}`,
+          idx: i,
+          kind: 'missing' as const,
+        })),
+      ];
+
+      const toRemove = await client.input.select({
+        message: 'Select condition to remove:',
+        choices: allConds.map((c, i) => ({
+          name: c.label,
+          value: i,
+        })),
+      });
+
+      const selected = allConds[toRemove as number];
+      if (selected.kind === 'has') {
+        hasConds.splice(selected.idx, 1);
+        (route.route as any).has = hasConds;
+      } else {
+        missingConds.splice(selected.idx, 1);
+        (route.route as any).missing = missingConds;
+      }
+    }
+
+    if (action === 'add') {
+      // Use the shared collector but with a temporary flags object
+      const tempFlags: Record<string, unknown> = {};
+      // Pre-populate with existing conditions for display
+      await collectInteractiveConditions(client, tempFlags);
+
+      // Append new conditions to route
+      const newHas = (tempFlags['--has'] as string[]) || [];
+      const newMissing = (tempFlags['--missing'] as string[]) || [];
+
+      if (newHas.length > 0) {
+        const parsed = parseConditions(newHas);
+        const existing = ((route.route as any).has ?? []) as HasField[];
+        (route.route as any).has = [...existing, ...parsed];
+      }
+      if (newMissing.length > 0) {
+        const parsed = parseConditions(newMissing);
+        const existing = ((route.route as any).missing ?? []) as HasField[];
+        (route.route as any).missing = [...existing, ...parsed];
+      }
+    }
+  }
+}
+
+async function editResponseHeaders(
+  client: Client,
+  route: RoutingRule
+): Promise<void> {
+  while (true) {
+    const headers = getResponseHeaders(route);
+
+    if (headers.length > 0) {
+      output.print('\n');
+      output.print(`  ${chalk.cyan('Response Headers:')}\n`);
+      headers.forEach((h, i) => {
+        output.print(
+          `    ${chalk.gray(`${i + 1}.`)} ${chalk.cyan(h.key)} = ${h.value}\n`
+        );
+      });
+      output.print('\n');
+    } else {
+      output.print('\n  No response headers set.\n\n');
+    }
+
+    const choices = [];
+    if (headers.length > 0) {
+      choices.push({ name: 'Remove a header', value: 'remove' });
+    }
+    choices.push({ name: 'Add/modify a header', value: 'add' });
+    choices.push({ name: 'Back', value: 'back' });
+
+    const action = await client.input.select({
+      message: 'Response Headers:',
+      choices,
+    });
+
+    if (action === 'back') break;
+
+    if (action === 'remove') {
+      const toRemove = await client.input.select({
+        message: 'Select header to remove:',
+        choices: headers.map((h, i) => ({
+          name: `${h.key} = ${h.value}`,
+          value: i,
+        })),
+      });
+
+      const headerKey = headers[toRemove as number].key;
+      const currentHeaders = { ...(route.route.headers ?? {}) };
+      delete currentHeaders[headerKey];
+      route.route.headers = currentHeaders;
+    }
+
+    if (action === 'add') {
+      const tempFlags: Record<string, unknown> = {};
+      await collectInteractiveHeaders(client, 'response', tempFlags);
+
+      // Merge set headers
+      const setHeaders = (tempFlags['--set-response-header'] as string[]) || [];
+      for (const h of setHeaders) {
+        const eqIdx = h.indexOf('=');
+        if (eqIdx !== -1) {
+          const key = h.slice(0, eqIdx).trim();
+          const value = h.slice(eqIdx + 1);
+          route.route.headers = {
+            ...(route.route.headers ?? {}),
+            [key]: value,
+          };
+        }
+      }
+
+      // Append/delete as transforms
+      const appendHeaders =
+        (tempFlags['--append-response-header'] as string[]) || [];
+      const deleteHeaders =
+        (tempFlags['--delete-response-header'] as string[]) || [];
+
+      const existing = ((route.route as any).transforms ?? []) as Transform[];
+      const newTransforms: Transform[] = [];
+
+      for (const h of appendHeaders) {
+        const eqIdx = h.indexOf('=');
+        if (eqIdx !== -1) {
+          newTransforms.push({
+            type: 'response.headers',
+            op: 'append',
+            target: { key: h.slice(0, eqIdx).trim() },
+            args: h.slice(eqIdx + 1),
+          });
+        }
+      }
+      for (const key of deleteHeaders) {
+        newTransforms.push({
+          type: 'response.headers',
+          op: 'delete',
+          target: { key: key.trim() },
+        });
+      }
+
+      if (newTransforms.length > 0) {
+        (route.route as any).transforms = [...existing, ...newTransforms];
+      }
+    }
+  }
+}
+
+async function editTransformsByType(
+  client: Client,
+  route: RoutingRule,
+  transformType: 'request.headers' | 'request.query',
+  headerType: 'request-header' | 'request-query'
+): Promise<void> {
+  const label =
+    transformType === 'request.headers' ? 'Request Headers' : 'Request Query';
+
+  while (true) {
+    const allTransforms = ((route.route as any).transforms ??
+      []) as Transform[];
+    const matching = allTransforms.filter(t => t.type === transformType);
+
+    if (matching.length > 0) {
+      output.print('\n');
+      output.print(`  ${chalk.cyan(`${label}:`)}\n`);
+      matching.forEach((t, i) => {
+        output.print(
+          `    ${chalk.gray(`${i + 1}.`)} ${formatTransformDisplay(t)}\n`
+        );
+      });
+      output.print('\n');
+    } else {
+      output.print(`\n  No ${label.toLowerCase()} set.\n\n`);
+    }
+
+    const choices = [];
+    if (matching.length > 0) {
+      choices.push({ name: 'Remove a transform', value: 'remove' });
+    }
+    choices.push({ name: 'Add a transform', value: 'add' });
+    choices.push({ name: 'Back', value: 'back' });
+
+    const action = await client.input.select({
+      message: `${label}:`,
+      choices,
+    });
+
+    if (action === 'back') break;
+
+    if (action === 'remove') {
+      const toRemove = await client.input.select({
+        message: 'Select transform to remove:',
+        choices: matching.map((t, i) => ({
+          name: formatTransformDisplay(t),
+          value: i,
+        })),
+      });
+
+      // Find the actual index in the full transforms array
+      let matchIdx = 0;
+      const removeIdx = allTransforms.findIndex(t => {
+        if (t.type === transformType) {
+          if (matchIdx === (toRemove as number)) return true;
+          matchIdx++;
+        }
+        return false;
+      });
+
+      if (removeIdx !== -1) {
+        allTransforms.splice(removeIdx, 1);
+        (route.route as any).transforms = allTransforms;
+      }
+    }
+
+    if (action === 'add') {
+      const tempFlags: Record<string, unknown> = {};
+      await collectInteractiveHeaders(client, headerType, tempFlags);
+
+      // Collect new transforms from temp flags
+      const tfFlags = extractTransformFlags(tempFlags);
+      const { transforms } = collectHeadersAndTransforms(tfFlags);
+
+      if (transforms.length > 0) {
+        (route.route as any).transforms = [...allTransforms, ...transforms];
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main edit command
+// ---------------------------------------------------------------------------
+
+export default async function edit(client: Client, argv: string[]) {
+  const parsed = await parseSubcommandArgs(argv, editSubcommand);
+  if (typeof parsed === 'number') return parsed;
+
+  const link = await ensureProjectLink(client);
+  if (typeof link === 'number') return link;
+
+  const { project, org } = link;
+  const teamId = org.type === 'team' ? org.id : undefined;
+  const { args, flags } = parsed;
+  const skipConfirmation = flags['--yes'] as boolean | undefined;
+  const identifier = args[0];
+
+  if (!identifier) {
+    output.error(
+      `Route name or ID is required. Usage: ${getCommandName('routes edit <name-or-id>')}`
+    );
+    return 1;
+  }
+
+  // Check for existing staging version (for auto-promote logic)
+  const { versions } = await getRouteVersions(client, project.id, { teamId });
+  const existingStagingVersion = versions.find(v => v.isStaging);
+
+  // Fetch all routes
+  output.spinner('Fetching routes');
+  const { routes } = await getRoutes(client, project.id, { teamId });
+  output.stopSpinner();
+
+  if (routes.length === 0) {
+    output.error('No routes found in this project.');
+    return 1;
+  }
+
+  // Resolve the route
+  const originalRoute = await resolveRoute(client, routes, identifier);
+  if (!originalRoute) {
+    output.error(
+      `No route found matching "${identifier}". Run ${chalk.cyan(
+        getCommandName('routes list')
+      )} to see all routes.`
+    );
+    return 1;
+  }
+
+  // Clone the route for mutation
+  const route = cloneRoute(originalRoute);
+
+  // Determine mode: flag-based or interactive
+  const hasEditFlags =
+    flags['--name'] !== undefined ||
+    flags['--description'] !== undefined ||
+    flags['--src'] !== undefined ||
+    flags['--src-syntax'] !== undefined ||
+    flags['--action'] !== undefined ||
+    flags['--dest'] !== undefined ||
+    flags['--status'] !== undefined ||
+    flags['--no-dest'] !== undefined ||
+    flags['--no-status'] !== undefined ||
+    flags['--has'] !== undefined ||
+    flags['--missing'] !== undefined ||
+    flags['--clear-conditions'] !== undefined ||
+    flags['--clear-headers'] !== undefined ||
+    flags['--clear-transforms'] !== undefined ||
+    hasAnyTransformFlags(flags);
+
+  if (hasEditFlags) {
+    // --- Flag-based mode ---
+    const error = applyFlagMutations(route, flags);
+    if (error) {
+      output.error(error);
+      return 1;
+    }
+  } else {
+    // --- Interactive mode ---
+    output.log(`\nEditing route "${originalRoute.name}"`);
+    printRouteConfig(route);
+
+    while (true) {
+      const hasConds = ((route.route as any).has ?? []).length;
+      const missingConds = ((route.route as any).missing ?? []).length;
+      const responseHeaders = getResponseHeaders(route).length;
+      const requestHeaders = getTransformsByType(
+        route,
+        'request.headers'
+      ).length;
+      const requestQuery = getTransformsByType(route, 'request.query').length;
+
+      const choice = await client.input.select({
+        message: 'What would you like to edit?',
+        choices: [
+          { name: 'Name', value: 'name' },
+          { name: 'Description', value: 'description' },
+          { name: 'Source pattern & syntax', value: 'source' },
+          {
+            name: `Primary action (${getPrimaryActionLabel(route)})`,
+            value: 'action',
+          },
+          {
+            name: `Conditions (${hasConds} has, ${missingConds} missing)`,
+            value: 'conditions',
+          },
+          {
+            name: `Response Headers (${responseHeaders})`,
+            value: 'response-headers',
+          },
+          {
+            name: `Request Headers (${requestHeaders})`,
+            value: 'request-headers',
+          },
+          {
+            name: `Request Query (${requestQuery})`,
+            value: 'request-query',
+          },
+          { name: 'Done - save changes', value: 'done' },
+        ],
+      });
+
+      switch (choice) {
+        case 'name':
+          await editName(client, route);
+          break;
+        case 'description':
+          await editDescription(client, route);
+          break;
+        case 'source':
+          await editSource(client, route);
+          break;
+        case 'action':
+          await editPrimaryAction(client, route);
+          break;
+        case 'conditions':
+          await editConditions(client, route);
+          break;
+        case 'response-headers':
+          await editResponseHeaders(client, route);
+          break;
+        case 'request-headers':
+          await editTransformsByType(
+            client,
+            route,
+            'request.headers',
+            'request-header'
+          );
+          break;
+        case 'request-query':
+          await editTransformsByType(
+            client,
+            route,
+            'request.query',
+            'request-query'
+          );
+          break;
+        case 'done':
+          break;
+      }
+
+      if (choice === 'done') break;
+    }
+  }
+
+  // Check if anything actually changed
+  if (JSON.stringify(route) === JSON.stringify(originalRoute)) {
+    output.log('No changes made.');
+    return 0;
+  }
+
+  // Send the update
+  const editStamp = stamp();
+  output.spinner(`Updating route "${route.name}"`);
+
+  try {
+    const { version } = await editRoute(
+      client,
+      project.id,
+      originalRoute.id,
+      {
+        route: {
+          name: route.name,
+          description: route.description,
+          enabled: route.enabled,
+          srcSyntax: route.srcSyntax,
+          route: route.route,
+        },
+      },
+      { teamId }
+    );
+
+    output.log(
+      `${chalk.cyan('Updated')} route "${route.name}" ${chalk.gray(editStamp())}`
+    );
+
+    // Auto-promote offer
+    await offerAutoPromote(
+      client,
+      project.id,
+      version,
+      !!existingStagingVersion,
+      { teamId, skipPrompts: skipConfirmation }
+    );
+
+    return 0;
+  } catch (e: unknown) {
+    const error = e as { message?: string; code?: string };
+    if (error.code === 'feature_not_enabled') {
+      output.error(
+        'Project-level routes are not enabled for this project. Please contact support.'
+      );
+    } else {
+      output.error(error.message || 'Failed to update route');
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/routes/index.ts
+++ b/packages/cli/src/commands/routes/index.ts
@@ -14,6 +14,7 @@ import {
   listVersionsSubcommand,
   inspectSubcommand,
   addSubcommand,
+  editSubcommand,
   deleteSubcommand,
   enableSubcommand,
   disableSubcommand,
@@ -32,6 +33,7 @@ const COMMAND_CONFIG = {
   'list-versions': getCommandAliases(listVersionsSubcommand),
   inspect: getCommandAliases(inspectSubcommand),
   add: getCommandAliases(addSubcommand),
+  edit: getCommandAliases(editSubcommand),
   delete: getCommandAliases(deleteSubcommand),
   enable: getCommandAliases(enableSubcommand),
   disable: getCommandAliases(disableSubcommand),
@@ -115,6 +117,14 @@ export default async function main(client: Client) {
       }
       telemetry.trackCliSubcommandAdd(subcommandOriginal);
       return add(client, args);
+    case 'edit':
+      if (needHelp) {
+        telemetry.trackCliFlagHelp('routes', subcommandOriginal);
+        printHelp(editSubcommand);
+        return 2;
+      }
+      telemetry.trackCliSubcommandEdit(subcommandOriginal);
+      return (await import('./edit')).default(client, args);
     case 'delete':
       if (needHelp) {
         telemetry.trackCliFlagHelp('routes', subcommandOriginal);

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -503,9 +503,7 @@ function formatRouteDetails(rule: RoutingRule): string {
       `  ${chalk.cyan('State:')}       ${chalk.yellow('Staged (not yet published)')}`
     );
   } else if (rule.staged === false) {
-    lines.push(
-      `  ${chalk.cyan('State:')}       ${chalk.green('Published')}`
-    );
+    lines.push(`  ${chalk.cyan('State:')}       ${chalk.green('Published')}`);
   }
   lines.push(`  ${chalk.cyan('Type:')}        ${typeLabels}`);
   lines.push('');

--- a/packages/cli/src/commands/routes/inspect.ts
+++ b/packages/cli/src/commands/routes/inspect.ts
@@ -488,10 +488,6 @@ function formatRouteDetails(rule: RoutingRule): string {
   const syntaxLabel = getSrcSyntaxLabel(rule);
   const statusText =
     rule.enabled === false ? chalk.red('Disabled') : chalk.green('Enabled');
-  const stagedText = rule.staged
-    ? chalk.yellow('Staged (not yet published)')
-    : chalk.green('Published');
-
   lines.push(`  ${chalk.bold(rule.name)}`);
   lines.push(`  ${chalk.gray(rule.id)}`);
   lines.push('');
@@ -502,7 +498,15 @@ function formatRouteDetails(rule: RoutingRule): string {
   }
 
   lines.push(`  ${chalk.cyan('Status:')}      ${statusText}`);
-  lines.push(`  ${chalk.cyan('State:')}       ${stagedText}`);
+  if (rule.staged === true) {
+    lines.push(
+      `  ${chalk.cyan('State:')}       ${chalk.yellow('Staged (not yet published)')}`
+    );
+  } else if (rule.staged === false) {
+    lines.push(
+      `  ${chalk.cyan('State:')}       ${chalk.green('Published')}`
+    );
+  }
   lines.push(`  ${chalk.cyan('Type:')}        ${typeLabels}`);
   lines.push('');
 

--- a/packages/cli/src/util/routes/interactive.ts
+++ b/packages/cli/src/util/routes/interactive.ts
@@ -1,0 +1,498 @@
+/**
+ * Shared interactive helpers for route commands (add, edit).
+ * Contains constants, pure utilities, flag processing, and interactive collectors
+ * for actions, conditions, and transforms.
+ */
+import type Client from '../client';
+import output from '../../output-manager';
+import {
+  collectTransforms,
+  collectResponseHeaders,
+  type TransformFlags,
+} from './parse-transforms';
+import type { Transform, SrcSyntax } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAX_NAME_LENGTH = 256;
+export const MAX_DESCRIPTION_LENGTH = 1024;
+export const MAX_CONDITIONS = 16;
+export const VALID_SYNTAXES: SrcSyntax[] = [
+  'regex',
+  'path-to-regexp',
+  'equals',
+];
+export const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
+export const VALID_ACTION_TYPES = [
+  'rewrite',
+  'redirect',
+  'set-status',
+] as const;
+export type ActionType = (typeof VALID_ACTION_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Action choices for interactive menus
+// ---------------------------------------------------------------------------
+
+export interface ActionChoice {
+  name: string;
+  value: string;
+  exclusive?: boolean;
+}
+
+export const ALL_ACTION_CHOICES: ActionChoice[] = [
+  { name: 'Rewrite', value: 'rewrite', exclusive: true },
+  { name: 'Redirect', value: 'redirect', exclusive: true },
+  { name: 'Set Status Code', value: 'set-status', exclusive: true },
+  { name: 'Response Headers', value: 'response-headers' },
+  { name: 'Request Headers', value: 'request-headers' },
+  { name: 'Request Query', value: 'request-query' },
+];
+
+// ---------------------------------------------------------------------------
+// Pure utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Strips leading and trailing quotes (single or double) from a string.
+ */
+export function stripQuotes(str: string): string {
+  if (str.startsWith('"') && str.endsWith('"') && str.length >= 2) {
+    return str.slice(1, -1);
+  }
+  if (str.startsWith("'") && str.endsWith("'") && str.length >= 2) {
+    return str.slice(1, -1);
+  }
+  return str;
+}
+
+// Condition operators and compilation are in parse-conditions.ts
+
+// ---------------------------------------------------------------------------
+// Flag processing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts transform flags from parsed CLI flags into a typed object.
+ */
+export function extractTransformFlags(
+  flags: Record<string, unknown>
+): TransformFlags {
+  return {
+    setResponseHeader: flags['--set-response-header'] as string[] | undefined,
+    appendResponseHeader: flags['--append-response-header'] as
+      | string[]
+      | undefined,
+    deleteResponseHeader: flags['--delete-response-header'] as
+      | string[]
+      | undefined,
+    setRequestHeader: flags['--set-request-header'] as string[] | undefined,
+    appendRequestHeader: flags['--append-request-header'] as
+      | string[]
+      | undefined,
+    deleteRequestHeader: flags['--delete-request-header'] as
+      | string[]
+      | undefined,
+    setRequestQuery: flags['--set-request-query'] as string[] | undefined,
+    appendRequestQuery: flags['--append-request-query'] as string[] | undefined,
+    deleteRequestQuery: flags['--delete-request-query'] as string[] | undefined,
+  };
+}
+
+/**
+ * Collects headers and transforms from transform flags.
+ * Response header 'set' operations go to headers object (matching frontend behavior).
+ * All other operations go to transforms array.
+ */
+export function collectHeadersAndTransforms(transformFlags: TransformFlags): {
+  headers: Record<string, string>;
+  transforms: Transform[];
+} {
+  const headers = transformFlags.setResponseHeader
+    ? collectResponseHeaders(transformFlags.setResponseHeader)
+    : {};
+
+  const transforms = collectTransforms({
+    ...transformFlags,
+    setResponseHeader: undefined, // Already handled in headers
+  });
+
+  return { headers, transforms };
+}
+
+/**
+ * Returns true if any transform flags are set.
+ */
+export function hasAnyTransformFlags(flags: Record<string, unknown>): boolean {
+  const tf = extractTransformFlags(flags);
+  return !!(
+    tf.setResponseHeader ||
+    tf.appendResponseHeader ||
+    tf.deleteResponseHeader ||
+    tf.setRequestHeader ||
+    tf.appendRequestHeader ||
+    tf.deleteRequestHeader ||
+    tf.setRequestQuery ||
+    tf.appendRequestQuery ||
+    tf.deleteRequestQuery
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Action type validation for flag mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the --action flag value and its required companion flags.
+ * Returns an error message string or null if valid.
+ */
+export function validateActionFlags(
+  action: string | undefined,
+  dest: string | undefined,
+  status: number | undefined
+): string | null {
+  if (!action) {
+    // No --action flag. If dest or status is provided, that's an error.
+    if (dest || status !== undefined) {
+      return '--action is required when using --dest or --status. Use --action rewrite, --action redirect, or --action set-status.';
+    }
+    return null;
+  }
+
+  if (!VALID_ACTION_TYPES.includes(action as ActionType)) {
+    return `Invalid action type: "${action}". Valid types: ${VALID_ACTION_TYPES.join(', ')}`;
+  }
+
+  switch (action) {
+    case 'rewrite':
+      if (!dest) return '--action rewrite requires --dest.';
+      if (status !== undefined)
+        return '--action rewrite does not accept --status.';
+      break;
+    case 'redirect':
+      if (!dest) return '--action redirect requires --dest.';
+      if (status === undefined)
+        return '--action redirect requires --status (301, 302, 307, or 308).';
+      if (!REDIRECT_STATUS_CODES.includes(status))
+        return `Invalid redirect status: ${status}. Must be one of: ${REDIRECT_STATUS_CODES.join(', ')}`;
+      break;
+    case 'set-status':
+      if (dest) return '--action set-status does not accept --dest.';
+      if (status === undefined) return '--action set-status requires --status.';
+      if (status < 100 || status > 599)
+        return 'Status code must be between 100 and 599.';
+      break;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Interactive collectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Collects the details for a specific action type interactively.
+ * Prompts for destination, status code, etc. based on the action type.
+ * Sets the result on the flags object for later processing.
+ */
+export async function collectActionDetails(
+  client: Client,
+  actionType: string,
+  flags: Record<string, unknown>
+): Promise<void> {
+  switch (actionType) {
+    case 'rewrite': {
+      const dest = await client.input.text({
+        message: 'Destination URL:',
+        validate: val => (val ? true : 'Destination is required'),
+      });
+      Object.assign(flags, { '--dest': dest });
+      break;
+    }
+    case 'redirect': {
+      const dest = await client.input.text({
+        message: 'Destination URL:',
+        validate: val => (val ? true : 'Destination is required'),
+      });
+      const status = await client.input.select({
+        message: 'Status code:',
+        choices: [
+          { name: '307 - Temporary Redirect (preserves method)', value: 307 },
+          { name: '308 - Permanent Redirect (preserves method)', value: 308 },
+          { name: '301 - Moved Permanently (may change to GET)', value: 301 },
+          { name: '302 - Found (may change to GET)', value: 302 },
+        ],
+      });
+      Object.assign(flags, { '--dest': dest, '--status': status });
+      break;
+    }
+    case 'set-status': {
+      const statusCode = await client.input.text({
+        message: 'HTTP status code:',
+        validate: val => {
+          const num = parseInt(val, 10);
+          if (isNaN(num) || num < 100 || num > 599) {
+            return 'Status code must be between 100 and 599';
+          }
+          return true;
+        },
+      });
+      Object.assign(flags, { '--status': parseInt(statusCode, 10) });
+      break;
+    }
+    case 'response-headers': {
+      await collectInteractiveHeaders(client, 'response', flags);
+      break;
+    }
+    case 'request-headers': {
+      await collectInteractiveHeaders(client, 'request-header', flags);
+      break;
+    }
+    case 'request-query': {
+      await collectInteractiveHeaders(client, 'request-query', flags);
+      break;
+    }
+  }
+}
+
+/**
+ * Interactive condition collection with operator support.
+ * Supports equals, contains, matches (regex), and exists operators,
+ * matching the frontend's condition-rows.tsx behavior.
+ */
+export async function collectInteractiveConditions(
+  client: Client,
+  flags: Record<string, unknown>
+): Promise<void> {
+  let addMore = true;
+
+  while (addMore) {
+    const currentHas = (flags['--has'] as string[]) || [];
+    const currentMissing = (flags['--missing'] as string[]) || [];
+
+    if (currentHas.length > 0 || currentMissing.length > 0) {
+      output.log('\nCurrent conditions:');
+      for (const c of currentHas) {
+        output.print(`  has: ${c}\n`);
+      }
+      for (const c of currentMissing) {
+        output.print(`  missing: ${c}\n`);
+      }
+      output.print('\n');
+    }
+
+    const conditionType = await client.input.select({
+      message: 'Condition type:',
+      choices: [
+        { name: 'has - Request must have this', value: 'has' },
+        { name: 'missing - Request must NOT have this', value: 'missing' },
+      ],
+    });
+
+    const targetType = await client.input.select({
+      message: 'What to check:',
+      choices: [
+        { name: 'Header', value: 'header' },
+        { name: 'Cookie', value: 'cookie' },
+        { name: 'Query Parameter', value: 'query' },
+        { name: 'Host', value: 'host' },
+      ],
+    });
+
+    let conditionValue: string;
+
+    if (targetType === 'host') {
+      const operator = await client.input.select({
+        message: 'How to match the host:',
+        choices: [
+          { name: 'Equals', value: 'eq' },
+          { name: 'Contains', value: 'contains' },
+          { name: 'Matches (regex)', value: 're' },
+        ],
+      });
+
+      const hostInput = await client.input.text({
+        message: operator === 're' ? 'Host pattern (regex):' : 'Host value:',
+        validate: val => {
+          if (!val) return 'Host value is required';
+          if (operator === 're') {
+            try {
+              new RegExp(val);
+              return true;
+            } catch {
+              return 'Invalid regex pattern';
+            }
+          }
+          return true;
+        },
+      });
+
+      // Store as host:op=value — parseConditions will compile the operator
+      conditionValue = `host:${operator}=${hostInput}`;
+    } else {
+      const key = await client.input.text({
+        message: `${targetType.charAt(0).toUpperCase() + targetType.slice(1)} name:`,
+        validate: val => (val ? true : `${targetType} name is required`),
+      });
+
+      const operator = await client.input.select({
+        message: 'How to match the value:',
+        choices: [
+          { name: 'Exists (any value)', value: 'exists' },
+          { name: 'Equals', value: 'eq' },
+          { name: 'Contains', value: 'contains' },
+          { name: 'Matches (regex)', value: 're' },
+        ],
+      });
+
+      if (operator === 'exists') {
+        // Store as type:key:exists — parseConditions will handle it
+        conditionValue = `${targetType}:${key}:exists`;
+      } else {
+        const valueInput = await client.input.text({
+          message: operator === 're' ? 'Value pattern (regex):' : 'Value:',
+          validate: val => {
+            if (!val) return 'Value is required';
+            if (operator === 're') {
+              try {
+                new RegExp(val);
+                return true;
+              } catch {
+                return 'Invalid regex pattern';
+              }
+            }
+            return true;
+          },
+        });
+
+        // Store as type:key:op=value — parseConditions will compile the operator
+        conditionValue = `${targetType}:${key}:${operator}=${valueInput}`;
+      }
+    }
+
+    const flagName = conditionType === 'has' ? '--has' : '--missing';
+    const existing = (flags[flagName] as string[]) || [];
+    flags[flagName] = [...existing, conditionValue];
+
+    const totalConditions =
+      ((flags['--has'] as string[]) || []).length +
+      ((flags['--missing'] as string[]) || []).length;
+
+    if (totalConditions >= MAX_CONDITIONS) {
+      output.warn(`Maximum ${MAX_CONDITIONS} conditions reached.`);
+      break;
+    }
+
+    addMore = await client.input.confirm('Add another condition?', false);
+  }
+}
+
+/**
+ * Formats currently collected headers/params from flags for display.
+ */
+export function formatCollectedItems(
+  flags: Record<string, unknown>,
+  type: 'response' | 'request-header' | 'request-query'
+): string[] {
+  const items: string[] = [];
+  const prefix =
+    type === 'response'
+      ? 'response-header'
+      : type === 'request-header'
+        ? 'request-header'
+        : 'request-query';
+
+  const setItems = (flags[`--set-${prefix}`] as string[]) || [];
+  const appendItems = (flags[`--append-${prefix}`] as string[]) || [];
+  const deleteItems = (flags[`--delete-${prefix}`] as string[]) || [];
+
+  for (const item of setItems) {
+    items.push(`  set: ${item}`);
+  }
+  for (const item of appendItems) {
+    items.push(`  append: ${item}`);
+  }
+  for (const item of deleteItems) {
+    items.push(`  delete: ${item}`);
+  }
+
+  return items;
+}
+
+/**
+ * Interactive header/transform collection for modify actions.
+ * Supports response headers, request headers, and request query parameters.
+ */
+export async function collectInteractiveHeaders(
+  client: Client,
+  type: 'response' | 'request-header' | 'request-query',
+  flags: Record<string, unknown>
+): Promise<void> {
+  const flagName =
+    type === 'response'
+      ? '--set-response-header'
+      : type === 'request-header'
+        ? '--set-request-header'
+        : '--set-request-query';
+
+  const sectionName =
+    type === 'response'
+      ? 'Response Headers'
+      : type === 'request-header'
+        ? 'Request Headers'
+        : 'Request Query Parameters';
+
+  const itemName =
+    type === 'response'
+      ? 'response header'
+      : type === 'request-header'
+        ? 'request header'
+        : 'query parameter';
+
+  output.log(`\n--- ${sectionName} ---`);
+
+  let addMore = true;
+  while (addMore) {
+    const collected = formatCollectedItems(flags, type);
+    if (collected.length > 0) {
+      output.log(`\nCurrent ${sectionName.toLowerCase()}:`);
+      for (const item of collected) {
+        output.print(`${item}\n`);
+      }
+      output.print('\n');
+    }
+
+    const op = await client.input.select({
+      message: `${sectionName} operation:`,
+      choices: [
+        { name: 'Set', value: 'set' },
+        { name: 'Append', value: 'append' },
+        { name: 'Delete', value: 'delete' },
+      ],
+    });
+
+    const key = await client.input.text({
+      message: `${itemName.charAt(0).toUpperCase() + itemName.slice(1)} name:`,
+      validate: val => (val ? true : `${itemName} name is required`),
+    });
+
+    if (op === 'delete') {
+      const opFlagName = flagName.replace('--set-', '--delete-');
+      const existing = (flags[opFlagName] as string[]) || [];
+      flags[opFlagName] = [...existing, key];
+    } else {
+      const value = await client.input.text({
+        message: `${itemName.charAt(0).toUpperCase() + itemName.slice(1)} value:`,
+      });
+      const opFlagName =
+        op === 'append' ? flagName.replace('--set-', '--append-') : flagName;
+      const existing = (flags[opFlagName] as string[]) || [];
+      flags[opFlagName] = [...existing, `${key}=${value}`];
+    }
+
+    addMore = await client.input.confirm(`Add another ${itemName}?`, false);
+  }
+}

--- a/packages/cli/src/util/routes/interactive.ts
+++ b/packages/cli/src/util/routes/interactive.ts
@@ -174,7 +174,7 @@ export function validateActionFlags(
     case 'redirect':
       if (!dest) return '--action redirect requires --dest.';
       if (status === undefined)
-        return '--action redirect requires --status (301, 302, 307, or 308).';
+        return `--action redirect requires --status (${REDIRECT_STATUS_CODES.join(', ')}).`;
       if (!REDIRECT_STATUS_CODES.includes(status))
         return `Invalid redirect status: ${status}. Must be one of: ${REDIRECT_STATUS_CODES.join(', ')}`;
       break;
@@ -224,6 +224,7 @@ export async function collectActionDetails(
           { name: '308 - Permanent Redirect (preserves method)', value: 308 },
           { name: '301 - Moved Permanently (may change to GET)', value: 301 },
           { name: '302 - Found (may change to GET)', value: 302 },
+          { name: '303 - See Other', value: 303 },
         ],
       });
       Object.assign(flags, { '--dest': dest, '--status': status });

--- a/packages/cli/src/util/routes/interactive.ts
+++ b/packages/cli/src/util/routes/interactive.ts
@@ -220,10 +220,10 @@ export async function collectActionDetails(
       const status = await client.input.select({
         message: 'Status code:',
         choices: [
-          { name: '307 - Temporary Redirect (preserves method)', value: 307 },
-          { name: '308 - Permanent Redirect (preserves method)', value: 308 },
-          { name: '301 - Moved Permanently (may change to GET)', value: 301 },
-          { name: '302 - Found (may change to GET)', value: 302 },
+          { name: '307 - Temporary Redirect', value: 307 },
+          { name: '308 - Permanent Redirect', value: 308 },
+          { name: '301 - Moved Permanently', value: 301 },
+          { name: '302 - Found', value: 302 },
           { name: '303 - See Other', value: 303 },
         ],
       });

--- a/packages/cli/src/util/routes/types.ts
+++ b/packages/cli/src/util/routes/types.ts
@@ -22,7 +22,7 @@ export interface RoutingRule {
   name: string;
   description?: string;
   enabled?: boolean;
-  staged: boolean;
+  staged?: boolean;
   route: RouteWithSrc;
   /**
    * The syntax type of the source pattern.

--- a/packages/cli/src/util/telemetry/commands/routes/index.ts
+++ b/packages/cli/src/util/telemetry/commands/routes/index.ts
@@ -85,6 +85,34 @@ export class RoutesTelemetryClient
       value: actual,
     });
   }
+
+  trackCliSubcommandDelete(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'delete',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandEnable(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'enable',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandDisable(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'disable',
+      value: actual,
+    });
+  }
+
+  trackCliSubcommandReorder(actual: string) {
+    this.trackCliSubcommand({
+      subcommand: 'reorder',
+      value: actual,
+    });
+  }
 }
 
 /**

--- a/packages/cli/src/util/telemetry/commands/routes/index.ts
+++ b/packages/cli/src/util/telemetry/commands/routes/index.ts
@@ -3,6 +3,7 @@ import type { TelemetryMethods } from '../../types';
 import type {
   routesCommand,
   addSubcommand,
+  editSubcommand,
 } from '../../../../commands/routes/command';
 
 export class RoutesTelemetryClient
@@ -323,6 +324,191 @@ export class RoutesAddTelemetryClient
   trackCliFlagRequestTransforms(hasRequestTransforms: boolean) {
     if (hasRequestTransforms) {
       this.trackCliFlag('request-transforms');
+    }
+  }
+}
+
+/**
+ * Telemetry client for the `routes edit` subcommand.
+ */
+export class RoutesEditTelemetryClient
+  extends TelemetryClient
+  implements TelemetryMethods<typeof editSubcommand>
+{
+  trackCliArgumentNameOrId(id: string | undefined) {
+    if (id) {
+      this.trackCliArgument({ arg: 'name-or-id', value: this.redactedValue });
+    }
+  }
+
+  trackCliFlagYes(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('yes');
+    }
+  }
+
+  trackCliFlagNoDest(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('no-dest');
+    }
+  }
+
+  trackCliFlagNoStatus(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('no-status');
+    }
+  }
+
+  trackCliFlagClearConditions(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('clear-conditions');
+    }
+  }
+
+  trackCliFlagClearHeaders(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('clear-headers');
+    }
+  }
+
+  trackCliFlagClearTransforms(flag: boolean | undefined) {
+    if (flag) {
+      this.trackCliFlag('clear-transforms');
+    }
+  }
+
+  trackCliOptionName(name: string | undefined) {
+    if (name) {
+      this.trackCliOption({ option: 'name', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionDescription(desc: string | undefined) {
+    if (desc) {
+      this.trackCliOption({ option: 'description', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionSrc(src: string | undefined) {
+    if (src) {
+      this.trackCliOption({ option: 'src', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionSrcSyntax(syntax: string | undefined) {
+    if (syntax) {
+      this.trackCliOption({ option: 'src-syntax', value: syntax });
+    }
+  }
+
+  trackCliOptionAction(action: string | undefined) {
+    if (action) {
+      this.trackCliOption({ option: 'action', value: action });
+    }
+  }
+
+  trackCliOptionDest(dest: string | undefined) {
+    if (dest) {
+      this.trackCliOption({ option: 'dest', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionStatus(status: number | undefined) {
+    if (status !== undefined) {
+      this.trackCliOption({ option: 'status', value: String(status) });
+    }
+  }
+
+  trackCliOptionSetResponseHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'set-response-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAppendResponseHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'append-response-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDeleteResponseHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'delete-response-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSetRequestHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'set-request-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAppendRequestHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'append-request-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDeleteRequestHeader(h: [string] | undefined) {
+    if (h && h.length > 0) {
+      this.trackCliOption({
+        option: 'delete-request-header',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionSetRequestQuery(p: [string] | undefined) {
+    if (p && p.length > 0) {
+      this.trackCliOption({
+        option: 'set-request-query',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionAppendRequestQuery(p: [string] | undefined) {
+    if (p && p.length > 0) {
+      this.trackCliOption({
+        option: 'append-request-query',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionDeleteRequestQuery(p: [string] | undefined) {
+    if (p && p.length > 0) {
+      this.trackCliOption({
+        option: 'delete-request-query',
+        value: this.redactedValue,
+      });
+    }
+  }
+
+  trackCliOptionHas(conditions: [string] | undefined) {
+    if (conditions && conditions.length > 0) {
+      this.trackCliOption({ option: 'has', value: this.redactedValue });
+    }
+  }
+
+  trackCliOptionMissing(conditions: [string] | undefined) {
+    if (conditions && conditions.length > 0) {
+      this.trackCliOption({ option: 'missing', value: this.redactedValue });
     }
   }
 }

--- a/packages/cli/src/util/telemetry/commands/routes/index.ts
+++ b/packages/cli/src/util/telemetry/commands/routes/index.ts
@@ -86,30 +86,9 @@ export class RoutesTelemetryClient
     });
   }
 
-  trackCliSubcommandDelete(actual: string) {
+  trackCliSubcommandEdit(actual: string) {
     this.trackCliSubcommand({
-      subcommand: 'delete',
-      value: actual,
-    });
-  }
-
-  trackCliSubcommandEnable(actual: string) {
-    this.trackCliSubcommand({
-      subcommand: 'enable',
-      value: actual,
-    });
-  }
-
-  trackCliSubcommandDisable(actual: string) {
-    this.trackCliSubcommand({
-      subcommand: 'disable',
-      value: actual,
-    });
-  }
-
-  trackCliSubcommandReorder(actual: string) {
-    this.trackCliSubcommand({
-      subcommand: 'reorder',
+      subcommand: 'edit',
       value: actual,
     });
   }

--- a/packages/cli/test/mocks/routes.ts
+++ b/packages/cli/test/mocks/routes.ts
@@ -741,18 +741,31 @@ export function useEditRouteComprehensive() {
           'X-Custom': 'value',
         },
         transforms: [
-          { type: 'request.headers', op: 'set', target: { key: 'X-Forwarded-Host' }, args: 'myapp.com' },
+          {
+            type: 'request.headers',
+            op: 'set',
+            target: { key: 'X-Forwarded-Host' },
+            args: 'myapp.com',
+          },
           { type: 'request.headers', op: 'delete', target: { key: 'X-Debug' } },
-          { type: 'request.query', op: 'set', target: { key: 'source' }, args: 'cli' },
-          { type: 'response.headers', op: 'append', target: { key: 'Vary' }, args: 'Accept' },
+          {
+            type: 'request.query',
+            op: 'set',
+            target: { key: 'source' },
+            args: 'cli',
+          },
+          {
+            type: 'response.headers',
+            op: 'append',
+            target: { key: 'Vary' },
+            args: 'Accept',
+          },
         ],
         has: [
           { type: 'header', key: 'Authorization' },
           { type: 'cookie', key: 'session', value: '^.+$' },
         ],
-        missing: [
-          { type: 'header', key: 'X-Block' },
-        ],
+        missing: [{ type: 'header', key: 'X-Block' }],
         continue: true,
       },
       routeTypes: ['rewrite', 'transform'],
@@ -838,31 +851,36 @@ export function useEditRouteComprehensive() {
     }
   );
 
-  client.scenario.patch('/v1/projects/:projectId/routes/:routeId', (req, res) => {
-    const body = req.body as Record<string, unknown>;
-    capturedBodies.edit = body;
+  client.scenario.patch(
+    '/v1/projects/:projectId/routes/:routeId',
+    (req, res) => {
+      const body = req.body as Record<string, unknown>;
+      capturedBodies.edit = body;
 
-    res.json({
-      route: {
-        id: req.params.routeId,
-        ...(body.route as Record<string, unknown>),
-        staged: true,
-      },
-      version: {
-        id: 'new-staging-version',
-        s3Key: 'routes/staging.json',
-        lastModified: Date.now(),
-        createdBy: 'user@example.com',
-        isStaging: true,
-        isLive: false,
-        ruleCount: routes.length,
-      },
-    });
-  });
+      res.json({
+        route: {
+          id: req.params.routeId,
+          ...(body.route as Record<string, unknown>),
+          staged: true,
+        },
+        version: {
+          id: 'new-staging-version',
+          s3Key: 'routes/staging.json',
+          lastModified: Date.now(),
+          createdBy: 'user@example.com',
+          isStaging: true,
+          isLive: false,
+          ruleCount: routes.length,
+        },
+      });
+    }
+  );
 }
 
 export function useStageRoutesWithSingleRoute() {
-  const routes = [{ ...createRoute(0), name: 'Only Route', id: 'only-route-id' }];
+  const routes = [
+    { ...createRoute(0), name: 'Only Route', id: 'only-route-id' },
+  ];
 
   client.scenario.get('/v1/projects/:projectId/routes', (_req, res) => {
     res.json({
@@ -897,7 +915,12 @@ export function useStageRoutesWithSingleRoute() {
 
 export function useEditRouteWithApiError() {
   const routes = [
-    { ...createRoute(0), name: 'Test Route', id: 'test-route-id', enabled: false },
+    {
+      ...createRoute(0),
+      name: 'Test Route',
+      id: 'test-route-id',
+      enabled: false,
+    },
   ];
 
   client.scenario.get('/v1/projects/:projectId/routes', (_req, res) => {
@@ -930,14 +953,17 @@ export function useEditRouteWithApiError() {
     }
   );
 
-  client.scenario.patch('/v1/projects/:projectId/routes/:routeId', (_req, res) => {
-    res.status(403).json({
-      error: {
-        code: 'feature_not_enabled',
-        message: 'Project-level routes are not enabled for this project.',
-      },
-    });
-  });
+  client.scenario.patch(
+    '/v1/projects/:projectId/routes/:routeId',
+    (_req, res) => {
+      res.status(403).json({
+        error: {
+          code: 'feature_not_enabled',
+          message: 'Project-level routes are not enabled for this project.',
+        },
+      });
+    }
+  );
 }
 
 export function useRoutesForInspect() {

--- a/packages/cli/test/mocks/routes.ts
+++ b/packages/cli/test/mocks/routes.ts
@@ -720,6 +720,147 @@ export function useStageRoutes() {
   });
 }
 
+/**
+ * Rich mock for comprehensive edit testing.
+ * Provides routes with all feature combinations for thorough edit mutation testing.
+ */
+export function useEditRouteComprehensive() {
+  const routes = [
+    {
+      id: 'rewrite-route',
+      name: 'API Rewrite',
+      description: 'Proxies API requests',
+      enabled: true,
+      staged: false,
+      srcSyntax: 'path-to-regexp',
+      route: {
+        src: '/api/:path*',
+        dest: 'https://api.example.com/:path*',
+        headers: {
+          'Cache-Control': 'no-cache',
+          'X-Custom': 'value',
+        },
+        transforms: [
+          { type: 'request.headers', op: 'set', target: { key: 'X-Forwarded-Host' }, args: 'myapp.com' },
+          { type: 'request.headers', op: 'delete', target: { key: 'X-Debug' } },
+          { type: 'request.query', op: 'set', target: { key: 'source' }, args: 'cli' },
+          { type: 'response.headers', op: 'append', target: { key: 'Vary' }, args: 'Accept' },
+        ],
+        has: [
+          { type: 'header', key: 'Authorization' },
+          { type: 'cookie', key: 'session', value: '^.+$' },
+        ],
+        missing: [
+          { type: 'header', key: 'X-Block' },
+        ],
+        continue: true,
+      },
+      routeTypes: ['rewrite', 'transform'],
+    },
+    {
+      id: 'redirect-route',
+      name: 'Blog Redirect',
+      description: 'Redirects old blog to new',
+      enabled: true,
+      staged: false,
+      srcSyntax: 'equals',
+      route: {
+        src: '/blog',
+        dest: '/articles',
+        status: 301,
+      },
+      routeTypes: ['redirect'],
+    },
+    {
+      id: 'status-route',
+      name: 'Block Admin',
+      description: 'Blocks admin access',
+      enabled: false,
+      staged: false,
+      srcSyntax: 'regex',
+      route: {
+        src: '^/admin/.*$',
+        status: 403,
+      },
+      routeTypes: ['set_status'],
+    },
+    {
+      id: 'header-only-route',
+      name: 'CORS Headers',
+      enabled: true,
+      staged: false,
+      srcSyntax: 'regex',
+      route: {
+        src: '^/api/.*$',
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST',
+        },
+        continue: true,
+      },
+      routeTypes: ['header'],
+    },
+  ];
+
+  client.scenario.get('/v1/projects/:projectId/routes', (_req, res) => {
+    res.json({
+      routes,
+      version: {
+        id: 'live-version',
+        s3Key: 'routes/live.json',
+        lastModified: Date.now(),
+        createdBy: 'user@example.com',
+        isLive: true,
+        ruleCount: routes.length,
+      },
+    });
+  });
+
+  client.scenario.get(
+    '/v1/projects/:projectId/routes/versions',
+    (_req, res) => {
+      res.json({
+        versions: [
+          {
+            id: 'staging-version',
+            isLive: false,
+            isStaging: true,
+            ruleCount: routes.length,
+          },
+          {
+            id: 'live-version',
+            isLive: true,
+            isStaging: false,
+            ruleCount: routes.length,
+          },
+        ],
+      });
+    }
+  );
+
+  client.scenario.patch('/v1/projects/:projectId/routes/:routeId', (req, res) => {
+    const body = req.body as Record<string, unknown>;
+    capturedBodies.edit = body;
+
+    res.json({
+      route: {
+        id: req.params.routeId,
+        ...(body.route as Record<string, unknown>),
+        staged: true,
+      },
+      version: {
+        id: 'new-staging-version',
+        s3Key: 'routes/staging.json',
+        lastModified: Date.now(),
+        createdBy: 'user@example.com',
+        isStaging: true,
+        isLive: false,
+        ruleCount: routes.length,
+      },
+    });
+  });
+}
+
 export function useStageRoutesWithSingleRoute() {
   const routes = [{ ...createRoute(0), name: 'Only Route', id: 'only-route-id' }];
 

--- a/packages/cli/test/mocks/routes.ts
+++ b/packages/cli/test/mocks/routes.ts
@@ -19,7 +19,20 @@ function createRoute(index: number) {
   const isRedirect = index % 3 === 1;
   const isSetStatus = index % 3 === 2;
 
-  const route: Record<string, unknown> = {
+  const route: {
+    src: string;
+    dest?: string;
+    status?: number;
+    headers?: Record<string, string>;
+    continue?: boolean;
+    transforms?: Array<{
+      type: string;
+      op: string;
+      target: { key: string };
+      args?: string;
+    }>;
+    has?: Array<{ type: string; key?: string; value?: string }>;
+  } = {
     src: `/path-${index}/(.*)`,
   };
 
@@ -64,11 +77,11 @@ function createRoute(index: number) {
     staged: index % 5 === 1, // Every 5th route (starting at 1) is staged
     srcSyntax: index % 2 === 0 ? 'regex' : 'path-to-regexp',
     route,
-    routeTypes: isSetStatus
-      ? ['set_status']
+    routeType: isSetStatus
+      ? ('set_status' as const)
       : isRedirect
-        ? ['redirect']
-        : ['rewrite'],
+        ? ('redirect' as const)
+        : ('rewrite' as const),
   };
 }
 
@@ -768,7 +781,7 @@ export function useEditRouteComprehensive() {
         missing: [{ type: 'header', key: 'X-Block' }],
         continue: true,
       },
-      routeTypes: ['rewrite', 'transform'],
+      routeType: 'rewrite',
     },
     {
       id: 'redirect-route',
@@ -782,7 +795,7 @@ export function useEditRouteComprehensive() {
         dest: '/articles',
         status: 301,
       },
-      routeTypes: ['redirect'],
+      routeType: 'redirect',
     },
     {
       id: 'status-route',
@@ -795,7 +808,7 @@ export function useEditRouteComprehensive() {
         src: '^/admin/.*$',
         status: 403,
       },
-      routeTypes: ['set_status'],
+      routeType: 'set_status',
     },
     {
       id: 'header-only-route',
@@ -811,7 +824,7 @@ export function useEditRouteComprehensive() {
         },
         continue: true,
       },
-      routeTypes: ['header'],
+      routeType: 'transform',
     },
   ];
 

--- a/packages/cli/test/unit/commands/routes/add.test.ts
+++ b/packages/cli/test/unit/commands/routes/add.test.ts
@@ -701,6 +701,76 @@ describe('routes add', () => {
       await expect(exitCodePromise).resolves.toEqual(1);
     });
 
+    it('should error when --action rewrite without --dest', async () => {
+      useAddRoute();
+      client.setArgv(
+        'routes',
+        'add',
+        'My Route',
+        '--src',
+        '/path',
+        '--action',
+        'rewrite',
+        '--yes'
+      );
+      const exitCodePromise = routes(client);
+      await expect(client.stderr).toOutput('requires --dest');
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error when --action redirect without --dest', async () => {
+      useAddRoute();
+      client.setArgv(
+        'routes',
+        'add',
+        'My Route',
+        '--src',
+        '/path',
+        '--action',
+        'redirect',
+        '--status',
+        '301',
+        '--yes'
+      );
+      const exitCodePromise = routes(client);
+      await expect(client.stderr).toOutput('requires --dest');
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error when --action set-status without --status', async () => {
+      useAddRoute();
+      client.setArgv(
+        'routes',
+        'add',
+        'My Route',
+        '--src',
+        '/path',
+        '--action',
+        'set-status',
+        '--yes'
+      );
+      const exitCodePromise = routes(client);
+      await expect(client.stderr).toOutput('requires --status');
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
+    it('should error when --action is invalid', async () => {
+      useAddRoute();
+      client.setArgv(
+        'routes',
+        'add',
+        'My Route',
+        '--src',
+        '/path',
+        '--action',
+        'foobar',
+        '--yes'
+      );
+      const exitCodePromise = routes(client);
+      await expect(client.stderr).toOutput('Invalid action type');
+      await expect(exitCodePromise).resolves.toEqual(1);
+    });
+
     it('should error on status code below 100', async () => {
       useAddRoute();
 

--- a/packages/cli/test/unit/commands/routes/delete.test.ts
+++ b/packages/cli/test/unit/commands/routes/delete.test.ts
@@ -80,4 +80,17 @@ describe('routes delete', () => {
     expect(exitCode).toEqual(0);
     await expect(client.stderr).toOutput('Deleted');
   });
+
+  it('should verify delete body contains correct route IDs', async () => {
+    useDeleteRoute();
+    client.setArgv('routes', 'delete', 'Route A', 'Route B', '--yes');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    const { capturedBodies } = await import('../../../mocks/routes');
+    const body = capturedBodies.delete as any;
+    expect(body.routeIds).toContain('route-a-id');
+    expect(body.routeIds).toContain('route-b-id');
+    expect(body.routeIds).toHaveLength(2);
+  });
 });

--- a/packages/cli/test/unit/commands/routes/disable.test.ts
+++ b/packages/cli/test/unit/commands/routes/disable.test.ts
@@ -56,4 +56,15 @@ describe('routes disable', () => {
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput('No route found');
   });
+
+  it('should send enabled: false in PATCH body', async () => {
+    useEditRoute();
+    client.setArgv('routes', 'disable', 'Enabled Route');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    const { capturedBodies } = await import('../../../mocks/routes');
+    const body = capturedBodies.edit as any;
+    expect(body.route.enabled).toBe(false);
+  });
 });

--- a/packages/cli/test/unit/commands/routes/edit.test.ts
+++ b/packages/cli/test/unit/commands/routes/edit.test.ts
@@ -4,7 +4,12 @@ import { useUser } from '../../../mocks/user';
 import { useProject, defaultProject } from '../../../mocks/project';
 import { useTeams } from '../../../mocks/team';
 import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
-import { useEditRoute } from '../../../mocks/routes';
+import {
+  useEditRoute,
+  useEditRouteComprehensive,
+  useEditRouteWithApiError,
+  capturedBodies,
+} from '../../../mocks/routes';
 import routes from '../../../../src/commands/routes';
 
 describe('routes edit', () => {
@@ -18,6 +23,8 @@ describe('routes edit', () => {
     });
     const cwd = setupUnitFixture('commands/routes');
     client.cwd = cwd;
+    // Reset captured bodies
+    capturedBodies.edit = undefined;
   });
 
   it('should show help with --help flag', async () => {
@@ -41,331 +48,861 @@ describe('routes edit', () => {
     await expect(client.stderr).toOutput('No route found');
   });
 
-  describe('flag-based mode', () => {
+  // ---------------------------------------------------------------------------
+  // Metadata edits
+  // ---------------------------------------------------------------------------
+
+  describe('metadata changes', () => {
     it('should change route name', async () => {
-      useEditRoute();
-      client.setArgv('routes', 'edit', 'Enabled Route', '--name', 'New Name');
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--name',
+        'New API Proxy'
+      );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
       await expect(client.stderr).toOutput('Updated');
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.name).toBe('New API Proxy');
+      // Everything else should be preserved
+      expect(body.route.route.dest).toBe('https://api.example.com/:path*');
     });
 
     it('should change route description', async () => {
-      useEditRoute();
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
+        'API Rewrite',
         '--description',
-        'New description'
+        'Updated proxy description'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.description).toBe('Updated proxy description');
     });
 
-    it('should change destination', async () => {
-      useEditRoute();
-      client.setArgv('routes', 'edit', 'Enabled Route', '--dest', '/new-dest');
+    it('should clear description with empty string', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--description', '');
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.description).toBeUndefined();
     });
 
-    it('should switch to redirect with --action', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--action',
-        'redirect',
-        '--dest',
-        '/new',
-        '--status',
-        '301'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should switch to set-status with --action', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--action',
-        'set-status',
-        '--status',
-        '403'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should add a response header', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--set-response-header',
-        'X-Custom=value'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should add a request header transform', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--set-request-header',
-        'X-Forwarded=host'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should add a request query transform', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--set-request-query',
-        'utm_source=cli'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should add a has condition', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--has',
-        'header:Authorization'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should add a missing condition', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--missing',
-        'cookie:session'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should clear conditions and add new ones', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--clear-conditions',
-        '--has',
-        'header:X-New'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should clear headers', async () => {
-      useEditRoute();
-      client.setArgv('routes', 'edit', 'Enabled Route', '--clear-headers');
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should clear transforms', async () => {
-      useEditRoute();
-      client.setArgv('routes', 'edit', 'Enabled Route', '--clear-transforms');
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should error on invalid action type', async () => {
-      useEditRoute();
-      client.setArgv('routes', 'edit', 'Enabled Route', '--action', 'invalid');
+    it('should error when name is too long', async () => {
+      useEditRouteComprehensive();
+      const longName = 'a'.repeat(257);
+      client.setArgv('routes', 'edit', 'API Rewrite', '--name', longName);
       const exitCode = await routes(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('Invalid action type');
+      await expect(client.stderr).toOutput('256 characters or less');
     });
+  });
 
-    it('should error when --action redirect missing --status', async () => {
-      useEditRoute();
+  // ---------------------------------------------------------------------------
+  // Source pattern edits
+  // ---------------------------------------------------------------------------
+
+  describe('source pattern changes', () => {
+    it('should change source pattern', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
-        '--action',
-        'redirect',
-        '--dest',
-        '/new'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('requires --status');
-    });
-
-    it('should change source pattern and syntax', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
+        'API Rewrite',
         '--src',
-        '/new-path',
+        '/v2/api/:path*'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.src).toBe('/v2/api/:path*');
+    });
+
+    it('should change source syntax', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--src-syntax', 'regex');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.srcSyntax).toBe('regex');
+    });
+
+    it('should change both source and syntax together', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--src',
+        '/old-blog',
         '--src-syntax',
         'equals'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.src).toBe('/old-blog');
+      expect(body.route.srcSyntax).toBe('equals');
     });
 
-    it('should remove destination with --no-dest', async () => {
-      useEditRoute();
+    it('should error on invalid syntax', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--src-syntax', 'glob');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid syntax');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Primary action changes (rewrite, redirect, set-status)
+  // ---------------------------------------------------------------------------
+
+  describe('primary action changes', () => {
+    it('should change rewrite destination', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
+        'API Rewrite',
+        '--dest',
+        'https://new-api.example.com/:path*'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBe('https://new-api.example.com/:path*');
+      // Status should not appear (was a rewrite, stays a rewrite)
+      expect(body.route.route.status).toBeUndefined();
+    });
+
+    it('should change redirect destination while keeping status', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--dest',
+        '/new-articles'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBe('/new-articles');
+      expect(body.route.route.status).toBe(301); // preserved
+    });
+
+    it('should change redirect status code', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'Blog Redirect', '--status', '308');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.status).toBe(308);
+      expect(body.route.route.dest).toBe('/articles'); // preserved
+    });
+
+    it('should switch from rewrite to redirect', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--action',
+        'redirect',
+        '--dest',
+        '/new-api',
+        '--status',
+        '301'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBe('/new-api');
+      expect(body.route.route.status).toBe(301);
+    });
+
+    it('should switch from redirect to rewrite', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--action',
+        'rewrite',
+        '--dest',
+        '/articles-page'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBe('/articles-page');
+      // Status should be removed when switching to rewrite
+      expect(body.route.route.status).toBeUndefined();
+    });
+
+    it('should switch from redirect to set-status', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--action',
+        'set-status',
+        '--status',
+        '410'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Dest should be removed when switching to set-status
+      expect(body.route.route.dest).toBeUndefined();
+      expect(body.route.route.status).toBe(410);
+    });
+
+    it('should switch from set-status to rewrite', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Block Admin',
+        '--action',
+        'rewrite',
+        '--dest',
+        '/admin-panel'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBe('/admin-panel');
+      // Status should be removed
+      expect(body.route.route.status).toBeUndefined();
+    });
+
+    it('should remove destination with --no-dest', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
         '--no-dest',
         '--action',
         'set-status',
         '--status',
-        '403'
+        '503'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBeUndefined();
+      expect(body.route.route.status).toBe(503);
     });
 
     it('should remove status with --no-status', async () => {
-      useEditRoute();
-      // Disabled Route is createRoute(1) which has status: 301
-      client.setArgv('routes', 'edit', 'Disabled Route', '--no-status');
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-      await expect(client.stderr).toOutput('Updated');
-    });
-
-    it('should verify PATCH body contains correct name change', async () => {
-      useEditRoute();
-      client.setArgv(
-        'routes',
-        'edit',
-        'Enabled Route',
-        '--name',
-        'New Name'
-      );
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'Blog Redirect', '--no-status');
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
 
-      const { capturedBodies } = await import('../../../mocks/routes');
       const body = capturedBodies.edit as any;
-      expect(body.route.name).toBe('New Name');
+      expect(body.route.route.status).toBeUndefined();
+      // Dest is preserved
+      expect(body.route.route.dest).toBe('/articles');
     });
+  });
 
-    it('should verify PATCH body contains enabled: true for enabled route', async () => {
-      useEditRoute();
+  // ---------------------------------------------------------------------------
+  // Response header edits
+  // ---------------------------------------------------------------------------
+
+  describe('response header changes', () => {
+    it('should add a new response header to existing headers', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
-        '--description',
-        'New desc'
+        'API Rewrite',
+        '--set-response-header',
+        'X-New-Header=new-value'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(0);
 
-      const { capturedBodies } = await import('../../../mocks/routes');
       const body = capturedBodies.edit as any;
-      expect(body.route.enabled).toBe(true);
+      // Original headers should be preserved
+      expect(body.route.route.headers['Cache-Control']).toBe('no-cache');
+      expect(body.route.route.headers['X-Custom']).toBe('value');
+      // New header should be added
+      expect(body.route.route.headers['X-New-Header']).toBe('new-value');
     });
 
-    it('should handle API error gracefully', async () => {
-      const { useEditRouteWithApiError } = await import(
-        '../../../mocks/routes'
-      );
-      useEditRouteWithApiError();
+    it('should overwrite an existing response header', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Test Route',
-        '--name',
-        'New Name'
+        'API Rewrite',
+        '--set-response-header',
+        'Cache-Control=public, max-age=3600'
       );
       const exitCode = await routes(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('not enabled');
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.headers['Cache-Control']).toBe(
+        'public, max-age=3600'
+      );
+      // Other headers preserved
+      expect(body.route.route.headers['X-Custom']).toBe('value');
     });
 
-    it('should error when --action redirect without --status', async () => {
-      useEditRoute();
+    it('should clear all response headers', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--clear-headers');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(Object.keys(body.route.route.headers)).toHaveLength(0);
+    });
+
+    it('should clear headers then add new ones', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
+        'API Rewrite',
+        '--clear-headers',
+        '--set-response-header',
+        'X-Only-Header=only'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.headers).toEqual({ 'X-Only-Header': 'only' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Transform edits (request headers, request query)
+  // ---------------------------------------------------------------------------
+
+  describe('transform changes', () => {
+    it('should add a request header transform to existing transforms', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--set-request-header',
+        'X-New=new'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      const transforms = body.route.route.transforms;
+      // Original 4 transforms + 1 new
+      expect(transforms.length).toBeGreaterThanOrEqual(5);
+      const newTransform = transforms.find(
+        (t: any) =>
+          t.type === 'request.headers' &&
+          t.op === 'set' &&
+          t.target.key === 'X-New'
+      );
+      expect(newTransform).toBeDefined();
+      expect(newTransform.args).toBe('new');
+    });
+
+    it('should add a request query transform', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--delete-request-query',
+        'utm_source'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      const transforms = body.route.route.transforms;
+      const deleteTransform = transforms.find(
+        (t: any) =>
+          t.type === 'request.query' &&
+          t.op === 'delete' &&
+          t.target.key === 'utm_source'
+      );
+      expect(deleteTransform).toBeDefined();
+    });
+
+    it('should add an append response header transform', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--append-response-header',
+        'Set-Cookie=session=abc'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      const transforms = body.route.route.transforms;
+      const appendTransform = transforms.find(
+        (t: any) =>
+          t.type === 'response.headers' &&
+          t.op === 'append' &&
+          t.target.key === 'Set-Cookie'
+      );
+      expect(appendTransform).toBeDefined();
+    });
+
+    it('should clear all transforms', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--clear-transforms');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.transforms).toHaveLength(0);
+    });
+
+    it('should clear transforms then add new ones', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--clear-transforms',
+        '--set-request-header',
+        'X-Only=only'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.transforms).toHaveLength(1);
+      expect(body.route.route.transforms[0].target.key).toBe('X-Only');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Condition edits
+  // ---------------------------------------------------------------------------
+
+  describe('condition changes', () => {
+    it('should add a has condition to existing conditions', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--has',
+        'query:version:2'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Original 2 has conditions + 1 new
+      expect(body.route.route.has).toHaveLength(3);
+      const newCond = body.route.route.has.find(
+        (c: any) => c.type === 'query' && c.key === 'version'
+      );
+      expect(newCond).toBeDefined();
+    });
+
+    it('should add a missing condition to existing conditions', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--missing',
+        'cookie:banned'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Original 1 missing condition + 1 new
+      expect(body.route.route.missing).toHaveLength(2);
+    });
+
+    it('should clear all conditions', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--clear-conditions');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.has).toHaveLength(0);
+      expect(body.route.route.missing).toHaveLength(0);
+    });
+
+    it('should clear conditions and add new ones', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--clear-conditions',
+        '--has',
+        'header:X-API-Key'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.has).toHaveLength(1);
+      expect(body.route.route.has[0].key).toBe('X-API-Key');
+      expect(body.route.route.missing).toHaveLength(0);
+    });
+
+    it('should add a host condition', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--has',
+        'host:blog.example.com'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.has).toHaveLength(1);
+      expect(body.route.route.has[0].type).toBe('host');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // continue field recomputation
+  // ---------------------------------------------------------------------------
+
+  describe('continue field', () => {
+    it('should set continue:true when adding response headers to a route without them', async () => {
+      useEditRouteComprehensive();
+      // Blog Redirect has no headers/transforms, so adding headers should set continue
+      // But it has status 301 (redirect/terminating), so continue should NOT be set
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--set-response-header',
+        'X-Test=test'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Redirect is terminating, so continue should NOT be set even with headers
+      expect(body.route.route.continue).toBeUndefined();
+    });
+
+    it('should preserve continue:true for header-only route edits', async () => {
+      useEditRouteComprehensive();
+      // CORS Headers is header-only with continue:true
+      client.setArgv(
+        'routes',
+        'edit',
+        'CORS Headers',
+        '--set-response-header',
+        'X-Frame-Options=DENY'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.continue).toBe(true);
+    });
+
+    it('should remove continue when switching from header-only to set-status', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'CORS Headers',
+        '--action',
+        'set-status',
+        '--status',
+        '204',
+        '--clear-headers'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // set-status is terminating, continue should not be set
+      expect(body.route.route.continue).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Combined feature edits
+  // ---------------------------------------------------------------------------
+
+  describe('combined changes', () => {
+    it('should change name, dest, and add header in one command', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--name',
+        'Updated Proxy',
+        '--dest',
+        'https://v2.api.example.com/:path*',
+        '--set-response-header',
+        'X-Version=2'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.name).toBe('Updated Proxy');
+      expect(body.route.route.dest).toBe('https://v2.api.example.com/:path*');
+      expect(body.route.route.headers['X-Version']).toBe('2');
+      // Original headers preserved
+      expect(body.route.route.headers['Cache-Control']).toBe('no-cache');
+    });
+
+    it('should switch action type and clear transforms simultaneously', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--action',
+        'set-status',
+        '--status',
+        '503',
+        '--clear-transforms'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.dest).toBeUndefined();
+      expect(body.route.route.status).toBe(503);
+      expect(body.route.route.transforms).toHaveLength(0);
+    });
+
+    it('should clear everything and rebuild minimal route', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'API Rewrite',
+        '--clear-conditions',
+        '--clear-headers',
+        '--clear-transforms',
         '--action',
         'redirect',
         '--dest',
-        '/new'
+        '/gone',
+        '--status',
+        '301'
       );
       const exitCode = await routes(client);
-      expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('requires --status');
-    });
+      expect(exitCode).toEqual(0);
 
-    it('should error when --action rewrite without --dest', async () => {
-      useEditRoute();
+      const body = capturedBodies.edit as any;
+      expect(body.route.route.has).toHaveLength(0);
+      expect(body.route.route.missing).toHaveLength(0);
+      expect(Object.keys(body.route.route.headers)).toHaveLength(0);
+      expect(body.route.route.transforms).toHaveLength(0);
+      expect(body.route.route.dest).toBe('/gone');
+      expect(body.route.route.status).toBe(301);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Validation errors
+  // ---------------------------------------------------------------------------
+
+  describe('validation errors', () => {
+    it('should error when --action redirect without --dest', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
+        'Block Admin',
         '--action',
-        'rewrite'
+        'redirect',
+        '--status',
+        '301'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(1);
       await expect(client.stderr).toOutput('requires --dest');
     });
 
-    it('should error on invalid syntax value', async () => {
-      useEditRoute();
+    it('should error when --action rewrite without --dest', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'Block Admin', '--action', 'rewrite');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('requires --dest');
+    });
+
+    it('should error when --action set-status without --status', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--action', 'set-status');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('requires --status');
+    });
+
+    it('should error on invalid action type', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--action', 'foobar');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid action type');
+    });
+
+    it('should error when redirect status is not valid', async () => {
+      useEditRouteComprehensive();
       client.setArgv(
         'routes',
         'edit',
-        'Enabled Route',
-        '--syntax',
-        'invalid'
+        'API Rewrite',
+        '--action',
+        'redirect',
+        '--dest',
+        '/new',
+        '--status',
+        '404'
       );
       const exitCode = await routes(client);
       expect(exitCode).toEqual(1);
-      await expect(client.stderr).toOutput('Invalid syntax');
+      await expect(client.stderr).toOutput('Invalid redirect status');
+    });
+
+    it('should error on invalid condition format', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--has', 'invalid');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid condition');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // No changes detection
+  // ---------------------------------------------------------------------------
+
+  describe('no changes', () => {
+    it('should report no changes when setting dest to same value', async () => {
+      useEditRouteComprehensive();
+      // Setting dest to the same value it already has → no actual change
+      client.setArgv('routes', 'edit', 'Blog Redirect', '--dest', '/articles');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('No changes made');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // API error handling
+  // ---------------------------------------------------------------------------
+
+  describe('API errors', () => {
+    it('should handle feature_not_enabled error', async () => {
+      useEditRouteWithApiError();
+      client.setArgv('routes', 'edit', 'Test Route', '--name', 'New Name');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('not enabled');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preservation of existing data
+  // ---------------------------------------------------------------------------
+
+  describe('data preservation', () => {
+    it('should preserve existing conditions when only changing name', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--name', 'Renamed');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Conditions should be preserved
+      expect(body.route.route.has).toHaveLength(2);
+      expect(body.route.route.missing).toHaveLength(1);
+    });
+
+    it('should preserve existing transforms when only changing dest', async () => {
+      useEditRouteComprehensive();
+      client.setArgv('routes', 'edit', 'API Rewrite', '--dest', '/new');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      // Original 4 transforms should be preserved
+      expect(body.route.route.transforms).toHaveLength(4);
+    });
+
+    it('should preserve enabled state when editing other fields', async () => {
+      useEditRouteComprehensive();
+      // Block Admin is disabled (enabled: false)
+      client.setArgv(
+        'routes',
+        'edit',
+        'Block Admin',
+        '--description',
+        'Updated'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.enabled).toBe(false); // preserved
+    });
+
+    it('should preserve srcSyntax when editing other fields', async () => {
+      useEditRouteComprehensive();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Blog Redirect',
+        '--dest',
+        '/new-articles'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+
+      const body = capturedBodies.edit as any;
+      expect(body.route.srcSyntax).toBe('equals'); // preserved
     });
   });
 });

--- a/packages/cli/test/unit/commands/routes/edit.test.ts
+++ b/packages/cli/test/unit/commands/routes/edit.test.ts
@@ -602,67 +602,7 @@ describe('routes edit', () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // continue field recomputation
-  // ---------------------------------------------------------------------------
-
-  describe('continue field', () => {
-    it('should set continue:true when adding response headers to a route without them', async () => {
-      useEditRouteComprehensive();
-      // Blog Redirect has no headers/transforms, so adding headers should set continue
-      // But it has status 301 (redirect/terminating), so continue should NOT be set
-      client.setArgv(
-        'routes',
-        'edit',
-        'Blog Redirect',
-        '--set-response-header',
-        'X-Test=test'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-
-      const body = capturedBodies.edit as any;
-      // Redirect is terminating, so continue should NOT be set even with headers
-      expect(body.route.route.continue).toBeUndefined();
-    });
-
-    it('should preserve continue:true for header-only route edits', async () => {
-      useEditRouteComprehensive();
-      // CORS Headers is header-only with continue:true
-      client.setArgv(
-        'routes',
-        'edit',
-        'CORS Headers',
-        '--set-response-header',
-        'X-Frame-Options=DENY'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-
-      const body = capturedBodies.edit as any;
-      expect(body.route.route.continue).toBe(true);
-    });
-
-    it('should remove continue when switching from header-only to set-status', async () => {
-      useEditRouteComprehensive();
-      client.setArgv(
-        'routes',
-        'edit',
-        'CORS Headers',
-        '--action',
-        'set-status',
-        '--status',
-        '204',
-        '--clear-headers'
-      );
-      const exitCode = await routes(client);
-      expect(exitCode).toEqual(0);
-
-      const body = capturedBodies.edit as any;
-      // set-status is terminating, continue should not be set
-      expect(body.route.route.continue).toBeUndefined();
-    });
-  });
+  // Note: The `continue` field is handled by the API, not the CLI.
 
   // ---------------------------------------------------------------------------
   // Combined feature edits

--- a/packages/cli/test/unit/commands/routes/edit.test.ts
+++ b/packages/cli/test/unit/commands/routes/edit.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { client } from '../../../mocks/client';
+import { useUser } from '../../../mocks/user';
+import { useProject, defaultProject } from '../../../mocks/project';
+import { useTeams } from '../../../mocks/team';
+import { setupUnitFixture } from '../../../helpers/setup-unit-fixture';
+import { useEditRoute } from '../../../mocks/routes';
+import routes from '../../../../src/commands/routes';
+
+describe('routes edit', () => {
+  beforeEach(() => {
+    useUser();
+    useTeams('team_dummy');
+    useProject({
+      ...defaultProject,
+      id: 'routes-test-project',
+      name: 'routes-test',
+    });
+    const cwd = setupUnitFixture('commands/routes');
+    client.cwd = cwd;
+  });
+
+  it('should show help with --help flag', async () => {
+    client.setArgv('routes', 'edit', '--help');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(2);
+  });
+
+  it('should error when no args provided', async () => {
+    useEditRoute();
+    client.setArgv('routes', 'edit');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(1);
+  });
+
+  it('should error when route not found', async () => {
+    useEditRoute();
+    client.setArgv('routes', 'edit', 'nonexistent', '--name', 'New Name');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('No route found');
+  });
+
+  describe('flag-based mode', () => {
+    it('should change route name', async () => {
+      useEditRoute();
+      client.setArgv('routes', 'edit', 'Enabled Route', '--name', 'New Name');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should change route description', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--description',
+        'New description'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should change destination', async () => {
+      useEditRoute();
+      client.setArgv('routes', 'edit', 'Enabled Route', '--dest', '/new-dest');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should switch to redirect with --action', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--action',
+        'redirect',
+        '--dest',
+        '/new',
+        '--status',
+        '301'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should switch to set-status with --action', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--action',
+        'set-status',
+        '--status',
+        '403'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should add a response header', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--set-response-header',
+        'X-Custom=value'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should add a request header transform', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--set-request-header',
+        'X-Forwarded=host'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should add a request query transform', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--set-request-query',
+        'utm_source=cli'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should add a has condition', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--has',
+        'header:Authorization'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should add a missing condition', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--missing',
+        'cookie:session'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should clear conditions and add new ones', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--clear-conditions',
+        '--has',
+        'header:X-New'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should clear headers', async () => {
+      useEditRoute();
+      client.setArgv('routes', 'edit', 'Enabled Route', '--clear-headers');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should clear transforms', async () => {
+      useEditRoute();
+      client.setArgv('routes', 'edit', 'Enabled Route', '--clear-transforms');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+
+    it('should error on invalid action type', async () => {
+      useEditRoute();
+      client.setArgv('routes', 'edit', 'Enabled Route', '--action', 'invalid');
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('Invalid action type');
+    });
+
+    it('should error when --action redirect missing --status', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--action',
+        'redirect',
+        '--dest',
+        '/new'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(1);
+      await expect(client.stderr).toOutput('requires --status');
+    });
+
+    it('should change source pattern and syntax', async () => {
+      useEditRoute();
+      client.setArgv(
+        'routes',
+        'edit',
+        'Enabled Route',
+        '--src',
+        '/new-path',
+        '--src-syntax',
+        'equals'
+      );
+      const exitCode = await routes(client);
+      expect(exitCode).toEqual(0);
+      await expect(client.stderr).toOutput('Updated');
+    });
+  });
+});

--- a/packages/cli/test/unit/commands/routes/enable.test.ts
+++ b/packages/cli/test/unit/commands/routes/enable.test.ts
@@ -56,4 +56,26 @@ describe('routes enable', () => {
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput('No route found');
   });
+
+  it('should send enabled: true in PATCH body', async () => {
+    useEditRoute();
+    client.setArgv('routes', 'enable', 'Disabled Route');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(0);
+
+    const { capturedBodies } = await import('../../../mocks/routes');
+    const body = capturedBodies.edit as any;
+    expect(body.route.enabled).toBe(true);
+  });
+
+  it('should handle API error gracefully', async () => {
+    const { useEditRouteWithApiError } = await import(
+      '../../../mocks/routes'
+    );
+    useEditRouteWithApiError();
+    client.setArgv('routes', 'enable', 'Test Route');
+    const exitCode = await routes(client);
+    expect(exitCode).toEqual(1);
+    await expect(client.stderr).toOutput('not enabled');
+  });
 });

--- a/packages/cli/test/unit/commands/routes/enable.test.ts
+++ b/packages/cli/test/unit/commands/routes/enable.test.ts
@@ -69,9 +69,7 @@ describe('routes enable', () => {
   });
 
   it('should handle API error gracefully', async () => {
-    const { useEditRouteWithApiError } = await import(
-      '../../../mocks/routes'
-    );
+    const { useEditRouteWithApiError } = await import('../../../mocks/routes');
     useEditRouteWithApiError();
     client.setArgv('routes', 'enable', 'Test Route');
     const exitCode = await routes(client);

--- a/packages/cli/test/unit/commands/routes/list.test.ts
+++ b/packages/cli/test/unit/commands/routes/list.test.ts
@@ -194,8 +194,32 @@ describe('routes list', () => {
       client.setArgv('routes', 'list', '--expand');
       const exitCode = await routes(client);
       expect(exitCode, 'exit code for "routes list --expand"').toEqual(0);
-      // Default routes have no srcSyntax, so should show 'Regex' (the default)
       await expect(client.stderr).toOutput('Regex');
+    });
+
+    it('should show Enabled and Disabled status in table view', async () => {
+      useRoutes(4); // Route 0: disabled (index%3===0), Route 1: enabled, Route 2: enabled, Route 3: disabled
+      client.setArgv('routes', 'list');
+      const exitCode = await routes(client);
+      expect(exitCode, 'exit code for "routes list"').toEqual(0);
+      // Route 0 is disabled, appears first in table; Route 1 is enabled
+      await expect(client.stderr).toOutput('Disabled');
+    });
+
+    it('should show transforms in expanded view', async () => {
+      useRoutes(1); // Route 0 has a request header transform
+      client.setArgv('routes', 'list', '--expand');
+      const exitCode = await routes(client);
+      expect(exitCode, 'exit code for "routes list --expand"').toEqual(0);
+      await expect(client.stderr).toOutput('Transforms');
+    });
+
+    it('should show conditions in expanded view', async () => {
+      useRoutes(2); // Route 1 has a has condition
+      client.setArgv('routes', 'list', '--expand');
+      const exitCode = await routes(client);
+      expect(exitCode, 'exit code for "routes list --expand"').toEqual(0);
+      await expect(client.stderr).toOutput('Has conditions');
     });
   });
 });

--- a/packages/cli/test/unit/commands/routes/reorder.test.ts
+++ b/packages/cli/test/unit/commands/routes/reorder.test.ts
@@ -243,14 +243,7 @@ describe('routes reorder', () => {
 
   it('should error on position 0', async () => {
     useStageRoutes();
-    client.setArgv(
-      'routes',
-      'reorder',
-      'Route 1',
-      '--position',
-      '0',
-      '--yes'
-    );
+    client.setArgv('routes', 'reorder', 'Route 1', '--position', '0', '--yes');
     const exitCode = await routes(client);
     expect(exitCode).toEqual(1);
     await expect(client.stderr).toOutput('must be 1 or greater');


### PR DESCRIPTION
- Extract shared interactive helpers into util/routes/interactive.ts
  (constants, utilities, flag processing, interactive collectors)
- Require explicit --action flag for routes add (rewrite/redirect/set-status)
- Add routes edit command with:
  - Flag-based mode: --name, --dest, --status, --action, --src, --syntax,
    --no-dest, --no-status, --clear-conditions/headers/transforms,
    all transform flags, --has, --missing
  - Interactive mode: top-level menu with sub-menus for each section
    (name, description, source, primary action, conditions,
    response headers, request headers, request query)
  - Granular condition editing: show existing, remove individual, add new
  - Granular transform editing: same remove/add per type
  - Deep clone + diff detection (no-op if unchanged)
  - Auto-promote offer after changes
- Wire up edit in index.ts with dynamic import, add telemetry
- Add editSubcommand definition with full flag set in command.ts