### PR TITLE
fix(react-router): generate stable entry point for local development

### DIFF
--- a/packages/react-router/vite.ts
+++ b/packages/react-router/vite.ts
@@ -178,6 +178,23 @@ export function vercelPreset(): Preset {
 
     const assetsDir = viteConfig?.build?.assetsDir;
 
+    // Create a stable entry point for local development (re-exports the dynamic bundle)
+    try {
+      const buildDir = reactRouterConfig.buildDirectory || 'build';
+      const serverDir = join(buildDir, 'server');
+      const nodeBundleId = Object.keys(buildManifest?.serverBundles || {}).find(
+        id => id.startsWith('nodejs')
+      );
+
+      if (nodeBundleId) {
+        const entryPointPath = join(serverDir, 'index.js');
+        const content = `export * from "./${nodeBundleId}/index.js";`;
+        writeFileSync(entryPointPath, content);
+      }
+    } catch (error) {
+      // Fail silently if directories don't match expectations or permissions denied
+    }
+
     const json = JSON.stringify(
       {
         buildManifest,


### PR DESCRIPTION
The `@vercel/react-router` preset builds to a dynamic directory (e.g., `build/server/nodejs_<HASH>/`), but the local `start` script expects a fixed entry point at `build/server/index.js`. This breaks local development (`npm start` fails).

Modified `vite.ts` to generate a `build/server/index.js` file that re-exports the generated bundle. This allows `react-router-serve` to locate the server entry point automatically, fixing the local developer experience.

Fixes #13137