### PR TITLE
[python] Verify uv binary is executable in findUvBinary

### DIFF
--- a/.changeset/smart-apricots-tease.md
+++ b/.changeset/smart-apricots-tease.md
@@ -1,0 +1,5 @@
+---
+'@vercel/python': patch
+---
+
+More thoroughly check for local uv installation


### PR DESCRIPTION
Instead of only checking file existence, run `uv --version` to confirm
the binary actually works before returning it.  This protects from
possibly broken local uv installs.
