### PR TITLE
[cli] Fix rate limit retry time message

### DIFF
--- a/.changeset/fix-rate-limit-retry-time.md
+++ b/.changeset/fix-rate-limit-retry-time.md
@@ -1,0 +1,5 @@
+---
+'vercel': patch
+---
+
+Fixed deployment rate limit error message displaying incorrect retry time

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -224,7 +224,7 @@ export default class Now {
 
       if (error.limit && error.limit.reset) {
         const { reset } = error.limit;
-        const difference = reset * 1000 - Date.now();
+        const difference = reset - Date.now();
 
         msg += `Please retry in ${ms(difference, { long: true })}.`;
       } else {


### PR DESCRIPTION
The CLI displays "Please retry in 20470344 days" when a deployment flood rate limit is exceeded

`error.limit.reset` is epoch milliseconds, not epoch seconds, so the `* 1000` is incorrect