### PR TITLE
[cli] add hash to definitions version

### DIFF
--- a/.changeset/fresh-items-boil.md
+++ b/.changeset/fresh-items-boil.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fix in experimental VERCEL_EXPERIMENTAL_EMBED_FLAG_DEFINITIONS, which adds a hash to the version number of the emitted definitions package.


### PR DESCRIPTION
Previously the generated `package.json` would always have version `1.0.0`, but this can mess with the caching of build tools. We now emit `1.0.0-{hash}` instead of `1.0.0`.