### PR TITLE
[cli] Add interactive and flag based configuration of rolling releases

### DIFF
--- a/.changeset/quiet-wolves-flow.md
+++ b/.changeset/quiet-wolves-flow.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Add interactive and flag based configuration of rolling releases

--- a/packages/cli/src/commands/rolling-release/command.ts
+++ b/packages/cli/src/commands/rolling-release/command.ts
@@ -8,7 +8,19 @@ export const configureSubcommand = {
   arguments: [],
   examples: [
     {
-      name: 'Configure a new rolling release with an intial stage of 10% that lasts for 5 minutes before automatically advancing to 100%',
+      name: 'Enable automatic rolling release: 10% for 5 minutes, then 50% for 10 minutes, then 100%',
+      value: `${packageName} rolling-release configure --enable --advancement-type=automatic --stage=10,5m --stage=50,10m`,
+    },
+    {
+      name: 'Enable manual-approval rolling release: 10%, then 50%, then 100% (each stage requires approval)',
+      value: `${packageName} rolling-release configure --enable --advancement-type=manual-approval --stage=10 --stage=50`,
+    },
+    {
+      name: 'Disable rolling releases',
+      value: `${packageName} rolling-release configure --disable`,
+    },
+    {
+      name: 'Configure with raw JSON (advanced)',
       value: `${packageName} rolling-release configure --cfg='{"enabled":true, "advancementType":"automatic", "stages":[{"targetPercentage":10,"duration":5},{"targetPercentage":100}]}'`,
     },
   ],
@@ -18,7 +30,38 @@ export const configureSubcommand = {
       shorthand: null,
       deprecated: false,
       type: String,
-      description: "The project's rolling release configuration",
+      description: 'Raw JSON configuration (advanced). Overrides other flags.',
+    },
+    {
+      name: 'enable',
+      shorthand: null,
+      deprecated: false,
+      type: Boolean,
+      description: 'Enable rolling releases for this project',
+    },
+    {
+      name: 'disable',
+      shorthand: null,
+      deprecated: false,
+      type: Boolean,
+      description: 'Disable rolling releases for this project',
+    },
+    {
+      name: 'advancement-type',
+      shorthand: null,
+      deprecated: false,
+      type: String,
+      argument: 'TYPE',
+      description: 'How stages advance: "automatic" or "manual-approval"',
+    },
+    {
+      name: 'stage',
+      shorthand: null,
+      deprecated: false,
+      type: [String],
+      argument: 'PERCENTAGE[,DURATION]',
+      description:
+        'Add a rollout stage. Percentage (1-99) with optional duration for automatic advancement (e.g. "10,5m"). Can be specified multiple times. A final 100% stage is added automatically.',
     },
   ],
 } as const;
