### PR TITLE
[ppr] Support config.cacheComponents

### DIFF
--- a/.changeset/strange-donuts-melt.md
+++ b/.changeset/strange-donuts-melt.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next": patch
+---
+
+[ppr] Support config.cacheComponents

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1528,14 +1528,17 @@ export const build: BuildV2 = async buildOptions => {
         requiredServerFilesManifest.config.experimental?.ppr ===
           'incremental' ||
         requiredServerFilesManifest.config.experimental?.cacheComponents ===
-          true
+          true ||
+        requiredServerFilesManifest?.config?.cacheComponents === true ||
+        true
       : false;
 
     // When this is true, then it means all routes are PPR enabled.
     const isAppFullPPREnabled = requiredServerFilesManifest
       ? requiredServerFilesManifest?.config.experimental?.ppr === true ||
         requiredServerFilesManifest.config.experimental?.cacheComponents ===
-          true
+          true ||
+        requiredServerFilesManifest?.config?.cacheComponents === true
       : false;
 
     const isAppClientSegmentCacheEnabled =

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1529,8 +1529,7 @@ export const build: BuildV2 = async buildOptions => {
           'incremental' ||
         requiredServerFilesManifest.config.experimental?.cacheComponents ===
           true ||
-        requiredServerFilesManifest?.config?.cacheComponents === true ||
-        true
+        requiredServerFilesManifest?.config?.cacheComponents === true
       : false;
 
     // When this is true, then it means all routes are PPR enabled.

--- a/packages/next/src/utils.ts
+++ b/packages/next/src/utils.ts
@@ -1119,6 +1119,9 @@ export async function createLambdaFromPseudoLayers({
 // https://github.com/vercel/next.js/blob/6169e786020b63e101cc09285e1277e278cd34b8/packages/next/src/server/config-shared.ts#L1588
 export type NextConfigRuntime = {
   pageExtensions: string[];
+  // experimental.cacheComponents has been moved out of experimental
+  // at https://github.com/vercel/next.js/pull/85035
+  cacheComponents?: boolean;
   experimental?: {
     cacheComponents?: boolean;
     clientParamParsingOrigins?: string[];


### PR DESCRIPTION
Next.js deployment tests were failing due to error:

```
Error: Invariant: prefetchDataRoute can't be set without PPR
```

See https://github.com/vercel/next.js/pull/89648