@@ -141,7 +184,8 @@ export const fetchSubcommand = {
 export const rollingReleaseCommand = {
   name: 'rolling-release',
   aliases: ['rr'],
-  description: "Manage your project's rolling release.",
+  description:
+    'Rolling releases gradually shift traffic to a new deployment in stages, allowing you to monitor for errors before serving all traffic. Learn more: https://vercel.com/docs/rolling-releases',
   arguments: [],
   subcommands: [
     configureSubcommand,
@@ -154,40 +198,32 @@ export const rollingReleaseCommand = {
   options: [],
   examples: [
     {
+      name: 'Enable automatic rolling release with two stages',
+      value: `${packageName} rr configure --enable --advancement-type=automatic --stage=10,5m --stage=50,10m`,
+    },
+    {
+      name: 'Enable manual-approval rolling release',
+      value: `${packageName} rr configure --enable --advancement-type=manual-approval --stage=10 --stage=50`,
+    },
+    {
+      name: 'Disable rolling releases',
+      value: `${packageName} rr configure --disable`,
+    },
+    {
       name: 'Start a rolling release',
       value: `${packageName} rr start --dpl=dpl_123`,
     },
     {
-      name: 'Start a rolling release using URL',
-      value: `${packageName} rr start --dpl=https://example.vercel.app`,
-    },
-    {
-      name: 'Configure a new rolling release with an intial stage of 10% that lasts for 5 minutes before automatically advancing to 100%',
-      value: `${packageName} rolling-release configure --cfg='{"enabled":true, "advancementType":"automatic", "stages":[{"targetPercentage":10,"duration":5},{"targetPercentage":100}]}'`,
-    },
-    {
-      name: 'Configure a new rolling release with an intial stage of 10% that requires approval, prior to advancing to 100%',
-      value: `${packageName} rolling-release configure --cfg='{"enabled":true, "advancementType":"manual-approval","stages":[{"targetPercentage":10},{"targetPercentage":100}]}'`,
-    },
-    {
-      name: 'Configure a new rolling release with an intial stage of 10% that requires approval, prior to advancing to 50%, and then again to 100%',
-      value: `${packageName} rolling-release configure --cfg='{"enabled":true, "advancementType":"manual-approval", "stages":[{"targetPercentage":10},{"targetPercentage":50},{"targetPercentage":100}]}'`,
-    },
-    {
-      name: 'Disable rolling releases',
-      value: `${packageName} rolling-release configure --cfg='disable'`,
-    },
-    {
       name: 'Approve an active rolling release stage',
-      value: `${packageName} rolling-release approve --currentStageIndex=0 --dpl=dpl_123`,
+      value: `${packageName} rr approve --currentStageIndex=0 --dpl=dpl_123`,
     },
     {
-      name: 'Abort an active rolling release.',
-      value: `${packageName} rolling-release abort --dpl=dpl_123`,
+      name: 'Abort an active rolling release',
+      value: `${packageName} rr abort --dpl=dpl_123`,
     },
     {
-      name: 'Complete an active rolling release.',
-      value: `${packageName} rolling-release complete --dpl=dpl_123`,
+      name: 'Complete an active rolling release',
+      value: `${packageName} rr complete --dpl=dpl_123`,
     },
   ],
 } as const;

--- a/packages/cli/src/commands/rolling-release/configure-rolling-release.ts
+++ b/packages/cli/src/commands/rolling-release/configure-rolling-release.ts
@@ -2,15 +2,292 @@ import type Client from '../../util/client';
 import type {
   JSONObject,
   ProjectRollingRelease,
+  RollingReleaseAdvancementType,
 } from '@vercel-internals/types';
 import output from '../../output-manager';
 
+export type ConfigureResult =
+  | { config: ProjectRollingRelease | undefined; exitCode?: undefined }
+  | { config?: undefined; exitCode: number };
+
 /**
- * Requests a rolling release document.
+ * Parses a duration string (e.g. "5m", "1h", "10") into minutes.
+ * Returns undefined if the string is invalid.
+ */
+export function parseDuration(value: string): number | undefined {
+  const match = value.match(/^(\d+)(m|h)?$/);
+  if (!match) return undefined;
+  const num = parseInt(match[1], 10);
+  if (isNaN(num) || num <= 0) return undefined;
+  const unit = match[2];
+  if (unit === 'h') return num * 60;
+  return num;
+}
+
+function parseStageFlags(
+  stageFlags: string[],
+  advancementType: RollingReleaseAdvancementType
+):
+  | { stages: { targetPercentage: number; duration?: number }[]; error: null }
+  | { stages: null; error: string } {
+  const stages: { targetPercentage: number; duration?: number }[] = [];
+
+  for (const stageValue of stageFlags) {
+    const parts = stageValue.split(',');
+    const percentage = parseInt(parts[0], 10);
+
+    if (isNaN(percentage) || percentage < 1 || percentage > 99) {
+      return {
+        stages: null,
+        error: `Invalid stage percentage "${parts[0]}". Must be a number between 1 and 99.`,
+      };
+    }
+
+    if (parts.length > 1) {
+      if (advancementType === 'manual-approval') {
+        return {
+          stages: null,
+          error:
+            'Duration must not be provided for stages when advancement type is "manual-approval".',
+        };
+      }
+      const duration = parseDuration(parts[1]);
+      if (duration === undefined) {
+        return {
+          stages: null,
+          error: `Invalid duration "${parts[1]}". Use a format like "5m", "1h", or a plain number (minutes).`,
+        };
+      }
+      stages.push({ targetPercentage: percentage, duration });
+    } else {
+      if (advancementType === 'automatic') {
+        return {
+          stages: null,
+          error:
+            'Duration is required for each stage when advancement type is "automatic". Use the format "PERCENTAGE,DURATION" (e.g. "10,5m").',
+        };
+      }
+      stages.push({ targetPercentage: percentage });
+    }
+  }
+
+  for (let i = 1; i < stages.length; i++) {
+    if (stages[i].targetPercentage <= stages[i - 1].targetPercentage) {
+      return {
+        stages: null,
+        error: 'Stage percentages must be in ascending order.',
+      };
+    }
+  }
+
+  return { stages, error: null };
+}
+
+async function interactiveConfigure(client: Client): Promise<ConfigureResult> {
+  const action = await client.input.select<'enable' | 'disable'>({
+    message: 'Would you like to enable or disable rolling releases?',
+    choices: [
+      { name: 'Enable', value: 'enable' },
+      { name: 'Disable', value: 'disable' },
+    ],
+  });
+
+  if (action === 'disable') {
+    return { config: undefined };
+  }
+
+  const advancementType =
+    await client.input.select<RollingReleaseAdvancementType>({
+      message: 'How should stages advance?',
+      choices: [
+        {
+          name: 'automatic - Stages advance automatically after a set duration',
+          value: 'automatic',
+        },
+        {
+          name: 'manual-approval - Each stage requires manual approval to advance',
+          value: 'manual-approval',
+        },
+      ],
+    });
+
+  const stages: { targetPercentage: number; duration?: number }[] = [];
+  let stageNumber = 1;
+  let addMore = true;
+
+  while (addMore) {
+    const percentageStr = await client.input.text({
+      message: `Enter traffic percentage for stage ${stageNumber} (1-99):`,
+      validate: (val: string) => {
+        const num = parseInt(val, 10);
+        if (isNaN(num) || num < 1 || num > 99) {
+          return 'Percentage must be a number between 1 and 99.';
+        }
+        if (
+          stages.length > 0 &&
+          num <= stages[stages.length - 1].targetPercentage
+        ) {
+          return `Percentage must be greater than the previous stage (${stages[stages.length - 1].targetPercentage}%).`;
+        }
+        return true;
+      },
+    });
+    const percentage = parseInt(percentageStr, 10);
+
+    let duration: number | undefined;
+    if (advancementType === 'automatic') {
+      const durationStr = await client.input.text({
+        message: `Enter duration for this stage (e.g. 5m, 1h):`,
+        validate: (val: string) => {
+          const parsed = parseDuration(val);
+          if (parsed === undefined) {
+            return 'Invalid duration. Use a format like "5m", "1h", or a plain number (minutes).';
+          }
+          return true;
+        },
+      });
+      duration = parseDuration(durationStr);
+    }
+
+    stages.push({ targetPercentage: percentage, duration });
+    stageNumber++;
+
+    addMore = await client.input.confirm('Add another stage?', false);
+  }
+
+  output.log('');
+  output.log('Rolling release configuration:');
+  output.log(`  Advancement: ${advancementType}`);
+  stages.forEach((stage, i) => {
+    const durationText =
+      stage.duration !== undefined ? ` for ${stage.duration} minutes` : '';
+    output.log(`  Stage ${i + 1}: ${stage.targetPercentage}%${durationText}`);
+  });
+  output.log(`  Stage ${stages.length + 1}: 100% (final)`);
+  output.log('');
+
+  const confirmed = await client.input.confirm(
+    'Apply this configuration?',
+    true
+  );
+  if (!confirmed) {
+    output.log('Configuration cancelled.');
+    return { exitCode: 0 };
+  }
+
+  return {
+    config: {
+      enabled: true,
+      advancementType,
+      stages: [...stages, { targetPercentage: 100 }],
+    },
+  };
+}
+
+/**
+ * Resolves the rolling release configuration from CLI flags or interactive prompts.
+ *
+ * Priority:
+ * 1. --cfg (raw JSON, backwards compatible)
+ * 2. --disable
+ * 3. --enable + --advancement-type + --stage
+ * 4. Interactive mode (TTY, no flags)
+ * 5. Error (non-TTY, no flags)
+ */
+export async function buildConfigurePayload({
+  client,
+  cfgString,
+  enableFlag,
+  disableFlag,
+  advancementType,
+  stageFlags,
+}: {
+  client: Client;
+  cfgString: string | undefined;
+  enableFlag: boolean | undefined;
+  disableFlag: boolean | undefined;
+  advancementType: string | undefined;
+  stageFlags: string[] | undefined;
+}): Promise<ConfigureResult> {
+  if (cfgString !== undefined) {
+    if (cfgString === 'disable') {
+      return { config: undefined };
+    }
+    try {
+      const cfg = JSON.parse(cfgString);
+      return { config: cfg };
+    } catch {
+      output.error('Invalid JSON provided for --cfg option.');
+      return { exitCode: 1 };
+    }
+  }
+
+  if (disableFlag) {
+    if (enableFlag) {
+      output.error('--enable and --disable are mutually exclusive.');
+      return { exitCode: 1 };
+    }
+    return { config: undefined };
+  }
+
+  if (enableFlag) {
+    if (
+      advancementType !== 'automatic' &&
+      advancementType !== 'manual-approval'
+    ) {
+      output.error(
+        '--advancement-type is required when using --enable. Must be "automatic" or "manual-approval".'
+      );
+      return { exitCode: 1 };
+    }
+
+    if (!stageFlags || stageFlags.length === 0) {
+      output.error('At least one --stage is required when using --enable.');
+      return { exitCode: 1 };
+    }
+
+    const parsed = parseStageFlags(stageFlags, advancementType);
+    if (parsed.error !== null) {
+      output.error(parsed.error);
+      return { exitCode: 1 };
+    }
+
+    return {
+      config: {
+        enabled: true,
+        advancementType,
+        stages: [...parsed.stages, { targetPercentage: 100 }],
+      },
+    };
+  }
+
+  const hasAnyFlags =
+    advancementType !== undefined ||
+    (stageFlags !== undefined && stageFlags.length > 0);
+
+  if (hasAnyFlags) {
+    output.error(
+      '--enable or --disable is required when using --advancement-type or --stage flags.'
+    );
+    return { exitCode: 1 };
+  }
+
+  if (client.stdin.isTTY) {
+    return interactiveConfigure(client);
+  }
+
+  output.error(
+    'Missing configuration flags. Use --enable/--disable with --advancement-type and --stage, or run interactively in a terminal.'
+  );
+  return { exitCode: 1 };
+}
+
+/**
+ * Configures rolling release settings for a project.
  * @param {Client} client - The Vercel client instance
  * @param {string} projectId - The projectId to request the rolling release for
  * @param {string} teamId - The team to request the rolling release for
- * @param {ProjectRollingRelease} rollingReleaseConfig- The rolling release configuration to store.
+ * @param {ProjectRollingRelease} rollingReleaseConfig - The rolling release configuration to store.
  * @returns {Promise<number>} Resolves an exit code; 0 on success
  */
 export default async function configureRollingRelease({
@@ -24,7 +301,6 @@ export default async function configureRollingRelease({
   teamId: string;
   rollingReleaseConfig: ProjectRollingRelease | undefined;
 }): Promise<number> {
-  // request the promotion
   const body = {
     ...rollingReleaseConfig,
     enabled: Boolean(rollingReleaseConfig),
@@ -39,7 +315,11 @@ export default async function configureRollingRelease({
     }
   );
 
-  output.log('Successfully configured rolling releases.');
+  if (rollingReleaseConfig) {
+    output.log('Successfully configured rolling releases.');
+  } else {
+    output.log('Successfully disabled rolling releases.');
+  }
 
   return 0;
 }

--- a/packages/cli/src/util/telemetry/commands/rolling-release/index.ts
+++ b/packages/cli/src/util/telemetry/commands/rolling-release/index.ts
@@ -84,4 +84,34 @@ export class RollingReleaseTelemetryClient
       value: actual,
     });
   }
+
+  trackCliFlagEnable(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('enable');
+    }
+  }
+
+  trackCliFlagDisable(value: boolean | undefined) {
+    if (value) {
+      this.trackCliFlag('disable');
+    }
+  }
+
+  trackCliOptionAdvancementType(value: string | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'advancement-type',
+        value,
+      });
+    }
+  }
+
+  trackCliOptionStage(value: string[] | undefined) {
+    if (value) {
+      this.trackCliOption({
+        option: 'stage',
+        value: value.join(','),
+      });
+    }
+  }
 }

--- a/packages/cli/test/unit/commands/rolling-release/configure.test.ts
+++ b/packages/cli/test/unit/commands/rolling-release/configure.test.ts
@@ -1,0 +1,451 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { client } from '../../../mocks/client';
+import rollingRelease from '../../../../src/commands/rolling-release/index';
+import { parseDuration } from '../../../../src/commands/rolling-release/configure-rolling-release';
+import * as linkModule from '../../../../src/util/projects/link';
+
+vi.mock('../../../../src/util/projects/link');
+
+const mockedGetLinkedProject = vi.mocked(linkModule.getLinkedProject);
+
+describe('parseDuration', () => {
+  it('should parse minutes', () => {
+    expect(parseDuration('5m')).toBe(5);
+    expect(parseDuration('10m')).toBe(10);
+  });
+
+  it('should parse hours', () => {
+    expect(parseDuration('1h')).toBe(60);
+    expect(parseDuration('2h')).toBe(120);
+  });
+
+  it('should treat plain numbers as minutes', () => {
+    expect(parseDuration('5')).toBe(5);
+    expect(parseDuration('30')).toBe(30);
+  });
+
+  it('should return undefined for invalid values', () => {
+    expect(parseDuration('')).toBeUndefined();
+    expect(parseDuration('abc')).toBeUndefined();
+    expect(parseDuration('0m')).toBeUndefined();
+    expect(parseDuration('-5m')).toBeUndefined();
+    expect(parseDuration('5s')).toBeUndefined();
+  });
+});
+
+describe('rolling-release configure', () => {
+  let patchBody: any;
+  let patchCalled: boolean;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.reset();
+    patchBody = undefined;
+    patchCalled = false;
+
+    client.scenario.patch(
+      '/v1/projects/:projectId/rolling-release/config',
+      (req, res) => {
+        patchCalled = true;
+        patchBody = req.body;
+        res.json({});
+      }
+    );
+
+    mockedGetLinkedProject.mockResolvedValue({
+      status: 'linked',
+      project: {
+        id: 'proj_123',
+        name: 'my-project',
+        accountId: 'org_123',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+      },
+      org: { id: 'org_123', slug: 'my-org', type: 'team' },
+    });
+  });
+
+  describe('--cfg flag (legacy)', () => {
+    it('should configure with raw JSON', async () => {
+      const cfg = JSON.stringify({
+        enabled: true,
+        advancementType: 'automatic',
+        stages: [
+          { targetPercentage: 10, duration: 5 },
+          { targetPercentage: 100 },
+        ],
+      });
+      client.setArgv('rolling-release', 'configure', `--cfg=${cfg}`);
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchCalled).toBe(true);
+    });
+
+    it('should disable with --cfg=disable', async () => {
+      client.setArgv('rolling-release', 'configure', '--cfg=disable');
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ enabled: false });
+    });
+
+    it('should error on invalid JSON for --cfg', async () => {
+      client.setArgv('rolling-release', 'configure', '--cfg=not-json');
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid JSON provided for --cfg option.'
+      );
+      expect(await exitCodePromise).toBe(1);
+      expect(patchCalled).toBe(false);
+    });
+  });
+
+  describe('--disable flag', () => {
+    it('should disable rolling releases', async () => {
+      client.setArgv('rolling-release', 'configure', '--disable');
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({ enabled: false });
+    });
+  });
+
+  describe('--enable flag with automatic advancement', () => {
+    it('should configure automatic rolling release with stages', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=automatic',
+        '--stage=10,5m',
+        '--stage=50,10m'
+      );
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        enabled: true,
+        advancementType: 'automatic',
+        stages: [
+          { targetPercentage: 10, duration: 5 },
+          { targetPercentage: 50, duration: 10 },
+          { targetPercentage: 100 },
+        ],
+      });
+    });
+
+    it('should parse hour durations', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=automatic',
+        '--stage=10,1h'
+      );
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        enabled: true,
+        advancementType: 'automatic',
+        stages: [
+          { targetPercentage: 10, duration: 60 },
+          { targetPercentage: 100 },
+        ],
+      });
+    });
+  });
+
+  describe('--enable flag with manual-approval advancement', () => {
+    it('should configure manual-approval rolling release with stages', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=manual-approval',
+        '--stage=10',
+        '--stage=50'
+      );
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        enabled: true,
+        advancementType: 'manual-approval',
+        stages: [
+          { targetPercentage: 10 },
+          { targetPercentage: 50 },
+          { targetPercentage: 100 },
+        ],
+      });
+    });
+  });
+
+  describe('validation errors', () => {
+    it('should error when --enable and --disable are both set', async () => {
+      client.setArgv('rolling-release', 'configure', '--enable', '--disable');
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: --enable and --disable are mutually exclusive.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when --enable is used without --advancement-type', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--stage=10,5m'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: --advancement-type is required when using --enable. Must be "automatic" or "manual-approval".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when --enable is used with invalid --advancement-type', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=invalid',
+        '--stage=10,5m'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: --advancement-type is required when using --enable. Must be "automatic" or "manual-approval".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when --enable is used without --stage', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=automatic'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: At least one --stage is required when using --enable.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when stage percentage is out of range', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=automatic',
+        '--stage=100,5m'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Invalid stage percentage "100". Must be a number between 1 and 99.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when stage percentages are not in ascending order', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=manual-approval',
+        '--stage=50',
+        '--stage=10'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Stage percentages must be in ascending order.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when duration is missing for automatic advancement', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=automatic',
+        '--stage=10'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Duration is required for each stage when advancement type is "automatic". Use the format "PERCENTAGE,DURATION" (e.g. "10,5m").'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when duration is provided for manual-approval advancement', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--enable',
+        '--advancement-type=manual-approval',
+        '--stage=10,5m'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Duration must not be provided for stages when advancement type is "manual-approval".'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error when --advancement-type is used without --enable or --disable', async () => {
+      client.setArgv(
+        'rolling-release',
+        'configure',
+        '--advancement-type=automatic',
+        '--stage=10,5m'
+      );
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: --enable or --disable is required when using --advancement-type or --stage flags.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+
+    it('should error in non-TTY mode with no flags', async () => {
+      client.setArgv('rolling-release', 'configure');
+      (client.stdin as any).isTTY = false;
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput(
+        'Error: Missing configuration flags. Use --enable/--disable with --advancement-type and --stage, or run interactively in a terminal.'
+      );
+      expect(await exitCodePromise).toBe(1);
+    });
+  });
+
+  describe('interactive mode', () => {
+    it('should disable via interactive prompt', async () => {
+      client.setArgv('rolling-release', 'configure');
+      client.input.select = vi.fn().mockResolvedValue('disable');
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(client.input.select).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Would you like to enable or disable rolling releases?',
+        })
+      );
+      expect(patchBody).toEqual({ enabled: false });
+    });
+
+    it('should enable automatic rolling release via interactive prompt', async () => {
+      client.setArgv('rolling-release', 'configure');
+
+      client.input.select = vi
+        .fn()
+        .mockResolvedValueOnce('enable')
+        .mockResolvedValueOnce('automatic');
+      client.input.text = vi
+        .fn()
+        .mockResolvedValueOnce('10') // percentage
+        .mockResolvedValueOnce('5m'); // duration
+      client.input.confirm = vi
+        .fn()
+        .mockResolvedValueOnce(false) // don't add another stage
+        .mockResolvedValueOnce(true); // apply config
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        enabled: true,
+        advancementType: 'automatic',
+        stages: [
+          { targetPercentage: 10, duration: 5 },
+          { targetPercentage: 100 },
+        ],
+      });
+    });
+
+    it('should enable manual-approval with multiple stages via interactive prompt', async () => {
+      client.setArgv('rolling-release', 'configure');
+
+      client.input.select = vi
+        .fn()
+        .mockResolvedValueOnce('enable')
+        .mockResolvedValueOnce('manual-approval');
+      client.input.text = vi
+        .fn()
+        .mockResolvedValueOnce('10') // stage 1 percentage
+        .mockResolvedValueOnce('50'); // stage 2 percentage
+      client.input.confirm = vi
+        .fn()
+        .mockResolvedValueOnce(true) // add another stage
+        .mockResolvedValueOnce(false) // don't add another stage
+        .mockResolvedValueOnce(true); // apply config
+
+      const exitCode = await rollingRelease(client);
+
+      expect(exitCode).toBe(0);
+      expect(patchBody).toEqual({
+        enabled: true,
+        advancementType: 'manual-approval',
+        stages: [
+          { targetPercentage: 10 },
+          { targetPercentage: 50 },
+          { targetPercentage: 100 },
+        ],
+      });
+    });
+
+    it('should cancel when user declines to apply', async () => {
+      client.setArgv('rolling-release', 'configure');
+
+      client.input.select = vi
+        .fn()
+        .mockResolvedValueOnce('enable')
+        .mockResolvedValueOnce('automatic');
+      client.input.text = vi
+        .fn()
+        .mockResolvedValueOnce('10')
+        .mockResolvedValueOnce('5m');
+      client.input.confirm = vi
+        .fn()
+        .mockResolvedValueOnce(false) // no more stages
+        .mockResolvedValueOnce(false); // decline to apply
+
+      const exitCodePromise = rollingRelease(client);
+
+      await expect(client.stderr).toOutput('Configuration cancelled.');
+      expect(await exitCodePromise).toBe(0);
+      expect(patchCalled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds interactive and flag based configuration to the `vercel rolling-release configure` command so that users and agents don't need to know the JSON configuration syntax.

- `vercel rolling-release configure` is an interactive flow where the user can select options for each stage
- `vercel rolling-release configure --enable --advancement-type automatic --stage 10,3m --stage 50,5m` would enable rolling releases with automatic advancement with 2 stages at 10% for 3m and 50% for 5m.